### PR TITLE
ci: extract changelog for GitHub release notes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -108,8 +108,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
+
       - name: Install toolchain
         uses: moonrepo/setup-rust@v0
       - name: Build main binary

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -83,8 +83,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -141,8 +139,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
 
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -210,6 +206,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Extract changelog
+        run: |
+          bash scripts/print-changelog.sh ${{ needs.build.outputs.version }} >| ${{ github.workspace }}/RELEASE_NOTES
       - name: Create GitHub release and tag
         uses: softprops/action-gh-release@v1
         env:
@@ -219,6 +218,7 @@ jobs:
           tag_name: cli/v${{ needs.build.outputs.version }}
           draft: false
           prerelease: ${{ needs.build.outputs.prerelease == 'true' }}
+          body_path: ${{ github.workspace }}/RELEASE_NOTES
           files: |
             biome-*
           fail_on_unmatched_files: true

--- a/.github/workflows/release_js_api.yml
+++ b/.github/workflows/release_js_api.yml
@@ -59,8 +59,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -154,6 +152,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Extract changelog
+        run: |
+          bash scripts/print-changelog.sh ${{ needs.build.outputs.version }} >| ${{ github.workspace }}/RELEASE_NOTES
       - name: Create GitHub release and tag
         uses: softprops/action-gh-release@v1
         env:
@@ -163,4 +164,5 @@ jobs:
           tag_name: js-api/v${{ needs.build.outputs.version }}
           draft: false
           prerelease: ${{ needs.build.outputs.prerelease == 'true' }}
+          body_path: ${{ github.workspace }}/RELEASE_NOTES
           generate_release_notes: true

--- a/.github/workflows/release_lsp.yml
+++ b/.github/workflows/release_lsp.yml
@@ -106,8 +106,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
 
       - name: Install toolchain
         uses: moonrepo/setup-rust@v0
@@ -228,6 +226,9 @@ jobs:
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
 
+      - name: Extract changelog
+        run: |
+          bash scripts/print-changelog.sh ${{ needs.build.outputs.version }} >| ${{ github.workspace }}/RELEASE_NOTES
       - name: Create GitHub release and tag
         uses: softprops/action-gh-release@v1
         env:
@@ -237,6 +238,7 @@ jobs:
           tag_name: lsp/v${{ needs.build.outputs.version }}
           draft: false
           prerelease: ${{ needs.build.outputs.prerelease == 'true' }}
+          body_path: ${{ github.workspace }}/RELEASE_NOTES
           files: |
             biome_lsp-*.vsix
           fail_on_unmatched_files: true

--- a/.github/workflows/website_deploy_preview.yml
+++ b/.github/workflows/website_deploy_preview.yml
@@ -11,9 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: Website deployment
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v3
+
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/website_deploy_prod.yml
+++ b/.github/workflows/website_deploy_prod.yml
@@ -11,9 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: Website deployment
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v3
+
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:

--- a/scripts/print-changelog.sh
+++ b/scripts/print-changelog.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -eu
+
+# Print a changelog section (default: `Unreleased`).
+
+VERSION="Unreleased"
+
+if test -n "${1:-}" && grep -Eq "^## $1($| )" CHANGELOG.md; then
+    # The specified version has a dedicated section in the changelog
+    VERSION="$1"
+fi
+
+# print Changelog of $VERSION
+awk -v version="$VERSION" '/^## / { if (p) { exit }; if ($2 == version) { p=1; next} } p' CHANGELOG.md


### PR DESCRIPTION
## Summary

This PR updates the release workflows.
GitHub Release notes are now generated from the changelog.
The script extract the first subsection that starts with a digit, e.g. `## 1.1.0`. This allows to skip `## Unreleased`. 

The changelog should be updated before every release.

I also removed useless `fetch-depth` parameter that is [set to `1` by default](https://github.com/actions/checkout).

## Test Plan

Next release.