### PR TITLE
fix(formatter): suppress `default_constructed_unit_structs` on formatter generated code

### DIFF
--- a/crates/biome_js_formatter/src/generated.rs
+++ b/crates/biome_js_formatter/src/generated.rs
@@ -18,7 +18,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsScript {
         crate::js::auxiliary::script::FormatJsScript,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::auxiliary::script::FormatJsScript)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::auxiliary::script::FormatJsScript::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsScript {
@@ -27,7 +31,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsScript {
         crate::js::auxiliary::script::FormatJsScript,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::auxiliary::script::FormatJsScript)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::auxiliary::script::FormatJsScript::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsModule> for crate::js::auxiliary::module::FormatJsModule {
@@ -44,7 +52,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsModule {
         crate::js::auxiliary::module::FormatJsModule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::auxiliary::module::FormatJsModule)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::auxiliary::module::FormatJsModule::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsModule {
@@ -53,7 +65,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsModule {
         crate::js::auxiliary::module::FormatJsModule,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::auxiliary::module::FormatJsModule)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::auxiliary::module::FormatJsModule::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsExpressionSnipped>
@@ -76,9 +92,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExpressionSnipped {
         crate::js::auxiliary::expression_snipped::FormatJsExpressionSnipped,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::auxiliary::expression_snipped::FormatJsExpressionSnipped,
+            crate::js::auxiliary::expression_snipped::FormatJsExpressionSnipped::default(),
         )
     }
 }
@@ -88,9 +105,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExpressionSnipped {
         crate::js::auxiliary::expression_snipped::FormatJsExpressionSnipped,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::auxiliary::expression_snipped::FormatJsExpressionSnipped,
+            crate::js::auxiliary::expression_snipped::FormatJsExpressionSnipped::default(),
         )
     }
 }
@@ -110,7 +128,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDirective {
         crate::js::auxiliary::directive::FormatJsDirective,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::auxiliary::directive::FormatJsDirective)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::auxiliary::directive::FormatJsDirective::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDirective {
@@ -119,7 +141,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDirective {
         crate::js::auxiliary::directive::FormatJsDirective,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::auxiliary::directive::FormatJsDirective)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::auxiliary::directive::FormatJsDirective::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsBlockStatement>
@@ -142,9 +168,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBlockStatement {
         crate::js::statements::block_statement::FormatJsBlockStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::block_statement::FormatJsBlockStatement,
+            crate::js::statements::block_statement::FormatJsBlockStatement::default(),
         )
     }
 }
@@ -154,9 +181,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBlockStatement {
         crate::js::statements::block_statement::FormatJsBlockStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::block_statement::FormatJsBlockStatement,
+            crate::js::statements::block_statement::FormatJsBlockStatement::default(),
         )
     }
 }
@@ -180,9 +208,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBreakStatement {
         crate::js::statements::break_statement::FormatJsBreakStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::break_statement::FormatJsBreakStatement,
+            crate::js::statements::break_statement::FormatJsBreakStatement::default(),
         )
     }
 }
@@ -192,9 +221,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBreakStatement {
         crate::js::statements::break_statement::FormatJsBreakStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::break_statement::FormatJsBreakStatement,
+            crate::js::statements::break_statement::FormatJsBreakStatement::default(),
         )
     }
 }
@@ -218,9 +248,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsClassDeclaration {
         crate::js::declarations::class_declaration::FormatJsClassDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::declarations::class_declaration::FormatJsClassDeclaration,
+            crate::js::declarations::class_declaration::FormatJsClassDeclaration::default(),
         )
     }
 }
@@ -230,9 +261,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsClassDeclaration {
         crate::js::declarations::class_declaration::FormatJsClassDeclaration,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::declarations::class_declaration::FormatJsClassDeclaration,
+            crate::js::declarations::class_declaration::FormatJsClassDeclaration::default(),
         )
     }
 }
@@ -256,9 +288,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsContinueStatement {
         crate::js::statements::continue_statement::FormatJsContinueStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::continue_statement::FormatJsContinueStatement,
+            crate::js::statements::continue_statement::FormatJsContinueStatement::default(),
         )
     }
 }
@@ -268,9 +301,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsContinueStatement {
         crate::js::statements::continue_statement::FormatJsContinueStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::continue_statement::FormatJsContinueStatement,
+            crate::js::statements::continue_statement::FormatJsContinueStatement::default(),
         )
     }
 }
@@ -294,9 +328,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDebuggerStatement {
         crate::js::statements::debugger_statement::FormatJsDebuggerStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::debugger_statement::FormatJsDebuggerStatement,
+            crate::js::statements::debugger_statement::FormatJsDebuggerStatement::default(),
         )
     }
 }
@@ -306,9 +341,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDebuggerStatement {
         crate::js::statements::debugger_statement::FormatJsDebuggerStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::debugger_statement::FormatJsDebuggerStatement,
+            crate::js::statements::debugger_statement::FormatJsDebuggerStatement::default(),
         )
     }
 }
@@ -332,9 +368,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDoWhileStatement {
         crate::js::statements::do_while_statement::FormatJsDoWhileStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::do_while_statement::FormatJsDoWhileStatement,
+            crate::js::statements::do_while_statement::FormatJsDoWhileStatement::default(),
         )
     }
 }
@@ -344,9 +381,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDoWhileStatement {
         crate::js::statements::do_while_statement::FormatJsDoWhileStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::do_while_statement::FormatJsDoWhileStatement,
+            crate::js::statements::do_while_statement::FormatJsDoWhileStatement::default(),
         )
     }
 }
@@ -370,9 +408,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsEmptyStatement {
         crate::js::statements::empty_statement::FormatJsEmptyStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::empty_statement::FormatJsEmptyStatement,
+            crate::js::statements::empty_statement::FormatJsEmptyStatement::default(),
         )
     }
 }
@@ -382,9 +421,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsEmptyStatement {
         crate::js::statements::empty_statement::FormatJsEmptyStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::empty_statement::FormatJsEmptyStatement,
+            crate::js::statements::empty_statement::FormatJsEmptyStatement::default(),
         )
     }
 }
@@ -408,9 +448,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExpressionStatement {
         crate::js::statements::expression_statement::FormatJsExpressionStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::expression_statement::FormatJsExpressionStatement,
+            crate::js::statements::expression_statement::FormatJsExpressionStatement::default(),
         )
     }
 }
@@ -420,9 +461,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExpressionStatement {
         crate::js::statements::expression_statement::FormatJsExpressionStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::expression_statement::FormatJsExpressionStatement,
+            crate::js::statements::expression_statement::FormatJsExpressionStatement::default(),
         )
     }
 }
@@ -446,9 +488,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsForInStatement {
         crate::js::statements::for_in_statement::FormatJsForInStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::for_in_statement::FormatJsForInStatement,
+            crate::js::statements::for_in_statement::FormatJsForInStatement::default(),
         )
     }
 }
@@ -458,9 +501,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsForInStatement {
         crate::js::statements::for_in_statement::FormatJsForInStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::for_in_statement::FormatJsForInStatement,
+            crate::js::statements::for_in_statement::FormatJsForInStatement::default(),
         )
     }
 }
@@ -484,9 +528,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsForOfStatement {
         crate::js::statements::for_of_statement::FormatJsForOfStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::for_of_statement::FormatJsForOfStatement,
+            crate::js::statements::for_of_statement::FormatJsForOfStatement::default(),
         )
     }
 }
@@ -496,9 +541,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsForOfStatement {
         crate::js::statements::for_of_statement::FormatJsForOfStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::for_of_statement::FormatJsForOfStatement,
+            crate::js::statements::for_of_statement::FormatJsForOfStatement::default(),
         )
     }
 }
@@ -518,9 +564,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsForStatement {
         crate::js::statements::for_statement::FormatJsForStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::for_statement::FormatJsForStatement,
+            crate::js::statements::for_statement::FormatJsForStatement::default(),
         )
     }
 }
@@ -530,9 +577,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsForStatement {
         crate::js::statements::for_statement::FormatJsForStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::for_statement::FormatJsForStatement,
+            crate::js::statements::for_statement::FormatJsForStatement::default(),
         )
     }
 }
@@ -552,9 +600,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsIfStatement {
         crate::js::statements::if_statement::FormatJsIfStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::if_statement::FormatJsIfStatement,
+            crate::js::statements::if_statement::FormatJsIfStatement::default(),
         )
     }
 }
@@ -564,9 +613,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsIfStatement {
         crate::js::statements::if_statement::FormatJsIfStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::if_statement::FormatJsIfStatement,
+            crate::js::statements::if_statement::FormatJsIfStatement::default(),
         )
     }
 }
@@ -590,9 +640,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsLabeledStatement {
         crate::js::statements::labeled_statement::FormatJsLabeledStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::labeled_statement::FormatJsLabeledStatement,
+            crate::js::statements::labeled_statement::FormatJsLabeledStatement::default(),
         )
     }
 }
@@ -602,9 +653,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsLabeledStatement {
         crate::js::statements::labeled_statement::FormatJsLabeledStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::labeled_statement::FormatJsLabeledStatement,
+            crate::js::statements::labeled_statement::FormatJsLabeledStatement::default(),
         )
     }
 }
@@ -628,9 +680,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsReturnStatement {
         crate::js::statements::return_statement::FormatJsReturnStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::return_statement::FormatJsReturnStatement,
+            crate::js::statements::return_statement::FormatJsReturnStatement::default(),
         )
     }
 }
@@ -640,9 +693,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsReturnStatement {
         crate::js::statements::return_statement::FormatJsReturnStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::return_statement::FormatJsReturnStatement,
+            crate::js::statements::return_statement::FormatJsReturnStatement::default(),
         )
     }
 }
@@ -666,9 +720,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSwitchStatement {
         crate::js::statements::switch_statement::FormatJsSwitchStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::switch_statement::FormatJsSwitchStatement,
+            crate::js::statements::switch_statement::FormatJsSwitchStatement::default(),
         )
     }
 }
@@ -678,9 +733,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSwitchStatement {
         crate::js::statements::switch_statement::FormatJsSwitchStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::switch_statement::FormatJsSwitchStatement,
+            crate::js::statements::switch_statement::FormatJsSwitchStatement::default(),
         )
     }
 }
@@ -704,9 +760,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsThrowStatement {
         crate::js::statements::throw_statement::FormatJsThrowStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::throw_statement::FormatJsThrowStatement,
+            crate::js::statements::throw_statement::FormatJsThrowStatement::default(),
         )
     }
 }
@@ -716,9 +773,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsThrowStatement {
         crate::js::statements::throw_statement::FormatJsThrowStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::throw_statement::FormatJsThrowStatement,
+            crate::js::statements::throw_statement::FormatJsThrowStatement::default(),
         )
     }
 }
@@ -742,9 +800,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsTryFinallyStatement {
         crate::js::statements::try_finally_statement::FormatJsTryFinallyStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::try_finally_statement::FormatJsTryFinallyStatement,
+            crate::js::statements::try_finally_statement::FormatJsTryFinallyStatement::default(),
         )
     }
 }
@@ -754,9 +813,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsTryFinallyStatement {
         crate::js::statements::try_finally_statement::FormatJsTryFinallyStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::try_finally_statement::FormatJsTryFinallyStatement,
+            crate::js::statements::try_finally_statement::FormatJsTryFinallyStatement::default(),
         )
     }
 }
@@ -776,9 +836,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsTryStatement {
         crate::js::statements::try_statement::FormatJsTryStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::try_statement::FormatJsTryStatement,
+            crate::js::statements::try_statement::FormatJsTryStatement::default(),
         )
     }
 }
@@ -788,9 +849,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsTryStatement {
         crate::js::statements::try_statement::FormatJsTryStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::try_statement::FormatJsTryStatement,
+            crate::js::statements::try_statement::FormatJsTryStatement::default(),
         )
     }
 }
@@ -814,9 +876,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsVariableStatement {
         crate::js::statements::variable_statement::FormatJsVariableStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::variable_statement::FormatJsVariableStatement,
+            crate::js::statements::variable_statement::FormatJsVariableStatement::default(),
         )
     }
 }
@@ -826,9 +889,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsVariableStatement {
         crate::js::statements::variable_statement::FormatJsVariableStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::variable_statement::FormatJsVariableStatement,
+            crate::js::statements::variable_statement::FormatJsVariableStatement::default(),
         )
     }
 }
@@ -852,9 +916,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsWhileStatement {
         crate::js::statements::while_statement::FormatJsWhileStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::while_statement::FormatJsWhileStatement,
+            crate::js::statements::while_statement::FormatJsWhileStatement::default(),
         )
     }
 }
@@ -864,9 +929,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsWhileStatement {
         crate::js::statements::while_statement::FormatJsWhileStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::while_statement::FormatJsWhileStatement,
+            crate::js::statements::while_statement::FormatJsWhileStatement::default(),
         )
     }
 }
@@ -890,9 +956,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsWithStatement {
         crate::js::statements::with_statement::FormatJsWithStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::statements::with_statement::FormatJsWithStatement,
+            crate::js::statements::with_statement::FormatJsWithStatement::default(),
         )
     }
 }
@@ -902,9 +969,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsWithStatement {
         crate::js::statements::with_statement::FormatJsWithStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::statements::with_statement::FormatJsWithStatement,
+            crate::js::statements::with_statement::FormatJsWithStatement::default(),
         )
     }
 }
@@ -928,9 +996,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsFunctionDeclaration {
         crate::js::declarations::function_declaration::FormatJsFunctionDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::declarations::function_declaration::FormatJsFunctionDeclaration,
+            crate::js::declarations::function_declaration::FormatJsFunctionDeclaration::default(),
         )
     }
 }
@@ -940,9 +1009,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsFunctionDeclaration {
         crate::js::declarations::function_declaration::FormatJsFunctionDeclaration,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::declarations::function_declaration::FormatJsFunctionDeclaration,
+            crate::js::declarations::function_declaration::FormatJsFunctionDeclaration::default(),
         )
     }
 }
@@ -966,9 +1036,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsEnumDeclaration {
         crate::ts::declarations::enum_declaration::FormatTsEnumDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::declarations::enum_declaration::FormatTsEnumDeclaration,
+            crate::ts::declarations::enum_declaration::FormatTsEnumDeclaration::default(),
         )
     }
 }
@@ -978,9 +1049,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsEnumDeclaration {
         crate::ts::declarations::enum_declaration::FormatTsEnumDeclaration,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::declarations::enum_declaration::FormatTsEnumDeclaration,
+            crate::ts::declarations::enum_declaration::FormatTsEnumDeclaration::default(),
         )
     }
 }
@@ -1004,9 +1076,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeAliasDeclaration {
         crate::ts::declarations::type_alias_declaration::FormatTsTypeAliasDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::declarations::type_alias_declaration::FormatTsTypeAliasDeclaration,
+            crate::ts::declarations::type_alias_declaration::FormatTsTypeAliasDeclaration::default(
+            ),
         )
     }
 }
@@ -1016,9 +1090,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeAliasDeclaration {
         crate::ts::declarations::type_alias_declaration::FormatTsTypeAliasDeclaration,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::declarations::type_alias_declaration::FormatTsTypeAliasDeclaration,
+            crate::ts::declarations::type_alias_declaration::FormatTsTypeAliasDeclaration::default(
+            ),
         )
     }
 }
@@ -1042,9 +1118,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsInterfaceDeclaration {
         crate::ts::declarations::interface_declaration::FormatTsInterfaceDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::declarations::interface_declaration::FormatTsInterfaceDeclaration,
+            crate::ts::declarations::interface_declaration::FormatTsInterfaceDeclaration::default(),
         )
     }
 }
@@ -1054,9 +1131,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsInterfaceDeclaration {
         crate::ts::declarations::interface_declaration::FormatTsInterfaceDeclaration,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::declarations::interface_declaration::FormatTsInterfaceDeclaration,
+            crate::ts::declarations::interface_declaration::FormatTsInterfaceDeclaration::default(),
         )
     }
 }
@@ -1080,7 +1158,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsDeclareFunctionDeclaration
         crate::ts::declarations::declare_function_declaration::FormatTsDeclareFunctionDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: declarations :: declare_function_declaration :: FormatTsDeclareFunctionDeclaration)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: declarations :: declare_function_declaration :: FormatTsDeclareFunctionDeclaration :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDeclareFunctionDeclaration {
@@ -1089,7 +1168,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDeclareFunctionDeclarati
         crate::ts::declarations::declare_function_declaration::FormatTsDeclareFunctionDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: declarations :: declare_function_declaration :: FormatTsDeclareFunctionDeclaration)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: declarations :: declare_function_declaration :: FormatTsDeclareFunctionDeclaration :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsDeclareStatement>
@@ -1112,9 +1192,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsDeclareStatement {
         crate::ts::statements::declare_statement::FormatTsDeclareStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::statements::declare_statement::FormatTsDeclareStatement,
+            crate::ts::statements::declare_statement::FormatTsDeclareStatement::default(),
         )
     }
 }
@@ -1124,9 +1205,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDeclareStatement {
         crate::ts::statements::declare_statement::FormatTsDeclareStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::statements::declare_statement::FormatTsDeclareStatement,
+            crate::ts::statements::declare_statement::FormatTsDeclareStatement::default(),
         )
     }
 }
@@ -1150,9 +1232,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsModuleDeclaration {
         crate::ts::declarations::module_declaration::FormatTsModuleDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::declarations::module_declaration::FormatTsModuleDeclaration,
+            crate::ts::declarations::module_declaration::FormatTsModuleDeclaration::default(),
         )
     }
 }
@@ -1162,9 +1245,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsModuleDeclaration {
         crate::ts::declarations::module_declaration::FormatTsModuleDeclaration,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::declarations::module_declaration::FormatTsModuleDeclaration,
+            crate::ts::declarations::module_declaration::FormatTsModuleDeclaration::default(),
         )
     }
 }
@@ -1188,10 +1272,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsExternalModuleDeclaration 
         crate::ts::declarations::external_module_declaration::FormatTsExternalModuleDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::declarations::external_module_declaration::FormatTsExternalModuleDeclaration,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: declarations :: external_module_declaration :: FormatTsExternalModuleDeclaration :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExternalModuleDeclaration {
@@ -1200,10 +1282,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExternalModuleDeclaratio
         crate::ts::declarations::external_module_declaration::FormatTsExternalModuleDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::declarations::external_module_declaration::FormatTsExternalModuleDeclaration,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: declarations :: external_module_declaration :: FormatTsExternalModuleDeclaration :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsGlobalDeclaration>
@@ -1226,9 +1306,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsGlobalDeclaration {
         crate::ts::declarations::global_declaration::FormatTsGlobalDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::declarations::global_declaration::FormatTsGlobalDeclaration,
+            crate::ts::declarations::global_declaration::FormatTsGlobalDeclaration::default(),
         )
     }
 }
@@ -1238,9 +1319,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsGlobalDeclaration {
         crate::ts::declarations::global_declaration::FormatTsGlobalDeclaration,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::declarations::global_declaration::FormatTsGlobalDeclaration,
+            crate::ts::declarations::global_declaration::FormatTsGlobalDeclaration::default(),
         )
     }
 }
@@ -1264,10 +1346,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsImportEqualsDeclaration {
         crate::ts::declarations::import_equals_declaration::FormatTsImportEqualsDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::declarations::import_equals_declaration::FormatTsImportEqualsDeclaration,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: declarations :: import_equals_declaration :: FormatTsImportEqualsDeclaration :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsImportEqualsDeclaration {
@@ -1276,10 +1356,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsImportEqualsDeclaration 
         crate::ts::declarations::import_equals_declaration::FormatTsImportEqualsDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::declarations::import_equals_declaration::FormatTsImportEqualsDeclaration,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: declarations :: import_equals_declaration :: FormatTsImportEqualsDeclaration :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsElseClause>
@@ -1298,7 +1376,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsElseClause {
         crate::js::auxiliary::else_clause::FormatJsElseClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::auxiliary::else_clause::FormatJsElseClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::auxiliary::else_clause::FormatJsElseClause::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsElseClause {
@@ -1307,7 +1389,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsElseClause {
         crate::js::auxiliary::else_clause::FormatJsElseClause,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::auxiliary::else_clause::FormatJsElseClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::auxiliary::else_clause::FormatJsElseClause::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsVariableDeclaration>
@@ -1330,9 +1416,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclaration {
         crate::js::declarations::variable_declaration::FormatJsVariableDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::declarations::variable_declaration::FormatJsVariableDeclaration,
+            crate::js::declarations::variable_declaration::FormatJsVariableDeclaration::default(),
         )
     }
 }
@@ -1342,9 +1429,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclaration {
         crate::js::declarations::variable_declaration::FormatJsVariableDeclaration,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::declarations::variable_declaration::FormatJsVariableDeclaration,
+            crate::js::declarations::variable_declaration::FormatJsVariableDeclaration::default(),
         )
     }
 }
@@ -1368,10 +1456,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsForVariableDeclaration {
         crate::js::declarations::for_variable_declaration::FormatJsForVariableDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::declarations::for_variable_declaration::FormatJsForVariableDeclaration,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: declarations :: for_variable_declaration :: FormatJsForVariableDeclaration :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsForVariableDeclaration {
@@ -1380,10 +1466,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsForVariableDeclaration {
         crate::js::declarations::for_variable_declaration::FormatJsForVariableDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::declarations::for_variable_declaration::FormatJsForVariableDeclaration,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: declarations :: for_variable_declaration :: FormatJsForVariableDeclaration :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsVariableDeclarator>
@@ -1406,9 +1490,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclarator {
         crate::js::auxiliary::variable_declarator::FormatJsVariableDeclarator,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::auxiliary::variable_declarator::FormatJsVariableDeclarator,
+            crate::js::auxiliary::variable_declarator::FormatJsVariableDeclarator::default(),
         )
     }
 }
@@ -1418,9 +1503,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclarator {
         crate::js::auxiliary::variable_declarator::FormatJsVariableDeclarator,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::auxiliary::variable_declarator::FormatJsVariableDeclarator,
+            crate::js::auxiliary::variable_declarator::FormatJsVariableDeclarator::default(),
         )
     }
 }
@@ -1440,7 +1526,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsCaseClause {
         crate::js::auxiliary::case_clause::FormatJsCaseClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::auxiliary::case_clause::FormatJsCaseClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::auxiliary::case_clause::FormatJsCaseClause::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsCaseClause {
@@ -1449,7 +1539,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsCaseClause {
         crate::js::auxiliary::case_clause::FormatJsCaseClause,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::auxiliary::case_clause::FormatJsCaseClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::auxiliary::case_clause::FormatJsCaseClause::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsDefaultClause>
@@ -1472,9 +1566,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDefaultClause {
         crate::js::auxiliary::default_clause::FormatJsDefaultClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::auxiliary::default_clause::FormatJsDefaultClause,
+            crate::js::auxiliary::default_clause::FormatJsDefaultClause::default(),
         )
     }
 }
@@ -1484,9 +1579,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDefaultClause {
         crate::js::auxiliary::default_clause::FormatJsDefaultClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::auxiliary::default_clause::FormatJsDefaultClause,
+            crate::js::auxiliary::default_clause::FormatJsDefaultClause::default(),
         )
     }
 }
@@ -1506,9 +1602,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsCatchClause {
         crate::js::auxiliary::catch_clause::FormatJsCatchClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::auxiliary::catch_clause::FormatJsCatchClause,
+            crate::js::auxiliary::catch_clause::FormatJsCatchClause::default(),
         )
     }
 }
@@ -1518,9 +1615,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsCatchClause {
         crate::js::auxiliary::catch_clause::FormatJsCatchClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::auxiliary::catch_clause::FormatJsCatchClause,
+            crate::js::auxiliary::catch_clause::FormatJsCatchClause::default(),
         )
     }
 }
@@ -1544,9 +1642,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsFinallyClause {
         crate::js::auxiliary::finally_clause::FormatJsFinallyClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::auxiliary::finally_clause::FormatJsFinallyClause,
+            crate::js::auxiliary::finally_clause::FormatJsFinallyClause::default(),
         )
     }
 }
@@ -1556,9 +1655,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsFinallyClause {
         crate::js::auxiliary::finally_clause::FormatJsFinallyClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::auxiliary::finally_clause::FormatJsFinallyClause,
+            crate::js::auxiliary::finally_clause::FormatJsFinallyClause::default(),
         )
     }
 }
@@ -1582,9 +1682,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsCatchDeclaration {
         crate::js::declarations::catch_declaration::FormatJsCatchDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::declarations::catch_declaration::FormatJsCatchDeclaration,
+            crate::js::declarations::catch_declaration::FormatJsCatchDeclaration::default(),
         )
     }
 }
@@ -1594,9 +1695,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsCatchDeclaration {
         crate::js::declarations::catch_declaration::FormatJsCatchDeclaration,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::declarations::catch_declaration::FormatJsCatchDeclaration,
+            crate::js::declarations::catch_declaration::FormatJsCatchDeclaration::default(),
         )
     }
 }
@@ -1620,9 +1722,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeAnnotation {
         crate::ts::auxiliary::type_annotation::FormatTsTypeAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::type_annotation::FormatTsTypeAnnotation,
+            crate::ts::auxiliary::type_annotation::FormatTsTypeAnnotation::default(),
         )
     }
 }
@@ -1632,9 +1735,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeAnnotation {
         crate::ts::auxiliary::type_annotation::FormatTsTypeAnnotation,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::type_annotation::FormatTsTypeAnnotation,
+            crate::ts::auxiliary::type_annotation::FormatTsTypeAnnotation::default(),
         )
     }
 }
@@ -1658,9 +1762,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportMetaExpression {
         crate::js::expressions::import_meta_expression::FormatJsImportMetaExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::import_meta_expression::FormatJsImportMetaExpression,
+            crate::js::expressions::import_meta_expression::FormatJsImportMetaExpression::default(),
         )
     }
 }
@@ -1670,9 +1775,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportMetaExpression {
         crate::js::expressions::import_meta_expression::FormatJsImportMetaExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::import_meta_expression::FormatJsImportMetaExpression,
+            crate::js::expressions::import_meta_expression::FormatJsImportMetaExpression::default(),
         )
     }
 }
@@ -1696,6 +1802,7 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayExpression {
         crate::js::expressions::array_expression::FormatJsArrayExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::array_expression::FormatJsArrayExpression::default(),
@@ -1708,6 +1815,7 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayExpression {
         crate::js::expressions::array_expression::FormatJsArrayExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::array_expression::FormatJsArrayExpression::default(),
@@ -1734,6 +1842,7 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrowFunctionExpression {
         crate::js::expressions::arrow_function_expression::FormatJsArrowFunctionExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: expressions :: arrow_function_expression :: FormatJsArrowFunctionExpression :: default ())
     }
 }
@@ -1743,6 +1852,7 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrowFunctionExpression 
         crate::js::expressions::arrow_function_expression::FormatJsArrowFunctionExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: expressions :: arrow_function_expression :: FormatJsArrowFunctionExpression :: default ())
     }
 }
@@ -1766,9 +1876,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsAssignmentExpression {
         crate::js::expressions::assignment_expression::FormatJsAssignmentExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::assignment_expression::FormatJsAssignmentExpression,
+            crate::js::expressions::assignment_expression::FormatJsAssignmentExpression::default(),
         )
     }
 }
@@ -1778,9 +1889,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsAssignmentExpression {
         crate::js::expressions::assignment_expression::FormatJsAssignmentExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::assignment_expression::FormatJsAssignmentExpression,
+            crate::js::expressions::assignment_expression::FormatJsAssignmentExpression::default(),
         )
     }
 }
@@ -1804,9 +1916,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsAwaitExpression {
         crate::js::expressions::await_expression::FormatJsAwaitExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::await_expression::FormatJsAwaitExpression,
+            crate::js::expressions::await_expression::FormatJsAwaitExpression::default(),
         )
     }
 }
@@ -1816,9 +1929,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsAwaitExpression {
         crate::js::expressions::await_expression::FormatJsAwaitExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::await_expression::FormatJsAwaitExpression,
+            crate::js::expressions::await_expression::FormatJsAwaitExpression::default(),
         )
     }
 }
@@ -1842,9 +1956,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBinaryExpression {
         crate::js::expressions::binary_expression::FormatJsBinaryExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::binary_expression::FormatJsBinaryExpression,
+            crate::js::expressions::binary_expression::FormatJsBinaryExpression::default(),
         )
     }
 }
@@ -1854,9 +1969,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBinaryExpression {
         crate::js::expressions::binary_expression::FormatJsBinaryExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::binary_expression::FormatJsBinaryExpression,
+            crate::js::expressions::binary_expression::FormatJsBinaryExpression::default(),
         )
     }
 }
@@ -1880,9 +1996,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsCallExpression {
         crate::js::expressions::call_expression::FormatJsCallExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::call_expression::FormatJsCallExpression,
+            crate::js::expressions::call_expression::FormatJsCallExpression::default(),
         )
     }
 }
@@ -1892,9 +2009,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsCallExpression {
         crate::js::expressions::call_expression::FormatJsCallExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::call_expression::FormatJsCallExpression,
+            crate::js::expressions::call_expression::FormatJsCallExpression::default(),
         )
     }
 }
@@ -1918,9 +2036,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsClassExpression {
         crate::js::expressions::class_expression::FormatJsClassExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::class_expression::FormatJsClassExpression,
+            crate::js::expressions::class_expression::FormatJsClassExpression::default(),
         )
     }
 }
@@ -1930,9 +2049,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsClassExpression {
         crate::js::expressions::class_expression::FormatJsClassExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::class_expression::FormatJsClassExpression,
+            crate::js::expressions::class_expression::FormatJsClassExpression::default(),
         )
     }
 }
