### PR TITLE
fix(website): avatar overlapping with header nav

### DIFF
--- a/website/src/styles/_blog.scss
+++ b/website/src/styles/_blog.scss
@@ -91,11 +91,11 @@
 		}
 
 		&:first-child {
-			z-index: 2;
+			z-index: 1;
 		}
 
 		&:last-child {
-			z-index: 1;
+			z-index: 0;
 		}
 	}
 


### PR DESCRIPTION
Hello everyone,
Congrats on the fork and thank you for the library in the first place.

## Summary
While surfing the blog posts I've come around this visual bug:
<img width="1260" alt="Screenshot 2023-08-29 at 22 46 59" src="https://github.com/biomejs/biome/assets/101177974/c25509c1-70a6-4d70-93e9-8e2365dafc8f">
So I fixed it very quickly by changing avatars' z-indexes.
I think I could achieve the same result by bumping up header's z-index as well (or uniquely that), let me know if you'd prefer this way and I'll gladly change it.

Thank you!

