### PR TITLE
docs(website): fix broken links on getting-started

### DIFF
--- a/website/src/content/docs/guides/getting-started.mdx
+++ b/website/src/content/docs/guides/getting-started.mdx
@@ -16,7 +16,7 @@ import CodeBlockHeader from "@src/components/CodeBlockHeader.astro";
 
 ## Installation
 
-The fastest way to download Biome is to use `npm` or your preferred package manager. The CLI is also available as a [standalone executable](/standalone-executable) if you want to use Biome without installing Node.js.
+The fastest way to download Biome is to use `npm` or your preferred package manager. The CLI is also available as a [standalone executable](/guides/manual-installation) if you want to use Biome without installing Node.js.
 
 To install Biome, run the following commands in a directory containing a `package.json` file.
 
@@ -64,7 +64,7 @@ After running the `init` command, you'll now have a new `biome.json` file in you
 }
 ```
 
-The `linter.enabled: true` enables the linter and `rules.recommended: true` enables the [recommended rules](/lint/rules/).
+The `linter.enabled: true` enables the linter and `rules.recommended: true` enables the [recommended rules](/linter/rules/).
 
 Formatting is enabled because the configuration doesn't explicitly [disable](/configuration/#formatterenabled) formatting with `formatter.enabled: false`.
 
@@ -118,6 +118,6 @@ Success! You're now ready to use Biome. 🥳
 
 * Learn more about how to use and configure the [formatter](/formatter)
 * Learn more about how to use and configure the [linter](/linter)
-* Get familiar with the [CLI options](/cli)
-* Get familiar with the [configuration options](/configuration)
+* Get familiar with the [CLI options](/reference/cli)
+* Get familiar with the [configuration options](/reference/configuration)
 * Join our [community on Discord](https://discord.gg/BypW39g6Yc)


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR updates/fixes the broken links on the Getting Started page.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

* Change working directory to `/website` & run the local dev server:  `pnpm start`
* Navigate to Getting Started screen: `localhost:3000:/getting-started`
* Click previously broken links & ensure they are working:
  - under **Installation** section -> *standalone executable*
  - under **Configuration** section -> *recommended rules*
  - under **Next Steps** section -> *CLI Options* and *configuration options*



<!-- What demonstrates that your implementation is correct? -->