@@ -1956,10 +2076,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberExpression {
         crate::js::expressions::computed_member_expression::FormatJsComputedMemberExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::expressions::computed_member_expression::FormatJsComputedMemberExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: expressions :: computed_member_expression :: FormatJsComputedMemberExpression :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberExpression {
@@ -1968,10 +2086,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberExpression
         crate::js::expressions::computed_member_expression::FormatJsComputedMemberExpression,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::expressions::computed_member_expression::FormatJsComputedMemberExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: expressions :: computed_member_expression :: FormatJsComputedMemberExpression :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsConditionalExpression>
@@ -1994,6 +2110,7 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsConditionalExpression {
         crate::js::expressions::conditional_expression::FormatJsConditionalExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::conditional_expression::FormatJsConditionalExpression::default(
@@ -2007,6 +2124,7 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsConditionalExpression {
         crate::js::expressions::conditional_expression::FormatJsConditionalExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::conditional_expression::FormatJsConditionalExpression::default(
@@ -2034,6 +2152,7 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsFunctionExpression {
         crate::js::expressions::function_expression::FormatJsFunctionExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::function_expression::FormatJsFunctionExpression::default(),
@@ -2046,6 +2165,7 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsFunctionExpression {
         crate::js::expressions::function_expression::FormatJsFunctionExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::function_expression::FormatJsFunctionExpression::default(),
@@ -2072,9 +2192,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsIdentifierExpression {
         crate::js::expressions::identifier_expression::FormatJsIdentifierExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::identifier_expression::FormatJsIdentifierExpression,
+            crate::js::expressions::identifier_expression::FormatJsIdentifierExpression::default(),
         )
     }
 }
@@ -2084,9 +2205,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsIdentifierExpression {
         crate::js::expressions::identifier_expression::FormatJsIdentifierExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::identifier_expression::FormatJsIdentifierExpression,
+            crate::js::expressions::identifier_expression::FormatJsIdentifierExpression::default(),
         )
     }
 }
@@ -2110,9 +2232,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportCallExpression {
         crate::js::expressions::import_call_expression::FormatJsImportCallExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::import_call_expression::FormatJsImportCallExpression,
+            crate::js::expressions::import_call_expression::FormatJsImportCallExpression::default(),
         )
     }
 }
@@ -2122,9 +2245,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportCallExpression {
         crate::js::expressions::import_call_expression::FormatJsImportCallExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::import_call_expression::FormatJsImportCallExpression,
+            crate::js::expressions::import_call_expression::FormatJsImportCallExpression::default(),
         )
     }
 }
@@ -2144,9 +2268,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsInExpression {
         crate::js::expressions::in_expression::FormatJsInExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::in_expression::FormatJsInExpression,
+            crate::js::expressions::in_expression::FormatJsInExpression::default(),
         )
     }
 }
@@ -2156,9 +2281,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsInExpression {
         crate::js::expressions::in_expression::FormatJsInExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::in_expression::FormatJsInExpression,
+            crate::js::expressions::in_expression::FormatJsInExpression::default(),
         )
     }
 }
@@ -2182,9 +2308,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsInstanceofExpression {
         crate::js::expressions::instanceof_expression::FormatJsInstanceofExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::instanceof_expression::FormatJsInstanceofExpression,
+            crate::js::expressions::instanceof_expression::FormatJsInstanceofExpression::default(),
         )
     }
 }
@@ -2194,9 +2321,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsInstanceofExpression {
         crate::js::expressions::instanceof_expression::FormatJsInstanceofExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::instanceof_expression::FormatJsInstanceofExpression,
+            crate::js::expressions::instanceof_expression::FormatJsInstanceofExpression::default(),
         )
     }
 }
@@ -2220,9 +2348,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsLogicalExpression {
         crate::js::expressions::logical_expression::FormatJsLogicalExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::logical_expression::FormatJsLogicalExpression,
+            crate::js::expressions::logical_expression::FormatJsLogicalExpression::default(),
         )
     }
 }
@@ -2232,9 +2361,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsLogicalExpression {
         crate::js::expressions::logical_expression::FormatJsLogicalExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::logical_expression::FormatJsLogicalExpression,
+            crate::js::expressions::logical_expression::FormatJsLogicalExpression::default(),
         )
     }
 }
@@ -2258,9 +2388,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNewExpression {
         crate::js::expressions::new_expression::FormatJsNewExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::new_expression::FormatJsNewExpression,
+            crate::js::expressions::new_expression::FormatJsNewExpression::default(),
         )
     }
 }
@@ -2270,9 +2401,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNewExpression {
         crate::js::expressions::new_expression::FormatJsNewExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::new_expression::FormatJsNewExpression,
+            crate::js::expressions::new_expression::FormatJsNewExpression::default(),
         )
     }
 }
@@ -2296,9 +2428,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectExpression {
         crate::js::expressions::object_expression::FormatJsObjectExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::object_expression::FormatJsObjectExpression,
+            crate::js::expressions::object_expression::FormatJsObjectExpression::default(),
         )
     }
 }
@@ -2308,9 +2441,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectExpression {
         crate::js::expressions::object_expression::FormatJsObjectExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::object_expression::FormatJsObjectExpression,
+            crate::js::expressions::object_expression::FormatJsObjectExpression::default(),
         )
     }
 }
@@ -2334,10 +2468,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsParenthesizedExpression {
         crate::js::expressions::parenthesized_expression::FormatJsParenthesizedExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::expressions::parenthesized_expression::FormatJsParenthesizedExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: expressions :: parenthesized_expression :: FormatJsParenthesizedExpression :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsParenthesizedExpression {
@@ -2346,10 +2478,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsParenthesizedExpression 
         crate::js::expressions::parenthesized_expression::FormatJsParenthesizedExpression,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::expressions::parenthesized_expression::FormatJsParenthesizedExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: expressions :: parenthesized_expression :: FormatJsParenthesizedExpression :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsPostUpdateExpression>
@@ -2372,9 +2502,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPostUpdateExpression {
         crate::js::expressions::post_update_expression::FormatJsPostUpdateExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::post_update_expression::FormatJsPostUpdateExpression,
+            crate::js::expressions::post_update_expression::FormatJsPostUpdateExpression::default(),
         )
     }
 }
@@ -2384,9 +2515,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPostUpdateExpression {
         crate::js::expressions::post_update_expression::FormatJsPostUpdateExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::post_update_expression::FormatJsPostUpdateExpression,
+            crate::js::expressions::post_update_expression::FormatJsPostUpdateExpression::default(),
         )
     }
 }
@@ -2410,9 +2542,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPreUpdateExpression {
         crate::js::expressions::pre_update_expression::FormatJsPreUpdateExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::pre_update_expression::FormatJsPreUpdateExpression,
+            crate::js::expressions::pre_update_expression::FormatJsPreUpdateExpression::default(),
         )
     }
 }
@@ -2422,9 +2555,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPreUpdateExpression {
         crate::js::expressions::pre_update_expression::FormatJsPreUpdateExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::pre_update_expression::FormatJsPreUpdateExpression,
+            crate::js::expressions::pre_update_expression::FormatJsPreUpdateExpression::default(),
         )
     }
 }
@@ -2448,9 +2582,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSequenceExpression {
         crate::js::expressions::sequence_expression::FormatJsSequenceExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::sequence_expression::FormatJsSequenceExpression,
+            crate::js::expressions::sequence_expression::FormatJsSequenceExpression::default(),
         )
     }
 }
@@ -2460,9 +2595,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSequenceExpression {
         crate::js::expressions::sequence_expression::FormatJsSequenceExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::sequence_expression::FormatJsSequenceExpression,
+            crate::js::expressions::sequence_expression::FormatJsSequenceExpression::default(),
         )
     }
 }
@@ -2486,10 +2622,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsStaticMemberExpression {
         crate::js::expressions::static_member_expression::FormatJsStaticMemberExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::expressions::static_member_expression::FormatJsStaticMemberExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: expressions :: static_member_expression :: FormatJsStaticMemberExpression :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStaticMemberExpression {
@@ -2498,10 +2632,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStaticMemberExpression {
         crate::js::expressions::static_member_expression::FormatJsStaticMemberExpression,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::expressions::static_member_expression::FormatJsStaticMemberExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: expressions :: static_member_expression :: FormatJsStaticMemberExpression :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsSuperExpression>
@@ -2524,9 +2656,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSuperExpression {
         crate::js::expressions::super_expression::FormatJsSuperExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::super_expression::FormatJsSuperExpression,
+            crate::js::expressions::super_expression::FormatJsSuperExpression::default(),
         )
     }
 }
@@ -2536,9 +2669,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSuperExpression {
         crate::js::expressions::super_expression::FormatJsSuperExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::super_expression::FormatJsSuperExpression,
+            crate::js::expressions::super_expression::FormatJsSuperExpression::default(),
         )
     }
 }
@@ -2562,9 +2696,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsThisExpression {
         crate::js::expressions::this_expression::FormatJsThisExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::this_expression::FormatJsThisExpression,
+            crate::js::expressions::this_expression::FormatJsThisExpression::default(),
         )
     }
 }
@@ -2574,9 +2709,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsThisExpression {
         crate::js::expressions::this_expression::FormatJsThisExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::this_expression::FormatJsThisExpression,
+            crate::js::expressions::this_expression::FormatJsThisExpression::default(),
         )
     }
 }
@@ -2600,9 +2736,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsUnaryExpression {
         crate::js::expressions::unary_expression::FormatJsUnaryExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::unary_expression::FormatJsUnaryExpression,
+            crate::js::expressions::unary_expression::FormatJsUnaryExpression::default(),
         )
     }
 }
@@ -2612,9 +2749,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsUnaryExpression {
         crate::js::expressions::unary_expression::FormatJsUnaryExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::unary_expression::FormatJsUnaryExpression,
+            crate::js::expressions::unary_expression::FormatJsUnaryExpression::default(),
         )
     }
 }
@@ -2638,9 +2776,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsYieldExpression {
         crate::js::expressions::yield_expression::FormatJsYieldExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::yield_expression::FormatJsYieldExpression,
+            crate::js::expressions::yield_expression::FormatJsYieldExpression::default(),
         )
     }
 }
@@ -2650,9 +2789,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsYieldExpression {
         crate::js::expressions::yield_expression::FormatJsYieldExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::yield_expression::FormatJsYieldExpression,
+            crate::js::expressions::yield_expression::FormatJsYieldExpression::default(),
         )
     }
 }
@@ -2676,9 +2816,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNewTargetExpression {
         crate::js::expressions::new_target_expression::FormatJsNewTargetExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::new_target_expression::FormatJsNewTargetExpression,
+            crate::js::expressions::new_target_expression::FormatJsNewTargetExpression::default(),
         )
     }
 }
@@ -2688,9 +2829,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNewTargetExpression {
         crate::js::expressions::new_target_expression::FormatJsNewTargetExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::new_target_expression::FormatJsNewTargetExpression,
+            crate::js::expressions::new_target_expression::FormatJsNewTargetExpression::default(),
         )
     }
 }
@@ -2714,9 +2856,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsTemplateExpression {
         crate::js::expressions::template_expression::FormatJsTemplateExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::template_expression::FormatJsTemplateExpression,
+            crate::js::expressions::template_expression::FormatJsTemplateExpression::default(),
         )
     }
 }
@@ -2726,9 +2869,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsTemplateExpression {
         crate::js::expressions::template_expression::FormatJsTemplateExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::template_expression::FormatJsTemplateExpression,
+            crate::js::expressions::template_expression::FormatJsTemplateExpression::default(),
         )
     }
 }
@@ -2752,10 +2896,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeAssertionExpression {
         crate::ts::expressions::type_assertion_expression::FormatTsTypeAssertionExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::expressions::type_assertion_expression::FormatTsTypeAssertionExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: expressions :: type_assertion_expression :: FormatTsTypeAssertionExpression :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeAssertionExpression {
@@ -2764,10 +2906,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeAssertionExpression 
         crate::ts::expressions::type_assertion_expression::FormatTsTypeAssertionExpression,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::expressions::type_assertion_expression::FormatTsTypeAssertionExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: expressions :: type_assertion_expression :: FormatTsTypeAssertionExpression :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsAsExpression>
@@ -2786,9 +2926,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAsExpression {
         crate::ts::expressions::as_expression::FormatTsAsExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::expressions::as_expression::FormatTsAsExpression,
+            crate::ts::expressions::as_expression::FormatTsAsExpression::default(),
         )
     }
 }
@@ -2798,9 +2939,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAsExpression {
         crate::ts::expressions::as_expression::FormatTsAsExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::expressions::as_expression::FormatTsAsExpression,
+            crate::ts::expressions::as_expression::FormatTsAsExpression::default(),
         )
     }
 }
@@ -2824,9 +2966,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsSatisfiesExpression {
         crate::ts::expressions::satisfies_expression::FormatTsSatisfiesExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::expressions::satisfies_expression::FormatTsSatisfiesExpression,
+            crate::ts::expressions::satisfies_expression::FormatTsSatisfiesExpression::default(),
         )
     }
 }
@@ -2836,9 +2979,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsSatisfiesExpression {
         crate::ts::expressions::satisfies_expression::FormatTsSatisfiesExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::expressions::satisfies_expression::FormatTsSatisfiesExpression,
+            crate::ts::expressions::satisfies_expression::FormatTsSatisfiesExpression::default(),
         )
     }
 }
@@ -2862,7 +3006,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNonNullAssertionExpression
         crate::ts::expressions::non_null_assertion_expression::FormatTsNonNullAssertionExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: expressions :: non_null_assertion_expression :: FormatTsNonNullAssertionExpression)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: expressions :: non_null_assertion_expression :: FormatTsNonNullAssertionExpression :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNonNullAssertionExpression {
@@ -2871,7 +3016,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNonNullAssertionExpressi
         crate::ts::expressions::non_null_assertion_expression::FormatTsNonNullAssertionExpression,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: expressions :: non_null_assertion_expression :: FormatTsNonNullAssertionExpression)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: expressions :: non_null_assertion_expression :: FormatTsNonNullAssertionExpression :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsInstantiationExpression>
@@ -2894,10 +3040,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsInstantiationExpression {
         crate::ts::expressions::instantiation_expression::FormatTsInstantiationExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::expressions::instantiation_expression::FormatTsInstantiationExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: expressions :: instantiation_expression :: FormatTsInstantiationExpression :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsInstantiationExpression {
@@ -2906,10 +3050,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsInstantiationExpression 
         crate::ts::expressions::instantiation_expression::FormatTsInstantiationExpression,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::expressions::instantiation_expression::FormatTsInstantiationExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: expressions :: instantiation_expression :: FormatTsInstantiationExpression :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsxTagExpression>
@@ -2932,9 +3074,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxTagExpression {
         crate::jsx::expressions::tag_expression::FormatJsxTagExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::expressions::tag_expression::FormatJsxTagExpression,
+            crate::jsx::expressions::tag_expression::FormatJsxTagExpression::default(),
         )
     }
 }
@@ -2944,9 +3087,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxTagExpression {
         crate::jsx::expressions::tag_expression::FormatJsxTagExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::expressions::tag_expression::FormatJsxTagExpression,
+            crate::jsx::expressions::tag_expression::FormatJsxTagExpression::default(),
         )
     }
 }
@@ -2970,9 +3114,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeArguments {
         crate::ts::expressions::type_arguments::FormatTsTypeArguments,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::expressions::type_arguments::FormatTsTypeArguments,
+            crate::ts::expressions::type_arguments::FormatTsTypeArguments::default(),
         )
     }
 }
@@ -2982,9 +3127,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeArguments {
         crate::ts::expressions::type_arguments::FormatTsTypeArguments,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::expressions::type_arguments::FormatTsTypeArguments,
+            crate::ts::expressions::type_arguments::FormatTsTypeArguments::default(),
         )
     }
 }
@@ -3008,9 +3154,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsTemplateChunkElement {
         crate::js::auxiliary::template_chunk_element::FormatJsTemplateChunkElement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::auxiliary::template_chunk_element::FormatJsTemplateChunkElement,
+            crate::js::auxiliary::template_chunk_element::FormatJsTemplateChunkElement::default(),
         )
     }
 }
@@ -3020,9 +3167,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsTemplateChunkElement {
         crate::js::auxiliary::template_chunk_element::FormatJsTemplateChunkElement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::auxiliary::template_chunk_element::FormatJsTemplateChunkElement,
+            crate::js::auxiliary::template_chunk_element::FormatJsTemplateChunkElement::default(),
         )
     }
 }
@@ -3046,6 +3194,7 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsTemplateElement {
         crate::js::auxiliary::template_element::FormatJsTemplateElement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::template_element::FormatJsTemplateElement::default(),
@@ -3058,6 +3207,7 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsTemplateElement {
         crate::js::auxiliary::template_element::FormatJsTemplateElement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::template_element::FormatJsTemplateElement::default(),
@@ -3084,9 +3234,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsCallArguments {
         crate::js::expressions::call_arguments::FormatJsCallArguments,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::call_arguments::FormatJsCallArguments,
+            crate::js::expressions::call_arguments::FormatJsCallArguments::default(),
         )
     }
 }
@@ -3096,9 +3247,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsCallArguments {
         crate::js::expressions::call_arguments::FormatJsCallArguments,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::call_arguments::FormatJsCallArguments,
+            crate::js::expressions::call_arguments::FormatJsCallArguments::default(),
         )
     }
 }
@@ -3122,9 +3274,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsYieldArgument {
         crate::js::expressions::yield_argument::FormatJsYieldArgument,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::yield_argument::FormatJsYieldArgument,
+            crate::js::expressions::yield_argument::FormatJsYieldArgument::default(),
         )
     }
 }
@@ -3134,9 +3287,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsYieldArgument {
         crate::js::expressions::yield_argument::FormatJsYieldArgument,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::yield_argument::FormatJsYieldArgument,
+            crate::js::expressions::yield_argument::FormatJsYieldArgument::default(),
         )
     }
 }
@@ -3160,6 +3314,7 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeParameters {
         crate::ts::bindings::type_parameters::FormatTsTypeParameters,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::bindings::type_parameters::FormatTsTypeParameters::default(),
@@ -3172,6 +3327,7 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeParameters {
         crate::ts::bindings::type_parameters::FormatTsTypeParameters,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::bindings::type_parameters::FormatTsTypeParameters::default(),
@@ -3194,7 +3350,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsParameters {
         crate::js::bindings::parameters::FormatJsParameters,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::bindings::parameters::FormatJsParameters)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::bindings::parameters::FormatJsParameters::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsParameters {
@@ -3203,7 +3363,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsParameters {
         crate::js::bindings::parameters::FormatJsParameters,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::bindings::parameters::FormatJsParameters)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::bindings::parameters::FormatJsParameters::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsReturnTypeAnnotation>
@@ -3226,9 +3390,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsReturnTypeAnnotation {
         crate::ts::auxiliary::return_type_annotation::FormatTsReturnTypeAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::return_type_annotation::FormatTsReturnTypeAnnotation,
+            crate::ts::auxiliary::return_type_annotation::FormatTsReturnTypeAnnotation::default(),
         )
     }
 }
@@ -3238,9 +3403,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsReturnTypeAnnotation {
         crate::ts::auxiliary::return_type_annotation::FormatTsReturnTypeAnnotation,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::return_type_annotation::FormatTsReturnTypeAnnotation,
+            crate::ts::auxiliary::return_type_annotation::FormatTsReturnTypeAnnotation::default(),
         )
     }
 }
@@ -3260,9 +3426,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsFunctionBody {
         crate::js::auxiliary::function_body::FormatJsFunctionBody,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::auxiliary::function_body::FormatJsFunctionBody,
+            crate::js::auxiliary::function_body::FormatJsFunctionBody::default(),
         )
     }
 }
@@ -3272,9 +3439,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsFunctionBody {
         crate::js::auxiliary::function_body::FormatJsFunctionBody,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::auxiliary::function_body::FormatJsFunctionBody,
+            crate::js::auxiliary::function_body::FormatJsFunctionBody::default(),
         )
     }
 }
@@ -3292,7 +3460,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSpread {
         crate::js::auxiliary::spread::FormatJsSpread,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::auxiliary::spread::FormatJsSpread)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::auxiliary::spread::FormatJsSpread::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSpread {
@@ -3301,7 +3473,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSpread {
         crate::js::auxiliary::spread::FormatJsSpread,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::auxiliary::spread::FormatJsSpread)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::auxiliary::spread::FormatJsSpread::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsArrayHole>
@@ -3320,7 +3496,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayHole {
         crate::js::auxiliary::array_hole::FormatJsArrayHole,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::auxiliary::array_hole::FormatJsArrayHole)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::auxiliary::array_hole::FormatJsArrayHole::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayHole {
@@ -3329,7 +3509,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayHole {
         crate::js::auxiliary::array_hole::FormatJsArrayHole,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::auxiliary::array_hole::FormatJsArrayHole)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::auxiliary::array_hole::FormatJsArrayHole::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsReferenceIdentifier>
@@ -3352,9 +3536,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsReferenceIdentifier {
         crate::js::auxiliary::reference_identifier::FormatJsReferenceIdentifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::auxiliary::reference_identifier::FormatJsReferenceIdentifier,
+            crate::js::auxiliary::reference_identifier::FormatJsReferenceIdentifier::default(),
         )
     }
 }
@@ -3364,9 +3549,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsReferenceIdentifier {
         crate::js::auxiliary::reference_identifier::FormatJsReferenceIdentifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::auxiliary::reference_identifier::FormatJsReferenceIdentifier,
+            crate::js::auxiliary::reference_identifier::FormatJsReferenceIdentifier::default(),
         )
     }
 }
@@ -3386,9 +3572,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPrivateName {
         crate::js::auxiliary::private_name::FormatJsPrivateName,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::auxiliary::private_name::FormatJsPrivateName,
+            crate::js::auxiliary::private_name::FormatJsPrivateName::default(),
         )
     }
 }
@@ -3398,9 +3585,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPrivateName {
         crate::js::auxiliary::private_name::FormatJsPrivateName,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::auxiliary::private_name::FormatJsPrivateName,
+            crate::js::auxiliary::private_name::FormatJsPrivateName::default(),
         )
     }
 }
@@ -3424,9 +3612,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsLiteralMemberName {
         crate::js::objects::literal_member_name::FormatJsLiteralMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::objects::literal_member_name::FormatJsLiteralMemberName,
+            crate::js::objects::literal_member_name::FormatJsLiteralMemberName::default(),
         )
     }
 }
@@ -3436,9 +3625,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsLiteralMemberName {
         crate::js::objects::literal_member_name::FormatJsLiteralMemberName,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::objects::literal_member_name::FormatJsLiteralMemberName,
+            crate::js::objects::literal_member_name::FormatJsLiteralMemberName::default(),
         )
     }
 }
@@ -3462,9 +3652,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberName {
         crate::js::objects::computed_member_name::FormatJsComputedMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::objects::computed_member_name::FormatJsComputedMemberName,
+            crate::js::objects::computed_member_name::FormatJsComputedMemberName::default(),
         )
     }
 }
@@ -3474,9 +3665,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberName {
         crate::js::objects::computed_member_name::FormatJsComputedMemberName,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::objects::computed_member_name::FormatJsComputedMemberName,
+            crate::js::objects::computed_member_name::FormatJsComputedMemberName::default(),
         )
     }
 }
@@ -3500,9 +3692,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPropertyObjectMember {
         crate::js::objects::property_object_member::FormatJsPropertyObjectMember,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::objects::property_object_member::FormatJsPropertyObjectMember,
+            crate::js::objects::property_object_member::FormatJsPropertyObjectMember::default(),
         )
     }
 }
@@ -3512,9 +3705,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPropertyObjectMember {
         crate::js::objects::property_object_member::FormatJsPropertyObjectMember,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::objects::property_object_member::FormatJsPropertyObjectMember,
+            crate::js::objects::property_object_member::FormatJsPropertyObjectMember::default(),
         )
     }
 }
@@ -3538,9 +3732,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsMethodObjectMember {
         crate::js::objects::method_object_member::FormatJsMethodObjectMember,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::objects::method_object_member::FormatJsMethodObjectMember,
+            crate::js::objects::method_object_member::FormatJsMethodObjectMember::default(),
         )
     }
 }
@@ -3550,9 +3745,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsMethodObjectMember {
         crate::js::objects::method_object_member::FormatJsMethodObjectMember,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::objects::method_object_member::FormatJsMethodObjectMember,
+            crate::js::objects::method_object_member::FormatJsMethodObjectMember::default(),
         )
     }
 }
@@ -3576,9 +3772,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsGetterObjectMember {
         crate::js::objects::getter_object_member::FormatJsGetterObjectMember,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::objects::getter_object_member::FormatJsGetterObjectMember,
+            crate::js::objects::getter_object_member::FormatJsGetterObjectMember::default(),
         )
     }
 }
@@ -3588,9 +3785,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsGetterObjectMember {
         crate::js::objects::getter_object_member::FormatJsGetterObjectMember,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::objects::getter_object_member::FormatJsGetterObjectMember,
+            crate::js::objects::getter_object_member::FormatJsGetterObjectMember::default(),
         )
     }
 }
@@ -3614,9 +3812,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSetterObjectMember {
         crate::js::objects::setter_object_member::FormatJsSetterObjectMember,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::objects::setter_object_member::FormatJsSetterObjectMember,
+            crate::js::objects::setter_object_member::FormatJsSetterObjectMember::default(),
         )
     }
 }
@@ -3626,9 +3825,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSetterObjectMember {
         crate::js::objects::setter_object_member::FormatJsSetterObjectMember,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::objects::setter_object_member::FormatJsSetterObjectMember,
+            crate::js::objects::setter_object_member::FormatJsSetterObjectMember::default(),
         )
     }
 }
@@ -3652,7 +3852,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsShorthandPropertyObjectMem
         crate::js::objects::shorthand_property_object_member::FormatJsShorthandPropertyObjectMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: objects :: shorthand_property_object_member :: FormatJsShorthandPropertyObjectMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: objects :: shorthand_property_object_member :: FormatJsShorthandPropertyObjectMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsShorthandPropertyObjectMember {
@@ -3661,7 +3862,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsShorthandPropertyObjectM
         crate::js::objects::shorthand_property_object_member::FormatJsShorthandPropertyObjectMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: objects :: shorthand_property_object_member :: FormatJsShorthandPropertyObjectMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: objects :: shorthand_property_object_member :: FormatJsShorthandPropertyObjectMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsExtendsClause>
@@ -3684,9 +3886,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExtendsClause {
         crate::js::classes::extends_clause::FormatJsExtendsClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::classes::extends_clause::FormatJsExtendsClause,
+            crate::js::classes::extends_clause::FormatJsExtendsClause::default(),
         )
     }
 }
@@ -3696,9 +3899,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExtendsClause {
         crate::js::classes::extends_clause::FormatJsExtendsClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::classes::extends_clause::FormatJsExtendsClause,
+            crate::js::classes::extends_clause::FormatJsExtendsClause::default(),
         )
     }
 }
@@ -3722,9 +3926,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsImplementsClause {
         crate::ts::auxiliary::implements_clause::FormatTsImplementsClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::implements_clause::FormatTsImplementsClause,
+            crate::ts::auxiliary::implements_clause::FormatTsImplementsClause::default(),
         )
     }
 }
@@ -3734,9 +3939,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsImplementsClause {
         crate::ts::auxiliary::implements_clause::FormatTsImplementsClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::implements_clause::FormatTsImplementsClause,
+            crate::ts::auxiliary::implements_clause::FormatTsImplementsClause::default(),
         )
     }
 }
@@ -3744,13 +3950,15 @@ impl FormatRule < biome_js_syntax :: JsClassExportDefaultDeclaration > for crate
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsClassExportDefaultDeclaration {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsClassExportDefaultDeclaration , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsClassExportDefaultDeclaration {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsClassExportDefaultDeclaration , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsPrivateClassMemberName>
@@ -3773,9 +3981,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPrivateClassMemberName {
         crate::js::objects::private_class_member_name::FormatJsPrivateClassMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::objects::private_class_member_name::FormatJsPrivateClassMemberName,
+            crate::js::objects::private_class_member_name::FormatJsPrivateClassMemberName::default(
+            ),
         )
     }
 }
@@ -3785,9 +3995,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPrivateClassMemberName {
         crate::js::objects::private_class_member_name::FormatJsPrivateClassMemberName,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::objects::private_class_member_name::FormatJsPrivateClassMemberName,
+            crate::js::objects::private_class_member_name::FormatJsPrivateClassMemberName::default(
+            ),
         )
     }
 }
@@ -3811,9 +4023,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsConstructorClassMember {
         crate::js::classes::constructor_class_member::FormatJsConstructorClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::classes::constructor_class_member::FormatJsConstructorClassMember,
+            crate::js::classes::constructor_class_member::FormatJsConstructorClassMember::default(),
         )
     }
 }
@@ -3823,9 +4036,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsConstructorClassMember {
         crate::js::classes::constructor_class_member::FormatJsConstructorClassMember,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::classes::constructor_class_member::FormatJsConstructorClassMember,
+            crate::js::classes::constructor_class_member::FormatJsConstructorClassMember::default(),
         )
     }
 }
@@ -3833,13 +4047,15 @@ impl FormatRule < biome_js_syntax :: JsStaticInitializationBlockClassMember > fo
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsStaticInitializationBlockClassMember {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsStaticInitializationBlockClassMember , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStaticInitializationBlockClassMember {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsStaticInitializationBlockClassMember , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsPropertyClassMember>
@@ -3862,9 +4078,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPropertyClassMember {
         crate::js::classes::property_class_member::FormatJsPropertyClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::classes::property_class_member::FormatJsPropertyClassMember,
+            crate::js::classes::property_class_member::FormatJsPropertyClassMember::default(),
         )
     }
 }
