### PR TITLE
feat(vscode): lower minimum engine version to `1.80.0`

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -15,14 +15,14 @@
 			"devDependencies": {
 				"@types/node": "^18.17.5",
 				"@types/resolve": "^1.20.2",
-				"@types/vscode": "^1.81.0",
+				"@types/vscode": "^1.80.0",
 				"@vscode/vsce": "^2.20.1",
 				"esbuild": "^0.19.2",
 				"typescript": "^5.1.6"
 			},
 			"engines": {
 				"npm": "^9",
-				"vscode": "^1.81.0"
+				"vscode": "^1.80.0"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -24,7 +24,7 @@
 		"url": "https://github.com/biomejs/biome/issues"
 	},
 	"engines": {
-		"vscode": "^1.81.0",
+		"vscode": "^1.80.0",
 		"npm": "^9"
 	},
 	"capabilities": {
@@ -149,10 +149,10 @@
 	"devDependencies": {
 		"@types/node": "^18.17.5",
 		"@types/resolve": "^1.20.2",
-		"@types/vscode": "^1.81.0",
+		"@types/vscode": "^1.80.0",
+		"@vscode/vsce": "^2.20.1",
 		"esbuild": "^0.19.2",
-		"typescript": "^5.1.6",
-		"@vscode/vsce": "^2.20.1"
+		"typescript": "^5.1.6"
 	},
 	"dependencies": {
 		"resolve": "^1.22.4",


### PR DESCRIPTION

## Summary

As discussed in https://github.com/biomejs/biome/discussions/230.

This PR lowers the minimal engine version for the VS Code extension to `1.80.0`.
