### PR TITLE
release: 1.1.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,9 @@ jobs:
         with:
           components: rustfmt
       - name: Run rustfmt
-        run: cargo fmt --all --verbose -- --check
+        run: |
+          cargo fmt --all --verbose -- --check
+          taplo format --check
 
   lint:
     name: Lint Rust Files

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run format
         run: |
           cargo fmt --all --check
-          taplo fmt -- --locked
+          taplo format --check
 
   lint:
     name: Lint Rust Files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ## Unreleased
 
+### Analyzer
 ### CLI
 ### Configuration
 ### Editors
@@ -18,6 +19,14 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 ### Linter
 ### Parser
 ### VSCode
+
+## 1.1.1 (2023-09-07)
+
+### Analyzer
+
+#### Bug fixes
+
+- The diagnostic for `// rome-ignore` suppression comment should not be a warning. A warning could block the CI, marking a gradual migration difficult. The code action that changes `// rome-ignore` to `// biome-ignore` is disabled as consequence.
 
 ## 1.1.0 (2023-09-06)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ inherits = "release"
 
 [workspace.dependencies]
 # Internal crates
+biome_lsp                   = { path = "./crates/biome_lsp" }
+biome_markup                = { version = "0.0.1", path = "./crates/biome_markup" }
+biome_test_utils            = { path = "./crates/biome_test_utils" }
 rome_analyze                = { path = "./crates/rome_analyze" }
 rome_aria                   = { path = "./crates/rome_aria" }
 rome_aria_metadata          = { path = "./crates/rome_aria_metadata" }
@@ -54,14 +57,11 @@ rome_json_factory           = { version = "0.2.0", path = "./crates/rome_json_fa
 rome_json_formatter         = { path = "./crates/rome_json_formatter" }
 rome_json_parser            = { path = "./crates/rome_json_parser" }
 rome_json_syntax            = { version = "0.2.0", path = "./crates/rome_json_syntax" }
-biome_lsp                    = { path = "./crates/biome_lsp" }
-biome_markup                 = { version = "0.0.1", path = "./crates/biome_markup" }
 rome_migrate                = { path = "./crates/rome_migrate" }
 rome_parser                 = { version = "0.2.0", path = "./crates/rome_parser" }
 rome_rowan                  = { version = "0.2.0", path = "./crates/rome_rowan" }
 rome_service                = { path = "./crates/rome_service" }
 rome_suppression            = { version = "0.2.0", path = "./crates/rome_suppression" }
-biome_test_utils             = { path = "./crates/biome_test_utils" }
 rome_text_edit              = { version = "0.0.1", path = "./crates/rome_text_edit" }
 rome_text_size              = { version = "0.0.1", path = "./crates/rome_text_size" }
 tests_macros                = { path = "./crates/tests_macros" }

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -46,7 +46,9 @@ pub use crate::syntax::{Ast, SyntaxVisitor};
 pub use crate::visitor::{NodeVisitor, Visitor, VisitorContext, VisitorFinishContext};
 
 use rome_console::markup;
-use rome_diagnostics::{category, Applicability, Diagnostic, DiagnosticExt, DiagnosticTags};
+use rome_diagnostics::{
+    category, Applicability, Diagnostic, DiagnosticExt, DiagnosticTags, Severity,
+};
 use rome_rowan::{
     AstNode, BatchMutation, Direction, Language, SyntaxElement, SyntaxToken, TextLen, TextRange,
     TextSize, TokenAtOffset, TriviaPiece, TriviaPieceKind, WalkEvent,
@@ -462,6 +464,7 @@ where
                         "// rome-ignore is deprecated, use // biome-ignore instead",
                     )
                     .with_tags(DiagnosticTags::DEPRECATED_CODE)
+                    .with_severity(Severity::Information)
                 })
                 .with_action(move || create_suppression_comment_action(token));
 

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow              = "1.0.52"
+biome_lsp           = { workspace = true }
 bpaf                = { workspace = true }
 crossbeam           = "0.8.1"
 dashmap             = { workspace = true }
@@ -29,7 +30,6 @@ rome_fs             = { workspace = true }
 rome_json_formatter = { workspace = true }
 rome_json_parser    = { workspace = true }
 rome_json_syntax    = { workspace = true }
-biome_lsp            = { workspace = true }
 rome_migrate        = { workspace = true }
 rome_rowan          = { workspace = true }
 rome_service        = { workspace = true }