@@ -3874,9 +4091,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPropertyClassMember {
         crate::js::classes::property_class_member::FormatJsPropertyClassMember,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::classes::property_class_member::FormatJsPropertyClassMember,
+            crate::js::classes::property_class_member::FormatJsPropertyClassMember::default(),
         )
     }
 }
@@ -3900,9 +4118,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsMethodClassMember {
         crate::js::classes::method_class_member::FormatJsMethodClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::classes::method_class_member::FormatJsMethodClassMember,
+            crate::js::classes::method_class_member::FormatJsMethodClassMember::default(),
         )
     }
 }
@@ -3912,9 +4131,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsMethodClassMember {
         crate::js::classes::method_class_member::FormatJsMethodClassMember,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::classes::method_class_member::FormatJsMethodClassMember,
+            crate::js::classes::method_class_member::FormatJsMethodClassMember::default(),
         )
     }
 }
@@ -3938,9 +4158,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsGetterClassMember {
         crate::js::classes::getter_class_member::FormatJsGetterClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::classes::getter_class_member::FormatJsGetterClassMember,
+            crate::js::classes::getter_class_member::FormatJsGetterClassMember::default(),
         )
     }
 }
@@ -3950,9 +4171,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsGetterClassMember {
         crate::js::classes::getter_class_member::FormatJsGetterClassMember,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::classes::getter_class_member::FormatJsGetterClassMember,
+            crate::js::classes::getter_class_member::FormatJsGetterClassMember::default(),
         )
     }
 }
@@ -3976,9 +4198,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSetterClassMember {
         crate::js::classes::setter_class_member::FormatJsSetterClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::classes::setter_class_member::FormatJsSetterClassMember,
+            crate::js::classes::setter_class_member::FormatJsSetterClassMember::default(),
         )
     }
 }
@@ -3988,9 +4211,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSetterClassMember {
         crate::js::classes::setter_class_member::FormatJsSetterClassMember,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::classes::setter_class_member::FormatJsSetterClassMember,
+            crate::js::classes::setter_class_member::FormatJsSetterClassMember::default(),
         )
     }
 }
@@ -3998,13 +4222,15 @@ impl FormatRule < biome_js_syntax :: TsConstructorSignatureClassMember > for cra
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsConstructorSignatureClassMember {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: TsConstructorSignatureClassMember , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsConstructorSignatureClassMember {
     type Format = FormatOwnedWithRule < biome_js_syntax :: TsConstructorSignatureClassMember , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsPropertySignatureClassMember>
@@ -4027,7 +4253,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureClassMemb
         crate::ts::classes::property_signature_class_member::FormatTsPropertySignatureClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: classes :: property_signature_class_member :: FormatTsPropertySignatureClassMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: classes :: property_signature_class_member :: FormatTsPropertySignatureClassMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureClassMember {
@@ -4036,20 +4263,23 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureClassMe
         crate::ts::classes::property_signature_class_member::FormatTsPropertySignatureClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: classes :: property_signature_class_member :: FormatTsPropertySignatureClassMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: classes :: property_signature_class_member :: FormatTsPropertySignatureClassMember :: default ())
     }
 }
 impl FormatRule < biome_js_syntax :: TsInitializedPropertySignatureClassMember > for crate :: ts :: classes :: initialized_property_signature_class_member :: FormatTsInitializedPropertySignatureClassMember { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & biome_js_syntax :: TsInitializedPropertySignatureClassMember , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < biome_js_syntax :: TsInitializedPropertySignatureClassMember > :: fmt (self , node , f) } }
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsInitializedPropertySignatureClassMember {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: TsInitializedPropertySignatureClassMember , crate :: ts :: classes :: initialized_property_signature_class_member :: FormatTsInitializedPropertySignatureClassMember > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: classes :: initialized_property_signature_class_member :: FormatTsInitializedPropertySignatureClassMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: classes :: initialized_property_signature_class_member :: FormatTsInitializedPropertySignatureClassMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsInitializedPropertySignatureClassMember {
     type Format = FormatOwnedWithRule < biome_js_syntax :: TsInitializedPropertySignatureClassMember , crate :: ts :: classes :: initialized_property_signature_class_member :: FormatTsInitializedPropertySignatureClassMember > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: classes :: initialized_property_signature_class_member :: FormatTsInitializedPropertySignatureClassMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: classes :: initialized_property_signature_class_member :: FormatTsInitializedPropertySignatureClassMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsMethodSignatureClassMember>
@@ -4072,10 +4302,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureClassMember
         crate::ts::classes::method_signature_class_member::FormatTsMethodSignatureClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::classes::method_signature_class_member::FormatTsMethodSignatureClassMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: classes :: method_signature_class_member :: FormatTsMethodSignatureClassMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureClassMember {
@@ -4084,10 +4312,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureClassMemb
         crate::ts::classes::method_signature_class_member::FormatTsMethodSignatureClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::classes::method_signature_class_member::FormatTsMethodSignatureClassMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: classes :: method_signature_class_member :: FormatTsMethodSignatureClassMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsGetterSignatureClassMember>
@@ -4110,10 +4336,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsGetterSignatureClassMember
         crate::ts::classes::getter_signature_class_member::FormatTsGetterSignatureClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::classes::getter_signature_class_member::FormatTsGetterSignatureClassMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: classes :: getter_signature_class_member :: FormatTsGetterSignatureClassMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsGetterSignatureClassMember {
@@ -4122,10 +4346,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsGetterSignatureClassMemb
         crate::ts::classes::getter_signature_class_member::FormatTsGetterSignatureClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::classes::getter_signature_class_member::FormatTsGetterSignatureClassMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: classes :: getter_signature_class_member :: FormatTsGetterSignatureClassMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsSetterSignatureClassMember>
@@ -4148,10 +4370,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsSetterSignatureClassMember
         crate::ts::classes::setter_signature_class_member::FormatTsSetterSignatureClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::classes::setter_signature_class_member::FormatTsSetterSignatureClassMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: classes :: setter_signature_class_member :: FormatTsSetterSignatureClassMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsSetterSignatureClassMember {
@@ -4160,10 +4380,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsSetterSignatureClassMemb
         crate::ts::classes::setter_signature_class_member::FormatTsSetterSignatureClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::classes::setter_signature_class_member::FormatTsSetterSignatureClassMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: classes :: setter_signature_class_member :: FormatTsSetterSignatureClassMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsIndexSignatureClassMember>
@@ -4186,10 +4404,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureClassMember 
         crate::ts::classes::index_signature_class_member::FormatTsIndexSignatureClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::classes::index_signature_class_member::FormatTsIndexSignatureClassMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: classes :: index_signature_class_member :: FormatTsIndexSignatureClassMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureClassMember {
@@ -4198,10 +4414,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureClassMembe
         crate::ts::classes::index_signature_class_member::FormatTsIndexSignatureClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::classes::index_signature_class_member::FormatTsIndexSignatureClassMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: classes :: index_signature_class_member :: FormatTsIndexSignatureClassMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsEmptyClassMember>
@@ -4224,9 +4438,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsEmptyClassMember {
         crate::js::classes::empty_class_member::FormatJsEmptyClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::classes::empty_class_member::FormatJsEmptyClassMember,
+            crate::js::classes::empty_class_member::FormatJsEmptyClassMember::default(),
         )
     }
 }
@@ -4236,9 +4451,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsEmptyClassMember {
         crate::js::classes::empty_class_member::FormatJsEmptyClassMember,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::classes::empty_class_member::FormatJsEmptyClassMember,
+            crate::js::classes::empty_class_member::FormatJsEmptyClassMember::default(),
         )
     }
 }
@@ -4262,9 +4478,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsStaticModifier {
         crate::js::auxiliary::static_modifier::FormatJsStaticModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::auxiliary::static_modifier::FormatJsStaticModifier,
+            crate::js::auxiliary::static_modifier::FormatJsStaticModifier::default(),
         )
     }
 }
@@ -4274,9 +4491,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStaticModifier {
         crate::js::auxiliary::static_modifier::FormatJsStaticModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::auxiliary::static_modifier::FormatJsStaticModifier,
+            crate::js::auxiliary::static_modifier::FormatJsStaticModifier::default(),
         )
     }
 }
@@ -4300,9 +4518,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsAccessorModifier {
         crate::js::auxiliary::accessor_modifier::FormatJsAccessorModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::auxiliary::accessor_modifier::FormatJsAccessorModifier,
+            crate::js::auxiliary::accessor_modifier::FormatJsAccessorModifier::default(),
         )
     }
 }
@@ -4312,9 +4531,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsAccessorModifier {
         crate::js::auxiliary::accessor_modifier::FormatJsAccessorModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::auxiliary::accessor_modifier::FormatJsAccessorModifier,
+            crate::js::auxiliary::accessor_modifier::FormatJsAccessorModifier::default(),
         )
     }
 }
@@ -4338,9 +4558,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsDeclareModifier {
         crate::ts::auxiliary::declare_modifier::FormatTsDeclareModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::declare_modifier::FormatTsDeclareModifier,
+            crate::ts::auxiliary::declare_modifier::FormatTsDeclareModifier::default(),
         )
     }
 }
@@ -4350,9 +4571,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDeclareModifier {
         crate::ts::auxiliary::declare_modifier::FormatTsDeclareModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::declare_modifier::FormatTsDeclareModifier,
+            crate::ts::auxiliary::declare_modifier::FormatTsDeclareModifier::default(),
         )
     }
 }
@@ -4376,9 +4598,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsReadonlyModifier {
         crate::ts::auxiliary::readonly_modifier::FormatTsReadonlyModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::readonly_modifier::FormatTsReadonlyModifier,
+            crate::ts::auxiliary::readonly_modifier::FormatTsReadonlyModifier::default(),
         )
     }
 }
@@ -4388,9 +4611,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsReadonlyModifier {
         crate::ts::auxiliary::readonly_modifier::FormatTsReadonlyModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::readonly_modifier::FormatTsReadonlyModifier,
+            crate::ts::auxiliary::readonly_modifier::FormatTsReadonlyModifier::default(),
         )
     }
 }
@@ -4414,9 +4638,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAbstractModifier {
         crate::ts::auxiliary::abstract_modifier::FormatTsAbstractModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::abstract_modifier::FormatTsAbstractModifier,
+            crate::ts::auxiliary::abstract_modifier::FormatTsAbstractModifier::default(),
         )
     }
 }
@@ -4426,9 +4651,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAbstractModifier {
         crate::ts::auxiliary::abstract_modifier::FormatTsAbstractModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::abstract_modifier::FormatTsAbstractModifier,
+            crate::ts::auxiliary::abstract_modifier::FormatTsAbstractModifier::default(),
         )
     }
 }
@@ -4452,9 +4678,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsOverrideModifier {
         crate::ts::auxiliary::override_modifier::FormatTsOverrideModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::override_modifier::FormatTsOverrideModifier,
+            crate::ts::auxiliary::override_modifier::FormatTsOverrideModifier::default(),
         )
     }
 }
@@ -4464,9 +4691,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsOverrideModifier {
         crate::ts::auxiliary::override_modifier::FormatTsOverrideModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::override_modifier::FormatTsOverrideModifier,
+            crate::ts::auxiliary::override_modifier::FormatTsOverrideModifier::default(),
         )
     }
 }
@@ -4490,9 +4718,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAccessibilityModifier {
         crate::ts::auxiliary::accessibility_modifier::FormatTsAccessibilityModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::accessibility_modifier::FormatTsAccessibilityModifier,
+            crate::ts::auxiliary::accessibility_modifier::FormatTsAccessibilityModifier::default(),
         )
     }
 }
@@ -4502,9 +4731,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAccessibilityModifier {
         crate::ts::auxiliary::accessibility_modifier::FormatTsAccessibilityModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::accessibility_modifier::FormatTsAccessibilityModifier,
+            crate::ts::auxiliary::accessibility_modifier::FormatTsAccessibilityModifier::default(),
         )
     }
 }
@@ -4528,9 +4758,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsConstModifier {
         crate::ts::auxiliary::const_modifier::FormatTsConstModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::const_modifier::FormatTsConstModifier,
+            crate::ts::auxiliary::const_modifier::FormatTsConstModifier::default(),
         )
     }
 }
@@ -4540,9 +4771,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsConstModifier {
         crate::ts::auxiliary::const_modifier::FormatTsConstModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::const_modifier::FormatTsConstModifier,
+            crate::ts::auxiliary::const_modifier::FormatTsConstModifier::default(),
         )
     }
 }
@@ -4562,7 +4794,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsInModifier {
         crate::ts::auxiliary::in_modifier::FormatTsInModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::auxiliary::in_modifier::FormatTsInModifier)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::auxiliary::in_modifier::FormatTsInModifier::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsInModifier {
@@ -4571,7 +4807,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsInModifier {
         crate::ts::auxiliary::in_modifier::FormatTsInModifier,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::auxiliary::in_modifier::FormatTsInModifier)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::auxiliary::in_modifier::FormatTsInModifier::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsOutModifier>
@@ -4590,9 +4830,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsOutModifier {
         crate::ts::auxiliary::out_modifier::FormatTsOutModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::out_modifier::FormatTsOutModifier,
+            crate::ts::auxiliary::out_modifier::FormatTsOutModifier::default(),
         )
     }
 }
@@ -4602,9 +4843,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsOutModifier {
         crate::ts::auxiliary::out_modifier::FormatTsOutModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::out_modifier::FormatTsOutModifier,
+            crate::ts::auxiliary::out_modifier::FormatTsOutModifier::default(),
         )
     }
 }
@@ -4628,9 +4870,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsConstructorParameters {
         crate::js::bindings::constructor_parameters::FormatJsConstructorParameters,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::bindings::constructor_parameters::FormatJsConstructorParameters,
+            crate::js::bindings::constructor_parameters::FormatJsConstructorParameters::default(),
         )
     }
 }
@@ -4640,9 +4883,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsConstructorParameters {
         crate::js::bindings::constructor_parameters::FormatJsConstructorParameters,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::bindings::constructor_parameters::FormatJsConstructorParameters,
+            crate::js::bindings::constructor_parameters::FormatJsConstructorParameters::default(),
         )
     }
 }
@@ -4666,9 +4910,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsRestParameter {
         crate::js::bindings::rest_parameter::FormatJsRestParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::bindings::rest_parameter::FormatJsRestParameter,
+            crate::js::bindings::rest_parameter::FormatJsRestParameter::default(),
         )
     }
 }
@@ -4678,9 +4923,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsRestParameter {
         crate::js::bindings::rest_parameter::FormatJsRestParameter,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::bindings::rest_parameter::FormatJsRestParameter,
+            crate::js::bindings::rest_parameter::FormatJsRestParameter::default(),
         )
     }
 }
@@ -4704,9 +4950,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsPropertyParameter {
         crate::ts::bindings::property_parameter::FormatTsPropertyParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::bindings::property_parameter::FormatTsPropertyParameter,
+            crate::ts::bindings::property_parameter::FormatTsPropertyParameter::default(),
         )
     }
 }
@@ -4716,9 +4963,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertyParameter {
         crate::ts::bindings::property_parameter::FormatTsPropertyParameter,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::bindings::property_parameter::FormatTsPropertyParameter,
+            crate::ts::bindings::property_parameter::FormatTsPropertyParameter::default(),
         )
     }
 }
@@ -4742,6 +4990,7 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsInitializerClause {
         crate::js::auxiliary::initializer_clause::FormatJsInitializerClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::initializer_clause::FormatJsInitializerClause::default(),
@@ -4754,6 +5003,7 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsInitializerClause {
         crate::js::auxiliary::initializer_clause::FormatJsInitializerClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::initializer_clause::FormatJsInitializerClause::default(),
@@ -4776,7 +5026,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDecorator {
         crate::js::auxiliary::decorator::FormatJsDecorator,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::auxiliary::decorator::FormatJsDecorator)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::auxiliary::decorator::FormatJsDecorator::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDecorator {
@@ -4785,7 +5039,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDecorator {
         crate::js::auxiliary::decorator::FormatJsDecorator,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::auxiliary::decorator::FormatJsDecorator)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::auxiliary::decorator::FormatJsDecorator::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsOptionalPropertyAnnotation>
@@ -4808,10 +5066,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsOptionalPropertyAnnotation
         crate::ts::auxiliary::optional_property_annotation::FormatTsOptionalPropertyAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::auxiliary::optional_property_annotation::FormatTsOptionalPropertyAnnotation,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: optional_property_annotation :: FormatTsOptionalPropertyAnnotation :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsOptionalPropertyAnnotation {
@@ -4820,10 +5076,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsOptionalPropertyAnnotati
         crate::ts::auxiliary::optional_property_annotation::FormatTsOptionalPropertyAnnotation,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::auxiliary::optional_property_annotation::FormatTsOptionalPropertyAnnotation,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: optional_property_annotation :: FormatTsOptionalPropertyAnnotation :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsDefinitePropertyAnnotation>
@@ -4846,10 +5100,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsDefinitePropertyAnnotation
         crate::ts::auxiliary::definite_property_annotation::FormatTsDefinitePropertyAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::auxiliary::definite_property_annotation::FormatTsDefinitePropertyAnnotation,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: definite_property_annotation :: FormatTsDefinitePropertyAnnotation :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDefinitePropertyAnnotation {
@@ -4858,10 +5110,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDefinitePropertyAnnotati
         crate::ts::auxiliary::definite_property_annotation::FormatTsDefinitePropertyAnnotation,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::auxiliary::definite_property_annotation::FormatTsDefinitePropertyAnnotation,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: definite_property_annotation :: FormatTsDefinitePropertyAnnotation :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsIndexSignatureParameter>
@@ -4884,10 +5134,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureParameter {
         crate::ts::bindings::index_signature_parameter::FormatTsIndexSignatureParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::bindings::index_signature_parameter::FormatTsIndexSignatureParameter,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: bindings :: index_signature_parameter :: FormatTsIndexSignatureParameter :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureParameter {
@@ -4896,10 +5144,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureParameter 
         crate::ts::bindings::index_signature_parameter::FormatTsIndexSignatureParameter,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::bindings::index_signature_parameter::FormatTsIndexSignatureParameter,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: bindings :: index_signature_parameter :: FormatTsIndexSignatureParameter :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsIdentifierAssignment>
@@ -4922,9 +5168,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsIdentifierAssignment {
         crate::js::assignments::identifier_assignment::FormatJsIdentifierAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::assignments::identifier_assignment::FormatJsIdentifierAssignment,
+            crate::js::assignments::identifier_assignment::FormatJsIdentifierAssignment::default(),
         )
     }
 }
@@ -4934,9 +5181,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsIdentifierAssignment {
         crate::js::assignments::identifier_assignment::FormatJsIdentifierAssignment,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::assignments::identifier_assignment::FormatJsIdentifierAssignment,
+            crate::js::assignments::identifier_assignment::FormatJsIdentifierAssignment::default(),
         )
     }
 }
@@ -4960,10 +5208,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsStaticMemberAssignment {
         crate::js::assignments::static_member_assignment::FormatJsStaticMemberAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::assignments::static_member_assignment::FormatJsStaticMemberAssignment,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: assignments :: static_member_assignment :: FormatJsStaticMemberAssignment :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStaticMemberAssignment {
@@ -4972,10 +5218,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStaticMemberAssignment {
         crate::js::assignments::static_member_assignment::FormatJsStaticMemberAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::assignments::static_member_assignment::FormatJsStaticMemberAssignment,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: assignments :: static_member_assignment :: FormatJsStaticMemberAssignment :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsComputedMemberAssignment>
@@ -4998,10 +5242,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberAssignment {
         crate::js::assignments::computed_member_assignment::FormatJsComputedMemberAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::assignments::computed_member_assignment::FormatJsComputedMemberAssignment,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: assignments :: computed_member_assignment :: FormatJsComputedMemberAssignment :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberAssignment {
@@ -5010,10 +5252,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberAssignment
         crate::js::assignments::computed_member_assignment::FormatJsComputedMemberAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::assignments::computed_member_assignment::FormatJsComputedMemberAssignment,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: assignments :: computed_member_assignment :: FormatJsComputedMemberAssignment :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsParenthesizedAssignment>
@@ -5036,10 +5276,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsParenthesizedAssignment {
         crate::js::assignments::parenthesized_assignment::FormatJsParenthesizedAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::assignments::parenthesized_assignment::FormatJsParenthesizedAssignment,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: assignments :: parenthesized_assignment :: FormatJsParenthesizedAssignment :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsParenthesizedAssignment {
@@ -5048,10 +5286,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsParenthesizedAssignment 
         crate::js::assignments::parenthesized_assignment::FormatJsParenthesizedAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::assignments::parenthesized_assignment::FormatJsParenthesizedAssignment,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: assignments :: parenthesized_assignment :: FormatJsParenthesizedAssignment :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsNonNullAssertionAssignment>
@@ -5074,7 +5310,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNonNullAssertionAssignment
         crate::ts::assignments::non_null_assertion_assignment::FormatTsNonNullAssertionAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: assignments :: non_null_assertion_assignment :: FormatTsNonNullAssertionAssignment)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: assignments :: non_null_assertion_assignment :: FormatTsNonNullAssertionAssignment :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNonNullAssertionAssignment {
@@ -5083,7 +5320,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNonNullAssertionAssignme
         crate::ts::assignments::non_null_assertion_assignment::FormatTsNonNullAssertionAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: assignments :: non_null_assertion_assignment :: FormatTsNonNullAssertionAssignment)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: assignments :: non_null_assertion_assignment :: FormatTsNonNullAssertionAssignment :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsAsAssignment>
@@ -5102,9 +5340,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAsAssignment {
         crate::ts::assignments::as_assignment::FormatTsAsAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::assignments::as_assignment::FormatTsAsAssignment,
+            crate::ts::assignments::as_assignment::FormatTsAsAssignment::default(),
         )
     }
 }
@@ -5114,9 +5353,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAsAssignment {
         crate::ts::assignments::as_assignment::FormatTsAsAssignment,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::assignments::as_assignment::FormatTsAsAssignment,
+            crate::ts::assignments::as_assignment::FormatTsAsAssignment::default(),
         )
     }
 }
@@ -5140,9 +5380,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsSatisfiesAssignment {
         crate::ts::assignments::satisfies_assignment::FormatTsSatisfiesAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::assignments::satisfies_assignment::FormatTsSatisfiesAssignment,
+            crate::ts::assignments::satisfies_assignment::FormatTsSatisfiesAssignment::default(),
         )
     }
 }
@@ -5152,9 +5393,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsSatisfiesAssignment {
         crate::ts::assignments::satisfies_assignment::FormatTsSatisfiesAssignment,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::assignments::satisfies_assignment::FormatTsSatisfiesAssignment,
+            crate::ts::assignments::satisfies_assignment::FormatTsSatisfiesAssignment::default(),
         )
     }
 }
@@ -5178,10 +5420,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeAssertionAssignment {
         crate::ts::assignments::type_assertion_assignment::FormatTsTypeAssertionAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::assignments::type_assertion_assignment::FormatTsTypeAssertionAssignment,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: assignments :: type_assertion_assignment :: FormatTsTypeAssertionAssignment :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeAssertionAssignment {
@@ -5190,10 +5430,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeAssertionAssignment 
         crate::ts::assignments::type_assertion_assignment::FormatTsTypeAssertionAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::assignments::type_assertion_assignment::FormatTsTypeAssertionAssignment,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: assignments :: type_assertion_assignment :: FormatTsTypeAssertionAssignment :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsAssignmentWithDefault>
@@ -5216,9 +5454,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsAssignmentWithDefault {
         crate::js::assignments::assignment_with_default::FormatJsAssignmentWithDefault,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::assignments::assignment_with_default::FormatJsAssignmentWithDefault,
+            crate::js::assignments::assignment_with_default::FormatJsAssignmentWithDefault::default(
+            ),
         )
     }
 }
@@ -5228,9 +5468,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsAssignmentWithDefault {
         crate::js::assignments::assignment_with_default::FormatJsAssignmentWithDefault,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::assignments::assignment_with_default::FormatJsAssignmentWithDefault,
+            crate::js::assignments::assignment_with_default::FormatJsAssignmentWithDefault::default(
+            ),
         )
     }
 }
@@ -5254,10 +5496,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPattern {
         crate::js::assignments::array_assignment_pattern::FormatJsArrayAssignmentPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::assignments::array_assignment_pattern::FormatJsArrayAssignmentPattern,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern :: FormatJsArrayAssignmentPattern :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPattern {
@@ -5266,10 +5506,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPattern {
         crate::js::assignments::array_assignment_pattern::FormatJsArrayAssignmentPattern,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::assignments::array_assignment_pattern::FormatJsArrayAssignmentPattern,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern :: FormatJsArrayAssignmentPattern :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsObjectAssignmentPattern>
@@ -5292,10 +5530,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPattern {
         crate::js::assignments::object_assignment_pattern::FormatJsObjectAssignmentPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::assignments::object_assignment_pattern::FormatJsObjectAssignmentPattern,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern :: FormatJsObjectAssignmentPattern :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPattern {
@@ -5304,49 +5540,53 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPattern 
         crate::js::assignments::object_assignment_pattern::FormatJsObjectAssignmentPattern,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::assignments::object_assignment_pattern::FormatJsObjectAssignmentPattern,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern :: FormatJsObjectAssignmentPattern :: default ())
     }
 }
 impl FormatRule < biome_js_syntax :: JsArrayAssignmentPatternRestElement > for crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & biome_js_syntax :: JsArrayAssignmentPatternRestElement , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < biome_js_syntax :: JsArrayAssignmentPatternRestElement > :: fmt (self , node , f) } }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPatternRestElement {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsArrayAssignmentPatternRestElement , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPatternRestElement {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsArrayAssignmentPatternRestElement , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement :: default ())
     }
 }
 impl FormatRule < biome_js_syntax :: JsObjectAssignmentPatternShorthandProperty > for crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & biome_js_syntax :: JsObjectAssignmentPatternShorthandProperty , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < biome_js_syntax :: JsObjectAssignmentPatternShorthandProperty > :: fmt (self , node , f) } }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternShorthandProperty {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsObjectAssignmentPatternShorthandProperty , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternShorthandProperty {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsObjectAssignmentPatternShorthandProperty , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty :: default ())
     }
 }
 impl FormatRule < biome_js_syntax :: JsObjectAssignmentPatternProperty > for crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & biome_js_syntax :: JsObjectAssignmentPatternProperty , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < biome_js_syntax :: JsObjectAssignmentPatternProperty > :: fmt (self , node , f) } }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternProperty {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsObjectAssignmentPatternProperty , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternProperty {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsObjectAssignmentPatternProperty , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsObjectAssignmentPatternRest>
@@ -5369,7 +5609,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternRes
         crate::js::assignments::object_assignment_pattern_rest::FormatJsObjectAssignmentPatternRest,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_rest :: FormatJsObjectAssignmentPatternRest)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_rest :: FormatJsObjectAssignmentPatternRest :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternRest {
@@ -5378,7 +5619,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternR
         crate::js::assignments::object_assignment_pattern_rest::FormatJsObjectAssignmentPatternRest,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_rest :: FormatJsObjectAssignmentPatternRest)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_rest :: FormatJsObjectAssignmentPatternRest :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsIdentifierBinding>
@@ -5401,9 +5643,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsIdentifierBinding {
         crate::js::bindings::identifier_binding::FormatJsIdentifierBinding,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::bindings::identifier_binding::FormatJsIdentifierBinding,
+            crate::js::bindings::identifier_binding::FormatJsIdentifierBinding::default(),
         )
     }
 }
@@ -5413,9 +5656,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsIdentifierBinding {
         crate::js::bindings::identifier_binding::FormatJsIdentifierBinding,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::bindings::identifier_binding::FormatJsIdentifierBinding,
+            crate::js::bindings::identifier_binding::FormatJsIdentifierBinding::default(),
         )
     }
 }
@@ -5439,10 +5683,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBindingPatternWithDefault 
         crate::js::bindings::binding_pattern_with_default::FormatJsBindingPatternWithDefault,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::bindings::binding_pattern_with_default::FormatJsBindingPatternWithDefault,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: bindings :: binding_pattern_with_default :: FormatJsBindingPatternWithDefault :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBindingPatternWithDefault {
@@ -5451,10 +5693,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBindingPatternWithDefaul
         crate::js::bindings::binding_pattern_with_default::FormatJsBindingPatternWithDefault,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::bindings::binding_pattern_with_default::FormatJsBindingPatternWithDefault,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: bindings :: binding_pattern_with_default :: FormatJsBindingPatternWithDefault :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsArrayBindingPattern>
@@ -5477,9 +5717,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPattern {
         crate::js::bindings::array_binding_pattern::FormatJsArrayBindingPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::bindings::array_binding_pattern::FormatJsArrayBindingPattern,
+            crate::js::bindings::array_binding_pattern::FormatJsArrayBindingPattern::default(),
         )
     }
 }
@@ -5489,9 +5730,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPattern {
         crate::js::bindings::array_binding_pattern::FormatJsArrayBindingPattern,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::bindings::array_binding_pattern::FormatJsArrayBindingPattern,
+            crate::js::bindings::array_binding_pattern::FormatJsArrayBindingPattern::default(),
         )
     }
 }
@@ -5515,9 +5757,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPattern {
         crate::js::bindings::object_binding_pattern::FormatJsObjectBindingPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::bindings::object_binding_pattern::FormatJsObjectBindingPattern,
+            crate::js::bindings::object_binding_pattern::FormatJsObjectBindingPattern::default(),
         )
     }
 }
@@ -5527,9 +5770,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPattern {
         crate::js::bindings::object_binding_pattern::FormatJsObjectBindingPattern,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::bindings::object_binding_pattern::FormatJsObjectBindingPattern,
+            crate::js::bindings::object_binding_pattern::FormatJsObjectBindingPattern::default(),
         )
     }
 }
