### PR TITLE
ci(release_lsp): fix extension packaging

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -156,5 +156,8 @@
 	"dependencies": {
 		"resolve": "^1.22.4",
 		"vscode-languageclient": "^8.1.0"
+	},
+	"vsce": {
+		"dependencies": false
 	}
 }


### PR DESCRIPTION
## Summary

Related to #249 

I forgot to add the `--no-dependencies` flag to the build script in the CI.

To fix this globally, I've set the setting in the `vsce` key of the extension's `package.json`

## Test Plan

I ran the [pipeline](https://github.com/nhedger/biome/actions/runs/6159195934) on my fork
