### PR TITLE
fix(vscode): enable and recognise JSONC files

### DIFF
--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -94,10 +94,10 @@ impl Language {
 
     /// Returns the language corresponding to this language ID
     ///
-    /// See the [microsoft spec] <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem>
+    /// See the [microsoft spec]
     /// for a list of language identifiers
     ///
-    /// [microsoft spec]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
+    /// [microsoft spec]: https://code.visualstudio.com/docs/languages/identifiers
     pub fn from_language_id(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "javascript" => Language::JavaScript,

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
 	"publisher": "biomejs",
 	"displayName": "Biome",
 	"description": "Biome LSP VS Code Extension",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"icon": "icon.png",
 	"activationEvents": [
 		"onLanguage:javascript",
@@ -11,6 +11,7 @@
 		"onLanguage:typescript",
 		"onLanguage:typescriptreact",
 		"onLanguage:json",
+		"onLanguage:jsonc",
 		"onCommand:biome.syntaxTree"
 	],
 	"main": "./out/main.js",

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -64,6 +64,7 @@ export async function activate(context: ExtensionContext) {
 		{ language: "javascriptreact", scheme: "file" },
 		{ language: "typescriptreact", scheme: "file" },
 		{ language: "json", scheme: "file" },
+		{ language: "jsonc", scheme: "file" },
 	];
 
 	const clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes the VSCode extension. It enables and recognises the extension for `jsonc` files.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I tested manually by creating a JSON file

<img width="514" alt="Screenshot 2023-08-29 at 17 43 42" src="https://github.com/biomejs/biome/assets/602478/8da13b41-971f-492a-b7c9-e93fab5903a9">


<!-- What demonstrates that your implementation is correct? -->
