### PR TITLE
fix(biome-lsp): only filter quickactions when action category is 'quickfix.biome'

### DIFF
--- a/crates/biome_lsp/src/handlers/analysis.rs
+++ b/crates/biome_lsp/src/handlers/analysis.rs
@@ -61,7 +61,7 @@ pub(crate) fn code_actions(
             let kind = kind.as_str();
             if FIX_ALL_CATEGORY.matches(kind) {
                 has_fix_all = true;
-            } else if ActionCategory::QuickFix.matches(kind) {
+            } else if ActionCategory::QuickFix.to_str() == kind {
                 // The action is a on-save quick-fixes
                 has_quick_fix = true;
             }


### PR DESCRIPTION
## Summary

This PR resolves an issue that was blocking #185 

As biome_lsp only need to avoid unsafe fixes when the code action is on-save quick-fixes, I changed the logic a little, to check if the value is 'quickfix.biome' instead of 'quickfix'

Now Intellij can pull all actions of kind 'quickfix' and vscode will not apply unsafe fixes on-save

## Test Plan

- [x] Added some tests for quickfix.biome CodeActionKind
- [x] Tested manually on VSCode
- [x] Tested manually on IntelliJ
