### PR TITLE
fix(website/playground): fix missing scroll

### DIFF
--- a/website/src/styles/playground/_diagnostics.scss
+++ b/website/src/styles/playground/_diagnostics.scss
@@ -19,6 +19,7 @@
 }
 
 .diagnostics-console {
+  overflow: auto;
   font-size: 14px;
 }
 


### PR DESCRIPTION
## Summary

Closes #120

## Test Plan

Viewing the code on the Rome site, I noticed that the pre tag contained the overflow property as auto and when I removed it, the scrollbar was the same as on the Biome site.

I decided to assign the property in the diagnostics-console class to select only the pre tag in the playground console, which had a scrolling problem.
