### PR TITLE
fix: use `biome.json` instead

### DIFF
--- a/crates/rome_cli/src/diagnostics.rs
+++ b/crates/rome_cli/src/diagnostics.rs
@@ -269,7 +269,7 @@ pub struct NoVcsFolderFound {
     severity = Warning,
     message(
         description = "The configuration file {path} is deprecated. Use biome.json instead.",
-        message("The configuration file "<Emphasis>{self.path}</Emphasis>" is deprecated. Use "<Emphasis>"biome.json"</Emphasis>"n instead."),
+        message("The configuration file "<Emphasis>{self.path}</Emphasis>" is deprecated. Use "<Emphasis>"biome.json"</Emphasis>" instead."),
     )
 )]
 pub struct DeprecatedConfigurationFile {

--- a/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_resolves_when_using_config_path.snap
+++ b/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_resolves_when_using_config_path.snap
@@ -29,14 +29,62 @@ debugger; console.log("string");
 # Termination Message
 
 ```block
-config/rome.json internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Biome couldn't read the file
-  
-  × Biome couldn't read the following file, maybe for permissions reasons or it doesn't exists: config/rome.json
+  × Some errors were emitted while running checks.
   
 
 
+```
+
+# Emitted Messages
+
+```block
+test.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This is an unexpected use of the debugger statement.
+  
+  > 1 │ debugger; console.log("string");·
+      │ ^^^^^^^^^
+  
+  i Suggested fix: Remove debugger statement
+  
+    1 │ debugger;·console.log("string");·
+      │ ----------                       
+
+```
+
+```block
+test.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The file contains diagnostics that needs to be addressed.
+  
+
+```
+
+```block
+test.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - debugger;·console.log("string");·
+      1 │ + debugger;
+      2 │ + console.log('string');
+      3 │ + 
+  
+
+```
+
+```block
+test.js check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The file contains diagnostics that needs to be addressed.
+  
+
+```
+
+```block
+Checked 1 file(s) in <TIME>
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/fs_files_ignore_symlink.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/fs_files_ignore_symlink.snap
@@ -7,7 +7,7 @@ expression: content
 ```block
 rome.json internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The configuration file rome.json is deprecated. Use biome.jsonn instead.
+  ! The configuration file rome.json is deprecated. Use biome.json instead.
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_format/custom_config_file_path.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/custom_config_file_path.snap
@@ -30,7 +30,7 @@ function f() {
 ```block
 rome.json internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The configuration file rome.json is deprecated. Use biome.jsonn instead.
+  ! The configuration file rome.json is deprecated. Use biome.json instead.
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_lint/fs_files_ignore_symlink.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_lint/fs_files_ignore_symlink.snap
@@ -7,7 +7,7 @@ expression: content
 ```block
 rome.json internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The configuration file rome.json is deprecated. Use biome.jsonn instead.
+  ! The configuration file rome.json is deprecated. Use biome.json instead.
   
 
 ```

--- a/crates/rome_fs/src/fs.rs
+++ b/crates/rome_fs/src/fs.rs
@@ -13,8 +13,6 @@ use tracing::{error, info};
 mod memory;
 mod os;
 
-pub const CONFIG_NAMES: [&str; 2] = [ROME_JSON, BIOME_JSON];
-
 pub const ROME_JSON: &str = "rome.json";
 pub const BIOME_JSON: &str = "biome.json";
 
@@ -28,9 +26,10 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
     /// efficiently batch many filesystem read operations
     fn traversal<'scope>(&'scope self, func: BoxedTraversal<'_, 'scope>);
 
+    // TODO: remove once we remove `rome.json` support [2.0]
     /// Returns the temporary configuration files that are supported
-    fn config_names(&self) -> [&str; 2] {
-        CONFIG_NAMES
+    fn deprecated_config_name(&self) -> &str {
+        ROME_JSON
     }
 
     /// Returns the name of the main configuration file

--- a/crates/rome_fs/src/lib.rs
+++ b/crates/rome_fs/src/lib.rs
@@ -5,7 +5,7 @@ mod path;
 pub use fs::{
     AutoSearchResult, ErrorEntry, File, FileSystem, FileSystemDiagnostic, FileSystemExt,
     MemoryFileSystem, OpenOptions, OsFileSystem, TraversalContext, TraversalScope, BIOME_JSON,
-    CONFIG_NAMES, ROME_JSON,
+    ROME_JSON,
 };
 pub use interner::PathInterner;
 pub use path::RomePath;

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -327,7 +327,8 @@ pub fn load_config(
     file_system: &DynRef<dyn FileSystem>,
     base_path: ConfigurationBasePath,
 ) -> LoadConfig {
-    let config_names = file_system.config_names();
+    let config_name = file_system.config_name();
+    let deprecated_config_name = file_system.deprecated_config_name();
     let working_directory = file_system.working_directory();
     let configuration_directory = match base_path {
         ConfigurationBasePath::Lsp(ref path) | ConfigurationBasePath::FromUser(ref path) => {
@@ -340,14 +341,25 @@ pub fn load_config(
     };
     let should_error = base_path.is_from_user();
 
-    let mut auto_search_result = None;
-    for config_name in config_names {
-        let result =
-            file_system.auto_search(configuration_directory.clone(), config_name, should_error)?;
-        if result.is_some() {
+    let auto_search_result;
+    let result =
+        file_system.auto_search(configuration_directory.clone(), config_name, should_error);
+    if let Ok(result) = result {
+        if result.is_none() {
+            auto_search_result = file_system.auto_search(
+                configuration_directory.clone(),
+                deprecated_config_name,
+                should_error,
+            )?;
+        } else {
             auto_search_result = result;
-            break;
         }
+    } else {
+        auto_search_result = file_system.auto_search(
+            configuration_directory.clone(),
+            deprecated_config_name,
+            should_error,
+        )?;
     }
 
     if let Some(auto_search_result) = auto_search_result {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/118

I decided not to emit a diagnostic for the presence of a double configuration because it would mean applying the auto-discovery again for a file we wouldn't use, which isn't optimal. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

The change caught a bug, which has been updated.

<!-- What demonstrates that your implementation is correct? -->