--- a/crates/rome_cli/src/commands/daemon.rs
+++ b/crates/rome_cli/src/commands/daemon.rs
@@ -215,7 +215,7 @@ const SELF_FILTER: LevelFilter = if cfg!(debug_assertions) {
 impl LoggingFilter {
     fn is_enabled(&self, meta: &Metadata<'_>) -> bool {
         // TODO: keep "rome" until all internal crates are moved to "biome_"
-        let filter = if meta.target().starts_with("rome") {
+        let filter = if meta.target().starts_with("rome") || meta.target().starts_with("biome") {
             SELF_FILTER
         } else {
             LevelFilter::INFO

--- a/crates/rome_cli/tests/snapshots/main_commands_check/deprecated_suppression_comment.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/deprecated_suppression_comment.snap
@@ -25,7 +25,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 file.js:1:1 suppressions/deprecatedSuppressionComment  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! // rome-ignore is deprecated, use // biome-ignore instead
+  i // rome-ignore is deprecated, use // biome-ignore instead
   
   > 1 │ // rome-ignore lint(suspicious/noDoubleEquals): test
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/rome_cli/tests/snapshots/main_commands_lint/deprecated_suppression_comment.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_lint/deprecated_suppression_comment.snap
@@ -14,7 +14,7 @@ a == b;
 ```block
 file.js:1:1 suppressions/deprecatedSuppressionComment  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! // rome-ignore is deprecated, use // biome-ignore instead
+  i // rome-ignore is deprecated, use // biome-ignore instead
   
   > 1 │ // rome-ignore lint(suspicious/noDoubleEquals): test
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/rome_console/Cargo.toml
+++ b/crates/rome_console/Cargo.toml
@@ -11,7 +11,7 @@ version              = "0.0.1"
 
 [dependencies]
 atty           = { workspace = true }
-biome_markup    = { workspace = true }
+biome_markup   = { workspace = true }
 rome_text_size = { workspace = true }
 schemars       = { workspace = true, optional = true }
 serde          = { workspace = true, optional = true, features = ["derive"] }

--- a/crates/rome_js_analyze/Cargo.toml
+++ b/crates/rome_js_analyze/Cargo.toml
@@ -31,12 +31,12 @@ serde_json            = { workspace = true }
 smallvec              = { workspace = true }
 
 [dev-dependencies]
-countme         = { workspace = true, features = ["enable"] }
-insta           = { workspace = true, features = ["glob"] }
-rome_js_parser  = { workspace = true, features = ["tests"] }
 biome_test_utils = { workspace = true }
-rome_text_edit  = { workspace = true }
-tests_macros    = { workspace = true }
+countme          = { workspace = true, features = ["enable"] }
+insta            = { workspace = true, features = ["glob"] }
+rome_js_parser   = { workspace = true, features = ["tests"] }
+rome_text_edit   = { workspace = true }
+tests_macros     = { workspace = true }
 
 [features]
 schema = ["schemars", "rome_deserialize/schema"]

--- a/crates/rome_js_semantic/Cargo.toml
+++ b/crates/rome_js_semantic/Cargo.toml
@@ -15,7 +15,7 @@ rust-lapper    = "1.0.1"
 rustc-hash     = { workspace = true }
 
 [dev-dependencies]
+biome_markup     = { workspace = true }
 rome_console     = { workspace = true }
 rome_diagnostics = { workspace = true }
 rome_js_parser   = { workspace = true }
-biome_markup      = { workspace = true }

--- a/crates/rome_js_transform/Cargo.toml
+++ b/crates/rome_js_transform/Cargo.toml
@@ -19,9 +19,9 @@ rome_rowan       = { workspace = true }
 
 
 [dev-dependencies]
+biome_test_utils  = { workspace = true }
 insta             = { workspace = true }
 rome_analyze      = { workspace = true }
 rome_js_formatter = { workspace = true }
 rome_js_parser    = { workspace = true }
-biome_test_utils   = { workspace = true }
 tests_macros      = { workspace = true }

--- a/crates/rome_json_analyze/Cargo.toml
+++ b/crates/rome_json_analyze/Cargo.toml
@@ -17,9 +17,9 @@ rome_json_syntax = { workspace = true }
 rome_rowan       = { workspace = true }
 
 [dev-dependencies]
+biome_test_utils  = { workspace = true }
 insta             = { workspace = true, features = ["glob"] }
 rome_json_factory = { workspace = true }
 rome_json_parser  = { workspace = true }
 rome_service      = { workspace = true }
-biome_test_utils   = { workspace = true }
 tests_macros      = { workspace = true }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
 	"publisher": "biomejs",
 	"displayName": "Biome",
 	"description": "Biome LSP VS Code Extension",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"icon": "icon.png",
 	"activationEvents": [
 		"onLanguage:javascript",

--- a/packages/@biomejs/biome/package.json
+++ b/packages/@biomejs/biome/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@biomejs/biome",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "bin": "bin/biome",
     "scripts": {
         "postinstall": "node scripts/postinstall.js"

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -16,6 +16,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ## Unreleased
 
+### Analyzer
 ### CLI
 ### Configuration
 ### Editors
@@ -24,6 +25,14 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 ### Linter
 ### Parser
 ### VSCode
+
+## 1.1.1 (2023-09-07)
+
+### Analyzer
+
+#### Bug fixes
+
+- The diagnostic for `// rome-ignore` suppression comment should not be a warning. A warning could block the CI, marking a gradual migration difficult. The code action that changes `// rome-ignore` to `// biome-ignore` is disabled as consequence.
 
 ## 1.1.0 (2023-09-06)
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Emitting a diagnostic warning for `// rome-ignore` was a bad idea. Context: https://discord.com/channels/1132231889290285117/1149249347276517386

This PR downgrades the diagnostic to information severity. We lose the code action, but this fix won't block user's CI.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

`just ready`

Manually tested the LSP:

<img width="501" alt="Screenshot 2023-09-07 at 09 42 11" src="https://github.com/biomejs/biome/assets/602478/414b497e-b56c-47c2-a043-8179383c9321">


<!-- What demonstrates that your implementation is correct? -->
