### PR TITLE
Update configuration.mdx

### DIFF
--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -234,14 +234,14 @@ An array of Unix shell style patterns.
 
 ### `linter.rules.recommended`
 
-Enables the [recommended rules](/lint/rules) for all groups.
+Enables the [recommended rules](/linter/rules) for all groups.
 
 > Default: `true`
 
 
 ### `linter.rules.all`
 
-Enable or disable all [rules](/lint/rules) for all groups.
+Enable or disable all [rules](/linter/rules) for all groups.
 
 If `recommended` and `all` are both `true`, Biome will emit a diagnostic and fallback to its defaults.
 


### PR DESCRIPTION
## Summary

The original links to the linter configuration options return a 404 on transition, likely because of the route changes after the project rebrand

## Test Plan

Changing this in the live version immediately fixes the issue, and rebuilding the package locally confirms functionality
