### PR TITLE
fix(lint/noUselessConstructor): ignore constructor with default param…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,6 +498,8 @@ The following rules are now recommended:
 
   The rule no longer reports false positive diagnostics when accessing properties directly from a hook and calling a hook inside function arguments.
 
+- Fix [noUselessConstructor](https://biomejs.dev/lint/rules/noUselessConstructor/) which erroneously reported constructors with default parameters [rome#4781](https://github.com/rome/tools/issues/4781)
+
 - Fix [noUselessFragments](https://biomejs.dev/lint/rules/nouselessfragments/)'s panics when running `biome check --apply-unsafe` ([#4637](https://github.com/rome/tools/issues/4639))
 
   This rule's code action emits an invalid AST, so I fixed using JsxString instead of JsStringLiteral

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ rome_text_size              = { version = "0.0.1", path = "./crates/rome_text_si
 tests_macros                = { path = "./crates/tests_macros" }
 
 # Crates needed in the workspace
+atty              = "0.2.14"
 bitflags          = "2.3.1"
 bpaf              = { version = "0.9.3", features = ["derive"] }
 countme           = "3.0.1"
@@ -83,7 +84,6 @@ serde             = { version = "1.0.163", features = ["derive"], default-featur
 serde_json        = "1.0.96"
 smallvec          = { version = "1.10.0", features = ["union", "const_new"] }
 tracing           = { version = "0.1.37", default-features = false, features = ["std"] }
-atty = "0.2.14"
 # pinning to version 1.18 to avoid multiple versions of windows-sys as dependency
 tokio = { version = "~1.18.5" }
 

--- a/crates/rome_console/Cargo.toml
+++ b/crates/rome_console/Cargo.toml
@@ -10,7 +10,7 @@ version              = "0.0.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atty           = {  workspace = true }
+atty           = { workspace = true }
 rome_markup    = { workspace = true }
 rome_text_size = { workspace = true }
 schemars       = { workspace = true, optional = true }

--- a/crates/rome_js_analyze/src/analyzers/complexity/no_useless_constructor.rs
+++ b/crates/rome_js_analyze/src/analyzers/complexity/no_useless_constructor.rs
@@ -90,14 +90,20 @@ impl Rule for NoUselessConstructor {
         if is_not_public {
             return None;
         }
-        let has_parameter_property = constructor
+        let has_param_property_or_default_param = constructor
             .parameters()
             .ok()?
             .parameters()
             .iter()
             .filter_map(|x| x.ok())
-            .any(|x| TsPropertyParameter::can_cast(x.syntax().kind()));
-        if has_parameter_property {
+            .any(|x| {
+                TsPropertyParameter::can_cast(x.syntax().kind())
+                    || x.as_any_js_formal_parameter()
+                        .and_then(|x| x.as_js_formal_parameter())
+                        .and_then(|x| x.initializer())
+                        .is_some()
+            });
+        if has_param_property_or_default_param {
             return None;
         }
         let has_parent_class = constructor

--- a/crates/rome_js_analyze/tests/specs/complexity/noUselessConstructor/valid.jsonc
+++ b/crates/rome_js_analyze/tests/specs/complexity/noUselessConstructor/valid.jsonc
@@ -1,5 +1,6 @@
 [
     "class A { }",
+    "class A { constructor(a, b = 0){ } }",
     "class A { constructor(){ doSomething(); } }",
     "class A extends B { constructor(){} }",
     "class A extends B { constructor(){ super('foo'); } }",

--- a/crates/rome_js_analyze/tests/specs/complexity/noUselessConstructor/valid.jsonc.snap
+++ b/crates/rome_js_analyze/tests/specs/complexity/noUselessConstructor/valid.jsonc.snap
@@ -1,11 +1,15 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
-assertion_line: 96
 expression: valid.jsonc
 ---
 # Input
 ```js
 class A { }
+```
+
+# Input
+```js
+class A { constructor(a, b = 0){ } }
 ```
 
 # Input

--- a/website/src/pages/internals/changelog.mdx
+++ b/website/src/pages/internals/changelog.mdx
@@ -504,6 +504,8 @@ The following rules are now recommended:
 
   The rule no longer reports false positive diagnostics when accessing properties directly from a hook and calling a hook inside function arguments.
 
+- Fix [noUselessConstructor](https://biomejs.dev/lint/rules/noUselessConstructor/) which erroneously reported constructors with default parameters [rome#4781](https://github.com/rome/tools/issues/4781)
+
 - Fix [noUselessFragments](https://biomejs.dev/lint/rules/nouselessfragments/)'s panics when running `biome check --apply-unsafe` ([#4637](https://github.com/rome/tools/issues/4639))
 
   This rule's code action emits an invalid AST, so I fixed using JsxString instead of JsStringLiteral


### PR DESCRIPTION
## Summary

Fix [rome#4781](https://github.com/rome/tools/issues/4781)

## Test Plan

New test included