@@ -5537,13 +5781,15 @@ impl FormatRule < biome_js_syntax :: JsArrayBindingPatternRestElement > for crat
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPatternRestElement {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsArrayBindingPatternRestElement , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPatternRestElement {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsArrayBindingPatternRestElement , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsObjectBindingPatternProperty>
@@ -5566,7 +5812,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternProper
         crate::js::bindings::object_binding_pattern_property::FormatJsObjectBindingPatternProperty,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_property :: FormatJsObjectBindingPatternProperty)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_property :: FormatJsObjectBindingPatternProperty :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternProperty {
@@ -5575,7 +5822,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternProp
         crate::js::bindings::object_binding_pattern_property::FormatJsObjectBindingPatternProperty,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_property :: FormatJsObjectBindingPatternProperty)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_property :: FormatJsObjectBindingPatternProperty :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsObjectBindingPatternRest>
@@ -5598,10 +5846,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternRest {
         crate::js::bindings::object_binding_pattern_rest::FormatJsObjectBindingPatternRest,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::bindings::object_binding_pattern_rest::FormatJsObjectBindingPatternRest,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_rest :: FormatJsObjectBindingPatternRest :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternRest {
@@ -5610,23 +5856,23 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternRest
         crate::js::bindings::object_binding_pattern_rest::FormatJsObjectBindingPatternRest,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::bindings::object_binding_pattern_rest::FormatJsObjectBindingPatternRest,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_rest :: FormatJsObjectBindingPatternRest :: default ())
     }
 }
 impl FormatRule < biome_js_syntax :: JsObjectBindingPatternShorthandProperty > for crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & biome_js_syntax :: JsObjectBindingPatternShorthandProperty , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < biome_js_syntax :: JsObjectBindingPatternShorthandProperty > :: fmt (self , node , f) } }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternShorthandProperty {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsObjectBindingPatternShorthandProperty , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternShorthandProperty {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsObjectBindingPatternShorthandProperty , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsStringLiteralExpression>
@@ -5649,10 +5895,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsStringLiteralExpression {
         crate::js::expressions::string_literal_expression::FormatJsStringLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::expressions::string_literal_expression::FormatJsStringLiteralExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: expressions :: string_literal_expression :: FormatJsStringLiteralExpression :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStringLiteralExpression {
@@ -5661,10 +5905,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStringLiteralExpression 
         crate::js::expressions::string_literal_expression::FormatJsStringLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::expressions::string_literal_expression::FormatJsStringLiteralExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: expressions :: string_literal_expression :: FormatJsStringLiteralExpression :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsNumberLiteralExpression>
@@ -5687,10 +5929,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNumberLiteralExpression {
         crate::js::expressions::number_literal_expression::FormatJsNumberLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::expressions::number_literal_expression::FormatJsNumberLiteralExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: expressions :: number_literal_expression :: FormatJsNumberLiteralExpression :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNumberLiteralExpression {
@@ -5699,10 +5939,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNumberLiteralExpression 
         crate::js::expressions::number_literal_expression::FormatJsNumberLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::expressions::number_literal_expression::FormatJsNumberLiteralExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: expressions :: number_literal_expression :: FormatJsNumberLiteralExpression :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsBigintLiteralExpression>
@@ -5725,10 +5963,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBigintLiteralExpression {
         crate::js::expressions::bigint_literal_expression::FormatJsBigintLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::expressions::bigint_literal_expression::FormatJsBigintLiteralExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: expressions :: bigint_literal_expression :: FormatJsBigintLiteralExpression :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBigintLiteralExpression {
@@ -5737,10 +5973,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBigintLiteralExpression 
         crate::js::expressions::bigint_literal_expression::FormatJsBigintLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::expressions::bigint_literal_expression::FormatJsBigintLiteralExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: expressions :: bigint_literal_expression :: FormatJsBigintLiteralExpression :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsBooleanLiteralExpression>
@@ -5763,10 +5997,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBooleanLiteralExpression {
         crate::js::expressions::boolean_literal_expression::FormatJsBooleanLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::expressions::boolean_literal_expression::FormatJsBooleanLiteralExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: expressions :: boolean_literal_expression :: FormatJsBooleanLiteralExpression :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBooleanLiteralExpression {
@@ -5775,10 +6007,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBooleanLiteralExpression
         crate::js::expressions::boolean_literal_expression::FormatJsBooleanLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::expressions::boolean_literal_expression::FormatJsBooleanLiteralExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: expressions :: boolean_literal_expression :: FormatJsBooleanLiteralExpression :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsNullLiteralExpression>
@@ -5801,9 +6031,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNullLiteralExpression {
         crate::js::expressions::null_literal_expression::FormatJsNullLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::expressions::null_literal_expression::FormatJsNullLiteralExpression,
+            crate::js::expressions::null_literal_expression::FormatJsNullLiteralExpression::default(
+            ),
         )
     }
 }
@@ -5813,9 +6045,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNullLiteralExpression {
         crate::js::expressions::null_literal_expression::FormatJsNullLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::expressions::null_literal_expression::FormatJsNullLiteralExpression,
+            crate::js::expressions::null_literal_expression::FormatJsNullLiteralExpression::default(
+            ),
         )
     }
 }
@@ -5839,10 +6073,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsRegexLiteralExpression {
         crate::js::expressions::regex_literal_expression::FormatJsRegexLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::expressions::regex_literal_expression::FormatJsRegexLiteralExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: expressions :: regex_literal_expression :: FormatJsRegexLiteralExpression :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsRegexLiteralExpression {
@@ -5851,10 +6083,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsRegexLiteralExpression {
         crate::js::expressions::regex_literal_expression::FormatJsRegexLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::expressions::regex_literal_expression::FormatJsRegexLiteralExpression,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: expressions :: regex_literal_expression :: FormatJsRegexLiteralExpression :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsVariableDeclarationClause>
@@ -5877,10 +6107,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclarationClause 
         crate::js::auxiliary::variable_declaration_clause::FormatJsVariableDeclarationClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::auxiliary::variable_declaration_clause::FormatJsVariableDeclarationClause,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: auxiliary :: variable_declaration_clause :: FormatJsVariableDeclarationClause :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclarationClause {
@@ -5889,10 +6117,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclarationClaus
         crate::js::auxiliary::variable_declaration_clause::FormatJsVariableDeclarationClause,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::auxiliary::variable_declaration_clause::FormatJsVariableDeclarationClause,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: auxiliary :: variable_declaration_clause :: FormatJsVariableDeclarationClause :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsDefiniteVariableAnnotation>
@@ -5915,10 +6141,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsDefiniteVariableAnnotation
         crate::ts::auxiliary::definite_variable_annotation::FormatTsDefiniteVariableAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::auxiliary::definite_variable_annotation::FormatTsDefiniteVariableAnnotation,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: definite_variable_annotation :: FormatTsDefiniteVariableAnnotation :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDefiniteVariableAnnotation {
@@ -5927,10 +6151,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDefiniteVariableAnnotati
         crate::ts::auxiliary::definite_variable_annotation::FormatTsDefiniteVariableAnnotation,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::auxiliary::definite_variable_annotation::FormatTsDefiniteVariableAnnotation,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: definite_variable_annotation :: FormatTsDefiniteVariableAnnotation :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsExport> for crate::js::module::export::FormatJsExport {
@@ -5944,14 +6166,16 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExport {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::JsExport, crate::js::module::export::FormatJsExport>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::module::export::FormatJsExport)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::js::module::export::FormatJsExport::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExport {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::JsExport, crate::js::module::export::FormatJsExport>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::module::export::FormatJsExport)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::js::module::export::FormatJsExport::default())
     }
 }
 impl FormatRule<biome_js_syntax::JsImport> for crate::js::module::import::FormatJsImport {
@@ -5965,14 +6189,16 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImport {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::JsImport, crate::js::module::import::FormatJsImport>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::module::import::FormatJsImport)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::js::module::import::FormatJsImport::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImport {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::JsImport, crate::js::module::import::FormatJsImport>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::module::import::FormatJsImport)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::js::module::import::FormatJsImport::default())
     }
 }
 impl FormatRule<biome_js_syntax::JsImportBareClause>
@@ -5995,9 +6221,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportBareClause {
         crate::js::module::import_bare_clause::FormatJsImportBareClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::import_bare_clause::FormatJsImportBareClause,
+            crate::js::module::import_bare_clause::FormatJsImportBareClause::default(),
         )
     }
 }
@@ -6007,9 +6234,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportBareClause {
         crate::js::module::import_bare_clause::FormatJsImportBareClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::import_bare_clause::FormatJsImportBareClause,
+            crate::js::module::import_bare_clause::FormatJsImportBareClause::default(),
         )
     }
 }
@@ -6033,9 +6261,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportNamedClause {
         crate::js::module::import_named_clause::FormatJsImportNamedClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::import_named_clause::FormatJsImportNamedClause,
+            crate::js::module::import_named_clause::FormatJsImportNamedClause::default(),
         )
     }
 }
@@ -6045,9 +6274,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportNamedClause {
         crate::js::module::import_named_clause::FormatJsImportNamedClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::import_named_clause::FormatJsImportNamedClause,
+            crate::js::module::import_named_clause::FormatJsImportNamedClause::default(),
         )
     }
 }
@@ -6071,9 +6301,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportDefaultClause {
         crate::js::module::import_default_clause::FormatJsImportDefaultClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::import_default_clause::FormatJsImportDefaultClause,
+            crate::js::module::import_default_clause::FormatJsImportDefaultClause::default(),
         )
     }
 }
@@ -6083,9 +6314,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportDefaultClause {
         crate::js::module::import_default_clause::FormatJsImportDefaultClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::import_default_clause::FormatJsImportDefaultClause,
+            crate::js::module::import_default_clause::FormatJsImportDefaultClause::default(),
         )
     }
 }
@@ -6109,9 +6341,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportNamespaceClause {
         crate::js::module::import_namespace_clause::FormatJsImportNamespaceClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::import_namespace_clause::FormatJsImportNamespaceClause,
+            crate::js::module::import_namespace_clause::FormatJsImportNamespaceClause::default(),
         )
     }
 }
@@ -6121,9 +6354,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportNamespaceClause {
         crate::js::module::import_namespace_clause::FormatJsImportNamespaceClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::import_namespace_clause::FormatJsImportNamespaceClause,
+            crate::js::module::import_namespace_clause::FormatJsImportNamespaceClause::default(),
         )
     }
 }
@@ -6143,7 +6377,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsModuleSource {
         crate::js::module::module_source::FormatJsModuleSource,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::module::module_source::FormatJsModuleSource)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::module::module_source::FormatJsModuleSource::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsModuleSource {
@@ -6152,7 +6390,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsModuleSource {
         crate::js::module::module_source::FormatJsModuleSource,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::module::module_source::FormatJsModuleSource)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::module::module_source::FormatJsModuleSource::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsImportAssertion>
@@ -6175,9 +6417,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportAssertion {
         crate::js::module::import_assertion::FormatJsImportAssertion,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::import_assertion::FormatJsImportAssertion,
+            crate::js::module::import_assertion::FormatJsImportAssertion::default(),
         )
     }
 }
@@ -6187,9 +6430,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportAssertion {
         crate::js::module::import_assertion::FormatJsImportAssertion,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::import_assertion::FormatJsImportAssertion,
+            crate::js::module::import_assertion::FormatJsImportAssertion::default(),
         )
     }
 }
@@ -6213,9 +6457,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDefaultImportSpecifier {
         crate::js::module::default_import_specifier::FormatJsDefaultImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::default_import_specifier::FormatJsDefaultImportSpecifier,
+            crate::js::module::default_import_specifier::FormatJsDefaultImportSpecifier::default(),
         )
     }
 }
@@ -6225,9 +6470,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDefaultImportSpecifier {
         crate::js::module::default_import_specifier::FormatJsDefaultImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::default_import_specifier::FormatJsDefaultImportSpecifier,
+            crate::js::module::default_import_specifier::FormatJsDefaultImportSpecifier::default(),
         )
     }
 }
@@ -6251,9 +6497,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNamedImportSpecifiers {
         crate::js::module::named_import_specifiers::FormatJsNamedImportSpecifiers,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::named_import_specifiers::FormatJsNamedImportSpecifiers,
+            crate::js::module::named_import_specifiers::FormatJsNamedImportSpecifiers::default(),
         )
     }
 }
@@ -6263,9 +6510,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNamedImportSpecifiers {
         crate::js::module::named_import_specifiers::FormatJsNamedImportSpecifiers,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::named_import_specifiers::FormatJsNamedImportSpecifiers,
+            crate::js::module::named_import_specifiers::FormatJsNamedImportSpecifiers::default(),
         )
     }
 }
@@ -6289,10 +6537,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNamespaceImportSpecifier {
         crate::js::module::namespace_import_specifier::FormatJsNamespaceImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::module::namespace_import_specifier::FormatJsNamespaceImportSpecifier,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: module :: namespace_import_specifier :: FormatJsNamespaceImportSpecifier :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNamespaceImportSpecifier {
@@ -6301,10 +6547,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNamespaceImportSpecifier
         crate::js::module::namespace_import_specifier::FormatJsNamespaceImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::module::namespace_import_specifier::FormatJsNamespaceImportSpecifier,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: module :: namespace_import_specifier :: FormatJsNamespaceImportSpecifier :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsShorthandNamedImportSpecifier>
@@ -6327,7 +6571,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsShorthandNamedImportSpecif
         crate::js::module::shorthand_named_import_specifier::FormatJsShorthandNamedImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: module :: shorthand_named_import_specifier :: FormatJsShorthandNamedImportSpecifier)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: module :: shorthand_named_import_specifier :: FormatJsShorthandNamedImportSpecifier :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsShorthandNamedImportSpecifier {
@@ -6336,7 +6581,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsShorthandNamedImportSpec
         crate::js::module::shorthand_named_import_specifier::FormatJsShorthandNamedImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: module :: shorthand_named_import_specifier :: FormatJsShorthandNamedImportSpecifier)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: module :: shorthand_named_import_specifier :: FormatJsShorthandNamedImportSpecifier :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsNamedImportSpecifier>
@@ -6359,9 +6605,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNamedImportSpecifier {
         crate::js::module::named_import_specifier::FormatJsNamedImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::named_import_specifier::FormatJsNamedImportSpecifier,
+            crate::js::module::named_import_specifier::FormatJsNamedImportSpecifier::default(),
         )
     }
 }
@@ -6371,9 +6618,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNamedImportSpecifier {
         crate::js::module::named_import_specifier::FormatJsNamedImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::named_import_specifier::FormatJsNamedImportSpecifier,
+            crate::js::module::named_import_specifier::FormatJsNamedImportSpecifier::default(),
         )
     }
 }
@@ -6397,9 +6645,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsLiteralExportName {
         crate::js::module::literal_export_name::FormatJsLiteralExportName,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::literal_export_name::FormatJsLiteralExportName,
+            crate::js::module::literal_export_name::FormatJsLiteralExportName::default(),
         )
     }
 }
@@ -6409,9 +6658,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsLiteralExportName {
         crate::js::module::literal_export_name::FormatJsLiteralExportName,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::literal_export_name::FormatJsLiteralExportName,
+            crate::js::module::literal_export_name::FormatJsLiteralExportName::default(),
         )
     }
 }
@@ -6435,9 +6685,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportAssertionEntry {
         crate::js::module::import_assertion_entry::FormatJsImportAssertionEntry,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::import_assertion_entry::FormatJsImportAssertionEntry,
+            crate::js::module::import_assertion_entry::FormatJsImportAssertionEntry::default(),
         )
     }
 }
@@ -6447,9 +6698,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportAssertionEntry {
         crate::js::module::import_assertion_entry::FormatJsImportAssertionEntry,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::import_assertion_entry::FormatJsImportAssertionEntry,
+            crate::js::module::import_assertion_entry::FormatJsImportAssertionEntry::default(),
         )
     }
 }
@@ -6469,13 +6721,15 @@ impl FormatRule<biome_js_syntax::JsExportDefaultDeclarationClause>
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportDefaultDeclarationClause {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsExportDefaultDeclarationClause , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportDefaultDeclarationClause {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsExportDefaultDeclarationClause , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsExportDefaultExpressionClause>
@@ -6498,7 +6752,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportDefaultExpressionCla
         crate::js::module::export_default_expression_clause::FormatJsExportDefaultExpressionClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: module :: export_default_expression_clause :: FormatJsExportDefaultExpressionClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: module :: export_default_expression_clause :: FormatJsExportDefaultExpressionClause :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportDefaultExpressionClause {
@@ -6507,7 +6762,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportDefaultExpressionC
         crate::js::module::export_default_expression_clause::FormatJsExportDefaultExpressionClause,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: module :: export_default_expression_clause :: FormatJsExportDefaultExpressionClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: module :: export_default_expression_clause :: FormatJsExportDefaultExpressionClause :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsExportNamedClause>
@@ -6530,9 +6786,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedClause {
         crate::js::module::export_named_clause::FormatJsExportNamedClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::export_named_clause::FormatJsExportNamedClause,
+            crate::js::module::export_named_clause::FormatJsExportNamedClause::default(),
         )
     }
 }
@@ -6542,9 +6799,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedClause {
         crate::js::module::export_named_clause::FormatJsExportNamedClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::export_named_clause::FormatJsExportNamedClause,
+            crate::js::module::export_named_clause::FormatJsExportNamedClause::default(),
         )
     }
 }
@@ -6568,9 +6826,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportFromClause {
         crate::js::module::export_from_clause::FormatJsExportFromClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::export_from_clause::FormatJsExportFromClause,
+            crate::js::module::export_from_clause::FormatJsExportFromClause::default(),
         )
     }
 }
@@ -6580,9 +6839,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportFromClause {
         crate::js::module::export_from_clause::FormatJsExportFromClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::export_from_clause::FormatJsExportFromClause,
+            crate::js::module::export_from_clause::FormatJsExportFromClause::default(),
         )
     }
 }
@@ -6606,9 +6866,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromClause {
         crate::js::module::export_named_from_clause::FormatJsExportNamedFromClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::export_named_from_clause::FormatJsExportNamedFromClause,
+            crate::js::module::export_named_from_clause::FormatJsExportNamedFromClause::default(),
         )
     }
 }
@@ -6618,9 +6879,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromClause {
         crate::js::module::export_named_from_clause::FormatJsExportNamedFromClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::export_named_from_clause::FormatJsExportNamedFromClause,
+            crate::js::module::export_named_from_clause::FormatJsExportNamedFromClause::default(),
         )
     }
 }
@@ -6644,9 +6906,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsExportAsNamespaceClause {
         crate::ts::module::export_as_namespace_clause::FormatTsExportAsNamespaceClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::module::export_as_namespace_clause::FormatTsExportAsNamespaceClause,
+            crate::ts::module::export_as_namespace_clause::FormatTsExportAsNamespaceClause::default(
+            ),
         )
     }
 }
@@ -6656,9 +6920,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExportAsNamespaceClause 
         crate::ts::module::export_as_namespace_clause::FormatTsExportAsNamespaceClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::module::export_as_namespace_clause::FormatTsExportAsNamespaceClause,
+            crate::ts::module::export_as_namespace_clause::FormatTsExportAsNamespaceClause::default(
+            ),
         )
     }
 }
@@ -6682,9 +6948,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsExportAssignmentClause {
         crate::ts::module::export_assignment_clause::FormatTsExportAssignmentClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::module::export_assignment_clause::FormatTsExportAssignmentClause,
+            crate::ts::module::export_assignment_clause::FormatTsExportAssignmentClause::default(),
         )
     }
 }
@@ -6694,9 +6961,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExportAssignmentClause {
         crate::ts::module::export_assignment_clause::FormatTsExportAssignmentClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::module::export_assignment_clause::FormatTsExportAssignmentClause,
+            crate::ts::module::export_assignment_clause::FormatTsExportAssignmentClause::default(),
         )
     }
 }
@@ -6720,9 +6988,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsExportDeclareClause {
         crate::ts::module::export_declare_clause::FormatTsExportDeclareClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::module::export_declare_clause::FormatTsExportDeclareClause,
+            crate::ts::module::export_declare_clause::FormatTsExportDeclareClause::default(),
         )
     }
 }
@@ -6732,9 +7001,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExportDeclareClause {
         crate::ts::module::export_declare_clause::FormatTsExportDeclareClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::module::export_declare_clause::FormatTsExportDeclareClause,
+            crate::ts::module::export_declare_clause::FormatTsExportDeclareClause::default(),
         )
     }
 }
@@ -6742,26 +7012,30 @@ impl FormatRule < biome_js_syntax :: JsFunctionExportDefaultDeclaration > for cr
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsFunctionExportDefaultDeclaration {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsFunctionExportDefaultDeclaration , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsFunctionExportDefaultDeclaration {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsFunctionExportDefaultDeclaration , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration :: default ())
     }
 }
 impl FormatRule < biome_js_syntax :: TsDeclareFunctionExportDefaultDeclaration > for crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & biome_js_syntax :: TsDeclareFunctionExportDefaultDeclaration , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < biome_js_syntax :: TsDeclareFunctionExportDefaultDeclaration > :: fmt (self , node , f) } }
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsDeclareFunctionExportDefaultDeclaration {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: TsDeclareFunctionExportDefaultDeclaration , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDeclareFunctionExportDefaultDeclaration {
     type Format = FormatOwnedWithRule < biome_js_syntax :: TsDeclareFunctionExportDefaultDeclaration , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsExportNamedShorthandSpecifier>
@@ -6784,7 +7058,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedShorthandSpecif
         crate::js::module::export_named_shorthand_specifier::FormatJsExportNamedShorthandSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: module :: export_named_shorthand_specifier :: FormatJsExportNamedShorthandSpecifier)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: module :: export_named_shorthand_specifier :: FormatJsExportNamedShorthandSpecifier :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedShorthandSpecifier {
@@ -6793,7 +7068,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedShorthandSpec
         crate::js::module::export_named_shorthand_specifier::FormatJsExportNamedShorthandSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: module :: export_named_shorthand_specifier :: FormatJsExportNamedShorthandSpecifier)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: module :: export_named_shorthand_specifier :: FormatJsExportNamedShorthandSpecifier :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsExportNamedSpecifier>
@@ -6816,9 +7092,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedSpecifier {
         crate::js::module::export_named_specifier::FormatJsExportNamedSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::export_named_specifier::FormatJsExportNamedSpecifier,
+            crate::js::module::export_named_specifier::FormatJsExportNamedSpecifier::default(),
         )
     }
 }
@@ -6828,9 +7105,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedSpecifier {
         crate::js::module::export_named_specifier::FormatJsExportNamedSpecifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::export_named_specifier::FormatJsExportNamedSpecifier,
+            crate::js::module::export_named_specifier::FormatJsExportNamedSpecifier::default(),
         )
     }
 }
@@ -6854,9 +7132,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportAsClause {
         crate::js::module::export_as_clause::FormatJsExportAsClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::module::export_as_clause::FormatJsExportAsClause,
+            crate::js::module::export_as_clause::FormatJsExportAsClause::default(),
         )
     }
 }
@@ -6866,9 +7145,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportAsClause {
         crate::js::module::export_as_clause::FormatJsExportAsClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::module::export_as_clause::FormatJsExportAsClause,
+            crate::js::module::export_as_clause::FormatJsExportAsClause::default(),
         )
     }
 }
@@ -6892,10 +7172,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromSpecifier {
         crate::js::module::export_named_from_specifier::FormatJsExportNamedFromSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::module::export_named_from_specifier::FormatJsExportNamedFromSpecifier,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: module :: export_named_from_specifier :: FormatJsExportNamedFromSpecifier :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromSpecifier {
@@ -6904,10 +7182,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromSpecifier
         crate::js::module::export_named_from_specifier::FormatJsExportNamedFromSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::module::export_named_from_specifier::FormatJsExportNamedFromSpecifier,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: module :: export_named_from_specifier :: FormatJsExportNamedFromSpecifier :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsName> for crate::js::auxiliary::name::FormatJsName {
@@ -6921,14 +7197,16 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsName {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::JsName, crate::js::auxiliary::name::FormatJsName>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::auxiliary::name::FormatJsName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::js::auxiliary::name::FormatJsName::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsName {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::JsName, crate::js::auxiliary::name::FormatJsName>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::auxiliary::name::FormatJsName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::js::auxiliary::name::FormatJsName::default())
     }
 }
 impl FormatRule<biome_js_syntax::JsFormalParameter>
@@ -6951,9 +7229,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsFormalParameter {
         crate::js::bindings::formal_parameter::FormatJsFormalParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::bindings::formal_parameter::FormatJsFormalParameter,
+            crate::js::bindings::formal_parameter::FormatJsFormalParameter::default(),
         )
     }
 }
@@ -6963,9 +7242,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsFormalParameter {
         crate::js::bindings::formal_parameter::FormatJsFormalParameter,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::bindings::formal_parameter::FormatJsFormalParameter,
+            crate::js::bindings::formal_parameter::FormatJsFormalParameter::default(),
         )
     }
 }
@@ -6989,9 +7269,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsThisParameter {
         crate::ts::bindings::this_parameter::FormatTsThisParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::bindings::this_parameter::FormatTsThisParameter,
+            crate::ts::bindings::this_parameter::FormatTsThisParameter::default(),
         )
     }
 }
@@ -7001,9 +7282,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsThisParameter {
         crate::ts::bindings::this_parameter::FormatTsThisParameter,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::bindings::this_parameter::FormatTsThisParameter,
+            crate::ts::bindings::this_parameter::FormatTsThisParameter::default(),
         )
     }
 }
@@ -7021,7 +7303,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAnyType {
         crate::ts::types::any_type::FormatTsAnyType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::any_type::FormatTsAnyType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::ts::types::any_type::FormatTsAnyType::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAnyType {
@@ -7030,7 +7313,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAnyType {
         crate::ts::types::any_type::FormatTsAnyType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::any_type::FormatTsAnyType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::ts::types::any_type::FormatTsAnyType::default())
     }
 }
 impl FormatRule<biome_js_syntax::TsUnknownType>
