### PR TITLE
fix: support deno

### DIFF
--- a/packages/@biomejs/biome/bin/biome
+++ b/packages/@biomejs/biome/bin/biome
@@ -18,6 +18,7 @@ const PLATFORMS = {
 
 const binPath = env.ROME_BINARY || PLATFORMS?.[platform]?.[arch];
 if (binPath) {
+	const packageManager = detectPackageManager();
 	const result = require("child_process").spawnSync(
 		require.resolve(binPath),
 		process.argv.slice(2),
@@ -28,7 +29,9 @@ if (binPath) {
 				...env,
 				JS_RUNTIME_VERSION: version,
 				JS_RUNTIME_NAME: release.name,
-				NODE_PACKAGE_MANAGER: detectPackageManager(),
+				...(packageManager === null
+					? { NODE_PACKAGE_MANAGER: packageManager }
+					: {}),
 			},
 		},
 	);


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
Deno cannot directly run Biome via `deno run -A npm:@biomejs/biome check`.


```ts
import child_process from 'node:child_process';
import process from 'node:process';

child_process.spawn(process.execPath, ['bar.js'], {
	stdio: [process.stdin, process.stdout, process.stderr]
});
```
<img width="1281" alt="image" src="https://github.com/biomejs/biome/assets/19145952/1dbed390-fa18-48eb-a354-b2bd49588f35">

deno can not run when env  have a `null` or `undefined` value


May be it is the bug of deno.  https://github.com/denoland/deno/issues/20373
But it can fix this error.




<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

It run correctly when I changed it.

<!-- What demonstrates that your implementation is correct? -->


<img width="1383" alt="image" src="https://github.com/biomejs/biome/assets/19145952/c6c81b4c-e405-4e05-80fe-3deda198aaff">




