### PR TITLE
docs: fix 'performance reason' typo everywhere left

### DIFF
--- a/website/src/pages/configuration.mdx
+++ b/website/src/pages/configuration.mdx
@@ -146,7 +146,7 @@ The files defined in this array:
 ### `files.maxSize`
 
 The maximum allowed size for source code files in bytes. Files above
-this limit will be ignored for performance reason.
+this limit will be ignored for performance reasons.
 
 > Default: 1024*1024 (1MB)
 

--- a/website/src/pages/linter/index.mdx
+++ b/website/src/pages/linter/index.mdx
@@ -42,7 +42,7 @@ Available options:
                         configuration, it will attempt to use the current working directory. If no
                         current working directory can't be found, Biome won't use the VCS integration.
         --files-max-size <NUMBER>  The maximum allowed size for source code files in bytes. Files
-                        above this limit will be ignored for performance reason. Defaults to 1 MiB
+                        above this limit will be ignored for performance reasons. Defaults to 1 MiB
         --indent-style <tab|space>  The indent style.
         --indent-size <NUMBER>  The size of the indentation, 2 by default
         --line-width <NUMBER>  What's the max width of a line. Defaults to 80.


### PR DESCRIPTION
## Summary

Copy of https://github.com/rome/tools/pull/4782 for Biome. Looks like @ematipico fixed most of the cases in that original PR already, but I found a few stragglers.