@@ -7049,7 +7333,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsUnknownType {
         crate::ts::types::unknown_type::FormatTsUnknownType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::unknown_type::FormatTsUnknownType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::unknown_type::FormatTsUnknownType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsUnknownType {
@@ -7058,7 +7346,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsUnknownType {
         crate::ts::types::unknown_type::FormatTsUnknownType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::unknown_type::FormatTsUnknownType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::unknown_type::FormatTsUnknownType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsNumberType>
@@ -7077,7 +7369,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNumberType {
         crate::ts::types::number_type::FormatTsNumberType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::number_type::FormatTsNumberType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::number_type::FormatTsNumberType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNumberType {
@@ -7086,7 +7382,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNumberType {
         crate::ts::types::number_type::FormatTsNumberType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::number_type::FormatTsNumberType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::number_type::FormatTsNumberType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsBooleanType>
@@ -7105,7 +7405,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsBooleanType {
         crate::ts::types::boolean_type::FormatTsBooleanType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::boolean_type::FormatTsBooleanType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::boolean_type::FormatTsBooleanType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsBooleanType {
@@ -7114,7 +7418,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsBooleanType {
         crate::ts::types::boolean_type::FormatTsBooleanType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::boolean_type::FormatTsBooleanType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::boolean_type::FormatTsBooleanType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsBigintType>
@@ -7133,7 +7441,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsBigintType {
         crate::ts::types::bigint_type::FormatTsBigintType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::bigint_type::FormatTsBigintType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::bigint_type::FormatTsBigintType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsBigintType {
@@ -7142,7 +7454,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsBigintType {
         crate::ts::types::bigint_type::FormatTsBigintType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::bigint_type::FormatTsBigintType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::bigint_type::FormatTsBigintType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsStringType>
@@ -7161,7 +7477,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsStringType {
         crate::ts::types::string_type::FormatTsStringType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::string_type::FormatTsStringType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::string_type::FormatTsStringType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsStringType {
@@ -7170,7 +7490,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsStringType {
         crate::ts::types::string_type::FormatTsStringType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::string_type::FormatTsStringType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::string_type::FormatTsStringType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsSymbolType>
@@ -7189,7 +7513,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsSymbolType {
         crate::ts::types::symbol_type::FormatTsSymbolType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::symbol_type::FormatTsSymbolType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::symbol_type::FormatTsSymbolType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsSymbolType {
@@ -7198,7 +7526,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsSymbolType {
         crate::ts::types::symbol_type::FormatTsSymbolType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::symbol_type::FormatTsSymbolType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::symbol_type::FormatTsSymbolType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsVoidType> for crate::ts::types::void_type::FormatTsVoidType {
@@ -7215,7 +7547,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsVoidType {
         crate::ts::types::void_type::FormatTsVoidType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::void_type::FormatTsVoidType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::void_type::FormatTsVoidType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsVoidType {
@@ -7224,7 +7560,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsVoidType {
         crate::ts::types::void_type::FormatTsVoidType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::void_type::FormatTsVoidType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::void_type::FormatTsVoidType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsUndefinedType>
@@ -7247,9 +7587,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsUndefinedType {
         crate::ts::types::undefined_type::FormatTsUndefinedType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::undefined_type::FormatTsUndefinedType,
+            crate::ts::types::undefined_type::FormatTsUndefinedType::default(),
         )
     }
 }
@@ -7259,9 +7600,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsUndefinedType {
         crate::ts::types::undefined_type::FormatTsUndefinedType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::undefined_type::FormatTsUndefinedType,
+            crate::ts::types::undefined_type::FormatTsUndefinedType::default(),
         )
     }
 }
@@ -7279,7 +7621,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNeverType {
         crate::ts::types::never_type::FormatTsNeverType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::never_type::FormatTsNeverType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::never_type::FormatTsNeverType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNeverType {
@@ -7288,7 +7634,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNeverType {
         crate::ts::types::never_type::FormatTsNeverType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::never_type::FormatTsNeverType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::never_type::FormatTsNeverType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsParenthesizedType>
@@ -7311,9 +7661,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsParenthesizedType {
         crate::ts::types::parenthesized_type::FormatTsParenthesizedType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::parenthesized_type::FormatTsParenthesizedType,
+            crate::ts::types::parenthesized_type::FormatTsParenthesizedType::default(),
         )
     }
 }
@@ -7323,9 +7674,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsParenthesizedType {
         crate::ts::types::parenthesized_type::FormatTsParenthesizedType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::parenthesized_type::FormatTsParenthesizedType,
+            crate::ts::types::parenthesized_type::FormatTsParenthesizedType::default(),
         )
     }
 }
@@ -7349,9 +7701,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsReferenceType {
         crate::ts::types::reference_type::FormatTsReferenceType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::reference_type::FormatTsReferenceType,
+            crate::ts::types::reference_type::FormatTsReferenceType::default(),
         )
     }
 }
@@ -7361,9 +7714,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsReferenceType {
         crate::ts::types::reference_type::FormatTsReferenceType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::reference_type::FormatTsReferenceType,
+            crate::ts::types::reference_type::FormatTsReferenceType::default(),
         )
     }
 }
@@ -7381,7 +7735,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsArrayType {
         crate::ts::types::array_type::FormatTsArrayType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::array_type::FormatTsArrayType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::array_type::FormatTsArrayType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsArrayType {
@@ -7390,7 +7748,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsArrayType {
         crate::ts::types::array_type::FormatTsArrayType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::array_type::FormatTsArrayType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::array_type::FormatTsArrayType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsTupleType> for crate::ts::types::tuple_type::FormatTsTupleType {
@@ -7407,7 +7769,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTupleType {
         crate::ts::types::tuple_type::FormatTsTupleType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::tuple_type::FormatTsTupleType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::tuple_type::FormatTsTupleType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTupleType {
@@ -7416,7 +7782,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTupleType {
         crate::ts::types::tuple_type::FormatTsTupleType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::tuple_type::FormatTsTupleType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::tuple_type::FormatTsTupleType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsTypeofType>
@@ -7435,7 +7805,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeofType {
         crate::ts::types::typeof_type::FormatTsTypeofType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::typeof_type::FormatTsTypeofType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::typeof_type::FormatTsTypeofType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeofType {
@@ -7444,7 +7818,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeofType {
         crate::ts::types::typeof_type::FormatTsTypeofType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::typeof_type::FormatTsTypeofType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::typeof_type::FormatTsTypeofType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsImportType>
@@ -7463,7 +7841,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsImportType {
         crate::ts::module::import_type::FormatTsImportType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::module::import_type::FormatTsImportType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::module::import_type::FormatTsImportType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsImportType {
@@ -7472,7 +7854,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsImportType {
         crate::ts::module::import_type::FormatTsImportType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::module::import_type::FormatTsImportType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::module::import_type::FormatTsImportType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsTypeOperatorType>
@@ -7495,9 +7881,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeOperatorType {
         crate::ts::types::type_operator_type::FormatTsTypeOperatorType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::type_operator_type::FormatTsTypeOperatorType,
+            crate::ts::types::type_operator_type::FormatTsTypeOperatorType::default(),
         )
     }
 }
@@ -7507,9 +7894,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeOperatorType {
         crate::ts::types::type_operator_type::FormatTsTypeOperatorType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::type_operator_type::FormatTsTypeOperatorType,
+            crate::ts::types::type_operator_type::FormatTsTypeOperatorType::default(),
         )
     }
 }
@@ -7533,9 +7921,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIndexedAccessType {
         crate::ts::types::indexed_access_type::FormatTsIndexedAccessType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::indexed_access_type::FormatTsIndexedAccessType,
+            crate::ts::types::indexed_access_type::FormatTsIndexedAccessType::default(),
         )
     }
 }
@@ -7545,9 +7934,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexedAccessType {
         crate::ts::types::indexed_access_type::FormatTsIndexedAccessType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::indexed_access_type::FormatTsIndexedAccessType,
+            crate::ts::types::indexed_access_type::FormatTsIndexedAccessType::default(),
         )
     }
 }
@@ -7567,7 +7957,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsMappedType {
         crate::ts::types::mapped_type::FormatTsMappedType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::mapped_type::FormatTsMappedType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::mapped_type::FormatTsMappedType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMappedType {
@@ -7576,7 +7970,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMappedType {
         crate::ts::types::mapped_type::FormatTsMappedType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::mapped_type::FormatTsMappedType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::mapped_type::FormatTsMappedType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsObjectType>
@@ -7595,7 +7993,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsObjectType {
         crate::ts::types::object_type::FormatTsObjectType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::object_type::FormatTsObjectType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::object_type::FormatTsObjectType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsObjectType {
@@ -7604,7 +8006,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsObjectType {
         crate::ts::types::object_type::FormatTsObjectType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::object_type::FormatTsObjectType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::object_type::FormatTsObjectType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsNonPrimitiveType>
@@ -7627,9 +8033,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNonPrimitiveType {
         crate::ts::types::non_primitive_type::FormatTsNonPrimitiveType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::non_primitive_type::FormatTsNonPrimitiveType,
+            crate::ts::types::non_primitive_type::FormatTsNonPrimitiveType::default(),
         )
     }
 }
@@ -7639,9 +8046,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNonPrimitiveType {
         crate::ts::types::non_primitive_type::FormatTsNonPrimitiveType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::non_primitive_type::FormatTsNonPrimitiveType,
+            crate::ts::types::non_primitive_type::FormatTsNonPrimitiveType::default(),
         )
     }
 }
@@ -7659,7 +8067,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsThisType {
         crate::ts::types::this_type::FormatTsThisType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::this_type::FormatTsThisType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::this_type::FormatTsThisType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsThisType {
@@ -7668,7 +8080,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsThisType {
         crate::ts::types::this_type::FormatTsThisType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::this_type::FormatTsThisType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::this_type::FormatTsThisType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsNumberLiteralType>
@@ -7691,9 +8107,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNumberLiteralType {
         crate::ts::types::number_literal_type::FormatTsNumberLiteralType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::number_literal_type::FormatTsNumberLiteralType,
+            crate::ts::types::number_literal_type::FormatTsNumberLiteralType::default(),
         )
     }
 }
@@ -7703,9 +8120,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNumberLiteralType {
         crate::ts::types::number_literal_type::FormatTsNumberLiteralType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::number_literal_type::FormatTsNumberLiteralType,
+            crate::ts::types::number_literal_type::FormatTsNumberLiteralType::default(),
         )
     }
 }
@@ -7729,9 +8147,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsBigintLiteralType {
         crate::ts::types::bigint_literal_type::FormatTsBigintLiteralType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::bigint_literal_type::FormatTsBigintLiteralType,
+            crate::ts::types::bigint_literal_type::FormatTsBigintLiteralType::default(),
         )
     }
 }
@@ -7741,9 +8160,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsBigintLiteralType {
         crate::ts::types::bigint_literal_type::FormatTsBigintLiteralType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::bigint_literal_type::FormatTsBigintLiteralType,
+            crate::ts::types::bigint_literal_type::FormatTsBigintLiteralType::default(),
         )
     }
 }
@@ -7767,9 +8187,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsStringLiteralType {
         crate::ts::types::string_literal_type::FormatTsStringLiteralType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::string_literal_type::FormatTsStringLiteralType,
+            crate::ts::types::string_literal_type::FormatTsStringLiteralType::default(),
         )
     }
 }
@@ -7779,9 +8200,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsStringLiteralType {
         crate::ts::types::string_literal_type::FormatTsStringLiteralType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::string_literal_type::FormatTsStringLiteralType,
+            crate::ts::types::string_literal_type::FormatTsStringLiteralType::default(),
         )
     }
 }
@@ -7805,9 +8227,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNullLiteralType {
         crate::ts::types::null_literal_type::FormatTsNullLiteralType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::null_literal_type::FormatTsNullLiteralType,
+            crate::ts::types::null_literal_type::FormatTsNullLiteralType::default(),
         )
     }
 }
@@ -7817,9 +8240,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNullLiteralType {
         crate::ts::types::null_literal_type::FormatTsNullLiteralType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::null_literal_type::FormatTsNullLiteralType,
+            crate::ts::types::null_literal_type::FormatTsNullLiteralType::default(),
         )
     }
 }
@@ -7843,9 +8267,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsBooleanLiteralType {
         crate::ts::types::boolean_literal_type::FormatTsBooleanLiteralType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::boolean_literal_type::FormatTsBooleanLiteralType,
+            crate::ts::types::boolean_literal_type::FormatTsBooleanLiteralType::default(),
         )
     }
 }
@@ -7855,9 +8280,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsBooleanLiteralType {
         crate::ts::types::boolean_literal_type::FormatTsBooleanLiteralType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::boolean_literal_type::FormatTsBooleanLiteralType,
+            crate::ts::types::boolean_literal_type::FormatTsBooleanLiteralType::default(),
         )
     }
 }
@@ -7881,9 +8307,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTemplateLiteralType {
         crate::ts::types::template_literal_type::FormatTsTemplateLiteralType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::template_literal_type::FormatTsTemplateLiteralType,
+            crate::ts::types::template_literal_type::FormatTsTemplateLiteralType::default(),
         )
     }
 }
@@ -7893,9 +8320,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTemplateLiteralType {
         crate::ts::types::template_literal_type::FormatTsTemplateLiteralType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::template_literal_type::FormatTsTemplateLiteralType,
+            crate::ts::types::template_literal_type::FormatTsTemplateLiteralType::default(),
         )
     }
 }
@@ -7913,7 +8341,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsInferType {
         crate::ts::types::infer_type::FormatTsInferType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::infer_type::FormatTsInferType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::infer_type::FormatTsInferType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsInferType {
@@ -7922,7 +8354,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsInferType {
         crate::ts::types::infer_type::FormatTsInferType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::infer_type::FormatTsInferType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::infer_type::FormatTsInferType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsIntersectionType>
@@ -7945,9 +8381,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIntersectionType {
         crate::ts::types::intersection_type::FormatTsIntersectionType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::intersection_type::FormatTsIntersectionType,
+            crate::ts::types::intersection_type::FormatTsIntersectionType::default(),
         )
     }
 }
@@ -7957,9 +8394,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIntersectionType {
         crate::ts::types::intersection_type::FormatTsIntersectionType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::intersection_type::FormatTsIntersectionType,
+            crate::ts::types::intersection_type::FormatTsIntersectionType::default(),
         )
     }
 }
@@ -7977,7 +8415,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsUnionType {
         crate::ts::types::union_type::FormatTsUnionType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::union_type::FormatTsUnionType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::union_type::FormatTsUnionType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsUnionType {
@@ -7986,7 +8428,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsUnionType {
         crate::ts::types::union_type::FormatTsUnionType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::union_type::FormatTsUnionType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::union_type::FormatTsUnionType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsFunctionType>
@@ -8005,7 +8451,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsFunctionType {
         crate::ts::types::function_type::FormatTsFunctionType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::types::function_type::FormatTsFunctionType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::types::function_type::FormatTsFunctionType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsFunctionType {
@@ -8014,7 +8464,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsFunctionType {
         crate::ts::types::function_type::FormatTsFunctionType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::types::function_type::FormatTsFunctionType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::types::function_type::FormatTsFunctionType::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsConstructorType>
@@ -8037,9 +8491,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsConstructorType {
         crate::ts::types::constructor_type::FormatTsConstructorType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::constructor_type::FormatTsConstructorType,
+            crate::ts::types::constructor_type::FormatTsConstructorType::default(),
         )
     }
 }
@@ -8049,9 +8504,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsConstructorType {
         crate::ts::types::constructor_type::FormatTsConstructorType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::constructor_type::FormatTsConstructorType,
+            crate::ts::types::constructor_type::FormatTsConstructorType::default(),
         )
     }
 }
@@ -8075,9 +8531,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsConditionalType {
         crate::ts::types::conditional_type::FormatTsConditionalType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::conditional_type::FormatTsConditionalType,
+            crate::ts::types::conditional_type::FormatTsConditionalType::default(),
         )
     }
 }
@@ -8087,9 +8544,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsConditionalType {
         crate::ts::types::conditional_type::FormatTsConditionalType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::conditional_type::FormatTsConditionalType,
+            crate::ts::types::conditional_type::FormatTsConditionalType::default(),
         )
     }
 }
@@ -8113,9 +8571,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIdentifierBinding {
         crate::ts::bindings::identifier_binding::FormatTsIdentifierBinding,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::bindings::identifier_binding::FormatTsIdentifierBinding,
+            crate::ts::bindings::identifier_binding::FormatTsIdentifierBinding::default(),
         )
     }
 }
@@ -8125,9 +8584,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIdentifierBinding {
         crate::ts::bindings::identifier_binding::FormatTsIdentifierBinding,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::bindings::identifier_binding::FormatTsIdentifierBinding,
+            crate::ts::bindings::identifier_binding::FormatTsIdentifierBinding::default(),
         )
     }
 }
@@ -8147,7 +8607,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsEnumMember {
         crate::ts::auxiliary::enum_member::FormatTsEnumMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::auxiliary::enum_member::FormatTsEnumMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::auxiliary::enum_member::FormatTsEnumMember::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsEnumMember {
@@ -8156,7 +8620,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsEnumMember {
         crate::ts::auxiliary::enum_member::FormatTsEnumMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::auxiliary::enum_member::FormatTsEnumMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::auxiliary::enum_member::FormatTsEnumMember::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::TsExternalModuleReference>
@@ -8179,10 +8647,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsExternalModuleReference {
         crate::ts::auxiliary::external_module_reference::FormatTsExternalModuleReference,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::auxiliary::external_module_reference::FormatTsExternalModuleReference,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: external_module_reference :: FormatTsExternalModuleReference :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExternalModuleReference {
@@ -8191,10 +8657,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExternalModuleReference 
         crate::ts::auxiliary::external_module_reference::FormatTsExternalModuleReference,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::auxiliary::external_module_reference::FormatTsExternalModuleReference,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: external_module_reference :: FormatTsExternalModuleReference :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsModuleBlock>
@@ -8213,9 +8677,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsModuleBlock {
         crate::ts::auxiliary::module_block::FormatTsModuleBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::module_block::FormatTsModuleBlock,
+            crate::ts::auxiliary::module_block::FormatTsModuleBlock::default(),
         )
     }
 }
@@ -8225,9 +8690,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsModuleBlock {
         crate::ts::auxiliary::module_block::FormatTsModuleBlock,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::module_block::FormatTsModuleBlock,
+            crate::ts::auxiliary::module_block::FormatTsModuleBlock::default(),
         )
     }
 }
@@ -8251,9 +8717,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsQualifiedModuleName {
         crate::ts::auxiliary::qualified_module_name::FormatTsQualifiedModuleName,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::qualified_module_name::FormatTsQualifiedModuleName,
+            crate::ts::auxiliary::qualified_module_name::FormatTsQualifiedModuleName::default(),
         )
     }
 }
@@ -8263,9 +8730,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsQualifiedModuleName {
         crate::ts::auxiliary::qualified_module_name::FormatTsQualifiedModuleName,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::qualified_module_name::FormatTsQualifiedModuleName,
+            crate::ts::auxiliary::qualified_module_name::FormatTsQualifiedModuleName::default(),
         )
     }
 }
@@ -8273,13 +8741,15 @@ impl FormatRule < biome_js_syntax :: TsEmptyExternalModuleDeclarationBody > for 
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsEmptyExternalModuleDeclarationBody {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: TsEmptyExternalModuleDeclarationBody , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsEmptyExternalModuleDeclarationBody {
     type Format = FormatOwnedWithRule < biome_js_syntax :: TsEmptyExternalModuleDeclarationBody , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsTypeParameterName>
@@ -8302,9 +8772,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeParameterName {
         crate::ts::auxiliary::type_parameter_name::FormatTsTypeParameterName,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::type_parameter_name::FormatTsTypeParameterName,
+            crate::ts::auxiliary::type_parameter_name::FormatTsTypeParameterName::default(),
         )
     }
 }
@@ -8314,9 +8785,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeParameterName {
         crate::ts::auxiliary::type_parameter_name::FormatTsTypeParameterName,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::type_parameter_name::FormatTsTypeParameterName,
+            crate::ts::auxiliary::type_parameter_name::FormatTsTypeParameterName::default(),
         )
     }
 }
@@ -8340,9 +8812,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeConstraintClause {
         crate::ts::auxiliary::type_constraint_clause::FormatTsTypeConstraintClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::type_constraint_clause::FormatTsTypeConstraintClause,
+            crate::ts::auxiliary::type_constraint_clause::FormatTsTypeConstraintClause::default(),
         )
     }
 }
@@ -8352,9 +8825,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeConstraintClause {
         crate::ts::auxiliary::type_constraint_clause::FormatTsTypeConstraintClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::type_constraint_clause::FormatTsTypeConstraintClause,
+            crate::ts::auxiliary::type_constraint_clause::FormatTsTypeConstraintClause::default(),
         )
     }
 }
@@ -8378,9 +8852,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsPredicateReturnType {
         crate::ts::types::predicate_return_type::FormatTsPredicateReturnType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::predicate_return_type::FormatTsPredicateReturnType,
+            crate::ts::types::predicate_return_type::FormatTsPredicateReturnType::default(),
         )
     }
 }
@@ -8390,9 +8865,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPredicateReturnType {
         crate::ts::types::predicate_return_type::FormatTsPredicateReturnType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::predicate_return_type::FormatTsPredicateReturnType,
+            crate::ts::types::predicate_return_type::FormatTsPredicateReturnType::default(),
         )
     }
 }
@@ -8416,9 +8892,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAssertsReturnType {
         crate::ts::types::asserts_return_type::FormatTsAssertsReturnType,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::types::asserts_return_type::FormatTsAssertsReturnType,
+            crate::ts::types::asserts_return_type::FormatTsAssertsReturnType::default(),
         )
     }
 }
@@ -8428,9 +8905,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAssertsReturnType {
         crate::ts::types::asserts_return_type::FormatTsAssertsReturnType,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::types::asserts_return_type::FormatTsAssertsReturnType,
+            crate::ts::types::asserts_return_type::FormatTsAssertsReturnType::default(),
         )
     }
 }
@@ -8454,9 +8932,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAssertsCondition {
         crate::ts::auxiliary::asserts_condition::FormatTsAssertsCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::asserts_condition::FormatTsAssertsCondition,
+            crate::ts::auxiliary::asserts_condition::FormatTsAssertsCondition::default(),
         )
     }
 }
@@ -8466,9 +8945,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAssertsCondition {
         crate::ts::auxiliary::asserts_condition::FormatTsAssertsCondition,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::asserts_condition::FormatTsAssertsCondition,
+            crate::ts::auxiliary::asserts_condition::FormatTsAssertsCondition::default(),
         )
     }
 }
@@ -8492,9 +8972,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeParameter {
         crate::ts::bindings::type_parameter::FormatTsTypeParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::bindings::type_parameter::FormatTsTypeParameter,
+            crate::ts::bindings::type_parameter::FormatTsTypeParameter::default(),
         )
     }
 }
@@ -8504,9 +8985,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeParameter {
         crate::ts::bindings::type_parameter::FormatTsTypeParameter,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::bindings::type_parameter::FormatTsTypeParameter,
+            crate::ts::bindings::type_parameter::FormatTsTypeParameter::default(),
         )
     }
 }
@@ -8530,9 +9012,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsDefaultTypeClause {
         crate::ts::auxiliary::default_type_clause::FormatTsDefaultTypeClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::default_type_clause::FormatTsDefaultTypeClause,
+            crate::ts::auxiliary::default_type_clause::FormatTsDefaultTypeClause::default(),
         )
     }
 }
@@ -8542,9 +9025,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDefaultTypeClause {
         crate::ts::auxiliary::default_type_clause::FormatTsDefaultTypeClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::default_type_clause::FormatTsDefaultTypeClause,
+            crate::ts::auxiliary::default_type_clause::FormatTsDefaultTypeClause::default(),
         )
     }
 }
@@ -8568,9 +9052,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsExtendsClause {
         crate::ts::classes::extends_clause::FormatTsExtendsClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::classes::extends_clause::FormatTsExtendsClause,
+            crate::ts::classes::extends_clause::FormatTsExtendsClause::default(),
         )
     }
 }
@@ -8580,9 +9065,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExtendsClause {
         crate::ts::classes::extends_clause::FormatTsExtendsClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::classes::extends_clause::FormatTsExtendsClause,
+            crate::ts::classes::extends_clause::FormatTsExtendsClause::default(),
         )
     }
 }
@@ -8606,10 +9092,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNameWithTypeArguments {
         crate::ts::expressions::name_with_type_arguments::FormatTsNameWithTypeArguments,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::expressions::name_with_type_arguments::FormatTsNameWithTypeArguments,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: expressions :: name_with_type_arguments :: FormatTsNameWithTypeArguments :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNameWithTypeArguments {
@@ -8618,10 +9102,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNameWithTypeArguments {
         crate::ts::expressions::name_with_type_arguments::FormatTsNameWithTypeArguments,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::expressions::name_with_type_arguments::FormatTsNameWithTypeArguments,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: expressions :: name_with_type_arguments :: FormatTsNameWithTypeArguments :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsCallSignatureTypeMember>
@@ -8644,10 +9126,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsCallSignatureTypeMember {
         crate::ts::auxiliary::call_signature_type_member::FormatTsCallSignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::auxiliary::call_signature_type_member::FormatTsCallSignatureTypeMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: call_signature_type_member :: FormatTsCallSignatureTypeMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsCallSignatureTypeMember {
@@ -8656,10 +9136,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsCallSignatureTypeMember 
         crate::ts::auxiliary::call_signature_type_member::FormatTsCallSignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::auxiliary::call_signature_type_member::FormatTsCallSignatureTypeMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: call_signature_type_member :: FormatTsCallSignatureTypeMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsPropertySignatureTypeMember>
@@ -8682,7 +9160,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureTypeMembe
         crate::ts::auxiliary::property_signature_type_member::FormatTsPropertySignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: property_signature_type_member :: FormatTsPropertySignatureTypeMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: property_signature_type_member :: FormatTsPropertySignatureTypeMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureTypeMember {
@@ -8691,7 +9170,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureTypeMem
         crate::ts::auxiliary::property_signature_type_member::FormatTsPropertySignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: property_signature_type_member :: FormatTsPropertySignatureTypeMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: property_signature_type_member :: FormatTsPropertySignatureTypeMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsConstructSignatureTypeMember>
@@ -8714,7 +9194,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsConstructSignatureTypeMemb
         crate::ts::auxiliary::construct_signature_type_member::FormatTsConstructSignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: construct_signature_type_member :: FormatTsConstructSignatureTypeMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: construct_signature_type_member :: FormatTsConstructSignatureTypeMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsConstructSignatureTypeMember {
@@ -8723,7 +9204,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsConstructSignatureTypeMe
         crate::ts::auxiliary::construct_signature_type_member::FormatTsConstructSignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: construct_signature_type_member :: FormatTsConstructSignatureTypeMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: construct_signature_type_member :: FormatTsConstructSignatureTypeMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsMethodSignatureTypeMember>
@@ -8746,10 +9228,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureTypeMember 
         crate::ts::auxiliary::method_signature_type_member::FormatTsMethodSignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::auxiliary::method_signature_type_member::FormatTsMethodSignatureTypeMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: method_signature_type_member :: FormatTsMethodSignatureTypeMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureTypeMember {
@@ -8758,10 +9238,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureTypeMembe
         crate::ts::auxiliary::method_signature_type_member::FormatTsMethodSignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::auxiliary::method_signature_type_member::FormatTsMethodSignatureTypeMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: method_signature_type_member :: FormatTsMethodSignatureTypeMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsGetterSignatureTypeMember>
@@ -8784,10 +9262,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsGetterSignatureTypeMember 
         crate::ts::auxiliary::getter_signature_type_member::FormatTsGetterSignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::auxiliary::getter_signature_type_member::FormatTsGetterSignatureTypeMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: getter_signature_type_member :: FormatTsGetterSignatureTypeMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsGetterSignatureTypeMember {
@@ -8796,10 +9272,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsGetterSignatureTypeMembe
         crate::ts::auxiliary::getter_signature_type_member::FormatTsGetterSignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::auxiliary::getter_signature_type_member::FormatTsGetterSignatureTypeMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: getter_signature_type_member :: FormatTsGetterSignatureTypeMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsSetterSignatureTypeMember>
@@ -8822,10 +9296,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsSetterSignatureTypeMember 
         crate::ts::auxiliary::setter_signature_type_member::FormatTsSetterSignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::auxiliary::setter_signature_type_member::FormatTsSetterSignatureTypeMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: setter_signature_type_member :: FormatTsSetterSignatureTypeMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsSetterSignatureTypeMember {
@@ -8834,10 +9306,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsSetterSignatureTypeMembe
         crate::ts::auxiliary::setter_signature_type_member::FormatTsSetterSignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::auxiliary::setter_signature_type_member::FormatTsSetterSignatureTypeMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: setter_signature_type_member :: FormatTsSetterSignatureTypeMember :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsIndexSignatureTypeMember>
@@ -8860,10 +9330,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureTypeMember {
         crate::ts::auxiliary::index_signature_type_member::FormatTsIndexSignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::auxiliary::index_signature_type_member::FormatTsIndexSignatureTypeMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: index_signature_type_member :: FormatTsIndexSignatureTypeMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureTypeMember {
@@ -8872,23 +9340,23 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureTypeMember
         crate::ts::auxiliary::index_signature_type_member::FormatTsIndexSignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::auxiliary::index_signature_type_member::FormatTsIndexSignatureTypeMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: index_signature_type_member :: FormatTsIndexSignatureTypeMember :: default ())
     }
 }
 impl FormatRule < biome_js_syntax :: TsMappedTypeReadonlyModifierClause > for crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & biome_js_syntax :: TsMappedTypeReadonlyModifierClause , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < biome_js_syntax :: TsMappedTypeReadonlyModifierClause > :: fmt (self , node , f) } }
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsMappedTypeReadonlyModifierClause {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: TsMappedTypeReadonlyModifierClause , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMappedTypeReadonlyModifierClause {
     type Format = FormatOwnedWithRule < biome_js_syntax :: TsMappedTypeReadonlyModifierClause , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsMappedTypeAsClause>
@@ -8911,9 +9379,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsMappedTypeAsClause {
         crate::ts::auxiliary::mapped_type_as_clause::FormatTsMappedTypeAsClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::mapped_type_as_clause::FormatTsMappedTypeAsClause,
+            crate::ts::auxiliary::mapped_type_as_clause::FormatTsMappedTypeAsClause::default(),
         )
     }
 }
@@ -8923,9 +9392,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMappedTypeAsClause {
         crate::ts::auxiliary::mapped_type_as_clause::FormatTsMappedTypeAsClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::mapped_type_as_clause::FormatTsMappedTypeAsClause,
+            crate::ts::auxiliary::mapped_type_as_clause::FormatTsMappedTypeAsClause::default(),
         )
     }
 }
@@ -8933,13 +9403,15 @@ impl FormatRule < biome_js_syntax :: TsMappedTypeOptionalModifierClause > for cr
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsMappedTypeOptionalModifierClause {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: TsMappedTypeOptionalModifierClause , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMappedTypeOptionalModifierClause {
     type Format = FormatOwnedWithRule < biome_js_syntax :: TsMappedTypeOptionalModifierClause , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsImportTypeQualifier>
@@ -8962,9 +9434,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsImportTypeQualifier {
         crate::ts::module::import_type_qualifier::FormatTsImportTypeQualifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::module::import_type_qualifier::FormatTsImportTypeQualifier,
+            crate::ts::module::import_type_qualifier::FormatTsImportTypeQualifier::default(),
         )
     }
 }
@@ -8974,9 +9447,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsImportTypeQualifier {
         crate::ts::module::import_type_qualifier::FormatTsImportTypeQualifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::module::import_type_qualifier::FormatTsImportTypeQualifier,
+            crate::ts::module::import_type_qualifier::FormatTsImportTypeQualifier::default(),
         )
     }
 }
@@ -9000,9 +9474,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNamedTupleTypeElement {
         crate::ts::auxiliary::named_tuple_type_element::FormatTsNamedTupleTypeElement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::named_tuple_type_element::FormatTsNamedTupleTypeElement,
+            crate::ts::auxiliary::named_tuple_type_element::FormatTsNamedTupleTypeElement::default(
+            ),
         )
     }
 }
@@ -9012,9 +9488,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNamedTupleTypeElement {
         crate::ts::auxiliary::named_tuple_type_element::FormatTsNamedTupleTypeElement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::named_tuple_type_element::FormatTsNamedTupleTypeElement,
+            crate::ts::auxiliary::named_tuple_type_element::FormatTsNamedTupleTypeElement::default(
+            ),
         )
     }
 }
@@ -9038,9 +9516,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsRestTupleTypeElement {
         crate::ts::auxiliary::rest_tuple_type_element::FormatTsRestTupleTypeElement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::rest_tuple_type_element::FormatTsRestTupleTypeElement,
+            crate::ts::auxiliary::rest_tuple_type_element::FormatTsRestTupleTypeElement::default(),
         )
     }
 }
@@ -9050,9 +9529,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsRestTupleTypeElement {
         crate::ts::auxiliary::rest_tuple_type_element::FormatTsRestTupleTypeElement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::rest_tuple_type_element::FormatTsRestTupleTypeElement,
+            crate::ts::auxiliary::rest_tuple_type_element::FormatTsRestTupleTypeElement::default(),
         )
     }
 }
