### PR TITLE
ci: update workflow deps and cancel jobs on PR update

### DIFF
--- a/.github/workflows/bench_analyzer.yml
+++ b/.github/workflows/bench_analyzer.yml
@@ -1,5 +1,5 @@
-# Parser benchmark, compares main and PR branch with Criterion.
-# Comment with text containing `!bench`, a new result will be commented at the bottom of this PR.
+# Analyzer benchmark, compares main and PR branch with Criterion.
+# Comment with text containing `!bench_analyzer`, a new result will be commented at the bottom of this PR.
 
 name: Analyzer Benchmark
 
@@ -29,13 +29,12 @@ jobs:
             return response.data.head.sha;
 
       - name: Checkout PR Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          submodules: false
           ref: ${{ steps.sha.outputs.result }}
 
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
 
       - name: Install critcmp
         run: cargo install critcmp
@@ -47,7 +46,7 @@ jobs:
         run: cargo bench_analyzer --save-baseline pr
 
       - name: Checkout Main Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           clean: false
           ref: main

--- a/.github/workflows/bench_cli.yml
+++ b/.github/workflows/bench_cli.yml
@@ -29,13 +29,12 @@ jobs:
             return response.data.head.sha;
 
       - name: Checkout PR Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          submodules: false
           ref: ${{ steps.sha.outputs.result }}
 
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
 
       - name: Install hyperfine
         run: cargo install hyperfine
@@ -47,7 +46,7 @@ jobs:
           cp target/release/biome benchmark/target/biome_pr
 
       - name: Checkout Main Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           clean: false
           ref: main
@@ -58,17 +57,17 @@ jobs:
           cp target/release/biome benchmark/target/biome_main
 
       - name: Checkout webpack
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: webpack/webpack
           path: benchmark/target/webpack
       - name: Checkout prettier
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: prettier/prettier
           path: benchmark/target/prettier
       - name: Checkout eslint
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: eslint/eslint
           path: benchmark/target/eslint

--- a/.github/workflows/bench_formatter.yml
+++ b/.github/workflows/bench_formatter.yml
@@ -1,5 +1,5 @@
-# Parser benchmark, compares main and PR branch with Criterion.
-# Comment with text containing `!bench`, a new result will be commented at the bottom of this PR.
+# Formatter benchmark, compares main and PR branch with Criterion.
+# Comment with text containing `!bench_formatter`, a new result will be commented at the bottom of this PR.
 
 name: Formatter Benchmark
 
@@ -29,13 +29,12 @@ jobs:
             return response.data.head.sha;
 
       - name: Checkout PR Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          submodules: false
           ref: ${{ steps.sha.outputs.result }}
 
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
 
       - name: Install critcmp
         run: cargo install critcmp
@@ -47,7 +46,7 @@ jobs:
         run: cargo bench_formatter --save-baseline pr
 
       - name: Checkout Main Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           clean: false
           ref: main

--- a/.github/workflows/bench_parser.yml
+++ b/.github/workflows/bench_parser.yml
@@ -1,5 +1,5 @@
 # Parser benchmark, compares main and PR branch with Criterion.
-# Comment with text containing `!bench`, a new result will be commented at the bottom of this PR.
+# Comment with text containing `!bench_parser`, a new result will be commented at the bottom of this PR.
 
 name: Parser Benchmark
 
@@ -28,13 +28,12 @@ jobs:
             const response = await github.request(context.payload.issue.pull_request.url);
             return response.data.head.sha;
       - name: Checkout PR Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          submodules: false
           ref: ${{ steps.sha.outputs.result }}
 
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
 
       - name: Install critcmp
         run: cargo install critcmp
@@ -46,7 +45,7 @@ jobs:
         run: cargo bench_parser --save-baseline pr
 
       - name: Checkout Main Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           clean: false
           ref: main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,16 +19,14 @@ jobs:
     name: Format Rust Files
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR Branch
-        uses: actions/checkout@v3
-        with:
-          submodules: false
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Support longpaths
         run: git config core.longpaths true
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
         with:
           components: rustfmt
           bins: taplo-cli
@@ -42,9 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
         with:
           components: clippy
       - name: Run cargo check
@@ -56,12 +54,10 @@ jobs:
     name: Check Dependencies
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR Branch
-        uses: actions/checkout@v3
-        with:
-          submodules: false
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
         with:
           channel: nightly
       - name: Install udeps
@@ -69,22 +65,20 @@ jobs:
       - name: Run udeps
         run: cargo +nightly udeps
 
-
   test:
+    name: Test
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
           - os: windows-latest
           - os: ubuntu-latest
           - os: macos-latest
-
-    name: Test
-    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
         with:
           bins: cargo-nextest
       - name: Run tests on ${{ matrix.os }}
@@ -95,23 +89,21 @@ jobs:
   coverage:
     name: Test262 Coverage
     runs-on: ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-
     steps:
       # ref: https://github.com/orgs/community/discussions/26952
       - name: Support longpaths
         if: matrix.os == 'windows-latest'
         run: git config --system core.longpaths true
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
       - name: Compile
         run: cargo build --release --locked -p xtask_coverage
       - name: Run Test262 suite

--- a/.github/workflows/parser_conformance.yml
+++ b/.github/workflows/parser_conformance.yml
@@ -21,29 +21,22 @@ jobs:
     permissions:
       pull-requests: write
     name: Parser conformance
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest ]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout PR Branch
-        uses: actions/checkout@v3
-        with:
-          submodules: false
+        uses: actions/checkout@v4
 
       - name: Support longpaths
         run: git config core.longpaths true
 
       - name: Checkout PR Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
 
       - name: Compile
         run: cargo build --release --locked -p xtask_coverage
