### PR TITLE
fix(cli): set the right name for binary executable

### DIFF
--- a/packages/@biomejs/backend-jsonrpc/src/command.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/command.ts
@@ -14,16 +14,16 @@ export function getCommand(): string | null {
 
 	const PLATFORMS: PlatformPaths = {
 		win32: {
-			x64: "@biomejs/cli-win32-x64/rome.exe",
-			arm64: "@biomejs/cli-win32-arm64/rome.exe",
+			x64: "@biomejs/cli-win32-x64/biome.exe",
+			arm64: "@biomejs/cli-win32-arm64/biome.exe",
 		},
 		darwin: {
-			x64: "@biomejs/cli-darwin-x64/rome",
-			arm64: "@biomejs/cli-darwin-arm64/rome",
+			x64: "@biomejs/cli-darwin-x64/biome",
+			arm64: "@biomejs/cli-darwin-arm64/biome",
 		},
 		linux: {
-			x64: "@biomejs/cli-linux-x64/rome",
-			arm64: "@biomejs/cli-linux-arm64/rome",
+			x64: "@biomejs/cli-linux-x64/biome",
+			arm64: "@biomejs/cli-linux-arm64/biome",
 		},
 	};
 

--- a/packages/@biomejs/biome/scripts/postinstall.js
+++ b/packages/@biomejs/biome/scripts/postinstall.js
@@ -2,16 +2,16 @@ const { platform, arch } = process;
 
 const PLATFORMS = {
 	win32: {
-		x64: "@biomejs/cli-win32-x64/rome.exe",
-		arm64: "@biomejs/cli-win32-arm64/rome.exe",
+		x64: "@biomejs/cli-win32-x64/biome.exe",
+		arm64: "@biomejs/cli-win32-arm64/biome.exe",
 	},
 	darwin: {
-		x64: "@biomejs/cli-darwin-x64/rome",
-		arm64: "@biomejs/cli-darwin-arm64/rome",
+		x64: "@biomejs/cli-darwin-x64/biome",
+		arm64: "@biomejs/cli-darwin-arm64/biome",
 	},
 	linux: {
-		x64: "@biomejs/cli-linux-x64/rome",
-		arm64: "@biomejs/cli-linux-arm64/rome",
+		x64: "@biomejs/cli-linux-x64/biome",
+		arm64: "@biomejs/cli-linux-arm64/biome",
 	},
 };
 
@@ -22,13 +22,13 @@ if (binName) {
 		binPath = require.resolve(binName);
 	} catch {
 		console.warn(
-			`The Biome CLI postinstall script failed to resolve the binary file "${binName}". Running Biome from the npm package will probably not work correctly.`,
+			`The Biome CLI postinstall script failed to resolve the binary file "${binName}". Running Biome from the npm package will probably not work correctly.`
 		);
 	}
 } else {
 	console.warn(
 		"The Biome CLI package doesn't ship with prebuilt binaries for your platform yet. " +
 			"You can still use the CLI by cloning the biomejs/biome repo from GitHub, " +
-			"and follow the instructions there to build the CLI for your platform.",
+			"and follow the instructions there to build the CLI for your platform."
 	);
 }


### PR DESCRIPTION
## Summary

Postinstall script fails to find the right executable 

```
The Biome CLI postinstall script failed to resolve the binary file "@biomejs/cli-linux-x64/rome". Running Biome from the npm package will probably not work correctly.
```