@@ -9076,10 +9556,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsOptionalTupleTypeElement {
         crate::ts::auxiliary::optional_tuple_type_element::FormatTsOptionalTupleTypeElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::auxiliary::optional_tuple_type_element::FormatTsOptionalTupleTypeElement,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: optional_tuple_type_element :: FormatTsOptionalTupleTypeElement :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsOptionalTupleTypeElement {
@@ -9088,10 +9566,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsOptionalTupleTypeElement
         crate::ts::auxiliary::optional_tuple_type_element::FormatTsOptionalTupleTypeElement,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::auxiliary::optional_tuple_type_element::FormatTsOptionalTupleTypeElement,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: optional_tuple_type_element :: FormatTsOptionalTupleTypeElement :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsTemplateChunkElement>
@@ -9114,9 +9590,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTemplateChunkElement {
         crate::ts::auxiliary::template_chunk_element::FormatTsTemplateChunkElement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::template_chunk_element::FormatTsTemplateChunkElement,
+            crate::ts::auxiliary::template_chunk_element::FormatTsTemplateChunkElement::default(),
         )
     }
 }
@@ -9126,9 +9603,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTemplateChunkElement {
         crate::ts::auxiliary::template_chunk_element::FormatTsTemplateChunkElement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::template_chunk_element::FormatTsTemplateChunkElement,
+            crate::ts::auxiliary::template_chunk_element::FormatTsTemplateChunkElement::default(),
         )
     }
 }
@@ -9152,6 +9630,7 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTemplateElement {
         crate::ts::auxiliary::template_element::FormatTsTemplateElement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::template_element::FormatTsTemplateElement::default(),
@@ -9164,6 +9643,7 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTemplateElement {
         crate::ts::auxiliary::template_element::FormatTsTemplateElement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::template_element::FormatTsTemplateElement::default(),
@@ -9190,9 +9670,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsQualifiedName {
         crate::ts::auxiliary::qualified_name::FormatTsQualifiedName,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::auxiliary::qualified_name::FormatTsQualifiedName,
+            crate::ts::auxiliary::qualified_name::FormatTsQualifiedName::default(),
         )
     }
 }
@@ -9202,9 +9683,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsQualifiedName {
         crate::ts::auxiliary::qualified_name::FormatTsQualifiedName,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::auxiliary::qualified_name::FormatTsQualifiedName,
+            crate::ts::auxiliary::qualified_name::FormatTsQualifiedName::default(),
         )
     }
 }
@@ -9222,7 +9704,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxElement {
         crate::jsx::tag::element::FormatJsxElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::jsx::tag::element::FormatJsxElement)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::jsx::tag::element::FormatJsxElement::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxElement {
@@ -9231,7 +9714,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxElement {
         crate::jsx::tag::element::FormatJsxElement,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::jsx::tag::element::FormatJsxElement)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::jsx::tag::element::FormatJsxElement::default())
     }
 }
 impl FormatRule<biome_js_syntax::JsxSelfClosingElement>
@@ -9254,9 +9738,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxSelfClosingElement {
         crate::jsx::tag::self_closing_element::FormatJsxSelfClosingElement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::tag::self_closing_element::FormatJsxSelfClosingElement,
+            crate::jsx::tag::self_closing_element::FormatJsxSelfClosingElement::default(),
         )
     }
 }
@@ -9266,9 +9751,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxSelfClosingElement {
         crate::jsx::tag::self_closing_element::FormatJsxSelfClosingElement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::tag::self_closing_element::FormatJsxSelfClosingElement,
+            crate::jsx::tag::self_closing_element::FormatJsxSelfClosingElement::default(),
         )
     }
 }
@@ -9286,7 +9772,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxFragment {
         crate::jsx::tag::fragment::FormatJsxFragment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::jsx::tag::fragment::FormatJsxFragment)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::jsx::tag::fragment::FormatJsxFragment::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxFragment {
@@ -9295,7 +9785,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxFragment {
         crate::jsx::tag::fragment::FormatJsxFragment,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::jsx::tag::fragment::FormatJsxFragment)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::jsx::tag::fragment::FormatJsxFragment::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsxOpeningElement>
@@ -9318,9 +9812,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxOpeningElement {
         crate::jsx::tag::opening_element::FormatJsxOpeningElement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::tag::opening_element::FormatJsxOpeningElement,
+            crate::jsx::tag::opening_element::FormatJsxOpeningElement::default(),
         )
     }
 }
@@ -9330,9 +9825,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxOpeningElement {
         crate::jsx::tag::opening_element::FormatJsxOpeningElement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::tag::opening_element::FormatJsxOpeningElement,
+            crate::jsx::tag::opening_element::FormatJsxOpeningElement::default(),
         )
     }
 }
@@ -9356,9 +9852,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxClosingElement {
         crate::jsx::tag::closing_element::FormatJsxClosingElement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::tag::closing_element::FormatJsxClosingElement,
+            crate::jsx::tag::closing_element::FormatJsxClosingElement::default(),
         )
     }
 }
@@ -9368,9 +9865,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxClosingElement {
         crate::jsx::tag::closing_element::FormatJsxClosingElement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::tag::closing_element::FormatJsxClosingElement,
+            crate::jsx::tag::closing_element::FormatJsxClosingElement::default(),
         )
     }
 }
@@ -9394,9 +9892,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxOpeningFragment {
         crate::jsx::tag::opening_fragment::FormatJsxOpeningFragment,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::tag::opening_fragment::FormatJsxOpeningFragment,
+            crate::jsx::tag::opening_fragment::FormatJsxOpeningFragment::default(),
         )
     }
 }
@@ -9406,9 +9905,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxOpeningFragment {
         crate::jsx::tag::opening_fragment::FormatJsxOpeningFragment,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::tag::opening_fragment::FormatJsxOpeningFragment,
+            crate::jsx::tag::opening_fragment::FormatJsxOpeningFragment::default(),
         )
     }
 }
@@ -9432,9 +9932,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxClosingFragment {
         crate::jsx::tag::closing_fragment::FormatJsxClosingFragment,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::tag::closing_fragment::FormatJsxClosingFragment,
+            crate::jsx::tag::closing_fragment::FormatJsxClosingFragment::default(),
         )
     }
 }
@@ -9444,9 +9945,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxClosingFragment {
         crate::jsx::tag::closing_fragment::FormatJsxClosingFragment,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::tag::closing_fragment::FormatJsxClosingFragment,
+            crate::jsx::tag::closing_fragment::FormatJsxClosingFragment::default(),
         )
     }
 }
@@ -9461,14 +9963,16 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxName {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::JsxName, crate::jsx::auxiliary::name::FormatJsxName>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::jsx::auxiliary::name::FormatJsxName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::jsx::auxiliary::name::FormatJsxName::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxName {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::JsxName, crate::jsx::auxiliary::name::FormatJsxName>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::jsx::auxiliary::name::FormatJsxName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::jsx::auxiliary::name::FormatJsxName::default())
     }
 }
 impl FormatRule<biome_js_syntax::JsxReferenceIdentifier>
@@ -9491,9 +9995,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxReferenceIdentifier {
         crate::jsx::auxiliary::reference_identifier::FormatJsxReferenceIdentifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::auxiliary::reference_identifier::FormatJsxReferenceIdentifier,
+            crate::jsx::auxiliary::reference_identifier::FormatJsxReferenceIdentifier::default(),
         )
     }
 }
@@ -9503,9 +10008,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxReferenceIdentifier {
         crate::jsx::auxiliary::reference_identifier::FormatJsxReferenceIdentifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::auxiliary::reference_identifier::FormatJsxReferenceIdentifier,
+            crate::jsx::auxiliary::reference_identifier::FormatJsxReferenceIdentifier::default(),
         )
     }
 }
@@ -9529,9 +10035,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxNamespaceName {
         crate::jsx::auxiliary::namespace_name::FormatJsxNamespaceName,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::auxiliary::namespace_name::FormatJsxNamespaceName,
+            crate::jsx::auxiliary::namespace_name::FormatJsxNamespaceName::default(),
         )
     }
 }
@@ -9541,9 +10048,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxNamespaceName {
         crate::jsx::auxiliary::namespace_name::FormatJsxNamespaceName,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::auxiliary::namespace_name::FormatJsxNamespaceName,
+            crate::jsx::auxiliary::namespace_name::FormatJsxNamespaceName::default(),
         )
     }
 }
@@ -9563,7 +10071,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxMemberName {
         crate::jsx::objects::member_name::FormatJsxMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::jsx::objects::member_name::FormatJsxMemberName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::jsx::objects::member_name::FormatJsxMemberName::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxMemberName {
@@ -9572,7 +10084,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxMemberName {
         crate::jsx::objects::member_name::FormatJsxMemberName,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::jsx::objects::member_name::FormatJsxMemberName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::jsx::objects::member_name::FormatJsxMemberName::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsxAttribute>
@@ -9591,7 +10107,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxAttribute {
         crate::jsx::attribute::attribute::FormatJsxAttribute,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::jsx::attribute::attribute::FormatJsxAttribute)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::jsx::attribute::attribute::FormatJsxAttribute::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxAttribute {
@@ -9600,7 +10120,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxAttribute {
         crate::jsx::attribute::attribute::FormatJsxAttribute,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::jsx::attribute::attribute::FormatJsxAttribute)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::jsx::attribute::attribute::FormatJsxAttribute::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsxSpreadAttribute>
@@ -9623,9 +10147,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxSpreadAttribute {
         crate::jsx::attribute::spread_attribute::FormatJsxSpreadAttribute,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::attribute::spread_attribute::FormatJsxSpreadAttribute,
+            crate::jsx::attribute::spread_attribute::FormatJsxSpreadAttribute::default(),
         )
     }
 }
@@ -9635,9 +10160,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxSpreadAttribute {
         crate::jsx::attribute::spread_attribute::FormatJsxSpreadAttribute,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::attribute::spread_attribute::FormatJsxSpreadAttribute,
+            crate::jsx::attribute::spread_attribute::FormatJsxSpreadAttribute::default(),
         )
     }
 }
@@ -9661,7 +10187,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxAttributeInitializerClaus
         crate::jsx::attribute::attribute_initializer_clause::FormatJsxAttributeInitializerClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: jsx :: attribute :: attribute_initializer_clause :: FormatJsxAttributeInitializerClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: jsx :: attribute :: attribute_initializer_clause :: FormatJsxAttributeInitializerClause :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxAttributeInitializerClause {
@@ -9670,7 +10197,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxAttributeInitializerCla
         crate::jsx::attribute::attribute_initializer_clause::FormatJsxAttributeInitializerClause,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: jsx :: attribute :: attribute_initializer_clause :: FormatJsxAttributeInitializerClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: jsx :: attribute :: attribute_initializer_clause :: FormatJsxAttributeInitializerClause :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsxString> for crate::jsx::auxiliary::string::FormatJsxString {
@@ -9687,7 +10215,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxString {
         crate::jsx::auxiliary::string::FormatJsxString,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::jsx::auxiliary::string::FormatJsxString)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::jsx::auxiliary::string::FormatJsxString::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxString {
@@ -9696,7 +10228,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxString {
         crate::jsx::auxiliary::string::FormatJsxString,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::jsx::auxiliary::string::FormatJsxString)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::jsx::auxiliary::string::FormatJsxString::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsxExpressionAttributeValue>
@@ -9719,10 +10255,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxExpressionAttributeValue 
         crate::jsx::attribute::expression_attribute_value::FormatJsxExpressionAttributeValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::jsx::attribute::expression_attribute_value::FormatJsxExpressionAttributeValue,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: jsx :: attribute :: expression_attribute_value :: FormatJsxExpressionAttributeValue :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxExpressionAttributeValue {
@@ -9731,10 +10265,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxExpressionAttributeValu
         crate::jsx::attribute::expression_attribute_value::FormatJsxExpressionAttributeValue,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::jsx::attribute::expression_attribute_value::FormatJsxExpressionAttributeValue,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: jsx :: attribute :: expression_attribute_value :: FormatJsxExpressionAttributeValue :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsxText> for crate::jsx::auxiliary::text::FormatJsxText {
@@ -9748,14 +10280,16 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxText {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::JsxText, crate::jsx::auxiliary::text::FormatJsxText>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::jsx::auxiliary::text::FormatJsxText)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::jsx::auxiliary::text::FormatJsxText::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxText {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::JsxText, crate::jsx::auxiliary::text::FormatJsxText>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::jsx::auxiliary::text::FormatJsxText)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::jsx::auxiliary::text::FormatJsxText::default())
     }
 }
 impl FormatRule<biome_js_syntax::JsxExpressionChild>
@@ -9778,9 +10312,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxExpressionChild {
         crate::jsx::auxiliary::expression_child::FormatJsxExpressionChild,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::auxiliary::expression_child::FormatJsxExpressionChild,
+            crate::jsx::auxiliary::expression_child::FormatJsxExpressionChild::default(),
         )
     }
 }
@@ -9790,9 +10325,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxExpressionChild {
         crate::jsx::auxiliary::expression_child::FormatJsxExpressionChild,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::auxiliary::expression_child::FormatJsxExpressionChild,
+            crate::jsx::auxiliary::expression_child::FormatJsxExpressionChild::default(),
         )
     }
 }
@@ -9812,9 +10348,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxSpreadChild {
         crate::jsx::auxiliary::spread_child::FormatJsxSpreadChild,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::auxiliary::spread_child::FormatJsxSpreadChild,
+            crate::jsx::auxiliary::spread_child::FormatJsxSpreadChild::default(),
         )
     }
 }
@@ -9824,34 +10361,39 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxSpreadChild {
         crate::jsx::auxiliary::spread_child::FormatJsxSpreadChild,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::auxiliary::spread_child::FormatJsxSpreadChild,
+            crate::jsx::auxiliary::spread_child::FormatJsxSpreadChild::default(),
         )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPatternElementList {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsArrayAssignmentPatternElementList , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPatternElementList {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsArrayAssignmentPatternElementList , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPatternElementList {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsArrayBindingPatternElementList , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPatternElementList {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsArrayBindingPatternElementList , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayElementList {
@@ -9861,6 +10403,7 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayElementList {
         crate::js::lists::array_element_list::FormatJsArrayElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::array_element_list::FormatJsArrayElementList::default(),
@@ -9873,6 +10416,7 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayElementList {
         crate::js::lists::array_element_list::FormatJsArrayElementList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::array_element_list::FormatJsArrayElementList::default(),
@@ -9886,9 +10430,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsCallArgumentList {
         crate::js::lists::call_argument_list::FormatJsCallArgumentList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::call_argument_list::FormatJsCallArgumentList,
+            crate::js::lists::call_argument_list::FormatJsCallArgumentList::default(),
         )
     }
 }
@@ -9898,9 +10443,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsCallArgumentList {
         crate::js::lists::call_argument_list::FormatJsCallArgumentList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::call_argument_list::FormatJsCallArgumentList,
+            crate::js::lists::call_argument_list::FormatJsCallArgumentList::default(),
         )
     }
 }
@@ -9911,9 +10457,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsClassMemberList {
         crate::js::lists::class_member_list::FormatJsClassMemberList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::class_member_list::FormatJsClassMemberList,
+            crate::js::lists::class_member_list::FormatJsClassMemberList::default(),
         )
     }
 }
@@ -9923,9 +10470,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsClassMemberList {
         crate::js::lists::class_member_list::FormatJsClassMemberList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::class_member_list::FormatJsClassMemberList,
+            crate::js::lists::class_member_list::FormatJsClassMemberList::default(),
         )
     }
 }
@@ -9936,9 +10484,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsConstructorModifierList {
         crate::js::lists::constructor_modifier_list::FormatJsConstructorModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::constructor_modifier_list::FormatJsConstructorModifierList,
+            crate::js::lists::constructor_modifier_list::FormatJsConstructorModifierList::default(),
         )
     }
 }
@@ -9948,9 +10497,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsConstructorModifierList 
         crate::js::lists::constructor_modifier_list::FormatJsConstructorModifierList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::constructor_modifier_list::FormatJsConstructorModifierList,
+            crate::js::lists::constructor_modifier_list::FormatJsConstructorModifierList::default(),
         )
     }
 }
@@ -9961,9 +10511,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsConstructorParameterList {
         crate::js::lists::constructor_parameter_list::FormatJsConstructorParameterList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::constructor_parameter_list::FormatJsConstructorParameterList,
+            crate::js::lists::constructor_parameter_list::FormatJsConstructorParameterList::default(
+            ),
         )
     }
 }
@@ -9973,9 +10525,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsConstructorParameterList
         crate::js::lists::constructor_parameter_list::FormatJsConstructorParameterList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::constructor_parameter_list::FormatJsConstructorParameterList,
+            crate::js::lists::constructor_parameter_list::FormatJsConstructorParameterList::default(
+            ),
         )
     }
 }
@@ -9986,9 +10540,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDecoratorList {
         crate::js::lists::decorator_list::FormatJsDecoratorList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::decorator_list::FormatJsDecoratorList,
+            crate::js::lists::decorator_list::FormatJsDecoratorList::default(),
         )
     }
 }
@@ -9998,9 +10553,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDecoratorList {
         crate::js::lists::decorator_list::FormatJsDecoratorList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::decorator_list::FormatJsDecoratorList,
+            crate::js::lists::decorator_list::FormatJsDecoratorList::default(),
         )
     }
 }
@@ -10011,9 +10567,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDirectiveList {
         crate::js::lists::directive_list::FormatJsDirectiveList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::directive_list::FormatJsDirectiveList,
+            crate::js::lists::directive_list::FormatJsDirectiveList::default(),
         )
     }
 }
@@ -10023,9 +10580,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDirectiveList {
         crate::js::lists::directive_list::FormatJsDirectiveList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::directive_list::FormatJsDirectiveList,
+            crate::js::lists::directive_list::FormatJsDirectiveList::default(),
         )
     }
 }
@@ -10036,7 +10594,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromSpecifierLi
         crate::js::lists::export_named_from_specifier_list::FormatJsExportNamedFromSpecifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: lists :: export_named_from_specifier_list :: FormatJsExportNamedFromSpecifierList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: lists :: export_named_from_specifier_list :: FormatJsExportNamedFromSpecifierList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromSpecifierList {
@@ -10045,7 +10604,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromSpecifier
         crate::js::lists::export_named_from_specifier_list::FormatJsExportNamedFromSpecifierList,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: lists :: export_named_from_specifier_list :: FormatJsExportNamedFromSpecifierList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: lists :: export_named_from_specifier_list :: FormatJsExportNamedFromSpecifierList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedSpecifierList {
@@ -10055,10 +10615,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedSpecifierList {
         crate::js::lists::export_named_specifier_list::FormatJsExportNamedSpecifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::lists::export_named_specifier_list::FormatJsExportNamedSpecifierList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: lists :: export_named_specifier_list :: FormatJsExportNamedSpecifierList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedSpecifierList {
@@ -10067,10 +10625,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedSpecifierList
         crate::js::lists::export_named_specifier_list::FormatJsExportNamedSpecifierList,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::lists::export_named_specifier_list::FormatJsExportNamedSpecifierList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: lists :: export_named_specifier_list :: FormatJsExportNamedSpecifierList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportAssertionEntryList {
@@ -10080,10 +10636,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportAssertionEntryList {
         crate::js::lists::import_assertion_entry_list::FormatJsImportAssertionEntryList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::lists::import_assertion_entry_list::FormatJsImportAssertionEntryList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: lists :: import_assertion_entry_list :: FormatJsImportAssertionEntryList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportAssertionEntryList {
@@ -10092,10 +10646,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportAssertionEntryList
         crate::js::lists::import_assertion_entry_list::FormatJsImportAssertionEntryList,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::lists::import_assertion_entry_list::FormatJsImportAssertionEntryList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: lists :: import_assertion_entry_list :: FormatJsImportAssertionEntryList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsMethodModifierList {
@@ -10105,9 +10657,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsMethodModifierList {
         crate::js::lists::method_modifier_list::FormatJsMethodModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::method_modifier_list::FormatJsMethodModifierList,
+            crate::js::lists::method_modifier_list::FormatJsMethodModifierList::default(),
         )
     }
 }
@@ -10117,9 +10670,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsMethodModifierList {
         crate::js::lists::method_modifier_list::FormatJsMethodModifierList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::method_modifier_list::FormatJsMethodModifierList,
+            crate::js::lists::method_modifier_list::FormatJsMethodModifierList::default(),
         )
     }
 }
@@ -10130,9 +10684,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsModuleItemList {
         crate::js::lists::module_item_list::FormatJsModuleItemList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::module_item_list::FormatJsModuleItemList,
+            crate::js::lists::module_item_list::FormatJsModuleItemList::default(),
         )
     }
 }
@@ -10142,9 +10697,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsModuleItemList {
         crate::js::lists::module_item_list::FormatJsModuleItemList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::module_item_list::FormatJsModuleItemList,
+            crate::js::lists::module_item_list::FormatJsModuleItemList::default(),
         )
     }
 }
@@ -10155,10 +10711,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNamedImportSpecifierList {
         crate::js::lists::named_import_specifier_list::FormatJsNamedImportSpecifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::lists::named_import_specifier_list::FormatJsNamedImportSpecifierList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: lists :: named_import_specifier_list :: FormatJsNamedImportSpecifierList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNamedImportSpecifierList {
@@ -10167,34 +10721,36 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNamedImportSpecifierList
         crate::js::lists::named_import_specifier_list::FormatJsNamedImportSpecifierList,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::lists::named_import_specifier_list::FormatJsNamedImportSpecifierList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: lists :: named_import_specifier_list :: FormatJsNamedImportSpecifierList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternPropertyList {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsObjectAssignmentPatternPropertyList , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternPropertyList {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsObjectAssignmentPatternPropertyList , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternPropertyList {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsObjectBindingPatternPropertyList , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList > ;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternPropertyList {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsObjectBindingPatternPropertyList , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList > ;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectMemberList {
@@ -10204,9 +10760,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectMemberList {
         crate::js::lists::object_member_list::FormatJsObjectMemberList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::object_member_list::FormatJsObjectMemberList,
+            crate::js::lists::object_member_list::FormatJsObjectMemberList::default(),
         )
     }
 }
@@ -10216,9 +10773,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectMemberList {
         crate::js::lists::object_member_list::FormatJsObjectMemberList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::object_member_list::FormatJsObjectMemberList,
+            crate::js::lists::object_member_list::FormatJsObjectMemberList::default(),
         )
     }
 }
@@ -10229,9 +10787,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsParameterList {
         crate::js::lists::parameter_list::FormatJsParameterList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::parameter_list::FormatJsParameterList,
+            crate::js::lists::parameter_list::FormatJsParameterList::default(),
         )
     }
 }
@@ -10241,9 +10800,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsParameterList {
         crate::js::lists::parameter_list::FormatJsParameterList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::parameter_list::FormatJsParameterList,
+            crate::js::lists::parameter_list::FormatJsParameterList::default(),
         )
     }
 }
@@ -10254,9 +10814,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPropertyModifierList {
         crate::js::lists::property_modifier_list::FormatJsPropertyModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::property_modifier_list::FormatJsPropertyModifierList,
+            crate::js::lists::property_modifier_list::FormatJsPropertyModifierList::default(),
         )
     }
 }
@@ -10266,9 +10827,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPropertyModifierList {
         crate::js::lists::property_modifier_list::FormatJsPropertyModifierList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::property_modifier_list::FormatJsPropertyModifierList,
+            crate::js::lists::property_modifier_list::FormatJsPropertyModifierList::default(),
         )
     }
 }
@@ -10279,9 +10841,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsStatementList {
         crate::js::lists::statement_list::FormatJsStatementList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::statement_list::FormatJsStatementList,
+            crate::js::lists::statement_list::FormatJsStatementList::default(),
         )
     }
 }
@@ -10291,9 +10854,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStatementList {
         crate::js::lists::statement_list::FormatJsStatementList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::statement_list::FormatJsStatementList,
+            crate::js::lists::statement_list::FormatJsStatementList::default(),
         )
     }
 }
@@ -10304,9 +10868,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSwitchCaseList {
         crate::js::lists::switch_case_list::FormatJsSwitchCaseList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::switch_case_list::FormatJsSwitchCaseList,
+            crate::js::lists::switch_case_list::FormatJsSwitchCaseList::default(),
         )
     }
 }
@@ -10316,9 +10881,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSwitchCaseList {
         crate::js::lists::switch_case_list::FormatJsSwitchCaseList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::switch_case_list::FormatJsSwitchCaseList,
+            crate::js::lists::switch_case_list::FormatJsSwitchCaseList::default(),
         )
     }
 }
@@ -10329,6 +10895,7 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsTemplateElementList {
         crate::js::lists::template_element_list::FormatJsTemplateElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::template_element_list::FormatJsTemplateElementList::default(),
@@ -10341,6 +10908,7 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsTemplateElementList {
         crate::js::lists::template_element_list::FormatJsTemplateElementList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::template_element_list::FormatJsTemplateElementList::default(),
@@ -10354,9 +10922,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclaratorList {
         crate::js::lists::variable_declarator_list::FormatJsVariableDeclaratorList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::lists::variable_declarator_list::FormatJsVariableDeclaratorList,
+            crate::js::lists::variable_declarator_list::FormatJsVariableDeclaratorList::default(),
         )
     }
 }
@@ -10366,9 +10935,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclaratorList {
         crate::js::lists::variable_declarator_list::FormatJsVariableDeclaratorList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::lists::variable_declarator_list::FormatJsVariableDeclaratorList,
+            crate::js::lists::variable_declarator_list::FormatJsVariableDeclaratorList::default(),
         )
     }
 }
@@ -10379,9 +10949,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxAttributeList {
         crate::jsx::lists::attribute_list::FormatJsxAttributeList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::lists::attribute_list::FormatJsxAttributeList,
+            crate::jsx::lists::attribute_list::FormatJsxAttributeList::default(),
         )
     }
 }
@@ -10391,9 +10962,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxAttributeList {
         crate::jsx::lists::attribute_list::FormatJsxAttributeList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::lists::attribute_list::FormatJsxAttributeList,
+            crate::jsx::lists::attribute_list::FormatJsxAttributeList::default(),
         )
     }
 }
@@ -10404,6 +10976,7 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxChildList {
         crate::jsx::lists::child_list::FormatJsxChildList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::lists::child_list::FormatJsxChildList::default(),
@@ -10416,6 +10989,7 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxChildList {
         crate::jsx::lists::child_list::FormatJsxChildList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::lists::child_list::FormatJsxChildList::default(),
@@ -10429,9 +11003,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsEnumMemberList {
         crate::ts::lists::enum_member_list::FormatTsEnumMemberList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::lists::enum_member_list::FormatTsEnumMemberList,
+            crate::ts::lists::enum_member_list::FormatTsEnumMemberList::default(),
         )
     }
 }
@@ -10441,9 +11016,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsEnumMemberList {
         crate::ts::lists::enum_member_list::FormatTsEnumMemberList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::lists::enum_member_list::FormatTsEnumMemberList,
+            crate::ts::lists::enum_member_list::FormatTsEnumMemberList::default(),
         )
     }
 }
@@ -10454,10 +11030,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureModifierList
         crate::ts::lists::index_signature_modifier_list::FormatTsIndexSignatureModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::lists::index_signature_modifier_list::FormatTsIndexSignatureModifierList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: lists :: index_signature_modifier_list :: FormatTsIndexSignatureModifierList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureModifierList {
@@ -10466,10 +11040,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureModifierLi
         crate::ts::lists::index_signature_modifier_list::FormatTsIndexSignatureModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::lists::index_signature_modifier_list::FormatTsIndexSignatureModifierList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: lists :: index_signature_modifier_list :: FormatTsIndexSignatureModifierList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsIntersectionTypeElementList {
@@ -10479,10 +11051,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIntersectionTypeElementLis
         crate::ts::lists::intersection_type_element_list::FormatTsIntersectionTypeElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::lists::intersection_type_element_list::FormatTsIntersectionTypeElementList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: lists :: intersection_type_element_list :: FormatTsIntersectionTypeElementList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIntersectionTypeElementList {
@@ -10491,10 +11061,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIntersectionTypeElementL
         crate::ts::lists::intersection_type_element_list::FormatTsIntersectionTypeElementList,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::lists::intersection_type_element_list::FormatTsIntersectionTypeElementList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: lists :: intersection_type_element_list :: FormatTsIntersectionTypeElementList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureModifierList {
@@ -10504,10 +11072,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureModifierLis
         crate::ts::lists::method_signature_modifier_list::FormatTsMethodSignatureModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::lists::method_signature_modifier_list::FormatTsMethodSignatureModifierList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: lists :: method_signature_modifier_list :: FormatTsMethodSignatureModifierList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureModifierList {
@@ -10516,10 +11082,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureModifierL
         crate::ts::lists::method_signature_modifier_list::FormatTsMethodSignatureModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::lists::method_signature_modifier_list::FormatTsMethodSignatureModifierList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: lists :: method_signature_modifier_list :: FormatTsMethodSignatureModifierList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsPropertyParameterModifierList {
@@ -10529,7 +11093,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsPropertyParameterModifierL
         crate::ts::lists::property_parameter_modifier_list::FormatTsPropertyParameterModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: lists :: property_parameter_modifier_list :: FormatTsPropertyParameterModifierList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: lists :: property_parameter_modifier_list :: FormatTsPropertyParameterModifierList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertyParameterModifierList {
@@ -10538,7 +11103,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertyParameterModifie
         crate::ts::lists::property_parameter_modifier_list::FormatTsPropertyParameterModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: lists :: property_parameter_modifier_list :: FormatTsPropertyParameterModifierList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: lists :: property_parameter_modifier_list :: FormatTsPropertyParameterModifierList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureModifierList {
@@ -10548,7 +11114,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureModifierL
         crate::ts::lists::property_signature_modifier_list::FormatTsPropertySignatureModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: lists :: property_signature_modifier_list :: FormatTsPropertySignatureModifierList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: lists :: property_signature_modifier_list :: FormatTsPropertySignatureModifierList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureModifierList {
@@ -10557,7 +11124,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureModifie
         crate::ts::lists::property_signature_modifier_list::FormatTsPropertySignatureModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: lists :: property_signature_modifier_list :: FormatTsPropertySignatureModifierList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: lists :: property_signature_modifier_list :: FormatTsPropertySignatureModifierList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsTemplateElementList {
@@ -10567,9 +11135,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTemplateElementList {
         crate::ts::lists::template_element_list::FormatTsTemplateElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::lists::template_element_list::FormatTsTemplateElementList,
+            crate::ts::lists::template_element_list::FormatTsTemplateElementList::default(),
         )
     }
 }
@@ -10579,9 +11148,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTemplateElementList {
         crate::ts::lists::template_element_list::FormatTsTemplateElementList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::lists::template_element_list::FormatTsTemplateElementList,
+            crate::ts::lists::template_element_list::FormatTsTemplateElementList::default(),
         )
     }
 }
@@ -10592,9 +11162,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTupleTypeElementList {
         crate::ts::lists::tuple_type_element_list::FormatTsTupleTypeElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::lists::tuple_type_element_list::FormatTsTupleTypeElementList,
+            crate::ts::lists::tuple_type_element_list::FormatTsTupleTypeElementList::default(),
         )
     }
 }
@@ -10604,9 +11175,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTupleTypeElementList {
         crate::ts::lists::tuple_type_element_list::FormatTsTupleTypeElementList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::lists::tuple_type_element_list::FormatTsTupleTypeElementList,
+            crate::ts::lists::tuple_type_element_list::FormatTsTupleTypeElementList::default(),
         )
     }
 }
@@ -10617,9 +11189,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeArgumentList {
         crate::ts::lists::type_argument_list::FormatTsTypeArgumentList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::lists::type_argument_list::FormatTsTypeArgumentList,
+            crate::ts::lists::type_argument_list::FormatTsTypeArgumentList::default(),
         )
     }
 }
