### PR TITLE
fix(vscode): server bin path resolution

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -135,7 +135,7 @@
 	"license": "MIT",
 	"scripts": {
 		"compile": "esbuild src/main.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node --target=node14",
-		"watch": "pnpm run compile -- --sourcemap --watch",
+		"watch": "pnpm run compile --sourcemap --watch",
 		"package": "vsce package --no-dependencies -o biome_lsp.vsix",
 		"build": "pnpm run compile --minify && pnpm run package",
 		"install-extension": "code --install-extension biome_lsp.vsix --force",

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -363,6 +363,7 @@ async function getSocket(
 ): Promise<string> {
 	const process = spawn(command, ["__print_socket"], {
 		stdio: [null, "pipe", "pipe"],
+		shell: true,
 	});
 
 	const stdout = { content: "" };

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -243,14 +243,6 @@ async function getWorkspaceRelativePath(path: string) {
 async function getWorkspaceDependency(
 	outputChannel: OutputChannel,
 ): Promise<string | undefined> {
-	const packageName = PLATFORMS[process.platform]?.[process.arch]?.package;
-
-	const manifestName = `${packageName}/package.json`;
-	const binaryName =
-		process.platform === "win32"
-			? `${packageName}/biome.exe`
-			: `${packageName}/biome`;
-
 	for (const workspaceFolder of workspace.workspaceFolders) {
 		const path = Uri.joinPath(
 			workspaceFolder.uri,

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -265,7 +265,7 @@ async function getWorkspaceDependency(
 	}
 
 	window.showWarningMessage(
-		"Unable to resolve the biome server from your dependencies.",
+		"Unable to resolve the biome server from your dependencies. Make sure it's correctly installed, or untick the `requireConfiguration` setting to use the bundled binary.",
 	);
 
 	return undefined;

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -259,12 +259,14 @@ async function getWorkspaceDependency(
 			"biome",
 		);
 
-		if ((await fileExists(path))) {
+		if (await fileExists(path)) {
 			return path.fsPath;
 		}
 	}
 
-	window.showWarningMessage("Unable to resolve the biome server from your dependencies.");
+	window.showWarningMessage(
+		"Unable to resolve the biome server from your dependencies.",
+	);
 
 	return undefined;
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue where the VS Code extension cannot resolve the path to the biome CLI when using certain package managers, notably pnpm.

The new strategy is to point to the `node_modules/.bin/biome` path, which is consistent for all package managers.


## Test Plan

- [x] Tested working with npm on:
	- [x] macOS
	- [x] Windows
	- [x] Linux
- [x] Tested working with pnpm on:
	- [x] macOS
	- [x] Windows
	- [x] Linux
- [x] Tested working with yarn on:
	- [x] macOS
	- [x] Windows
	- [x] Linux
- [x] Tested working with bun on:
	- [x] macOS
	- [x] ~Windows~ (not applicable at the moment)
	- [x] Linux

---

I'd like some help to test under Windows, I don't have a machine handy.