### PR TITLE
fix(lint/noUndeclaredVariables): recognize `Uppercase`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   + `${a + b}px`
    ```
 
+- Fix [#106](https://github.com/biomejs/biome/issues/106)
+
+  [noUndeclaredVariables](https://biomejs.dev/lint/rules/noUndeclaredVariables/) now correctly recognizes some TypeScript types such as `Uppercase`.
+
 ### Parser
 ### VSCode
 

--- a/crates/rome_js_analyze/src/globals/browser.rs
+++ b/crates/rome_js_analyze/src/globals/browser.rs
@@ -1,3 +1,4 @@
+/// Sorted array of browser builtin
 pub const BROWSER: [&str; 706] = [
     "AbortController",
     "AbortSignal",
@@ -876,3 +877,10 @@ pub const WORKER: [&str; 71] = [
     "setInterval",
     "setTimeout",
 ];
+
+#[test]
+fn test_order() {
+    for items in BROWSER.windows(2) {
+        assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
+    }
+}

--- a/crates/rome_js_analyze/src/globals/node.rs
+++ b/crates/rome_js_analyze/src/globals/node.rs
@@ -1,3 +1,4 @@
+/// Sorted array of Node builtin
 pub const BUILTIN: [&str; 29] = [
     "AbortController",
     "AbortSignal",
@@ -67,4 +68,15 @@ pub const NODE: [&str; 34] = [
     "structuredClone",
 ];
 
+/// Sorted array of CommonJs builtin
 pub const COMMON_JS: [&str; 4] = ["exports", "global", "module", "require"];
+
+#[test]
+fn test_order() {
+    for items in BUILTIN.windows(2) {
+        assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
+    }
+    for items in COMMON_JS.windows(2) {
+        assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
+    }
+}

--- a/crates/rome_js_analyze/src/globals/runtime.rs
+++ b/crates/rome_js_analyze/src/globals/runtime.rs
@@ -1,3 +1,4 @@
+/// Sorted array of builtin
 pub const BUILTIN: [&str; 66] = [
     "AggregateError",
     "Array",
@@ -364,3 +365,10 @@ pub const ES_2021: [&str; 66] = [
     "unescape",
     "valueOf",
 ];
+
+#[test]
+fn test_order() {
+    for items in BUILTIN.windows(2) {
+        assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
+    }
+}

--- a/crates/rome_js_analyze/src/globals/typescript.rs
+++ b/crates/rome_js_analyze/src/globals/typescript.rs
@@ -1,3 +1,4 @@
+/// Sorted array of TypeScript builtin
 pub const TYPESCRIPT_BUILTIN: [&str; 140] = [
     "AggregateErrorConstructor",
     "ArrayBufferConstructor",
@@ -125,18 +126,25 @@ pub const TYPESCRIPT_BUILTIN: [&str; 140] = [
     "Thenable",
     "ThisParameterType",
     "ThisType",
-    "TypedPropertyDescriptor",
     "TypeErrorConstructor",
+    "TypedPropertyDescriptor",
+    "URIErrorConstructor",
     "Uint16ArrayConstructor",
     "Uint32ArrayConstructor",
     "Uint8ArrayConstructor",
     "Uint8ClampedArrayConstructor",
     "Uncapitalize",
     "Uppercase",
-    "URIErrorConstructor",
     "WeakKey",
     "WeakKeyTypes",
     "WeakMapConstructor",
     "WeakRefConstructor",
     "WeakSetConstructor",
 ];
+
+#[test]
+fn test_order() {
+    for items in TYPESCRIPT_BUILTIN.windows(2) {
+        assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
+    }
+}

--- a/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validTsGlobals.ts
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validTsGlobals.ts
@@ -1,1 +1,2 @@
 type B<T> = PromiseLike<T>;
+type U<T extends string> = Uppercase<T>;

--- a/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validTsGlobals.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validTsGlobals.ts.snap
@@ -5,6 +5,7 @@ expression: validTsGlobals.ts
 # Input
 ```js
 type B<T> = PromiseLike<T>;
+type U<T extends string> = Uppercase<T>;
 
 ```
 

--- a/website/src/pages/internals/changelog.mdx
+++ b/website/src/pages/internals/changelog.mdx
@@ -52,7 +52,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   Some frameworks, such as Material UI, rely on the case-sensitivity of JSX properties.
   For example, [TextField has two properties with the same name, but distinct cases](https://mui.com/material-ui/api/text-field/#TextField-prop-inputProps):
 
-  ```html
+  ```jsx
   <TextField inputLabelProps="" InputLabelProps=""></TextField>
   ```
 
@@ -73,6 +73,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   - a + b + "px"
   + `${a + b}px`
    ```
+
+- Fix [#106](https://github.com/biomejs/biome/issues/106)
+
+  [noUndeclaredVariables](https://biomejs.dev/lint/rules/noUndeclaredVariables/) now correctly recognizes some TypeScript types such as `Uppercase`.
 
 ### Parser
 ### VSCode


### PR DESCRIPTION
## Summary

Fix #106.
The list of TypeScript globals was sorted in a natural order instead of a byte order.

## Test Plan

To avoid this issue I added a test that asserts the order of the list.