### PR TITLE
feat(lint/useIsNan): add code fix action

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/use_is_nan.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/use_is_nan.rs
@@ -202,7 +202,7 @@ fn create_unary_expression(
     nan_expression: AnyJsExpression,
 ) -> Option<AnyJsExpression> {
     if with_inequality {
-        let unary = make::js_unary_expression(make::token(T![!]), nan_expression.into());
+        let unary = make::js_unary_expression(make::token(T![!]), nan_expression);
         return Some(unary.into());
     }
 
@@ -222,7 +222,7 @@ fn create_is_nan_expression(nan: AnyJsExpression) -> Option<AnyJsExpression> {
                 make::js_name(make::ident("isNaN")).into(),
             );
 
-            return Some(is_nan_expression.into());
+            Some(is_nan_expression.into())
         }
         AnyJsExpression::JsStaticMemberExpression(member_expression) => {
             let is_nan_expression =
@@ -247,11 +247,11 @@ fn create_is_nan_expression(nan: AnyJsExpression) -> Option<AnyJsExpression> {
                 make::js_name(make::ident("Number")).into(),
             );
 
-            return Some(
+            Some(
                 is_nan_expression
                     .with_object(member_expression.into())
                     .into(),
-            );
+            )
         }
         _ => None,
     }
@@ -283,7 +283,7 @@ fn get_literal(
         return Some((left, right));
     }
 
-    return Some((right, left));
+    Some((right, left))
 }
 
 /// Checks whether an expression has `NaN`, `Number.NaN`, or `Number['NaN']`.

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/use_is_nan.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/use_is_nan.rs
@@ -280,10 +280,10 @@ fn get_literal(
         .with_trailing_trivia_pieces([])?;
 
     if !is_nan_on_left {
-        return Some((left, right));
+        Some((left, right))
+    } else {
+        Some((right, left))
     }
-
-    Some((right, left))
 }
 
 /// Checks whether an expression has `NaN`, `Number.NaN`, or `Number['NaN']`.

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/use_is_nan.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/use_is_nan.rs
@@ -162,7 +162,11 @@ impl Rule for UseIsNan {
                     let with_inequality = contains_inequality(bin_expr).unwrap_or(false);
                     let is_nan_expression = create_is_nan_expression(&with_inequality);
 
-                    let arg = AnyJsCallArgument::AnyJsExpression(literal.with_leading_trivia_pieces([])?.with_trailing_trivia_pieces([])?);
+                    let arg = AnyJsCallArgument::AnyJsExpression(
+                        literal
+                            .with_leading_trivia_pieces([])?
+                            .with_trailing_trivia_pieces([])?,
+                    );
                     let args = make::js_call_arguments(
                         make::token(T!['(']),
                         make::js_call_argument_list([arg], []),
@@ -187,7 +191,7 @@ impl Rule for UseIsNan {
                     });
                 }
 
-                return None;
+                None
             }
             UseIsNanQuery::JsCaseClause(_) => None,
             UseIsNanQuery::JsSwitchStatement(_) => None,
@@ -213,8 +217,10 @@ fn create_is_nan_expression(with_inequality: &bool) -> AnyJsExpression {
 fn contains_inequality(bin_expr: &JsBinaryExpression) -> Option<bool> {
     let binary_operator = bin_expr.operator().ok()?;
 
-    Some(matches!(binary_operator,
-        JsBinaryOperator::Inequality | JsBinaryOperator::StrictInequality))
+    Some(matches!(
+        binary_operator,
+        JsBinaryOperator::Inequality | JsBinaryOperator::StrictInequality
+    ))
 }
 
 fn get_literal(bin_expr: &JsBinaryExpression, model: &SemanticModel) -> Option<AnyJsExpression> {
@@ -231,7 +237,7 @@ fn get_literal(bin_expr: &JsBinaryExpression, model: &SemanticModel) -> Option<A
         };
     }
 
