### PR TITLE
refactor(lint/noFallthroughSwitchClause): use CFG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 ### Formatter
 ### JavaScript APIs
 ### Linter
+#### Enhancements
+
+- [noFallthroughSwitchClause](https://biomejs.dev/linter/rules/no-fallthrough-switch-clause/) reports most of invalid codes.
+
+  The rule now relies on control flow analysis and thus reports more complex case fallthrough.
+
 ### Parser
 ### VSCode
 

--- a/crates/rome_control_flow/src/builder.rs
+++ b/crates/rome_control_flow/src/builder.rs
@@ -8,7 +8,7 @@ use crate::{
 /// Identifier for a block in a [ControlFlowGraph]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct BlockId {
-    index: u32,
+    pub(crate) index: u32,
 }
 
 impl BlockId {
@@ -17,6 +17,9 @@ impl BlockId {
         self.index
     }
 }
+
+/// Id of the first block of every Control Flow Graph
+pub const ROOT_BLOCK_ID: BlockId = BlockId { index: 0 };
 
 /// Helper struct for building an instance of [ControlFlowGraph], the builder
 /// keeps track of an "insertion cursor" within the graph where [Instruction]
@@ -96,10 +99,8 @@ impl<L: Language> FunctionBuilder<L> {
     /// with this builder will automatically declare an exception edge towards
     /// the topmost entry in this stack
     pub fn push_exception_target(&mut self, kind: ExceptionHandlerKind, target: BlockId) {
-        self.exception_target.push(ExceptionHandler {
-            kind,
-            target: target.index(),
-        });
+        self.exception_target
+            .push(ExceptionHandler { kind, target });
     }
 
     /// Remove the topmost entry from the exception stack

--- a/crates/rome_control_flow/src/lib.rs
+++ b/crates/rome_control_flow/src/lib.rs
@@ -29,6 +29,26 @@ impl<L: Language> ControlFlowGraph<L> {
             node,
         }
     }
+
+    /// Returns the block identified by `id`.
+    pub fn get(&self, id: BlockId) -> &BasicBlock<L> {
+        // SAFETY: safe conversion because a block id corresponds to its index in `self.blocks`.
+        let block_index = id.index() as usize;
+        &self.blocks[block_index]
+    }
+
+    /// Returns pairs that contain a block identifier and the associated block
+    pub fn block_id_iter(&self) -> impl Iterator<Item = (BlockId, &BasicBlock<L>)> {
+        // SAFETY: safe conversion because a block id corresponds to its index in `self.blocks`.
+        self.blocks.iter().enumerate().map(|(index, block)| {
+            (
+                BlockId {
+                    index: index as u32,
+                },
+                block,
+            )
+        })
+    }
 }
 
 /// A basic block represents an atomic unit of control flow, a flat list of
