### PR TITLE
ci(labeler): add A-Changelog label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -56,6 +56,9 @@ A-Website:
 A-LSP:
   - crates/rome_lsp/**
 
+A-Changelog:
+  - CHANGELOG.md
+
 L-Javascript:
   - crates/rome_js_*/**
 


### PR DESCRIPTION
## Summary

Add automatic labeling with label `A-Changelog` when the changelog is edited.
This allows quickly identifying PRs without changelog entry. 

## Test Plan

CI