-    return None;
+    None
 }
 
 /// Checks whether an expression has `NaN`, `Number.NaN`, or `Number['NaN']`.

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/use_is_nan.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/use_is_nan.rs
@@ -1,7 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_rule, ActionCategory, Rule, RuleDiagnostic};
-use rome_console::markup;
-use rome_diagnostics::Applicability;
+use biome_console::markup;
+use biome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_semantic::SemanticModel;
 use rome_js_syntax::{

--- a/crates/rome_js_analyze/tests/specs/correctness/useIsNan/invalid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/useIsNan/invalid.js.snap
@@ -849,7 +849,7 @@ invalid.js:33:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━�
     31 31 │   Number.NaN >= "abc";
     32 32 │   "abc" >= Number.NaN;
     33    │ - x·===·Number?.NaN;
-       33 │ + Number.isNaN(x);
+       33 │ + Number?.isNaN(x);
     34 34 │   x === Number['NaN'];
     35 35 │   
   
@@ -897,7 +897,7 @@ invalid.js:36:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━�
     34 34 │   x === Number['NaN'];
     35 35 │   
     36    │ - 123·==·globalThis.NaN;
-       36 │ + Number.isNaN(123);
+       36 │ + globalThis.Number.isNaN(123);
     37 37 │   123 == window.NaN;
     38 38 │   123 == globalThis.Number.NaN;
   
@@ -920,7 +920,7 @@ invalid.js:37:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━�
     35 35 │   
     36 36 │   123 == globalThis.NaN;
     37    │ - 123·==·window.NaN;
-       37 │ + Number.isNaN(123);
+       37 │ + window.Number.isNaN(123);
     38 38 │   123 == globalThis.Number.NaN;
     39 39 │   
   
@@ -944,7 +944,7 @@ invalid.js:38:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━�
     36 36 │   123 == globalThis.NaN;
     37 37 │   123 == window.NaN;
     38    │ - 123·==·globalThis.Number.NaN;
-       38 │ + Number.isNaN(123);
+       38 │ + globalThis.Number.isNaN(123);
     39 39 │   
     40 40 │   // switch-case
   

--- a/crates/rome_js_analyze/tests/specs/correctness/useIsNan/invalid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/useIsNan/invalid.js.snap
@@ -71,7 +71,7 @@ switch(Number.NaN) { case Number.NaN: break; }
 
 # Diagnostics
 ```
-invalid.js:1:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:1:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -80,11 +80,18 @@ invalid.js:1:1 lint/correctness/useIsNan ━━━━━━━━━━━━━
     2 │ 123 === NaN;
     3 │ NaN === "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+     1    │ - 123·==·NaN;
+        1 │ + Number.isNaN(123);
+     2  2 │   123 === NaN;
+     3  3 │   NaN === "abc";
+  
 
 ```
 
 ```
-invalid.js:2:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:2:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -94,11 +101,19 @@ invalid.js:2:1 lint/correctness/useIsNan ━━━━━━━━━━━━━
     3 │ NaN === "abc";
     4 │ NaN == "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+     1  1 │   123 == NaN;
+     2    │ - 123·===·NaN;
+        2 │ + Number.isNaN(123);
+     3  3 │   NaN === "abc";
+     4  4 │   NaN == "abc";
+  
 
 ```
 
 ```
-invalid.js:3:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:3:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -109,11 +124,20 @@ invalid.js:3:1 lint/correctness/useIsNan ━━━━━━━━━━━━━
     4 │ NaN == "abc";
     5 │ 123 != NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+     1  1 │   123 == NaN;
+     2  2 │   123 === NaN;
+     3    │ - NaN·===·"abc";
+        3 │ + Number.isNaN("abc");
+     4  4 │   NaN == "abc";
+     5  5 │   123 != NaN;
+  
 
 ```
 
 ```
-invalid.js:4:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:4:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -124,11 +148,20 @@ invalid.js:4:1 lint/correctness/useIsNan ━━━━━━━━━━━━━
     5 │ 123 != NaN;
     6 │ 123 !== NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+     2  2 │   123 === NaN;
+     3  3 │   NaN === "abc";
+     4    │ - NaN·==·"abc";
+        4 │ + Number.isNaN("abc");
+     5  5 │   123 != NaN;
+     6  6 │   123 !== NaN;
+  
 
 ```
 
 ```
-invalid.js:5:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:5:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -139,11 +172,20 @@ invalid.js:5:1 lint/correctness/useIsNan ━━━━━━━━━━━━━
     6 │ 123 !== NaN;
     7 │ NaN !== "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+     3  3 │   NaN === "abc";
+     4  4 │   NaN == "abc";
+     5    │ - 123·!=·NaN;
+        5 │ + !Number.isNaN(123);
+     6  6 │   123 !== NaN;
+     7  7 │   NaN !== "abc";
+  
 
 ```
 
 ```
-invalid.js:6:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:6:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -154,11 +196,20 @@ invalid.js:6:1 lint/correctness/useIsNan ━━━━━━━━━━━━━
     7 │ NaN !== "abc";
     8 │ NaN != "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+     4  4 │   NaN == "abc";
+     5  5 │   123 != NaN;
+     6    │ - 123·!==·NaN;
+        6 │ + !Number.isNaN(123);
+     7  7 │   NaN !== "abc";
+     8  8 │   NaN != "abc";
+  
 
 ```
 
 ```
-invalid.js:7:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:7:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -169,11 +220,20 @@ invalid.js:7:1 lint/correctness/useIsNan ━━━━━━━━━━━━━
     8 │ NaN != "abc";
     9 │ NaN < "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+     5  5 │   123 != NaN;
+     6  6 │   123 !== NaN;
+     7    │ - NaN·!==·"abc";
+        7 │ + !Number.isNaN("abc");
+     8  8 │   NaN != "abc";
+     9  9 │   NaN < "abc";
+  
 
 ```
 
 ```
-invalid.js:8:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:8:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -184,11 +244,20 @@ invalid.js:8:1 lint/correctness/useIsNan ━━━━━━━━━━━━━
      9 │ NaN < "abc";
     10 │ "abc" < NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+     6  6 │   123 !== NaN;
+     7  7 │   NaN !== "abc";
+     8    │ - NaN·!=·"abc";
+        8 │ + !Number.isNaN("abc");
+     9  9 │   NaN < "abc";
+    10 10 │   "abc" < NaN;
+  
 
 ```
 
 ```
-invalid.js:9:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:9:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -199,11 +268,20 @@ invalid.js:9:1 lint/correctness/useIsNan ━━━━━━━━━━━━━
     10 │ "abc" < NaN;
     11 │ NaN > "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+     7  7 │   NaN !== "abc";
+     8  8 │   NaN != "abc";
+     9    │ - NaN·<·"abc";
+        9 │ + Number.isNaN("abc");
+    10 10 │   "abc" < NaN;
+    11 11 │   NaN > "abc";
+  
 
 ```
 
 ```
-invalid.js:10:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:10:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -214,11 +292,20 @@ invalid.js:10:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     11 │ NaN > "abc";
     12 │ "abc" > NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+     8  8 │   NaN != "abc";
+     9  9 │   NaN < "abc";
+    10    │ - "abc"·<·NaN;
+       10 │ + Number.isNaN("abc");
+    11 11 │   NaN > "abc";
+    12 12 │   "abc" > NaN;
+  
 
 ```
 
 ```
-invalid.js:11:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:11:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -229,11 +316,20 @@ invalid.js:11:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     12 │ "abc" > NaN;
     13 │ NaN <= "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+     9  9 │   NaN < "abc";
+    10 10 │   "abc" < NaN;
+    11    │ - NaN·>·"abc";
+       11 │ + Number.isNaN("abc");
+    12 12 │   "abc" > NaN;
+    13 13 │   NaN <= "abc";
+  
 
 ```
 
 ```
-invalid.js:12:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:12:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -244,11 +340,20 @@ invalid.js:12:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     13 │ NaN <= "abc";
     14 │ "abc" <= NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    10 10 │   "abc" < NaN;
+    11 11 │   NaN > "abc";
+    12    │ - "abc"·>·NaN;
+       12 │ + Number.isNaN("abc");
+    13 13 │   NaN <= "abc";
+    14 14 │   "abc" <= NaN;
+  
 
 ```
 
 ```
-invalid.js:13:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:13:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -259,11 +364,20 @@ invalid.js:13:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     14 │ "abc" <= NaN;
     15 │ NaN >= "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    11 11 │   NaN > "abc";
+    12 12 │   "abc" > NaN;
+    13    │ - NaN·<=·"abc";
+       13 │ + Number.isNaN("abc");
+    14 14 │   "abc" <= NaN;
+    15 15 │   NaN >= "abc";
+  
 
 ```
 
 ```
-invalid.js:14:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:14:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -274,11 +388,20 @@ invalid.js:14:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     15 │ NaN >= "abc";
     16 │ "abc" >= NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    12 12 │   "abc" > NaN;
+    13 13 │   NaN <= "abc";
+    14    │ - "abc"·<=·NaN;
+       14 │ + Number.isNaN("abc");
+    15 15 │   NaN >= "abc";
+    16 16 │   "abc" >= NaN;
+  
 
 ```
 
 ```
-invalid.js:15:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:15:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -289,11 +412,20 @@ invalid.js:15:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     16 │ "abc" >= NaN;
     17 │ 123 == Number.NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    13 13 │   NaN <= "abc";
+    14 14 │   "abc" <= NaN;
+    15    │ - NaN·>=·"abc";
+       15 │ + Number.isNaN("abc");
+    16 16 │   "abc" >= NaN;
+    17 17 │   123 == Number.NaN;
+  
 
 ```
 
 ```
-invalid.js:16:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:16:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -304,11 +436,20 @@ invalid.js:16:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     17 │ 123 == Number.NaN;
     18 │ 123 === Number.NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    14 14 │   "abc" <= NaN;
+    15 15 │   NaN >= "abc";
+    16    │ - "abc"·>=·NaN;
+       16 │ + Number.isNaN("abc");
+    17 17 │   123 == Number.NaN;
+    18 18 │   123 === Number.NaN;
+  
 
 ```
 
 ```
-invalid.js:17:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:17:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -319,11 +460,20 @@ invalid.js:17:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     18 │ 123 === Number.NaN;
     19 │ Number.NaN === "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    15 15 │   NaN >= "abc";
+    16 16 │   "abc" >= NaN;
+    17    │ - 123·==·Number.NaN;
+       17 │ + Number.isNaN(123);
+    18 18 │   123 === Number.NaN;
+    19 19 │   Number.NaN === "abc";
+  
 
 ```
 
 ```
-invalid.js:18:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:18:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -334,11 +484,20 @@ invalid.js:18:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     19 │ Number.NaN === "abc";
     20 │ Number.NaN == "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    16 16 │   "abc" >= NaN;
+    17 17 │   123 == Number.NaN;
+    18    │ - 123·===·Number.NaN;
+       18 │ + Number.isNaN(123);
+    19 19 │   Number.NaN === "abc";
+    20 20 │   Number.NaN == "abc";
+  
 
 ```
 
 ```
-invalid.js:19:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:19:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -349,11 +508,20 @@ invalid.js:19:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     20 │ Number.NaN == "abc";
     21 │ 123 != Number.NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    17 17 │   123 == Number.NaN;
+    18 18 │   123 === Number.NaN;
+    19    │ - Number.NaN·===·"abc";
+       19 │ + Number.isNaN("abc");
+    20 20 │   Number.NaN == "abc";
+    21 21 │   123 != Number.NaN;
+  
 
 ```
 
 ```
-invalid.js:20:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:20:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -364,11 +532,20 @@ invalid.js:20:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     21 │ 123 != Number.NaN;
     22 │ 123 !== Number.NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    18 18 │   123 === Number.NaN;
+    19 19 │   Number.NaN === "abc";
+    20    │ - Number.NaN·==·"abc";
+       20 │ + Number.isNaN("abc");
+    21 21 │   123 != Number.NaN;
+    22 22 │   123 !== Number.NaN;
+  
 
 ```
 
 ```
-invalid.js:21:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:21:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -379,11 +556,20 @@ invalid.js:21:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     22 │ 123 !== Number.NaN;
     23 │ Number.NaN !== "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    19 19 │   Number.NaN === "abc";
+    20 20 │   Number.NaN == "abc";
+    21    │ - 123·!=·Number.NaN;
+       21 │ + !Number.isNaN(123);
+    22 22 │   123 !== Number.NaN;
+    23 23 │   Number.NaN !== "abc";
+  
 
 ```
 
 ```
-invalid.js:22:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:22:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -394,11 +580,20 @@ invalid.js:22:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     23 │ Number.NaN !== "abc";
     24 │ Number.NaN != "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    20 20 │   Number.NaN == "abc";
+    21 21 │   123 != Number.NaN;
+    22    │ - 123·!==·Number.NaN;
+       22 │ + !Number.isNaN(123);
+    23 23 │   Number.NaN !== "abc";
+    24 24 │   Number.NaN != "abc";
+  
 
 ```
 
 ```
-invalid.js:23:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:23:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -409,11 +604,20 @@ invalid.js:23:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     24 │ Number.NaN != "abc";
     25 │ Number.NaN < "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    21 21 │   123 != Number.NaN;
+    22 22 │   123 !== Number.NaN;
+    23    │ - Number.NaN·!==·"abc";
+       23 │ + !Number.isNaN("abc");
+    24 24 │   Number.NaN != "abc";
+    25 25 │   Number.NaN < "abc";
+  
 
 ```
 
 ```
-invalid.js:24:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:24:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -424,11 +628,20 @@ invalid.js:24:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     25 │ Number.NaN < "abc";
     26 │ "abc" < Number.NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    22 22 │   123 !== Number.NaN;
+    23 23 │   Number.NaN !== "abc";
+    24    │ - Number.NaN·!=·"abc";
+       24 │ + !Number.isNaN("abc");
+    25 25 │   Number.NaN < "abc";
+    26 26 │   "abc" < Number.NaN;
+  
 
 ```
 
 ```
-invalid.js:25:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:25:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -439,11 +652,20 @@ invalid.js:25:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     26 │ "abc" < Number.NaN;
     27 │ Number.NaN > "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    23 23 │   Number.NaN !== "abc";
+    24 24 │   Number.NaN != "abc";
+    25    │ - Number.NaN·<·"abc";
+       25 │ + Number.isNaN("abc");
+    26 26 │   "abc" < Number.NaN;
+    27 27 │   Number.NaN > "abc";
+  
 
 ```
 
 ```
-invalid.js:26:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:26:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -454,11 +676,20 @@ invalid.js:26:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     27 │ Number.NaN > "abc";
     28 │ "abc" > Number.NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    24 24 │   Number.NaN != "abc";
+    25 25 │   Number.NaN < "abc";
+    26    │ - "abc"·<·Number.NaN;
+       26 │ + Number.isNaN("abc");
+    27 27 │   Number.NaN > "abc";
+    28 28 │   "abc" > Number.NaN;
+  
 
 ```
 
 ```
-invalid.js:27:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:27:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -469,11 +700,20 @@ invalid.js:27:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     28 │ "abc" > Number.NaN;
     29 │ Number.NaN <= "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    25 25 │   Number.NaN < "abc";
+    26 26 │   "abc" < Number.NaN;
+    27    │ - Number.NaN·>·"abc";
+       27 │ + Number.isNaN("abc");
+    28 28 │   "abc" > Number.NaN;
+    29 29 │   Number.NaN <= "abc";
+  
 
 ```
 
 ```
-invalid.js:28:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:28:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -484,11 +724,20 @@ invalid.js:28:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     29 │ Number.NaN <= "abc";
     30 │ "abc" <= Number.NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    26 26 │   "abc" < Number.NaN;
+    27 27 │   Number.NaN > "abc";
+    28    │ - "abc"·>·Number.NaN;
+       28 │ + Number.isNaN("abc");
+    29 29 │   Number.NaN <= "abc";
+    30 30 │   "abc" <= Number.NaN;
+  
 
 ```
 
 ```
-invalid.js:29:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:29:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -499,11 +748,20 @@ invalid.js:29:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     30 │ "abc" <= Number.NaN;
     31 │ Number.NaN >= "abc";
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    27 27 │   Number.NaN > "abc";
+    28 28 │   "abc" > Number.NaN;
+    29    │ - Number.NaN·<=·"abc";
+       29 │ + Number.isNaN("abc");
+    30 30 │   "abc" <= Number.NaN;
+    31 31 │   Number.NaN >= "abc";
+  
 
 ```
 
 ```
-invalid.js:30:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:30:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -514,11 +772,20 @@ invalid.js:30:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     31 │ Number.NaN >= "abc";
     32 │ "abc" >= Number.NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    28 28 │   "abc" > Number.NaN;
+    29 29 │   Number.NaN <= "abc";
+    30    │ - "abc"·<=·Number.NaN;
+       30 │ + Number.isNaN("abc");
+    31 31 │   Number.NaN >= "abc";
+    32 32 │   "abc" >= Number.NaN;
+  
 
 ```
 
 ```
-invalid.js:31:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:31:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -529,11 +796,20 @@ invalid.js:31:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     32 │ "abc" >= Number.NaN;
     33 │ x === Number?.NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    29 29 │   Number.NaN <= "abc";
+    30 30 │   "abc" <= Number.NaN;
+    31    │ - Number.NaN·>=·"abc";
+       31 │ + Number.isNaN("abc");
+    32 32 │   "abc" >= Number.NaN;
+    33 33 │   x === Number?.NaN;
+  
 
 ```
 
 ```
-invalid.js:32:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:32:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -544,11 +820,20 @@ invalid.js:32:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     33 │ x === Number?.NaN;
     34 │ x === Number['NaN'];
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    30 30 │   "abc" <= Number.NaN;
+    31 31 │   Number.NaN >= "abc";
+    32    │ - "abc"·>=·Number.NaN;
+       32 │ + Number.isNaN("abc");
+    33 33 │   x === Number?.NaN;
+    34 34 │   x === Number['NaN'];
+  
 
 ```
 
 ```
-invalid.js:33:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:33:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -559,11 +844,20 @@ invalid.js:33:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     34 │ x === Number['NaN'];
     35 │ 
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    31 31 │   Number.NaN >= "abc";
+    32 32 │   "abc" >= Number.NaN;
+    33    │ - x·===·Number?.NaN;
+       33 │ + Number.isNaN(x);
+    34 34 │   x === Number['NaN'];
+    35 35 │   
+  
 
 ```
 
 ```
-invalid.js:34:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:34:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -574,11 +868,20 @@ invalid.js:34:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     35 │ 
     36 │ 123 == globalThis.NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    32 32 │   "abc" >= Number.NaN;
+    33 33 │   x === Number?.NaN;
+    34    │ - x·===·Number['NaN'];
+       34 │ + Number.isNaN(x);
+    35 35 │   
+    36 36 │   123 == globalThis.NaN;
+  
 
 ```
 
 ```
-invalid.js:36:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:36:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -589,11 +892,20 @@ invalid.js:36:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     37 │ 123 == window.NaN;
     38 │ 123 == globalThis.Number.NaN;
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    34 34 │   x === Number['NaN'];
+    35 35 │   
+    36    │ - 123·==·globalThis.NaN;
+       36 │ + Number.isNaN(123);
+    37 37 │   123 == window.NaN;
+    38 38 │   123 == globalThis.Number.NaN;
+  
 
 ```
 
 ```
-invalid.js:37:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:37:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -603,11 +915,20 @@ invalid.js:37:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
     38 │ 123 == globalThis.Number.NaN;
     39 │ 
   
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    35 35 │   
+    36 36 │   123 == globalThis.NaN;
+    37    │ - 123·==·window.NaN;
+       37 │ + Number.isNaN(123);
+    38 38 │   123 == globalThis.Number.NaN;
+    39 39 │   
+  
 
 ```
 
 ```
-invalid.js:38:1 lint/correctness/useIsNan ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:38:1 lint/correctness/useIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the Number.isNaN function to compare with NaN.
   
@@ -617,6 +938,15 @@ invalid.js:38:1 lint/correctness/useIsNan ━━━━━━━━━━━━�
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     39 │ 
     40 │ // switch-case
+  
+  i Suggested fix: Use Number.isNaN() instead.
+  
+    36 36 │   123 == globalThis.NaN;
+    37 37 │   123 == window.NaN;
+    38    │ - 123·==·globalThis.Number.NaN;
+       38 │ + Number.isNaN(123);
+    39 39 │   
+    40 40 │   // switch-case
   
 
 ```

--- a/website/src/content/docs/linter/rules/use-is-nan.md
+++ b/website/src/content/docs/linter/rules/use-is-nan.md
@@ -37,17 +37,17 @@ Source: [use-isnan](https://eslint.org/docs/latest/rules/use-isnan).
 <pre class="language-text"><code class="language-text">correctness/useIsNan.js:1:1 <a href="https://biomejs.dev/linter/rules/use-is-nan">lint/correctness/useIsNan</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Use the Number.isNaN function to compare with NaN.</span>
-
+  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>123 == NaN
    <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
-
+  
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>Number.isNaN()</strong></span><span style="color: rgb(38, 148, 255);"> instead.</span>
-
+  
     <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">1</span><span style="color: Tomato;">2</span><span style="color: Tomato;">3</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>=</strong></span><span style="color: Tomato;"><strong>=</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>N</strong></span><span style="color: Tomato;"><strong>a</strong></span><span style="color: Tomato;"><strong>N</strong></span>
       <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>u</strong></span><span style="color: MediumSeaGreen;"><strong>m</strong></span><span style="color: MediumSeaGreen;"><strong>b</strong></span><span style="color: MediumSeaGreen;"><strong>e</strong></span><span style="color: MediumSeaGreen;"><strong>r</strong></span><span style="color: MediumSeaGreen;"><strong>.</strong></span><span style="color: MediumSeaGreen;"><strong>i</strong></span><span style="color: MediumSeaGreen;"><strong>s</strong></span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>a</strong></span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>(</strong></span><span style="color: MediumSeaGreen;">1</span><span style="color: MediumSeaGreen;">2</span><span style="color: MediumSeaGreen;">3</span><span style="color: MediumSeaGreen;"><strong>)</strong></span>
-    <strong>2</strong> <strong>2</strong><strong> │ </strong>
-
+    <strong>2</strong> <strong>2</strong><strong> │ </strong>  
+  
 </code></pre>
 
 ```jsx
@@ -57,17 +57,17 @@ Source: [use-isnan](https://eslint.org/docs/latest/rules/use-isnan).
 <pre class="language-text"><code class="language-text">correctness/useIsNan.js:1:1 <a href="https://biomejs.dev/linter/rules/use-is-nan">lint/correctness/useIsNan</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Use the Number.isNaN function to compare with NaN.</span>
-
+  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>123 != NaN
    <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
-
+  
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>Number.isNaN()</strong></span><span style="color: rgb(38, 148, 255);"> instead.</span>
-
+  
     <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>1</strong></span><span style="color: Tomato;"><strong>2</strong></span><span style="color: Tomato;"><strong>3</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">!</span><span style="color: Tomato;"><strong>=</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>N</strong></span><span style="color: Tomato;"><strong>a</strong></span><span style="color: Tomato;"><strong>N</strong></span>
       <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">!</span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>u</strong></span><span style="color: MediumSeaGreen;"><strong>m</strong></span><span style="color: MediumSeaGreen;"><strong>b</strong></span><span style="color: MediumSeaGreen;"><strong>e</strong></span><span style="color: MediumSeaGreen;"><strong>r</strong></span><span style="color: MediumSeaGreen;"><strong>.</strong></span><span style="color: MediumSeaGreen;"><strong>i</strong></span><span style="color: MediumSeaGreen;"><strong>s</strong></span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>a</strong></span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>(</strong></span><span style="color: MediumSeaGreen;"><strong>1</strong></span><span style="color: MediumSeaGreen;"><strong>2</strong></span><span style="color: MediumSeaGreen;"><strong>3</strong></span><span style="color: MediumSeaGreen;"><strong>)</strong></span>
-    <strong>2</strong> <strong>2</strong><strong> │ </strong>
-
+    <strong>2</strong> <strong>2</strong><strong> │ </strong>  
+  
 </code></pre>
 
 ```jsx
@@ -77,11 +77,11 @@ switch(foo) { case (NaN): break; }
 <pre class="language-text"><code class="language-text">correctness/useIsNan.js:1:20 <a href="https://biomejs.dev/linter/rules/use-is-nan">lint/correctness/useIsNan</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">'case NaN' can never match. Use Number.isNaN before the switch.</span>
-
+  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>switch(foo) { case (NaN): break; }
    <strong>   │ </strong>                   <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
-
+  
 </code></pre>
 
 ```jsx
@@ -91,17 +91,17 @@ Number.NaN == "abc"
 <pre class="language-text"><code class="language-text">correctness/useIsNan.js:1:1 <a href="https://biomejs.dev/linter/rules/use-is-nan">lint/correctness/useIsNan</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Use the Number.isNaN function to compare with NaN.</span>
-
+  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>Number.NaN == &quot;abc&quot;
    <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
-
+  
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>Number.isNaN()</strong></span><span style="color: rgb(38, 148, 255);"> instead.</span>
-
+  
     <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>N</strong></span><span style="color: Tomato;"><strong>u</strong></span><span style="color: Tomato;"><strong>m</strong></span><span style="color: Tomato;"><strong>b</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>r</strong></span><span style="color: Tomato;"><strong>.</strong></span><span style="color: Tomato;"><strong>N</strong></span><span style="color: Tomato;"><strong>a</strong></span><span style="color: Tomato;"><strong>N</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>=</strong></span><span style="color: Tomato;"><strong>=</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">&quot;</span><span style="color: Tomato;">a</span><span style="color: Tomato;">b</span><span style="color: Tomato;">c</span><span style="color: Tomato;">&quot;</span>
       <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>u</strong></span><span style="color: MediumSeaGreen;"><strong>m</strong></span><span style="color: MediumSeaGreen;"><strong>b</strong></span><span style="color: MediumSeaGreen;"><strong>e</strong></span><span style="color: MediumSeaGreen;"><strong>r</strong></span><span style="color: MediumSeaGreen;"><strong>.</strong></span><span style="color: MediumSeaGreen;"><strong>i</strong></span><span style="color: MediumSeaGreen;"><strong>s</strong></span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>a</strong></span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>(</strong></span><span style="color: MediumSeaGreen;">&quot;</span><span style="color: MediumSeaGreen;">a</span><span style="color: MediumSeaGreen;">b</span><span style="color: MediumSeaGreen;">c</span><span style="color: MediumSeaGreen;">&quot;</span><span style="color: MediumSeaGreen;"><strong>)</strong></span>
-    <strong>2</strong> <strong>2</strong><strong> │ </strong>
-
+    <strong>2</strong> <strong>2</strong><strong> │ </strong>  
+  
 </code></pre>
 
 ### Valid

--- a/website/src/content/docs/linter/rules/use-is-nan.md
+++ b/website/src/content/docs/linter/rules/use-is-nan.md
@@ -34,28 +34,40 @@ Source: [use-isnan](https://eslint.org/docs/latest/rules/use-isnan).
 123 == NaN
 ```
 
-<pre class="language-text"><code class="language-text">correctness/useIsNan.js:1:1 <a href="https://biomejs.dev/linter/rules/use-is-nan">lint/correctness/useIsNan</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+<pre class="language-text"><code class="language-text">correctness/useIsNan.js:1:1 <a href="https://biomejs.dev/linter/rules/use-is-nan">lint/correctness/useIsNan</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Use the Number.isNaN function to compare with NaN.</span>
-  
+
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>123 == NaN
    <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
-  
+
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>Number.isNaN()</strong></span><span style="color: rgb(38, 148, 255);"> instead.</span>
+
+    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">1</span><span style="color: Tomato;">2</span><span style="color: Tomato;">3</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>=</strong></span><span style="color: Tomato;"><strong>=</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>N</strong></span><span style="color: Tomato;"><strong>a</strong></span><span style="color: Tomato;"><strong>N</strong></span>
+      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>u</strong></span><span style="color: MediumSeaGreen;"><strong>m</strong></span><span style="color: MediumSeaGreen;"><strong>b</strong></span><span style="color: MediumSeaGreen;"><strong>e</strong></span><span style="color: MediumSeaGreen;"><strong>r</strong></span><span style="color: MediumSeaGreen;"><strong>.</strong></span><span style="color: MediumSeaGreen;"><strong>i</strong></span><span style="color: MediumSeaGreen;"><strong>s</strong></span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>a</strong></span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>(</strong></span><span style="color: MediumSeaGreen;">1</span><span style="color: MediumSeaGreen;">2</span><span style="color: MediumSeaGreen;">3</span><span style="color: MediumSeaGreen;"><strong>)</strong></span>
+    <strong>2</strong> <strong>2</strong><strong> │ </strong>
+
 </code></pre>
 
 ```jsx
 123 != NaN
 ```
 
-<pre class="language-text"><code class="language-text">correctness/useIsNan.js:1:1 <a href="https://biomejs.dev/linter/rules/use-is-nan">lint/correctness/useIsNan</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+<pre class="language-text"><code class="language-text">correctness/useIsNan.js:1:1 <a href="https://biomejs.dev/linter/rules/use-is-nan">lint/correctness/useIsNan</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Use the Number.isNaN function to compare with NaN.</span>
-  
+
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>123 != NaN
    <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
-  
+
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>Number.isNaN()</strong></span><span style="color: rgb(38, 148, 255);"> instead.</span>
+
+    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>1</strong></span><span style="color: Tomato;"><strong>2</strong></span><span style="color: Tomato;"><strong>3</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">!</span><span style="color: Tomato;"><strong>=</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>N</strong></span><span style="color: Tomato;"><strong>a</strong></span><span style="color: Tomato;"><strong>N</strong></span>
+      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">!</span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>u</strong></span><span style="color: MediumSeaGreen;"><strong>m</strong></span><span style="color: MediumSeaGreen;"><strong>b</strong></span><span style="color: MediumSeaGreen;"><strong>e</strong></span><span style="color: MediumSeaGreen;"><strong>r</strong></span><span style="color: MediumSeaGreen;"><strong>.</strong></span><span style="color: MediumSeaGreen;"><strong>i</strong></span><span style="color: MediumSeaGreen;"><strong>s</strong></span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>a</strong></span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>(</strong></span><span style="color: MediumSeaGreen;"><strong>1</strong></span><span style="color: MediumSeaGreen;"><strong>2</strong></span><span style="color: MediumSeaGreen;"><strong>3</strong></span><span style="color: MediumSeaGreen;"><strong>)</strong></span>
+    <strong>2</strong> <strong>2</strong><strong> │ </strong>
+
 </code></pre>
 
 ```jsx
@@ -65,25 +77,31 @@ switch(foo) { case (NaN): break; }
 <pre class="language-text"><code class="language-text">correctness/useIsNan.js:1:20 <a href="https://biomejs.dev/linter/rules/use-is-nan">lint/correctness/useIsNan</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">'case NaN' can never match. Use Number.isNaN before the switch.</span>
-  
+
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>switch(foo) { case (NaN): break; }
    <strong>   │ </strong>                   <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
-  
+
 </code></pre>
 
 ```jsx
 Number.NaN == "abc"
 ```
 
-<pre class="language-text"><code class="language-text">correctness/useIsNan.js:1:1 <a href="https://biomejs.dev/linter/rules/use-is-nan">lint/correctness/useIsNan</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+<pre class="language-text"><code class="language-text">correctness/useIsNan.js:1:1 <a href="https://biomejs.dev/linter/rules/use-is-nan">lint/correctness/useIsNan</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Use the Number.isNaN function to compare with NaN.</span>
-  
+
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>Number.NaN == &quot;abc&quot;
    <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
-  
+
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>Number.isNaN()</strong></span><span style="color: rgb(38, 148, 255);"> instead.</span>
+
+    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>N</strong></span><span style="color: Tomato;"><strong>u</strong></span><span style="color: Tomato;"><strong>m</strong></span><span style="color: Tomato;"><strong>b</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>r</strong></span><span style="color: Tomato;"><strong>.</strong></span><span style="color: Tomato;"><strong>N</strong></span><span style="color: Tomato;"><strong>a</strong></span><span style="color: Tomato;"><strong>N</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>=</strong></span><span style="color: Tomato;"><strong>=</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">&quot;</span><span style="color: Tomato;">a</span><span style="color: Tomato;">b</span><span style="color: Tomato;">c</span><span style="color: Tomato;">&quot;</span>
+      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>u</strong></span><span style="color: MediumSeaGreen;"><strong>m</strong></span><span style="color: MediumSeaGreen;"><strong>b</strong></span><span style="color: MediumSeaGreen;"><strong>e</strong></span><span style="color: MediumSeaGreen;"><strong>r</strong></span><span style="color: MediumSeaGreen;"><strong>.</strong></span><span style="color: MediumSeaGreen;"><strong>i</strong></span><span style="color: MediumSeaGreen;"><strong>s</strong></span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>a</strong></span><span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>(</strong></span><span style="color: MediumSeaGreen;">&quot;</span><span style="color: MediumSeaGreen;">a</span><span style="color: MediumSeaGreen;">b</span><span style="color: MediumSeaGreen;">c</span><span style="color: MediumSeaGreen;">&quot;</span><span style="color: MediumSeaGreen;"><strong>)</strong></span>
+    <strong>2</strong> <strong>2</strong><strong> │ </strong>
+
 </code></pre>
 
 ### Valid


### PR DESCRIPTION

## Summary
Closes #96 

Provide code fix for useIsNaN rule:

```diff
- 123 == NaN
+ Number.isNaN(123)
```

```diff
- 123 === NaN
+ Number.isNaN(123)
```

```diff
- 123 !== NaN
+ !Number.isNaN(123)
```

```diff
- 123 != NaN
+ !Number.isNaN(123)
```


Should this rule support other operators like > < >= <=?

## Test Plan

- [x] Manual testing code fix using CLI :)  