### PR TITLE
fix: restore "nursery end" comment in `categories.rs`

### DIFF
--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -110,6 +110,7 @@ define_categories! {
     "lint/nursery/useIsArray": "https://biomejs.dev/linter/rules/use-is-array",
     "lint/nursery/useLiteralEnumMembers": "https://biomejs.dev/linter/rules/use-literal-enum-members",
     "lint/nursery/useNamingConvention": "https://biomejs.dev/linter/rules/use-naming-convention",
+    // nursery end
 
     // performance
     "lint/performance/noDelete": "https://biomejs.dev/linter/rules/no-delete",


### PR DESCRIPTION
## Summary
`just new-lintrule` asserts the existence of the `nursery end` comment in `categories.rs`. This pr adds it.


## Test Plan

work `just new-lintrule path name`

<!-- What demonstrates that your implementation is correct? -->
