### PR TITLE
refactor(analyzer): avoid cloning and redundant checks

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/complexity/no_useless_constructor.rs
+++ b/crates/rome_js_analyze/src/analyzers/complexity/no_useless_constructor.rs
@@ -182,12 +182,12 @@ fn is_delegating_initialization(
     super_call: &JsCallExpression,
 ) -> bool {
     let result = || {
-        let parameters = constructor.parameters().ok()?.parameters().iter();
-        let arguments = super_call.arguments().ok()?.args().iter();
-        if parameters.clone().count() != arguments.clone().count() {
+        let parameters = constructor.parameters().ok()?.parameters();
+        let arguments = super_call.arguments().ok()?.args();
+        if parameters.len() != arguments.len() {
             return None;
         }
-        let zipped = parameters.zip(arguments);
+        let zipped = parameters.iter().zip(arguments.iter());
         for (param, arg) in zipped {
             let param = param.ok()?;
             let arg = arg.ok()?;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_unsafe_optional_chaining.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_unsafe_optional_chaining.rs
@@ -81,8 +81,7 @@ impl Rule for NoUnsafeOptionalChaining {
         if !query_node.is_optional() {
             return None;
         }
-
-        let mut node: RuleNode = query_node.clone().into();
+        let mut node: RuleNode = RuleNode::cast_ref(query_node.syntax())?;
         let mut parent = node.parent::<RuleNode>();
         // parentheses limit the scope of short-circuiting in chains
         // (a?.b).c // here we have an error

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_nonoctal_decimal_escape.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_nonoctal_decimal_escape.rs
@@ -148,7 +148,7 @@ impl Rule for NoNonoctalDecimalEscape {
                         diagnostics_text_range: decimal_escape_range,
                         replace_from: decimal_escape.to_string(),
                         replace_to: decimal_char_unicode_escaped,
-                        replace_string_range: replace_string_range.clone(),
+                        replace_string_range,
                     });
                 } else {
                     // \8 -> 8
@@ -157,7 +157,7 @@ impl Rule for NoNonoctalDecimalEscape {
                         diagnostics_text_range: decimal_escape_range,
                         replace_from: decimal_escape.to_string(),
                         replace_to: decimal_char.to_string(),
-                        replace_string_range: replace_string_range.clone(),
+                        replace_string_range,
                     })
                 }
             }

--- a/crates/rome_js_analyze/src/analyzers/nursery/use_getter_return.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/use_getter_return.rs
@@ -117,8 +117,8 @@ impl Rule for UseGetterReturn {
                         }
                     }
                     InstructionKind::Return => {
-                        if let Some(NodeOrToken::Node(node)) = instruction.node.clone() {
-                            if let Some(return_stmt) = JsReturnStatement::cast(node) {
+                        if let Some(NodeOrToken::Node(ref node)) = instruction.node {
+                            if let Some(ref return_stmt) = JsReturnStatement::cast_ref(node) {
                                 if return_stmt.argument().is_none() {
                                     invalid_returns.push(InvalidGetterReturn::EmptyReturn(
                                         return_stmt.range(),

--- a/crates/rome_js_analyze/src/analyzers/suspicious/no_duplicate_class_members.rs
+++ b/crates/rome_js_analyze/src/analyzers/suspicious/no_duplicate_class_members.rs
@@ -132,16 +132,16 @@ impl AnyClassMemberDefinition {
     fn modifiers_list(&self) -> JsSyntaxList {
         match self {
             AnyClassMemberDefinition::JsGetterClassMember(node) => {
-                node.modifiers().syntax_list().clone()
+                node.modifiers().into_syntax_list()
             }
             AnyClassMemberDefinition::JsMethodClassMember(node) => {
-                node.modifiers().syntax_list().clone()
+                node.modifiers().into_syntax_list()
             }
             AnyClassMemberDefinition::JsPropertyClassMember(node) => {
-                node.modifiers().syntax_list().clone()
+                node.modifiers().into_syntax_list()
             }
             AnyClassMemberDefinition::JsSetterClassMember(node) => {
-                node.modifiers().syntax_list().clone()
+                node.modifiers().into_syntax_list()
             }
         }
     }

--- a/crates/rome_js_analyze/src/analyzers/suspicious/no_self_compare.rs
+++ b/crates/rome_js_analyze/src/analyzers/suspicious/no_self_compare.rs
@@ -41,19 +41,12 @@ impl Rule for NoSelfCompare {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-
         if !node.is_comparison_operator() {
             return None;
         }
-
         let left = node.left().ok()?;
         let right = node.right().ok()?;
-
-        if is_node_equal(left.syntax(), right.syntax()) {
-            return Some(());
-        }
-
-        None
+        is_node_equal(left.syntax(), right.syntax()).then_some(())
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/rome_js_analyze/src/utils.rs
+++ b/crates/rome_js_analyze/src/utils.rs
@@ -117,25 +117,15 @@ pub(crate) fn remove_declarator(
 pub(crate) fn is_node_equal(a_node: &JsSyntaxNode, b_node: &JsSyntaxNode) -> bool {
     let a_tree = a_node.preorder_with_tokens(Direction::Next);
     let b_tree = b_node.preorder_with_tokens(Direction::Next);
-
-    for (a_child, b_child) in iter::zip(a_tree, b_tree) {
-        let a_event = match a_child {
-            WalkEvent::Enter(event) => event,
-            WalkEvent::Leave(event) => event,
+    for (a_event, b_event) in iter::zip(a_tree, b_tree) {
+        let (WalkEvent::Enter(a_child), WalkEvent::Enter(b_child)) = (a_event, b_event) else {
+            continue;
         };
-
-        let b_event = match b_child {
-            WalkEvent::Enter(event) => event,
-            WalkEvent::Leave(event) => event,
-        };
-
-        if a_event.kind() != b_event.kind() {
+        if a_child.kind() != b_child.kind() {
             return false;
         }
-
-        let a_token = a_event.as_token();
-        let b_token = b_event.as_token();
-
+        let a_token = a_child.as_token();
+        let b_token = b_child.as_token();
         match (a_token, b_token) {
             // both are nodes
             (None, None) => continue,
@@ -150,6 +140,5 @@ pub(crate) fn is_node_equal(a_node: &JsSyntaxNode, b_node: &JsSyntaxNode) -> boo
             }
         }
     }
-
     true
 }

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -103,15 +103,15 @@ pub enum SemanticEvent {
 impl SemanticEvent {
     pub fn range(&self) -> &TextRange {
         match self {
-            SemanticEvent::DeclarationFound { range, .. } => range,
-            SemanticEvent::ScopeStarted { range, .. } => range,
-            SemanticEvent::ScopeEnded { range, .. } => range,
-            SemanticEvent::Read { range, .. } => range,
-            SemanticEvent::HoistedRead { range, .. } => range,
-            SemanticEvent::Write { range, .. } => range,
-            SemanticEvent::HoistedWrite { range, .. } => range,
-            SemanticEvent::UnresolvedReference { range, .. } => range,
-            SemanticEvent::Exported { range } => range,
+            SemanticEvent::DeclarationFound { range, .. }
+            | SemanticEvent::ScopeStarted { range, .. }
+            | SemanticEvent::ScopeEnded { range, .. }
+            | SemanticEvent::Read { range, .. }
+            | SemanticEvent::HoistedRead { range, .. }
+            | SemanticEvent::Write { range, .. }
+            | SemanticEvent::HoistedWrite { range, .. }
+            | SemanticEvent::UnresolvedReference { range, .. }
+            | SemanticEvent::Exported { range } => range,
         }
     }
 
@@ -190,10 +190,9 @@ impl Reference {
         matches!(self, Reference::Read { .. })
     }
 
-    pub fn range(&self) -> &TextRange {
+    pub fn range(&self) -> TextRange {
         match self {
-            Reference::Read { range, .. } => range,
-            Reference::Write { range } => range,
+            Reference::Read { range, .. } | Reference::Write { range } => *range,
         }
     }
 }
@@ -700,7 +699,7 @@ impl SemanticEventExtractor {
                     for reference in references {
                         self.stash.push_back(SemanticEvent::UnresolvedReference {
                             is_read: reference.is_read(),
-                            range: *reference.range(),
+                            range: reference.range(),
                         });
                     }
                 }


### PR DESCRIPTION
## Summary

- Avoid redundant verifications for `noSelfCompare` and `noDuplicateCase`.
- Avoid some cloning and delay others
- Remove redundant utility `remove_statement`
- Move `ast_utils` under `utils/`

## Test Plan

No change.
