### PR TITLE
chore: improve changelog generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,10 @@
+# Configure auto-generated GitHub Release Notes
+changelog:
+  exclude:
+    labels:
+      # Exclude PRs that are documented in `CHANGELOG.md`
+      - A-Changelog
+  categories:
+    - title: Other changes
+      labels:
+        - '*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,22 +17,29 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 ### Formatter
 ### JavaScript APIs
 ### Linter
+#### New features
+
+- Add [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type/) rule. The rule reports the unusual use of the `void` type. Contributed by [@shulandmimi](https://github.com/shulandmimi)
+
 #### Enhancements
 
-- [noFallthroughSwitchClause](https://biomejs.dev/linter/rules/no-fallthrough-switch-clause/) reports most of invalid codes.
+- [noFallthroughSwitchClause](https://biomejs.dev/linter/rules/no-fallthrough-switch-clause/) now relies on control flow analysis to report most of switch clause fallthrough. Contributed by [@Conaclos](https://github.com/Conaclos)
 
-  The rule now relies on control flow analysis and thus reports more complex case fallthrough.
-
-- [noUselessConstructor](https://biomejs.dev/linter/rules/no-useless-constructor/) no longer emits safe code fixes.
+- [noUselessConstructor](https://biomejs.dev/linter/rules/no-useless-constructor/) no longer emits safe code fixes. Contributed by [@Conaclos](https://github.com/Conaclos)
 
   All code fixes are now emitted as unsafe code fixes.
   Removing a constructor can change the behavior of a program.
 
+- [useCollapsedElseIf](https://biomejs.dev/linter/rules/use-collapsed-else-if/) now only provides safe code fixes. Contributed by [@Conaclos](https://github.com/Conaclos)
+
 #### Bug fixes
 
-- Fix [#182](https://github.com/biomejs/biome/issues/182), making [useLiteralKeys](https://biomejs.dev/linter/rules/use-literal-keys/) retains optional chaining.
-- Fix [#168](https://github.com/biomejs/biome/issues/168), fix [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) false positive case when stable hook is on a new line.
+- Fix [#182](https://github.com/biomejs/biome/issues/182), making [useLiteralKeys](https://biomejs.dev/linter/rules/use-literal-keys/) retains optional chaining. Contributed by [@denbezrukov](https://github.com/denbezrukov)
+
+- Fix [#168](https://github.com/biomejs/biome/issues/168), fix [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) false positive case when stable hook is on a new line. Contributed by [@denbezrukov](https://github.com/denbezrukov)
+
 - Fix [#137](https://github.com/biomejs/biome/issues/137), fix [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare/) false positive case with TypeScript module declaration:
+
   ```typescript
   declare module '*.gif' {
       const src: string;
@@ -43,6 +50,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   }
   ```
 
+  Contributed by [@denbezrukov](https://github.com/denbezrukov)
+
 ### Parser
 ### VSCode
 
@@ -52,7 +61,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Bug fixes
 
-- Fixed a case where an empty JSON file would cause the LSP server to crash.
+- Fix a case where an empty JSON file would cause the LSP server to crash. Contributed by [@ematipico](https://github.com/ematipico)
 
 ### Linter
 
@@ -72,10 +81,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   export * as MY_NAMESPACE from "./lib.js";
   ```
 
-- [noUselessConstructor](https://biomejs.dev/linter/rules/no-useless-constructor/) now ignores decorated classes and decorated parameters.
-  The rule now gives suggestions instead of safe fixes when parameters are annotated with types.
-
-- [useCollapsedElseIf](https://biomejs.dev/linter/rules/use-collapsed-else-if/) now only provides safe code fixes.
+- [noUselessConstructor](https://biomejs.dev/linter/rules/no-useless-constructor/) now ignores decorated classes and decorated parameters. The rule now gives suggestions instead of safe fixes when parameters are annotated with types. Contributed by [@Conaclos](https://github.com/Conaclos)
 
 ## 1.1.1 (2023-09-07)
 
@@ -83,7 +89,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Bug fixes
 
-- The diagnostic for `// rome-ignore` suppression comment should not be a warning. A warning could block the CI, marking a gradual migration difficult. The code action that changes `// rome-ignore` to `// biome-ignore` is disabled as consequence.
+- The diagnostic for `// rome-ignore` suppression comment should not be a warning. A warning could block the CI, marking a gradual migration difficult. The code action that changes `// rome-ignore` to `// biome-ignore` is disabled as consequence. Contributed by [@ematipico](https://github.com/ematipico).
 
 ## 1.1.0 (2023-09-06)
 
@@ -91,7 +97,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Enhancements
 
-- Add a code action to replace `rome-ignore` with `biome-ignore`. Use `biome check --apply-unsafe` to update all the comments. The action is not bulletproof, and it might generate unwanted code, that's why it's unsafe action.
+- Add a code action to replace `rome-ignore` with `biome-ignore`. Use `biome check --apply-unsafe` to update all the comments. The action is not bulletproof, and it might generate unwanted code, that's why it's unsafe action. Contributed by [@ematipico](https://github.com/ematipico)
 
 
 ### CLI
@@ -99,20 +105,19 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Enhancements
 
 - Biome now reports a diagnostics when a `rome.json` file is found.
-- `biome migrate --write` creates `biome.json` from `rome.json`, but it won't delete the `rome.json` file.
+- `biome migrate --write` creates `biome.json` from `rome.json`, but it won't delete the `rome.json` file. Contributed by [@ematipico](https://github.com/ematipico)
 
 #### Bug fixes
 
 - Biome uses `biome.json` first, then it attempts to use `rome.json`.
-- Fix a case where Biome couldn't compute correctly the ignored files when the VSC integration is enabled.
+- Fix a case where Biome couldn't compute correctly the ignored files when the VSC integration is enabled. Contributed by [@ematipico](https://github.com/ematipico)
 
 ### Configuration
 ### Editors
 
 #### Bug fixes
 
-- The LSP now uses its own socket and won't rely on Biome's socket. This fixes some cases where users were seeing
-multiple servers in the `rage` output.
+- The LSP now uses its own socket and won't rely on Biome's socket. This fixes some cases where users were seeing multiple servers in the `rage` output.
 
 ### Formatter
 
@@ -123,6 +128,10 @@ multiple servers in the `rage` output.
 
 ### JavaScript APIs
 ### Linter
+
+#### New features
+
+- Add [useCollapsedElseIf](https://biomejs.dev/linter/rules/use-collapsed-else-if/) rule. This new rule requires merging an `else` and an `if`, if the `if` statement is the only statement in the `else` block. Contributed by [@n-gude](https://github.com/n-gude)
 
 #### Enhancements
 
@@ -145,6 +154,8 @@ multiple servers in the `rage` output.
   + `\`${v}\``;
   ```
 
+  Contributed by [@Conaclos](https://github.com/Conaclos)
+
 - [useExponentiationOperator](https://biomejs.dev/linter/rules/use-exponentiation-operator/) suggests better code fixes.
 
   The rule now preserves any comment preceding the exponent,
@@ -156,7 +167,11 @@ multiple servers in the `rage` output.
   - Math.pow(a++, /**/ (2))
   + (a++) ** /**/ (2)
   ```
+
+  Contributed by [@Conaclos](https://github.com/Conaclos)
+
 - You can use `// biome-ignore` as suppression comment.
+
 - The `// rome-ignore` suppression is deprecated.
 
 #### Bug fixes
@@ -170,6 +185,8 @@ multiple servers in the `rage` output.
   <TextField inputLabelProps="" InputLabelProps=""></TextField>
   ```
 
+   Contributed by [@Conaclos](https://github.com/Conaclos)
+
 - Fix [#138](https://github.com/biomejs/biome/issues/138)
 
   [noCommaOperator](https://biomejs.dev/linter/rules/no-comma-operator/) now correctly ignores all use of comma operators inside the update part of a `for` loop.
@@ -182,6 +199,8 @@ multiple servers in the `rage` output.
     i++, j++, k++
   ) {}
   ```
+
+  Contributed by [@Conaclos](https://github.com/Conaclos)
 
 - Fix [rome#4713](https://github.com/rome/tools/issues/4713).
 
@@ -200,6 +219,8 @@ multiple servers in the `rage` output.
   - a + b + "px"
   + `${a + b}px`
    ```
+
+  Contributed by [@Conaclos](https://github.com/Conaclos)
 
 - Fix [rome#4109](https://github.com/rome/tools/issues/4109)
 
@@ -222,6 +243,8 @@ multiple servers in the `rage` output.
 
   As a sideeffect, the rule also suggests the removal of any inner comments.
 
+  Contributed by [@Conaclos](https://github.com/Conaclos)
+
 - Fix [rome#3850](https://github.com/rome/tools/issues/3850)
 
   Previously [useExponentiationOperator](https://biomejs.dev/linter/rules/use-exponentiation-operator/) suggested invalid code in a specific edge case:
@@ -238,13 +261,19 @@ multiple servers in the `rage` output.
   + 1 +(++a) ** 2
   ```
 
+  Contributed by [@Conaclos](https://github.com/Conaclos)
+
 - Fix [#106](https://github.com/biomejs/biome/issues/106)
 
   [noUndeclaredVariables](https://biomejs.dev/linter/rules/no-undeclared-variables/) now correctly recognizes some TypeScript types such as `Uppercase`.
 
+  Contributed by [@Conaclos](https://github.com/Conaclos)
+
 - Fix [rome#4616](https://github.com/rome/tools/issues/4616)
 
   Previously [noUnreachableSuper](https://biomejs.dev/linter/rules/no-unreacheable-super/) reported valid codes with complex nesting of control flow structures.
+
+  Contributed by [@Conaclos](https://github.com/Conaclos)
 
 ## 1.0.0 (2023-08-28)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,15 +260,16 @@ test(lint): add more cases to handle invalid rules
 ### Creating pull requests
 
 When creating a new pull request, it's preferable to use a conventional commit-formatted title, as this title will be used as the default commit message on the squashed commit after merging.
+See the [dedicated section](#Commit-messages) about conventional commit format.
 
 Please use the template provided.
 
 #### Changelog
 
-If the PR you're about to open is a bugfix/feature around Biome, you can add a new line to the `CHANGELOG.md`, but it's not mandatory.
+If the PR you're about to open is a bugfix/feature visible to Biome users, you CAN add a new bullet point to [CHANGELOG.md](./CHANGELOG.md). Although **not required**, we appreciate the effort.
 
-At the top of the file you will see a `Unreleased` section. The headings divide the sections by "feature", make sure
-to add a new bullet point.
+At the top of the file you will see a `Unreleased` section.
+The headings divide the sections by "scope"; you should be able to identify the scope that belongs to your change. If the change belongs to multiple scopes, you can copy the same sentence under those scopes.
 
 Here's a sample of the headings:
 
@@ -298,17 +299,37 @@ When you edit a blank section:
 
 - If your PR adds a **breaking change**, create a new heading called `#### BREAKING CHANGES` and add
   bullet point that explains the breaking changes; provide a migration path if possible.
-- If your PR adds a new feature of a fix, create a new heading called `#### Other changes` and
-  add a bullet point that explains the fix or the new feature. Make sure that this new heading
-  appears after the `#### BREAKING CHANGES` heading.
+  Read [how we version Biome](https://biomejs.dev/internals/versioning/) to determine if your change is breaking. A breaking change results in a major release.
+- If your PR adds a new feature, enhances an existing feature, or fixes a bug, create a new heading called `#### New features`, `#### Enhancements`, or `#### Bug fixes`. Ultimately, add a bullet point that explains the change.
+
+Make sure that the created subsections are ordered in the following order:
+
+```md
+#### BREAKING CHANGES
+
+#### New features
+
+#### Enhancements
+
+#### Bug fixes
+```
+
+Because the website displays the changelog, you should update the website using the following command:
+
+```sh
+just codegen-website
+```
 
 ##### Writing a changelog line
 
 - Use the present tense, e.g. "Add new feature", "Fix edge case".
 - If you fix a bug, please add the link to the issue, e.g. "Fix edge case [#4444]()".
+- You can add a mention `@user` for every contributor of the change.
 - Whenever applicable, add a code block to show your new changes. For example, for a new
   rule you might want to show an invalid case, for the formatter you might want to show
   how the new formatting changes, and so on.
+
+If in doubt, take a look to existing changelog lines.
 
 #### Documentation
 
@@ -346,3 +367,27 @@ Even minor versions are dedicated to official releases, e.g. `*.6.*`.
 ### Playground
 
 - [run the playground locally](/website/playground/README.md)
+
+## Releasing
+
+When releasing a new version of a Biome, follow these steps:
+
+1. [ ] Add a [changelog](./CHANGELOG.md) entry for every Pull Request that lacks one.
+   You can filter [merged PRs that don't update the changelog](https://github.com/biomejs/biome/pulls?q=is%3Apr+is%3Amerged+-label%3AA-Changelog).
+   Read our [guidelines for editing the changelog](#changelog).
+
+1. [ ] Based on the [changelog](./CHANGELOG.md), determine which version number to use.
+   See our [versioning guide](https://biomejs.dev/internals/versioning/) for more details.
+
+1. [ ] Rename `Unreleased` to `<version> (iso-date)` in the [changelog](./CHANGELOG.md).
+   Then update the website using `BIOME_VERSION=<version> cargo codegen-website`.
+
+1. [ ] Update `version` in [Biome's `package.json`](./packages/@biomejs/biome/package.json) if applicable.
+
+1. [ ] Update `version` in [Biome's LSP package.json](./editors/vscode/package.json) if applicable.
+   Note that the LSP follows a [distinct versioning scheme](https://biomejs.dev/internals/versioning/#visual-studio-code-extension).
+
+1. [ ] Linter rules have a `version` metadata directly defined in their implementation.
+   This field is set to `next` for newly created rules.
+   This field must be updated to the new version.
+   Then execute `just codegen-linter`.

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_confusing_void_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_confusing_void_type.rs
@@ -47,7 +47,7 @@ declare_rule! {
     /// printArg<void>(undefined);
     /// ```
     pub(crate) NoConfusingVoidType {
-        version: "1.0.0",
+        version: "next",
         name: "noConfusingVoidType",
         recommended: false,
     }

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_collapsed_else_if.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_collapsed_else_if.rs
@@ -83,7 +83,7 @@ declare_rule! {
     /// ```
     ///
     pub(crate) UseCollapsedElseIf {
-        version: "next",
+        version: "1.1.0",
         name: "useCollapsedElseIf",
         recommended: false,
     }

--- a/justfile
+++ b/justfile
@@ -37,6 +37,10 @@ codegen-linter:
   just codegen-bindings
   cargo lintdoc
 
+# Generates code generated files for the website
+codegen-website:
+  cargo codegen-website
+
 # Generates the linter documentation and Rust documentation
 documentation:
   cargo lintdoc

--- a/scripts/print-changelog.sh
+++ b/scripts/print-changelog.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eu
 
-# Print a changelog section (default: `Unreleased`).
+# Print a changelog section (default: first section).
 
-VERSION="Unreleased"
+VERSION=''
 
 if test -n "${1:-}" && grep -Eq "^## $1($| )" CHANGELOG.md; then
     # The specified version has a dedicated section in the changelog
@@ -11,4 +11,4 @@ if test -n "${1:-}" && grep -Eq "^## $1($| )" CHANGELOG.md; then
 fi
 
 # print Changelog of $VERSION
-awk -v version="$VERSION" '/^## / { if (p) { exit }; if ($2 == version) { p=1; next} } p' CHANGELOG.md
+awk -v version="$VERSION" '/^## / { if (p) { exit }; if (version == "" || $2 == version) { p=1; next} } p' CHANGELOG.md

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -23,22 +23,29 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 ### Formatter
 ### JavaScript APIs
 ### Linter
+#### New features
+
+- Add [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type/) rule. The rule reports the unusual use of the `void` type. Contributed by [@shulandmimi](https://github.com/shulandmimi)
+
 #### Enhancements
 
-- [noFallthroughSwitchClause](https://biomejs.dev/linter/rules/no-fallthrough-switch-clause/) reports most of invalid codes.
+- [noFallthroughSwitchClause](https://biomejs.dev/linter/rules/no-fallthrough-switch-clause/) now relies on control flow analysis to report most of switch clause fallthrough. Contributed by [@Conaclos](https://github.com/Conaclos)
 
-  The rule now relies on control flow analysis and thus reports more complex case fallthrough.
-
-- [noUselessConstructor](https://biomejs.dev/linter/rules/no-useless-constructor/) no longer emits safe code fixes.
+- [noUselessConstructor](https://biomejs.dev/linter/rules/no-useless-constructor/) no longer emits safe code fixes. Contributed by [@Conaclos](https://github.com/Conaclos)
 
   All code fixes are now emitted as unsafe code fixes.
   Removing a constructor can change the behavior of a program.
 
+- [useCollapsedElseIf](https://biomejs.dev/linter/rules/use-collapsed-else-if/) now only provides safe code fixes. Contributed by [@Conaclos](https://github.com/Conaclos)
+
 #### Bug fixes
 
-- Fix [#182](https://github.com/biomejs/biome/issues/182), making [useLiteralKeys](https://biomejs.dev/linter/rules/use-literal-keys/) retains optional chaining.
-- Fix [#168](https://github.com/biomejs/biome/issues/168), fix [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) false positive case when stable hook is on a new line.
+- Fix [#182](https://github.com/biomejs/biome/issues/182), making [useLiteralKeys](https://biomejs.dev/linter/rules/use-literal-keys/) retains optional chaining. Contributed by [@denbezrukov](https://github.com/denbezrukov)
+
+- Fix [#168](https://github.com/biomejs/biome/issues/168), fix [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) false positive case when stable hook is on a new line. Contributed by [@denbezrukov](https://github.com/denbezrukov)
+
 - Fix [#137](https://github.com/biomejs/biome/issues/137), fix [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare/) false positive case with TypeScript module declaration:
+
   ```typescript
   declare module '*.gif' {
       const src: string;
@@ -49,6 +56,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   }
   ```
 
+  Contributed by [@denbezrukov](https://github.com/denbezrukov)
+
 ### Parser
 ### VSCode
 
@@ -58,7 +67,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Bug fixes
 
-- Fixed a case where an empty JSON file would cause the LSP server to crash.
+- Fix a case where an empty JSON file would cause the LSP server to crash. Contributed by [@ematipico](https://github.com/ematipico)
 
 ### Linter
 
@@ -78,10 +87,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   export * as MY_NAMESPACE from "./lib.js";
   ```
 
-- [noUselessConstructor](https://biomejs.dev/linter/rules/no-useless-constructor/) now ignores decorated classes and decorated parameters.
-  The rule now gives suggestions instead of safe fixes when parameters are annotated with types.
-
-- [useCollapsedElseIf](https://biomejs.dev/linter/rules/use-collapsed-else-if/) now only provides safe code fixes.
+- [noUselessConstructor](https://biomejs.dev/linter/rules/no-useless-constructor/) now ignores decorated classes and decorated parameters. The rule now gives suggestions instead of safe fixes when parameters are annotated with types. Contributed by [@Conaclos](https://github.com/Conaclos)
 
 ## 1.1.1 (2023-09-07)
 
@@ -89,7 +95,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Bug fixes
 
-- The diagnostic for `// rome-ignore` suppression comment should not be a warning. A warning could block the CI, marking a gradual migration difficult. The code action that changes `// rome-ignore` to `// biome-ignore` is disabled as consequence.
+- The diagnostic for `// rome-ignore` suppression comment should not be a warning. A warning could block the CI, marking a gradual migration difficult. The code action that changes `// rome-ignore` to `// biome-ignore` is disabled as consequence. Contributed by [@ematipico](https://github.com/ematipico).
 
 ## 1.1.0 (2023-09-06)
 
@@ -97,7 +103,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Enhancements
 
-- Add a code action to replace `rome-ignore` with `biome-ignore`. Use `biome check --apply-unsafe` to update all the comments. The action is not bulletproof, and it might generate unwanted code, that's why it's unsafe action.
+- Add a code action to replace `rome-ignore` with `biome-ignore`. Use `biome check --apply-unsafe` to update all the comments. The action is not bulletproof, and it might generate unwanted code, that's why it's unsafe action. Contributed by [@ematipico](https://github.com/ematipico)
 
 
 ### CLI
@@ -105,20 +111,19 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Enhancements
 
 - Biome now reports a diagnostics when a `rome.json` file is found.
-- `biome migrate --write` creates `biome.json` from `rome.json`, but it won't delete the `rome.json` file.
+- `biome migrate --write` creates `biome.json` from `rome.json`, but it won't delete the `rome.json` file. Contributed by [@ematipico](https://github.com/ematipico)
 
 #### Bug fixes
 
 - Biome uses `biome.json` first, then it attempts to use `rome.json`.
-- Fix a case where Biome couldn't compute correctly the ignored files when the VSC integration is enabled.
+- Fix a case where Biome couldn't compute correctly the ignored files when the VSC integration is enabled. Contributed by [@ematipico](https://github.com/ematipico)
 
 ### Configuration
 ### Editors
 
 #### Bug fixes
 
-- The LSP now uses its own socket and won't rely on Biome's socket. This fixes some cases where users were seeing
-multiple servers in the `rage` output.
+- The LSP now uses its own socket and won't rely on Biome's socket. This fixes some cases where users were seeing multiple servers in the `rage` output.
 
 ### Formatter
 
@@ -129,6 +134,10 @@ multiple servers in the `rage` output.
 
 ### JavaScript APIs
 ### Linter
+
+#### New features
+
+- Add [useCollapsedElseIf](https://biomejs.dev/linter/rules/use-collapsed-else-if/) rule. This new rule requires merging an `else` and an `if`, if the `if` statement is the only statement in the `else` block. Contributed by [@n-gude](https://github.com/n-gude)
 
 #### Enhancements
 
@@ -151,6 +160,8 @@ multiple servers in the `rage` output.
   + `\`${v}\``;
   ```
 
+  Contributed by [@Conaclos](https://github.com/Conaclos)
+
 - [useExponentiationOperator](https://biomejs.dev/linter/rules/use-exponentiation-operator/) suggests better code fixes.
 
   The rule now preserves any comment preceding the exponent,
@@ -162,7 +173,11 @@ multiple servers in the `rage` output.
   - Math.pow(a++, /**/ (2))
   + (a++) ** /**/ (2)
   ```
+
+  Contributed by [@Conaclos](https://github.com/Conaclos)
+
 - You can use `// biome-ignore` as suppression comment.
+
 - The `// rome-ignore` suppression is deprecated.
 
 #### Bug fixes
@@ -176,6 +191,8 @@ multiple servers in the `rage` output.
   <TextField inputLabelProps="" InputLabelProps=""></TextField>
   ```
 
+   Contributed by [@Conaclos](https://github.com/Conaclos)
+
 - Fix [#138](https://github.com/biomejs/biome/issues/138)
 
   [noCommaOperator](https://biomejs.dev/linter/rules/no-comma-operator/) now correctly ignores all use of comma operators inside the update part of a `for` loop.
@@ -188,6 +205,8 @@ multiple servers in the `rage` output.
     i++, j++, k++
   ) {}
   ```
+
+  Contributed by [@Conaclos](https://github.com/Conaclos)
 
 - Fix [rome#4713](https://github.com/rome/tools/issues/4713).
 
@@ -206,6 +225,8 @@ multiple servers in the `rage` output.
   - a + b + "px"
   + `${a + b}px`
    ```
+
+  Contributed by [@Conaclos](https://github.com/Conaclos)
 
 - Fix [rome#4109](https://github.com/rome/tools/issues/4109)
 
@@ -228,6 +249,8 @@ multiple servers in the `rage` output.
 
   As a sideeffect, the rule also suggests the removal of any inner comments.
 
+  Contributed by [@Conaclos](https://github.com/Conaclos)
+
 - Fix [rome#3850](https://github.com/rome/tools/issues/3850)
 
   Previously [useExponentiationOperator](https://biomejs.dev/linter/rules/use-exponentiation-operator/) suggested invalid code in a specific edge case:
@@ -244,13 +267,19 @@ multiple servers in the `rage` output.
   + 1 +(++a) ** 2
   ```
 
+  Contributed by [@Conaclos](https://github.com/Conaclos)
+
 - Fix [#106](https://github.com/biomejs/biome/issues/106)
 
   [noUndeclaredVariables](https://biomejs.dev/linter/rules/no-undeclared-variables/) now correctly recognizes some TypeScript types such as `Uppercase`.
 
+  Contributed by [@Conaclos](https://github.com/Conaclos)
+
 - Fix [rome#4616](https://github.com/rome/tools/issues/4616)
 
   Previously [noUnreachableSuper](https://biomejs.dev/linter/rules/no-unreacheable-super/) reported valid codes with complex nesting of control flow structures.
+
+  Contributed by [@Conaclos](https://github.com/Conaclos)
 
 ## 1.0.0 (2023-08-28)
 

--- a/website/src/content/docs/linter/rules/no-confusing-void-type.md
+++ b/website/src/content/docs/linter/rules/no-confusing-void-type.md
@@ -1,5 +1,5 @@
 ---
-title: noConfusingVoidType (since v1.0.0)
+title: noConfusingVoidType (since vnext)
 ---
 
 

--- a/website/src/content/docs/linter/rules/use-collapsed-else-if.md
+++ b/website/src/content/docs/linter/rules/use-collapsed-else-if.md
@@ -1,5 +1,5 @@
 ---
-title: useCollapsedElseIf (since vnext)
+title: useCollapsedElseIf (since v1.1.0)
 ---
 
 


### PR DESCRIPTION
## Summary

This PR should improve the generation of release notes.
As before, we extract the changelog part of a release and append the generated GitHub notes. However, we now exclude all PRs labelled by `A-Changelog` ~or `S-Needs-changelog-update`~. The idea is to avoid including changelog entry already present in what we extracted.

To keep the computed Contributors section up-to-date, I propose adding who contributed to a change directly in the CHANGELOG. I updated some entries to give an example. If we decide to use this convention, I will update the rest of the CHANGELOG.

I updated the _changelog_ section of the CONTRIBUTING guide.   

I improved the script that extracts a changelog entry by always extracting the first section instead of looking for `Unreleased`. This should make the script more robust to potential typos.