### PR TITLE
fix(lint/noConfusingVoidType): separate invalid examples

### DIFF
--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -123,7 +123,7 @@ impl SemanticEvent {
     }
 }
 
-/// Extracts [SemanticEvent] from [SyntaxNode].
+/// Extracts [SemanticEvent] from [JsSyntaxNode].
 ///
 /// The extraction is not entirely pull based, nor entirely push based.
 /// This happens because some nodes can generate multiple events.
@@ -134,7 +134,7 @@ impl SemanticEvent {
 /// For a simpler way to extract [SemanticEvent] see [semantic_events] or [SemanticEventIterator].
 ///
 /// To use the [SemanticEventExtractor] one must push the current node, following
-/// the [PreOrder] of the tree, and must pull events until [Pop] returns [None].
+/// the pre-order of the tree, and must pull events until `pop` returns [None].
 ///
 /// ```rust
 /// use biome_js_parser::*;
@@ -1033,7 +1033,7 @@ impl Iterator for SemanticEventIterator {
     }
 }
 
-/// Extracts [SemanticEvent] from [SyntaxNode].
+/// Extracts [SemanticEvent] from [JsSyntaxNode].
 ///
 /// For a way to extract [SemanticEvent] which gives more control see [SemanticEventExtractor].
 ///

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -3,10 +3,10 @@ use biome_js_syntax::{AnyJsRoot, JsSyntaxNode, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::hash_map::Entry;
 
-/// Builds the [SemanticModel] consuming [SemanticEvent] and [SyntaxNode].
+/// Builds the [SemanticModel] consuming [SemanticEvent] and [JsSyntaxNode].
 /// For a good example on how to use it see [semantic_model].
 ///
-/// [SemanticModelBuilder] consumes all the [SemanticEvents] and build all the
+/// [SemanticModelBuilder] consumes all the [SemanticEvent] and build all the
 /// data necessary to build a [SemanticModelData], that is allocated with an [Arc]
 /// and stored inside the [SemanticModel].
 pub struct SemanticModelBuilder {

--- a/crates/biome_js_semantic/src/semantic_model/model.rs
+++ b/crates/biome_js_semantic/src/semantic_model/model.rs
@@ -102,7 +102,7 @@ impl PartialEq for SemanticModelData {
 impl Eq for SemanticModelData {}
 
 /// The façade for all semantic information.
-/// - Scope: [scope]
+/// - Scope: [Scope]
 /// - Declarations: [declaration]
 ///
 /// See [SemanticModelData] for more information about the internals.
@@ -338,7 +338,7 @@ impl SemanticModel {
         }
     }
 
-    /// Returns all [Call] of a [AnyJsFunction].
+    /// Returns all [FunctionCall] of a [AnyJsFunction].
     ///
     /// ```rust
     /// use biome_js_parser::JsParserOptions;

--- a/crates/biome_js_semantic/src/semantic_model/reference.rs
+++ b/crates/biome_js_semantic/src/semantic_model/reference.rs
@@ -102,7 +102,7 @@ impl Reference {
         matches!(reference.ty, SemanticModelReferenceType::Write { .. })
     }
 
-    /// Returns this reference as a [Call] if possible
+    /// Returns this reference as a [FunctionCall] if possible
     pub fn as_call(&self) -> Option<FunctionCall> {
         let call = self.syntax().ancestors().find(|x| {
             !matches!(

--- a/crates/biome_js_semantic/src/semantic_model/scope.rs
+++ b/crates/biome_js_semantic/src/semantic_model/scope.rs
@@ -97,7 +97,7 @@ impl Scope {
     }
 
     /// Checks if the current scope is one of the ancestor of "other". Given
-    /// that [ancestors] return "self" as the first scope,
+    /// that [Scope::ancestors] return "self" as the first scope,
     /// this function returns true for:
     ///
     /// ```rust,ignore
@@ -205,11 +205,11 @@ impl FusedIterator for ScopeBindingsIter {}
 /// get its [Scope].
 pub trait SemanticScopeExtensions {
     /// Returns the [Scope] which this object is part of.
-    /// See [scope](semantic_model::SemanticModel::scope)
+    /// See [scope](crate::SemanticModel::scope)
     fn scope(&self, model: &SemanticModel) -> Scope;
 
     /// Returns the [Scope] which this object was hosted to, if any.
-    /// See [scope](semantic_model::SemanticModel::scope_hoisted_to)
+    /// See [scope](crate::SemanticModel::scope_hoisted_to)
     fn scope_hoisted_to(&self, model: &SemanticModel) -> Option<Scope>;
 }
 

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_confusing_void_type.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_confusing_void_type.rs
@@ -4,7 +4,6 @@ use biome_js_syntax::{AnyTsType, JsSyntaxKind};
 use biome_rowan::{AstNode, SyntaxNode};
 
 declare_rule! {
-    ///
     /// Disallow `void` type outside of generic or return types.
     ///
     /// `void` in TypeScript refers to a function return that is meant to be ignored. Attempting to use a void type outside of a return type or generic type argument is often a sign of programmer error. void can also be misleading for other developers even if used correctly.
@@ -16,8 +15,7 @@ declare_rule! {
     /// ### Invalid
     ///
     /// ```ts,expect_diagnostic
-    /// type PossibleValues = number | void;
-    /// type MorePossibleValues = string | ((number & any) | (string | void));
+    /// let foo: void;
     /// ```
     ///
     /// ```ts,expect_diagnostic
@@ -31,22 +29,23 @@ declare_rule! {
     /// ```
     ///
     /// ```ts,expect_diagnostic
-    /// let foo: void;
-    /// let bar = 1 as unknown as void;
-    /// let baz = 1 as unknown as void | string;
+    /// type PossibleValues = number | void;
     /// ```
     ///
     /// ### Valid
     ///
     /// ```ts
     /// function foo(): void {};
-    /// function doSomething(this: void) {}
-    /// function printArg<T = void>(arg: T) {}
-    /// logAndReturn<void>(undefined);
-    /// let voidPromise: Promise<void> = new Promise<void>(() => { });
-    /// let voidMap: Map<string, void> = new Map<string, void>();
     /// ```
     ///
+    /// ```ts
+    /// function doSomething(this: void) {}
+    /// ```
+    ///
+    /// ```ts
+    /// function printArg<T = void>(arg: T) {}
+    /// printArg<void>(undefined);
+    /// ```
     pub(crate) NoConfusingVoidType {
         version: "1.0.0",
         name: "noConfusingVoidType",

--- a/website/src/content/docs/linter/rules/no-confusing-void-type.md
+++ b/website/src/content/docs/linter/rules/no-confusing-void-type.md
@@ -16,27 +16,16 @@ If you think you need this then you probably want the undefined type instead.
 ### Invalid
 
 ```ts
-type PossibleValues = number | void;
-type MorePossibleValues = string | ((number & any) | (string | void));
+let foo: void;
 ```
 
-<pre class="language-text"><code class="language-text">nursery/noConfusingVoidType.js:1:32 <a href="https://biomejs.dev/linter/rules/no-confusing-void-type">lint/nursery/noConfusingVoidType</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+<pre class="language-text"><code class="language-text">nursery/noConfusingVoidType.js:1:10 <a href="https://biomejs.dev/linter/rules/no-confusing-void-type">lint/nursery/noConfusingVoidType</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">void is not valid as a constituent in a union type</span>
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">void is only valid as a return type or a type argument in generic type</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>type PossibleValues = number | void;
-   <strong>   │ </strong>                               <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>2 │ </strong>type MorePossibleValues = string | ((number &amp; any) | (string | void));
-    <strong>3 │ </strong>
-  
-nursery/noConfusingVoidType.js:2:64 <a href="https://biomejs.dev/linter/rules/no-confusing-void-type">lint/nursery/noConfusingVoidType</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">void is not valid as a constituent in a union type</span>
-  
-    <strong>1 │ </strong>type PossibleValues = number | void;
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>type MorePossibleValues = string | ((number &amp; any) | (string | void));
-   <strong>   │ </strong>                                                               <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>3 │ </strong>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>let foo: void;
+   <strong>   │ </strong>         <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
   
 </code></pre>
 
@@ -73,29 +62,16 @@ interface Interface {
 </code></pre>
 
 ```ts
-let foo: void;
-let bar = 1 as unknown as void;
-let baz = 1 as unknown as void | string;
+type PossibleValues = number | void;
 ```
 
-<pre class="language-text"><code class="language-text">nursery/noConfusingVoidType.js:1:10 <a href="https://biomejs.dev/linter/rules/no-confusing-void-type">lint/nursery/noConfusingVoidType</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+<pre class="language-text"><code class="language-text">nursery/noConfusingVoidType.js:1:32 <a href="https://biomejs.dev/linter/rules/no-confusing-void-type">lint/nursery/noConfusingVoidType</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">void is only valid as a return type or a type argument in generic type</span>
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">void is not valid as a constituent in a union type</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>let foo: void;
-   <strong>   │ </strong>         <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>2 │ </strong>let bar = 1 as unknown as void;
-    <strong>3 │ </strong>let baz = 1 as unknown as void | string;
-  
-nursery/noConfusingVoidType.js:2:27 <a href="https://biomejs.dev/linter/rules/no-confusing-void-type">lint/nursery/noConfusingVoidType</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">void is only valid as a return type or a type argument in generic type</span>
-  
-    <strong>1 │ </strong>let foo: void;
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>let bar = 1 as unknown as void;
-   <strong>   │ </strong>                          <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>3 │ </strong>let baz = 1 as unknown as void | string;
-    <strong>4 │ </strong>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>type PossibleValues = number | void;
+   <strong>   │ </strong>                               <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
   
 </code></pre>
 
@@ -103,11 +79,15 @@ nursery/noConfusingVoidType.js:2:27 <a href="https://biomejs.dev/linter/rules/no
 
 ```ts
 function foo(): void {};
+```
+
+```ts
 function doSomething(this: void) {}
+```
+
+```ts
 function printArg<T = void>(arg: T) {}
-logAndReturn<void>(undefined);
-let voidPromise: Promise<void> = new Promise<void>(() => { });
-let voidMap: Map<string, void> = new Map<string, void>();
+printArg<void>(undefined);
 ```
 
 ## Related links


### PR DESCRIPTION
## Summary

Fix #222