### PR TITLE
fix(lsp): don't apply unsafe quick fixes on-save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,8 @@ New entries must be placed in a section entitled `Unreleased`.
 
 - The Biome LSP can now show diagnostics belonging to JSON lint rules.
 
+- The Biome LSP no longer applies unsafe quickfixes on-save when `editor.codeActionsOnSave.quifix.biome` is enabled.
+
 - Fix [#4564](https://github.com/rome/tools/issues/4564); files too large don't emit errors.
 
 - The Biome LSP sends client messages when files are ignored or too big.

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -364,7 +364,7 @@ pub struct FormatOnTypeParams {
 pub enum FixFileMode {
     /// Applies [safe](rome_diagnostics::Applicability::Always) fixes
     SafeFixes,
-    /// Applies [safe](rome_diagnostics::Applicability::Always) and suggested [safe](rome_diagnostics::Applicability::MaybeIncorrect)
+    /// Applies [safe](rome_diagnostics::Applicability::Always) and [unsafe](rome_diagnostics::Applicability::MaybeIncorrect) fixes
     SafeAndUnsafeFixes,
 }
 

--- a/website/src/pages/internals/changelog.mdx
+++ b/website/src/pages/internals/changelog.mdx
@@ -173,6 +173,8 @@ New entries must be placed in a section entitled `Unreleased`.
 
 - The Biome LSP can now show diagnostics belonging to JSON lint rules.
 
+- The Biome LSP no longer applies unsafe quickfixes on-save when `editor.codeActionsOnSave.quifix.biome` is enabled.
+
 - Fix [#4564](https://github.com/rome/tools/issues/4564); files too large don't emit errors.
 
 - The Biome LSP sends client messages when files are ignored or too big.


### PR DESCRIPTION
## Summary

This PR avoids applying unsafe fixes when quickfixes are triggered on-save.
Unsafe quickfixes are still available in the IDE via direct invocation. 

## Test Plan

Manually tested.
