### PR TITLE
fix(lint/noUnsafeDeclarationMerging): recoggnize ambient classes in ambient namespace

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_unsafe_declaration_merging.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_unsafe_declaration_merging.rs
@@ -1,10 +1,7 @@
 use crate::semantic_services::Semantic;
 use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
-use rome_js_syntax::{
-    binding_ext::AnyJsBindingDeclaration, TsDeclareStatement, TsExportDeclareClause,
-    TsInterfaceDeclaration,
-};
+use rome_js_syntax::{binding_ext::AnyJsBindingDeclaration, TsInterfaceDeclaration};
 use rome_rowan::{AstNode, TextRange};
 
 declare_rule! {
@@ -69,9 +66,7 @@ impl Rule for NoUnsafeDeclarationMerging {
                 binding.tree().declaration()
             {
                 // This is not unsafe of merging an interface and an ambient class.
-                if class.parent::<TsDeclareStatement>().is_none()
-                    && class.parent::<TsExportDeclareClause>().is_none()
-                {
+                if !class.is_ambient() {
                     if let Ok(id) = class.id() {
                         if let Some(id) = id.as_js_identifier_binding() {
                             if let Ok(name) = id.name_token() {

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnsafeDeclarationMerging/valid.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnsafeDeclarationMerging/valid.ts
@@ -27,3 +27,17 @@ declare class Foo8 {}
 
 export interface Foo9 {}
 export declare class Foo9 {}
+
+declare namespace A {
+  namespace B {
+    export interface Foo10 {}
+    export class Foo10 {}
+  }
+}
+
+export declare namespace A {
+  namespace B {
+    export interface Foo11 {}
+    export class Foo11 {}
+  }
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnsafeDeclarationMerging/valid.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnsafeDeclarationMerging/valid.ts.snap
@@ -34,6 +34,20 @@ declare class Foo8 {}
 export interface Foo9 {}
 export declare class Foo9 {}
 
+declare namespace A {
+  namespace B {
+    export interface Foo10 {}
+    export class Foo10 {}
+  }
+}
+
+export declare namespace A {
+  namespace B {
+    export interface Foo11 {}
+    export class Foo11 {}
+  }
+}
+
 ```
 
 

--- a/crates/rome_js_syntax/src/declaration_ext.rs
+++ b/crates/rome_js_syntax/src/declaration_ext.rs
@@ -1,8 +1,15 @@
 use rome_rowan::AstNode;
 
-use crate::{JsSyntaxKind, JsSyntaxNode, TsEnumDeclaration};
+use crate::{JsClassDeclaration, JsSyntaxKind, JsSyntaxNode, TsEnumDeclaration};
 
 impl TsEnumDeclaration {
+    /// Returns `true` if this enum is an ambient enum or in an ambient context.
+    pub fn is_ambient(&self) -> bool {
+        is_in_ambient_context(self.syntax())
+    }
+}
+
+impl JsClassDeclaration {
     /// Returns `true` if this enum is an ambient enum or in an ambient context.
     pub fn is_ambient(&self) -> bool {
         is_in_ambient_context(self.syntax())


### PR DESCRIPTION

## Summary

This is related to #19 but concerns noUnsafeDeclarationMerging.
This correctly recognizes ambient classes in ambient context.
Thus, the following code is not reported as unsafe because merging an ambient class and an interface is safe:

```
declare namespace A {
  namespace B {
    export interface Foo {}
    export class Foo {}
  }
}
```

## Test Plan

Tests included.
