### PR TITLE
chore: improve vscode extension debug dx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 .DS_Store
 Profile-*.json
 # Editor configuration
-.vscode
+.vscode/*
+!.vscode/extensions.json
+!.vscode/launch.json
+!.vscode/tasks.json
 .idea
 .vs
 # Release artifacts

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "nhedger.ts-esbuild-problem-matchers"
+    ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
-    "recommendations": [
-        "nhedger.ts-esbuild-problem-matchers"
-    ]
+	"recommendations": [
+		"nhedger.ts-esbuild-problem-matchers"
+	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "🧩 Debug Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--disable-extensions",
+				"--extensionDevelopmentKind=node",
+				"--extensionDevelopmentPath=${workspaceFolder}/editors/vscode"
+			],
+			"outFiles": ["${workspaceFolder}/out/**/*.js"],
+			"preLaunchTask": "npm: watch",
+			"sourceMapRenames": true
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,9 +6,9 @@
 			"script": "watch",
 			"isBackground": true,
 			"problemMatcher": "$ts-esbuild-watch",
-            "options": {
-                "cwd": "${workspaceFolder}/editors/vscode"
-            },
+			"options": {
+				"cwd": "${workspaceFolder}/editors/vscode"
+			},
 			"presentation": {
 				"echo": true,
 				"reveal": "always",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "watch",
+			"isBackground": true,
+			"problemMatcher": "$ts-esbuild-watch",
+            "options": {
+                "cwd": "${workspaceFolder}/editors/vscode"
+            },
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"showReuseMessage": false,
+				"clear": true
+			},
+			"group": "build"
+		}
+	]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,12 @@ When you apply changes to the binary, you need to do two things:
 When the daemon is running, it's possible to inspect its logs in the folder `biome-logs`, placed
 in the temporary folder of the operative system.
 
+### Debugging the VS Code extension
+
+The Biome VS Code extension can be debugged by running the `Debug Extension` launch configuration
+in VS Code. This will compile the extension, watch for modifications and start a separate VS Code
+instance with only the Biome extension installed.
+
 ### User files
 
 If files specific to your local development environment should be ignored, please add these files to a global git ignore file rather than to a git ignore file within Biome.


### PR DESCRIPTION
## Summary

This PR introduces a VS Code configuration that aims to improve the development experience of the Biome extension.

- [x] Adds a debug launch configuration
- [x] Adds a watch task that the debug launch depends on

https://github.com/biomejs/biome/assets/649677/302c8639-291c-49c8-a372-57ca4ef4a5ff