@@ -10629,9 +11202,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeArgumentList {
         crate::ts::lists::type_argument_list::FormatTsTypeArgumentList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::lists::type_argument_list::FormatTsTypeArgumentList,
+            crate::ts::lists::type_argument_list::FormatTsTypeArgumentList::default(),
         )
     }
 }
@@ -10642,7 +11216,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeList {
         crate::ts::lists::type_list::FormatTsTypeList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::lists::type_list::FormatTsTypeList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::lists::type_list::FormatTsTypeList::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeList {
@@ -10651,7 +11229,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeList {
         crate::ts::lists::type_list::FormatTsTypeList,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::lists::type_list::FormatTsTypeList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::lists::type_list::FormatTsTypeList::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeMemberList {
@@ -10661,9 +11243,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeMemberList {
         crate::ts::lists::type_member_list::FormatTsTypeMemberList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::lists::type_member_list::FormatTsTypeMemberList,
+            crate::ts::lists::type_member_list::FormatTsTypeMemberList::default(),
         )
     }
 }
@@ -10673,9 +11256,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeMemberList {
         crate::ts::lists::type_member_list::FormatTsTypeMemberList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::lists::type_member_list::FormatTsTypeMemberList,
+            crate::ts::lists::type_member_list::FormatTsTypeMemberList::default(),
         )
     }
 }
@@ -10686,9 +11270,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeParameterList {
         crate::ts::lists::type_parameter_list::FormatTsTypeParameterList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::lists::type_parameter_list::FormatTsTypeParameterList,
+            crate::ts::lists::type_parameter_list::FormatTsTypeParameterList::default(),
         )
     }
 }
@@ -10698,9 +11283,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeParameterList {
         crate::ts::lists::type_parameter_list::FormatTsTypeParameterList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::lists::type_parameter_list::FormatTsTypeParameterList,
+            crate::ts::lists::type_parameter_list::FormatTsTypeParameterList::default(),
         )
     }
 }
@@ -10711,10 +11297,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeParameterModifierList 
         crate::ts::lists::type_parameter_modifier_list::FormatTsTypeParameterModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::lists::type_parameter_modifier_list::FormatTsTypeParameterModifierList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: lists :: type_parameter_modifier_list :: FormatTsTypeParameterModifierList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeParameterModifierList {
@@ -10723,10 +11307,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeParameterModifierLis
         crate::ts::lists::type_parameter_modifier_list::FormatTsTypeParameterModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::lists::type_parameter_modifier_list::FormatTsTypeParameterModifierList,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: lists :: type_parameter_modifier_list :: FormatTsTypeParameterModifierList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsUnionTypeVariantList {
@@ -10736,6 +11318,7 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsUnionTypeVariantList {
         crate::ts::lists::union_type_variant_list::FormatTsUnionTypeVariantList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::lists::union_type_variant_list::FormatTsUnionTypeVariantList::default(),
@@ -10748,6 +11331,7 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsUnionTypeVariantList {
         crate::ts::lists::union_type_variant_list::FormatTsUnionTypeVariantList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::lists::union_type_variant_list::FormatTsUnionTypeVariantList::default(),
@@ -10765,14 +11349,16 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogus {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::JsBogus, crate::js::bogus::bogus::FormatJsBogus>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::bogus::bogus::FormatJsBogus)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::js::bogus::bogus::FormatJsBogus::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogus {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::JsBogus, crate::js::bogus::bogus::FormatJsBogus>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::bogus::bogus::FormatJsBogus)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::js::bogus::bogus::FormatJsBogus::default())
     }
 }
 impl FormatRule<biome_js_syntax::JsBogusStatement>
@@ -10795,9 +11381,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusStatement {
         crate::js::bogus::bogus_statement::FormatJsBogusStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::bogus::bogus_statement::FormatJsBogusStatement,
+            crate::js::bogus::bogus_statement::FormatJsBogusStatement::default(),
         )
     }
 }
@@ -10807,9 +11394,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusStatement {
         crate::js::bogus::bogus_statement::FormatJsBogusStatement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::bogus::bogus_statement::FormatJsBogusStatement,
+            crate::js::bogus::bogus_statement::FormatJsBogusStatement::default(),
         )
     }
 }
@@ -10833,9 +11421,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusExpression {
         crate::js::bogus::bogus_expression::FormatJsBogusExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::bogus::bogus_expression::FormatJsBogusExpression,
+            crate::js::bogus::bogus_expression::FormatJsBogusExpression::default(),
         )
     }
 }
@@ -10845,9 +11434,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusExpression {
         crate::js::bogus::bogus_expression::FormatJsBogusExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::bogus::bogus_expression::FormatJsBogusExpression,
+            crate::js::bogus::bogus_expression::FormatJsBogusExpression::default(),
         )
     }
 }
@@ -10867,7 +11457,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusMember {
         crate::js::bogus::bogus_member::FormatJsBogusMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::bogus::bogus_member::FormatJsBogusMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::bogus::bogus_member::FormatJsBogusMember::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusMember {
@@ -10876,7 +11470,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusMember {
         crate::js::bogus::bogus_member::FormatJsBogusMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::bogus::bogus_member::FormatJsBogusMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::bogus::bogus_member::FormatJsBogusMember::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsBogusBinding>
@@ -10895,7 +11493,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusBinding {
         crate::js::bogus::bogus_binding::FormatJsBogusBinding,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::bogus::bogus_binding::FormatJsBogusBinding)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::bogus::bogus_binding::FormatJsBogusBinding::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusBinding {
@@ -10904,7 +11506,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusBinding {
         crate::js::bogus::bogus_binding::FormatJsBogusBinding,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::bogus::bogus_binding::FormatJsBogusBinding)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::bogus::bogus_binding::FormatJsBogusBinding::default(),
+        )
     }
 }
 impl FormatRule<biome_js_syntax::JsBogusAssignment>
@@ -10927,9 +11533,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusAssignment {
         crate::js::bogus::bogus_assignment::FormatJsBogusAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::bogus::bogus_assignment::FormatJsBogusAssignment,
+            crate::js::bogus::bogus_assignment::FormatJsBogusAssignment::default(),
         )
     }
 }
@@ -10939,9 +11546,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusAssignment {
         crate::js::bogus::bogus_assignment::FormatJsBogusAssignment,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::bogus::bogus_assignment::FormatJsBogusAssignment,
+            crate::js::bogus::bogus_assignment::FormatJsBogusAssignment::default(),
         )
     }
 }
@@ -10965,9 +11573,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusParameter {
         crate::js::bogus::bogus_parameter::FormatJsBogusParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::bogus::bogus_parameter::FormatJsBogusParameter,
+            crate::js::bogus::bogus_parameter::FormatJsBogusParameter::default(),
         )
     }
 }
@@ -10977,9 +11586,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusParameter {
         crate::js::bogus::bogus_parameter::FormatJsBogusParameter,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::bogus::bogus_parameter::FormatJsBogusParameter,
+            crate::js::bogus::bogus_parameter::FormatJsBogusParameter::default(),
         )
     }
 }
@@ -11003,10 +11613,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusImportAssertionEntry 
         crate::js::bogus::bogus_import_assertion_entry::FormatJsBogusImportAssertionEntry,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::bogus::bogus_import_assertion_entry::FormatJsBogusImportAssertionEntry,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: bogus :: bogus_import_assertion_entry :: FormatJsBogusImportAssertionEntry :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusImportAssertionEntry {
@@ -11015,10 +11623,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusImportAssertionEntr
         crate::js::bogus::bogus_import_assertion_entry::FormatJsBogusImportAssertionEntry,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::bogus::bogus_import_assertion_entry::FormatJsBogusImportAssertionEntry,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: bogus :: bogus_import_assertion_entry :: FormatJsBogusImportAssertionEntry :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::JsBogusNamedImportSpecifier>
@@ -11041,10 +11647,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusNamedImportSpecifier 
         crate::js::bogus::bogus_named_import_specifier::FormatJsBogusNamedImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::bogus::bogus_named_import_specifier::FormatJsBogusNamedImportSpecifier,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: bogus :: bogus_named_import_specifier :: FormatJsBogusNamedImportSpecifier :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusNamedImportSpecifier {
@@ -11053,10 +11657,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusNamedImportSpecifie
         crate::js::bogus::bogus_named_import_specifier::FormatJsBogusNamedImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::bogus::bogus_named_import_specifier::FormatJsBogusNamedImportSpecifier,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: bogus :: bogus_named_import_specifier :: FormatJsBogusNamedImportSpecifier :: default ())
     }
 }
 impl FormatRule<biome_js_syntax::TsBogusType> for crate::ts::bogus::bogus_type::FormatTsBogusType {
@@ -11073,7 +11675,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsBogusType {
         crate::ts::bogus::bogus_type::FormatTsBogusType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::bogus::bogus_type::FormatTsBogusType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::bogus::bogus_type::FormatTsBogusType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsBogusType {
@@ -11082,21 +11688,27 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsBogusType {
         crate::ts::bogus::bogus_type::FormatTsBogusType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::bogus::bogus_type::FormatTsBogusType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::bogus::bogus_type::FormatTsBogusType::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsRoot {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyJsRoot, crate::js::any::root::FormatAnyJsRoot>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::root::FormatAnyJsRoot)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::js::any::root::FormatAnyJsRoot::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsRoot {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyJsRoot, crate::js::any::root::FormatAnyJsRoot>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::root::FormatAnyJsRoot)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::js::any::root::FormatAnyJsRoot::default())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsExpression {
@@ -11106,7 +11718,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsExpression {
         crate::js::any::expression::FormatAnyJsExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::expression::FormatAnyJsExpression)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::expression::FormatAnyJsExpression::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsExpression {
@@ -11115,7 +11731,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsExpression {
         crate::js::any::expression::FormatAnyJsExpression,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::expression::FormatAnyJsExpression)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::expression::FormatAnyJsExpression::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsStatement {
@@ -11125,7 +11745,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsStatement {
         crate::js::any::statement::FormatAnyJsStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::statement::FormatAnyJsStatement)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::statement::FormatAnyJsStatement::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsStatement {
@@ -11134,7 +11758,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsStatement {
         crate::js::any::statement::FormatAnyJsStatement,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::statement::FormatAnyJsStatement)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::statement::FormatAnyJsStatement::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsForInitializer {
@@ -11144,9 +11772,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsForInitializer {
         crate::js::any::for_initializer::FormatAnyJsForInitializer,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::for_initializer::FormatAnyJsForInitializer,
+            crate::js::any::for_initializer::FormatAnyJsForInitializer::default(),
         )
     }
 }
@@ -11156,9 +11785,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsForInitializer {
         crate::js::any::for_initializer::FormatAnyJsForInitializer,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::for_initializer::FormatAnyJsForInitializer,
+            crate::js::any::for_initializer::FormatAnyJsForInitializer::default(),
         )
     }
 }
@@ -11169,9 +11799,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsForInOrOfInitializer {
         crate::js::any::for_in_or_of_initializer::FormatAnyJsForInOrOfInitializer,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::for_in_or_of_initializer::FormatAnyJsForInOrOfInitializer,
+            crate::js::any::for_in_or_of_initializer::FormatAnyJsForInOrOfInitializer::default(),
         )
     }
 }
@@ -11181,9 +11812,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsForInOrOfInitializer 
         crate::js::any::for_in_or_of_initializer::FormatAnyJsForInOrOfInitializer,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::for_in_or_of_initializer::FormatAnyJsForInOrOfInitializer,
+            crate::js::any::for_in_or_of_initializer::FormatAnyJsForInOrOfInitializer::default(),
         )
     }
 }
@@ -11194,9 +11826,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsAssignmentPattern {
         crate::js::any::assignment_pattern::FormatAnyJsAssignmentPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::assignment_pattern::FormatAnyJsAssignmentPattern,
+            crate::js::any::assignment_pattern::FormatAnyJsAssignmentPattern::default(),
         )
     }
 }
@@ -11206,9 +11839,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsAssignmentPattern {
         crate::js::any::assignment_pattern::FormatAnyJsAssignmentPattern,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::assignment_pattern::FormatAnyJsAssignmentPattern,
+            crate::js::any::assignment_pattern::FormatAnyJsAssignmentPattern::default(),
         )
     }
 }
@@ -11219,7 +11853,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsSwitchClause {
         crate::js::any::switch_clause::FormatAnyJsSwitchClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::switch_clause::FormatAnyJsSwitchClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::switch_clause::FormatAnyJsSwitchClause::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsSwitchClause {
@@ -11228,7 +11866,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsSwitchClause {
         crate::js::any::switch_clause::FormatAnyJsSwitchClause,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::switch_clause::FormatAnyJsSwitchClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::switch_clause::FormatAnyJsSwitchClause::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsBindingPattern {
@@ -11238,9 +11880,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsBindingPattern {
         crate::js::any::binding_pattern::FormatAnyJsBindingPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::binding_pattern::FormatAnyJsBindingPattern,
+            crate::js::any::binding_pattern::FormatAnyJsBindingPattern::default(),
         )
     }
 }
@@ -11250,9 +11893,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsBindingPattern {
         crate::js::any::binding_pattern::FormatAnyJsBindingPattern,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::binding_pattern::FormatAnyJsBindingPattern,
+            crate::js::any::binding_pattern::FormatAnyJsBindingPattern::default(),
         )
     }
 }
@@ -11263,9 +11907,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsDeclarationClause {
         crate::js::any::declaration_clause::FormatAnyJsDeclarationClause,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::declaration_clause::FormatAnyJsDeclarationClause,
+            crate::js::any::declaration_clause::FormatAnyJsDeclarationClause::default(),
         )
     }
 }
@@ -11275,9 +11920,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsDeclarationClause {
         crate::js::any::declaration_clause::FormatAnyJsDeclarationClause,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::declaration_clause::FormatAnyJsDeclarationClause,
+            crate::js::any::declaration_clause::FormatAnyJsDeclarationClause::default(),
         )
     }
 }
@@ -11288,9 +11934,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsLiteralExpression {
         crate::js::any::literal_expression::FormatAnyJsLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::literal_expression::FormatAnyJsLiteralExpression,
+            crate::js::any::literal_expression::FormatAnyJsLiteralExpression::default(),
         )
     }
 }
@@ -11300,9 +11947,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsLiteralExpression {
         crate::js::any::literal_expression::FormatAnyJsLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::literal_expression::FormatAnyJsLiteralExpression,
+            crate::js::any::literal_expression::FormatAnyJsLiteralExpression::default(),
         )
     }
 }
@@ -11313,9 +11961,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsTemplateElement {
         crate::js::any::template_element::FormatAnyJsTemplateElement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::template_element::FormatAnyJsTemplateElement,
+            crate::js::any::template_element::FormatAnyJsTemplateElement::default(),
         )
     }
 }
@@ -11325,9 +11974,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsTemplateElement {
         crate::js::any::template_element::FormatAnyJsTemplateElement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::template_element::FormatAnyJsTemplateElement,
+            crate::js::any::template_element::FormatAnyJsTemplateElement::default(),
         )
     }
 }
@@ -11338,7 +11988,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsBinding {
         crate::js::any::binding::FormatAnyJsBinding,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::binding::FormatAnyJsBinding)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::js::any::binding::FormatAnyJsBinding::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsBinding {
@@ -11347,7 +11998,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsBinding {
         crate::js::any::binding::FormatAnyJsBinding,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::binding::FormatAnyJsBinding)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::js::any::binding::FormatAnyJsBinding::default())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsArrowFunctionParameters {
@@ -11357,9 +12009,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsArrowFunctionParameters
         crate::js::any::arrow_function_parameters::FormatAnyJsArrowFunctionParameters,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::arrow_function_parameters::FormatAnyJsArrowFunctionParameters,
+            crate::js::any::arrow_function_parameters::FormatAnyJsArrowFunctionParameters::default(
+            ),
         )
     }
 }
@@ -11369,9 +12023,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsArrowFunctionParamete
         crate::js::any::arrow_function_parameters::FormatAnyJsArrowFunctionParameters,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::arrow_function_parameters::FormatAnyJsArrowFunctionParameters,
+            crate::js::any::arrow_function_parameters::FormatAnyJsArrowFunctionParameters::default(
+            ),
         )
     }
 }
@@ -11382,7 +12038,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsFunctionBody {
         crate::js::any::function_body::FormatAnyJsFunctionBody,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::function_body::FormatAnyJsFunctionBody)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::function_body::FormatAnyJsFunctionBody::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsFunctionBody {
@@ -11391,7 +12051,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsFunctionBody {
         crate::js::any::function_body::FormatAnyJsFunctionBody,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::function_body::FormatAnyJsFunctionBody)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::function_body::FormatAnyJsFunctionBody::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayElement {
@@ -11401,7 +12065,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayElement {
         crate::js::any::array_element::FormatAnyJsArrayElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::array_element::FormatAnyJsArrayElement)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::array_element::FormatAnyJsArrayElement::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayElement {
@@ -11410,21 +12078,27 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayElement {
         crate::js::any::array_element::FormatAnyJsArrayElement,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::array_element::FormatAnyJsArrayElement)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::array_element::FormatAnyJsArrayElement::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsName {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyJsName, crate::js::any::name::FormatAnyJsName>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::name::FormatAnyJsName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::js::any::name::FormatAnyJsName::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsName {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyJsName, crate::js::any::name::FormatAnyJsName>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::name::FormatAnyJsName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::js::any::name::FormatAnyJsName::default())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsInProperty {
@@ -11434,7 +12108,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsInProperty {
         crate::js::any::in_property::FormatAnyJsInProperty,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::in_property::FormatAnyJsInProperty)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::in_property::FormatAnyJsInProperty::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsInProperty {
@@ -11443,7 +12121,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsInProperty {
         crate::js::any::in_property::FormatAnyJsInProperty,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::in_property::FormatAnyJsInProperty)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::in_property::FormatAnyJsInProperty::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsAssignment {
@@ -11453,7 +12135,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsAssignment {
         crate::js::any::assignment::FormatAnyJsAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::assignment::FormatAnyJsAssignment)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::assignment::FormatAnyJsAssignment::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsAssignment {
@@ -11462,7 +12148,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsAssignment {
         crate::js::any::assignment::FormatAnyJsAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::assignment::FormatAnyJsAssignment)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::assignment::FormatAnyJsAssignment::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectMemberName {
@@ -11472,9 +12162,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectMemberName {
         crate::js::any::object_member_name::FormatAnyJsObjectMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::object_member_name::FormatAnyJsObjectMemberName,
+            crate::js::any::object_member_name::FormatAnyJsObjectMemberName::default(),
         )
     }
 }
@@ -11484,9 +12175,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectMemberName {
         crate::js::any::object_member_name::FormatAnyJsObjectMemberName,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::object_member_name::FormatAnyJsObjectMemberName,
+            crate::js::any::object_member_name::FormatAnyJsObjectMemberName::default(),
         )
     }
 }
@@ -11497,7 +12189,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectMember {
         crate::js::any::object_member::FormatAnyJsObjectMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::object_member::FormatAnyJsObjectMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::object_member::FormatAnyJsObjectMember::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectMember {
@@ -11506,7 +12202,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectMember {
         crate::js::any::object_member::FormatAnyJsObjectMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::object_member::FormatAnyJsObjectMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::object_member::FormatAnyJsObjectMember::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsFormalParameter {
@@ -11516,9 +12216,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsFormalParameter {
         crate::js::any::formal_parameter::FormatAnyJsFormalParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::formal_parameter::FormatAnyJsFormalParameter,
+            crate::js::any::formal_parameter::FormatAnyJsFormalParameter::default(),
         )
     }
 }
@@ -11528,9 +12229,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsFormalParameter {
         crate::js::any::formal_parameter::FormatAnyJsFormalParameter,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::formal_parameter::FormatAnyJsFormalParameter,
+            crate::js::any::formal_parameter::FormatAnyJsFormalParameter::default(),
         )
     }
 }
@@ -11541,7 +12243,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsClassMember {
         crate::js::any::class_member::FormatAnyJsClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::class_member::FormatAnyJsClassMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::class_member::FormatAnyJsClassMember::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsClassMember {
@@ -11550,21 +12256,27 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsClassMember {
         crate::js::any::class_member::FormatAnyJsClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::class_member::FormatAnyJsClassMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::class_member::FormatAnyJsClassMember::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsClass {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyJsClass, crate::js::any::class::FormatAnyJsClass>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::class::FormatAnyJsClass)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::js::any::class::FormatAnyJsClass::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsClass {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyJsClass, crate::js::any::class::FormatAnyJsClass>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::class::FormatAnyJsClass)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::js::any::class::FormatAnyJsClass::default())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsClassMemberName {
@@ -11574,9 +12286,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsClassMemberName {
         crate::js::any::class_member_name::FormatAnyJsClassMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::class_member_name::FormatAnyJsClassMemberName,
+            crate::js::any::class_member_name::FormatAnyJsClassMemberName::default(),
         )
     }
 }
@@ -11586,9 +12299,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsClassMemberName {
         crate::js::any::class_member_name::FormatAnyJsClassMemberName,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::class_member_name::FormatAnyJsClassMemberName,
+            crate::js::any::class_member_name::FormatAnyJsClassMemberName::default(),
         )
     }
 }
@@ -11599,9 +12313,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsConstructorParameter {
         crate::js::any::constructor_parameter::FormatAnyJsConstructorParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::constructor_parameter::FormatAnyJsConstructorParameter,
+            crate::js::any::constructor_parameter::FormatAnyJsConstructorParameter::default(),
         )
     }
 }
@@ -11611,9 +12326,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsConstructorParameter 
         crate::js::any::constructor_parameter::FormatAnyJsConstructorParameter,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::constructor_parameter::FormatAnyJsConstructorParameter,
+            crate::js::any::constructor_parameter::FormatAnyJsConstructorParameter::default(),
         )
     }
 }
@@ -11624,10 +12340,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertyParameterModifi
         crate::ts::any::property_parameter_modifier::FormatAnyTsPropertyParameterModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::any::property_parameter_modifier::FormatAnyTsPropertyParameterModifier,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: any :: property_parameter_modifier :: FormatAnyTsPropertyParameterModifier :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertyParameterModifier {
@@ -11636,10 +12350,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertyParameterModi
         crate::ts::any::property_parameter_modifier::FormatAnyTsPropertyParameterModifier,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::any::property_parameter_modifier::FormatAnyTsPropertyParameterModifier,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: any :: property_parameter_modifier :: FormatAnyTsPropertyParameterModifier :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertyAnnotation {
@@ -11649,9 +12361,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertyAnnotation {
         crate::ts::any::property_annotation::FormatAnyTsPropertyAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::any::property_annotation::FormatAnyTsPropertyAnnotation,
+            crate::ts::any::property_annotation::FormatAnyTsPropertyAnnotation::default(),
         )
     }
 }
@@ -11661,9 +12374,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertyAnnotation {
         crate::ts::any::property_annotation::FormatAnyTsPropertyAnnotation,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::any::property_annotation::FormatAnyTsPropertyAnnotation,
+            crate::ts::any::property_annotation::FormatAnyTsPropertyAnnotation::default(),
         )
     }
 }
@@ -11674,9 +12388,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsPropertyModifier {
         crate::js::any::property_modifier::FormatAnyJsPropertyModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::property_modifier::FormatAnyJsPropertyModifier,
+            crate::js::any::property_modifier::FormatAnyJsPropertyModifier::default(),
         )
     }
 }
@@ -11686,9 +12401,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsPropertyModifier {
         crate::js::any::property_modifier::FormatAnyJsPropertyModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::property_modifier::FormatAnyJsPropertyModifier,
+            crate::js::any::property_modifier::FormatAnyJsPropertyModifier::default(),
         )
     }
 }
@@ -11699,10 +12415,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertySignatureAnnota
         crate::ts::any::property_signature_annotation::FormatAnyTsPropertySignatureAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::any::property_signature_annotation::FormatAnyTsPropertySignatureAnnotation,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: any :: property_signature_annotation :: FormatAnyTsPropertySignatureAnnotation :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertySignatureAnnotation {
@@ -11711,10 +12425,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertySignatureAnno
         crate::ts::any::property_signature_annotation::FormatAnyTsPropertySignatureAnnotation,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::any::property_signature_annotation::FormatAnyTsPropertySignatureAnnotation,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: any :: property_signature_annotation :: FormatAnyTsPropertySignatureAnnotation :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertySignatureModifier {
@@ -11724,10 +12436,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertySignatureModifi
         crate::ts::any::property_signature_modifier::FormatAnyTsPropertySignatureModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::any::property_signature_modifier::FormatAnyTsPropertySignatureModifier,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: any :: property_signature_modifier :: FormatAnyTsPropertySignatureModifier :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertySignatureModifier {
@@ -11736,10 +12446,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertySignatureModi
         crate::ts::any::property_signature_modifier::FormatAnyTsPropertySignatureModifier,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::any::property_signature_modifier::FormatAnyTsPropertySignatureModifier,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: any :: property_signature_modifier :: FormatAnyTsPropertySignatureModifier :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsMethodModifier {
@@ -11749,9 +12457,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsMethodModifier {
         crate::js::any::method_modifier::FormatAnyJsMethodModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::method_modifier::FormatAnyJsMethodModifier,
+            crate::js::any::method_modifier::FormatAnyJsMethodModifier::default(),
         )
     }
 }
@@ -11761,9 +12470,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsMethodModifier {
         crate::js::any::method_modifier::FormatAnyJsMethodModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::method_modifier::FormatAnyJsMethodModifier,
+            crate::js::any::method_modifier::FormatAnyJsMethodModifier::default(),
         )
     }
 }
@@ -11774,9 +12484,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsMethodSignatureModifier
         crate::ts::any::method_signature_modifier::FormatAnyTsMethodSignatureModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::any::method_signature_modifier::FormatAnyTsMethodSignatureModifier,
+            crate::ts::any::method_signature_modifier::FormatAnyTsMethodSignatureModifier::default(
+            ),
         )
     }
 }
@@ -11786,9 +12498,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsMethodSignatureModifi
         crate::ts::any::method_signature_modifier::FormatAnyTsMethodSignatureModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::any::method_signature_modifier::FormatAnyTsMethodSignatureModifier,
+            crate::ts::any::method_signature_modifier::FormatAnyTsMethodSignatureModifier::default(
+            ),
         )
     }
 }
@@ -11799,9 +12513,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsIndexSignatureModifier 
         crate::ts::any::index_signature_modifier::FormatAnyTsIndexSignatureModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::any::index_signature_modifier::FormatAnyTsIndexSignatureModifier,
+            crate::ts::any::index_signature_modifier::FormatAnyTsIndexSignatureModifier::default(),
         )
     }
 }
@@ -11811,9 +12526,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsIndexSignatureModifie
         crate::ts::any::index_signature_modifier::FormatAnyTsIndexSignatureModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::any::index_signature_modifier::FormatAnyTsIndexSignatureModifier,
+            crate::ts::any::index_signature_modifier::FormatAnyTsIndexSignatureModifier::default(),
         )
     }
 }
