### PR TITLE
fix(lint/noCommaOperator): ignore update part of for loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,19 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   <TextField inputLabelProps="" InputLabelProps=""></TextField>
   ```
 
+- Fix [#138](https://github.com/biomejs/biome/issues/138)
+
+  [noCommaOperator](https://biomejs.dev/linter/rules/no-comma-operator/) now correctly ignores all use of comma operators inside the update part of a `for` loop.
+  The following code is now correctly ignored:
+
+  ```js
+  for (
+    let i = 0, j = 1, k = 2;
+    i < 100;
+    i++, j++, k++
+  ) {}
+  ```
+
 - Fix [rome#4713](https://github.com/rome/tools/issues/4713).
 
   Previously, [useTemplate](https://biomejs.dev/linter/rules/use-template/) made the following suggestion:

--- a/crates/rome_js_analyze/src/analyzers/style/no_comma_operator.rs
+++ b/crates/rome_js_analyze/src/analyzers/style/no_comma_operator.rs
@@ -53,6 +53,10 @@ impl Rule for NoCommaOperator {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let seq = ctx.query();
+        // Ignore nested sequences
+        if seq.parent::<JsSequenceExpression>().is_some() {
+            return None;
+        }
         if let Some(for_stmt) = seq.parent::<JsForStatement>() {
             // Allow comma operator in initializer and update parts of a `for`
             if for_stmt.test().map(AstNode::into_syntax).as_ref() != Some(seq.syntax()) {

--- a/crates/rome_js_analyze/tests/specs/style/noCommaOperator/valid.jsonc
+++ b/crates/rome_js_analyze/tests/specs/style/noCommaOperator/valid.jsonc
@@ -7,5 +7,6 @@
 
 	// Allowed comma operators
 	"for (i = 0, j = 0; test; );",
-	"for (; test; i++, j++);"
+	"for (; test; i++, j++);",
+	"for (let i = 0, j = 1, k = 2; i < 100; i++, j++, k++) {}"
 ]

--- a/crates/rome_js_analyze/tests/specs/style/noCommaOperator/valid.jsonc.snap
+++ b/crates/rome_js_analyze/tests/specs/style/noCommaOperator/valid.jsonc.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
-assertion_line: 92
 expression: valid.jsonc
 ---
 # Input
@@ -31,6 +30,11 @@ for (i = 0, j = 0; test; );
 # Input
 ```js
 for (; test; i++, j++);
+```
+
+# Input
+```js
+for (let i = 0, j = 1, k = 2; i < 100; i++, j++, k++) {}
 ```
 
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -78,6 +78,19 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   <TextField inputLabelProps="" InputLabelProps=""></TextField>
   ```
 
+- Fix [#138](https://github.com/biomejs/biome/issues/138)
+
+  [noCommaOperator](https://biomejs.dev/linter/rules/no-comma-operator/) now correctly ignores all use of comma operators inside the update part of a `for` loop.
+  The following code is now correctly ignored:
+
+  ```js
+  for (
+    let i = 0, j = 1, k = 2;
+    i < 100;
+    i++, j++, k++
+  ) {}
+  ```
+
 - Fix [rome#4713](https://github.com/rome/tools/issues/4713).
 
   Previously, [useTemplate](https://biomejs.dev/linter/rules/use-template/) made the following suggestion:


### PR DESCRIPTION
## Summary

Fix #138.

## Test Plan

New test included
