### PR TITLE
fix(analyzer): useExhaustiveDependencies error when useState is on a new line #168

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Fix [#182](https://github.com/biomejs/biome/issues/182), making [useLiteralKeys](https://biomejs.dev/linter/rules/use-literal-keys/) retains optional chaining.
-- Fix [#168](https://github.com/biomejs/biome/issues/168), fix [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) false positive case  when stable hook is on a new line.
+- Fix [#168](https://github.com/biomejs/biome/issues/168), fix [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) false positive case when stable hook is on a new line.
 
 ### Parser
 ### VSCode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Fix [#182](https://github.com/biomejs/biome/issues/182), making [useLiteralKeys](https://biomejs.dev/linter/rules/use-literal-keys/) retains optional chaining.
+- Fix [#168](https://github.com/biomejs/biome/issues/168), fix [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) false positive case  when stable hook is on a new line.
 
 ### Parser
 ### VSCode

--- a/crates/rome_js_analyze/src/react/hooks.rs
+++ b/crates/rome_js_analyze/src/react/hooks.rs
@@ -12,6 +12,7 @@ use biome_rowan::AstNode;
 use serde::{Deserialize, Serialize};
 
 /// Return result of [react_hook_with_dependency].
+#[derive(Debug)]
 pub(crate) struct ReactCallWithDependencyResult {
     pub(crate) function_name_range: TextRange,
     pub(crate) closure_node: Option<AnyJsExpression>,
@@ -243,7 +244,7 @@ pub fn is_binding_react_stable(
                 .ok()?
                 .value_token()
                 .ok()?
-                .token_text();
+                .token_text_trimmed();
 
             let stable = StableReactHookConfiguration {
                 hook_name: hook_name.to_string(),

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/newline.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/newline.js
@@ -1,0 +1,14 @@
+import { useState, useEffect } from 'react';
+
+export const OtherComponent = () => {
+	const [stringContent, setString] =
+		useState('Something');
+
+	useEffect(() => {
+		setString((content) => {
+			return `${content} other`;
+		});
+	}, []);
+
+	return stringContent;
+};

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/newline.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/newline.js.snap
@@ -4,6 +4,8 @@ expression: newline.js
 ---
 # Input
 ```js
+import { useState, useEffect } from 'react';
+
 export const OtherComponent = () => {
 	const [stringContent, setString] =
 		useState('Something');

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/newline.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/newline.js.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: newline.js
+---
+# Input
+```js
+export const OtherComponent = () => {
+	const [stringContent, setString] =
+		useState('Something');
+
+	useEffect(() => {
+		setString((content) => {
+			return `${content} other`;
+		});
+	}, []);
+
+	return stringContent;
+};
+
+```
+
+

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -32,6 +32,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Fix [#182](https://github.com/biomejs/biome/issues/182), making [useLiteralKeys](https://biomejs.dev/linter/rules/use-literal-keys/) retains optional chaining.
+- Fix [#168](https://github.com/biomejs/biome/issues/168), fix [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) false positive case when stable hook is on a new line.
 
 ### Parser
 ### VSCode


### PR DESCRIPTION

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fix #168

## Test Plan

`cargo test -p rome_js_analyze`