@@ -11821,14 +12537,16 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsType {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyTsType, crate::ts::any::ts_type::FormatAnyTsType>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::any::ts_type::FormatAnyTsType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::ts::any::ts_type::FormatAnyTsType::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsType {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyTsType, crate::ts::any::ts_type::FormatAnyTsType>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::any::ts_type::FormatAnyTsType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::ts::any::ts_type::FormatAnyTsType::default())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayAssignmentPatternElement {
@@ -11838,7 +12556,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayAssignmentPatternE
         crate::js::any::array_assignment_pattern_element::FormatAnyJsArrayAssignmentPatternElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: any :: array_assignment_pattern_element :: FormatAnyJsArrayAssignmentPatternElement)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: any :: array_assignment_pattern_element :: FormatAnyJsArrayAssignmentPatternElement :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayAssignmentPatternElement {
@@ -11847,7 +12566,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayAssignmentPatter
         crate::js::any::array_assignment_pattern_element::FormatAnyJsArrayAssignmentPatternElement,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: any :: array_assignment_pattern_element :: FormatAnyJsArrayAssignmentPatternElement)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: any :: array_assignment_pattern_element :: FormatAnyJsArrayAssignmentPatternElement :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectAssignmentPatternMember {
@@ -11857,7 +12577,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectAssignmentPattern
         crate::js::any::object_assignment_pattern_member::FormatAnyJsObjectAssignmentPatternMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: js :: any :: object_assignment_pattern_member :: FormatAnyJsObjectAssignmentPatternMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: any :: object_assignment_pattern_member :: FormatAnyJsObjectAssignmentPatternMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectAssignmentPatternMember {
@@ -11866,7 +12587,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectAssignmentPatte
         crate::js::any::object_assignment_pattern_member::FormatAnyJsObjectAssignmentPatternMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: js :: any :: object_assignment_pattern_member :: FormatAnyJsObjectAssignmentPatternMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: any :: object_assignment_pattern_member :: FormatAnyJsObjectAssignmentPatternMember :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayBindingPatternElement {
@@ -11876,10 +12598,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayBindingPatternElem
         crate::js::any::array_binding_pattern_element::FormatAnyJsArrayBindingPatternElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::any::array_binding_pattern_element::FormatAnyJsArrayBindingPatternElement,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: any :: array_binding_pattern_element :: FormatAnyJsArrayBindingPatternElement :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayBindingPatternElement {
@@ -11888,10 +12608,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayBindingPatternEl
         crate::js::any::array_binding_pattern_element::FormatAnyJsArrayBindingPatternElement,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::any::array_binding_pattern_element::FormatAnyJsArrayBindingPatternElement,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: any :: array_binding_pattern_element :: FormatAnyJsArrayBindingPatternElement :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectBindingPatternMember {
@@ -11901,10 +12619,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectBindingPatternMem
         crate::js::any::object_binding_pattern_member::FormatAnyJsObjectBindingPatternMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::any::object_binding_pattern_member::FormatAnyJsObjectBindingPatternMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: any :: object_binding_pattern_member :: FormatAnyJsObjectBindingPatternMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectBindingPatternMember {
@@ -11913,10 +12629,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectBindingPatternM
         crate::js::any::object_binding_pattern_member::FormatAnyJsObjectBindingPatternMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::any::object_binding_pattern_member::FormatAnyJsObjectBindingPatternMember,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: any :: object_binding_pattern_member :: FormatAnyJsObjectBindingPatternMember :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsDeclaration {
@@ -11926,7 +12640,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsDeclaration {
         crate::js::any::declaration::FormatAnyJsDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::declaration::FormatAnyJsDeclaration)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::declaration::FormatAnyJsDeclaration::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsDeclaration {
@@ -11935,7 +12653,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsDeclaration {
         crate::js::any::declaration::FormatAnyJsDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::declaration::FormatAnyJsDeclaration)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::declaration::FormatAnyJsDeclaration::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsReturnType {
@@ -11945,7 +12667,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsReturnType {
         crate::ts::any::return_type::FormatAnyTsReturnType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::any::return_type::FormatAnyTsReturnType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::any::return_type::FormatAnyTsReturnType::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsReturnType {
@@ -11954,7 +12680,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsReturnType {
         crate::ts::any::return_type::FormatAnyTsReturnType,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::any::return_type::FormatAnyTsReturnType)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::any::return_type::FormatAnyTsReturnType::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsVariableAnnotation {
@@ -11964,9 +12694,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsVariableAnnotation {
         crate::ts::any::variable_annotation::FormatAnyTsVariableAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::any::variable_annotation::FormatAnyTsVariableAnnotation,
+            crate::ts::any::variable_annotation::FormatAnyTsVariableAnnotation::default(),
         )
     }
 }
@@ -11976,9 +12707,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsVariableAnnotation {
         crate::ts::any::variable_annotation::FormatAnyTsVariableAnnotation,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::any::variable_annotation::FormatAnyTsVariableAnnotation,
+            crate::ts::any::variable_annotation::FormatAnyTsVariableAnnotation::default(),
         )
     }
 }
@@ -11989,7 +12721,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsModuleItem {
         crate::js::any::module_item::FormatAnyJsModuleItem,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::module_item::FormatAnyJsModuleItem)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::module_item::FormatAnyJsModuleItem::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsModuleItem {
@@ -11998,7 +12734,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsModuleItem {
         crate::js::any::module_item::FormatAnyJsModuleItem,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::module_item::FormatAnyJsModuleItem)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::module_item::FormatAnyJsModuleItem::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsImportClause {
@@ -12008,7 +12748,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsImportClause {
         crate::js::any::import_clause::FormatAnyJsImportClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::import_clause::FormatAnyJsImportClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::import_clause::FormatAnyJsImportClause::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsImportClause {
@@ -12017,7 +12761,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsImportClause {
         crate::js::any::import_clause::FormatAnyJsImportClause,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::import_clause::FormatAnyJsImportClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::import_clause::FormatAnyJsImportClause::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsNamedImport {
@@ -12027,7 +12775,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsNamedImport {
         crate::js::any::named_import::FormatAnyJsNamedImport,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::named_import::FormatAnyJsNamedImport)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::named_import::FormatAnyJsNamedImport::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsNamedImport {
@@ -12036,7 +12788,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsNamedImport {
         crate::js::any::named_import::FormatAnyJsNamedImport,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::named_import::FormatAnyJsNamedImport)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::named_import::FormatAnyJsNamedImport::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsNamedImportSpecifier {
@@ -12046,9 +12802,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsNamedImportSpecifier {
         crate::js::any::named_import_specifier::FormatAnyJsNamedImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::named_import_specifier::FormatAnyJsNamedImportSpecifier,
+            crate::js::any::named_import_specifier::FormatAnyJsNamedImportSpecifier::default(),
         )
     }
 }
@@ -12058,9 +12815,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsNamedImportSpecifier 
         crate::js::any::named_import_specifier::FormatAnyJsNamedImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::named_import_specifier::FormatAnyJsNamedImportSpecifier,
+            crate::js::any::named_import_specifier::FormatAnyJsNamedImportSpecifier::default(),
         )
     }
 }
@@ -12071,9 +12829,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsImportAssertionEntry {
         crate::js::any::import_assertion_entry::FormatAnyJsImportAssertionEntry,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::import_assertion_entry::FormatAnyJsImportAssertionEntry,
+            crate::js::any::import_assertion_entry::FormatAnyJsImportAssertionEntry::default(),
         )
     }
 }
@@ -12083,9 +12842,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsImportAssertionEntry 
         crate::js::any::import_assertion_entry::FormatAnyJsImportAssertionEntry,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::import_assertion_entry::FormatAnyJsImportAssertionEntry,
+            crate::js::any::import_assertion_entry::FormatAnyJsImportAssertionEntry::default(),
         )
     }
 }
@@ -12096,7 +12856,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsExportClause {
         crate::js::any::export_clause::FormatAnyJsExportClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::export_clause::FormatAnyJsExportClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::export_clause::FormatAnyJsExportClause::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsExportClause {
@@ -12105,7 +12869,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsExportClause {
         crate::js::any::export_clause::FormatAnyJsExportClause,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::export_clause::FormatAnyJsExportClause)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::export_clause::FormatAnyJsExportClause::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsExportDefaultDeclaration {
@@ -12115,10 +12883,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsExportDefaultDeclaratio
         crate::js::any::export_default_declaration::FormatAnyJsExportDefaultDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::js::any::export_default_declaration::FormatAnyJsExportDefaultDeclaration,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: js :: any :: export_default_declaration :: FormatAnyJsExportDefaultDeclaration :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsExportDefaultDeclaration {
@@ -12127,10 +12893,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsExportDefaultDeclarat
         crate::js::any::export_default_declaration::FormatAnyJsExportDefaultDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::js::any::export_default_declaration::FormatAnyJsExportDefaultDeclaration,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: js :: any :: export_default_declaration :: FormatAnyJsExportDefaultDeclaration :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsExportNamedSpecifier {
@@ -12140,9 +12904,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsExportNamedSpecifier {
         crate::js::any::export_named_specifier::FormatAnyJsExportNamedSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::js::any::export_named_specifier::FormatAnyJsExportNamedSpecifier,
+            crate::js::any::export_named_specifier::FormatAnyJsExportNamedSpecifier::default(),
         )
     }
 }
@@ -12152,9 +12917,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsExportNamedSpecifier 
         crate::js::any::export_named_specifier::FormatAnyJsExportNamedSpecifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::js::any::export_named_specifier::FormatAnyJsExportNamedSpecifier,
+            crate::js::any::export_named_specifier::FormatAnyJsExportNamedSpecifier::default(),
         )
     }
 }
@@ -12165,7 +12931,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsFunction {
         crate::js::any::function::FormatAnyJsFunction,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::function::FormatAnyJsFunction)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::function::FormatAnyJsFunction::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsFunction {
@@ -12174,7 +12944,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsFunction {
         crate::js::any::function::FormatAnyJsFunction,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::function::FormatAnyJsFunction)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::function::FormatAnyJsFunction::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsParameter {
@@ -12184,7 +12958,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsParameter {
         crate::js::any::parameter::FormatAnyJsParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::parameter::FormatAnyJsParameter)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::parameter::FormatAnyJsParameter::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsParameter {
@@ -12193,7 +12971,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsParameter {
         crate::js::any::parameter::FormatAnyJsParameter,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::parameter::FormatAnyJsParameter)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::parameter::FormatAnyJsParameter::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsCallArgument {
@@ -12203,7 +12985,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsCallArgument {
         crate::js::any::call_argument::FormatAnyJsCallArgument,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::call_argument::FormatAnyJsCallArgument)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::call_argument::FormatAnyJsCallArgument::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsCallArgument {
@@ -12212,7 +12998,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsCallArgument {
         crate::js::any::call_argument::FormatAnyJsCallArgument,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::call_argument::FormatAnyJsCallArgument)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::call_argument::FormatAnyJsCallArgument::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsDecorator {
@@ -12222,7 +13012,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsDecorator {
         crate::js::any::decorator::FormatAnyJsDecorator,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::js::any::decorator::FormatAnyJsDecorator)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::js::any::decorator::FormatAnyJsDecorator::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsDecorator {
@@ -12231,21 +13025,27 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsDecorator {
         crate::js::any::decorator::FormatAnyJsDecorator,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::js::any::decorator::FormatAnyJsDecorator)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::js::any::decorator::FormatAnyJsDecorator::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsName {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyTsName, crate::ts::any::name::FormatAnyTsName>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::any::name::FormatAnyTsName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::ts::any::name::FormatAnyTsName::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsName {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyTsName, crate::ts::any::name::FormatAnyTsName>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::any::name::FormatAnyTsName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::ts::any::name::FormatAnyTsName::default())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsModuleReference {
@@ -12255,9 +13055,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsModuleReference {
         crate::ts::any::module_reference::FormatAnyTsModuleReference,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::any::module_reference::FormatAnyTsModuleReference,
+            crate::ts::any::module_reference::FormatAnyTsModuleReference::default(),
         )
     }
 }
@@ -12267,9 +13068,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsModuleReference {
         crate::ts::any::module_reference::FormatAnyTsModuleReference,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::any::module_reference::FormatAnyTsModuleReference,
+            crate::ts::any::module_reference::FormatAnyTsModuleReference::default(),
         )
     }
 }
@@ -12280,7 +13082,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsModuleName {
         crate::ts::any::module_name::FormatAnyTsModuleName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::any::module_name::FormatAnyTsModuleName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::any::module_name::FormatAnyTsModuleName::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsModuleName {
@@ -12289,7 +13095,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsModuleName {
         crate::ts::any::module_name::FormatAnyTsModuleName,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::any::module_name::FormatAnyTsModuleName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::any::module_name::FormatAnyTsModuleName::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsExternalModuleDeclarationBody {
@@ -12299,7 +13109,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsExternalModuleDeclarati
         crate::ts::any::external_module_declaration_body::FormatAnyTsExternalModuleDeclarationBody,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule :: new (self , crate :: ts :: any :: external_module_declaration_body :: FormatAnyTsExternalModuleDeclarationBody)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: any :: external_module_declaration_body :: FormatAnyTsExternalModuleDeclarationBody :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsExternalModuleDeclarationBody {
@@ -12308,7 +13119,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsExternalModuleDeclara
         crate::ts::any::external_module_declaration_body::FormatAnyTsExternalModuleDeclarationBody,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule :: new (self , crate :: ts :: any :: external_module_declaration_body :: FormatAnyTsExternalModuleDeclarationBody)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: any :: external_module_declaration_body :: FormatAnyTsExternalModuleDeclarationBody :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsTypePredicateParameterName {
@@ -12318,10 +13130,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsTypePredicateParameterN
         crate::ts::any::type_predicate_parameter_name::FormatAnyTsTypePredicateParameterName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::ts::any::type_predicate_parameter_name::FormatAnyTsTypePredicateParameterName,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule :: new (self , crate :: ts :: any :: type_predicate_parameter_name :: FormatAnyTsTypePredicateParameterName :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsTypePredicateParameterName {
@@ -12330,10 +13140,8 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsTypePredicateParamete
         crate::ts::any::type_predicate_parameter_name::FormatAnyTsTypePredicateParameterName,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::ts::any::type_predicate_parameter_name::FormatAnyTsTypePredicateParameterName,
-        )
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule :: new (self , crate :: ts :: any :: type_predicate_parameter_name :: FormatAnyTsTypePredicateParameterName :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsTypeParameterModifier {
@@ -12343,9 +13151,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsTypeParameterModifier {
         crate::ts::any::type_parameter_modifier::FormatAnyTsTypeParameterModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::any::type_parameter_modifier::FormatAnyTsTypeParameterModifier,
+            crate::ts::any::type_parameter_modifier::FormatAnyTsTypeParameterModifier::default(),
         )
     }
 }
@@ -12355,9 +13164,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsTypeParameterModifier
         crate::ts::any::type_parameter_modifier::FormatAnyTsTypeParameterModifier,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::any::type_parameter_modifier::FormatAnyTsTypeParameterModifier,
+            crate::ts::any::type_parameter_modifier::FormatAnyTsTypeParameterModifier::default(),
         )
     }
 }
@@ -12368,7 +13178,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsTypeMember {
         crate::ts::any::type_member::FormatAnyTsTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::ts::any::type_member::FormatAnyTsTypeMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::ts::any::type_member::FormatAnyTsTypeMember::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsTypeMember {
@@ -12377,7 +13191,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsTypeMember {
         crate::ts::any::type_member::FormatAnyTsTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::ts::any::type_member::FormatAnyTsTypeMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::ts::any::type_member::FormatAnyTsTypeMember::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsTupleTypeElement {
@@ -12387,9 +13205,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsTupleTypeElement {
         crate::ts::any::tuple_type_element::FormatAnyTsTupleTypeElement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::any::tuple_type_element::FormatAnyTsTupleTypeElement,
+            crate::ts::any::tuple_type_element::FormatAnyTsTupleTypeElement::default(),
         )
     }
 }
@@ -12399,9 +13218,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsTupleTypeElement {
         crate::ts::any::tuple_type_element::FormatAnyTsTupleTypeElement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::any::tuple_type_element::FormatAnyTsTupleTypeElement,
+            crate::ts::any::tuple_type_element::FormatAnyTsTupleTypeElement::default(),
         )
     }
 }
@@ -12412,9 +13232,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsTemplateElement {
         crate::ts::any::template_element::FormatAnyTsTemplateElement,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::ts::any::template_element::FormatAnyTsTemplateElement,
+            crate::ts::any::template_element::FormatAnyTsTemplateElement::default(),
         )
     }
 }
@@ -12424,9 +13245,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsTemplateElement {
         crate::ts::any::template_element::FormatAnyTsTemplateElement,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::ts::any::template_element::FormatAnyTsTemplateElement,
+            crate::ts::any::template_element::FormatAnyTsTemplateElement::default(),
         )
     }
 }
@@ -12434,14 +13256,16 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxTag {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyJsxTag, crate::jsx::any::tag::FormatAnyJsxTag>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::jsx::any::tag::FormatAnyJsxTag)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::jsx::any::tag::FormatAnyJsxTag::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxTag {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyJsxTag, crate::jsx::any::tag::FormatAnyJsxTag>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::jsx::any::tag::FormatAnyJsxTag)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::jsx::any::tag::FormatAnyJsxTag::default())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxElementName {
@@ -12451,7 +13275,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxElementName {
         crate::jsx::any::element_name::FormatAnyJsxElementName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::jsx::any::element_name::FormatAnyJsxElementName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::jsx::any::element_name::FormatAnyJsxElementName::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxElementName {
@@ -12460,7 +13288,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxElementName {
         crate::jsx::any::element_name::FormatAnyJsxElementName,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::jsx::any::element_name::FormatAnyJsxElementName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::jsx::any::element_name::FormatAnyJsxElementName::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxObjectName {
@@ -12470,7 +13302,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxObjectName {
         crate::jsx::any::object_name::FormatAnyJsxObjectName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::jsx::any::object_name::FormatAnyJsxObjectName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::jsx::any::object_name::FormatAnyJsxObjectName::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxObjectName {
@@ -12479,21 +13315,27 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxObjectName {
         crate::jsx::any::object_name::FormatAnyJsxObjectName,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::jsx::any::object_name::FormatAnyJsxObjectName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::jsx::any::object_name::FormatAnyJsxObjectName::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxName {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyJsxName, crate::jsx::any::name::FormatAnyJsxName>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::jsx::any::name::FormatAnyJsxName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::jsx::any::name::FormatAnyJsxName::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxName {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyJsxName, crate::jsx::any::name::FormatAnyJsxName>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::jsx::any::name::FormatAnyJsxName)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::jsx::any::name::FormatAnyJsxName::default())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttribute {
@@ -12503,7 +13345,11 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttribute {
         crate::jsx::any::attribute::FormatAnyJsxAttribute,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::jsx::any::attribute::FormatAnyJsxAttribute)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::jsx::any::attribute::FormatAnyJsxAttribute::default(),
+        )
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttribute {
@@ -12512,7 +13358,11 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttribute {
         crate::jsx::any::attribute::FormatAnyJsxAttribute,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::jsx::any::attribute::FormatAnyJsxAttribute)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::jsx::any::attribute::FormatAnyJsxAttribute::default(),
+        )
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttributeName {
@@ -12522,9 +13372,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttributeName {
         crate::jsx::any::attribute_name::FormatAnyJsxAttributeName,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::any::attribute_name::FormatAnyJsxAttributeName,
+            crate::jsx::any::attribute_name::FormatAnyJsxAttributeName::default(),
         )
     }
 }
@@ -12534,9 +13385,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttributeName {
         crate::jsx::any::attribute_name::FormatAnyJsxAttributeName,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::any::attribute_name::FormatAnyJsxAttributeName,
+            crate::jsx::any::attribute_name::FormatAnyJsxAttributeName::default(),
         )
     }
 }
@@ -12547,9 +13399,10 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttributeValue {
         crate::jsx::any::attribute_value::FormatAnyJsxAttributeValue,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::jsx::any::attribute_value::FormatAnyJsxAttributeValue,
+            crate::jsx::any::attribute_value::FormatAnyJsxAttributeValue::default(),
         )
     }
 }
@@ -12559,9 +13412,10 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttributeValue {
         crate::jsx::any::attribute_value::FormatAnyJsxAttributeValue,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::jsx::any::attribute_value::FormatAnyJsxAttributeValue,
+            crate::jsx::any::attribute_value::FormatAnyJsxAttributeValue::default(),
         )
     }
 }
@@ -12572,7 +13426,8 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxChild {
         crate::jsx::any::child::FormatAnyJsxChild,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::jsx::any::child::FormatAnyJsxChild)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::jsx::any::child::FormatAnyJsxChild::default())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxChild {
@@ -12581,6 +13436,7 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxChild {
         crate::jsx::any::child::FormatAnyJsxChild,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::jsx::any::child::FormatAnyJsxChild)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::jsx::any::child::FormatAnyJsxChild::default())
     }
 }

--- a/crates/biome_json_formatter/src/generated.rs
+++ b/crates/biome_json_formatter/src/generated.rs
@@ -18,7 +18,11 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonRoot {
         crate::json::auxiliary::root::FormatJsonRoot,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::json::auxiliary::root::FormatJsonRoot)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::json::auxiliary::root::FormatJsonRoot::default(),
+        )
     }
 }
 impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonRoot {
@@ -27,7 +31,11 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonRoot {
         crate::json::auxiliary::root::FormatJsonRoot,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::json::auxiliary::root::FormatJsonRoot)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::auxiliary::root::FormatJsonRoot::default(),
+        )
     }
 }
 impl FormatRule<biome_json_syntax::JsonStringValue>
@@ -50,9 +58,10 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonStringValue {
         crate::json::value::string_value::FormatJsonStringValue,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::json::value::string_value::FormatJsonStringValue,
+            crate::json::value::string_value::FormatJsonStringValue::default(),
         )
     }
 }
@@ -62,9 +71,10 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonStringValue {
         crate::json::value::string_value::FormatJsonStringValue,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::json::value::string_value::FormatJsonStringValue,
+            crate::json::value::string_value::FormatJsonStringValue::default(),
         )
     }
 }
@@ -88,9 +98,10 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonBooleanValue {
         crate::json::value::boolean_value::FormatJsonBooleanValue,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::json::value::boolean_value::FormatJsonBooleanValue,
+            crate::json::value::boolean_value::FormatJsonBooleanValue::default(),
         )
     }
 }
@@ -100,9 +111,10 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonBooleanValue {
         crate::json::value::boolean_value::FormatJsonBooleanValue,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::json::value::boolean_value::FormatJsonBooleanValue,
+            crate::json::value::boolean_value::FormatJsonBooleanValue::default(),
         )
     }
 }
@@ -126,7 +138,11 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonNullValue {
         crate::json::value::null_value::FormatJsonNullValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::json::value::null_value::FormatJsonNullValue)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::json::value::null_value::FormatJsonNullValue::default(),
+        )
     }
 }
 impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonNullValue {
@@ -135,7 +151,11 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonNullValue {
         crate::json::value::null_value::FormatJsonNullValue,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::json::value::null_value::FormatJsonNullValue)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::value::null_value::FormatJsonNullValue::default(),
+        )
     }
 }
 impl FormatRule<biome_json_syntax::JsonNumberValue>
@@ -158,9 +178,10 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonNumberValue {
         crate::json::value::number_value::FormatJsonNumberValue,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::json::value::number_value::FormatJsonNumberValue,
+            crate::json::value::number_value::FormatJsonNumberValue::default(),
         )
     }
 }
@@ -170,9 +191,10 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonNumberValue {
         crate::json::value::number_value::FormatJsonNumberValue,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::json::value::number_value::FormatJsonNumberValue,
+            crate::json::value::number_value::FormatJsonNumberValue::default(),
         )
     }
 }
@@ -196,7 +218,11 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonArrayValue {
         crate::json::value::array_value::FormatJsonArrayValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::json::value::array_value::FormatJsonArrayValue)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::json::value::array_value::FormatJsonArrayValue::default(),
+        )
     }
 }
 impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonArrayValue {
@@ -205,7 +231,11 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonArrayValue {
         crate::json::value::array_value::FormatJsonArrayValue,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::json::value::array_value::FormatJsonArrayValue)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::value::array_value::FormatJsonArrayValue::default(),
+        )
     }
 }
 impl FormatRule<biome_json_syntax::JsonObjectValue>
@@ -228,9 +258,10 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonObjectValue {
         crate::json::value::object_value::FormatJsonObjectValue,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::json::value::object_value::FormatJsonObjectValue,
+            crate::json::value::object_value::FormatJsonObjectValue::default(),
         )
     }
 }
@@ -240,9 +271,10 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonObjectValue {
         crate::json::value::object_value::FormatJsonObjectValue,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::json::value::object_value::FormatJsonObjectValue,
+            crate::json::value::object_value::FormatJsonObjectValue::default(),
         )
     }
 }
@@ -262,7 +294,11 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonMember {
         crate::json::auxiliary::member::FormatJsonMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::json::auxiliary::member::FormatJsonMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::json::auxiliary::member::FormatJsonMember::default(),
+        )
     }
 }
 impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonMember {
@@ -271,7 +307,11 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonMember {
         crate::json::auxiliary::member::FormatJsonMember,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::json::auxiliary::member::FormatJsonMember)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::auxiliary::member::FormatJsonMember::default(),
+        )
     }
 }
 impl FormatRule<biome_json_syntax::JsonMemberName>
@@ -294,9 +334,10 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonMemberName {
         crate::json::auxiliary::member_name::FormatJsonMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::json::auxiliary::member_name::FormatJsonMemberName,
+            crate::json::auxiliary::member_name::FormatJsonMemberName::default(),
         )
     }
 }
@@ -306,9 +347,10 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonMemberName {
         crate::json::auxiliary::member_name::FormatJsonMemberName,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::json::auxiliary::member_name::FormatJsonMemberName,
+            crate::json::auxiliary::member_name::FormatJsonMemberName::default(),
         )
     }
 }
@@ -319,9 +361,10 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonArrayElementList {
         crate::json::lists::array_element_list::FormatJsonArrayElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
-            crate::json::lists::array_element_list::FormatJsonArrayElementList,
+            crate::json::lists::array_element_list::FormatJsonArrayElementList::default(),
         )
     }
 }
@@ -331,9 +374,10 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonArrayElementList {
         crate::json::lists::array_element_list::FormatJsonArrayElementList,
     >;
     fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
-            crate::json::lists::array_element_list::FormatJsonArrayElementList,
+            crate::json::lists::array_element_list::FormatJsonArrayElementList::default(),
         )
     }
 }
@@ -344,7 +388,11 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonMemberList {
         crate::json::lists::member_list::FormatJsonMemberList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::json::lists::member_list::FormatJsonMemberList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::json::lists::member_list::FormatJsonMemberList::default(),
+        )
     }
 }
 impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonMemberList {
@@ -353,7 +401,11 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonMemberList {
         crate::json::lists::member_list::FormatJsonMemberList,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::json::lists::member_list::FormatJsonMemberList)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::lists::member_list::FormatJsonMemberList::default(),
+        )
     }
 }
 impl FormatRule<biome_json_syntax::JsonBogus> for crate::json::bogus::bogus::FormatJsonBogus {
@@ -370,7 +422,8 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonBogus {
         crate::json::bogus::bogus::FormatJsonBogus,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::json::bogus::bogus::FormatJsonBogus)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::json::bogus::bogus::FormatJsonBogus::default())
     }
 }
 impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonBogus {
@@ -379,7 +432,8 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonBogus {
         crate::json::bogus::bogus::FormatJsonBogus,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::json::bogus::bogus::FormatJsonBogus)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::json::bogus::bogus::FormatJsonBogus::default())
     }
 }
 impl FormatRule<biome_json_syntax::JsonBogusValue>
@@ -402,7 +456,11 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonBogusValue {
         crate::json::bogus::bogus_value::FormatJsonBogusValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::json::bogus::bogus_value::FormatJsonBogusValue)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::json::bogus::bogus_value::FormatJsonBogusValue::default(),
+        )
     }
 }
 impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonBogusValue {
@@ -411,7 +469,11 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonBogusValue {
         crate::json::bogus::bogus_value::FormatJsonBogusValue,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::json::bogus::bogus_value::FormatJsonBogusValue)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::bogus::bogus_value::FormatJsonBogusValue::default(),
+        )
     }
 }
 impl AsFormat<JsonFormatContext> for biome_json_syntax::AnyJsonValue {
@@ -421,7 +483,8 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::AnyJsonValue {
         crate::json::any::value::FormatAnyJsonValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::json::any::value::FormatAnyJsonValue)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(self, crate::json::any::value::FormatAnyJsonValue::default())
     }
 }
 impl IntoFormat<JsonFormatContext> for biome_json_syntax::AnyJsonValue {
@@ -430,6 +493,7 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::AnyJsonValue {
         crate::json::any::value::FormatAnyJsonValue,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::json::any::value::FormatAnyJsonValue)
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(self, crate::json::any::value::FormatAnyJsonValue::default())
     }
 }

--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -484,6 +484,7 @@ impl BoilerplateImpls {
                 type Format<'a> = FormatRefWithRule<'a, #syntax_crate_ident::#node_id, #format_id>;
 
                 fn format(&self) -> Self::Format<'_> {
+                    #![allow(clippy::default_constructed_unit_structs)]
                     FormatRefWithRule::new(self, #format_id::default())
                 }
             }
@@ -492,6 +493,7 @@ impl BoilerplateImpls {
                 type Format = FormatOwnedWithRule<#syntax_crate_ident::#node_id, #format_id>;
 
                 fn into_format(self) -> Self::Format {
+                    #![allow(clippy::default_constructed_unit_structs)]
                     FormatOwnedWithRule::new(self, #format_id::default())
                 }
             }
@@ -505,8 +507,8 @@ impl BoilerplateImpls {
         let formatter_context_ident = self.language.format_context_ident();
 
         let tokens = quote! {
-            use biome_formatter::{FormatRefWithRule, FormatOwnedWithRule, FormatRule, FormatResult};
             use crate::{AsFormat, IntoFormat, FormatNodeRule, FormatBogusNodeRule, #formatter_ident, #formatter_context_ident};
+            use biome_formatter::{FormatRefWithRule, FormatOwnedWithRule, FormatRule, FormatResult};
 
             #( #impls )*
         };


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #240 by suppressing clippy lint `default_constructed_unit_structs`.

Added `#![allow(clippy::default_constructed_unit_structs)]`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
`cargo codegen formatter` then `just l` works