@@ -100,7 +120,7 @@ pub enum InstructionKind {
 #[derive(Debug, Clone, Copy)]
 pub struct ExceptionHandler {
     pub kind: ExceptionHandlerKind,
-    pub target: u32,
+    pub target: BlockId,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_unreachable.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_unreachable.rs
@@ -3,7 +3,8 @@ use std::{cmp::Ordering, collections::VecDeque, num::NonZeroU32, vec::IntoIter};
 use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use roaring::bitmap::RoaringBitmap;
 use rome_control_flow::{
-    builder::BlockId, ExceptionHandler, ExceptionHandlerKind, Instruction, InstructionKind,
+    builder::{BlockId, ROOT_BLOCK_ID},
+    ExceptionHandler, ExceptionHandlerKind, Instruction, InstructionKind,
 };
 use rome_js_syntax::{
     JsBlockStatement, JsCaseClause, JsDefaultClause, JsDoWhileStatement, JsForInStatement,
@@ -263,13 +264,12 @@ fn analyze_simple(cfg: &JsControlFlowGraph, signals: &mut UnreachableRanges) {
     let mut queue = VecDeque::new();
 
     if !cfg.blocks.is_empty() {
-        reachable_blocks.insert(0);
-        queue.push_back((0, None));
+        reachable_blocks.insert(ROOT_BLOCK_ID.index());
+        queue.push_back((ROOT_BLOCK_ID, None));
     }
 
-    while let Some((index, handlers)) = queue.pop_front() {
-        let index = index as usize;
-        let block = &cfg.blocks[index];
+    while let Some((block_id, handlers)) = queue.pop_front() {
+        let block = cfg.get(block_id);
 
         // Lookup the existence of an exception edge for this block but
         // defer its creation until an instruction that can throw is encountered
@@ -295,7 +295,7 @@ fn analyze_simple(cfg: &JsControlFlowGraph, signals: &mut UnreachableRanges) {
                 // additional path diverging towards the corresponding
                 // catch or finally block
                 if let Some((handler, handlers)) = exception_handlers.take() {
-                    if reachable_blocks.insert(handler.target) {
+                    if reachable_blocks.insert(handler.target.index()) {
                         queue.push_back((handler.target, find_catch_handlers(handlers)));
                     }
                 }
@@ -314,13 +314,13 @@ fn analyze_simple(cfg: &JsControlFlowGraph, signals: &mut UnreachableRanges) {
                         let handlers = handlers.and_then(<[_]>::split_first);
 
                         if let Some((handler, handlers)) = handlers {
-                            if reachable_blocks.insert(handler.target) {
+                            if reachable_blocks.insert(handler.target.index()) {
                                 queue.push_back((handler.target, Some(handlers)));
                             }
                         }
                     } else if reachable_blocks.insert(block.index()) {
                         // Insert an edge if this jump is reachable
-                        queue.push_back((block.index(), handlers));
+                        queue.push_back((block, handlers));
                     }
 
                     // Jump is a terminator instruction if it's unconditional
@@ -330,7 +330,7 @@ fn analyze_simple(cfg: &JsControlFlowGraph, signals: &mut UnreachableRanges) {
                 }
                 InstructionKind::Return => {
                     if let Some((handler, handlers)) = block.cleanup_handlers.split_first() {
-                        if reachable_blocks.insert(handler.target) {
+                        if reachable_blocks.insert(handler.target.index()) {
                             queue.push_back((handler.target, Some(handlers)));
                         }
                     }
@@ -366,9 +366,8 @@ fn analyze_fine(cfg: &JsControlFlowGraph, signals: &mut UnreachableRanges) {
     let block_paths = traverse_cfg(cfg, signals);
 
     // Detect unreachable blocks using the result of the above traversal
-    'blocks: for (index, block) in cfg.blocks.iter().enumerate() {
-        let index = index as u32;
-        match block_paths.get(&index) {
+    'blocks: for (block_id, block) in cfg.block_id_iter() {
+        match block_paths.get(&block_id) {
             // Block has incoming paths, but may be unreachable if they all
             // have a dominating terminator intruction
             Some(paths) => {
@@ -415,7 +414,7 @@ fn analyze_fine(cfg: &JsControlFlowGraph, signals: &mut UnreachableRanges) {
 /// created during the control flow traversal
 struct PathState<'cfg> {
     /// Index of the next block to visit
-    next_block: u32,
+    next_block: BlockId,
     /// Set of all blocks already visited on this path
     visited: RoaringBitmap,
     /// Current terminating instruction for the path, if one was
@@ -429,11 +428,11 @@ struct PathState<'cfg> {
 fn traverse_cfg(
     cfg: &JsControlFlowGraph,
     signals: &mut UnreachableRanges,
-) -> FxHashMap<u32, Vec<Option<Option<PathTerminator>>>> {
+) -> FxHashMap<BlockId, Vec<Option<Option<PathTerminator>>>> {
     let mut queue = VecDeque::new();
 
     queue.push_back(PathState {
-        next_block: 0,
+        next_block: ROOT_BLOCK_ID,
         visited: RoaringBitmap::new(),
         terminator: None,
         exception_handlers: None,
@@ -446,15 +445,14 @@ fn traverse_cfg(
     while let Some(mut path) = queue.pop_front() {
         // Add the block to the visited set for the path, and the current
         // state of the path to the global reachable blocks map
-        path.visited.insert(path.next_block);
+        path.visited.insert(path.next_block.index());
 
         block_paths
             .entry(path.next_block)
             .or_insert_with(Vec::new)
             .push(path.terminator);
 
-        let index = path.next_block as usize;
-        let block = &cfg.blocks[index];
+        let block = cfg.get(path.next_block);
 
         // Lookup the existence of an exception edge for this block but
         // defer its creation until an instruction that can throw is encountered
@@ -470,7 +468,7 @@ fn traverse_cfg(
                 // additional path diverging towards the corresponding
                 // catch or finally block
                 if let Some((handler, handlers)) = exception_handlers.take() {
-                    if !path.visited.contains(handler.target) {
+                    if !path.visited.contains(handler.target.index()) {
                         queue.push_back(PathState {
                             next_block: handler.target,
                             visited: path.visited.clone(),
@@ -575,7 +573,7 @@ fn handle_jump<'cfg>(
         let handlers = path.exception_handlers.and_then(<[_]>::split_first);
 
         if let Some((handler, handlers)) = handlers {
-            if !path.visited.contains(handler.target) {
+            if !path.visited.contains(handler.target.index()) {
                 queue.push_back(PathState {
                     next_block: handler.target,
                     visited: path.visited.clone(),
@@ -588,7 +586,7 @@ fn handle_jump<'cfg>(
         // Push the jump target block to the queue if it hasn't
         // been visited yet in this path
         queue.push_back(PathState {
-            next_block: block.index(),
+            next_block: block,
             visited: path.visited.clone(),
             terminator: path.terminator,
             exception_handlers: path.exception_handlers,
@@ -604,7 +602,7 @@ fn handle_return<'cfg>(
     cleanup_handlers: &'cfg [ExceptionHandler],
 ) {
     if let Some((handler, handlers)) = cleanup_handlers.split_first() {
-        if !path.visited.contains(handler.target) {
+        if !path.visited.contains(handler.target.index()) {
             queue.push_back(PathState {
                 next_block: handler.target,
                 visited: path.visited.clone(),

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_unreachable_super.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_unreachable_super.rs
@@ -1,6 +1,9 @@
 use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
-use rome_control_flow::{ExceptionHandlerKind, InstructionKind};
+use rome_control_flow::{
+    builder::{BlockId, ROOT_BLOCK_ID},
+    ExceptionHandlerKind, InstructionKind,
+};
 use rome_js_syntax::{
     AnyJsClass, AnyJsExpression, JsCallExpression, JsConstructorClassMember, JsSyntaxKind,
     JsThrowStatement, TextRange, WalkEvent,
@@ -82,7 +85,7 @@ pub(crate) enum RuleState {
 /// This allows traversing a control flow graph and retaining contextual information.
 #[derive(Debug, Copy, Clone)]
 struct BlockContext {
-    block_index: u32,
+    block_id: BlockId,
     super_call: Option<TextRange>,
 }
 
@@ -121,25 +124,19 @@ impl Rule for NoUnreachableSuper {
         // As soon as we detect the use of this without calling first `super`
 
         // stack of block contexts to process
-        let mut block_context_stack = Vec::new();
-        let mut visited_block_contexts = FxHashSet::default();
-        block_context_stack.push(BlockContext {
-            block_index: 0,
+        let mut block_context_stack = vec![BlockContext {
+            block_id: ROOT_BLOCK_ID,
             super_call: None,
-        });
-        // Set of couples (block_index, was_visited_with_super_call)
-        visited_block_contexts.insert((0u32, false));
+        }];
+        // Set of couples (block_id, was_visited_with_super_call)
+        let mut visited_block_contexts = FxHashSet::from_iter([(ROOT_BLOCK_ID, false)]);
         while let Some(BlockContext {
-            block_index,
+            block_id,
             super_call: mut super_,
         }) = block_context_stack.pop()
         {
             let had_super = super_.is_some();
-            // SAFETY: this is a safe conversion because it is already an index for `cfg.blocks`.
-            let block_index = block_index as usize;
-            let Some(block) = cfg.blocks.get(block_index) else {
-                continue;
-            };
+            let block = cfg.get(block_id);
             for instruction in block.instructions.iter() {
                 if let Some(NodeOrToken::Node(ref block_node)) = instruction.node {
                     let mut iter = block_node.preorder();
@@ -182,13 +179,14 @@ impl Rule for NoUnreachableSuper {
                 match instruction.kind {
                     InstructionKind::Statement => {}
                     InstructionKind::Jump {
-                        block, conditional, ..
+                        block: jump_block_id,
+                        conditional,
+                        ..
                     } => {
-                        let jump_block_index = block.index();
                         // Avoid cycles and redundant checks.
-                        if visited_block_contexts.insert((jump_block_index, super_.is_some())) {
+                        if visited_block_contexts.insert((jump_block_id, super_.is_some())) {
                             block_context_stack.push(BlockContext {
-                                block_index: jump_block_index,
+                                block_id: jump_block_id,
                                 super_call: super_,
                             });
                         }
@@ -222,7 +220,7 @@ impl Rule for NoUnreachableSuper {
                         // Avoid cycles and redundant checks.
                         if visited_block_contexts.insert((exception_handler.target, had_super)) {
                             block_context_stack.push(BlockContext {
-                                block_index: exception_handler.target,
+                                block_id: exception_handler.target,
                                 super_call: None,
                             });
                         }
@@ -231,7 +229,7 @@ impl Rule for NoUnreachableSuper {
                     // Avoid cycles and redundant checks.
                     if visited_block_contexts.insert((exception_handler.target, super_.is_some())) {
                         block_context_stack.push(BlockContext {
-                            block_index: exception_handler.target,
+                            block_id: exception_handler.target,
                             super_call: super_,
                         });
                     }

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_fallthrough_switch_clause.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_fallthrough_switch_clause.rs
@@ -1,10 +1,13 @@
-use rome_rowan::{AstNode, AstNodeList};
+use std::collections::VecDeque;
 
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
-use rome_js_syntax::{
-    AnyJsStatement, AnyJsSwitchClause, JsBlockStatement, JsStatementList, JsSwitchStatement,
-};
+use rome_control_flow::{ExceptionHandlerKind, InstructionKind};
+use rome_js_syntax::{JsDefaultClause, JsLanguage, JsSwitchStatement, JsSyntaxNode};
+use rome_rowan::{AstNode, AstNodeList, TextRange, WalkEvent};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{control_flow::AnyJsControlFlowRoot, ControlFlowGraph};
 
 declare_rule! {
     /// Disallow fallthrough of `switch` clauses.
@@ -19,22 +22,30 @@ declare_rule! {
     /// ### Invalid
     ///
     /// ```js,expect_diagnostic
-    /// switch(bar) {
+    /// switch (bar) {
     /// 	case 0:
     /// 		a();
     /// 	case 1:
-    /// 		b()
+    /// 		b();
     /// }
     /// ```
     ///
     /// ## Valid
     ///
     /// ```js
-    /// switch(foo) {
+    /// switch (foo) {
     /// 	case 1:
+    ///     case 2:
     /// 		doSomething();
     /// 		break;
-    /// 	case 2:
+    ///     case 3: {
+    ///         if (cond) {
+    ///             break;
+    ///         } else {
+    ///             break;
+    ///         }
+    ///     }
+    /// 	case 4:
     /// 		doSomething();
     /// }
     /// ```
@@ -47,36 +58,142 @@ declare_rule! {
 }
 
 impl Rule for NoFallthroughSwitchClause {
-    type Query = Ast<JsSwitchStatement>;
-    type State = AnyJsSwitchClause;
+    type Query = ControlFlowGraph;
+    type State = TextRange;
     type Signals = Vec<Self::State>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let query = ctx.query();
-        let mut signals: Self::Signals = Vec::new();
-        let mut cases = query.cases().into_iter().peekable();
-
-        while let Some(any_case) = cases.next() {
-            let is_last = cases.peek().is_none();
-
-            if is_last {
+        let cfg = ctx.query();
+        let mut fallthrough: Vec<TextRange> = vec![];
+        // Return early if the graph doesn't contain any switch statements.
+        // This avoids to allocate some memory.
+        if !has_switch_statement(&cfg.node) {
+            return fallthrough;
+        }
+        // block to process.
+        let mut block_stack = Vec::new();
+        let mut visited_blocks = FxHashSet::default();
+        block_stack.push(0u32);
+        visited_blocks.insert(0u32);
+        // Traverse the control flow graph and search for switch statements.
+        while let Some(block_index) = block_stack.pop() {
+            // SAFETY: this is a safe conversion because it is already an index for `cfg.blocks`.
+            let block_index = block_index as usize;
+            let Some(block) = cfg.blocks.get(block_index) else {
                 continue;
+            };
+            // Register exception handlers as blocks to process
+            // Ignore finally handler: they are already in the Control Flow Graph.
+            for exception_handler in block
+                .exception_handlers
+                .iter()
+                .filter(|x| matches!(x.kind, ExceptionHandlerKind::Catch))
+            {
+                // Avoid cycles and redundant checks.
+                if visited_blocks.insert(exception_handler.target) {
+                    block_stack.push(exception_handler.target);
+                }
             }
-
-            if case_fell(&any_case) {
-                signals.push(any_case);
+            // Traverse the instructions of the block searching for a switch statement.
+            // A switch statements is followed by conditional jumps (the cases),
+            // and a last unconditional jump (maybe the default clause)
+            let mut is_switch = false;
+            let mut switch_clauses = VecDeque::new();
+            let mut has_default_clause = false;
+            let mut switch_clause_blocks = FxHashSet::default();
+            let mut block_to_switch_clause_range = FxHashMap::default();
+            for instruction in block.instructions.iter() {
+                match instruction.kind {
+                    InstructionKind::Statement => {
+                        if let Some(node) = &instruction.node {
+                            if let Some(switch_stmt) =
+                                node.parent().and_then(JsSwitchStatement::cast)
+                            {
+                                if is_switch {
+                                    unreachable!("A block cannot contain two switch statements.")
+                                }
+                                is_switch = true;
+                                let switch_clause_nodes = switch_stmt.cases();
+                                let mut default_clause = None;
+                                switch_clauses = VecDeque::with_capacity(switch_clause_nodes.len());
+                                // Register in-order the switch cases, but the default clause which
+                                // is inserted at the end.
+                                // This mimics the order of the jumps in a blocks.
+                                // The default clause, if any is the last (unconditional) jump.
+                                for switch_clause in switch_clause_nodes {
+                                    if JsDefaultClause::can_cast(switch_clause.syntax().kind()) {
+                                        has_default_clause = true;
+                                        default_clause = Some(switch_clause);
+                                    } else {
+                                        switch_clauses.push_back(switch_clause);
+                                    }
+                                }
+                                if let Some(default_clause) = default_clause.take() {
+                                    switch_clauses.push_back(default_clause);
+                                }
+                            }
+                        }
+                    }
+                    InstructionKind::Jump {
+                        conditional, block, ..
+                    } => {
+                        let jump_block_index = block.index();
+                        // Avoid cycles and redundant checks.
+                        if visited_blocks.insert(jump_block_index) {
+                            block_stack.push(jump_block_index);
+                        }
+                        // If we are in a block of a switch statements,
+                        // then any conditional jump is a case and an unconditional jump
+                        // is a default clause if the switch has a default clause.
+                        if is_switch && (conditional || has_default_clause) {
+                            // Take the unconditional jump into account only if a default clause is present.
+                            switch_clause_blocks.insert(jump_block_index);
+                            let Some(switch_clause) = switch_clauses.pop_front() else {
+                                unreachable!("Missing switch clause.")
+                            };
+                            block_to_switch_clause_range.insert(
+                                jump_block_index,
+                                if switch_clause.consequent().is_empty() {
+                                    // Ignore empty switch clauses
+                                    None
+                                } else {
+                                    Some(switch_clause.range())
+                                },
+                            );
+                        }
+                        if !conditional {
+                            // The next instructions are unreachable.
+                            break;
+                        }
+                    }
+                    InstructionKind::Return => {
+                        // The next instructions are unreachable.
+                        break;
+                    }
+                }
+            }
+            if !switch_clause_blocks.is_empty() {
+                // Analyze the found switch clauses to detect any fallthrough.
+                register_fallthrough_switch_clauses(
+                    &block_to_switch_clause_range,
+                    &visited_blocks,
+                    cfg,
+                    &mut fallthrough,
+                );
             }
         }
-
-        signals
+        fallthrough
     }
 
-    fn diagnostic(_: &RuleContext<Self>, reference: &Self::State) -> Option<RuleDiagnostic> {
+    fn diagnostic(
+        _: &RuleContext<Self>,
+        switch_clause_range: &Self::State,
+    ) -> Option<RuleDiagnostic> {
         Some(
             RuleDiagnostic::new(
                 rule_category!(),
-                reference.syntax().text_trimmed_range(),
+                switch_clause_range,
                 markup! {
                     "This case is falling through to the next case."
                 },
@@ -88,31 +205,82 @@ impl Rule for NoFallthroughSwitchClause {
     }
 }
 
-fn case_fell(case: &AnyJsSwitchClause) -> bool {
-    let statements = case.consequent();
-    !has_fall_blocker_statement(&statements) && statements.iter().count() != 0
-}
-
-fn has_fall_blocker_statement(statements: &JsStatementList) -> bool {
-    for statement in statements.iter() {
-        if is_fall_blocker_statement(&statement) {
-            return true;
-        }
-        if let Some(block_statement) = JsBlockStatement::cast_ref(statement.syntax()) {
-            if has_fall_blocker_statement(&block_statement.statements()) {
+fn has_switch_statement(control_flow_root: &JsSyntaxNode) -> bool {
+    let mut iter = control_flow_root.preorder();
+    while let Some(node) = iter.next() {
+        if let WalkEvent::Enter(node) = node {
+            if JsSwitchStatement::can_cast(node.kind()) {
                 return true;
+            } else if AnyJsControlFlowRoot::can_cast(node.kind()) && control_flow_root != &node {
+                iter.skip_subtree()
             }
         }
     }
     false
 }
 
-fn is_fall_blocker_statement(statement: &AnyJsStatement) -> bool {
-    matches!(
-        statement,
-        AnyJsStatement::JsBreakStatement(_)
-            | AnyJsStatement::JsReturnStatement(_)
-            | AnyJsStatement::JsThrowStatement(_)
-            | AnyJsStatement::JsContinueStatement(_)
-    )
+fn register_fallthrough_switch_clauses(
+    block_to_switch_clause_range: &FxHashMap<u32, Option<TextRange>>,
+    visited_blocks: &FxHashSet<u32>,
+    cfg: &rome_control_flow::ControlFlowGraph<JsLanguage>,
+    fallthrough: &mut Vec<TextRange>,
+) {
+    let mut current_switch_clause = None;
+    // Register all switch clauses as block to process.
+    let mut block_stack: Vec<u32> = block_to_switch_clause_range.keys().copied().collect();
+    let mut visited_blocks = visited_blocks.clone();
+    // Traverse the control flow graph
+    while let Some(block_index) = block_stack.pop() {
+        current_switch_clause = block_to_switch_clause_range
+            .get(&block_index)
+            .or(current_switch_clause);
+        // SAFETY: this is a safe conversion because it is already an index for `cfg.blocks`.
+        let block_index = block_index as usize;
+        let Some(block) = cfg.blocks.get(block_index) else {
+            continue;
+        };
+        // Register exception handlers as blocks to process
+        // Ignore finally handler: they are already in the Control Flow Graph.
+        for exception_handler in block
+            .exception_handlers
+            .iter()
+            .filter(|x| matches!(x.kind, ExceptionHandlerKind::Catch))
+        {
+            // Avoid cycles and redundant checks.
+            if visited_blocks.insert(exception_handler.target) {
+                block_stack.push(exception_handler.target);
+            }
+        }
+        for instruction in block.instructions.iter() {
+            match instruction.kind {
+                InstructionKind::Statement => {}
+                InstructionKind::Jump {
+                    conditional, block, ..
+                } => {
+                    let jump_block_index = block.index();
+                    // Avoid cycles and redundant checks.
+                    if visited_blocks.insert(jump_block_index) {
+                        block_stack.push(jump_block_index);
+                    }
+                    if !conditional {
+                        if block_to_switch_clause_range.contains_key(&jump_block_index) {
+                            let Some(switch_clause_range) = current_switch_clause else {
+                                unreachable!("The current switch clause should be known.");
+                            };
+                            // Ignore empty switch clauses
+                            if let Some(switch_clause_range) = switch_clause_range {
+                                fallthrough.push(*switch_clause_range);
+                            }
+                        }
+                        // The next instructions are unreachable.
+                        break;
+                    }
+                }
+                InstructionKind::Return => {
+                    // The next instructions are unreachable.
+                    break;
+                }
+            }
+        }
+    }
 }

--- a/crates/rome_js_analyze/src/analyzers/nursery/use_getter_return.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/use_getter_return.rs
@@ -1,10 +1,10 @@
 use crate::ControlFlowGraph;
 use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use roaring::RoaringBitmap;
 use rome_console::markup;
-use rome_control_flow::{ExceptionHandlerKind, InstructionKind};
+use rome_control_flow::{builder::ROOT_BLOCK_ID, ExceptionHandlerKind, InstructionKind};
 use rome_js_syntax::{JsGetterClassMember, JsGetterObjectMember, JsReturnStatement};
 use rome_rowan::{AstNode, NodeOrToken, TextRange};
-use rustc_hash::FxHashSet;
 
 declare_rule! {
     /// Enforce `get` methods to always return a value.
@@ -81,21 +81,16 @@ impl Rule for UseGetterReturn {
             return invalid_returns;
         }
         // stack of blocks to process
-        let mut block_stack = Vec::new();
-        let mut visited_blocks = FxHashSet::default();
-        block_stack.push(0u32);
-        visited_blocks.insert(0u32);
-        while let Some(block_index) = block_stack.pop() {
-            // SAFETY: this is a safe conversion because it is already an index for `cfg.blocks`.
-            let block_index = block_index as usize;
-            let Some(block) = cfg.blocks.get(block_index) else {
-                continue;
-            };
+        let mut block_stack = vec![ROOT_BLOCK_ID];
+        let mut visited_blocks = RoaringBitmap::new();
+        visited_blocks.insert(ROOT_BLOCK_ID.index());
+        while let Some(block_id) = block_stack.pop() {
+            let block = cfg.get(block_id);
             for exception_handler in block.exception_handlers.iter() {
                 // Ignore finally handler: they are already in the Control Flow Graph.
                 if matches!(exception_handler.kind, ExceptionHandlerKind::Catch) {
                     // Avoid cycles and redundant checks.
-                    if visited_blocks.insert(exception_handler.target) {
+                    if visited_blocks.insert(exception_handler.target.index()) {
                         block_stack.push(exception_handler.target);
                     }
                 }
@@ -104,12 +99,13 @@ impl Rule for UseGetterReturn {
                 match instruction.kind {
                     InstructionKind::Statement => {}
                     InstructionKind::Jump {
-                        block, conditional, ..
+                        conditional,
+                        block: jump_block_id,
+                        ..
                     } => {
-                        let jump_block_index = block.index();
                         // Avoid cycles and redundant checks.
-                        if visited_blocks.insert(jump_block_index) {
-                            block_stack.push(jump_block_index);
+                        if visited_blocks.insert(jump_block_id.index()) {
+                            block_stack.push(jump_block_id);
                         }
                         if !conditional {
                             // The next instructions are unreachable.

--- a/crates/rome_js_analyze/tests/specs/nursery/noFallthroughSwitchClause/invalid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noFallthroughSwitchClause/invalid.js
@@ -1,3 +1,46 @@
 switch(bar) { case 0: a(); case 1: b() }
 
+switch(foo) { case 0: a(); default: b() }
+
 switch (bar) { case 0: a(); default: b(); case 1: c() }
+
+switch(foo) { case 0: if (a) { break; } default: b() }
+
+switch(foo) { case 0: try { throw 0; } catch (err) {} default: b() }
+
+switch(foo) { case 0: while (a) { break; } default: b() }
+
+switch(foo) { case 0: do { break; } while (a); default: b() }
+
+switch(foo) { case 0: {} default: b() }
+
+switch(foo) { case 0: a(); { /* falls through */ } default: b() }
+
+switch(foo) { case 0: { /* falls through */ } a(); default: b() }
+
+switch(foo) { case 0: if (a) { /* falls through */ } default: b() }
+
+switch(foo) { case 0: { { /* falls through */ } } default: b() }
+
+switch(foo) { case 0: { /* comment */ } default: b() }
+
+switch(foo) { case 0: a(); /* falling through */ default: b() }
+
+switch(foo) { case 0: a(); /* no break */ case 1: b(); }
+
+switch(foo) { case 0: a(); /* no break */ /* todo: fix readability */ default: b() }
+
+switch(foo) { case 0: { a(); /* no break */ /* todo: fix readability */ } default: b() }
+
+switch (a) { case 1: ; case 2: ; case 3: }
+
+function f () {
+    switch (a) {
+        case 0:
+            try { return foo(); } catch {} finally {}
+        case 1:
+            f();
+    }
+}
+
+switch (foo) { case 0: {} case 1: case 2: f(); }

--- a/crates/rome_js_analyze/tests/specs/nursery/noFallthroughSwitchClause/invalid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noFallthroughSwitchClause/invalid.js.snap
@@ -6,11 +6,73 @@ expression: invalid.js
 ```js
 switch(bar) { case 0: a(); case 1: b() }
 
+switch(foo) { case 0: a(); default: b() }
+
 switch (bar) { case 0: a(); default: b(); case 1: c() }
+
+switch(foo) { case 0: if (a) { break; } default: b() }
+
+switch(foo) { case 0: try { throw 0; } catch (err) {} default: b() }
+
+switch(foo) { case 0: while (a) { break; } default: b() }
+
+switch(foo) { case 0: do { break; } while (a); default: b() }
+
+switch(foo) { case 0: {} default: b() }
+
+switch(foo) { case 0: a(); { /* falls through */ } default: b() }
+
+switch(foo) { case 0: { /* falls through */ } a(); default: b() }
+
+switch(foo) { case 0: if (a) { /* falls through */ } default: b() }
+
+switch(foo) { case 0: { { /* falls through */ } } default: b() }
+
+switch(foo) { case 0: { /* comment */ } default: b() }
+
+switch(foo) { case 0: a(); /* falling through */ default: b() }
+
+switch(foo) { case 0: a(); /* no break */ case 1: b(); }
+
+switch(foo) { case 0: a(); /* no break */ /* todo: fix readability */ default: b() }
+
+switch(foo) { case 0: { a(); /* no break */ /* todo: fix readability */ } default: b() }
+
+switch (a) { case 1: ; case 2: ; case 3: }
+
+function f () {
+    switch (a) {
+        case 0:
+            try { return foo(); } catch {} finally {}
+        case 1:
+            f();
+    }
+}
+
+switch (foo) { case 0: {} case 1: case 2: f(); }
 
 ```
 
 # Diagnostics
+```
+invalid.js:39:9 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    37 │ function f () {
+    38 │     switch (a) {
+  > 39 │         case 0:
+       │         ^^^^^^^
+  > 40 │             try { return foo(); } catch {} finally {}
+       │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    41 │         case 1:
+    42 │             f();
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
 ```
 invalid.js:1:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -19,7 +81,7 @@ invalid.js:1:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━�
   > 1 │ switch(bar) { case 0: a(); case 1: b() }
       │               ^^^^^^^^^^^^
     2 │ 
-    3 │ switch (bar) { case 0: a(); default: b(); case 1: c() }
+    3 │ switch(foo) { case 0: a(); default: b() }
   
   i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
   
@@ -27,15 +89,33 @@ invalid.js:1:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━�
 ```
 
 ```
-invalid.js:3:16 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:3:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This case is falling through to the next case.
   
     1 │ switch(bar) { case 0: a(); case 1: b() }
     2 │ 
-  > 3 │ switch (bar) { case 0: a(); default: b(); case 1: c() }
+  > 3 │ switch(foo) { case 0: a(); default: b() }
+      │               ^^^^^^^^^^^^
+    4 │ 
+    5 │ switch (bar) { case 0: a(); default: b(); case 1: c() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:5:16 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    3 │ switch(foo) { case 0: a(); default: b() }
+    4 │ 
+  > 5 │ switch (bar) { case 0: a(); default: b(); case 1: c() }
       │                ^^^^^^^^^^^^
-    4 │ 
+    6 │ 
+    7 │ switch(foo) { case 0: if (a) { break; } default: b() }
   
   i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
   
@@ -43,15 +123,304 @@ invalid.js:3:16 lint/nursery/noFallthroughSwitchClause ━━━━━━━━�
 ```
 
 ```
-invalid.js:3:29 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:5:29 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This case is falling through to the next case.
   
-    1 │ switch(bar) { case 0: a(); case 1: b() }
-    2 │ 
-  > 3 │ switch (bar) { case 0: a(); default: b(); case 1: c() }
-      │                             ^^^^^^^^^^^^^
+    3 │ switch(foo) { case 0: a(); default: b() }
     4 │ 
+  > 5 │ switch (bar) { case 0: a(); default: b(); case 1: c() }
+      │                             ^^^^^^^^^^^^^
+    6 │ 
+    7 │ switch(foo) { case 0: if (a) { break; } default: b() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:7:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    5 │ switch (bar) { case 0: a(); default: b(); case 1: c() }
+    6 │ 
+  > 7 │ switch(foo) { case 0: if (a) { break; } default: b() }
+      │               ^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+    9 │ switch(foo) { case 0: try { throw 0; } catch (err) {} default: b() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:9:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+     7 │ switch(foo) { case 0: if (a) { break; } default: b() }
+     8 │ 
+   > 9 │ switch(foo) { case 0: try { throw 0; } catch (err) {} default: b() }
+       │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 
+    11 │ switch(foo) { case 0: while (a) { break; } default: b() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:11:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+     9 │ switch(foo) { case 0: try { throw 0; } catch (err) {} default: b() }
+    10 │ 
+  > 11 │ switch(foo) { case 0: while (a) { break; } default: b() }
+       │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ switch(foo) { case 0: do { break; } while (a); default: b() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:13:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    11 │ switch(foo) { case 0: while (a) { break; } default: b() }
+    12 │ 
+  > 13 │ switch(foo) { case 0: do { break; } while (a); default: b() }
+       │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ 
+    15 │ switch(foo) { case 0: {} default: b() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:15:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    13 │ switch(foo) { case 0: do { break; } while (a); default: b() }
+    14 │ 
+  > 15 │ switch(foo) { case 0: {} default: b() }
+       │               ^^^^^^^^^^
+    16 │ 
+    17 │ switch(foo) { case 0: a(); { /* falls through */ } default: b() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:17:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    15 │ switch(foo) { case 0: {} default: b() }
+    16 │ 
+  > 17 │ switch(foo) { case 0: a(); { /* falls through */ } default: b() }
+       │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    18 │ 
+    19 │ switch(foo) { case 0: { /* falls through */ } a(); default: b() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:19:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    17 │ switch(foo) { case 0: a(); { /* falls through */ } default: b() }
+    18 │ 
+  > 19 │ switch(foo) { case 0: { /* falls through */ } a(); default: b() }
+       │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    20 │ 
+    21 │ switch(foo) { case 0: if (a) { /* falls through */ } default: b() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:21:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    19 │ switch(foo) { case 0: { /* falls through */ } a(); default: b() }
+    20 │ 
+  > 21 │ switch(foo) { case 0: if (a) { /* falls through */ } default: b() }
+       │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    22 │ 
+    23 │ switch(foo) { case 0: { { /* falls through */ } } default: b() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:23:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    21 │ switch(foo) { case 0: if (a) { /* falls through */ } default: b() }
+    22 │ 
+  > 23 │ switch(foo) { case 0: { { /* falls through */ } } default: b() }
+       │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    24 │ 
+    25 │ switch(foo) { case 0: { /* comment */ } default: b() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:25:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    23 │ switch(foo) { case 0: { { /* falls through */ } } default: b() }
+    24 │ 
+  > 25 │ switch(foo) { case 0: { /* comment */ } default: b() }
+       │               ^^^^^^^^^^^^^^^^^^^^^^^^^
+    26 │ 
+    27 │ switch(foo) { case 0: a(); /* falling through */ default: b() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:27:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    25 │ switch(foo) { case 0: { /* comment */ } default: b() }
+    26 │ 
+  > 27 │ switch(foo) { case 0: a(); /* falling through */ default: b() }
+       │               ^^^^^^^^^^^^
+    28 │ 
+    29 │ switch(foo) { case 0: a(); /* no break */ case 1: b(); }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:29:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    27 │ switch(foo) { case 0: a(); /* falling through */ default: b() }
+    28 │ 
+  > 29 │ switch(foo) { case 0: a(); /* no break */ case 1: b(); }
+       │               ^^^^^^^^^^^^
+    30 │ 
+    31 │ switch(foo) { case 0: a(); /* no break */ /* todo: fix readability */ default: b() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:31:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    29 │ switch(foo) { case 0: a(); /* no break */ case 1: b(); }
+    30 │ 
+  > 31 │ switch(foo) { case 0: a(); /* no break */ /* todo: fix readability */ default: b() }
+       │               ^^^^^^^^^^^^
+    32 │ 
+    33 │ switch(foo) { case 0: { a(); /* no break */ /* todo: fix readability */ } default: b() }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:33:15 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    31 │ switch(foo) { case 0: a(); /* no break */ /* todo: fix readability */ default: b() }
+    32 │ 
+  > 33 │ switch(foo) { case 0: { a(); /* no break */ /* todo: fix readability */ } default: b() }
+       │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    34 │ 
+    35 │ switch (a) { case 1: ; case 2: ; case 3: }
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:35:14 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    33 │ switch(foo) { case 0: { a(); /* no break */ /* todo: fix readability */ } default: b() }
+    34 │ 
+  > 35 │ switch (a) { case 1: ; case 2: ; case 3: }
+       │              ^^^^^^^^^
+    36 │ 
+    37 │ function f () {
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:35:24 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    33 │ switch(foo) { case 0: { a(); /* no break */ /* todo: fix readability */ } default: b() }
+    34 │ 
+  > 35 │ switch (a) { case 1: ; case 2: ; case 3: }
+       │                        ^^^^^^^^^
+    36 │ 
+    37 │ function f () {
+  
+  i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
+  
+
+```
+
+```
+invalid.js:46:16 lint/nursery/noFallthroughSwitchClause ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This case is falling through to the next case.
+  
+    44 │ }
+    45 │ 
+  > 46 │ switch (foo) { case 0: {} case 1: case 2: f(); }
+       │                ^^^^^^^^^^
+    47 │ 
   
   i Add a `break` or `return` statement to the end of this case to prevent fallthrough.
   

--- a/crates/rome_js_analyze/tests/specs/nursery/noFallthroughSwitchClause/valid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noFallthroughSwitchClause/valid.js
@@ -1,3 +1,4 @@
+
 switch(foo) { case 1: doSomething(); break; case 2: doSomething(); }
 
 function bar(foo) { switch(foo) { case 1: doSomething(); return; case 2: doSomething(); } }
@@ -6,4 +7,89 @@ switch(foo) { case 1: doSomething(); throw new Error("Boo!"); case 2: doSomethin
 
 switch(foo) { case 1: case 2: doSomething(); }
 
+switch(foo) { case 0:   /* with comments */   case 1: b(); }
+
 switch(foo) { case 1: { doSomething(); break; } case 2: doSomething(); }
+
+function f(input) {
+    const a = input * 2;
+    switch(a) {
+        case 0: {
+            if (foo) {
+                return 0;
+            } else {
+                return 1;
+            }
+        }
+        case 2: {
+            while(a > 0) {
+                a--;
+                if (a === DEFAULT) {
+                    break;
+                }
+            }
+            if (a < 0) {
+                return a;
+            } else {
+                return 0;
+            }
+        }
+        default:
+            f();
+    }
+}
+
+function f() {
+	switch (a) {
+		case 0:
+			switch (b) {
+				case 0:
+					return 0;
+				default:
+					return 1;
+			}
+		case 2:
+		// do nothing
+	}
+}
+
+function f() {
+	switch (a) {
+		case 0:
+			try {
+				return foo();
+			} catch {
+				return 0;
+			} finally {
+			}
+		case 1:
+		// do nothing
+	}
+}
+
+function f() {
+	switch (a) {
+		case 0:
+			try {
+				foo();
+			} catch {
+			} finally {
+				return 0;
+			}
+		case 1:
+		// do nothing
+	}
+}
+
+function f() {
+	switch (a) {
+		case 0:
+			try {
+				foo();
+			} finally {
+				return 0;
+			}
+		case 1:
+		// do nothing
+	}
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noFallthroughSwitchClause/valid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noFallthroughSwitchClause/valid.js.snap
@@ -4,6 +4,7 @@ expression: valid.js
 ---
 # Input
 ```js
+
 switch(foo) { case 1: doSomething(); break; case 2: doSomething(); }
 
 function bar(foo) { switch(foo) { case 1: doSomething(); return; case 2: doSomething(); } }
@@ -12,7 +13,92 @@ switch(foo) { case 1: doSomething(); throw new Error("Boo!"); case 2: doSomethin
 
 switch(foo) { case 1: case 2: doSomething(); }
 
+switch(foo) { case 0:   /* with comments */   case 1: b(); }
+
 switch(foo) { case 1: { doSomething(); break; } case 2: doSomething(); }
+
+function f(input) {
+    const a = input * 2;
+    switch(a) {
+        case 0: {
+            if (foo) {
+                return 0;
+            } else {
+                return 1;
+            }
+        }
+        case 2: {
+            while(a > 0) {
+                a--;
+                if (a === DEFAULT) {
+                    break;
+                }
+            }
+            if (a < 0) {
+                return a;
+            } else {
+                return 0;
+            }
+        }
+        default:
+            f();
+    }
+}
+
+function f() {
+	switch (a) {
+		case 0:
+			switch (b) {
+				case 0:
+					return 0;
+				default:
+					return 1;
+			}
+		case 2:
+		// do nothing
+	}
+}
+
+function f() {
+	switch (a) {
+		case 0:
+			try {
+				return foo();
+			} catch {
+				return 0;
+			} finally {
+			}
+		case 1:
+		// do nothing
+	}
+}
+
+function f() {
+	switch (a) {
+		case 0:
+			try {
+				foo();
+			} catch {
+			} finally {
+				return 0;
+			}
+		case 1:
+		// do nothing
+	}
+}
+
+function f() {
+	switch (a) {
+		case 0:
+			try {
+				foo();
+			} finally {
+				return 0;
+			}
+		case 1:
+		// do nothing
+	}
+}
 
 ```
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -23,6 +23,12 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 ### Formatter
 ### JavaScript APIs
 ### Linter
+#### Enhancements
+
+- [noFallthroughSwitchClause](https://biomejs.dev/linter/rules/no-fallthrough-switch-clause/) reports most of invalid codes.
+
+  The rule now relies on control flow analysis and thus reports more complex case fallthrough.
+
 ### Parser
 ### VSCode
 

--- a/website/src/content/docs/linter/rules/no-fallthrough-switch-clause.md
+++ b/website/src/content/docs/linter/rules/no-fallthrough-switch-clause.md
@@ -15,11 +15,11 @@ Source: https://eslint.org/docs/latest/rules/no-fallthrough
 ### Invalid
 
 ```jsx
-switch(bar) {
+switch (bar) {
 	case 0:
 		a();
 	case 1:
-		b()
+		b();
 }
 ```
 
@@ -27,13 +27,13 @@ switch(bar) {
 
 <strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">This case is falling through to the next case.</span>
   
-    <strong>1 │ </strong>switch(bar) {
+    <strong>1 │ </strong>switch (bar) {
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>	case 0:
    <strong>   │ </strong>	<strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>		a();
    <strong>   │ </strong>		<strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>4 │ </strong>	case 1:
-    <strong>5 │ </strong>		b()
+    <strong>5 │ </strong>		b();
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Add a `break` or `return` statement to the end of this case to prevent fallthrough.</span>
   
@@ -42,11 +42,19 @@ switch(bar) {
 ## Valid
 
 ```jsx
-switch(foo) {
+switch (foo) {
 	case 1:
+    case 2:
 		doSomething();
 		break;
-	case 2:
+    case 3: {
+        if (cond) {
+            break;
+        } else {
+            break;
+        }
+    }
+	case 4:
 		doSomething();
 }
 ```


### PR DESCRIPTION
## Summary

This PR improves `noFallthroughSwitchClause` using the control flow graph query.

## Test Plan

Many new tests.