@@ -53,7 +46,7 @@ jobs:
         run: cargo coverage --json > new_results.json
 
       - name: Checkout main Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           clean: false
           ref: main
@@ -74,7 +67,6 @@ jobs:
           echo "comment<<EOF" >> $GITHUB_OUTPUT
           cat output >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-
 
       - name: Get the PR number
         if: github.event_name == 'pull_request'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,19 +13,24 @@ on:
       - 'rust-toolchain.toml'
       - 'rustfmt.toml'
 
+# Cancel jobs when the PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   RUST_LOG: info
   RUST_BACKTRACE: 1
 
 jobs:
   format:
-    name: Format Rust Files
+    name: Format and Lint Rust Files
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
         with:
           components: rustfmt
           bins: taplo-cli
@@ -39,14 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR Branch
-        uses: actions/checkout@v3
-        with:
-          submodules: false
+        uses: actions/checkout@v4
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
         with:
           components: clippy
-      - name: Run cargo check
+      - name: Run clippy
         run: cargo lint
 
   check-dependencies:
@@ -54,32 +57,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR Branch
-        uses: actions/checkout@v3
-        with:
-          submodules: false
+        uses: actions/checkout@v4
       - name: Install toolchain
         run:  rustup toolchain install nightly
       - name: Install udeps
         run: cargo install cargo-udeps --locked
-      - name: Run udeps
+      - name: Detect unused dependencies using udeps
         run: cargo +nightly udeps
 
-
   test:
+    name: Test
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
           - os: windows-latest
           - os: ubuntu-latest
-
-    name: Test
-    runs-on: ${{ matrix.os }}
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
         with:
           bins: cargo-nextest
       - name: Run tests
@@ -90,12 +88,11 @@ jobs:
   fuzz-all:
     name: Build and init fuzzers
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
         with:
           bins: cargo-fuzz
       - name: Run init-fuzzer
@@ -104,16 +101,13 @@ jobs:
   test-node-api:
     name: Test node.js API
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
       - name: Build main binary
         run: cargo build -p biome_cli --release
-
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
@@ -150,22 +144,21 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
       - name: Run doc command
         run: cargo documentation
 
   codegen:
     name: Codegen
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
       - name: Run the grammar codegen
         run: cargo codegen grammar
       - name: Run the analyzer codegen

--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -8,8 +8,13 @@ on:
     paths: # Only run when changes are made to js code
       - 'website/**'
       - 'editors/**'
-#      - 'crates/**'
+#     - 'crates/**'
       - 'packages/@biomejs/js-api/**'
+
+# Cancel jobs when the PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 env:
   RUST_LOG: info
@@ -21,18 +26,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-
+        uses: actions/checkout@v4
       - name: Run Biome Format
         run: cargo biome-cli-dev ci editors website packages/@biomejs/js-api
+
   type-check:
     name: Type-check JS Files
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR Branch
-        uses: actions/checkout@v3
-        with:
-          submodules: false
+        uses: actions/checkout@v4
       - uses: jetli/wasm-pack-action@v0.4.0
       - name: Cache pnpm modules
         uses: actions/cache@v3
@@ -45,7 +48,7 @@ jobs:
         with:
           version: 8
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
       - name: Build WASM module for the web
         run: wasm-pack build --out-dir ../../packages/@biomejs/wasm-web --target web --scope biomedev crates/biome_wasm
       - name: Install libraries

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -19,7 +19,7 @@ jobs:
       nightly: ${{ env.nightly }}
       version_changed: ${{ steps.version.outputs.changed }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check nightly status
         id: nightly
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -138,7 +138,7 @@ jobs:
     needs: check
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -171,7 +171,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download CLI artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/release_js_api.yml
+++ b/.github/workflows/release_js_api.yml
@@ -19,7 +19,7 @@ jobs:
       nightly: ${{ env.nightly }}
       version_changed: ${{ steps.version.outputs.changed }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check nightly status
         id: nightly
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -123,7 +123,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download package artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/release_lsp.yml
+++ b/.github/workflows/release_lsp.yml
@@ -23,7 +23,7 @@ jobs:
       nightly: ${{ env.nightly }}
       version_changed: ${{ steps.version.outputs.changed }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check nightly status
         id: nightly
@@ -105,10 +105,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
         with:
           targets: ${{ matrix.target }}
 
@@ -194,7 +194,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download extension artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -24,9 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR Branch
-        uses: actions/checkout@v3
-        with:
-          submodules: false
+        uses: actions/checkout@v4
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
         with:
@@ -42,7 +40,7 @@ jobs:
         with:
           version: 8
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
       - name: Install libraries
         working-directory: packages/@biomejs/js-api
         run: pnpm i

--- a/.github/workflows/website_deploy_preview.yml
+++ b/.github/workflows/website_deploy_preview.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - main
+# Cancel jobs when the PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 jobs:
   preview-deploy:
     runs-on: ubuntu-latest
@@ -13,7 +17,7 @@ jobs:
     # Check if the event is not triggered by a fork
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -30,7 +34,7 @@ jobs:
         with:
           version: 8
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
         with:

--- a/.github/workflows/website_deploy_prod.yml
+++ b/.github/workflows/website_deploy_prod.yml
@@ -12,7 +12,7 @@ jobs:
     environment: Website deployment
     if: ${{ github.repository_owner == 'biomejs' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -29,7 +29,7 @@ jobs:
         with:
           version: 8
       - name: Install toolchain
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
         with:


### PR DESCRIPTION
## Summary

- Upgrade action versions
- remove settings set to their default
- cancel current jobs when a PR is updated (hopefully freeing some runners)
- deploy website only when the `website` folder is changed

## Test Plan

CI