### PR TITLE
feat(js_parser): better diagnostic for infer type #243

### DIFF
--- a/.github/workflows/parser_conformance.yml
+++ b/.github/workflows/parser_conformance.yml
@@ -8,7 +8,7 @@ on:
       - 'crates/biome_js_syntax/**'
       - 'crates/biome_js_factory/**'
       - 'crates/biome_js_semantic/**'
-      - 'crates/rome_js_parser/**'
+      - 'crates/biome_js_parser/**'
       - 'crates/biome_rowan/**'
       - 'xtask/**'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Fix [#294](https://github.com/biomejs/biome/issues/294). [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type/) no longer reports false positives for return types. Contributed by @b4s36t4
 
 ### Parser
+
+- Enhance diagnostic for infer type handling in the parser. The 'infer' keyword can only be utilized within the 'extends' clause of a conditional type. Using it outside of this context will result in an error. Ensure that any type declarations using 'infer' are correctly placed within the conditional type structure to avoid parsing issues. Contributed by @denbezrukov
+
 ### VSCode
 
 ## 1.2.2 (2023-09-16)

--- a/crates/biome_js_formatter/src/ts/types/infer_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/infer_type.rs
@@ -47,14 +47,31 @@ mod tests {
 
     #[test]
     fn needs_parentheses() {
-        assert_needs_parentheses!("let s: (infer string)[] = symbol();", TsInferType);
+        assert_needs_parentheses!(
+            "type A = T extends (infer string)[] ? string : never",
+            TsInferType
+        );
+        assert_needs_parentheses!(
+            "type A = T extends unique (infer string) ? string : never",
+            TsInferType
+        );
 
-        assert_needs_parentheses!("let s: unique (infer string);", TsInferType);
+        assert_not_needs_parentheses!(
+            "type A = T extends [number, ...infer string] ? string : never",
+            TsInferType
+        );
+        assert_needs_parentheses!(
+            "type A = T extends [(infer string)?] ? string : never",
+            TsInferType
+        );
 
-        assert_not_needs_parentheses!("let s: [number, ...infer string]", TsInferType);
-        assert_needs_parentheses!("let s: [(infer string)?]", TsInferType);
-
-        assert_needs_parentheses!("let s: (infer string)[a]", TsInferType);
-        assert_not_needs_parentheses!("let s: a[(infer string)]", TsInferType);
+        assert_needs_parentheses!(
+            "type A = T extends (infer string)[a] ? string : never",
+            TsInferType
+        );
+        assert_not_needs_parentheses!(
+            "type A = T extends a[(infer string)] ? string : never",
+            TsInferType
+        );
     }
 }

--- a/crates/biome_js_parser/src/syntax/jsx/mod.rs
+++ b/crates/biome_js_parser/src/syntax/jsx/mod.rs
@@ -15,6 +15,7 @@ use crate::syntax::jsx::jsx_parse_errors::{
     jsx_expected_attribute, jsx_expected_attribute_value, jsx_expected_children,
     jsx_expected_closing_tag,
 };
+use crate::syntax::typescript::TypeContext;
 use crate::JsSyntaxFeature::TypeScript;
 use crate::{parser::RecoveryResult, JsParser, ParseRecovery, ParsedSyntax};
 use crate::{Absent, Present};
@@ -158,7 +159,7 @@ fn parse_any_jsx_opening_tag(p: &mut JsParser, in_expression: bool) -> Option<Op
         // <NonGeneric />;
         // <Generic<true> />;
         // <Generic<true>></Generic>;
-        let _ = parse_ts_type_arguments(p);
+        let _ = parse_ts_type_arguments(p, TypeContext::default());
     }
 
     JsxAttributeList.parse_list(p);

--- a/crates/biome_js_parser/src/syntax/stmt.rs
+++ b/crates/biome_js_parser/src/syntax/stmt.rs
@@ -1506,7 +1506,7 @@ fn parse_variable_declarator(
 // !function test() {}
 fn parse_ts_variable_annotation(p: &mut JsParser) -> ParsedSyntax {
     if !p.at(T![!]) {
-        return parse_ts_type_annotation(p);
+        return parse_ts_type_annotation(p, TypeContext::default());
     }
 
     if p.has_preceding_line_break() {
@@ -1516,7 +1516,8 @@ fn parse_ts_variable_annotation(p: &mut JsParser) -> ParsedSyntax {
     let m = p.start();
     p.bump(T![!]);
 
-    parse_ts_type_annotation(p).or_add_diagnostic(p, |_, _| expected_token(T![:]));
+    parse_ts_type_annotation(p, TypeContext::default())
+        .or_add_diagnostic(p, |_, _| expected_token(T![:]));
 
     Present(m.complete(p, TS_DEFINITE_VARIABLE_ANNOTATION))
 }

--- a/crates/biome_js_parser/src/syntax/typescript.rs
+++ b/crates/biome_js_parser/src/syntax/typescript.rs
@@ -124,7 +124,7 @@ fn parse_ts_name_with_type_arguments(p: &mut JsParser) -> ParsedSyntax {
         let m = name.precede(p);
 
         if !p.has_preceding_line_break() {
-            parse_ts_type_arguments(p).ok();
+            parse_ts_type_arguments(p, TypeContext::default()).ok();
         }
 
         m.complete(p, TS_NAME_WITH_TYPE_ARGUMENTS)
@@ -176,6 +176,7 @@ pub(crate) fn expect_ts_index_signature_member(
     p: &mut JsParser,
     m: Marker,
     parent: MemberParent,
+    context: TypeContext,
 ) -> CompletedMarker {
     while is_nth_at_modifier(p, 0, false) {
         if p.eat(T![readonly]) {
@@ -195,12 +196,12 @@ pub(crate) fn expect_ts_index_signature_member(
 
     let parameter = p.start();
     parse_identifier_binding(p).or_add_diagnostic(p, expected_identifier);
-    parse_ts_type_annotation(p).unwrap(); // It's a computed member name if the type annotation is missing
+    parse_ts_type_annotation(p, context).unwrap(); // It's a computed member name if the type annotation is missing
     parameter.complete(p, TS_INDEX_SIGNATURE_PARAMETER);
 
     p.expect(T![']']);
 
-    parse_ts_type_annotation(p).or_add_diagnostic(p, |p, range| {
+    parse_ts_type_annotation(p, context).or_add_diagnostic(p, |p, range| {
         p.err_builder("An index signature must have a type annotation", range)
     });
 

--- a/crates/biome_js_parser/src/syntax/typescript/statement.rs
+++ b/crates/biome_js_parser/src/syntax/typescript/statement.rs
@@ -304,7 +304,7 @@ pub(crate) fn parse_ts_interface_declaration(p: &mut JsParser) -> ParsedSyntax {
     parse_ts_type_parameters(p, TypeContext::default().and_allow_in_out_modifier(true)).ok();
     eat_interface_heritage_clause(p);
     p.expect(T!['{']);
-    TypeMembers.parse_list(p);
+    TypeMembers::default().parse_list(p);
     p.expect(T!['}']);
 
     Present(m.complete(p, TS_INTERFACE_DECLARATION))

--- a/crates/biome_js_parser/src/syntax/typescript/ts_parse_error.rs
+++ b/crates/biome_js_parser/src/syntax/typescript/ts_parse_error.rs
@@ -128,3 +128,10 @@ pub(crate) fn expected_ts_type(p: &JsParser, range: TextRange) -> ParseDiagnosti
 pub(crate) fn expected_ts_type_parameter(p: &JsParser, range: TextRange) -> ParseDiagnostic {
     expected_node("type parameter", range).into_diagnostic(p)
 }
+
+pub(crate) fn infer_not_allowed(p: &JsParser, range: TextRange) -> ParseDiagnostic {
+    p.err_builder(
+        "'infer' declarations are only permitted in the 'extends' clause of a conditional type.",
+        range,
+    )
+}

--- a/crates/biome_js_parser/src/tests.rs
+++ b/crates/biome_js_parser/src/tests.rs
@@ -408,9 +408,7 @@ fn diagnostics_print_correctly() {
 #[test]
 pub fn quick_test() {
     let code = r#"
-
-
-        (@dec a) => {}
+        type Equals = A extends (x: B extends C ? D : E) => 0 ? F : G;
     "#;
     let root = parse(
         code,

--- a/crates/biome_js_parser/test_data/inline/err/ts_infer_type_not_allowed.rast
+++ b/crates/biome_js_parser/test_data/inline/err/ts_infer_type_not_allowed.rast
@@ -1,0 +1,1065 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@0..5 "type" [] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@5..18 "WithSelectors" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@18..19 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@19..20 "S" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@20..22 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@22..24 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@24..26 "S" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@26..34 "extends" [] [Whitespace(" ")],
+                extends_type: TsObjectType {
+                    l_curly_token: L_CURLY@34..36 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [
+                        TsPropertySignatureTypeMember {
+                            readonly_token: missing (optional),
+                            name: JsLiteralMemberName {
+                                value: IDENT@36..44 "getState" [] [],
+                            },
+                            optional_token: missing (optional),
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@44..46 ":" [] [Whitespace(" ")],
+                                ty: TsFunctionType {
+                                    type_parameters: missing (optional),
+                                    parameters: JsParameters {
+                                        l_paren_token: L_PAREN@46..47 "(" [] [],
+                                        items: JsParameterList [],
+                                        r_paren_token: R_PAREN@47..49 ")" [] [Whitespace(" ")],
+                                    },
+                                    fat_arrow_token: FAT_ARROW@49..52 "=>" [] [Whitespace(" ")],
+                                    return_type: TsInferType {
+                                        infer_token: INFER_KW@52..58 "infer" [] [Whitespace(" ")],
+                                        name: TsTypeParameterName {
+                                            ident_token: IDENT@58..60 "T" [] [Whitespace(" ")],
+                                        },
+                                        constraint: missing (optional),
+                                    },
+                                },
+                            },
+                            separator_token: missing (optional),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@60..61 "}" [] [],
+                },
+                question_mark_token: QUESTION@61..66 "?" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                true_type: TsObjectType {
+                    l_curly_token: L_CURLY@66..68 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [
+                        TsPropertySignatureTypeMember {
+                            readonly_token: missing (optional),
+                            name: JsLiteralMemberName {
+                                value: IDENT@68..71 "use" [] [],
+                            },
+                            optional_token: missing (optional),
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@71..73 ":" [] [Whitespace(" ")],
+                                ty: TsMappedType {
+                                    l_curly_token: L_CURLY@73..75 "{" [] [Whitespace(" ")],
+                                    readonly_modifier: missing (optional),
+                                    l_brack_token: L_BRACK@75..76 "[" [] [],
+                                    property_name: TsTypeParameterName {
+                                        ident_token: IDENT@76..78 "K" [] [Whitespace(" ")],
+                                    },
+                                    in_token: IN_KW@78..81 "in" [] [Whitespace(" ")],
+                                    keys_type: TsTypeOperatorType {
+                                        operator_token: KEYOF_KW@81..87 "keyof" [] [Whitespace(" ")],
+                                        ty: TsBogusType {
+                                            items: [
+                                                INFER_KW@87..103 "infer" [] [Whitespace(" "), Comments("/*error*/"), Whitespace(" ")],
+                                                TsTypeParameterName {
+                                                    ident_token: IDENT@103..104 "T" [] [],
+                                                },
+                                            ],
+                                        },
+                                    },
+                                    as_clause: missing (optional),
+                                    r_brack_token: R_BRACK@104..105 "]" [] [],
+                                    optional_modifier: missing (optional),
+                                    mapped_type: TsTypeAnnotation {
+                                        colon_token: COLON@105..107 ":" [] [Whitespace(" ")],
+                                        ty: TsFunctionType {
+                                            type_parameters: missing (optional),
+                                            parameters: JsParameters {
+                                                l_paren_token: L_PAREN@107..108 "(" [] [],
+                                                items: JsParameterList [],
+                                                r_paren_token: R_PAREN@108..110 ")" [] [Whitespace(" ")],
+                                            },
+                                            fat_arrow_token: FAT_ARROW@110..113 "=>" [] [Whitespace(" ")],
+                                            return_type: TsIndexedAccessType {
+                                                object_type: TsReferenceType {
+                                                    name: JsReferenceIdentifier {
+                                                        value_token: IDENT@113..114 "T" [] [],
+                                                    },
+                                                    type_arguments: missing (optional),
+                                                },
+                                                l_brack_token: L_BRACK@114..115 "[" [] [],
+                                                index_type: TsReferenceType {
+                                                    name: JsReferenceIdentifier {
+                                                        value_token: IDENT@115..116 "K" [] [],
+                                                    },
+                                                    type_arguments: missing (optional),
+                                                },
+                                                r_brack_token: R_BRACK@116..118 "]" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    },
+                                    semicolon_token: missing (optional),
+                                    r_curly_token: R_CURLY@118..120 "}" [] [Whitespace(" ")],
+                                },
+                            },
+                            separator_token: missing (optional),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@120..121 "}" [] [],
+                },
+                colon_token: COLON@121..126 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@126..131 "never" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@131..132 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@132..138 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@138..142 "TV1" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@142..144 "=" [] [Whitespace(" ")],
+            ty: TsTemplateLiteralType {
+                l_tick_token: BACKTICK@144..145 "`" [] [],
+                elements: TsTemplateElementList [
+                    TsTemplateElement {
+                        dollar_curly_token: DOLLAR_CURLY@145..147 "${" [] [],
+                        ty: TsBogusType {
+                            items: [
+                                INFER_KW@147..153 "infer" [] [Whitespace(" ")],
+                                TsTypeParameterName {
+                                    ident_token: IDENT@153..154 "X" [] [],
+                                },
+                            ],
+                        },
+                        r_curly_token: R_CURLY@154..155 "}" [] [],
+                    },
+                ],
+                r_tick_token: BACKTICK@155..156 "`" [] [],
+            },
+            semicolon_token: SEMICOLON@156..157 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@157..163 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@163..166 "T61" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@166..167 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@167..168 "T" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@168..170 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@170..172 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsParenthesizedType {
+                    l_paren_token: L_PAREN@172..173 "(" [] [],
+                    ty: TsBogusType {
+                        items: [
+                            INFER_KW@173..179 "infer" [] [Whitespace(" ")],
+                            TsTypeParameterName {
+                                ident_token: IDENT@179..180 "A" [] [],
+                            },
+                        ],
+                    },
+                    r_paren_token: R_PAREN@180..182 ")" [] [Whitespace(" ")],
+                },
+                extends_token: EXTENDS_KW@182..190 "extends" [] [Whitespace(" ")],
+                extends_type: TsInferType {
+                    infer_token: INFER_KW@190..196 "infer" [] [Whitespace(" ")],
+                    name: TsTypeParameterName {
+                        ident_token: IDENT@196..198 "B" [] [Whitespace(" ")],
+                    },
+                    constraint: missing (optional),
+                },
+                question_mark_token: QUESTION@198..200 "?" [] [Whitespace(" ")],
+                true_type: TsBogusType {
+                    items: [
+                        INFER_KW@200..206 "infer" [] [Whitespace(" ")],
+                        TsTypeParameterName {
+                            ident_token: IDENT@206..208 "C" [] [Whitespace(" ")],
+                        },
+                    ],
+                },
+                colon_token: COLON@208..210 ":" [] [Whitespace(" ")],
+                false_type: TsBogusType {
+                    items: [
+                        INFER_KW@210..216 "infer" [] [Whitespace(" ")],
+                        TsTypeParameterName {
+                            ident_token: IDENT@216..217 "D" [] [],
+                        },
+                    ],
+                },
+            },
+            semicolon_token: SEMICOLON@217..218 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@218..224 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@224..226 "A" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@226..228 "=" [] [Whitespace(" ")],
+            ty: TsObjectType {
+                l_curly_token: L_CURLY@228..229 "{" [] [],
+                members: TsTypeMemberList [
+                    TsPropertySignatureTypeMember {
+                        readonly_token: missing (optional),
+                        name: JsLiteralMemberName {
+                            value: IDENT@229..230 "a" [] [],
+                        },
+                        optional_token: missing (optional),
+                        type_annotation: TsTypeAnnotation {
+                            colon_token: COLON@230..232 ":" [] [Whitespace(" ")],
+                            ty: TsBogusType {
+                                items: [
+                                    INFER_KW@232..238 "infer" [] [Whitespace(" ")],
+                                    TsTypeParameterName {
+                                        ident_token: IDENT@238..239 "T" [] [],
+                                    },
+                                ],
+                            },
+                        },
+                        separator_token: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@239..240 "}" [] [],
+            },
+            semicolon_token: missing (optional),
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@240..246 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@246..248 "A" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@248..250 "=" [] [Whitespace(" ")],
+            ty: TsFunctionType {
+                type_parameters: missing (optional),
+                parameters: JsParameters {
+                    l_paren_token: L_PAREN@250..251 "(" [] [],
+                    items: JsParameterList [],
+                    r_paren_token: R_PAREN@251..253 ")" [] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@253..256 "=>" [] [Whitespace(" ")],
+                return_type: TsBogusType {
+                    items: [
+                        INFER_KW@256..262 "infer" [] [Whitespace(" ")],
+                        TsTypeParameterName {
+                            ident_token: IDENT@262..263 "T" [] [],
+                        },
+                    ],
+                },
+            },
+            semicolon_token: SEMICOLON@263..264 ";" [] [],
+        },
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                await_token: missing (optional),
+                kind: LET_KW@264..269 "let" [Newline("\n")] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@269..270 "s" [] [],
+                        },
+                        variable_annotation: TsTypeAnnotation {
+                            colon_token: COLON@270..272 ":" [] [Whitespace(" ")],
+                            ty: TsArrayType {
+                                element_type: TsParenthesizedType {
+                                    l_paren_token: L_PAREN@272..273 "(" [] [],
+                                    ty: TsBogusType {
+                                        items: [
+                                            INFER_KW@273..279 "infer" [] [Whitespace(" ")],
+                                            TsTypeParameterName {
+                                                ident_token: IDENT@279..285 "string" [] [],
+                                            },
+                                        ],
+                                    },
+                                    r_paren_token: R_PAREN@285..286 ")" [] [],
+                                },
+                                l_brack_token: L_BRACK@286..287 "[" [] [],
+                                r_brack_token: R_BRACK@287..289 "]" [] [Whitespace(" ")],
+                            },
+                        },
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@289..291 "=" [] [Whitespace(" ")],
+                            expression: JsCallExpression {
+                                callee: JsIdentifierExpression {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@291..297 "symbol" [] [],
+                                    },
+                                },
+                                optional_chain_token: missing (optional),
+                                type_arguments: missing (optional),
+                                arguments: JsCallArguments {
+                                    l_paren_token: L_PAREN@297..298 "(" [] [],
+                                    args: JsCallArgumentList [],
+                                    r_paren_token: R_PAREN@298..299 ")" [] [],
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@299..300 ";" [] [],
+        },
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                await_token: missing (optional),
+                kind: LET_KW@300..305 "let" [Newline("\n")] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@305..306 "s" [] [],
+                        },
+                        variable_annotation: TsTypeAnnotation {
+                            colon_token: COLON@306..308 ":" [] [Whitespace(" ")],
+                            ty: TsTypeOperatorType {
+                                operator_token: UNIQUE_KW@308..315 "unique" [] [Whitespace(" ")],
+                                ty: TsParenthesizedType {
+                                    l_paren_token: L_PAREN@315..316 "(" [] [],
+                                    ty: TsBogusType {
+                                        items: [
+                                            INFER_KW@316..322 "infer" [] [Whitespace(" ")],
+                                            TsTypeParameterName {
+                                                ident_token: IDENT@322..328 "string" [] [],
+                                            },
+                                        ],
+                                    },
+                                    r_paren_token: R_PAREN@328..329 ")" [] [],
+                                },
+                            },
+                        },
+                        initializer: missing (optional),
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@329..330 ";" [] [],
+        },
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                await_token: missing (optional),
+                kind: LET_KW@330..335 "let" [Newline("\n")] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@335..336 "s" [] [],
+                        },
+                        variable_annotation: TsTypeAnnotation {
+                            colon_token: COLON@336..338 ":" [] [Whitespace(" ")],
+                            ty: TsTupleType {
+                                l_brack_token: L_BRACK@338..339 "[" [] [],
+                                elements: TsTupleTypeElementList [
+                                    TsNumberType {
+                                        number_token: NUMBER_KW@339..345 "number" [] [],
+                                    },
+                                    COMMA@345..347 "," [] [Whitespace(" ")],
+                                    TsRestTupleTypeElement {
+                                        dotdotdot_token: DOT3@347..350 "..." [] [],
+                                        ty: TsBogusType {
+                                            items: [
+                                                INFER_KW@350..356 "infer" [] [Whitespace(" ")],
+                                                TsTypeParameterName {
+                                                    ident_token: IDENT@356..362 "string" [] [],
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                                r_brack_token: R_BRACK@362..363 "]" [] [],
+                            },
+                        },
+                        initializer: missing (optional),
+                    },
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                await_token: missing (optional),
+                kind: LET_KW@363..368 "let" [Newline("\n")] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@368..369 "s" [] [],
+                        },
+                        variable_annotation: TsTypeAnnotation {
+                            colon_token: COLON@369..371 ":" [] [Whitespace(" ")],
+                            ty: TsTupleType {
+                                l_brack_token: L_BRACK@371..372 "[" [] [],
+                                elements: TsTupleTypeElementList [
+                                    TsOptionalTupleTypeElement {
+                                        ty: TsParenthesizedType {
+                                            l_paren_token: L_PAREN@372..373 "(" [] [],
+                                            ty: TsBogusType {
+                                                items: [
+                                                    INFER_KW@373..379 "infer" [] [Whitespace(" ")],
+                                                    TsTypeParameterName {
+                                                        ident_token: IDENT@379..385 "string" [] [],
+                                                    },
+                                                ],
+                                            },
+                                            r_paren_token: R_PAREN@385..386 ")" [] [],
+                                        },
+                                        question_mark_token: QUESTION@386..387 "?" [] [],
+                                    },
+                                ],
+                                r_brack_token: R_BRACK@387..388 "]" [] [],
+                            },
+                        },
+                        initializer: missing (optional),
+                    },
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                await_token: missing (optional),
+                kind: LET_KW@388..393 "let" [Newline("\n")] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@393..394 "s" [] [],
+                        },
+                        variable_annotation: TsTypeAnnotation {
+                            colon_token: COLON@394..396 ":" [] [Whitespace(" ")],
+                            ty: TsIndexedAccessType {
+                                object_type: TsParenthesizedType {
+                                    l_paren_token: L_PAREN@396..397 "(" [] [],
+                                    ty: TsBogusType {
+                                        items: [
+                                            INFER_KW@397..403 "infer" [] [Whitespace(" ")],
+                                            TsTypeParameterName {
+                                                ident_token: IDENT@403..409 "string" [] [],
+                                            },
+                                        ],
+                                    },
+                                    r_paren_token: R_PAREN@409..410 ")" [] [],
+                                },
+                                l_brack_token: L_BRACK@410..411 "[" [] [],
+                                index_type: TsReferenceType {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@411..412 "a" [] [],
+                                    },
+                                    type_arguments: missing (optional),
+                                },
+                                r_brack_token: R_BRACK@412..413 "]" [] [],
+                            },
+                        },
+                        initializer: missing (optional),
+                    },
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                await_token: missing (optional),
+                kind: LET_KW@413..418 "let" [Newline("\n")] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@418..419 "s" [] [],
+                        },
+                        variable_annotation: TsTypeAnnotation {
+                            colon_token: COLON@419..421 ":" [] [Whitespace(" ")],
+                            ty: TsIndexedAccessType {
+                                object_type: TsReferenceType {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@421..422 "a" [] [],
+                                    },
+                                    type_arguments: missing (optional),
+                                },
+                                l_brack_token: L_BRACK@422..423 "[" [] [],
+                                index_type: TsParenthesizedType {
+                                    l_paren_token: L_PAREN@423..424 "(" [] [],
+                                    ty: TsBogusType {
+                                        items: [
+                                            INFER_KW@424..430 "infer" [] [Whitespace(" ")],
+                                            TsTypeParameterName {
+                                                ident_token: IDENT@430..436 "string" [] [],
+                                            },
+                                        ],
+                                    },
+                                    r_paren_token: R_PAREN@436..437 ")" [] [],
+                                },
+                                r_brack_token: R_BRACK@437..438 "]" [] [],
+                            },
+                        },
+                        initializer: missing (optional),
+                    },
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+    eof_token: EOF@438..439 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..439
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..438
+    0: TS_TYPE_ALIAS_DECLARATION@0..132
+      0: TYPE_KW@0..5 "type" [] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@5..18
+        0: IDENT@5..18 "WithSelectors" [] []
+      2: TS_TYPE_PARAMETERS@18..22
+        0: L_ANGLE@18..19 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@19..20
+          0: TS_TYPE_PARAMETER@19..20
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@19..19
+            1: TS_TYPE_PARAMETER_NAME@19..20
+              0: IDENT@19..20 "S" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@20..22 ">" [] [Whitespace(" ")]
+      3: EQ@22..24 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@24..131
+        0: TS_REFERENCE_TYPE@24..26
+          0: JS_REFERENCE_IDENTIFIER@24..26
+            0: IDENT@24..26 "S" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@26..34 "extends" [] [Whitespace(" ")]
+        2: TS_OBJECT_TYPE@34..61
+          0: L_CURLY@34..36 "{" [] [Whitespace(" ")]
+          1: TS_TYPE_MEMBER_LIST@36..60
+            0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@36..60
+              0: (empty)
+              1: JS_LITERAL_MEMBER_NAME@36..44
+                0: IDENT@36..44 "getState" [] []
+              2: (empty)
+              3: TS_TYPE_ANNOTATION@44..60
+                0: COLON@44..46 ":" [] [Whitespace(" ")]
+                1: TS_FUNCTION_TYPE@46..60
+                  0: (empty)
+                  1: JS_PARAMETERS@46..49
+                    0: L_PAREN@46..47 "(" [] []
+                    1: JS_PARAMETER_LIST@47..47
+                    2: R_PAREN@47..49 ")" [] [Whitespace(" ")]
+                  2: FAT_ARROW@49..52 "=>" [] [Whitespace(" ")]
+                  3: TS_INFER_TYPE@52..60
+                    0: INFER_KW@52..58 "infer" [] [Whitespace(" ")]
+                    1: TS_TYPE_PARAMETER_NAME@58..60
+                      0: IDENT@58..60 "T" [] [Whitespace(" ")]
+                    2: (empty)
+              4: (empty)
+          2: R_CURLY@60..61 "}" [] []
+        3: QUESTION@61..66 "?" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+        4: TS_OBJECT_TYPE@66..121
+          0: L_CURLY@66..68 "{" [] [Whitespace(" ")]
+          1: TS_TYPE_MEMBER_LIST@68..120
+            0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@68..120
+              0: (empty)
+              1: JS_LITERAL_MEMBER_NAME@68..71
+                0: IDENT@68..71 "use" [] []
+              2: (empty)
+              3: TS_TYPE_ANNOTATION@71..120
+                0: COLON@71..73 ":" [] [Whitespace(" ")]
+                1: TS_MAPPED_TYPE@73..120
+                  0: L_CURLY@73..75 "{" [] [Whitespace(" ")]
+                  1: (empty)
+                  2: L_BRACK@75..76 "[" [] []
+                  3: TS_TYPE_PARAMETER_NAME@76..78
+                    0: IDENT@76..78 "K" [] [Whitespace(" ")]
+                  4: IN_KW@78..81 "in" [] [Whitespace(" ")]
+                  5: TS_TYPE_OPERATOR_TYPE@81..104
+                    0: KEYOF_KW@81..87 "keyof" [] [Whitespace(" ")]
+                    1: TS_BOGUS_TYPE@87..104
+                      0: INFER_KW@87..103 "infer" [] [Whitespace(" "), Comments("/*error*/"), Whitespace(" ")]
+                      1: TS_TYPE_PARAMETER_NAME@103..104
+                        0: IDENT@103..104 "T" [] []
+                  6: (empty)
+                  7: R_BRACK@104..105 "]" [] []
+                  8: (empty)
+                  9: TS_TYPE_ANNOTATION@105..118
+                    0: COLON@105..107 ":" [] [Whitespace(" ")]
+                    1: TS_FUNCTION_TYPE@107..118
+                      0: (empty)
+                      1: JS_PARAMETERS@107..110
+                        0: L_PAREN@107..108 "(" [] []
+                        1: JS_PARAMETER_LIST@108..108
+                        2: R_PAREN@108..110 ")" [] [Whitespace(" ")]
+                      2: FAT_ARROW@110..113 "=>" [] [Whitespace(" ")]
+                      3: TS_INDEXED_ACCESS_TYPE@113..118
+                        0: TS_REFERENCE_TYPE@113..114
+                          0: JS_REFERENCE_IDENTIFIER@113..114
+                            0: IDENT@113..114 "T" [] []
+                          1: (empty)
+                        1: L_BRACK@114..115 "[" [] []
+                        2: TS_REFERENCE_TYPE@115..116
+                          0: JS_REFERENCE_IDENTIFIER@115..116
+                            0: IDENT@115..116 "K" [] []
+                          1: (empty)
+                        3: R_BRACK@116..118 "]" [] [Whitespace(" ")]
+                  10: (empty)
+                  11: R_CURLY@118..120 "}" [] [Whitespace(" ")]
+              4: (empty)
+          2: R_CURLY@120..121 "}" [] []
+        5: COLON@121..126 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@126..131
+          0: NEVER_KW@126..131 "never" [] []
+      5: SEMICOLON@131..132 ";" [] []
+    1: TS_TYPE_ALIAS_DECLARATION@132..157
+      0: TYPE_KW@132..138 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@138..142
+        0: IDENT@138..142 "TV1" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@142..144 "=" [] [Whitespace(" ")]
+      4: TS_TEMPLATE_LITERAL_TYPE@144..156
+        0: BACKTICK@144..145 "`" [] []
+        1: TS_TEMPLATE_ELEMENT_LIST@145..155
+          0: TS_TEMPLATE_ELEMENT@145..155
+            0: DOLLAR_CURLY@145..147 "${" [] []
+            1: TS_BOGUS_TYPE@147..154
+              0: INFER_KW@147..153 "infer" [] [Whitespace(" ")]
+              1: TS_TYPE_PARAMETER_NAME@153..154
+                0: IDENT@153..154 "X" [] []
+            2: R_CURLY@154..155 "}" [] []
+        2: BACKTICK@155..156 "`" [] []
+      5: SEMICOLON@156..157 ";" [] []
+    2: TS_TYPE_ALIAS_DECLARATION@157..218
+      0: TYPE_KW@157..163 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@163..166
+        0: IDENT@163..166 "T61" [] []
+      2: TS_TYPE_PARAMETERS@166..170
+        0: L_ANGLE@166..167 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@167..168
+          0: TS_TYPE_PARAMETER@167..168
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@167..167
+            1: TS_TYPE_PARAMETER_NAME@167..168
+              0: IDENT@167..168 "T" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@168..170 ">" [] [Whitespace(" ")]
+      3: EQ@170..172 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@172..217
+        0: TS_PARENTHESIZED_TYPE@172..182
+          0: L_PAREN@172..173 "(" [] []
+          1: TS_BOGUS_TYPE@173..180
+            0: INFER_KW@173..179 "infer" [] [Whitespace(" ")]
+            1: TS_TYPE_PARAMETER_NAME@179..180
+              0: IDENT@179..180 "A" [] []
+          2: R_PAREN@180..182 ")" [] [Whitespace(" ")]
+        1: EXTENDS_KW@182..190 "extends" [] [Whitespace(" ")]
+        2: TS_INFER_TYPE@190..198
+          0: INFER_KW@190..196 "infer" [] [Whitespace(" ")]
+          1: TS_TYPE_PARAMETER_NAME@196..198
+            0: IDENT@196..198 "B" [] [Whitespace(" ")]
+          2: (empty)
+        3: QUESTION@198..200 "?" [] [Whitespace(" ")]
+        4: TS_BOGUS_TYPE@200..208
+          0: INFER_KW@200..206 "infer" [] [Whitespace(" ")]
+          1: TS_TYPE_PARAMETER_NAME@206..208
+            0: IDENT@206..208 "C" [] [Whitespace(" ")]
+        5: COLON@208..210 ":" [] [Whitespace(" ")]
+        6: TS_BOGUS_TYPE@210..217
+          0: INFER_KW@210..216 "infer" [] [Whitespace(" ")]
+          1: TS_TYPE_PARAMETER_NAME@216..217
+            0: IDENT@216..217 "D" [] []
+      5: SEMICOLON@217..218 ";" [] []
+    3: TS_TYPE_ALIAS_DECLARATION@218..240
+      0: TYPE_KW@218..224 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@224..226
+        0: IDENT@224..226 "A" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@226..228 "=" [] [Whitespace(" ")]
+      4: TS_OBJECT_TYPE@228..240
+        0: L_CURLY@228..229 "{" [] []
+        1: TS_TYPE_MEMBER_LIST@229..239
+          0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@229..239
+            0: (empty)
+            1: JS_LITERAL_MEMBER_NAME@229..230
+              0: IDENT@229..230 "a" [] []
+            2: (empty)
+            3: TS_TYPE_ANNOTATION@230..239
+              0: COLON@230..232 ":" [] [Whitespace(" ")]
+              1: TS_BOGUS_TYPE@232..239
+                0: INFER_KW@232..238 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@238..239
+                  0: IDENT@238..239 "T" [] []
+            4: (empty)
+        2: R_CURLY@239..240 "}" [] []
+      5: (empty)
+    4: TS_TYPE_ALIAS_DECLARATION@240..264
+      0: TYPE_KW@240..246 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@246..248
+        0: IDENT@246..248 "A" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@248..250 "=" [] [Whitespace(" ")]
+      4: TS_FUNCTION_TYPE@250..263
+        0: (empty)
+        1: JS_PARAMETERS@250..253
+          0: L_PAREN@250..251 "(" [] []
+          1: JS_PARAMETER_LIST@251..251
+          2: R_PAREN@251..253 ")" [] [Whitespace(" ")]
+        2: FAT_ARROW@253..256 "=>" [] [Whitespace(" ")]
+        3: TS_BOGUS_TYPE@256..263
+          0: INFER_KW@256..262 "infer" [] [Whitespace(" ")]
+          1: TS_TYPE_PARAMETER_NAME@262..263
+            0: IDENT@262..263 "T" [] []
+      5: SEMICOLON@263..264 ";" [] []
+    5: JS_VARIABLE_STATEMENT@264..300
+      0: JS_VARIABLE_DECLARATION@264..299
+        0: (empty)
+        1: LET_KW@264..269 "let" [Newline("\n")] [Whitespace(" ")]
+        2: JS_VARIABLE_DECLARATOR_LIST@269..299
+          0: JS_VARIABLE_DECLARATOR@269..299
+            0: JS_IDENTIFIER_BINDING@269..270
+              0: IDENT@269..270 "s" [] []
+            1: TS_TYPE_ANNOTATION@270..289
+              0: COLON@270..272 ":" [] [Whitespace(" ")]
+              1: TS_ARRAY_TYPE@272..289
+                0: TS_PARENTHESIZED_TYPE@272..286
+                  0: L_PAREN@272..273 "(" [] []
+                  1: TS_BOGUS_TYPE@273..285
+                    0: INFER_KW@273..279 "infer" [] [Whitespace(" ")]
+                    1: TS_TYPE_PARAMETER_NAME@279..285
+                      0: IDENT@279..285 "string" [] []
+                  2: R_PAREN@285..286 ")" [] []
+                1: L_BRACK@286..287 "[" [] []
+                2: R_BRACK@287..289 "]" [] [Whitespace(" ")]
+            2: JS_INITIALIZER_CLAUSE@289..299
+              0: EQ@289..291 "=" [] [Whitespace(" ")]
+              1: JS_CALL_EXPRESSION@291..299
+                0: JS_IDENTIFIER_EXPRESSION@291..297
+                  0: JS_REFERENCE_IDENTIFIER@291..297
+                    0: IDENT@291..297 "symbol" [] []
+                1: (empty)
+                2: (empty)
+                3: JS_CALL_ARGUMENTS@297..299
+                  0: L_PAREN@297..298 "(" [] []
+                  1: JS_CALL_ARGUMENT_LIST@298..298
+                  2: R_PAREN@298..299 ")" [] []
+      1: SEMICOLON@299..300 ";" [] []
+    6: JS_VARIABLE_STATEMENT@300..330
+      0: JS_VARIABLE_DECLARATION@300..329
+        0: (empty)
+        1: LET_KW@300..305 "let" [Newline("\n")] [Whitespace(" ")]
+        2: JS_VARIABLE_DECLARATOR_LIST@305..329
+          0: JS_VARIABLE_DECLARATOR@305..329
+            0: JS_IDENTIFIER_BINDING@305..306
+              0: IDENT@305..306 "s" [] []
+            1: TS_TYPE_ANNOTATION@306..329
+              0: COLON@306..308 ":" [] [Whitespace(" ")]
+              1: TS_TYPE_OPERATOR_TYPE@308..329
+                0: UNIQUE_KW@308..315 "unique" [] [Whitespace(" ")]
+                1: TS_PARENTHESIZED_TYPE@315..329
+                  0: L_PAREN@315..316 "(" [] []
+                  1: TS_BOGUS_TYPE@316..328
+                    0: INFER_KW@316..322 "infer" [] [Whitespace(" ")]
+                    1: TS_TYPE_PARAMETER_NAME@322..328
+                      0: IDENT@322..328 "string" [] []
+                  2: R_PAREN@328..329 ")" [] []
+            2: (empty)
+      1: SEMICOLON@329..330 ";" [] []
+    7: JS_VARIABLE_STATEMENT@330..363
+      0: JS_VARIABLE_DECLARATION@330..363
+        0: (empty)
+        1: LET_KW@330..335 "let" [Newline("\n")] [Whitespace(" ")]
+        2: JS_VARIABLE_DECLARATOR_LIST@335..363
+          0: JS_VARIABLE_DECLARATOR@335..363
+            0: JS_IDENTIFIER_BINDING@335..336
+              0: IDENT@335..336 "s" [] []
+            1: TS_TYPE_ANNOTATION@336..363
+              0: COLON@336..338 ":" [] [Whitespace(" ")]
+              1: TS_TUPLE_TYPE@338..363
+                0: L_BRACK@338..339 "[" [] []
+                1: TS_TUPLE_TYPE_ELEMENT_LIST@339..362
+                  0: TS_NUMBER_TYPE@339..345
+                    0: NUMBER_KW@339..345 "number" [] []
+                  1: COMMA@345..347 "," [] [Whitespace(" ")]
+                  2: TS_REST_TUPLE_TYPE_ELEMENT@347..362
+                    0: DOT3@347..350 "..." [] []
+                    1: TS_BOGUS_TYPE@350..362
+                      0: INFER_KW@350..356 "infer" [] [Whitespace(" ")]
+                      1: TS_TYPE_PARAMETER_NAME@356..362
+                        0: IDENT@356..362 "string" [] []
+                2: R_BRACK@362..363 "]" [] []
+            2: (empty)
+      1: (empty)
+    8: JS_VARIABLE_STATEMENT@363..388
+      0: JS_VARIABLE_DECLARATION@363..388
+        0: (empty)
+        1: LET_KW@363..368 "let" [Newline("\n")] [Whitespace(" ")]
+        2: JS_VARIABLE_DECLARATOR_LIST@368..388
+          0: JS_VARIABLE_DECLARATOR@368..388
+            0: JS_IDENTIFIER_BINDING@368..369
+              0: IDENT@368..369 "s" [] []
+            1: TS_TYPE_ANNOTATION@369..388
+              0: COLON@369..371 ":" [] [Whitespace(" ")]
+              1: TS_TUPLE_TYPE@371..388
+                0: L_BRACK@371..372 "[" [] []
+                1: TS_TUPLE_TYPE_ELEMENT_LIST@372..387
+                  0: TS_OPTIONAL_TUPLE_TYPE_ELEMENT@372..387
+                    0: TS_PARENTHESIZED_TYPE@372..386
+                      0: L_PAREN@372..373 "(" [] []
+                      1: TS_BOGUS_TYPE@373..385
+                        0: INFER_KW@373..379 "infer" [] [Whitespace(" ")]
+                        1: TS_TYPE_PARAMETER_NAME@379..385
+                          0: IDENT@379..385 "string" [] []
+                      2: R_PAREN@385..386 ")" [] []
+                    1: QUESTION@386..387 "?" [] []
+                2: R_BRACK@387..388 "]" [] []
+            2: (empty)
+      1: (empty)
+    9: JS_VARIABLE_STATEMENT@388..413
+      0: JS_VARIABLE_DECLARATION@388..413
+        0: (empty)
+        1: LET_KW@388..393 "let" [Newline("\n")] [Whitespace(" ")]
+        2: JS_VARIABLE_DECLARATOR_LIST@393..413
+          0: JS_VARIABLE_DECLARATOR@393..413
+            0: JS_IDENTIFIER_BINDING@393..394
+              0: IDENT@393..394 "s" [] []
+            1: TS_TYPE_ANNOTATION@394..413
+              0: COLON@394..396 ":" [] [Whitespace(" ")]
+              1: TS_INDEXED_ACCESS_TYPE@396..413
+                0: TS_PARENTHESIZED_TYPE@396..410
+                  0: L_PAREN@396..397 "(" [] []
+                  1: TS_BOGUS_TYPE@397..409
+                    0: INFER_KW@397..403 "infer" [] [Whitespace(" ")]
+                    1: TS_TYPE_PARAMETER_NAME@403..409
+                      0: IDENT@403..409 "string" [] []
+                  2: R_PAREN@409..410 ")" [] []
+                1: L_BRACK@410..411 "[" [] []
+                2: TS_REFERENCE_TYPE@411..412
+                  0: JS_REFERENCE_IDENTIFIER@411..412
+                    0: IDENT@411..412 "a" [] []
+                  1: (empty)
+                3: R_BRACK@412..413 "]" [] []
+            2: (empty)
+      1: (empty)
+    10: JS_VARIABLE_STATEMENT@413..438
+      0: JS_VARIABLE_DECLARATION@413..438
+        0: (empty)
+        1: LET_KW@413..418 "let" [Newline("\n")] [Whitespace(" ")]
+        2: JS_VARIABLE_DECLARATOR_LIST@418..438
+          0: JS_VARIABLE_DECLARATOR@418..438
+            0: JS_IDENTIFIER_BINDING@418..419
+              0: IDENT@418..419 "s" [] []
+            1: TS_TYPE_ANNOTATION@419..438
+              0: COLON@419..421 ":" [] [Whitespace(" ")]
+              1: TS_INDEXED_ACCESS_TYPE@421..438
+                0: TS_REFERENCE_TYPE@421..422
+                  0: JS_REFERENCE_IDENTIFIER@421..422
+                    0: IDENT@421..422 "a" [] []
+                  1: (empty)
+                1: L_BRACK@422..423 "[" [] []
+                2: TS_PARENTHESIZED_TYPE@423..437
+                  0: L_PAREN@423..424 "(" [] []
+                  1: TS_BOGUS_TYPE@424..436
+                    0: INFER_KW@424..430 "infer" [] [Whitespace(" ")]
+                    1: TS_TYPE_PARAMETER_NAME@430..436
+                      0: IDENT@430..436 "string" [] []
+                  2: R_PAREN@436..437 ")" [] []
+                3: R_BRACK@437..438 "]" [] []
+            2: (empty)
+      1: (empty)
+  3: EOF@438..439 "" [Newline("\n")] []
+--
+ts_infer_type_not_allowed.ts:2:26 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+  
+    1 │ type WithSelectors<S> = S extends { getState: () => infer T }
+  > 2 │   ? { use: { [K in keyof infer /*error*/ T]: () => T[K] } }
+      │                          ^^^^^^^^^^^^^^^^^
+    3 │   : never;
+    4 │ type TV1 = `${infer X}`;
+  
+--
+ts_infer_type_not_allowed.ts:4:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+  
+    2 │   ? { use: { [K in keyof infer /*error*/ T]: () => T[K] } }
+    3 │   : never;
+  > 4 │ type TV1 = `${infer X}`;
+      │               ^^^^^^^
+    5 │ type T61<T> = (infer A) extends infer B ? infer C : infer D;
+    6 │ type A = {a: infer T}
+  
+--
+ts_infer_type_not_allowed.ts:5:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+  
+    3 │   : never;
+    4 │ type TV1 = `${infer X}`;
+  > 5 │ type T61<T> = (infer A) extends infer B ? infer C : infer D;
+      │                ^^^^^^^
+    6 │ type A = {a: infer T}
+    7 │ type A = () => infer T;
+  
+--
+ts_infer_type_not_allowed.ts:5:43 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+  
+    3 │   : never;
+    4 │ type TV1 = `${infer X}`;
+  > 5 │ type T61<T> = (infer A) extends infer B ? infer C : infer D;
+      │                                           ^^^^^^^
+    6 │ type A = {a: infer T}
+    7 │ type A = () => infer T;
+  
+--
+ts_infer_type_not_allowed.ts:5:53 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+  
+    3 │   : never;
+    4 │ type TV1 = `${infer X}`;
+  > 5 │ type T61<T> = (infer A) extends infer B ? infer C : infer D;
+      │                                                     ^^^^^^^
+    6 │ type A = {a: infer T}
+    7 │ type A = () => infer T;
+  
+--
+ts_infer_type_not_allowed.ts:6:14 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+  
+    4 │ type TV1 = `${infer X}`;
+    5 │ type T61<T> = (infer A) extends infer B ? infer C : infer D;
+  > 6 │ type A = {a: infer T}
+      │              ^^^^^^^
+    7 │ type A = () => infer T;
+    8 │ let s: (infer string)[] = symbol();
+  
+--
+ts_infer_type_not_allowed.ts:7:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+  
+    5 │ type T61<T> = (infer A) extends infer B ? infer C : infer D;
+    6 │ type A = {a: infer T}
+  > 7 │ type A = () => infer T;
+      │                ^^^^^^^
+    8 │ let s: (infer string)[] = symbol();
+    9 │ let s: unique (infer string);
+  
+--
+ts_infer_type_not_allowed.ts:8:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+  
+     6 │ type A = {a: infer T}
+     7 │ type A = () => infer T;
+   > 8 │ let s: (infer string)[] = symbol();
+       │         ^^^^^^^^^^^^
+     9 │ let s: unique (infer string);
+    10 │ let s: [number, ...infer string]
+  
+--
+ts_infer_type_not_allowed.ts:9:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+  
+     7 │ type A = () => infer T;
+     8 │ let s: (infer string)[] = symbol();
+   > 9 │ let s: unique (infer string);
+       │                ^^^^^^^^^^^^
+    10 │ let s: [number, ...infer string]
+    11 │ let s: [(infer string)?]
+  
+--
+ts_infer_type_not_allowed.ts:10:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+  
+     8 │ let s: (infer string)[] = symbol();
+     9 │ let s: unique (infer string);
+  > 10 │ let s: [number, ...infer string]
+       │                    ^^^^^^^^^^^^
+    11 │ let s: [(infer string)?]
+    12 │ let s: (infer string)[a]
+  
+--
+ts_infer_type_not_allowed.ts:11:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+  
+     9 │ let s: unique (infer string);
+    10 │ let s: [number, ...infer string]
+  > 11 │ let s: [(infer string)?]
+       │          ^^^^^^^^^^^^
+    12 │ let s: (infer string)[a]
+    13 │ let s: a[(infer string)]
+  
+--
+ts_infer_type_not_allowed.ts:12:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+  
+    10 │ let s: [number, ...infer string]
+    11 │ let s: [(infer string)?]
+  > 12 │ let s: (infer string)[a]
+       │         ^^^^^^^^^^^^
+    13 │ let s: a[(infer string)]
+    14 │ 
+  
+--
+ts_infer_type_not_allowed.ts:13:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+  
+    11 │ let s: [(infer string)?]
+    12 │ let s: (infer string)[a]
+  > 13 │ let s: a[(infer string)]
+       │           ^^^^^^^^^^^^
+    14 │ 
+  
+--
+type WithSelectors<S> = S extends { getState: () => infer T }
+  ? { use: { [K in keyof infer /*error*/ T]: () => T[K] } }
+  : never;
+type TV1 = `${infer X}`;
+type T61<T> = (infer A) extends infer B ? infer C : infer D;
+type A = {a: infer T}
+type A = () => infer T;
+let s: (infer string)[] = symbol();
+let s: unique (infer string);
+let s: [number, ...infer string]
+let s: [(infer string)?]
+let s: (infer string)[a]
+let s: a[(infer string)]

--- a/crates/biome_js_parser/test_data/inline/err/ts_infer_type_not_allowed.ts
+++ b/crates/biome_js_parser/test_data/inline/err/ts_infer_type_not_allowed.ts
@@ -1,0 +1,13 @@
+type WithSelectors<S> = S extends { getState: () => infer T }
+  ? { use: { [K in keyof infer /*error*/ T]: () => T[K] } }
+  : never;
+type TV1 = `${infer X}`;
+type T61<T> = (infer A) extends infer B ? infer C : infer D;
+type A = {a: infer T}
+type A = () => infer T;
+let s: (infer string)[] = symbol();
+let s: unique (infer string);
+let s: [number, ...infer string]
+let s: [(infer string)?]
+let s: (infer string)[a]
+let s: a[(infer string)]

--- a/crates/biome_js_parser/test_data/inline/ok/ts_conditional_type.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/ts_conditional_type.rast
@@ -559,14 +559,853 @@ JsModule {
             },
             semicolon_token: SEMICOLON@552..553 ";" [] [],
         },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@553..559 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@559..566 "Equals" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@566..568 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@568..570 "A" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@570..578 "extends" [] [Whitespace(" ")],
+                extends_type: TsFunctionType {
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@578..579 "(" [] [],
+                        items: JsParameterList [
+                            JsFormalParameter {
+                                decorators: JsDecoratorList [],
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@579..580 "x" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@580..582 ":" [] [Whitespace(" ")],
+                                    ty: TsConditionalType {
+                                        check_type: TsReferenceType {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@582..584 "B" [] [Whitespace(" ")],
+                                            },
+                                            type_arguments: missing (optional),
+                                        },
+                                        extends_token: EXTENDS_KW@584..592 "extends" [] [Whitespace(" ")],
+                                        extends_type: TsReferenceType {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@592..594 "C" [] [Whitespace(" ")],
+                                            },
+                                            type_arguments: missing (optional),
+                                        },
+                                        question_mark_token: QUESTION@594..596 "?" [] [Whitespace(" ")],
+                                        true_type: TsReferenceType {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@596..598 "D" [] [Whitespace(" ")],
+                                            },
+                                            type_arguments: missing (optional),
+                                        },
+                                        colon_token: COLON@598..600 ":" [] [Whitespace(" ")],
+                                        false_type: TsReferenceType {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@600..601 "E" [] [],
+                                            },
+                                            type_arguments: missing (optional),
+                                        },
+                                    },
+                                },
+                                initializer: missing (optional),
+                            },
+                        ],
+                        r_paren_token: R_PAREN@601..603 ")" [] [Whitespace(" ")],
+                    },
+                    fat_arrow_token: FAT_ARROW@603..606 "=>" [] [Whitespace(" ")],
+                    return_type: TsNumberLiteralType {
+                        minus_token: missing (optional),
+                        literal_token: JS_NUMBER_LITERAL@606..608 "0" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@608..610 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@610..612 "F" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@612..614 ":" [] [Whitespace(" ")],
+                false_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@614..615 "G" [] [],
+                    },
+                    type_arguments: missing (optional),
+                },
+            },
+            semicolon_token: SEMICOLON@615..616 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@616..622 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@622..627 "Curry" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@627..628 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@628..630 "F" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@630..638 "extends" [] [Whitespace(" ")],
+                            ty: TsParenthesizedType {
+                                l_paren_token: L_PAREN@638..639 "(" [] [],
+                                ty: TsFunctionType {
+                                    type_parameters: missing (optional),
+                                    parameters: JsParameters {
+                                        l_paren_token: L_PAREN@639..640 "(" [] [],
+                                        items: JsParameterList [
+                                            JsRestParameter {
+                                                decorators: JsDecoratorList [],
+                                                dotdotdot_token: DOT3@640..643 "..." [] [],
+                                                binding: JsIdentifierBinding {
+                                                    name_token: IDENT@643..647 "args" [] [],
+                                                },
+                                                type_annotation: TsTypeAnnotation {
+                                                    colon_token: COLON@647..649 ":" [] [Whitespace(" ")],
+                                                    ty: TsAnyType {
+                                                        any_token: ANY_KW@649..652 "any" [] [],
+                                                    },
+                                                },
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@652..654 ")" [] [Whitespace(" ")],
+                                    },
+                                    fat_arrow_token: FAT_ARROW@654..657 "=>" [] [Whitespace(" ")],
+                                    return_type: TsAnyType {
+                                        any_token: ANY_KW@657..660 "any" [] [],
+                                    },
+                                },
+                                r_paren_token: R_PAREN@660..661 ")" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@661..663 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@663..664 "=" [] [],
+            ty: TsFunctionType {
+                type_parameters: TsTypeParameters {
+                    l_angle_token: L_ANGLE@664..670 "<" [Newline("\n"), Whitespace("    ")] [],
+                    items: TsTypeParameterList [
+                        TsTypeParameter {
+                            modifiers: TsTypeParameterModifierList [],
+                            name: TsTypeParameterName {
+                                ident_token: IDENT@670..672 "T" [] [Whitespace(" ")],
+                            },
+                            constraint: TsTypeConstraintClause {
+                                extends_token: EXTENDS_KW@672..680 "extends" [] [Whitespace(" ")],
+                                ty: TsArrayType {
+                                    element_type: TsAnyType {
+                                        any_token: ANY_KW@680..683 "any" [] [],
+                                    },
+                                    l_brack_token: L_BRACK@683..684 "[" [] [],
+                                    r_brack_token: R_BRACK@684..685 "]" [] [],
+                                },
+                            },
+                            default: missing (optional),
+                        },
+                    ],
+                    r_angle_token: R_ANGLE@685..686 ">" [] [],
+                },
+                parameters: JsParameters {
+                    l_paren_token: L_PAREN@686..687 "(" [] [],
+                    items: JsParameterList [
+                        JsRestParameter {
+                            decorators: JsDecoratorList [],
+                            dotdotdot_token: DOT3@687..690 "..." [] [],
+                            binding: JsIdentifierBinding {
+                                name_token: IDENT@690..694 "args" [] [],
+                            },
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@694..696 ":" [] [Whitespace(" ")],
+                                ty: TsReferenceType {
+                                    name: TsQualifiedName {
+                                        left: JsReferenceIdentifier {
+                                            value_token: IDENT@696..701 "Tools" [] [],
+                                        },
+                                        dot_token: DOT@701..702 "." [] [],
+                                        right: JsName {
+                                            value_token: IDENT@702..706 "Cast" [] [],
+                                        },
+                                    },
+                                    type_arguments: TsTypeArguments {
+                                        l_angle_token: L_ANGLE@706..707 "<" [] [],
+                                        ts_type_argument_list: TsTypeArgumentList [
+                                            TsReferenceType {
+                                                name: TsQualifiedName {
+                                                    left: JsReferenceIdentifier {
+                                                        value_token: IDENT@707..712 "Tools" [] [],
+                                                    },
+                                                    dot_token: DOT@712..713 "." [] [],
+                                                    right: JsName {
+                                                        value_token: IDENT@713..717 "Cast" [] [],
+                                                    },
+                                                },
+                                                type_arguments: TsTypeArguments {
+                                                    l_angle_token: L_ANGLE@717..718 "<" [] [],
+                                                    ts_type_argument_list: TsTypeArgumentList [
+                                                        TsReferenceType {
+                                                            name: JsReferenceIdentifier {
+                                                                value_token: IDENT@718..719 "T" [] [],
+                                                            },
+                                                            type_arguments: missing (optional),
+                                                        },
+                                                        COMMA@719..721 "," [] [Whitespace(" ")],
+                                                        TsReferenceType {
+                                                            name: JsReferenceIdentifier {
+                                                                value_token: IDENT@721..725 "Gaps" [] [],
+                                                            },
+                                                            type_arguments: TsTypeArguments {
+                                                                l_angle_token: L_ANGLE@725..726 "<" [] [],
+                                                                ts_type_argument_list: TsTypeArgumentList [
+                                                                    TsReferenceType {
+                                                                        name: JsReferenceIdentifier {
+                                                                            value_token: IDENT@726..736 "Parameters" [] [],
+                                                                        },
+                                                                        type_arguments: TsTypeArguments {
+                                                                            l_angle_token: L_ANGLE@736..737 "<" [] [],
+                                                                            ts_type_argument_list: TsTypeArgumentList [
+                                                                                TsReferenceType {
+                                                                                    name: JsReferenceIdentifier {
+                                                                                        value_token: IDENT@737..738 "F" [] [],
+                                                                                    },
+                                                                                    type_arguments: missing (optional),
+                                                                                },
+                                                                            ],
+                                                                            r_angle_token: R_ANGLE@738..739 ">" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                                r_angle_token: R_ANGLE@739..740 ">" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                    r_angle_token: R_ANGLE@740..741 ">" [] [],
+                                                },
+                                            },
+                                            COMMA@741..743 "," [] [Whitespace(" ")],
+                                            TsArrayType {
+                                                element_type: TsAnyType {
+                                                    any_token: ANY_KW@743..746 "any" [] [],
+                                                },
+                                                l_brack_token: L_BRACK@746..747 "[" [] [],
+                                                r_brack_token: R_BRACK@747..748 "]" [] [],
+                                            },
+                                        ],
+                                        r_angle_token: R_ANGLE@748..749 ">" [] [],
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                    r_paren_token: R_PAREN@749..751 ")" [] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@751..753 "=>" [] [],
+                return_type: TsConditionalType {
+                    check_type: TsReferenceType {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@753..769 "GapsOf" [Newline("\n"), Whitespace("         ")] [],
+                        },
+                        type_arguments: TsTypeArguments {
+                            l_angle_token: L_ANGLE@769..770 "<" [] [],
+                            ts_type_argument_list: TsTypeArgumentList [
+                                TsReferenceType {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@770..771 "T" [] [],
+                                    },
+                                    type_arguments: missing (optional),
+                                },
+                                COMMA@771..773 "," [] [Whitespace(" ")],
+                                TsReferenceType {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@773..783 "Parameters" [] [],
+                                    },
+                                    type_arguments: TsTypeArguments {
+                                        l_angle_token: L_ANGLE@783..784 "<" [] [],
+                                        ts_type_argument_list: TsTypeArgumentList [
+                                            TsReferenceType {
+                                                name: JsReferenceIdentifier {
+                                                    value_token: IDENT@784..785 "F" [] [],
+                                                },
+                                                type_arguments: missing (optional),
+                                            },
+                                        ],
+                                        r_angle_token: R_ANGLE@785..786 ">" [] [],
+                                    },
+                                },
+                            ],
+                            r_angle_token: R_ANGLE@786..788 ">" [] [Whitespace(" ")],
+                        },
+                    },
+                    extends_token: EXTENDS_KW@788..796 "extends" [] [Whitespace(" ")],
+                    extends_type: TsTupleType {
+                        l_brack_token: L_BRACK@796..797 "[" [] [],
+                        elements: TsTupleTypeElementList [
+                            TsAnyType {
+                                any_token: ANY_KW@797..800 "any" [] [],
+                            },
+                            COMMA@800..802 "," [] [Whitespace(" ")],
+                            TsRestTupleTypeElement {
+                                dotdotdot_token: DOT3@802..805 "..." [] [],
+                                ty: TsArrayType {
+                                    element_type: TsAnyType {
+                                        any_token: ANY_KW@805..808 "any" [] [],
+                                    },
+                                    l_brack_token: L_BRACK@808..809 "[" [] [],
+                                    r_brack_token: R_BRACK@809..810 "]" [] [],
+                                },
+                            },
+                        ],
+                        r_brack_token: R_BRACK@810..811 "]" [] [],
+                    },
+                    question_mark_token: QUESTION@811..823 "?" [Newline("\n"), Whitespace("         ")] [Whitespace(" ")],
+                    true_type: TsReferenceType {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@823..828 "Curry" [] [],
+                        },
+                        type_arguments: TsTypeArguments {
+                            l_angle_token: L_ANGLE@828..829 "<" [] [],
+                            ts_type_argument_list: TsTypeArgumentList [
+                                TsFunctionType {
+                                    type_parameters: missing (optional),
+                                    parameters: JsParameters {
+                                        l_paren_token: L_PAREN@829..830 "(" [] [],
+                                        items: JsParameterList [
+                                            JsRestParameter {
+                                                decorators: JsDecoratorList [],
+                                                dotdotdot_token: DOT3@830..833 "..." [] [],
+                                                binding: JsIdentifierBinding {
+                                                    name_token: IDENT@833..837 "args" [] [],
+                                                },
+                                                type_annotation: TsTypeAnnotation {
+                                                    colon_token: COLON@837..839 ":" [] [Whitespace(" ")],
+                                                    ty: TsConditionalType {
+                                                        check_type: TsReferenceType {
+                                                            name: JsReferenceIdentifier {
+                                                                value_token: IDENT@839..845 "GapsOf" [] [],
+                                                            },
+                                                            type_arguments: TsTypeArguments {
+                                                                l_angle_token: L_ANGLE@845..846 "<" [] [],
+                                                                ts_type_argument_list: TsTypeArgumentList [
+                                                                    TsReferenceType {
+                                                                        name: JsReferenceIdentifier {
+                                                                            value_token: IDENT@846..847 "T" [] [],
+                                                                        },
+                                                                        type_arguments: missing (optional),
+                                                                    },
+                                                                    COMMA@847..849 "," [] [Whitespace(" ")],
+                                                                    TsReferenceType {
+                                                                        name: JsReferenceIdentifier {
+                                                                            value_token: IDENT@849..859 "Parameters" [] [],
+                                                                        },
+                                                                        type_arguments: TsTypeArguments {
+                                                                            l_angle_token: L_ANGLE@859..860 "<" [] [],
+                                                                            ts_type_argument_list: TsTypeArgumentList [
+                                                                                TsReferenceType {
+                                                                                    name: JsReferenceIdentifier {
+                                                                                        value_token: IDENT@860..861 "F" [] [],
+                                                                                    },
+                                                                                    type_arguments: missing (optional),
+                                                                                },
+                                                                            ],
+                                                                            r_angle_token: R_ANGLE@861..862 ">" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                                r_angle_token: R_ANGLE@862..864 ">" [] [Whitespace(" ")],
+                                                            },
+                                                        },
+                                                        extends_token: EXTENDS_KW@864..872 "extends" [] [Whitespace(" ")],
+                                                        extends_type: TsInferType {
+                                                            infer_token: INFER_KW@872..878 "infer" [] [Whitespace(" ")],
+                                                            name: TsTypeParameterName {
+                                                                ident_token: IDENT@878..880 "G" [] [Whitespace(" ")],
+                                                            },
+                                                            constraint: missing (optional),
+                                                        },
+                                                        question_mark_token: QUESTION@880..882 "?" [] [Whitespace(" ")],
+                                                        true_type: TsReferenceType {
+                                                            name: TsQualifiedName {
+                                                                left: JsReferenceIdentifier {
+                                                                    value_token: IDENT@882..887 "Tools" [] [],
+                                                                },
+                                                                dot_token: DOT@887..888 "." [] [],
+                                                                right: JsName {
+                                                                    value_token: IDENT@888..892 "Cast" [] [],
+                                                                },
+                                                            },
+                                                            type_arguments: TsTypeArguments {
+                                                                l_angle_token: L_ANGLE@892..893 "<" [] [],
+                                                                ts_type_argument_list: TsTypeArgumentList [
+                                                                    TsReferenceType {
+                                                                        name: JsReferenceIdentifier {
+                                                                            value_token: IDENT@893..894 "G" [] [],
+                                                                        },
+                                                                        type_arguments: missing (optional),
+                                                                    },
+                                                                    COMMA@894..896 "," [] [Whitespace(" ")],
+                                                                    TsArrayType {
+                                                                        element_type: TsAnyType {
+                                                                            any_token: ANY_KW@896..899 "any" [] [],
+                                                                        },
+                                                                        l_brack_token: L_BRACK@899..900 "[" [] [],
+                                                                        r_brack_token: R_BRACK@900..901 "]" [] [],
+                                                                    },
+                                                                ],
+                                                                r_angle_token: R_ANGLE@901..903 ">" [] [Whitespace(" ")],
+                                                            },
+                                                        },
+                                                        colon_token: COLON@903..905 ":" [] [Whitespace(" ")],
+                                                        false_type: TsNeverType {
+                                                            never_token: NEVER_KW@905..910 "never" [] [],
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@910..912 ")" [] [Whitespace(" ")],
+                                    },
+                                    fat_arrow_token: FAT_ARROW@912..915 "=>" [] [Whitespace(" ")],
+                                    return_type: TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@915..925 "ReturnType" [] [],
+                                        },
+                                        type_arguments: TsTypeArguments {
+                                            l_angle_token: L_ANGLE@925..926 "<" [] [],
+                                            ts_type_argument_list: TsTypeArgumentList [
+                                                TsReferenceType {
+                                                    name: JsReferenceIdentifier {
+                                                        value_token: IDENT@926..927 "F" [] [],
+                                                    },
+                                                    type_arguments: missing (optional),
+                                                },
+                                            ],
+                                            r_angle_token: R_ANGLE@927..928 ">" [] [],
+                                        },
+                                    },
+                                },
+                            ],
+                            r_angle_token: R_ANGLE@928..929 ">" [] [],
+                        },
+                    },
+                    colon_token: COLON@929..941 ":" [Newline("\n"), Whitespace("         ")] [Whitespace(" ")],
+                    false_type: TsReferenceType {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@941..951 "ReturnType" [] [],
+                        },
+                        type_arguments: TsTypeArguments {
+                            l_angle_token: L_ANGLE@951..952 "<" [] [],
+                            ts_type_argument_list: TsTypeArgumentList [
+                                TsReferenceType {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@952..953 "F" [] [],
+                                    },
+                                    type_arguments: missing (optional),
+                                },
+                            ],
+                            r_angle_token: R_ANGLE@953..954 ">" [] [],
+                        },
+                    },
+                },
+            },
+            semicolon_token: SEMICOLON@954..955 ";" [] [],
+        },
+        TsInterfaceDeclaration {
+            interface_token: INTERFACE_KW@955..966 "interface" [Newline("\n")] [Whitespace(" ")],
+            id: TsIdentifierBinding {
+                name_token: IDENT@966..978 "GapsOfWorker" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@978..979 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@979..982 "T1" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@982..990 "extends" [] [Whitespace(" ")],
+                            ty: TsArrayType {
+                                element_type: TsAnyType {
+                                    any_token: ANY_KW@990..993 "any" [] [],
+                                },
+                                l_brack_token: L_BRACK@993..994 "[" [] [],
+                                r_brack_token: R_BRACK@994..995 "]" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                    },
+                    COMMA@995..997 "," [] [Whitespace(" ")],
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@997..1000 "T2" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@1000..1008 "extends" [] [Whitespace(" ")],
+                            ty: TsArrayType {
+                                element_type: TsAnyType {
+                                    any_token: ANY_KW@1008..1011 "any" [] [],
+                                },
+                                l_brack_token: L_BRACK@1011..1012 "[" [] [],
+                                r_brack_token: R_BRACK@1012..1013 "]" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                    },
+                    COMMA@1013..1015 "," [] [Whitespace(" ")],
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@1015..1018 "TN" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@1018..1026 "extends" [] [Whitespace(" ")],
+                            ty: TsArrayType {
+                                element_type: TsAnyType {
+                                    any_token: ANY_KW@1026..1029 "any" [] [],
+                                },
+                                l_brack_token: L_BRACK@1029..1030 "[" [] [],
+                                r_brack_token: R_BRACK@1030..1032 "]" [] [Whitespace(" ")],
+                            },
+                        },
+                        default: TsDefaultTypeClause {
+                            eq_token: EQ@1032..1034 "=" [] [Whitespace(" ")],
+                            ty: TsTupleType {
+                                l_brack_token: L_BRACK@1034..1035 "[" [] [],
+                                elements: TsTupleTypeElementList [],
+                                r_brack_token: R_BRACK@1035..1036 "]" [] [],
+                            },
+                        },
+                    },
+                    COMMA@1036..1038 "," [] [Whitespace(" ")],
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@1038..1040 "I" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@1040..1048 "extends" [] [Whitespace(" ")],
+                            ty: TsArrayType {
+                                element_type: TsAnyType {
+                                    any_token: ANY_KW@1048..1051 "any" [] [],
+                                },
+                                l_brack_token: L_BRACK@1051..1052 "[" [] [],
+                                r_brack_token: R_BRACK@1052..1054 "]" [] [Whitespace(" ")],
+                            },
+                        },
+                        default: TsDefaultTypeClause {
+                            eq_token: EQ@1054..1056 "=" [] [Whitespace(" ")],
+                            ty: TsTupleType {
+                                l_brack_token: L_BRACK@1056..1057 "[" [] [],
+                                elements: TsTupleTypeElementList [],
+                                r_brack_token: R_BRACK@1057..1058 "]" [] [],
+                            },
+                        },
+                    },
+                ],
+                r_angle_token: R_ANGLE@1058..1060 ">" [] [Whitespace(" ")],
+            },
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@1060..1061 "{" [] [],
+            members: TsTypeMemberList [
+                TsPropertySignatureTypeMember {
+                    readonly_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: JS_NUMBER_LITERAL@1061..1067 "0" [Newline("\n"), Whitespace("    ")] [],
+                    },
+                    optional_token: missing (optional),
+                    type_annotation: TsTypeAnnotation {
+                        colon_token: COLON@1067..1069 ":" [] [Whitespace(" ")],
+                        ty: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1069..1075 "GapsOf" [] [],
+                            },
+                            type_arguments: TsTypeArguments {
+                                l_angle_token: L_ANGLE@1075..1076 "<" [] [],
+                                ts_type_argument_list: TsTypeArgumentList [
+                                    TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@1076..1078 "T1" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                    COMMA@1078..1080 "," [] [Whitespace(" ")],
+                                    TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@1080..1082 "T2" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                    COMMA@1082..1084 "," [] [Whitespace(" ")],
+                                    TsConditionalType {
+                                        check_type: TsReferenceType {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@1084..1089 "GapOf" [] [],
+                                            },
+                                            type_arguments: TsTypeArguments {
+                                                l_angle_token: L_ANGLE@1089..1090 "<" [] [],
+                                                ts_type_argument_list: TsTypeArgumentList [
+                                                    TsReferenceType {
+                                                        name: JsReferenceIdentifier {
+                                                            value_token: IDENT@1090..1092 "T1" [] [],
+                                                        },
+                                                        type_arguments: missing (optional),
+                                                    },
+                                                    COMMA@1092..1094 "," [] [Whitespace(" ")],
+                                                    TsReferenceType {
+                                                        name: JsReferenceIdentifier {
+                                                            value_token: IDENT@1094..1096 "T2" [] [],
+                                                        },
+                                                        type_arguments: missing (optional),
+                                                    },
+                                                    COMMA@1096..1098 "," [] [Whitespace(" ")],
+                                                    TsReferenceType {
+                                                        name: JsReferenceIdentifier {
+                                                            value_token: IDENT@1098..1100 "TN" [] [],
+                                                        },
+                                                        type_arguments: missing (optional),
+                                                    },
+                                                    COMMA@1100..1102 "," [] [Whitespace(" ")],
+                                                    TsReferenceType {
+                                                        name: JsReferenceIdentifier {
+                                                            value_token: IDENT@1102..1103 "I" [] [],
+                                                        },
+                                                        type_arguments: missing (optional),
+                                                    },
+                                                ],
+                                                r_angle_token: R_ANGLE@1103..1105 ">" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                        extends_token: EXTENDS_KW@1105..1113 "extends" [] [Whitespace(" ")],
+                                        extends_type: TsInferType {
+                                            infer_token: INFER_KW@1113..1119 "infer" [] [Whitespace(" ")],
+                                            name: TsTypeParameterName {
+                                                ident_token: IDENT@1119..1121 "G" [] [Whitespace(" ")],
+                                            },
+                                            constraint: missing (optional),
+                                        },
+                                        question_mark_token: QUESTION@1121..1123 "?" [] [Whitespace(" ")],
+                                        true_type: TsReferenceType {
+                                            name: TsQualifiedName {
+                                                left: JsReferenceIdentifier {
+                                                    value_token: IDENT@1123..1128 "Tools" [] [],
+                                                },
+                                                dot_token: DOT@1128..1129 "." [] [],
+                                                right: JsName {
+                                                    value_token: IDENT@1129..1133 "Cast" [] [],
+                                                },
+                                            },
+                                            type_arguments: TsTypeArguments {
+                                                l_angle_token: L_ANGLE@1133..1134 "<" [] [],
+                                                ts_type_argument_list: TsTypeArgumentList [
+                                                    TsReferenceType {
+                                                        name: JsReferenceIdentifier {
+                                                            value_token: IDENT@1134..1135 "G" [] [],
+                                                        },
+                                                        type_arguments: missing (optional),
+                                                    },
+                                                    COMMA@1135..1137 "," [] [Whitespace(" ")],
+                                                    TsArrayType {
+                                                        element_type: TsAnyType {
+                                                            any_token: ANY_KW@1137..1140 "any" [] [],
+                                                        },
+                                                        l_brack_token: L_BRACK@1140..1141 "[" [] [],
+                                                        r_brack_token: R_BRACK@1141..1142 "]" [] [],
+                                                    },
+                                                ],
+                                                r_angle_token: R_ANGLE@1142..1144 ">" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                        colon_token: COLON@1144..1146 ":" [] [Whitespace(" ")],
+                                        false_type: TsNeverType {
+                                            never_token: NEVER_KW@1146..1151 "never" [] [],
+                                        },
+                                    },
+                                    COMMA@1151..1153 "," [] [Whitespace(" ")],
+                                    TsReferenceType {
+                                        name: TsQualifiedName {
+                                            left: JsReferenceIdentifier {
+                                                value_token: IDENT@1153..1158 "Tools" [] [],
+                                            },
+                                            dot_token: DOT@1158..1159 "." [] [],
+                                            right: JsName {
+                                                value_token: IDENT@1159..1163 "Next" [] [],
+                                            },
+                                        },
+                                        type_arguments: TsTypeArguments {
+                                            l_angle_token: L_ANGLE@1163..1164 "<" [] [],
+                                            ts_type_argument_list: TsTypeArgumentList [
+                                                TsReferenceType {
+                                                    name: JsReferenceIdentifier {
+                                                        value_token: IDENT@1164..1165 "I" [] [],
+                                                    },
+                                                    type_arguments: missing (optional),
+                                                },
+                                            ],
+                                            r_angle_token: R_ANGLE@1165..1166 ">" [] [],
+                                        },
+                                    },
+                                ],
+                                r_angle_token: R_ANGLE@1166..1167 ">" [] [],
+                            },
+                        },
+                    },
+                    separator_token: SEMICOLON@1167..1168 ";" [] [],
+                },
+                TsPropertySignatureTypeMember {
+                    readonly_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: JS_NUMBER_LITERAL@1168..1174 "1" [Newline("\n"), Whitespace("    ")] [],
+                    },
+                    optional_token: missing (optional),
+                    type_annotation: TsTypeAnnotation {
+                        colon_token: COLON@1174..1176 ":" [] [Whitespace(" ")],
+                        ty: TsReferenceType {
+                            name: TsQualifiedName {
+                                left: JsReferenceIdentifier {
+                                    value_token: IDENT@1176..1181 "Tools" [] [],
+                                },
+                                dot_token: DOT@1181..1182 "." [] [],
+                                right: JsName {
+                                    value_token: IDENT@1182..1188 "Concat" [] [],
+                                },
+                            },
+                            type_arguments: TsTypeArguments {
+                                l_angle_token: L_ANGLE@1188..1189 "<" [] [],
+                                ts_type_argument_list: TsTypeArgumentList [
+                                    TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@1189..1191 "TN" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                    COMMA@1191..1193 "," [] [Whitespace(" ")],
+                                    TsConditionalType {
+                                        check_type: TsReferenceType {
+                                            name: TsQualifiedName {
+                                                left: JsReferenceIdentifier {
+                                                    value_token: IDENT@1193..1198 "Tools" [] [],
+                                                },
+                                                dot_token: DOT@1198..1199 "." [] [],
+                                                right: JsName {
+                                                    value_token: IDENT@1199..1203 "Drop" [] [],
+                                                },
+                                            },
+                                            type_arguments: TsTypeArguments {
+                                                l_angle_token: L_ANGLE@1203..1204 "<" [] [],
+                                                ts_type_argument_list: TsTypeArgumentList [
+                                                    TsReferenceType {
+                                                        name: TsQualifiedName {
+                                                            left: JsReferenceIdentifier {
+                                                                value_token: IDENT@1204..1209 "Tools" [] [],
+                                                            },
+                                                            dot_token: DOT@1209..1210 "." [] [],
+                                                            right: JsName {
+                                                                value_token: IDENT@1210..1213 "Pos" [] [],
+                                                            },
+                                                        },
+                                                        type_arguments: TsTypeArguments {
+                                                            l_angle_token: L_ANGLE@1213..1214 "<" [] [],
+                                                            ts_type_argument_list: TsTypeArgumentList [
+                                                                TsReferenceType {
+                                                                    name: JsReferenceIdentifier {
+                                                                        value_token: IDENT@1214..1215 "I" [] [],
+                                                                    },
+                                                                    type_arguments: missing (optional),
+                                                                },
+                                                            ],
+                                                            r_angle_token: R_ANGLE@1215..1216 ">" [] [],
+                                                        },
+                                                    },
+                                                    COMMA@1216..1218 "," [] [Whitespace(" ")],
+                                                    TsReferenceType {
+                                                        name: JsReferenceIdentifier {
+                                                            value_token: IDENT@1218..1220 "T2" [] [],
+                                                        },
+                                                        type_arguments: missing (optional),
+                                                    },
+                                                ],
+                                                r_angle_token: R_ANGLE@1220..1222 ">" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                        extends_token: EXTENDS_KW@1222..1230 "extends" [] [Whitespace(" ")],
+                                        extends_type: TsInferType {
+                                            infer_token: INFER_KW@1230..1236 "infer" [] [Whitespace(" ")],
+                                            name: TsTypeParameterName {
+                                                ident_token: IDENT@1236..1238 "D" [] [Whitespace(" ")],
+                                            },
+                                            constraint: missing (optional),
+                                        },
+                                        question_mark_token: QUESTION@1238..1240 "?" [] [Whitespace(" ")],
+                                        true_type: TsReferenceType {
+                                            name: TsQualifiedName {
+                                                left: JsReferenceIdentifier {
+                                                    value_token: IDENT@1240..1245 "Tools" [] [],
+                                                },
+                                                dot_token: DOT@1245..1246 "." [] [],
+                                                right: JsName {
+                                                    value_token: IDENT@1246..1250 "Cast" [] [],
+                                                },
+                                            },
+                                            type_arguments: TsTypeArguments {
+                                                l_angle_token: L_ANGLE@1250..1251 "<" [] [],
+                                                ts_type_argument_list: TsTypeArgumentList [
+                                                    TsReferenceType {
+                                                        name: JsReferenceIdentifier {
+                                                            value_token: IDENT@1251..1252 "D" [] [],
+                                                        },
+                                                        type_arguments: missing (optional),
+                                                    },
+                                                    COMMA@1252..1254 "," [] [Whitespace(" ")],
+                                                    TsArrayType {
+                                                        element_type: TsAnyType {
+                                                            any_token: ANY_KW@1254..1257 "any" [] [],
+                                                        },
+                                                        l_brack_token: L_BRACK@1257..1258 "[" [] [],
+                                                        r_brack_token: R_BRACK@1258..1259 "]" [] [],
+                                                    },
+                                                ],
+                                                r_angle_token: R_ANGLE@1259..1261 ">" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                        colon_token: COLON@1261..1263 ":" [] [Whitespace(" ")],
+                                        false_type: TsNeverType {
+                                            never_token: NEVER_KW@1263..1268 "never" [] [],
+                                        },
+                                    },
+                                ],
+                                r_angle_token: R_ANGLE@1268..1269 ">" [] [],
+                            },
+                        },
+                    },
+                    separator_token: SEMICOLON@1269..1270 ";" [] [],
+                },
+            ],
+            r_curly_token: R_CURLY@1270..1272 "}" [Newline("\n")] [],
+        },
     ],
-    eof_token: EOF@553..554 "" [Newline("\n")] [],
+    eof_token: EOF@1272..1273 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..554
+0: JS_MODULE@0..1273
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..553
+  2: JS_MODULE_ITEM_LIST@0..1272
     0: TS_TYPE_ALIAS_DECLARATION@0..16
       0: TYPE_KW@0..5 "type" [] [Whitespace(" ")]
       1: TS_IDENTIFIER_BINDING@5..7
@@ -967,4 +1806,581 @@ JsModule {
         6: TS_NEVER_TYPE@547..552
           0: NEVER_KW@547..552 "never" [] []
       5: SEMICOLON@552..553 ";" [] []
-  3: EOF@553..554 "" [Newline("\n")] []
+    9: TS_TYPE_ALIAS_DECLARATION@553..616
+      0: TYPE_KW@553..559 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@559..566
+        0: IDENT@559..566 "Equals" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@566..568 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@568..615
+        0: TS_REFERENCE_TYPE@568..570
+          0: JS_REFERENCE_IDENTIFIER@568..570
+            0: IDENT@568..570 "A" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@570..578 "extends" [] [Whitespace(" ")]
+        2: TS_FUNCTION_TYPE@578..608
+          0: (empty)
+          1: JS_PARAMETERS@578..603
+            0: L_PAREN@578..579 "(" [] []
+            1: JS_PARAMETER_LIST@579..601
+              0: JS_FORMAL_PARAMETER@579..601
+                0: JS_DECORATOR_LIST@579..579
+                1: JS_IDENTIFIER_BINDING@579..580
+                  0: IDENT@579..580 "x" [] []
+                2: (empty)
+                3: TS_TYPE_ANNOTATION@580..601
+                  0: COLON@580..582 ":" [] [Whitespace(" ")]
+                  1: TS_CONDITIONAL_TYPE@582..601
+                    0: TS_REFERENCE_TYPE@582..584
+                      0: JS_REFERENCE_IDENTIFIER@582..584
+                        0: IDENT@582..584 "B" [] [Whitespace(" ")]
+                      1: (empty)
+                    1: EXTENDS_KW@584..592 "extends" [] [Whitespace(" ")]
+                    2: TS_REFERENCE_TYPE@592..594
+                      0: JS_REFERENCE_IDENTIFIER@592..594
+                        0: IDENT@592..594 "C" [] [Whitespace(" ")]
+                      1: (empty)
+                    3: QUESTION@594..596 "?" [] [Whitespace(" ")]
+                    4: TS_REFERENCE_TYPE@596..598
+                      0: JS_REFERENCE_IDENTIFIER@596..598
+                        0: IDENT@596..598 "D" [] [Whitespace(" ")]
+                      1: (empty)
+                    5: COLON@598..600 ":" [] [Whitespace(" ")]
+                    6: TS_REFERENCE_TYPE@600..601
+                      0: JS_REFERENCE_IDENTIFIER@600..601
+                        0: IDENT@600..601 "E" [] []
+                      1: (empty)
+                4: (empty)
+            2: R_PAREN@601..603 ")" [] [Whitespace(" ")]
+          2: FAT_ARROW@603..606 "=>" [] [Whitespace(" ")]
+          3: TS_NUMBER_LITERAL_TYPE@606..608
+            0: (empty)
+            1: JS_NUMBER_LITERAL@606..608 "0" [] [Whitespace(" ")]
+        3: QUESTION@608..610 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@610..612
+          0: JS_REFERENCE_IDENTIFIER@610..612
+            0: IDENT@610..612 "F" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@612..614 ":" [] [Whitespace(" ")]
+        6: TS_REFERENCE_TYPE@614..615
+          0: JS_REFERENCE_IDENTIFIER@614..615
+            0: IDENT@614..615 "G" [] []
+          1: (empty)
+      5: SEMICOLON@615..616 ";" [] []
+    10: TS_TYPE_ALIAS_DECLARATION@616..955
+      0: TYPE_KW@616..622 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@622..627
+        0: IDENT@622..627 "Curry" [] []
+      2: TS_TYPE_PARAMETERS@627..663
+        0: L_ANGLE@627..628 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@628..661
+          0: TS_TYPE_PARAMETER@628..661
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@628..628
+            1: TS_TYPE_PARAMETER_NAME@628..630
+              0: IDENT@628..630 "F" [] [Whitespace(" ")]
+            2: TS_TYPE_CONSTRAINT_CLAUSE@630..661
+              0: EXTENDS_KW@630..638 "extends" [] [Whitespace(" ")]
+              1: TS_PARENTHESIZED_TYPE@638..661
+                0: L_PAREN@638..639 "(" [] []
+                1: TS_FUNCTION_TYPE@639..660
+                  0: (empty)
+                  1: JS_PARAMETERS@639..654
+                    0: L_PAREN@639..640 "(" [] []
+                    1: JS_PARAMETER_LIST@640..652
+                      0: JS_REST_PARAMETER@640..652
+                        0: JS_DECORATOR_LIST@640..640
+                        1: DOT3@640..643 "..." [] []
+                        2: JS_IDENTIFIER_BINDING@643..647
+                          0: IDENT@643..647 "args" [] []
+                        3: TS_TYPE_ANNOTATION@647..652
+                          0: COLON@647..649 ":" [] [Whitespace(" ")]
+                          1: TS_ANY_TYPE@649..652
+                            0: ANY_KW@649..652 "any" [] []
+                    2: R_PAREN@652..654 ")" [] [Whitespace(" ")]
+                  2: FAT_ARROW@654..657 "=>" [] [Whitespace(" ")]
+                  3: TS_ANY_TYPE@657..660
+                    0: ANY_KW@657..660 "any" [] []
+                2: R_PAREN@660..661 ")" [] []
+            3: (empty)
+        2: R_ANGLE@661..663 ">" [] [Whitespace(" ")]
+      3: EQ@663..664 "=" [] []
+      4: TS_FUNCTION_TYPE@664..954
+        0: TS_TYPE_PARAMETERS@664..686
+          0: L_ANGLE@664..670 "<" [Newline("\n"), Whitespace("    ")] []
+          1: TS_TYPE_PARAMETER_LIST@670..685
+            0: TS_TYPE_PARAMETER@670..685
+              0: TS_TYPE_PARAMETER_MODIFIER_LIST@670..670
+              1: TS_TYPE_PARAMETER_NAME@670..672
+                0: IDENT@670..672 "T" [] [Whitespace(" ")]
+              2: TS_TYPE_CONSTRAINT_CLAUSE@672..685
+                0: EXTENDS_KW@672..680 "extends" [] [Whitespace(" ")]
+                1: TS_ARRAY_TYPE@680..685
+                  0: TS_ANY_TYPE@680..683
+                    0: ANY_KW@680..683 "any" [] []
+                  1: L_BRACK@683..684 "[" [] []
+                  2: R_BRACK@684..685 "]" [] []
+              3: (empty)
+          2: R_ANGLE@685..686 ">" [] []
+        1: JS_PARAMETERS@686..751
+          0: L_PAREN@686..687 "(" [] []
+          1: JS_PARAMETER_LIST@687..749
+            0: JS_REST_PARAMETER@687..749
+              0: JS_DECORATOR_LIST@687..687
+              1: DOT3@687..690 "..." [] []
+              2: JS_IDENTIFIER_BINDING@690..694
+                0: IDENT@690..694 "args" [] []
+              3: TS_TYPE_ANNOTATION@694..749
+                0: COLON@694..696 ":" [] [Whitespace(" ")]
+                1: TS_REFERENCE_TYPE@696..749
+                  0: TS_QUALIFIED_NAME@696..706
+                    0: JS_REFERENCE_IDENTIFIER@696..701
+                      0: IDENT@696..701 "Tools" [] []
+                    1: DOT@701..702 "." [] []
+                    2: JS_NAME@702..706
+                      0: IDENT@702..706 "Cast" [] []
+                  1: TS_TYPE_ARGUMENTS@706..749
+                    0: L_ANGLE@706..707 "<" [] []
+                    1: TS_TYPE_ARGUMENT_LIST@707..748
+                      0: TS_REFERENCE_TYPE@707..741
+                        0: TS_QUALIFIED_NAME@707..717
+                          0: JS_REFERENCE_IDENTIFIER@707..712
+                            0: IDENT@707..712 "Tools" [] []
+                          1: DOT@712..713 "." [] []
+                          2: JS_NAME@713..717
+                            0: IDENT@713..717 "Cast" [] []
+                        1: TS_TYPE_ARGUMENTS@717..741
+                          0: L_ANGLE@717..718 "<" [] []
+                          1: TS_TYPE_ARGUMENT_LIST@718..740
+                            0: TS_REFERENCE_TYPE@718..719
+                              0: JS_REFERENCE_IDENTIFIER@718..719
+                                0: IDENT@718..719 "T" [] []
+                              1: (empty)
+                            1: COMMA@719..721 "," [] [Whitespace(" ")]
+                            2: TS_REFERENCE_TYPE@721..740
+                              0: JS_REFERENCE_IDENTIFIER@721..725
+                                0: IDENT@721..725 "Gaps" [] []
+                              1: TS_TYPE_ARGUMENTS@725..740
+                                0: L_ANGLE@725..726 "<" [] []
+                                1: TS_TYPE_ARGUMENT_LIST@726..739
+                                  0: TS_REFERENCE_TYPE@726..739
+                                    0: JS_REFERENCE_IDENTIFIER@726..736
+                                      0: IDENT@726..736 "Parameters" [] []
+                                    1: TS_TYPE_ARGUMENTS@736..739
+                                      0: L_ANGLE@736..737 "<" [] []
+                                      1: TS_TYPE_ARGUMENT_LIST@737..738
+                                        0: TS_REFERENCE_TYPE@737..738
+                                          0: JS_REFERENCE_IDENTIFIER@737..738
+                                            0: IDENT@737..738 "F" [] []
+                                          1: (empty)
+                                      2: R_ANGLE@738..739 ">" [] []
+                                2: R_ANGLE@739..740 ">" [] []
+                          2: R_ANGLE@740..741 ">" [] []
+                      1: COMMA@741..743 "," [] [Whitespace(" ")]
+                      2: TS_ARRAY_TYPE@743..748
+                        0: TS_ANY_TYPE@743..746
+                          0: ANY_KW@743..746 "any" [] []
+                        1: L_BRACK@746..747 "[" [] []
+                        2: R_BRACK@747..748 "]" [] []
+                    2: R_ANGLE@748..749 ">" [] []
+          2: R_PAREN@749..751 ")" [] [Whitespace(" ")]
+        2: FAT_ARROW@751..753 "=>" [] []
+        3: TS_CONDITIONAL_TYPE@753..954
+          0: TS_REFERENCE_TYPE@753..788
+            0: JS_REFERENCE_IDENTIFIER@753..769
+              0: IDENT@753..769 "GapsOf" [Newline("\n"), Whitespace("         ")] []
+            1: TS_TYPE_ARGUMENTS@769..788
+              0: L_ANGLE@769..770 "<" [] []
+              1: TS_TYPE_ARGUMENT_LIST@770..786
+                0: TS_REFERENCE_TYPE@770..771
+                  0: JS_REFERENCE_IDENTIFIER@770..771
+                    0: IDENT@770..771 "T" [] []
+                  1: (empty)
+                1: COMMA@771..773 "," [] [Whitespace(" ")]
+                2: TS_REFERENCE_TYPE@773..786
+                  0: JS_REFERENCE_IDENTIFIER@773..783
+                    0: IDENT@773..783 "Parameters" [] []
+                  1: TS_TYPE_ARGUMENTS@783..786
+                    0: L_ANGLE@783..784 "<" [] []
+                    1: TS_TYPE_ARGUMENT_LIST@784..785
+                      0: TS_REFERENCE_TYPE@784..785
+                        0: JS_REFERENCE_IDENTIFIER@784..785
+                          0: IDENT@784..785 "F" [] []
+                        1: (empty)
+                    2: R_ANGLE@785..786 ">" [] []
+              2: R_ANGLE@786..788 ">" [] [Whitespace(" ")]
+          1: EXTENDS_KW@788..796 "extends" [] [Whitespace(" ")]
+          2: TS_TUPLE_TYPE@796..811
+            0: L_BRACK@796..797 "[" [] []
+            1: TS_TUPLE_TYPE_ELEMENT_LIST@797..810
+              0: TS_ANY_TYPE@797..800
+                0: ANY_KW@797..800 "any" [] []
+              1: COMMA@800..802 "," [] [Whitespace(" ")]
+              2: TS_REST_TUPLE_TYPE_ELEMENT@802..810
+                0: DOT3@802..805 "..." [] []
+                1: TS_ARRAY_TYPE@805..810
+                  0: TS_ANY_TYPE@805..808
+                    0: ANY_KW@805..808 "any" [] []
+                  1: L_BRACK@808..809 "[" [] []
+                  2: R_BRACK@809..810 "]" [] []
+            2: R_BRACK@810..811 "]" [] []
+          3: QUESTION@811..823 "?" [Newline("\n"), Whitespace("         ")] [Whitespace(" ")]
+          4: TS_REFERENCE_TYPE@823..929
+            0: JS_REFERENCE_IDENTIFIER@823..828
+              0: IDENT@823..828 "Curry" [] []
+            1: TS_TYPE_ARGUMENTS@828..929
+              0: L_ANGLE@828..829 "<" [] []
+              1: TS_TYPE_ARGUMENT_LIST@829..928
+                0: TS_FUNCTION_TYPE@829..928
+                  0: (empty)
+                  1: JS_PARAMETERS@829..912
+                    0: L_PAREN@829..830 "(" [] []
+                    1: JS_PARAMETER_LIST@830..910
+                      0: JS_REST_PARAMETER@830..910
+                        0: JS_DECORATOR_LIST@830..830
+                        1: DOT3@830..833 "..." [] []
+                        2: JS_IDENTIFIER_BINDING@833..837
+                          0: IDENT@833..837 "args" [] []
+                        3: TS_TYPE_ANNOTATION@837..910
+                          0: COLON@837..839 ":" [] [Whitespace(" ")]
+                          1: TS_CONDITIONAL_TYPE@839..910
+                            0: TS_REFERENCE_TYPE@839..864
+                              0: JS_REFERENCE_IDENTIFIER@839..845
+                                0: IDENT@839..845 "GapsOf" [] []
+                              1: TS_TYPE_ARGUMENTS@845..864
+                                0: L_ANGLE@845..846 "<" [] []
+                                1: TS_TYPE_ARGUMENT_LIST@846..862
+                                  0: TS_REFERENCE_TYPE@846..847
+                                    0: JS_REFERENCE_IDENTIFIER@846..847
+                                      0: IDENT@846..847 "T" [] []
+                                    1: (empty)
+                                  1: COMMA@847..849 "," [] [Whitespace(" ")]
+                                  2: TS_REFERENCE_TYPE@849..862
+                                    0: JS_REFERENCE_IDENTIFIER@849..859
+                                      0: IDENT@849..859 "Parameters" [] []
+                                    1: TS_TYPE_ARGUMENTS@859..862
+                                      0: L_ANGLE@859..860 "<" [] []
+                                      1: TS_TYPE_ARGUMENT_LIST@860..861
+                                        0: TS_REFERENCE_TYPE@860..861
+                                          0: JS_REFERENCE_IDENTIFIER@860..861
+                                            0: IDENT@860..861 "F" [] []
+                                          1: (empty)
+                                      2: R_ANGLE@861..862 ">" [] []
+                                2: R_ANGLE@862..864 ">" [] [Whitespace(" ")]
+                            1: EXTENDS_KW@864..872 "extends" [] [Whitespace(" ")]
+                            2: TS_INFER_TYPE@872..880
+                              0: INFER_KW@872..878 "infer" [] [Whitespace(" ")]
+                              1: TS_TYPE_PARAMETER_NAME@878..880
+                                0: IDENT@878..880 "G" [] [Whitespace(" ")]
+                              2: (empty)
+                            3: QUESTION@880..882 "?" [] [Whitespace(" ")]
+                            4: TS_REFERENCE_TYPE@882..903
+                              0: TS_QUALIFIED_NAME@882..892
+                                0: JS_REFERENCE_IDENTIFIER@882..887
+                                  0: IDENT@882..887 "Tools" [] []
+                                1: DOT@887..888 "." [] []
+                                2: JS_NAME@888..892
+                                  0: IDENT@888..892 "Cast" [] []
+                              1: TS_TYPE_ARGUMENTS@892..903
+                                0: L_ANGLE@892..893 "<" [] []
+                                1: TS_TYPE_ARGUMENT_LIST@893..901
+                                  0: TS_REFERENCE_TYPE@893..894
+                                    0: JS_REFERENCE_IDENTIFIER@893..894
+                                      0: IDENT@893..894 "G" [] []
+                                    1: (empty)
+                                  1: COMMA@894..896 "," [] [Whitespace(" ")]
+                                  2: TS_ARRAY_TYPE@896..901
+                                    0: TS_ANY_TYPE@896..899
+                                      0: ANY_KW@896..899 "any" [] []
+                                    1: L_BRACK@899..900 "[" [] []
+                                    2: R_BRACK@900..901 "]" [] []
+                                2: R_ANGLE@901..903 ">" [] [Whitespace(" ")]
+                            5: COLON@903..905 ":" [] [Whitespace(" ")]
+                            6: TS_NEVER_TYPE@905..910
+                              0: NEVER_KW@905..910 "never" [] []
+                    2: R_PAREN@910..912 ")" [] [Whitespace(" ")]
+                  2: FAT_ARROW@912..915 "=>" [] [Whitespace(" ")]
+                  3: TS_REFERENCE_TYPE@915..928
+                    0: JS_REFERENCE_IDENTIFIER@915..925
+                      0: IDENT@915..925 "ReturnType" [] []
+                    1: TS_TYPE_ARGUMENTS@925..928
+                      0: L_ANGLE@925..926 "<" [] []
+                      1: TS_TYPE_ARGUMENT_LIST@926..927
+                        0: TS_REFERENCE_TYPE@926..927
+                          0: JS_REFERENCE_IDENTIFIER@926..927
+                            0: IDENT@926..927 "F" [] []
+                          1: (empty)
+                      2: R_ANGLE@927..928 ">" [] []
+              2: R_ANGLE@928..929 ">" [] []
+          5: COLON@929..941 ":" [Newline("\n"), Whitespace("         ")] [Whitespace(" ")]
+          6: TS_REFERENCE_TYPE@941..954
+            0: JS_REFERENCE_IDENTIFIER@941..951
+              0: IDENT@941..951 "ReturnType" [] []
+            1: TS_TYPE_ARGUMENTS@951..954
+              0: L_ANGLE@951..952 "<" [] []
+              1: TS_TYPE_ARGUMENT_LIST@952..953
+                0: TS_REFERENCE_TYPE@952..953
+                  0: JS_REFERENCE_IDENTIFIER@952..953
+                    0: IDENT@952..953 "F" [] []
+                  1: (empty)
+              2: R_ANGLE@953..954 ">" [] []
+      5: SEMICOLON@954..955 ";" [] []
+    11: TS_INTERFACE_DECLARATION@955..1272
+      0: INTERFACE_KW@955..966 "interface" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@966..978
+        0: IDENT@966..978 "GapsOfWorker" [] []
+      2: TS_TYPE_PARAMETERS@978..1060
+        0: L_ANGLE@978..979 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@979..1058
+          0: TS_TYPE_PARAMETER@979..995
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@979..979
+            1: TS_TYPE_PARAMETER_NAME@979..982
+              0: IDENT@979..982 "T1" [] [Whitespace(" ")]
+            2: TS_TYPE_CONSTRAINT_CLAUSE@982..995
+              0: EXTENDS_KW@982..990 "extends" [] [Whitespace(" ")]
+              1: TS_ARRAY_TYPE@990..995
+                0: TS_ANY_TYPE@990..993
+                  0: ANY_KW@990..993 "any" [] []
+                1: L_BRACK@993..994 "[" [] []
+                2: R_BRACK@994..995 "]" [] []
+            3: (empty)
+          1: COMMA@995..997 "," [] [Whitespace(" ")]
+          2: TS_TYPE_PARAMETER@997..1013
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@997..997
+            1: TS_TYPE_PARAMETER_NAME@997..1000
+              0: IDENT@997..1000 "T2" [] [Whitespace(" ")]
+            2: TS_TYPE_CONSTRAINT_CLAUSE@1000..1013
+              0: EXTENDS_KW@1000..1008 "extends" [] [Whitespace(" ")]
+              1: TS_ARRAY_TYPE@1008..1013
+                0: TS_ANY_TYPE@1008..1011
+                  0: ANY_KW@1008..1011 "any" [] []
+                1: L_BRACK@1011..1012 "[" [] []
+                2: R_BRACK@1012..1013 "]" [] []
+            3: (empty)
+          3: COMMA@1013..1015 "," [] [Whitespace(" ")]
+          4: TS_TYPE_PARAMETER@1015..1036
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@1015..1015
+            1: TS_TYPE_PARAMETER_NAME@1015..1018
+              0: IDENT@1015..1018 "TN" [] [Whitespace(" ")]
+            2: TS_TYPE_CONSTRAINT_CLAUSE@1018..1032
+              0: EXTENDS_KW@1018..1026 "extends" [] [Whitespace(" ")]
+              1: TS_ARRAY_TYPE@1026..1032
+                0: TS_ANY_TYPE@1026..1029
+                  0: ANY_KW@1026..1029 "any" [] []
+                1: L_BRACK@1029..1030 "[" [] []
+                2: R_BRACK@1030..1032 "]" [] [Whitespace(" ")]
+            3: TS_DEFAULT_TYPE_CLAUSE@1032..1036
+              0: EQ@1032..1034 "=" [] [Whitespace(" ")]
+              1: TS_TUPLE_TYPE@1034..1036
+                0: L_BRACK@1034..1035 "[" [] []
+                1: TS_TUPLE_TYPE_ELEMENT_LIST@1035..1035
+                2: R_BRACK@1035..1036 "]" [] []
+          5: COMMA@1036..1038 "," [] [Whitespace(" ")]
+          6: TS_TYPE_PARAMETER@1038..1058
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@1038..1038
+            1: TS_TYPE_PARAMETER_NAME@1038..1040
+              0: IDENT@1038..1040 "I" [] [Whitespace(" ")]
+            2: TS_TYPE_CONSTRAINT_CLAUSE@1040..1054
+              0: EXTENDS_KW@1040..1048 "extends" [] [Whitespace(" ")]
+              1: TS_ARRAY_TYPE@1048..1054
+                0: TS_ANY_TYPE@1048..1051
+                  0: ANY_KW@1048..1051 "any" [] []
+                1: L_BRACK@1051..1052 "[" [] []
+                2: R_BRACK@1052..1054 "]" [] [Whitespace(" ")]
+            3: TS_DEFAULT_TYPE_CLAUSE@1054..1058
+              0: EQ@1054..1056 "=" [] [Whitespace(" ")]
+              1: TS_TUPLE_TYPE@1056..1058
+                0: L_BRACK@1056..1057 "[" [] []
+                1: TS_TUPLE_TYPE_ELEMENT_LIST@1057..1057
+                2: R_BRACK@1057..1058 "]" [] []
+        2: R_ANGLE@1058..1060 ">" [] [Whitespace(" ")]
+      3: (empty)
+      4: L_CURLY@1060..1061 "{" [] []
+      5: TS_TYPE_MEMBER_LIST@1061..1270
+        0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@1061..1168
+          0: (empty)
+          1: JS_LITERAL_MEMBER_NAME@1061..1067
+            0: JS_NUMBER_LITERAL@1061..1067 "0" [Newline("\n"), Whitespace("    ")] []
+          2: (empty)
+          3: TS_TYPE_ANNOTATION@1067..1167
+            0: COLON@1067..1069 ":" [] [Whitespace(" ")]
+            1: TS_REFERENCE_TYPE@1069..1167
+              0: JS_REFERENCE_IDENTIFIER@1069..1075
+                0: IDENT@1069..1075 "GapsOf" [] []
+              1: TS_TYPE_ARGUMENTS@1075..1167
+                0: L_ANGLE@1075..1076 "<" [] []
+                1: TS_TYPE_ARGUMENT_LIST@1076..1166
+                  0: TS_REFERENCE_TYPE@1076..1078
+                    0: JS_REFERENCE_IDENTIFIER@1076..1078
+                      0: IDENT@1076..1078 "T1" [] []
+                    1: (empty)
+                  1: COMMA@1078..1080 "," [] [Whitespace(" ")]
+                  2: TS_REFERENCE_TYPE@1080..1082
+                    0: JS_REFERENCE_IDENTIFIER@1080..1082
+                      0: IDENT@1080..1082 "T2" [] []
+                    1: (empty)
+                  3: COMMA@1082..1084 "," [] [Whitespace(" ")]
+                  4: TS_CONDITIONAL_TYPE@1084..1151
+                    0: TS_REFERENCE_TYPE@1084..1105
+                      0: JS_REFERENCE_IDENTIFIER@1084..1089
+                        0: IDENT@1084..1089 "GapOf" [] []
+                      1: TS_TYPE_ARGUMENTS@1089..1105
+                        0: L_ANGLE@1089..1090 "<" [] []
+                        1: TS_TYPE_ARGUMENT_LIST@1090..1103
+                          0: TS_REFERENCE_TYPE@1090..1092
+                            0: JS_REFERENCE_IDENTIFIER@1090..1092
+                              0: IDENT@1090..1092 "T1" [] []
+                            1: (empty)
+                          1: COMMA@1092..1094 "," [] [Whitespace(" ")]
+                          2: TS_REFERENCE_TYPE@1094..1096
+                            0: JS_REFERENCE_IDENTIFIER@1094..1096
+                              0: IDENT@1094..1096 "T2" [] []
+                            1: (empty)
+                          3: COMMA@1096..1098 "," [] [Whitespace(" ")]
+                          4: TS_REFERENCE_TYPE@1098..1100
+                            0: JS_REFERENCE_IDENTIFIER@1098..1100
+                              0: IDENT@1098..1100 "TN" [] []
+                            1: (empty)
+                          5: COMMA@1100..1102 "," [] [Whitespace(" ")]
+                          6: TS_REFERENCE_TYPE@1102..1103
+                            0: JS_REFERENCE_IDENTIFIER@1102..1103
+                              0: IDENT@1102..1103 "I" [] []
+                            1: (empty)
+                        2: R_ANGLE@1103..1105 ">" [] [Whitespace(" ")]
+                    1: EXTENDS_KW@1105..1113 "extends" [] [Whitespace(" ")]
+                    2: TS_INFER_TYPE@1113..1121
+                      0: INFER_KW@1113..1119 "infer" [] [Whitespace(" ")]
+                      1: TS_TYPE_PARAMETER_NAME@1119..1121
+                        0: IDENT@1119..1121 "G" [] [Whitespace(" ")]
+                      2: (empty)
+                    3: QUESTION@1121..1123 "?" [] [Whitespace(" ")]
+                    4: TS_REFERENCE_TYPE@1123..1144
+                      0: TS_QUALIFIED_NAME@1123..1133
+                        0: JS_REFERENCE_IDENTIFIER@1123..1128
+                          0: IDENT@1123..1128 "Tools" [] []
+                        1: DOT@1128..1129 "." [] []
+                        2: JS_NAME@1129..1133
+                          0: IDENT@1129..1133 "Cast" [] []
+                      1: TS_TYPE_ARGUMENTS@1133..1144
+                        0: L_ANGLE@1133..1134 "<" [] []
+                        1: TS_TYPE_ARGUMENT_LIST@1134..1142
+                          0: TS_REFERENCE_TYPE@1134..1135
+                            0: JS_REFERENCE_IDENTIFIER@1134..1135
+                              0: IDENT@1134..1135 "G" [] []
+                            1: (empty)
+                          1: COMMA@1135..1137 "," [] [Whitespace(" ")]
+                          2: TS_ARRAY_TYPE@1137..1142
+                            0: TS_ANY_TYPE@1137..1140
+                              0: ANY_KW@1137..1140 "any" [] []
+                            1: L_BRACK@1140..1141 "[" [] []
+                            2: R_BRACK@1141..1142 "]" [] []
+                        2: R_ANGLE@1142..1144 ">" [] [Whitespace(" ")]
+                    5: COLON@1144..1146 ":" [] [Whitespace(" ")]
+                    6: TS_NEVER_TYPE@1146..1151
+                      0: NEVER_KW@1146..1151 "never" [] []
+                  5: COMMA@1151..1153 "," [] [Whitespace(" ")]
+                  6: TS_REFERENCE_TYPE@1153..1166
+                    0: TS_QUALIFIED_NAME@1153..1163
+                      0: JS_REFERENCE_IDENTIFIER@1153..1158
+                        0: IDENT@1153..1158 "Tools" [] []
+                      1: DOT@1158..1159 "." [] []
+                      2: JS_NAME@1159..1163
+                        0: IDENT@1159..1163 "Next" [] []
+                    1: TS_TYPE_ARGUMENTS@1163..1166
+                      0: L_ANGLE@1163..1164 "<" [] []
+                      1: TS_TYPE_ARGUMENT_LIST@1164..1165
+                        0: TS_REFERENCE_TYPE@1164..1165
+                          0: JS_REFERENCE_IDENTIFIER@1164..1165
+                            0: IDENT@1164..1165 "I" [] []
+                          1: (empty)
+                      2: R_ANGLE@1165..1166 ">" [] []
+                2: R_ANGLE@1166..1167 ">" [] []
+          4: SEMICOLON@1167..1168 ";" [] []
+        1: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@1168..1270
+          0: (empty)
+          1: JS_LITERAL_MEMBER_NAME@1168..1174
+            0: JS_NUMBER_LITERAL@1168..1174 "1" [Newline("\n"), Whitespace("    ")] []
+          2: (empty)
+          3: TS_TYPE_ANNOTATION@1174..1269
+            0: COLON@1174..1176 ":" [] [Whitespace(" ")]
+            1: TS_REFERENCE_TYPE@1176..1269
+              0: TS_QUALIFIED_NAME@1176..1188
+                0: JS_REFERENCE_IDENTIFIER@1176..1181
+                  0: IDENT@1176..1181 "Tools" [] []
+                1: DOT@1181..1182 "." [] []
+                2: JS_NAME@1182..1188
+                  0: IDENT@1182..1188 "Concat" [] []
+              1: TS_TYPE_ARGUMENTS@1188..1269
+                0: L_ANGLE@1188..1189 "<" [] []
+                1: TS_TYPE_ARGUMENT_LIST@1189..1268
+                  0: TS_REFERENCE_TYPE@1189..1191
+                    0: JS_REFERENCE_IDENTIFIER@1189..1191
+                      0: IDENT@1189..1191 "TN" [] []
+                    1: (empty)
+                  1: COMMA@1191..1193 "," [] [Whitespace(" ")]
+                  2: TS_CONDITIONAL_TYPE@1193..1268
+                    0: TS_REFERENCE_TYPE@1193..1222
+                      0: TS_QUALIFIED_NAME@1193..1203
+                        0: JS_REFERENCE_IDENTIFIER@1193..1198
+                          0: IDENT@1193..1198 "Tools" [] []
+                        1: DOT@1198..1199 "." [] []
+                        2: JS_NAME@1199..1203
+                          0: IDENT@1199..1203 "Drop" [] []
+                      1: TS_TYPE_ARGUMENTS@1203..1222
+                        0: L_ANGLE@1203..1204 "<" [] []
+                        1: TS_TYPE_ARGUMENT_LIST@1204..1220
+                          0: TS_REFERENCE_TYPE@1204..1216
+                            0: TS_QUALIFIED_NAME@1204..1213
+                              0: JS_REFERENCE_IDENTIFIER@1204..1209
+                                0: IDENT@1204..1209 "Tools" [] []
+                              1: DOT@1209..1210 "." [] []
+                              2: JS_NAME@1210..1213
+                                0: IDENT@1210..1213 "Pos" [] []
+                            1: TS_TYPE_ARGUMENTS@1213..1216
+                              0: L_ANGLE@1213..1214 "<" [] []
+                              1: TS_TYPE_ARGUMENT_LIST@1214..1215
+                                0: TS_REFERENCE_TYPE@1214..1215
+                                  0: JS_REFERENCE_IDENTIFIER@1214..1215
+                                    0: IDENT@1214..1215 "I" [] []
+                                  1: (empty)
+                              2: R_ANGLE@1215..1216 ">" [] []
+                          1: COMMA@1216..1218 "," [] [Whitespace(" ")]
+                          2: TS_REFERENCE_TYPE@1218..1220
+                            0: JS_REFERENCE_IDENTIFIER@1218..1220
+                              0: IDENT@1218..1220 "T2" [] []
+                            1: (empty)
+                        2: R_ANGLE@1220..1222 ">" [] [Whitespace(" ")]
+                    1: EXTENDS_KW@1222..1230 "extends" [] [Whitespace(" ")]
+                    2: TS_INFER_TYPE@1230..1238
+                      0: INFER_KW@1230..1236 "infer" [] [Whitespace(" ")]
+                      1: TS_TYPE_PARAMETER_NAME@1236..1238
+                        0: IDENT@1236..1238 "D" [] [Whitespace(" ")]
+                      2: (empty)
+                    3: QUESTION@1238..1240 "?" [] [Whitespace(" ")]
+                    4: TS_REFERENCE_TYPE@1240..1261
+                      0: TS_QUALIFIED_NAME@1240..1250
+                        0: JS_REFERENCE_IDENTIFIER@1240..1245
+                          0: IDENT@1240..1245 "Tools" [] []
+                        1: DOT@1245..1246 "." [] []
+                        2: JS_NAME@1246..1250
+                          0: IDENT@1246..1250 "Cast" [] []
+                      1: TS_TYPE_ARGUMENTS@1250..1261
+                        0: L_ANGLE@1250..1251 "<" [] []
+                        1: TS_TYPE_ARGUMENT_LIST@1251..1259
+                          0: TS_REFERENCE_TYPE@1251..1252
+                            0: JS_REFERENCE_IDENTIFIER@1251..1252
+                              0: IDENT@1251..1252 "D" [] []
+                            1: (empty)
+                          1: COMMA@1252..1254 "," [] [Whitespace(" ")]
+                          2: TS_ARRAY_TYPE@1254..1259
+                            0: TS_ANY_TYPE@1254..1257
+                              0: ANY_KW@1254..1257 "any" [] []
+                            1: L_BRACK@1257..1258 "[" [] []
+                            2: R_BRACK@1258..1259 "]" [] []
+                        2: R_ANGLE@1259..1261 ">" [] [Whitespace(" ")]
+                    5: COLON@1261..1263 ":" [] [Whitespace(" ")]
+                    6: TS_NEVER_TYPE@1263..1268
+                      0: NEVER_KW@1263..1268 "never" [] []
+                2: R_ANGLE@1268..1269 ">" [] []
+          4: SEMICOLON@1269..1270 ";" [] []
+      6: R_CURLY@1270..1272 "}" [Newline("\n")] []
+  3: EOF@1272..1273 "" [Newline("\n")] []

--- a/crates/biome_js_parser/test_data/inline/ok/ts_conditional_type.ts
+++ b/crates/biome_js_parser/test_data/inline/ok/ts_conditional_type.ts
@@ -7,3 +7,13 @@ type F<T> = T extends { [P in infer U extends keyof T ? 1 : 0]: 1; } ? 1 : 0;
 type G<T> = T extends [unknown, infer S extends string] ? S : never;
 type H = A extends () => B extends C ? D : E ? F : G;
 type J<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
+type Equals = A extends (x: B extends C ? D : E) => 0 ? F : G;
+type Curry<F extends ((...args: any) => any)> =
+    <T extends any[]>(...args: Tools.Cast<Tools.Cast<T, Gaps<Parameters<F>>>, any[]>) =>
+         GapsOf<T, Parameters<F>> extends [any, ...any[]]
+         ? Curry<(...args: GapsOf<T, Parameters<F>> extends infer G ? Tools.Cast<G, any[]> : never) => ReturnType<F>>
+         : ReturnType<F>;
+interface GapsOfWorker<T1 extends any[], T2 extends any[], TN extends any[] = [], I extends any[] = []> {
+    0: GapsOf<T1, T2, GapOf<T1, T2, TN, I> extends infer G ? Tools.Cast<G, any[]> : never, Tools.Next<I>>;
+    1: Tools.Concat<TN, Tools.Drop<Tools.Pos<I>, T2> extends infer D ? Tools.Cast<D, any[]> : never>;
+}

--- a/crates/biome_js_parser/test_data/inline/ok/ts_infer_type_allowed.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/ts_infer_type_allowed.rast
@@ -1,0 +1,5216 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@0..5 "type" [] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@5..9 "Args" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@9..10 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@10..11 "F" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@11..13 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@13..15 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@15..17 "F" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@17..25 "extends" [] [Whitespace(" ")],
+                extends_type: TsFunctionType {
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@25..26 "(" [] [],
+                        items: JsParameterList [
+                            JsRestParameter {
+                                decorators: JsDecoratorList [],
+                                dotdotdot_token: DOT3@26..29 "..." [] [],
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@29..33 "args" [] [],
+                                },
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@33..35 ":" [] [Whitespace(" ")],
+                                    ty: TsInferType {
+                                        infer_token: INFER_KW@35..41 "infer" [] [Whitespace(" ")],
+                                        name: TsTypeParameterName {
+                                            ident_token: IDENT@41..42 "A" [] [],
+                                        },
+                                        constraint: missing (optional),
+                                    },
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@42..44 ")" [] [Whitespace(" ")],
+                    },
+                    fat_arrow_token: FAT_ARROW@44..47 "=>" [] [Whitespace(" ")],
+                    return_type: TsVoidType {
+                        void_token: VOID_KW@47..52 "void" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@52..54 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@54..56 "A" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@56..58 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@58..63 "never" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@63..64 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@64..70 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@70..72 "A" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@72..74 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@74..76 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@76..84 "extends" [] [Whitespace(" ")],
+                extends_type: TsImportType {
+                    typeof_token: missing (optional),
+                    import_token: IMPORT_KW@84..90 "import" [] [],
+                    l_paren_token: L_PAREN@90..91 "(" [] [],
+                    argument_token: JS_STRING_LITERAL@91..97 "\"test\"" [] [],
+                    r_paren_token: R_PAREN@97..98 ")" [] [],
+                    qualifier_clause: TsImportTypeQualifier {
+                        dot_token: DOT@98..99 "." [] [],
+                        right: JsReferenceIdentifier {
+                            value_token: IDENT@99..100 "C" [] [],
+                        },
+                    },
+                    type_arguments: TsTypeArguments {
+                        l_angle_token: L_ANGLE@100..101 "<" [] [],
+                        ts_type_argument_list: TsTypeArgumentList [
+                            TsInferType {
+                                infer_token: INFER_KW@101..107 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@107..108 "P" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                        ],
+                        r_angle_token: R_ANGLE@108..110 ">" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@110..112 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@112..114 "P" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@114..116 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@116..121 "never" [] [],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@121..127 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@127..129 "A" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@129..131 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@131..133 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@133..141 "extends" [] [Whitespace(" ")],
+                extends_type: TsTypeofType {
+                    typeof_token: TYPEOF_KW@141..148 "typeof" [] [Whitespace(" ")],
+                    expression_name: JsReferenceIdentifier {
+                        value_token: IDENT@148..153 "Array" [] [],
+                    },
+                    type_arguments: TsTypeArguments {
+                        l_angle_token: L_ANGLE@153..154 "<" [] [],
+                        ts_type_argument_list: TsTypeArgumentList [
+                            TsInferType {
+                                infer_token: INFER_KW@154..160 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@160..161 "P" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                        ],
+                        r_angle_token: R_ANGLE@161..163 ">" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@163..165 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@165..167 "P" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@167..169 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@169..174 "never" [] [],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@174..180 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@180..182 "A" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@182..184 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@184..186 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@186..194 "extends" [] [Whitespace(" ")],
+                extends_type: TsObjectType {
+                    l_curly_token: L_CURLY@194..196 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [
+                        TsMethodSignatureTypeMember {
+                            name: JsLiteralMemberName {
+                                value: IDENT@196..199 "set" [] [],
+                            },
+                            optional_token: missing (optional),
+                            type_parameters: missing (optional),
+                            parameters: JsParameters {
+                                l_paren_token: L_PAREN@199..200 "(" [] [],
+                                items: JsParameterList [
+                                    JsFormalParameter {
+                                        decorators: JsDecoratorList [],
+                                        binding: JsIdentifierBinding {
+                                            name_token: IDENT@200..201 "a" [] [],
+                                        },
+                                        question_mark_token: missing (optional),
+                                        type_annotation: TsTypeAnnotation {
+                                            colon_token: COLON@201..203 ":" [] [Whitespace(" ")],
+                                            ty: TsInferType {
+                                                infer_token: INFER_KW@203..209 "infer" [] [Whitespace(" ")],
+                                                name: TsTypeParameterName {
+                                                    ident_token: IDENT@209..210 "P" [] [],
+                                                },
+                                                constraint: missing (optional),
+                                            },
+                                        },
+                                        initializer: missing (optional),
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@210..211 ")" [] [],
+                            },
+                            return_type_annotation: TsReturnTypeAnnotation {
+                                colon_token: COLON@211..213 ":" [] [Whitespace(" ")],
+                                ty: TsNumberType {
+                                    number_token: NUMBER_KW@213..220 "number" [] [Whitespace(" ")],
+                                },
+                            },
+                            separator_token: missing (optional),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@220..222 "}" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@222..224 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@224..226 "P" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@226..228 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@228..233 "never" [] [],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@233..239 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@239..241 "A" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@241..243 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@243..245 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@245..253 "extends" [] [Whitespace(" ")],
+                extends_type: TsObjectType {
+                    l_curly_token: L_CURLY@253..255 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [
+                        TsMethodSignatureTypeMember {
+                            name: JsLiteralMemberName {
+                                value: IDENT@255..258 "get" [] [],
+                            },
+                            optional_token: missing (optional),
+                            type_parameters: missing (optional),
+                            parameters: JsParameters {
+                                l_paren_token: L_PAREN@258..259 "(" [] [],
+                                items: JsParameterList [],
+                                r_paren_token: R_PAREN@259..260 ")" [] [],
+                            },
+                            return_type_annotation: TsReturnTypeAnnotation {
+                                colon_token: COLON@260..262 ":" [] [Whitespace(" ")],
+                                ty: TsInferType {
+                                    infer_token: INFER_KW@262..268 "infer" [] [Whitespace(" ")],
+                                    name: TsTypeParameterName {
+                                        ident_token: IDENT@268..270 "P" [] [Whitespace(" ")],
+                                    },
+                                    constraint: missing (optional),
+                                },
+                            },
+                            separator_token: missing (optional),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@270..272 "}" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@272..274 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@274..276 "P" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@276..278 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@278..283 "never" [] [],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@283..289 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@289..291 "A" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@291..293 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@293..295 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@295..303 "extends" [] [Whitespace(" ")],
+                extends_type: TsObjectType {
+                    l_curly_token: L_CURLY@303..305 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [
+                        TsMethodSignatureTypeMember {
+                            name: JsLiteralMemberName {
+                                value: IDENT@305..311 "method" [] [],
+                            },
+                            optional_token: missing (optional),
+                            type_parameters: missing (optional),
+                            parameters: JsParameters {
+                                l_paren_token: L_PAREN@311..312 "(" [] [],
+                                items: JsParameterList [
+                                    TsThisParameter {
+                                        this_token: THIS_KW@312..316 "this" [] [],
+                                        type_annotation: TsTypeAnnotation {
+                                            colon_token: COLON@316..318 ":" [] [Whitespace(" ")],
+                                            ty: TsInferType {
+                                                infer_token: INFER_KW@318..324 "infer" [] [Whitespace(" ")],
+                                                name: TsTypeParameterName {
+                                                    ident_token: IDENT@324..325 "P" [] [],
+                                                },
+                                                constraint: missing (optional),
+                                            },
+                                        },
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@325..326 ")" [] [],
+                            },
+                            return_type_annotation: TsReturnTypeAnnotation {
+                                colon_token: COLON@326..328 ":" [] [Whitespace(" ")],
+                                ty: TsNumberType {
+                                    number_token: NUMBER_KW@328..335 "number" [] [Whitespace(" ")],
+                                },
+                            },
+                            separator_token: missing (optional),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@335..337 "}" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@337..339 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@339..341 "P" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@341..343 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@343..348 "never" [] [],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@348..354 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@354..360 "valid9" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@360..361 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@361..362 "T" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@362..364 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@364..366 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@366..368 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@368..376 "extends" [] [Whitespace(" ")],
+                extends_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@376..381 "Array" [] [],
+                    },
+                    type_arguments: TsTypeArguments {
+                        l_angle_token: L_ANGLE@381..382 "<" [] [],
+                        ts_type_argument_list: TsTypeArgumentList [
+                            TsInferType {
+                                infer_token: INFER_KW@382..388 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@388..389 "R" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                        ],
+                        r_angle_token: R_ANGLE@389..391 ">" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@391..393 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@393..395 "R" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@395..397 ":" [] [Whitespace(" ")],
+                false_type: TsAnyType {
+                    any_token: ANY_KW@397..400 "any" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@400..401 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@401..407 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@407..429 "ContentBetweenBrackets" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@429..430 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@430..431 "S" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@431..433 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@433..435 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@435..437 "S" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@437..445 "extends" [] [Whitespace(" ")],
+                extends_type: TsTemplateLiteralType {
+                    l_tick_token: BACKTICK@445..446 "`" [] [],
+                    elements: TsTemplateElementList [
+                        TsTemplateChunkElement {
+                            template_chunk_token: TEMPLATE_CHUNK@446..447 "[" [] [],
+                        },
+                        TsTemplateElement {
+                            dollar_curly_token: DOLLAR_CURLY@447..449 "${" [] [],
+                            ty: TsInferType {
+                                infer_token: INFER_KW@449..455 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@455..456 "T" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                            r_curly_token: R_CURLY@456..457 "}" [] [],
+                        },
+                        TsTemplateChunkElement {
+                            template_chunk_token: TEMPLATE_CHUNK@457..458 "]" [] [],
+                        },
+                    ],
+                    r_tick_token: BACKTICK@458..460 "`" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@460..462 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@462..464 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@464..466 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@466..471 "never" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@471..472 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@472..478 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@478..491 "WithSelectors" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@491..492 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@492..493 "S" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@493..495 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@495..497 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@497..499 "S" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@499..507 "extends" [] [Whitespace(" ")],
+                extends_type: TsObjectType {
+                    l_curly_token: L_CURLY@507..509 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [
+                        TsPropertySignatureTypeMember {
+                            readonly_token: missing (optional),
+                            name: JsLiteralMemberName {
+                                value: IDENT@509..517 "getState" [] [],
+                            },
+                            optional_token: missing (optional),
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@517..519 ":" [] [Whitespace(" ")],
+                                ty: TsFunctionType {
+                                    type_parameters: missing (optional),
+                                    parameters: JsParameters {
+                                        l_paren_token: L_PAREN@519..520 "(" [] [],
+                                        items: JsParameterList [],
+                                        r_paren_token: R_PAREN@520..522 ")" [] [Whitespace(" ")],
+                                    },
+                                    fat_arrow_token: FAT_ARROW@522..525 "=>" [] [Whitespace(" ")],
+                                    return_type: TsInferType {
+                                        infer_token: INFER_KW@525..531 "infer" [] [Whitespace(" ")],
+                                        name: TsTypeParameterName {
+                                            ident_token: IDENT@531..533 "T" [] [Whitespace(" ")],
+                                        },
+                                        constraint: missing (optional),
+                                    },
+                                },
+                            },
+                            separator_token: missing (optional),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@533..534 "}" [] [],
+                },
+                question_mark_token: QUESTION@534..541 "?" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                true_type: TsIntersectionType {
+                    leading_separator_token: missing (optional),
+                    types: TsIntersectionTypeElementList [
+                        TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@541..543 "S" [] [Whitespace(" ")],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                        AMP@543..545 "&" [] [Whitespace(" ")],
+                        TsObjectType {
+                            l_curly_token: L_CURLY@545..547 "{" [] [Whitespace(" ")],
+                            members: TsTypeMemberList [
+                                TsPropertySignatureTypeMember {
+                                    readonly_token: missing (optional),
+                                    name: JsLiteralMemberName {
+                                        value: IDENT@547..550 "use" [] [],
+                                    },
+                                    optional_token: missing (optional),
+                                    type_annotation: TsTypeAnnotation {
+                                        colon_token: COLON@550..552 ":" [] [Whitespace(" ")],
+                                        ty: TsMappedType {
+                                            l_curly_token: L_CURLY@552..554 "{" [] [Whitespace(" ")],
+                                            readonly_modifier: missing (optional),
+                                            l_brack_token: L_BRACK@554..555 "[" [] [],
+                                            property_name: TsTypeParameterName {
+                                                ident_token: IDENT@555..557 "K" [] [Whitespace(" ")],
+                                            },
+                                            in_token: IN_KW@557..560 "in" [] [Whitespace(" ")],
+                                            keys_type: TsTypeOperatorType {
+                                                operator_token: KEYOF_KW@560..566 "keyof" [] [Whitespace(" ")],
+                                                ty: TsReferenceType {
+                                                    name: JsReferenceIdentifier {
+                                                        value_token: IDENT@566..567 "T" [] [],
+                                                    },
+                                                    type_arguments: missing (optional),
+                                                },
+                                            },
+                                            as_clause: missing (optional),
+                                            r_brack_token: R_BRACK@567..568 "]" [] [],
+                                            optional_modifier: missing (optional),
+                                            mapped_type: TsTypeAnnotation {
+                                                colon_token: COLON@568..570 ":" [] [Whitespace(" ")],
+                                                ty: TsFunctionType {
+                                                    type_parameters: missing (optional),
+                                                    parameters: JsParameters {
+                                                        l_paren_token: L_PAREN@570..571 "(" [] [],
+                                                        items: JsParameterList [],
+                                                        r_paren_token: R_PAREN@571..573 ")" [] [Whitespace(" ")],
+                                                    },
+                                                    fat_arrow_token: FAT_ARROW@573..576 "=>" [] [Whitespace(" ")],
+                                                    return_type: TsIndexedAccessType {
+                                                        object_type: TsReferenceType {
+                                                            name: JsReferenceIdentifier {
+                                                                value_token: IDENT@576..577 "T" [] [],
+                                                            },
+                                                            type_arguments: missing (optional),
+                                                        },
+                                                        l_brack_token: L_BRACK@577..578 "[" [] [],
+                                                        index_type: TsReferenceType {
+                                                            name: JsReferenceIdentifier {
+                                                                value_token: IDENT@578..579 "K" [] [],
+                                                            },
+                                                            type_arguments: missing (optional),
+                                                        },
+                                                        r_brack_token: R_BRACK@579..581 "]" [] [Whitespace(" ")],
+                                                    },
+                                                },
+                                            },
+                                            semicolon_token: missing (optional),
+                                            r_curly_token: R_CURLY@581..583 "}" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                    separator_token: missing (optional),
+                                },
+                            ],
+                            r_curly_token: R_CURLY@583..584 "}" [] [],
+                        },
+                    ],
+                },
+                colon_token: COLON@584..591 ":" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@591..596 "never" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@596..597 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@597..603 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@603..605 "A" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@605..607 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@607..614 "MyType" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@614..622 "extends" [] [Whitespace(" ")],
+                extends_type: TsParenthesizedType {
+                    l_paren_token: L_PAREN@622..623 "(" [] [],
+                    ty: TsConditionalType {
+                        check_type: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@623..633 "OtherType" [] [Whitespace(" ")],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                        extends_token: EXTENDS_KW@633..641 "extends" [] [Whitespace(" ")],
+                        extends_type: TsInferType {
+                            infer_token: INFER_KW@641..647 "infer" [] [Whitespace(" ")],
+                            name: TsTypeParameterName {
+                                ident_token: IDENT@647..649 "T" [] [Whitespace(" ")],
+                            },
+                            constraint: missing (optional),
+                        },
+                        question_mark_token: QUESTION@649..651 "?" [] [Whitespace(" ")],
+                        true_type: TsInferType {
+                            infer_token: INFER_KW@651..657 "infer" [] [Whitespace(" ")],
+                            name: TsTypeParameterName {
+                                ident_token: IDENT@657..659 "U" [] [Whitespace(" ")],
+                            },
+                            constraint: missing (optional),
+                        },
+                        colon_token: COLON@659..661 ":" [] [Whitespace(" ")],
+                        false_type: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@661..671 "InnerFalse" [] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                    },
+                    r_paren_token: R_PAREN@671..673 ")" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@673..675 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@675..685 "OuterTrue" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@685..687 ":" [] [Whitespace(" ")],
+                false_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@687..697 "OuterFalse" [] [],
+                    },
+                    type_arguments: missing (optional),
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@697..703 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@703..707 "Join" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@707..708 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@708..710 "T" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@710..718 "extends" [] [Whitespace(" ")],
+                            ty: TsArrayType {
+                                element_type: TsUnknownType {
+                                    unknown_token: UNKNOWN_KW@718..725 "unknown" [] [],
+                                },
+                                l_brack_token: L_BRACK@725..726 "[" [] [],
+                                r_brack_token: R_BRACK@726..727 "]" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                    },
+                    COMMA@727..729 "," [] [Whitespace(" ")],
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@729..731 "D" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@731..739 "extends" [] [Whitespace(" ")],
+                            ty: TsStringType {
+                                string_token: STRING_KW@739..745 "string" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@745..747 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@747..748 "=" [] [],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@748..756 "T" [Newline("\n"), Whitespace("     ")] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@756..764 "extends" [] [Whitespace(" ")],
+                extends_type: TsTupleType {
+                    l_brack_token: L_BRACK@764..765 "[" [] [],
+                    elements: TsTupleTypeElementList [],
+                    r_brack_token: R_BRACK@765..767 "]" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@767..769 "?" [] [Whitespace(" ")],
+                true_type: TsStringLiteralType {
+                    literal_token: JS_STRING_LITERAL@769..772 "''" [] [Whitespace(" ")],
+                },
+                colon_token: COLON@772..773 ":" [] [],
+                false_type: TsConditionalType {
+                    check_type: TsReferenceType {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@773..781 "T" [Newline("\n"), Whitespace("     ")] [Whitespace(" ")],
+                        },
+                        type_arguments: missing (optional),
+                    },
+                    extends_token: EXTENDS_KW@781..789 "extends" [] [Whitespace(" ")],
+                    extends_type: TsTupleType {
+                        l_brack_token: L_BRACK@789..790 "[" [] [],
+                        elements: TsTupleTypeElementList [
+                            TsUnionType {
+                                leading_separator_token: missing (optional),
+                                types: TsUnionTypeVariantList [
+                                    TsStringType {
+                                        string_token: STRING_KW@790..797 "string" [] [Whitespace(" ")],
+                                    },
+                                    PIPE@797..799 "|" [] [Whitespace(" ")],
+                                    TsNumberType {
+                                        number_token: NUMBER_KW@799..806 "number" [] [Whitespace(" ")],
+                                    },
+                                    PIPE@806..808 "|" [] [Whitespace(" ")],
+                                    TsBooleanType {
+                                        boolean_token: BOOLEAN_KW@808..816 "boolean" [] [Whitespace(" ")],
+                                    },
+                                    PIPE@816..818 "|" [] [Whitespace(" ")],
+                                    TsBigintType {
+                                        bigint_token: BIGINT_KW@818..824 "bigint" [] [],
+                                    },
+                                ],
+                            },
+                        ],
+                        r_brack_token: R_BRACK@824..826 "]" [] [Whitespace(" ")],
+                    },
+                    question_mark_token: QUESTION@826..828 "?" [] [Whitespace(" ")],
+                    true_type: TsTemplateLiteralType {
+                        l_tick_token: BACKTICK@828..829 "`" [] [],
+                        elements: TsTemplateElementList [
+                            TsTemplateElement {
+                                dollar_curly_token: DOLLAR_CURLY@829..831 "${" [] [],
+                                ty: TsIndexedAccessType {
+                                    object_type: TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@831..832 "T" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                    l_brack_token: L_BRACK@832..833 "[" [] [],
+                                    index_type: TsNumberLiteralType {
+                                        minus_token: missing (optional),
+                                        literal_token: JS_NUMBER_LITERAL@833..834 "0" [] [],
+                                    },
+                                    r_brack_token: R_BRACK@834..835 "]" [] [],
+                                },
+                                r_curly_token: R_CURLY@835..836 "}" [] [],
+                            },
+                        ],
+                        r_tick_token: BACKTICK@836..838 "`" [] [Whitespace(" ")],
+                    },
+                    colon_token: COLON@838..839 ":" [] [],
+                    false_type: TsConditionalType {
+                        check_type: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@839..847 "T" [Newline("\n"), Whitespace("     ")] [Whitespace(" ")],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                        extends_token: EXTENDS_KW@847..855 "extends" [] [Whitespace(" ")],
+                        extends_type: TsTupleType {
+                            l_brack_token: L_BRACK@855..856 "[" [] [],
+                            elements: TsTupleTypeElementList [
+                                TsUnionType {
+                                    leading_separator_token: missing (optional),
+                                    types: TsUnionTypeVariantList [
+                                        TsStringType {
+                                            string_token: STRING_KW@856..863 "string" [] [Whitespace(" ")],
+                                        },
+                                        PIPE@863..865 "|" [] [Whitespace(" ")],
+                                        TsNumberType {
+                                            number_token: NUMBER_KW@865..872 "number" [] [Whitespace(" ")],
+                                        },
+                                        PIPE@872..874 "|" [] [Whitespace(" ")],
+                                        TsBooleanType {
+                                            boolean_token: BOOLEAN_KW@874..882 "boolean" [] [Whitespace(" ")],
+                                        },
+                                        PIPE@882..884 "|" [] [Whitespace(" ")],
+                                        TsBigintType {
+                                            bigint_token: BIGINT_KW@884..890 "bigint" [] [],
+                                        },
+                                    ],
+                                },
+                                COMMA@890..892 "," [] [Whitespace(" ")],
+                                TsRestTupleTypeElement {
+                                    dotdotdot_token: DOT3@892..895 "..." [] [],
+                                    ty: TsInferType {
+                                        infer_token: INFER_KW@895..901 "infer" [] [Whitespace(" ")],
+                                        name: TsTypeParameterName {
+                                            ident_token: IDENT@901..902 "U" [] [],
+                                        },
+                                        constraint: missing (optional),
+                                    },
+                                },
+                            ],
+                            r_brack_token: R_BRACK@902..904 "]" [] [Whitespace(" ")],
+                        },
+                        question_mark_token: QUESTION@904..906 "?" [] [Whitespace(" ")],
+                        true_type: TsTemplateLiteralType {
+                            l_tick_token: BACKTICK@906..907 "`" [] [],
+                            elements: TsTemplateElementList [
+                                TsTemplateElement {
+                                    dollar_curly_token: DOLLAR_CURLY@907..909 "${" [] [],
+                                    ty: TsIndexedAccessType {
+                                        object_type: TsReferenceType {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@909..910 "T" [] [],
+                                            },
+                                            type_arguments: missing (optional),
+                                        },
+                                        l_brack_token: L_BRACK@910..911 "[" [] [],
+                                        index_type: TsNumberLiteralType {
+                                            minus_token: missing (optional),
+                                            literal_token: JS_NUMBER_LITERAL@911..912 "0" [] [],
+                                        },
+                                        r_brack_token: R_BRACK@912..913 "]" [] [],
+                                    },
+                                    r_curly_token: R_CURLY@913..914 "}" [] [],
+                                },
+                                TsTemplateElement {
+                                    dollar_curly_token: DOLLAR_CURLY@914..916 "${" [] [],
+                                    ty: TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@916..917 "D" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                    r_curly_token: R_CURLY@917..918 "}" [] [],
+                                },
+                                TsTemplateElement {
+                                    dollar_curly_token: DOLLAR_CURLY@918..920 "${" [] [],
+                                    ty: TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@920..924 "Join" [] [],
+                                        },
+                                        type_arguments: TsTypeArguments {
+                                            l_angle_token: L_ANGLE@924..925 "<" [] [],
+                                            ts_type_argument_list: TsTypeArgumentList [
+                                                TsReferenceType {
+                                                    name: JsReferenceIdentifier {
+                                                        value_token: IDENT@925..926 "U" [] [],
+                                                    },
+                                                    type_arguments: missing (optional),
+                                                },
+                                                COMMA@926..928 "," [] [Whitespace(" ")],
+                                                TsReferenceType {
+                                                    name: JsReferenceIdentifier {
+                                                        value_token: IDENT@928..929 "D" [] [],
+                                                    },
+                                                    type_arguments: missing (optional),
+                                                },
+                                            ],
+                                            r_angle_token: R_ANGLE@929..930 ">" [] [],
+                                        },
+                                    },
+                                    r_curly_token: R_CURLY@930..931 "}" [] [],
+                                },
+                            ],
+                            r_tick_token: BACKTICK@931..933 "`" [] [Whitespace(" ")],
+                        },
+                        colon_token: COLON@933..934 ":" [] [],
+                        false_type: TsStringType {
+                            string_token: STRING_KW@934..946 "string" [Newline("\n"), Whitespace("     ")] [],
+                        },
+                    },
+                },
+            },
+            semicolon_token: SEMICOLON@946..947 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@947..953 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@953..962 "MatchPair" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@962..963 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@963..965 "S" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@965..973 "extends" [] [Whitespace(" ")],
+                            ty: TsStringType {
+                                string_token: STRING_KW@973..979 "string" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@979..981 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@981..983 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@983..985 "S" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@985..993 "extends" [] [Whitespace(" ")],
+                extends_type: TsTemplateLiteralType {
+                    l_tick_token: BACKTICK@993..994 "`" [] [],
+                    elements: TsTemplateElementList [
+                        TsTemplateChunkElement {
+                            template_chunk_token: TEMPLATE_CHUNK@994..995 "[" [] [],
+                        },
+                        TsTemplateElement {
+                            dollar_curly_token: DOLLAR_CURLY@995..997 "${" [] [],
+                            ty: TsInferType {
+                                infer_token: INFER_KW@997..1003 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@1003..1004 "A" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                            r_curly_token: R_CURLY@1004..1005 "}" [] [],
+                        },
+                        TsTemplateChunkElement {
+                            template_chunk_token: TEMPLATE_CHUNK@1005..1006 "," [] [],
+                        },
+                        TsTemplateElement {
+                            dollar_curly_token: DOLLAR_CURLY@1006..1008 "${" [] [],
+                            ty: TsInferType {
+                                infer_token: INFER_KW@1008..1014 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@1014..1015 "B" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                            r_curly_token: R_CURLY@1015..1016 "}" [] [],
+                        },
+                        TsTemplateChunkElement {
+                            template_chunk_token: TEMPLATE_CHUNK@1016..1017 "]" [] [],
+                        },
+                    ],
+                    r_tick_token: BACKTICK@1017..1019 "`" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@1019..1021 "?" [] [Whitespace(" ")],
+                true_type: TsTupleType {
+                    l_brack_token: L_BRACK@1021..1022 "[" [] [],
+                    elements: TsTupleTypeElementList [
+                        TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1022..1023 "A" [] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                        COMMA@1023..1025 "," [] [Whitespace(" ")],
+                        TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1025..1026 "B" [] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                    ],
+                    r_brack_token: R_BRACK@1026..1028 "]" [] [Whitespace(" ")],
+                },
+                colon_token: COLON@1028..1030 ":" [] [Whitespace(" ")],
+                false_type: TsUnknownType {
+                    unknown_token: UNKNOWN_KW@1030..1037 "unknown" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@1037..1038 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@1038..1044 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@1044..1059 "FirstTwoAndRest" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@1059..1060 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@1060..1062 "S" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@1062..1070 "extends" [] [Whitespace(" ")],
+                            ty: TsStringType {
+                                string_token: STRING_KW@1070..1076 "string" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@1076..1078 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@1078..1080 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1080..1082 "S" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@1082..1090 "extends" [] [Whitespace(" ")],
+                extends_type: TsTemplateLiteralType {
+                    l_tick_token: BACKTICK@1090..1091 "`" [] [],
+                    elements: TsTemplateElementList [
+                        TsTemplateElement {
+                            dollar_curly_token: DOLLAR_CURLY@1091..1093 "${" [] [],
+                            ty: TsInferType {
+                                infer_token: INFER_KW@1093..1099 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@1099..1100 "A" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                            r_curly_token: R_CURLY@1100..1101 "}" [] [],
+                        },
+                        TsTemplateElement {
+                            dollar_curly_token: DOLLAR_CURLY@1101..1103 "${" [] [],
+                            ty: TsInferType {
+                                infer_token: INFER_KW@1103..1109 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@1109..1110 "B" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                            r_curly_token: R_CURLY@1110..1111 "}" [] [],
+                        },
+                        TsTemplateElement {
+                            dollar_curly_token: DOLLAR_CURLY@1111..1113 "${" [] [],
+                            ty: TsInferType {
+                                infer_token: INFER_KW@1113..1119 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@1119..1120 "R" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                            r_curly_token: R_CURLY@1120..1121 "}" [] [],
+                        },
+                    ],
+                    r_tick_token: BACKTICK@1121..1123 "`" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@1123..1125 "?" [] [Whitespace(" ")],
+                true_type: TsTupleType {
+                    l_brack_token: L_BRACK@1125..1126 "[" [] [],
+                    elements: TsTupleTypeElementList [
+                        TsTemplateLiteralType {
+                            l_tick_token: BACKTICK@1126..1127 "`" [] [],
+                            elements: TsTemplateElementList [
+                                TsTemplateElement {
+                                    dollar_curly_token: DOLLAR_CURLY@1127..1129 "${" [] [],
+                                    ty: TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@1129..1130 "A" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                    r_curly_token: R_CURLY@1130..1131 "}" [] [],
+                                },
+                                TsTemplateElement {
+                                    dollar_curly_token: DOLLAR_CURLY@1131..1133 "${" [] [],
+                                    ty: TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@1133..1134 "B" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                    r_curly_token: R_CURLY@1134..1135 "}" [] [],
+                                },
+                            ],
+                            r_tick_token: BACKTICK@1135..1136 "`" [] [],
+                        },
+                        COMMA@1136..1138 "," [] [Whitespace(" ")],
+                        TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1138..1139 "R" [] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                    ],
+                    r_brack_token: R_BRACK@1139..1141 "]" [] [Whitespace(" ")],
+                },
+                colon_token: COLON@1141..1143 ":" [] [Whitespace(" ")],
+                false_type: TsUnknownType {
+                    unknown_token: UNKNOWN_KW@1143..1150 "unknown" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@1150..1151 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@1151..1157 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@1157..1161 "Trim" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@1161..1162 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@1162..1164 "S" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@1164..1172 "extends" [] [Whitespace(" ")],
+                            ty: TsStringType {
+                                string_token: STRING_KW@1172..1178 "string" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@1178..1180 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@1180..1181 "=" [] [],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1181..1189 "S" [Newline("\n"), Whitespace("     ")] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@1189..1197 "extends" [] [Whitespace(" ")],
+                extends_type: TsTemplateLiteralType {
+                    l_tick_token: BACKTICK@1197..1198 "`" [] [],
+                    elements: TsTemplateElementList [
+                        TsTemplateElement {
+                            dollar_curly_token: DOLLAR_CURLY@1198..1200 "${" [] [],
+                            ty: TsInferType {
+                                infer_token: INFER_KW@1200..1206 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@1206..1207 "T" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                            r_curly_token: R_CURLY@1207..1208 "}" [] [],
+                        },
+                        TsTemplateChunkElement {
+                            template_chunk_token: TEMPLATE_CHUNK@1208..1209 " " [] [],
+                        },
+                    ],
+                    r_tick_token: BACKTICK@1209..1211 "`" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@1211..1213 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1213..1217 "Trim" [] [],
+                    },
+                    type_arguments: TsTypeArguments {
+                        l_angle_token: L_ANGLE@1217..1218 "<" [] [],
+                        ts_type_argument_list: TsTypeArgumentList [
+                            TsReferenceType {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@1218..1219 "T" [] [],
+                                },
+                                type_arguments: missing (optional),
+                            },
+                        ],
+                        r_angle_token: R_ANGLE@1219..1221 ">" [] [Whitespace(" ")],
+                    },
+                },
+                colon_token: COLON@1221..1222 ":" [] [],
+                false_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1222..1229 "S" [Newline("\n"), Whitespace("     ")] [],
+                    },
+                    type_arguments: missing (optional),
+                },
+            },
+            semicolon_token: SEMICOLON@1229..1230 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@1230..1236 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@1236..1239 "Foo" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@1239..1240 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@1240..1241 "T" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@1241..1243 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@1243..1245 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1245..1247 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@1247..1255 "extends" [] [Whitespace(" ")],
+                extends_type: TsTemplateLiteralType {
+                    l_tick_token: BACKTICK@1255..1256 "`" [] [],
+                    elements: TsTemplateElementList [
+                        TsTemplateChunkElement {
+                            template_chunk_token: TEMPLATE_CHUNK@1256..1257 "*" [] [],
+                        },
+                        TsTemplateElement {
+                            dollar_curly_token: DOLLAR_CURLY@1257..1259 "${" [] [],
+                            ty: TsInferType {
+                                infer_token: INFER_KW@1259..1265 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@1265..1266 "S" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                            r_curly_token: R_CURLY@1266..1267 "}" [] [],
+                        },
+                        TsTemplateChunkElement {
+                            template_chunk_token: TEMPLATE_CHUNK@1267..1268 "*" [] [],
+                        },
+                    ],
+                    r_tick_token: BACKTICK@1268..1270 "`" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@1270..1272 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1272..1274 "S" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@1274..1276 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@1276..1281 "never" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@1281..1282 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@1282..1288 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@1288..1296 "Unpacked" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@1296..1297 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@1297..1298 "T" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@1298..1300 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@1300..1302 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1302..1304 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@1304..1312 "extends" [] [Whitespace(" ")],
+                extends_type: TsArrayType {
+                    element_type: TsParenthesizedType {
+                        l_paren_token: L_PAREN@1312..1313 "(" [] [],
+                        ty: TsInferType {
+                            infer_token: INFER_KW@1313..1319 "infer" [] [Whitespace(" ")],
+                            name: TsTypeParameterName {
+                                ident_token: IDENT@1319..1320 "U" [] [],
+                            },
+                            constraint: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@1320..1321 ")" [] [],
+                    },
+                    l_brack_token: L_BRACK@1321..1322 "[" [] [],
+                    r_brack_token: R_BRACK@1322..1324 "]" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@1324..1326 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1326..1328 "U" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@1328..1329 ":" [] [],
+                false_type: TsConditionalType {
+                    check_type: TsReferenceType {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@1329..1336 "T" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                        },
+                        type_arguments: missing (optional),
+                    },
+                    extends_token: EXTENDS_KW@1336..1344 "extends" [] [Whitespace(" ")],
+                    extends_type: TsFunctionType {
+                        type_parameters: missing (optional),
+                        parameters: JsParameters {
+                            l_paren_token: L_PAREN@1344..1345 "(" [] [],
+                            items: JsParameterList [
+                                JsRestParameter {
+                                    decorators: JsDecoratorList [],
+                                    dotdotdot_token: DOT3@1345..1348 "..." [] [],
+                                    binding: JsIdentifierBinding {
+                                        name_token: IDENT@1348..1352 "args" [] [],
+                                    },
+                                    type_annotation: TsTypeAnnotation {
+                                        colon_token: COLON@1352..1354 ":" [] [Whitespace(" ")],
+                                        ty: TsArrayType {
+                                            element_type: TsAnyType {
+                                                any_token: ANY_KW@1354..1357 "any" [] [],
+                                            },
+                                            l_brack_token: L_BRACK@1357..1358 "[" [] [],
+                                            r_brack_token: R_BRACK@1358..1359 "]" [] [],
+                                        },
+                                    },
+                                },
+                            ],
+                            r_paren_token: R_PAREN@1359..1361 ")" [] [Whitespace(" ")],
+                        },
+                        fat_arrow_token: FAT_ARROW@1361..1364 "=>" [] [Whitespace(" ")],
+                        return_type: TsInferType {
+                            infer_token: INFER_KW@1364..1370 "infer" [] [Whitespace(" ")],
+                            name: TsTypeParameterName {
+                                ident_token: IDENT@1370..1372 "U" [] [Whitespace(" ")],
+                            },
+                            constraint: missing (optional),
+                        },
+                    },
+                    question_mark_token: QUESTION@1372..1374 "?" [] [Whitespace(" ")],
+                    true_type: TsReferenceType {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@1374..1376 "U" [] [Whitespace(" ")],
+                        },
+                        type_arguments: missing (optional),
+                    },
+                    colon_token: COLON@1376..1377 ":" [] [],
+                    false_type: TsConditionalType {
+                        check_type: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1377..1384 "T" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                        extends_token: EXTENDS_KW@1384..1392 "extends" [] [Whitespace(" ")],
+                        extends_type: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1392..1399 "Promise" [] [],
+                            },
+                            type_arguments: TsTypeArguments {
+                                l_angle_token: L_ANGLE@1399..1400 "<" [] [],
+                                ts_type_argument_list: TsTypeArgumentList [
+                                    TsInferType {
+                                        infer_token: INFER_KW@1400..1406 "infer" [] [Whitespace(" ")],
+                                        name: TsTypeParameterName {
+                                            ident_token: IDENT@1406..1407 "U" [] [],
+                                        },
+                                        constraint: missing (optional),
+                                    },
+                                ],
+                                r_angle_token: R_ANGLE@1407..1409 ">" [] [Whitespace(" ")],
+                            },
+                        },
+                        question_mark_token: QUESTION@1409..1411 "?" [] [Whitespace(" ")],
+                        true_type: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1411..1413 "U" [] [Whitespace(" ")],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                        colon_token: COLON@1413..1414 ":" [] [],
+                        false_type: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1414..1420 "T" [Newline("\n"), Whitespace("    ")] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                    },
+                },
+            },
+            semicolon_token: SEMICOLON@1420..1421 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@1421..1427 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@1427..1439 "ArgumentType" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@1439..1440 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@1440..1442 "T" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@1442..1450 "extends" [] [Whitespace(" ")],
+                            ty: TsFunctionType {
+                                type_parameters: missing (optional),
+                                parameters: JsParameters {
+                                    l_paren_token: L_PAREN@1450..1451 "(" [] [],
+                                    items: JsParameterList [
+                                        JsFormalParameter {
+                                            decorators: JsDecoratorList [],
+                                            binding: JsIdentifierBinding {
+                                                name_token: IDENT@1451..1452 "x" [] [],
+                                            },
+                                            question_mark_token: missing (optional),
+                                            type_annotation: TsTypeAnnotation {
+                                                colon_token: COLON@1452..1454 ":" [] [Whitespace(" ")],
+                                                ty: TsAnyType {
+                                                    any_token: ANY_KW@1454..1457 "any" [] [],
+                                                },
+                                            },
+                                            initializer: missing (optional),
+                                        },
+                                    ],
+                                    r_paren_token: R_PAREN@1457..1459 ")" [] [Whitespace(" ")],
+                                },
+                                fat_arrow_token: FAT_ARROW@1459..1462 "=>" [] [Whitespace(" ")],
+                                return_type: TsAnyType {
+                                    any_token: ANY_KW@1462..1465 "any" [] [],
+                                },
+                            },
+                        },
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@1465..1467 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@1467..1469 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1469..1471 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@1471..1479 "extends" [] [Whitespace(" ")],
+                extends_type: TsFunctionType {
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@1479..1480 "(" [] [],
+                        items: JsParameterList [
+                            JsFormalParameter {
+                                decorators: JsDecoratorList [],
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@1480..1481 "a" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@1481..1483 ":" [] [Whitespace(" ")],
+                                    ty: TsInferType {
+                                        infer_token: INFER_KW@1483..1489 "infer" [] [Whitespace(" ")],
+                                        name: TsTypeParameterName {
+                                            ident_token: IDENT@1489..1490 "A" [] [],
+                                        },
+                                        constraint: missing (optional),
+                                    },
+                                },
+                                initializer: missing (optional),
+                            },
+                        ],
+                        r_paren_token: R_PAREN@1490..1492 ")" [] [Whitespace(" ")],
+                    },
+                    fat_arrow_token: FAT_ARROW@1492..1495 "=>" [] [Whitespace(" ")],
+                    return_type: TsAnyType {
+                        any_token: ANY_KW@1495..1499 "any" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@1499..1501 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1501..1503 "A" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@1503..1505 ":" [] [Whitespace(" ")],
+                false_type: TsAnyType {
+                    any_token: ANY_KW@1505..1508 "any" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@1508..1509 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@1509..1515 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@1515..1517 "X3" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@1517..1518 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@1518..1519 "T" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@1519..1521 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@1521..1523 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1523..1525 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@1525..1533 "extends" [] [Whitespace(" ")],
+                extends_type: TsObjectType {
+                    l_curly_token: L_CURLY@1533..1535 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [
+                        TsPropertySignatureTypeMember {
+                            readonly_token: missing (optional),
+                            name: JsLiteralMemberName {
+                                value: IDENT@1535..1536 "a" [] [],
+                            },
+                            optional_token: missing (optional),
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@1536..1538 ":" [] [Whitespace(" ")],
+                                ty: TsFunctionType {
+                                    type_parameters: missing (optional),
+                                    parameters: JsParameters {
+                                        l_paren_token: L_PAREN@1538..1539 "(" [] [],
+                                        items: JsParameterList [
+                                            JsFormalParameter {
+                                                decorators: JsDecoratorList [],
+                                                binding: JsIdentifierBinding {
+                                                    name_token: IDENT@1539..1540 "x" [] [],
+                                                },
+                                                question_mark_token: missing (optional),
+                                                type_annotation: TsTypeAnnotation {
+                                                    colon_token: COLON@1540..1542 ":" [] [Whitespace(" ")],
+                                                    ty: TsInferType {
+                                                        infer_token: INFER_KW@1542..1548 "infer" [] [Whitespace(" ")],
+                                                        name: TsTypeParameterName {
+                                                            ident_token: IDENT@1548..1549 "U" [] [],
+                                                        },
+                                                        constraint: missing (optional),
+                                                    },
+                                                },
+                                                initializer: missing (optional),
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@1549..1551 ")" [] [Whitespace(" ")],
+                                    },
+                                    fat_arrow_token: FAT_ARROW@1551..1554 "=>" [] [Whitespace(" ")],
+                                    return_type: TsVoidType {
+                                        void_token: VOID_KW@1554..1558 "void" [] [],
+                                    },
+                                },
+                            },
+                            separator_token: COMMA@1558..1560 "," [] [Whitespace(" ")],
+                        },
+                        TsPropertySignatureTypeMember {
+                            readonly_token: missing (optional),
+                            name: JsLiteralMemberName {
+                                value: IDENT@1560..1561 "b" [] [],
+                            },
+                            optional_token: missing (optional),
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@1561..1563 ":" [] [Whitespace(" ")],
+                                ty: TsFunctionType {
+                                    type_parameters: missing (optional),
+                                    parameters: JsParameters {
+                                        l_paren_token: L_PAREN@1563..1564 "(" [] [],
+                                        items: JsParameterList [
+                                            JsFormalParameter {
+                                                decorators: JsDecoratorList [],
+                                                binding: JsIdentifierBinding {
+                                                    name_token: IDENT@1564..1565 "x" [] [],
+                                                },
+                                                question_mark_token: missing (optional),
+                                                type_annotation: TsTypeAnnotation {
+                                                    colon_token: COLON@1565..1567 ":" [] [Whitespace(" ")],
+                                                    ty: TsInferType {
+                                                        infer_token: INFER_KW@1567..1573 "infer" [] [Whitespace(" ")],
+                                                        name: TsTypeParameterName {
+                                                            ident_token: IDENT@1573..1574 "U" [] [],
+                                                        },
+                                                        constraint: missing (optional),
+                                                    },
+                                                },
+                                                initializer: missing (optional),
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@1574..1576 ")" [] [Whitespace(" ")],
+                                    },
+                                    fat_arrow_token: FAT_ARROW@1576..1579 "=>" [] [Whitespace(" ")],
+                                    return_type: TsVoidType {
+                                        void_token: VOID_KW@1579..1584 "void" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                            separator_token: missing (optional),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1584..1586 "}" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@1586..1588 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1588..1590 "U" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@1590..1592 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@1592..1597 "never" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@1597..1598 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@1598..1604 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@1604..1606 "X1" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@1606..1607 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@1607..1609 "T" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@1609..1617 "extends" [] [Whitespace(" ")],
+                            ty: TsObjectType {
+                                l_curly_token: L_CURLY@1617..1619 "{" [] [Whitespace(" ")],
+                                members: TsTypeMemberList [
+                                    TsPropertySignatureTypeMember {
+                                        readonly_token: missing (optional),
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@1619..1620 "x" [] [],
+                                        },
+                                        optional_token: missing (optional),
+                                        type_annotation: TsTypeAnnotation {
+                                            colon_token: COLON@1620..1622 ":" [] [Whitespace(" ")],
+                                            ty: TsAnyType {
+                                                any_token: ANY_KW@1622..1625 "any" [] [],
+                                            },
+                                        },
+                                        separator_token: COMMA@1625..1627 "," [] [Whitespace(" ")],
+                                    },
+                                    TsPropertySignatureTypeMember {
+                                        readonly_token: missing (optional),
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@1627..1628 "y" [] [],
+                                        },
+                                        optional_token: missing (optional),
+                                        type_annotation: TsTypeAnnotation {
+                                            colon_token: COLON@1628..1630 ":" [] [Whitespace(" ")],
+                                            ty: TsAnyType {
+                                                any_token: ANY_KW@1630..1634 "any" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                        separator_token: missing (optional),
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@1634..1635 "}" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@1635..1637 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@1637..1639 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1639..1641 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@1641..1649 "extends" [] [Whitespace(" ")],
+                extends_type: TsObjectType {
+                    l_curly_token: L_CURLY@1649..1651 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [
+                        TsPropertySignatureTypeMember {
+                            readonly_token: missing (optional),
+                            name: JsLiteralMemberName {
+                                value: IDENT@1651..1652 "x" [] [],
+                            },
+                            optional_token: missing (optional),
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@1652..1654 ":" [] [Whitespace(" ")],
+                                ty: TsInferType {
+                                    infer_token: INFER_KW@1654..1660 "infer" [] [Whitespace(" ")],
+                                    name: TsTypeParameterName {
+                                        ident_token: IDENT@1660..1661 "X" [] [],
+                                    },
+                                    constraint: missing (optional),
+                                },
+                            },
+                            separator_token: COMMA@1661..1663 "," [] [Whitespace(" ")],
+                        },
+                        TsPropertySignatureTypeMember {
+                            readonly_token: missing (optional),
+                            name: JsLiteralMemberName {
+                                value: IDENT@1663..1664 "y" [] [],
+                            },
+                            optional_token: missing (optional),
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@1664..1666 ":" [] [Whitespace(" ")],
+                                ty: TsInferType {
+                                    infer_token: INFER_KW@1666..1672 "infer" [] [Whitespace(" ")],
+                                    name: TsTypeParameterName {
+                                        ident_token: IDENT@1672..1674 "Y" [] [Whitespace(" ")],
+                                    },
+                                    constraint: missing (optional),
+                                },
+                            },
+                            separator_token: missing (optional),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1674..1676 "}" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@1676..1678 "?" [] [Whitespace(" ")],
+                true_type: TsTupleType {
+                    l_brack_token: L_BRACK@1678..1679 "[" [] [],
+                    elements: TsTupleTypeElementList [
+                        TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1679..1680 "X" [] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                        COMMA@1680..1682 "," [] [Whitespace(" ")],
+                        TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1682..1683 "Y" [] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                    ],
+                    r_brack_token: R_BRACK@1683..1685 "]" [] [Whitespace(" ")],
+                },
+                colon_token: COLON@1685..1687 ":" [] [Whitespace(" ")],
+                false_type: TsAnyType {
+                    any_token: ANY_KW@1687..1690 "any" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@1690..1691 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@1691..1697 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@1697..1700 "T62" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@1700..1701 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@1701..1702 "T" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@1702..1704 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@1704..1706 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1706..1708 "U" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@1708..1716 "extends" [] [Whitespace(" ")],
+                extends_type: TsArrayType {
+                    element_type: TsParenthesizedType {
+                        l_paren_token: L_PAREN@1716..1717 "(" [] [],
+                        ty: TsInferType {
+                            infer_token: INFER_KW@1717..1723 "infer" [] [Whitespace(" ")],
+                            name: TsTypeParameterName {
+                                ident_token: IDENT@1723..1724 "U" [] [],
+                            },
+                            constraint: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@1724..1725 ")" [] [],
+                    },
+                    l_brack_token: L_BRACK@1725..1726 "[" [] [],
+                    r_brack_token: R_BRACK@1726..1728 "]" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@1728..1730 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1730..1732 "U" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@1732..1734 ":" [] [Whitespace(" ")],
+                false_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1734..1735 "U" [] [],
+                    },
+                    type_arguments: missing (optional),
+                },
+            },
+            semicolon_token: SEMICOLON@1735..1736 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@1736..1742 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@1742..1745 "T63" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@1745..1746 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@1746..1747 "T" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@1747..1749 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@1749..1751 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1751..1753 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@1753..1761 "extends" [] [Whitespace(" ")],
+                extends_type: TsParenthesizedType {
+                    l_paren_token: L_PAREN@1761..1762 "(" [] [],
+                    ty: TsConditionalType {
+                        check_type: TsParenthesizedType {
+                            l_paren_token: L_PAREN@1762..1763 "(" [] [],
+                            ty: TsInferType {
+                                infer_token: INFER_KW@1763..1769 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@1769..1770 "A" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                            r_paren_token: R_PAREN@1770..1772 ")" [] [Whitespace(" ")],
+                        },
+                        extends_token: EXTENDS_KW@1772..1780 "extends" [] [Whitespace(" ")],
+                        extends_type: TsInferType {
+                            infer_token: INFER_KW@1780..1786 "infer" [] [Whitespace(" ")],
+                            name: TsTypeParameterName {
+                                ident_token: IDENT@1786..1788 "B" [] [Whitespace(" ")],
+                            },
+                            constraint: missing (optional),
+                        },
+                        question_mark_token: QUESTION@1788..1790 "?" [] [Whitespace(" ")],
+                        true_type: TsInferType {
+                            infer_token: INFER_KW@1790..1796 "infer" [] [Whitespace(" ")],
+                            name: TsTypeParameterName {
+                                ident_token: IDENT@1796..1798 "C" [] [Whitespace(" ")],
+                            },
+                            constraint: missing (optional),
+                        },
+                        colon_token: COLON@1798..1800 ":" [] [Whitespace(" ")],
+                        false_type: TsInferType {
+                            infer_token: INFER_KW@1800..1806 "infer" [] [Whitespace(" ")],
+                            name: TsTypeParameterName {
+                                ident_token: IDENT@1806..1807 "D" [] [],
+                            },
+                            constraint: missing (optional),
+                        },
+                    },
+                    r_paren_token: R_PAREN@1807..1809 ")" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@1809..1811 "?" [] [Whitespace(" ")],
+                true_type: TsStringType {
+                    string_token: STRING_KW@1811..1818 "string" [] [Whitespace(" ")],
+                },
+                colon_token: COLON@1818..1820 ":" [] [Whitespace(" ")],
+                false_type: TsNumberType {
+                    number_token: NUMBER_KW@1820..1826 "number" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@1826..1827 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@1827..1833 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@1833..1836 "T75" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@1836..1837 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@1837..1838 "T" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@1838..1840 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@1840..1842 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1842..1844 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@1844..1852 "extends" [] [Whitespace(" ")],
+                extends_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1852..1855 "T74" [] [],
+                    },
+                    type_arguments: TsTypeArguments {
+                        l_angle_token: L_ANGLE@1855..1856 "<" [] [],
+                        ts_type_argument_list: TsTypeArgumentList [
+                            TsInferType {
+                                infer_token: INFER_KW@1856..1862 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@1862..1863 "U" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                            COMMA@1863..1865 "," [] [Whitespace(" ")],
+                            TsInferType {
+                                infer_token: INFER_KW@1865..1871 "infer" [] [Whitespace(" ")],
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@1871..1872 "U" [] [],
+                                },
+                                constraint: missing (optional),
+                            },
+                        ],
+                        r_angle_token: R_ANGLE@1872..1874 ">" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@1874..1876 "?" [] [Whitespace(" ")],
+                true_type: TsUnionType {
+                    leading_separator_token: missing (optional),
+                    types: TsUnionTypeVariantList [
+                        TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1876..1879 "T70" [] [],
+                            },
+                            type_arguments: TsTypeArguments {
+                                l_angle_token: L_ANGLE@1879..1880 "<" [] [],
+                                ts_type_argument_list: TsTypeArgumentList [
+                                    TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@1880..1881 "U" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                ],
+                                r_angle_token: R_ANGLE@1881..1883 ">" [] [Whitespace(" ")],
+                            },
+                        },
+                        PIPE@1883..1885 "|" [] [Whitespace(" ")],
+                        TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1885..1888 "T72" [] [],
+                            },
+                            type_arguments: TsTypeArguments {
+                                l_angle_token: L_ANGLE@1888..1889 "<" [] [],
+                                ts_type_argument_list: TsTypeArgumentList [
+                                    TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@1889..1890 "U" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                ],
+                                r_angle_token: R_ANGLE@1890..1892 ">" [] [Whitespace(" ")],
+                            },
+                        },
+                        PIPE@1892..1894 "|" [] [Whitespace(" ")],
+                        TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1894..1897 "T74" [] [],
+                            },
+                            type_arguments: TsTypeArguments {
+                                l_angle_token: L_ANGLE@1897..1898 "<" [] [],
+                                ts_type_argument_list: TsTypeArgumentList [
+                                    TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@1898..1899 "U" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                    COMMA@1899..1901 "," [] [Whitespace(" ")],
+                                    TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@1901..1902 "U" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                ],
+                                r_angle_token: R_ANGLE@1902..1904 ">" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+                colon_token: COLON@1904..1906 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@1906..1911 "never" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@1911..1912 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@1912..1918 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@1918..1927 "Jsonified" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@1927..1928 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@1928..1929 "T" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@1929..1931 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@1931..1933 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1933..1935 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@1935..1943 "extends" [] [Whitespace(" ")],
+                extends_type: TsUnionType {
+                    leading_separator_token: missing (optional),
+                    types: TsUnionTypeVariantList [
+                        TsStringType {
+                            string_token: STRING_KW@1943..1950 "string" [] [Whitespace(" ")],
+                        },
+                        PIPE@1950..1952 "|" [] [Whitespace(" ")],
+                        TsNumberType {
+                            number_token: NUMBER_KW@1952..1959 "number" [] [Whitespace(" ")],
+                        },
+                        PIPE@1959..1961 "|" [] [Whitespace(" ")],
+                        TsBooleanType {
+                            boolean_token: BOOLEAN_KW@1961..1969 "boolean" [] [Whitespace(" ")],
+                        },
+                        PIPE@1969..1971 "|" [] [Whitespace(" ")],
+                        TsNullLiteralType {
+                            literal_token: NULL_KW@1971..1976 "null" [] [Whitespace(" ")],
+                        },
+                    ],
+                },
+                question_mark_token: QUESTION@1976..1978 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@1978..1979 "T" [] [],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@1979..1986 ":" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                false_type: TsConditionalType {
+                    check_type: TsReferenceType {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@1986..1988 "T" [] [Whitespace(" ")],
+                        },
+                        type_arguments: missing (optional),
+                    },
+                    extends_token: EXTENDS_KW@1988..1996 "extends" [] [Whitespace(" ")],
+                    extends_type: TsUnionType {
+                        leading_separator_token: missing (optional),
+                        types: TsUnionTypeVariantList [
+                            TsUndefinedType {
+                                undefined_token: UNDEFINED_KW@1996..2006 "undefined" [] [Whitespace(" ")],
+                            },
+                            PIPE@2006..2008 "|" [] [Whitespace(" ")],
+                            TsReferenceType {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@2008..2017 "Function" [] [Whitespace(" ")],
+                                },
+                                type_arguments: missing (optional),
+                            },
+                        ],
+                    },
+                    question_mark_token: QUESTION@2017..2019 "?" [] [Whitespace(" ")],
+                    true_type: TsNeverType {
+                        never_token: NEVER_KW@2019..2024 "never" [] [],
+                    },
+                    colon_token: COLON@2024..2031 ":" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                    false_type: TsConditionalType {
+                        check_type: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@2031..2033 "T" [] [Whitespace(" ")],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                        extends_token: EXTENDS_KW@2033..2041 "extends" [] [Whitespace(" ")],
+                        extends_type: TsObjectType {
+                            l_curly_token: L_CURLY@2041..2043 "{" [] [Whitespace(" ")],
+                            members: TsTypeMemberList [
+                                TsMethodSignatureTypeMember {
+                                    name: JsLiteralMemberName {
+                                        value: IDENT@2043..2049 "toJSON" [] [],
+                                    },
+                                    optional_token: missing (optional),
+                                    type_parameters: missing (optional),
+                                    parameters: JsParameters {
+                                        l_paren_token: L_PAREN@2049..2050 "(" [] [],
+                                        items: JsParameterList [],
+                                        r_paren_token: R_PAREN@2050..2051 ")" [] [],
+                                    },
+                                    return_type_annotation: TsReturnTypeAnnotation {
+                                        colon_token: COLON@2051..2053 ":" [] [Whitespace(" ")],
+                                        ty: TsInferType {
+                                            infer_token: INFER_KW@2053..2059 "infer" [] [Whitespace(" ")],
+                                            name: TsTypeParameterName {
+                                                ident_token: IDENT@2059..2061 "R" [] [Whitespace(" ")],
+                                            },
+                                            constraint: missing (optional),
+                                        },
+                                    },
+                                    separator_token: missing (optional),
+                                },
+                            ],
+                            r_curly_token: R_CURLY@2061..2063 "}" [] [Whitespace(" ")],
+                        },
+                        question_mark_token: QUESTION@2063..2065 "?" [] [Whitespace(" ")],
+                        true_type: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@2065..2066 "R" [] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                        colon_token: COLON@2066..2073 ":" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                        false_type: TsConditionalType {
+                            check_type: TsReferenceType {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@2073..2075 "T" [] [Whitespace(" ")],
+                                },
+                                type_arguments: missing (optional),
+                            },
+                            extends_token: EXTENDS_KW@2075..2083 "extends" [] [Whitespace(" ")],
+                            extends_type: TsNonPrimitiveType {
+                                object_token: OBJECT_KW@2083..2090 "object" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: QUESTION@2090..2092 "?" [] [Whitespace(" ")],
+                            true_type: TsReferenceType {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@2092..2107 "JsonifiedObject" [] [],
+                                },
+                                type_arguments: TsTypeArguments {
+                                    l_angle_token: L_ANGLE@2107..2108 "<" [] [],
+                                    ts_type_argument_list: TsTypeArgumentList [
+                                        TsReferenceType {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@2108..2109 "T" [] [],
+                                            },
+                                            type_arguments: missing (optional),
+                                        },
+                                    ],
+                                    r_angle_token: R_ANGLE@2109..2110 ">" [] [],
+                                },
+                            },
+                            colon_token: COLON@2110..2113 ":" [Newline("\n")] [Whitespace(" ")],
+                            false_type: TsStringLiteralType {
+                                literal_token: JS_STRING_LITERAL@2113..2127 "\"what is this\"" [] [],
+                            },
+                        },
+                    },
+                },
+            },
+            semicolon_token: SEMICOLON@2127..2128 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@2128..2134 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@2134..2137 "T1" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@2137..2139 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2139..2142 "F1" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@2142..2150 "extends" [] [Whitespace(" ")],
+                extends_type: TsFunctionType {
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@2150..2151 "(" [] [],
+                        items: JsParameterList [
+                            JsRestParameter {
+                                decorators: JsDecoratorList [],
+                                dotdotdot_token: DOT3@2151..2154 "..." [] [],
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@2154..2158 "args" [] [],
+                                },
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@2158..2160 ":" [] [Whitespace(" ")],
+                                    ty: TsParenthesizedType {
+                                        l_paren_token: L_PAREN@2160..2161 "(" [] [],
+                                        ty: TsInferType {
+                                            infer_token: INFER_KW@2161..2167 "infer" [] [Whitespace(" ")],
+                                            name: TsTypeParameterName {
+                                                ident_token: IDENT@2167..2168 "T" [] [],
+                                            },
+                                            constraint: missing (optional),
+                                        },
+                                        r_paren_token: R_PAREN@2168..2169 ")" [] [],
+                                    },
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@2169..2171 ")" [] [Whitespace(" ")],
+                    },
+                    fat_arrow_token: FAT_ARROW@2171..2174 "=>" [] [Whitespace(" ")],
+                    return_type: TsVoidType {
+                        void_token: VOID_KW@2174..2179 "void" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@2179..2181 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2181..2183 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@2183..2185 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@2185..2190 "never" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@2190..2191 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@2191..2197 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@2197..2200 "T2" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@2200..2202 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2202..2205 "F1" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@2205..2213 "extends" [] [Whitespace(" ")],
+                extends_type: TsFunctionType {
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@2213..2214 "(" [] [],
+                        items: JsParameterList [
+                            JsFormalParameter {
+                                decorators: JsDecoratorList [],
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@2214..2218 "args" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@2218..2220 ":" [] [Whitespace(" ")],
+                                    ty: TsTupleType {
+                                        l_brack_token: L_BRACK@2220..2221 "[" [] [],
+                                        elements: TsTupleTypeElementList [
+                                            TsRestTupleTypeElement {
+                                                dotdotdot_token: DOT3@2221..2224 "..." [] [],
+                                                ty: TsParenthesizedType {
+                                                    l_paren_token: L_PAREN@2224..2225 "(" [] [],
+                                                    ty: TsInferType {
+                                                        infer_token: INFER_KW@2225..2231 "infer" [] [Whitespace(" ")],
+                                                        name: TsTypeParameterName {
+                                                            ident_token: IDENT@2231..2232 "T" [] [],
+                                                        },
+                                                        constraint: missing (optional),
+                                                    },
+                                                    r_paren_token: R_PAREN@2232..2233 ")" [] [],
+                                                },
+                                            },
+                                        ],
+                                        r_brack_token: R_BRACK@2233..2234 "]" [] [],
+                                    },
+                                },
+                                initializer: missing (optional),
+                            },
+                        ],
+                        r_paren_token: R_PAREN@2234..2236 ")" [] [Whitespace(" ")],
+                    },
+                    fat_arrow_token: FAT_ARROW@2236..2239 "=>" [] [Whitespace(" ")],
+                    return_type: TsVoidType {
+                        void_token: VOID_KW@2239..2244 "void" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@2244..2246 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2246..2248 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@2248..2250 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@2250..2255 "never" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@2255..2256 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@2256..2262 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@2262..2264 "T3" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@2264..2265 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@2265..2266 "T" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@2266..2268 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@2268..2270 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2270..2272 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@2272..2280 "extends" [] [Whitespace(" ")],
+                extends_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2280..2288 "IsNumber" [] [],
+                    },
+                    type_arguments: TsTypeArguments {
+                        l_angle_token: L_ANGLE@2288..2289 "<" [] [],
+                        ts_type_argument_list: TsTypeArgumentList [
+                            TsParenthesizedType {
+                                l_paren_token: L_PAREN@2289..2290 "(" [] [],
+                                ty: TsInferType {
+                                    infer_token: INFER_KW@2290..2296 "infer" [] [Whitespace(" ")],
+                                    name: TsTypeParameterName {
+                                        ident_token: IDENT@2296..2297 "N" [] [],
+                                    },
+                                    constraint: missing (optional),
+                                },
+                                r_paren_token: R_PAREN@2297..2298 ")" [] [],
+                            },
+                        ],
+                        r_angle_token: R_ANGLE@2298..2300 ">" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@2300..2302 "?" [] [Whitespace(" ")],
+                true_type: TsBooleanLiteralType {
+                    literal: TRUE_KW@2302..2307 "true" [] [Whitespace(" ")],
+                },
+                colon_token: COLON@2307..2309 ":" [] [Whitespace(" ")],
+                false_type: TsBooleanLiteralType {
+                    literal: FALSE_KW@2309..2314 "false" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@2314..2315 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@2315..2321 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@2321..2324 "T4" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@2324..2326 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2326..2329 "F1" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@2329..2337 "extends" [] [Whitespace(" ")],
+                extends_type: TsFunctionType {
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@2337..2338 "(" [] [],
+                        items: JsParameterList [
+                            JsRestParameter {
+                                decorators: JsDecoratorList [],
+                                dotdotdot_token: DOT3@2338..2341 "..." [] [],
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@2341..2345 "args" [] [],
+                                },
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@2345..2347 ":" [] [Whitespace(" ")],
+                                    ty: TsParenthesizedType {
+                                        l_paren_token: L_PAREN@2347..2348 "(" [] [],
+                                        ty: TsParenthesizedType {
+                                            l_paren_token: L_PAREN@2348..2349 "(" [] [],
+                                            ty: TsInferType {
+                                                infer_token: INFER_KW@2349..2355 "infer" [] [Whitespace(" ")],
+                                                name: TsTypeParameterName {
+                                                    ident_token: IDENT@2355..2356 "T" [] [],
+                                                },
+                                                constraint: missing (optional),
+                                            },
+                                            r_paren_token: R_PAREN@2356..2357 ")" [] [],
+                                        },
+                                        r_paren_token: R_PAREN@2357..2358 ")" [] [],
+                                    },
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@2358..2360 ")" [] [Whitespace(" ")],
+                    },
+                    fat_arrow_token: FAT_ARROW@2360..2363 "=>" [] [Whitespace(" ")],
+                    return_type: TsVoidType {
+                        void_token: VOID_KW@2363..2368 "void" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@2368..2370 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2370..2372 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@2372..2374 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@2374..2379 "never" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@2379..2380 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@2380..2386 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@2386..2389 "T5" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@2389..2391 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2391..2394 "F1" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@2394..2402 "extends" [] [Whitespace(" ")],
+                extends_type: TsFunctionType {
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@2402..2403 "(" [] [],
+                        items: JsParameterList [
+                            JsFormalParameter {
+                                decorators: JsDecoratorList [],
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@2403..2407 "args" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@2407..2409 ":" [] [Whitespace(" ")],
+                                    ty: TsTupleType {
+                                        l_brack_token: L_BRACK@2409..2410 "[" [] [],
+                                        elements: TsTupleTypeElementList [
+                                            TsRestTupleTypeElement {
+                                                dotdotdot_token: DOT3@2410..2413 "..." [] [],
+                                                ty: TsParenthesizedType {
+                                                    l_paren_token: L_PAREN@2413..2414 "(" [] [],
+                                                    ty: TsParenthesizedType {
+                                                        l_paren_token: L_PAREN@2414..2415 "(" [] [],
+                                                        ty: TsInferType {
+                                                            infer_token: INFER_KW@2415..2421 "infer" [] [Whitespace(" ")],
+                                                            name: TsTypeParameterName {
+                                                                ident_token: IDENT@2421..2422 "T" [] [],
+                                                            },
+                                                            constraint: missing (optional),
+                                                        },
+                                                        r_paren_token: R_PAREN@2422..2423 ")" [] [],
+                                                    },
+                                                    r_paren_token: R_PAREN@2423..2424 ")" [] [],
+                                                },
+                                            },
+                                        ],
+                                        r_brack_token: R_BRACK@2424..2425 "]" [] [],
+                                    },
+                                },
+                                initializer: missing (optional),
+                            },
+                        ],
+                        r_paren_token: R_PAREN@2425..2427 ")" [] [Whitespace(" ")],
+                    },
+                    fat_arrow_token: FAT_ARROW@2427..2430 "=>" [] [Whitespace(" ")],
+                    return_type: TsVoidType {
+                        void_token: VOID_KW@2430..2435 "void" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@2435..2437 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2437..2439 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@2439..2441 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@2441..2446 "never" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@2446..2447 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@2447..2453 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@2453..2455 "T6" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@2455..2456 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@2456..2457 "T" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@2457..2459 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@2459..2461 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2461..2463 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@2463..2471 "extends" [] [Whitespace(" ")],
+                extends_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2471..2479 "IsNumber" [] [],
+                    },
+                    type_arguments: TsTypeArguments {
+                        l_angle_token: L_ANGLE@2479..2480 "<" [] [],
+                        ts_type_argument_list: TsTypeArgumentList [
+                            TsParenthesizedType {
+                                l_paren_token: L_PAREN@2480..2481 "(" [] [],
+                                ty: TsParenthesizedType {
+                                    l_paren_token: L_PAREN@2481..2482 "(" [] [],
+                                    ty: TsInferType {
+                                        infer_token: INFER_KW@2482..2488 "infer" [] [Whitespace(" ")],
+                                        name: TsTypeParameterName {
+                                            ident_token: IDENT@2488..2489 "N" [] [],
+                                        },
+                                        constraint: missing (optional),
+                                    },
+                                    r_paren_token: R_PAREN@2489..2490 ")" [] [],
+                                },
+                                r_paren_token: R_PAREN@2490..2491 ")" [] [],
+                            },
+                        ],
+                        r_angle_token: R_ANGLE@2491..2493 ">" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@2493..2495 "?" [] [Whitespace(" ")],
+                true_type: TsBooleanLiteralType {
+                    literal: TRUE_KW@2495..2500 "true" [] [Whitespace(" ")],
+                },
+                colon_token: COLON@2500..2502 ":" [] [Whitespace(" ")],
+                false_type: TsBooleanLiteralType {
+                    literal: FALSE_KW@2502..2507 "false" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@2507..2508 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@2508..2514 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@2514..2517 "T7" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@2517..2519 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2519..2522 "F1" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@2522..2530 "extends" [] [Whitespace(" ")],
+                extends_type: TsFunctionType {
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@2530..2531 "(" [] [],
+                        items: JsParameterList [
+                            JsRestParameter {
+                                decorators: JsDecoratorList [],
+                                dotdotdot_token: DOT3@2531..2534 "..." [] [],
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@2534..2538 "args" [] [],
+                                },
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@2538..2540 ":" [] [Whitespace(" ")],
+                                    ty: TsParenthesizedType {
+                                        l_paren_token: L_PAREN@2540..2541 "(" [] [],
+                                        ty: TsParenthesizedType {
+                                            l_paren_token: L_PAREN@2541..2542 "(" [] [],
+                                            ty: TsParenthesizedType {
+                                                l_paren_token: L_PAREN@2542..2543 "(" [] [],
+                                                ty: TsParenthesizedType {
+                                                    l_paren_token: L_PAREN@2543..2544 "(" [] [],
+                                                    ty: TsInferType {
+                                                        infer_token: INFER_KW@2544..2550 "infer" [] [Whitespace(" ")],
+                                                        name: TsTypeParameterName {
+                                                            ident_token: IDENT@2550..2551 "T" [] [],
+                                                        },
+                                                        constraint: missing (optional),
+                                                    },
+                                                    r_paren_token: R_PAREN@2551..2552 ")" [] [],
+                                                },
+                                                r_paren_token: R_PAREN@2552..2553 ")" [] [],
+                                            },
+                                            r_paren_token: R_PAREN@2553..2554 ")" [] [],
+                                        },
+                                        r_paren_token: R_PAREN@2554..2555 ")" [] [],
+                                    },
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@2555..2557 ")" [] [Whitespace(" ")],
+                    },
+                    fat_arrow_token: FAT_ARROW@2557..2560 "=>" [] [Whitespace(" ")],
+                    return_type: TsVoidType {
+                        void_token: VOID_KW@2560..2565 "void" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@2565..2567 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2567..2569 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@2569..2571 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@2571..2576 "never" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@2576..2577 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@2577..2583 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@2583..2586 "T8" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@2586..2588 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2588..2591 "F1" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@2591..2599 "extends" [] [Whitespace(" ")],
+                extends_type: TsFunctionType {
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@2599..2600 "(" [] [],
+                        items: JsParameterList [
+                            JsFormalParameter {
+                                decorators: JsDecoratorList [],
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@2600..2604 "args" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@2604..2606 ":" [] [Whitespace(" ")],
+                                    ty: TsTupleType {
+                                        l_brack_token: L_BRACK@2606..2607 "[" [] [],
+                                        elements: TsTupleTypeElementList [
+                                            TsRestTupleTypeElement {
+                                                dotdotdot_token: DOT3@2607..2610 "..." [] [],
+                                                ty: TsParenthesizedType {
+                                                    l_paren_token: L_PAREN@2610..2611 "(" [] [],
+                                                    ty: TsParenthesizedType {
+                                                        l_paren_token: L_PAREN@2611..2612 "(" [] [],
+                                                        ty: TsParenthesizedType {
+                                                            l_paren_token: L_PAREN@2612..2613 "(" [] [],
+                                                            ty: TsParenthesizedType {
+                                                                l_paren_token: L_PAREN@2613..2614 "(" [] [],
+                                                                ty: TsInferType {
+                                                                    infer_token: INFER_KW@2614..2620 "infer" [] [Whitespace(" ")],
+                                                                    name: TsTypeParameterName {
+                                                                        ident_token: IDENT@2620..2621 "T" [] [],
+                                                                    },
+                                                                    constraint: missing (optional),
+                                                                },
+                                                                r_paren_token: R_PAREN@2621..2622 ")" [] [],
+                                                            },
+                                                            r_paren_token: R_PAREN@2622..2623 ")" [] [],
+                                                        },
+                                                        r_paren_token: R_PAREN@2623..2624 ")" [] [],
+                                                    },
+                                                    r_paren_token: R_PAREN@2624..2625 ")" [] [],
+                                                },
+                                            },
+                                        ],
+                                        r_brack_token: R_BRACK@2625..2626 "]" [] [],
+                                    },
+                                },
+                                initializer: missing (optional),
+                            },
+                        ],
+                        r_paren_token: R_PAREN@2626..2628 ")" [] [Whitespace(" ")],
+                    },
+                    fat_arrow_token: FAT_ARROW@2628..2631 "=>" [] [Whitespace(" ")],
+                    return_type: TsVoidType {
+                        void_token: VOID_KW@2631..2636 "void" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@2636..2638 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2638..2640 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@2640..2642 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@2642..2647 "never" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@2647..2648 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@2648..2654 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@2654..2656 "T9" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@2656..2657 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@2657..2658 "T" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@2658..2660 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@2660..2662 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2662..2664 "T" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@2664..2672 "extends" [] [Whitespace(" ")],
+                extends_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2672..2680 "IsNumber" [] [],
+                    },
+                    type_arguments: TsTypeArguments {
+                        l_angle_token: L_ANGLE@2680..2681 "<" [] [],
+                        ts_type_argument_list: TsTypeArgumentList [
+                            TsParenthesizedType {
+                                l_paren_token: L_PAREN@2681..2682 "(" [] [],
+                                ty: TsParenthesizedType {
+                                    l_paren_token: L_PAREN@2682..2683 "(" [] [],
+                                    ty: TsParenthesizedType {
+                                        l_paren_token: L_PAREN@2683..2684 "(" [] [],
+                                        ty: TsParenthesizedType {
+                                            l_paren_token: L_PAREN@2684..2685 "(" [] [],
+                                            ty: TsInferType {
+                                                infer_token: INFER_KW@2685..2691 "infer" [] [Whitespace(" ")],
+                                                name: TsTypeParameterName {
+                                                    ident_token: IDENT@2691..2692 "N" [] [],
+                                                },
+                                                constraint: missing (optional),
+                                            },
+                                            r_paren_token: R_PAREN@2692..2693 ")" [] [],
+                                        },
+                                        r_paren_token: R_PAREN@2693..2694 ")" [] [],
+                                    },
+                                    r_paren_token: R_PAREN@2694..2695 ")" [] [],
+                                },
+                                r_paren_token: R_PAREN@2695..2696 ")" [] [],
+                            },
+                        ],
+                        r_angle_token: R_ANGLE@2696..2698 ">" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@2698..2700 "?" [] [Whitespace(" ")],
+                true_type: TsBooleanLiteralType {
+                    literal: TRUE_KW@2700..2705 "true" [] [Whitespace(" ")],
+                },
+                colon_token: COLON@2705..2707 ":" [] [Whitespace(" ")],
+                false_type: TsBooleanLiteralType {
+                    literal: FALSE_KW@2707..2712 "false" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@2712..2713 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@2713..2719 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@2719..2726 "Prepend" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@2726..2727 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@2727..2728 "E" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                    COMMA@2728..2730 "," [] [Whitespace(" ")],
+                    TsTypeParameter {
+                        modifiers: TsTypeParameterModifierList [],
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@2730..2732 "T" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@2732..2740 "extends" [] [Whitespace(" ")],
+                            ty: TsArrayType {
+                                element_type: TsAnyType {
+                                    any_token: ANY_KW@2740..2743 "any" [] [],
+                                },
+                                l_brack_token: L_BRACK@2743..2744 "[" [] [],
+                                r_brack_token: R_BRACK@2744..2745 "]" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@2745..2747 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@2747..2748 "=" [] [],
+            ty: TsConditionalType {
+                check_type: TsParenthesizedType {
+                    l_paren_token: L_PAREN@2748..2754 "(" [Newline("\n"), Whitespace("    ")] [],
+                    ty: TsFunctionType {
+                        type_parameters: missing (optional),
+                        parameters: JsParameters {
+                            l_paren_token: L_PAREN@2754..2755 "(" [] [],
+                            items: JsParameterList [
+                                JsFormalParameter {
+                                    decorators: JsDecoratorList [],
+                                    binding: JsIdentifierBinding {
+                                        name_token: IDENT@2755..2759 "head" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    type_annotation: TsTypeAnnotation {
+                                        colon_token: COLON@2759..2761 ":" [] [Whitespace(" ")],
+                                        ty: TsReferenceType {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@2761..2762 "E" [] [],
+                                            },
+                                            type_arguments: missing (optional),
+                                        },
+                                    },
+                                    initializer: missing (optional),
+                                },
+                                COMMA@2762..2764 "," [] [Whitespace(" ")],
+                                JsRestParameter {
+                                    decorators: JsDecoratorList [],
+                                    dotdotdot_token: DOT3@2764..2767 "..." [] [],
+                                    binding: JsIdentifierBinding {
+                                        name_token: IDENT@2767..2771 "args" [] [],
+                                    },
+                                    type_annotation: TsTypeAnnotation {
+                                        colon_token: COLON@2771..2773 ":" [] [Whitespace(" ")],
+                                        ty: TsReferenceType {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@2773..2774 "T" [] [],
+                                            },
+                                            type_arguments: missing (optional),
+                                        },
+                                    },
+                                },
+                            ],
+                            r_paren_token: R_PAREN@2774..2776 ")" [] [Whitespace(" ")],
+                        },
+                        fat_arrow_token: FAT_ARROW@2776..2779 "=>" [] [Whitespace(" ")],
+                        return_type: TsAnyType {
+                            any_token: ANY_KW@2779..2782 "any" [] [],
+                        },
+                    },
+                    r_paren_token: R_PAREN@2782..2784 ")" [] [Whitespace(" ")],
+                },
+                extends_token: EXTENDS_KW@2784..2792 "extends" [] [Whitespace(" ")],
+                extends_type: TsParenthesizedType {
+                    l_paren_token: L_PAREN@2792..2793 "(" [] [],
+                    ty: TsFunctionType {
+                        type_parameters: missing (optional),
+                        parameters: JsParameters {
+                            l_paren_token: L_PAREN@2793..2794 "(" [] [],
+                            items: JsParameterList [
+                                JsRestParameter {
+                                    decorators: JsDecoratorList [],
+                                    dotdotdot_token: DOT3@2794..2797 "..." [] [],
+                                    binding: JsIdentifierBinding {
+                                        name_token: IDENT@2797..2801 "args" [] [],
+                                    },
+                                    type_annotation: TsTypeAnnotation {
+                                        colon_token: COLON@2801..2803 ":" [] [Whitespace(" ")],
+                                        ty: TsInferType {
+                                            infer_token: INFER_KW@2803..2809 "infer" [] [Whitespace(" ")],
+                                            name: TsTypeParameterName {
+                                                ident_token: IDENT@2809..2810 "U" [] [],
+                                            },
+                                            constraint: missing (optional),
+                                        },
+                                    },
+                                },
+                            ],
+                            r_paren_token: R_PAREN@2810..2812 ")" [] [Whitespace(" ")],
+                        },
+                        fat_arrow_token: FAT_ARROW@2812..2815 "=>" [] [Whitespace(" ")],
+                        return_type: TsAnyType {
+                            any_token: ANY_KW@2815..2818 "any" [] [],
+                        },
+                    },
+                    r_paren_token: R_PAREN@2818..2819 ")" [] [],
+                },
+                question_mark_token: QUESTION@2819..2826 "?" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2826..2827 "U" [] [],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@2827..2834 ":" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                false_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@2834..2835 "T" [] [],
+                    },
+                    type_arguments: missing (optional),
+                },
+            },
+            semicolon_token: SEMICOLON@2835..2836 ";" [] [],
+        },
+    ],
+    eof_token: EOF@2836..2837 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..2837
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..2836
+    0: TS_TYPE_ALIAS_DECLARATION@0..64
+      0: TYPE_KW@0..5 "type" [] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@5..9
+        0: IDENT@5..9 "Args" [] []
+      2: TS_TYPE_PARAMETERS@9..13
+        0: L_ANGLE@9..10 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@10..11
+          0: TS_TYPE_PARAMETER@10..11
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@10..10
+            1: TS_TYPE_PARAMETER_NAME@10..11
+              0: IDENT@10..11 "F" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@11..13 ">" [] [Whitespace(" ")]
+      3: EQ@13..15 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@15..63
+        0: TS_REFERENCE_TYPE@15..17
+          0: JS_REFERENCE_IDENTIFIER@15..17
+            0: IDENT@15..17 "F" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@17..25 "extends" [] [Whitespace(" ")]
+        2: TS_FUNCTION_TYPE@25..52
+          0: (empty)
+          1: JS_PARAMETERS@25..44
+            0: L_PAREN@25..26 "(" [] []
+            1: JS_PARAMETER_LIST@26..42
+              0: JS_REST_PARAMETER@26..42
+                0: JS_DECORATOR_LIST@26..26
+                1: DOT3@26..29 "..." [] []
+                2: JS_IDENTIFIER_BINDING@29..33
+                  0: IDENT@29..33 "args" [] []
+                3: TS_TYPE_ANNOTATION@33..42
+                  0: COLON@33..35 ":" [] [Whitespace(" ")]
+                  1: TS_INFER_TYPE@35..42
+                    0: INFER_KW@35..41 "infer" [] [Whitespace(" ")]
+                    1: TS_TYPE_PARAMETER_NAME@41..42
+                      0: IDENT@41..42 "A" [] []
+                    2: (empty)
+            2: R_PAREN@42..44 ")" [] [Whitespace(" ")]
+          2: FAT_ARROW@44..47 "=>" [] [Whitespace(" ")]
+          3: TS_VOID_TYPE@47..52
+            0: VOID_KW@47..52 "void" [] [Whitespace(" ")]
+        3: QUESTION@52..54 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@54..56
+          0: JS_REFERENCE_IDENTIFIER@54..56
+            0: IDENT@54..56 "A" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@56..58 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@58..63
+          0: NEVER_KW@58..63 "never" [] []
+      5: SEMICOLON@63..64 ";" [] []
+    1: TS_TYPE_ALIAS_DECLARATION@64..121
+      0: TYPE_KW@64..70 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@70..72
+        0: IDENT@70..72 "A" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@72..74 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@74..121
+        0: TS_REFERENCE_TYPE@74..76
+          0: JS_REFERENCE_IDENTIFIER@74..76
+            0: IDENT@74..76 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@76..84 "extends" [] [Whitespace(" ")]
+        2: TS_IMPORT_TYPE@84..110
+          0: (empty)
+          1: IMPORT_KW@84..90 "import" [] []
+          2: L_PAREN@90..91 "(" [] []
+          3: JS_STRING_LITERAL@91..97 "\"test\"" [] []
+          4: R_PAREN@97..98 ")" [] []
+          5: TS_IMPORT_TYPE_QUALIFIER@98..100
+            0: DOT@98..99 "." [] []
+            1: JS_REFERENCE_IDENTIFIER@99..100
+              0: IDENT@99..100 "C" [] []
+          6: TS_TYPE_ARGUMENTS@100..110
+            0: L_ANGLE@100..101 "<" [] []
+            1: TS_TYPE_ARGUMENT_LIST@101..108
+              0: TS_INFER_TYPE@101..108
+                0: INFER_KW@101..107 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@107..108
+                  0: IDENT@107..108 "P" [] []
+                2: (empty)
+            2: R_ANGLE@108..110 ">" [] [Whitespace(" ")]
+        3: QUESTION@110..112 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@112..114
+          0: JS_REFERENCE_IDENTIFIER@112..114
+            0: IDENT@112..114 "P" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@114..116 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@116..121
+          0: NEVER_KW@116..121 "never" [] []
+      5: (empty)
+    2: TS_TYPE_ALIAS_DECLARATION@121..174
+      0: TYPE_KW@121..127 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@127..129
+        0: IDENT@127..129 "A" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@129..131 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@131..174
+        0: TS_REFERENCE_TYPE@131..133
+          0: JS_REFERENCE_IDENTIFIER@131..133
+            0: IDENT@131..133 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@133..141 "extends" [] [Whitespace(" ")]
+        2: TS_TYPEOF_TYPE@141..163
+          0: TYPEOF_KW@141..148 "typeof" [] [Whitespace(" ")]
+          1: JS_REFERENCE_IDENTIFIER@148..153
+            0: IDENT@148..153 "Array" [] []
+          2: TS_TYPE_ARGUMENTS@153..163
+            0: L_ANGLE@153..154 "<" [] []
+            1: TS_TYPE_ARGUMENT_LIST@154..161
+              0: TS_INFER_TYPE@154..161
+                0: INFER_KW@154..160 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@160..161
+                  0: IDENT@160..161 "P" [] []
+                2: (empty)
+            2: R_ANGLE@161..163 ">" [] [Whitespace(" ")]
+        3: QUESTION@163..165 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@165..167
+          0: JS_REFERENCE_IDENTIFIER@165..167
+            0: IDENT@165..167 "P" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@167..169 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@169..174
+          0: NEVER_KW@169..174 "never" [] []
+      5: (empty)
+    3: TS_TYPE_ALIAS_DECLARATION@174..233
+      0: TYPE_KW@174..180 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@180..182
+        0: IDENT@180..182 "A" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@182..184 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@184..233
+        0: TS_REFERENCE_TYPE@184..186
+          0: JS_REFERENCE_IDENTIFIER@184..186
+            0: IDENT@184..186 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@186..194 "extends" [] [Whitespace(" ")]
+        2: TS_OBJECT_TYPE@194..222
+          0: L_CURLY@194..196 "{" [] [Whitespace(" ")]
+          1: TS_TYPE_MEMBER_LIST@196..220
+            0: TS_METHOD_SIGNATURE_TYPE_MEMBER@196..220
+              0: JS_LITERAL_MEMBER_NAME@196..199
+                0: IDENT@196..199 "set" [] []
+              1: (empty)
+              2: (empty)
+              3: JS_PARAMETERS@199..211
+                0: L_PAREN@199..200 "(" [] []
+                1: JS_PARAMETER_LIST@200..210
+                  0: JS_FORMAL_PARAMETER@200..210
+                    0: JS_DECORATOR_LIST@200..200
+                    1: JS_IDENTIFIER_BINDING@200..201
+                      0: IDENT@200..201 "a" [] []
+                    2: (empty)
+                    3: TS_TYPE_ANNOTATION@201..210
+                      0: COLON@201..203 ":" [] [Whitespace(" ")]
+                      1: TS_INFER_TYPE@203..210
+                        0: INFER_KW@203..209 "infer" [] [Whitespace(" ")]
+                        1: TS_TYPE_PARAMETER_NAME@209..210
+                          0: IDENT@209..210 "P" [] []
+                        2: (empty)
+                    4: (empty)
+                2: R_PAREN@210..211 ")" [] []
+              4: TS_RETURN_TYPE_ANNOTATION@211..220
+                0: COLON@211..213 ":" [] [Whitespace(" ")]
+                1: TS_NUMBER_TYPE@213..220
+                  0: NUMBER_KW@213..220 "number" [] [Whitespace(" ")]
+              5: (empty)
+          2: R_CURLY@220..222 "}" [] [Whitespace(" ")]
+        3: QUESTION@222..224 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@224..226
+          0: JS_REFERENCE_IDENTIFIER@224..226
+            0: IDENT@224..226 "P" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@226..228 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@228..233
+          0: NEVER_KW@228..233 "never" [] []
+      5: (empty)
+    4: TS_TYPE_ALIAS_DECLARATION@233..283
+      0: TYPE_KW@233..239 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@239..241
+        0: IDENT@239..241 "A" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@241..243 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@243..283
+        0: TS_REFERENCE_TYPE@243..245
+          0: JS_REFERENCE_IDENTIFIER@243..245
+            0: IDENT@243..245 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@245..253 "extends" [] [Whitespace(" ")]
+        2: TS_OBJECT_TYPE@253..272
+          0: L_CURLY@253..255 "{" [] [Whitespace(" ")]
+          1: TS_TYPE_MEMBER_LIST@255..270
+            0: TS_METHOD_SIGNATURE_TYPE_MEMBER@255..270
+              0: JS_LITERAL_MEMBER_NAME@255..258
+                0: IDENT@255..258 "get" [] []
+              1: (empty)
+              2: (empty)
+              3: JS_PARAMETERS@258..260
+                0: L_PAREN@258..259 "(" [] []
+                1: JS_PARAMETER_LIST@259..259
+                2: R_PAREN@259..260 ")" [] []
+              4: TS_RETURN_TYPE_ANNOTATION@260..270
+                0: COLON@260..262 ":" [] [Whitespace(" ")]
+                1: TS_INFER_TYPE@262..270
+                  0: INFER_KW@262..268 "infer" [] [Whitespace(" ")]
+                  1: TS_TYPE_PARAMETER_NAME@268..270
+                    0: IDENT@268..270 "P" [] [Whitespace(" ")]
+                  2: (empty)
+              5: (empty)
+          2: R_CURLY@270..272 "}" [] [Whitespace(" ")]
+        3: QUESTION@272..274 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@274..276
+          0: JS_REFERENCE_IDENTIFIER@274..276
+            0: IDENT@274..276 "P" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@276..278 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@278..283
+          0: NEVER_KW@278..283 "never" [] []
+      5: (empty)
+    5: TS_TYPE_ALIAS_DECLARATION@283..348
+      0: TYPE_KW@283..289 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@289..291
+        0: IDENT@289..291 "A" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@291..293 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@293..348
+        0: TS_REFERENCE_TYPE@293..295
+          0: JS_REFERENCE_IDENTIFIER@293..295
+            0: IDENT@293..295 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@295..303 "extends" [] [Whitespace(" ")]
+        2: TS_OBJECT_TYPE@303..337
+          0: L_CURLY@303..305 "{" [] [Whitespace(" ")]
+          1: TS_TYPE_MEMBER_LIST@305..335
+            0: TS_METHOD_SIGNATURE_TYPE_MEMBER@305..335
+              0: JS_LITERAL_MEMBER_NAME@305..311
+                0: IDENT@305..311 "method" [] []
+              1: (empty)
+              2: (empty)
+              3: JS_PARAMETERS@311..326
+                0: L_PAREN@311..312 "(" [] []
+                1: JS_PARAMETER_LIST@312..325
+                  0: TS_THIS_PARAMETER@312..325
+                    0: THIS_KW@312..316 "this" [] []
+                    1: TS_TYPE_ANNOTATION@316..325
+                      0: COLON@316..318 ":" [] [Whitespace(" ")]
+                      1: TS_INFER_TYPE@318..325
+                        0: INFER_KW@318..324 "infer" [] [Whitespace(" ")]
+                        1: TS_TYPE_PARAMETER_NAME@324..325
+                          0: IDENT@324..325 "P" [] []
+                        2: (empty)
+                2: R_PAREN@325..326 ")" [] []
+              4: TS_RETURN_TYPE_ANNOTATION@326..335
+                0: COLON@326..328 ":" [] [Whitespace(" ")]
+                1: TS_NUMBER_TYPE@328..335
+                  0: NUMBER_KW@328..335 "number" [] [Whitespace(" ")]
+              5: (empty)
+          2: R_CURLY@335..337 "}" [] [Whitespace(" ")]
+        3: QUESTION@337..339 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@339..341
+          0: JS_REFERENCE_IDENTIFIER@339..341
+            0: IDENT@339..341 "P" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@341..343 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@343..348
+          0: NEVER_KW@343..348 "never" [] []
+      5: (empty)
+    6: TS_TYPE_ALIAS_DECLARATION@348..401
+      0: TYPE_KW@348..354 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@354..360
+        0: IDENT@354..360 "valid9" [] []
+      2: TS_TYPE_PARAMETERS@360..364
+        0: L_ANGLE@360..361 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@361..362
+          0: TS_TYPE_PARAMETER@361..362
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@361..361
+            1: TS_TYPE_PARAMETER_NAME@361..362
+              0: IDENT@361..362 "T" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@362..364 ">" [] [Whitespace(" ")]
+      3: EQ@364..366 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@366..400
+        0: TS_REFERENCE_TYPE@366..368
+          0: JS_REFERENCE_IDENTIFIER@366..368
+            0: IDENT@366..368 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@368..376 "extends" [] [Whitespace(" ")]
+        2: TS_REFERENCE_TYPE@376..391
+          0: JS_REFERENCE_IDENTIFIER@376..381
+            0: IDENT@376..381 "Array" [] []
+          1: TS_TYPE_ARGUMENTS@381..391
+            0: L_ANGLE@381..382 "<" [] []
+            1: TS_TYPE_ARGUMENT_LIST@382..389
+              0: TS_INFER_TYPE@382..389
+                0: INFER_KW@382..388 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@388..389
+                  0: IDENT@388..389 "R" [] []
+                2: (empty)
+            2: R_ANGLE@389..391 ">" [] [Whitespace(" ")]
+        3: QUESTION@391..393 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@393..395
+          0: JS_REFERENCE_IDENTIFIER@393..395
+            0: IDENT@393..395 "R" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@395..397 ":" [] [Whitespace(" ")]
+        6: TS_ANY_TYPE@397..400
+          0: ANY_KW@397..400 "any" [] []
+      5: SEMICOLON@400..401 ";" [] []
+    7: TS_TYPE_ALIAS_DECLARATION@401..472
+      0: TYPE_KW@401..407 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@407..429
+        0: IDENT@407..429 "ContentBetweenBrackets" [] []
+      2: TS_TYPE_PARAMETERS@429..433
+        0: L_ANGLE@429..430 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@430..431
+          0: TS_TYPE_PARAMETER@430..431
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@430..430
+            1: TS_TYPE_PARAMETER_NAME@430..431
+              0: IDENT@430..431 "S" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@431..433 ">" [] [Whitespace(" ")]
+      3: EQ@433..435 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@435..471
+        0: TS_REFERENCE_TYPE@435..437
+          0: JS_REFERENCE_IDENTIFIER@435..437
+            0: IDENT@435..437 "S" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@437..445 "extends" [] [Whitespace(" ")]
+        2: TS_TEMPLATE_LITERAL_TYPE@445..460
+          0: BACKTICK@445..446 "`" [] []
+          1: TS_TEMPLATE_ELEMENT_LIST@446..458
+            0: TS_TEMPLATE_CHUNK_ELEMENT@446..447
+              0: TEMPLATE_CHUNK@446..447 "[" [] []
+            1: TS_TEMPLATE_ELEMENT@447..457
+              0: DOLLAR_CURLY@447..449 "${" [] []
+              1: TS_INFER_TYPE@449..456
+                0: INFER_KW@449..455 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@455..456
+                  0: IDENT@455..456 "T" [] []
+                2: (empty)
+              2: R_CURLY@456..457 "}" [] []
+            2: TS_TEMPLATE_CHUNK_ELEMENT@457..458
+              0: TEMPLATE_CHUNK@457..458 "]" [] []
+          2: BACKTICK@458..460 "`" [] [Whitespace(" ")]
+        3: QUESTION@460..462 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@462..464
+          0: JS_REFERENCE_IDENTIFIER@462..464
+            0: IDENT@462..464 "T" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@464..466 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@466..471
+          0: NEVER_KW@466..471 "never" [] []
+      5: SEMICOLON@471..472 ";" [] []
+    8: TS_TYPE_ALIAS_DECLARATION@472..597
+      0: TYPE_KW@472..478 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@478..491
+        0: IDENT@478..491 "WithSelectors" [] []
+      2: TS_TYPE_PARAMETERS@491..495
+        0: L_ANGLE@491..492 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@492..493
+          0: TS_TYPE_PARAMETER@492..493
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@492..492
+            1: TS_TYPE_PARAMETER_NAME@492..493
+              0: IDENT@492..493 "S" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@493..495 ">" [] [Whitespace(" ")]
+      3: EQ@495..497 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@497..596
+        0: TS_REFERENCE_TYPE@497..499
+          0: JS_REFERENCE_IDENTIFIER@497..499
+            0: IDENT@497..499 "S" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@499..507 "extends" [] [Whitespace(" ")]
+        2: TS_OBJECT_TYPE@507..534
+          0: L_CURLY@507..509 "{" [] [Whitespace(" ")]
+          1: TS_TYPE_MEMBER_LIST@509..533
+            0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@509..533
+              0: (empty)
+              1: JS_LITERAL_MEMBER_NAME@509..517
+                0: IDENT@509..517 "getState" [] []
+              2: (empty)
+              3: TS_TYPE_ANNOTATION@517..533
+                0: COLON@517..519 ":" [] [Whitespace(" ")]
+                1: TS_FUNCTION_TYPE@519..533
+                  0: (empty)
+                  1: JS_PARAMETERS@519..522
+                    0: L_PAREN@519..520 "(" [] []
+                    1: JS_PARAMETER_LIST@520..520
+                    2: R_PAREN@520..522 ")" [] [Whitespace(" ")]
+                  2: FAT_ARROW@522..525 "=>" [] [Whitespace(" ")]
+                  3: TS_INFER_TYPE@525..533
+                    0: INFER_KW@525..531 "infer" [] [Whitespace(" ")]
+                    1: TS_TYPE_PARAMETER_NAME@531..533
+                      0: IDENT@531..533 "T" [] [Whitespace(" ")]
+                    2: (empty)
+              4: (empty)
+          2: R_CURLY@533..534 "}" [] []
+        3: QUESTION@534..541 "?" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+        4: TS_INTERSECTION_TYPE@541..584
+          0: (empty)
+          1: TS_INTERSECTION_TYPE_ELEMENT_LIST@541..584
+            0: TS_REFERENCE_TYPE@541..543
+              0: JS_REFERENCE_IDENTIFIER@541..543
+                0: IDENT@541..543 "S" [] [Whitespace(" ")]
+              1: (empty)
+            1: AMP@543..545 "&" [] [Whitespace(" ")]
+            2: TS_OBJECT_TYPE@545..584
+              0: L_CURLY@545..547 "{" [] [Whitespace(" ")]
+              1: TS_TYPE_MEMBER_LIST@547..583
+                0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@547..583
+                  0: (empty)
+                  1: JS_LITERAL_MEMBER_NAME@547..550
+                    0: IDENT@547..550 "use" [] []
+                  2: (empty)
+                  3: TS_TYPE_ANNOTATION@550..583
+                    0: COLON@550..552 ":" [] [Whitespace(" ")]
+                    1: TS_MAPPED_TYPE@552..583
+                      0: L_CURLY@552..554 "{" [] [Whitespace(" ")]
+                      1: (empty)
+                      2: L_BRACK@554..555 "[" [] []
+                      3: TS_TYPE_PARAMETER_NAME@555..557
+                        0: IDENT@555..557 "K" [] [Whitespace(" ")]
+                      4: IN_KW@557..560 "in" [] [Whitespace(" ")]
+                      5: TS_TYPE_OPERATOR_TYPE@560..567
+                        0: KEYOF_KW@560..566 "keyof" [] [Whitespace(" ")]
+                        1: TS_REFERENCE_TYPE@566..567
+                          0: JS_REFERENCE_IDENTIFIER@566..567
+                            0: IDENT@566..567 "T" [] []
+                          1: (empty)
+                      6: (empty)
+                      7: R_BRACK@567..568 "]" [] []
+                      8: (empty)
+                      9: TS_TYPE_ANNOTATION@568..581
+                        0: COLON@568..570 ":" [] [Whitespace(" ")]
+                        1: TS_FUNCTION_TYPE@570..581
+                          0: (empty)
+                          1: JS_PARAMETERS@570..573
+                            0: L_PAREN@570..571 "(" [] []
+                            1: JS_PARAMETER_LIST@571..571
+                            2: R_PAREN@571..573 ")" [] [Whitespace(" ")]
+                          2: FAT_ARROW@573..576 "=>" [] [Whitespace(" ")]
+                          3: TS_INDEXED_ACCESS_TYPE@576..581
+                            0: TS_REFERENCE_TYPE@576..577
+                              0: JS_REFERENCE_IDENTIFIER@576..577
+                                0: IDENT@576..577 "T" [] []
+                              1: (empty)
+                            1: L_BRACK@577..578 "[" [] []
+                            2: TS_REFERENCE_TYPE@578..579
+                              0: JS_REFERENCE_IDENTIFIER@578..579
+                                0: IDENT@578..579 "K" [] []
+                              1: (empty)
+                            3: R_BRACK@579..581 "]" [] [Whitespace(" ")]
+                      10: (empty)
+                      11: R_CURLY@581..583 "}" [] [Whitespace(" ")]
+                  4: (empty)
+              2: R_CURLY@583..584 "}" [] []
+        5: COLON@584..591 ":" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@591..596
+          0: NEVER_KW@591..596 "never" [] []
+      5: SEMICOLON@596..597 ";" [] []
+    9: TS_TYPE_ALIAS_DECLARATION@597..697
+      0: TYPE_KW@597..603 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@603..605
+        0: IDENT@603..605 "A" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@605..607 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@607..697
+        0: TS_REFERENCE_TYPE@607..614
+          0: JS_REFERENCE_IDENTIFIER@607..614
+            0: IDENT@607..614 "MyType" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@614..622 "extends" [] [Whitespace(" ")]
+        2: TS_PARENTHESIZED_TYPE@622..673
+          0: L_PAREN@622..623 "(" [] []
+          1: TS_CONDITIONAL_TYPE@623..671
+            0: TS_REFERENCE_TYPE@623..633
+              0: JS_REFERENCE_IDENTIFIER@623..633
+                0: IDENT@623..633 "OtherType" [] [Whitespace(" ")]
+              1: (empty)
+            1: EXTENDS_KW@633..641 "extends" [] [Whitespace(" ")]
+            2: TS_INFER_TYPE@641..649
+              0: INFER_KW@641..647 "infer" [] [Whitespace(" ")]
+              1: TS_TYPE_PARAMETER_NAME@647..649
+                0: IDENT@647..649 "T" [] [Whitespace(" ")]
+              2: (empty)
+            3: QUESTION@649..651 "?" [] [Whitespace(" ")]
+            4: TS_INFER_TYPE@651..659
+              0: INFER_KW@651..657 "infer" [] [Whitespace(" ")]
+              1: TS_TYPE_PARAMETER_NAME@657..659
+                0: IDENT@657..659 "U" [] [Whitespace(" ")]
+              2: (empty)
+            5: COLON@659..661 ":" [] [Whitespace(" ")]
+            6: TS_REFERENCE_TYPE@661..671
+              0: JS_REFERENCE_IDENTIFIER@661..671
+                0: IDENT@661..671 "InnerFalse" [] []
+              1: (empty)
+          2: R_PAREN@671..673 ")" [] [Whitespace(" ")]
+        3: QUESTION@673..675 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@675..685
+          0: JS_REFERENCE_IDENTIFIER@675..685
+            0: IDENT@675..685 "OuterTrue" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@685..687 ":" [] [Whitespace(" ")]
+        6: TS_REFERENCE_TYPE@687..697
+          0: JS_REFERENCE_IDENTIFIER@687..697
+            0: IDENT@687..697 "OuterFalse" [] []
+          1: (empty)
+      5: (empty)
+    10: TS_TYPE_ALIAS_DECLARATION@697..947
+      0: TYPE_KW@697..703 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@703..707
+        0: IDENT@703..707 "Join" [] []
+      2: TS_TYPE_PARAMETERS@707..747
+        0: L_ANGLE@707..708 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@708..745
+          0: TS_TYPE_PARAMETER@708..727
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@708..708
+            1: TS_TYPE_PARAMETER_NAME@708..710
+              0: IDENT@708..710 "T" [] [Whitespace(" ")]
+            2: TS_TYPE_CONSTRAINT_CLAUSE@710..727
+              0: EXTENDS_KW@710..718 "extends" [] [Whitespace(" ")]
+              1: TS_ARRAY_TYPE@718..727
+                0: TS_UNKNOWN_TYPE@718..725
+                  0: UNKNOWN_KW@718..725 "unknown" [] []
+                1: L_BRACK@725..726 "[" [] []
+                2: R_BRACK@726..727 "]" [] []
+            3: (empty)
+          1: COMMA@727..729 "," [] [Whitespace(" ")]
+          2: TS_TYPE_PARAMETER@729..745
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@729..729
+            1: TS_TYPE_PARAMETER_NAME@729..731
+              0: IDENT@729..731 "D" [] [Whitespace(" ")]
+            2: TS_TYPE_CONSTRAINT_CLAUSE@731..745
+              0: EXTENDS_KW@731..739 "extends" [] [Whitespace(" ")]
+              1: TS_STRING_TYPE@739..745
+                0: STRING_KW@739..745 "string" [] []
+            3: (empty)
+        2: R_ANGLE@745..747 ">" [] [Whitespace(" ")]
+      3: EQ@747..748 "=" [] []
+      4: TS_CONDITIONAL_TYPE@748..946
+        0: TS_REFERENCE_TYPE@748..756
+          0: JS_REFERENCE_IDENTIFIER@748..756
+            0: IDENT@748..756 "T" [Newline("\n"), Whitespace("     ")] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@756..764 "extends" [] [Whitespace(" ")]
+        2: TS_TUPLE_TYPE@764..767
+          0: L_BRACK@764..765 "[" [] []
+          1: TS_TUPLE_TYPE_ELEMENT_LIST@765..765
+          2: R_BRACK@765..767 "]" [] [Whitespace(" ")]
+        3: QUESTION@767..769 "?" [] [Whitespace(" ")]
+        4: TS_STRING_LITERAL_TYPE@769..772
+          0: JS_STRING_LITERAL@769..772 "''" [] [Whitespace(" ")]
+        5: COLON@772..773 ":" [] []
+        6: TS_CONDITIONAL_TYPE@773..946
+          0: TS_REFERENCE_TYPE@773..781
+            0: JS_REFERENCE_IDENTIFIER@773..781
+              0: IDENT@773..781 "T" [Newline("\n"), Whitespace("     ")] [Whitespace(" ")]
+            1: (empty)
+          1: EXTENDS_KW@781..789 "extends" [] [Whitespace(" ")]
+          2: TS_TUPLE_TYPE@789..826
+            0: L_BRACK@789..790 "[" [] []
+            1: TS_TUPLE_TYPE_ELEMENT_LIST@790..824
+              0: TS_UNION_TYPE@790..824
+                0: (empty)
+                1: TS_UNION_TYPE_VARIANT_LIST@790..824
+                  0: TS_STRING_TYPE@790..797
+                    0: STRING_KW@790..797 "string" [] [Whitespace(" ")]
+                  1: PIPE@797..799 "|" [] [Whitespace(" ")]
+                  2: TS_NUMBER_TYPE@799..806
+                    0: NUMBER_KW@799..806 "number" [] [Whitespace(" ")]
+                  3: PIPE@806..808 "|" [] [Whitespace(" ")]
+                  4: TS_BOOLEAN_TYPE@808..816
+                    0: BOOLEAN_KW@808..816 "boolean" [] [Whitespace(" ")]
+                  5: PIPE@816..818 "|" [] [Whitespace(" ")]
+                  6: TS_BIGINT_TYPE@818..824
+                    0: BIGINT_KW@818..824 "bigint" [] []
+            2: R_BRACK@824..826 "]" [] [Whitespace(" ")]
+          3: QUESTION@826..828 "?" [] [Whitespace(" ")]
+          4: TS_TEMPLATE_LITERAL_TYPE@828..838
+            0: BACKTICK@828..829 "`" [] []
+            1: TS_TEMPLATE_ELEMENT_LIST@829..836
+              0: TS_TEMPLATE_ELEMENT@829..836
+                0: DOLLAR_CURLY@829..831 "${" [] []
+                1: TS_INDEXED_ACCESS_TYPE@831..835
+                  0: TS_REFERENCE_TYPE@831..832
+                    0: JS_REFERENCE_IDENTIFIER@831..832
+                      0: IDENT@831..832 "T" [] []
+                    1: (empty)
+                  1: L_BRACK@832..833 "[" [] []
+                  2: TS_NUMBER_LITERAL_TYPE@833..834
+                    0: (empty)
+                    1: JS_NUMBER_LITERAL@833..834 "0" [] []
+                  3: R_BRACK@834..835 "]" [] []
+                2: R_CURLY@835..836 "}" [] []
+            2: BACKTICK@836..838 "`" [] [Whitespace(" ")]
+          5: COLON@838..839 ":" [] []
+          6: TS_CONDITIONAL_TYPE@839..946
+            0: TS_REFERENCE_TYPE@839..847
+              0: JS_REFERENCE_IDENTIFIER@839..847
+                0: IDENT@839..847 "T" [Newline("\n"), Whitespace("     ")] [Whitespace(" ")]
+              1: (empty)
+            1: EXTENDS_KW@847..855 "extends" [] [Whitespace(" ")]
+            2: TS_TUPLE_TYPE@855..904
+              0: L_BRACK@855..856 "[" [] []
+              1: TS_TUPLE_TYPE_ELEMENT_LIST@856..902
+                0: TS_UNION_TYPE@856..890
+                  0: (empty)
+                  1: TS_UNION_TYPE_VARIANT_LIST@856..890
+                    0: TS_STRING_TYPE@856..863
+                      0: STRING_KW@856..863 "string" [] [Whitespace(" ")]
+                    1: PIPE@863..865 "|" [] [Whitespace(" ")]
+                    2: TS_NUMBER_TYPE@865..872
+                      0: NUMBER_KW@865..872 "number" [] [Whitespace(" ")]
+                    3: PIPE@872..874 "|" [] [Whitespace(" ")]
+                    4: TS_BOOLEAN_TYPE@874..882
+                      0: BOOLEAN_KW@874..882 "boolean" [] [Whitespace(" ")]
+                    5: PIPE@882..884 "|" [] [Whitespace(" ")]
+                    6: TS_BIGINT_TYPE@884..890
+                      0: BIGINT_KW@884..890 "bigint" [] []
+                1: COMMA@890..892 "," [] [Whitespace(" ")]
+                2: TS_REST_TUPLE_TYPE_ELEMENT@892..902
+                  0: DOT3@892..895 "..." [] []
+                  1: TS_INFER_TYPE@895..902
+                    0: INFER_KW@895..901 "infer" [] [Whitespace(" ")]
+                    1: TS_TYPE_PARAMETER_NAME@901..902
+                      0: IDENT@901..902 "U" [] []
+                    2: (empty)
+              2: R_BRACK@902..904 "]" [] [Whitespace(" ")]
+            3: QUESTION@904..906 "?" [] [Whitespace(" ")]
+            4: TS_TEMPLATE_LITERAL_TYPE@906..933
+              0: BACKTICK@906..907 "`" [] []
+              1: TS_TEMPLATE_ELEMENT_LIST@907..931
+                0: TS_TEMPLATE_ELEMENT@907..914
+                  0: DOLLAR_CURLY@907..909 "${" [] []
+                  1: TS_INDEXED_ACCESS_TYPE@909..913
+                    0: TS_REFERENCE_TYPE@909..910
+                      0: JS_REFERENCE_IDENTIFIER@909..910
+                        0: IDENT@909..910 "T" [] []
+                      1: (empty)
+                    1: L_BRACK@910..911 "[" [] []
+                    2: TS_NUMBER_LITERAL_TYPE@911..912
+                      0: (empty)
+                      1: JS_NUMBER_LITERAL@911..912 "0" [] []
+                    3: R_BRACK@912..913 "]" [] []
+                  2: R_CURLY@913..914 "}" [] []
+                1: TS_TEMPLATE_ELEMENT@914..918
+                  0: DOLLAR_CURLY@914..916 "${" [] []
+                  1: TS_REFERENCE_TYPE@916..917
+                    0: JS_REFERENCE_IDENTIFIER@916..917
+                      0: IDENT@916..917 "D" [] []
+                    1: (empty)
+                  2: R_CURLY@917..918 "}" [] []
+                2: TS_TEMPLATE_ELEMENT@918..931
+                  0: DOLLAR_CURLY@918..920 "${" [] []
+                  1: TS_REFERENCE_TYPE@920..930
+                    0: JS_REFERENCE_IDENTIFIER@920..924
+                      0: IDENT@920..924 "Join" [] []
+                    1: TS_TYPE_ARGUMENTS@924..930
+                      0: L_ANGLE@924..925 "<" [] []
+                      1: TS_TYPE_ARGUMENT_LIST@925..929
+                        0: TS_REFERENCE_TYPE@925..926
+                          0: JS_REFERENCE_IDENTIFIER@925..926
+                            0: IDENT@925..926 "U" [] []
+                          1: (empty)
+                        1: COMMA@926..928 "," [] [Whitespace(" ")]
+                        2: TS_REFERENCE_TYPE@928..929
+                          0: JS_REFERENCE_IDENTIFIER@928..929
+                            0: IDENT@928..929 "D" [] []
+                          1: (empty)
+                      2: R_ANGLE@929..930 ">" [] []
+                  2: R_CURLY@930..931 "}" [] []
+              2: BACKTICK@931..933 "`" [] [Whitespace(" ")]
+            5: COLON@933..934 ":" [] []
+            6: TS_STRING_TYPE@934..946
+              0: STRING_KW@934..946 "string" [Newline("\n"), Whitespace("     ")] []
+      5: SEMICOLON@946..947 ";" [] []
+    11: TS_TYPE_ALIAS_DECLARATION@947..1038
+      0: TYPE_KW@947..953 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@953..962
+        0: IDENT@953..962 "MatchPair" [] []
+      2: TS_TYPE_PARAMETERS@962..981
+        0: L_ANGLE@962..963 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@963..979
+          0: TS_TYPE_PARAMETER@963..979
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@963..963
+            1: TS_TYPE_PARAMETER_NAME@963..965
+              0: IDENT@963..965 "S" [] [Whitespace(" ")]
+            2: TS_TYPE_CONSTRAINT_CLAUSE@965..979
+              0: EXTENDS_KW@965..973 "extends" [] [Whitespace(" ")]
+              1: TS_STRING_TYPE@973..979
+                0: STRING_KW@973..979 "string" [] []
+            3: (empty)
+        2: R_ANGLE@979..981 ">" [] [Whitespace(" ")]
+      3: EQ@981..983 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@983..1037
+        0: TS_REFERENCE_TYPE@983..985
+          0: JS_REFERENCE_IDENTIFIER@983..985
+            0: IDENT@983..985 "S" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@985..993 "extends" [] [Whitespace(" ")]
+        2: TS_TEMPLATE_LITERAL_TYPE@993..1019
+          0: BACKTICK@993..994 "`" [] []
+          1: TS_TEMPLATE_ELEMENT_LIST@994..1017
+            0: TS_TEMPLATE_CHUNK_ELEMENT@994..995
+              0: TEMPLATE_CHUNK@994..995 "[" [] []
+            1: TS_TEMPLATE_ELEMENT@995..1005
+              0: DOLLAR_CURLY@995..997 "${" [] []
+              1: TS_INFER_TYPE@997..1004
+                0: INFER_KW@997..1003 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@1003..1004
+                  0: IDENT@1003..1004 "A" [] []
+                2: (empty)
+              2: R_CURLY@1004..1005 "}" [] []
+            2: TS_TEMPLATE_CHUNK_ELEMENT@1005..1006
+              0: TEMPLATE_CHUNK@1005..1006 "," [] []
+            3: TS_TEMPLATE_ELEMENT@1006..1016
+              0: DOLLAR_CURLY@1006..1008 "${" [] []
+              1: TS_INFER_TYPE@1008..1015
+                0: INFER_KW@1008..1014 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@1014..1015
+                  0: IDENT@1014..1015 "B" [] []
+                2: (empty)
+              2: R_CURLY@1015..1016 "}" [] []
+            4: TS_TEMPLATE_CHUNK_ELEMENT@1016..1017
+              0: TEMPLATE_CHUNK@1016..1017 "]" [] []
+          2: BACKTICK@1017..1019 "`" [] [Whitespace(" ")]
+        3: QUESTION@1019..1021 "?" [] [Whitespace(" ")]
+        4: TS_TUPLE_TYPE@1021..1028
+          0: L_BRACK@1021..1022 "[" [] []
+          1: TS_TUPLE_TYPE_ELEMENT_LIST@1022..1026
+            0: TS_REFERENCE_TYPE@1022..1023
+              0: JS_REFERENCE_IDENTIFIER@1022..1023
+                0: IDENT@1022..1023 "A" [] []
+              1: (empty)
+            1: COMMA@1023..1025 "," [] [Whitespace(" ")]
+            2: TS_REFERENCE_TYPE@1025..1026
+              0: JS_REFERENCE_IDENTIFIER@1025..1026
+                0: IDENT@1025..1026 "B" [] []
+              1: (empty)
+          2: R_BRACK@1026..1028 "]" [] [Whitespace(" ")]
+        5: COLON@1028..1030 ":" [] [Whitespace(" ")]
+        6: TS_UNKNOWN_TYPE@1030..1037
+          0: UNKNOWN_KW@1030..1037 "unknown" [] []
+      5: SEMICOLON@1037..1038 ";" [] []
+    12: TS_TYPE_ALIAS_DECLARATION@1038..1151
+      0: TYPE_KW@1038..1044 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@1044..1059
+        0: IDENT@1044..1059 "FirstTwoAndRest" [] []
+      2: TS_TYPE_PARAMETERS@1059..1078
+        0: L_ANGLE@1059..1060 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@1060..1076
+          0: TS_TYPE_PARAMETER@1060..1076
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@1060..1060
+            1: TS_TYPE_PARAMETER_NAME@1060..1062
+              0: IDENT@1060..1062 "S" [] [Whitespace(" ")]
+            2: TS_TYPE_CONSTRAINT_CLAUSE@1062..1076
+              0: EXTENDS_KW@1062..1070 "extends" [] [Whitespace(" ")]
+              1: TS_STRING_TYPE@1070..1076
+                0: STRING_KW@1070..1076 "string" [] []
+            3: (empty)
+        2: R_ANGLE@1076..1078 ">" [] [Whitespace(" ")]
+      3: EQ@1078..1080 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@1080..1150
+        0: TS_REFERENCE_TYPE@1080..1082
+          0: JS_REFERENCE_IDENTIFIER@1080..1082
+            0: IDENT@1080..1082 "S" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@1082..1090 "extends" [] [Whitespace(" ")]
+        2: TS_TEMPLATE_LITERAL_TYPE@1090..1123
+          0: BACKTICK@1090..1091 "`" [] []
+          1: TS_TEMPLATE_ELEMENT_LIST@1091..1121
+            0: TS_TEMPLATE_ELEMENT@1091..1101
+              0: DOLLAR_CURLY@1091..1093 "${" [] []
+              1: TS_INFER_TYPE@1093..1100
+                0: INFER_KW@1093..1099 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@1099..1100
+                  0: IDENT@1099..1100 "A" [] []
+                2: (empty)
+              2: R_CURLY@1100..1101 "}" [] []
+            1: TS_TEMPLATE_ELEMENT@1101..1111
+              0: DOLLAR_CURLY@1101..1103 "${" [] []
+              1: TS_INFER_TYPE@1103..1110
+                0: INFER_KW@1103..1109 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@1109..1110
+                  0: IDENT@1109..1110 "B" [] []
+                2: (empty)
+              2: R_CURLY@1110..1111 "}" [] []
+            2: TS_TEMPLATE_ELEMENT@1111..1121
+              0: DOLLAR_CURLY@1111..1113 "${" [] []
+              1: TS_INFER_TYPE@1113..1120
+                0: INFER_KW@1113..1119 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@1119..1120
+                  0: IDENT@1119..1120 "R" [] []
+                2: (empty)
+              2: R_CURLY@1120..1121 "}" [] []
+          2: BACKTICK@1121..1123 "`" [] [Whitespace(" ")]
+        3: QUESTION@1123..1125 "?" [] [Whitespace(" ")]
+        4: TS_TUPLE_TYPE@1125..1141
+          0: L_BRACK@1125..1126 "[" [] []
+          1: TS_TUPLE_TYPE_ELEMENT_LIST@1126..1139
+            0: TS_TEMPLATE_LITERAL_TYPE@1126..1136
+              0: BACKTICK@1126..1127 "`" [] []
+              1: TS_TEMPLATE_ELEMENT_LIST@1127..1135
+                0: TS_TEMPLATE_ELEMENT@1127..1131
+                  0: DOLLAR_CURLY@1127..1129 "${" [] []
+                  1: TS_REFERENCE_TYPE@1129..1130
+                    0: JS_REFERENCE_IDENTIFIER@1129..1130
+                      0: IDENT@1129..1130 "A" [] []
+                    1: (empty)
+                  2: R_CURLY@1130..1131 "}" [] []
+                1: TS_TEMPLATE_ELEMENT@1131..1135
+                  0: DOLLAR_CURLY@1131..1133 "${" [] []
+                  1: TS_REFERENCE_TYPE@1133..1134
+                    0: JS_REFERENCE_IDENTIFIER@1133..1134
+                      0: IDENT@1133..1134 "B" [] []
+                    1: (empty)
+                  2: R_CURLY@1134..1135 "}" [] []
+              2: BACKTICK@1135..1136 "`" [] []
+            1: COMMA@1136..1138 "," [] [Whitespace(" ")]
+            2: TS_REFERENCE_TYPE@1138..1139
+              0: JS_REFERENCE_IDENTIFIER@1138..1139
+                0: IDENT@1138..1139 "R" [] []
+              1: (empty)
+          2: R_BRACK@1139..1141 "]" [] [Whitespace(" ")]
+        5: COLON@1141..1143 ":" [] [Whitespace(" ")]
+        6: TS_UNKNOWN_TYPE@1143..1150
+          0: UNKNOWN_KW@1143..1150 "unknown" [] []
+      5: SEMICOLON@1150..1151 ";" [] []
+    13: TS_TYPE_ALIAS_DECLARATION@1151..1230
+      0: TYPE_KW@1151..1157 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@1157..1161
+        0: IDENT@1157..1161 "Trim" [] []
+      2: TS_TYPE_PARAMETERS@1161..1180
+        0: L_ANGLE@1161..1162 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@1162..1178
+          0: TS_TYPE_PARAMETER@1162..1178
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@1162..1162
+            1: TS_TYPE_PARAMETER_NAME@1162..1164
+              0: IDENT@1162..1164 "S" [] [Whitespace(" ")]
+            2: TS_TYPE_CONSTRAINT_CLAUSE@1164..1178
+              0: EXTENDS_KW@1164..1172 "extends" [] [Whitespace(" ")]
+              1: TS_STRING_TYPE@1172..1178
+                0: STRING_KW@1172..1178 "string" [] []
+            3: (empty)
+        2: R_ANGLE@1178..1180 ">" [] [Whitespace(" ")]
+      3: EQ@1180..1181 "=" [] []
+      4: TS_CONDITIONAL_TYPE@1181..1229
+        0: TS_REFERENCE_TYPE@1181..1189
+          0: JS_REFERENCE_IDENTIFIER@1181..1189
+            0: IDENT@1181..1189 "S" [Newline("\n"), Whitespace("     ")] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@1189..1197 "extends" [] [Whitespace(" ")]
+        2: TS_TEMPLATE_LITERAL_TYPE@1197..1211
+          0: BACKTICK@1197..1198 "`" [] []
+          1: TS_TEMPLATE_ELEMENT_LIST@1198..1209
+            0: TS_TEMPLATE_ELEMENT@1198..1208
+              0: DOLLAR_CURLY@1198..1200 "${" [] []
+              1: TS_INFER_TYPE@1200..1207
+                0: INFER_KW@1200..1206 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@1206..1207
+                  0: IDENT@1206..1207 "T" [] []
+                2: (empty)
+              2: R_CURLY@1207..1208 "}" [] []
+            1: TS_TEMPLATE_CHUNK_ELEMENT@1208..1209
+              0: TEMPLATE_CHUNK@1208..1209 " " [] []
+          2: BACKTICK@1209..1211 "`" [] [Whitespace(" ")]
+        3: QUESTION@1211..1213 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@1213..1221
+          0: JS_REFERENCE_IDENTIFIER@1213..1217
+            0: IDENT@1213..1217 "Trim" [] []
+          1: TS_TYPE_ARGUMENTS@1217..1221
+            0: L_ANGLE@1217..1218 "<" [] []
+            1: TS_TYPE_ARGUMENT_LIST@1218..1219
+              0: TS_REFERENCE_TYPE@1218..1219
+                0: JS_REFERENCE_IDENTIFIER@1218..1219
+                  0: IDENT@1218..1219 "T" [] []
+                1: (empty)
+            2: R_ANGLE@1219..1221 ">" [] [Whitespace(" ")]
+        5: COLON@1221..1222 ":" [] []
+        6: TS_REFERENCE_TYPE@1222..1229
+          0: JS_REFERENCE_IDENTIFIER@1222..1229
+            0: IDENT@1222..1229 "S" [Newline("\n"), Whitespace("     ")] []
+          1: (empty)
+      5: SEMICOLON@1229..1230 ";" [] []
+    14: TS_TYPE_ALIAS_DECLARATION@1230..1282
+      0: TYPE_KW@1230..1236 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@1236..1239
+        0: IDENT@1236..1239 "Foo" [] []
+      2: TS_TYPE_PARAMETERS@1239..1243
+        0: L_ANGLE@1239..1240 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@1240..1241
+          0: TS_TYPE_PARAMETER@1240..1241
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@1240..1240
+            1: TS_TYPE_PARAMETER_NAME@1240..1241
+              0: IDENT@1240..1241 "T" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@1241..1243 ">" [] [Whitespace(" ")]
+      3: EQ@1243..1245 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@1245..1281
+        0: TS_REFERENCE_TYPE@1245..1247
+          0: JS_REFERENCE_IDENTIFIER@1245..1247
+            0: IDENT@1245..1247 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@1247..1255 "extends" [] [Whitespace(" ")]
+        2: TS_TEMPLATE_LITERAL_TYPE@1255..1270
+          0: BACKTICK@1255..1256 "`" [] []
+          1: TS_TEMPLATE_ELEMENT_LIST@1256..1268
+            0: TS_TEMPLATE_CHUNK_ELEMENT@1256..1257
+              0: TEMPLATE_CHUNK@1256..1257 "*" [] []
+            1: TS_TEMPLATE_ELEMENT@1257..1267
+              0: DOLLAR_CURLY@1257..1259 "${" [] []
+              1: TS_INFER_TYPE@1259..1266
+                0: INFER_KW@1259..1265 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@1265..1266
+                  0: IDENT@1265..1266 "S" [] []
+                2: (empty)
+              2: R_CURLY@1266..1267 "}" [] []
+            2: TS_TEMPLATE_CHUNK_ELEMENT@1267..1268
+              0: TEMPLATE_CHUNK@1267..1268 "*" [] []
+          2: BACKTICK@1268..1270 "`" [] [Whitespace(" ")]
+        3: QUESTION@1270..1272 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@1272..1274
+          0: JS_REFERENCE_IDENTIFIER@1272..1274
+            0: IDENT@1272..1274 "S" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@1274..1276 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@1276..1281
+          0: NEVER_KW@1276..1281 "never" [] []
+      5: SEMICOLON@1281..1282 ";" [] []
+    15: TS_TYPE_ALIAS_DECLARATION@1282..1421
+      0: TYPE_KW@1282..1288 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@1288..1296
+        0: IDENT@1288..1296 "Unpacked" [] []
+      2: TS_TYPE_PARAMETERS@1296..1300
+        0: L_ANGLE@1296..1297 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@1297..1298
+          0: TS_TYPE_PARAMETER@1297..1298
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@1297..1297
+            1: TS_TYPE_PARAMETER_NAME@1297..1298
+              0: IDENT@1297..1298 "T" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@1298..1300 ">" [] [Whitespace(" ")]
+      3: EQ@1300..1302 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@1302..1420
+        0: TS_REFERENCE_TYPE@1302..1304
+          0: JS_REFERENCE_IDENTIFIER@1302..1304
+            0: IDENT@1302..1304 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@1304..1312 "extends" [] [Whitespace(" ")]
+        2: TS_ARRAY_TYPE@1312..1324
+          0: TS_PARENTHESIZED_TYPE@1312..1321
+            0: L_PAREN@1312..1313 "(" [] []
+            1: TS_INFER_TYPE@1313..1320
+              0: INFER_KW@1313..1319 "infer" [] [Whitespace(" ")]
+              1: TS_TYPE_PARAMETER_NAME@1319..1320
+                0: IDENT@1319..1320 "U" [] []
+              2: (empty)
+            2: R_PAREN@1320..1321 ")" [] []
+          1: L_BRACK@1321..1322 "[" [] []
+          2: R_BRACK@1322..1324 "]" [] [Whitespace(" ")]
+        3: QUESTION@1324..1326 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@1326..1328
+          0: JS_REFERENCE_IDENTIFIER@1326..1328
+            0: IDENT@1326..1328 "U" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@1328..1329 ":" [] []
+        6: TS_CONDITIONAL_TYPE@1329..1420
+          0: TS_REFERENCE_TYPE@1329..1336
+            0: JS_REFERENCE_IDENTIFIER@1329..1336
+              0: IDENT@1329..1336 "T" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+            1: (empty)
+          1: EXTENDS_KW@1336..1344 "extends" [] [Whitespace(" ")]
+          2: TS_FUNCTION_TYPE@1344..1372
+            0: (empty)
+            1: JS_PARAMETERS@1344..1361
+              0: L_PAREN@1344..1345 "(" [] []
+              1: JS_PARAMETER_LIST@1345..1359
+                0: JS_REST_PARAMETER@1345..1359
+                  0: JS_DECORATOR_LIST@1345..1345
+                  1: DOT3@1345..1348 "..." [] []
+                  2: JS_IDENTIFIER_BINDING@1348..1352
+                    0: IDENT@1348..1352 "args" [] []
+                  3: TS_TYPE_ANNOTATION@1352..1359
+                    0: COLON@1352..1354 ":" [] [Whitespace(" ")]
+                    1: TS_ARRAY_TYPE@1354..1359
+                      0: TS_ANY_TYPE@1354..1357
+                        0: ANY_KW@1354..1357 "any" [] []
+                      1: L_BRACK@1357..1358 "[" [] []
+                      2: R_BRACK@1358..1359 "]" [] []
+              2: R_PAREN@1359..1361 ")" [] [Whitespace(" ")]
+            2: FAT_ARROW@1361..1364 "=>" [] [Whitespace(" ")]
+            3: TS_INFER_TYPE@1364..1372
+              0: INFER_KW@1364..1370 "infer" [] [Whitespace(" ")]
+              1: TS_TYPE_PARAMETER_NAME@1370..1372
+                0: IDENT@1370..1372 "U" [] [Whitespace(" ")]
+              2: (empty)
+          3: QUESTION@1372..1374 "?" [] [Whitespace(" ")]
+          4: TS_REFERENCE_TYPE@1374..1376
+            0: JS_REFERENCE_IDENTIFIER@1374..1376
+              0: IDENT@1374..1376 "U" [] [Whitespace(" ")]
+            1: (empty)
+          5: COLON@1376..1377 ":" [] []
+          6: TS_CONDITIONAL_TYPE@1377..1420
+            0: TS_REFERENCE_TYPE@1377..1384
+              0: JS_REFERENCE_IDENTIFIER@1377..1384
+                0: IDENT@1377..1384 "T" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+              1: (empty)
+            1: EXTENDS_KW@1384..1392 "extends" [] [Whitespace(" ")]
+            2: TS_REFERENCE_TYPE@1392..1409
+              0: JS_REFERENCE_IDENTIFIER@1392..1399
+                0: IDENT@1392..1399 "Promise" [] []
+              1: TS_TYPE_ARGUMENTS@1399..1409
+                0: L_ANGLE@1399..1400 "<" [] []
+                1: TS_TYPE_ARGUMENT_LIST@1400..1407
+                  0: TS_INFER_TYPE@1400..1407
+                    0: INFER_KW@1400..1406 "infer" [] [Whitespace(" ")]
+                    1: TS_TYPE_PARAMETER_NAME@1406..1407
+                      0: IDENT@1406..1407 "U" [] []
+                    2: (empty)
+                2: R_ANGLE@1407..1409 ">" [] [Whitespace(" ")]
+            3: QUESTION@1409..1411 "?" [] [Whitespace(" ")]
+            4: TS_REFERENCE_TYPE@1411..1413
+              0: JS_REFERENCE_IDENTIFIER@1411..1413
+                0: IDENT@1411..1413 "U" [] [Whitespace(" ")]
+              1: (empty)
+            5: COLON@1413..1414 ":" [] []
+            6: TS_REFERENCE_TYPE@1414..1420
+              0: JS_REFERENCE_IDENTIFIER@1414..1420
+                0: IDENT@1414..1420 "T" [Newline("\n"), Whitespace("    ")] []
+              1: (empty)
+      5: SEMICOLON@1420..1421 ";" [] []
+    16: TS_TYPE_ALIAS_DECLARATION@1421..1509
+      0: TYPE_KW@1421..1427 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@1427..1439
+        0: IDENT@1427..1439 "ArgumentType" [] []
+      2: TS_TYPE_PARAMETERS@1439..1467
+        0: L_ANGLE@1439..1440 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@1440..1465
+          0: TS_TYPE_PARAMETER@1440..1465
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@1440..1440
+            1: TS_TYPE_PARAMETER_NAME@1440..1442
+              0: IDENT@1440..1442 "T" [] [Whitespace(" ")]
+            2: TS_TYPE_CONSTRAINT_CLAUSE@1442..1465
+              0: EXTENDS_KW@1442..1450 "extends" [] [Whitespace(" ")]
+              1: TS_FUNCTION_TYPE@1450..1465
+                0: (empty)
+                1: JS_PARAMETERS@1450..1459
+                  0: L_PAREN@1450..1451 "(" [] []
+                  1: JS_PARAMETER_LIST@1451..1457
+                    0: JS_FORMAL_PARAMETER@1451..1457
+                      0: JS_DECORATOR_LIST@1451..1451
+                      1: JS_IDENTIFIER_BINDING@1451..1452
+                        0: IDENT@1451..1452 "x" [] []
+                      2: (empty)
+                      3: TS_TYPE_ANNOTATION@1452..1457
+                        0: COLON@1452..1454 ":" [] [Whitespace(" ")]
+                        1: TS_ANY_TYPE@1454..1457
+                          0: ANY_KW@1454..1457 "any" [] []
+                      4: (empty)
+                  2: R_PAREN@1457..1459 ")" [] [Whitespace(" ")]
+                2: FAT_ARROW@1459..1462 "=>" [] [Whitespace(" ")]
+                3: TS_ANY_TYPE@1462..1465
+                  0: ANY_KW@1462..1465 "any" [] []
+            3: (empty)
+        2: R_ANGLE@1465..1467 ">" [] [Whitespace(" ")]
+      3: EQ@1467..1469 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@1469..1508
+        0: TS_REFERENCE_TYPE@1469..1471
+          0: JS_REFERENCE_IDENTIFIER@1469..1471
+            0: IDENT@1469..1471 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@1471..1479 "extends" [] [Whitespace(" ")]
+        2: TS_FUNCTION_TYPE@1479..1499
+          0: (empty)
+          1: JS_PARAMETERS@1479..1492
+            0: L_PAREN@1479..1480 "(" [] []
+            1: JS_PARAMETER_LIST@1480..1490
+              0: JS_FORMAL_PARAMETER@1480..1490
+                0: JS_DECORATOR_LIST@1480..1480
+                1: JS_IDENTIFIER_BINDING@1480..1481
+                  0: IDENT@1480..1481 "a" [] []
+                2: (empty)
+                3: TS_TYPE_ANNOTATION@1481..1490
+                  0: COLON@1481..1483 ":" [] [Whitespace(" ")]
+                  1: TS_INFER_TYPE@1483..1490
+                    0: INFER_KW@1483..1489 "infer" [] [Whitespace(" ")]
+                    1: TS_TYPE_PARAMETER_NAME@1489..1490
+                      0: IDENT@1489..1490 "A" [] []
+                    2: (empty)
+                4: (empty)
+            2: R_PAREN@1490..1492 ")" [] [Whitespace(" ")]
+          2: FAT_ARROW@1492..1495 "=>" [] [Whitespace(" ")]
+          3: TS_ANY_TYPE@1495..1499
+            0: ANY_KW@1495..1499 "any" [] [Whitespace(" ")]
+        3: QUESTION@1499..1501 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@1501..1503
+          0: JS_REFERENCE_IDENTIFIER@1501..1503
+            0: IDENT@1501..1503 "A" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@1503..1505 ":" [] [Whitespace(" ")]
+        6: TS_ANY_TYPE@1505..1508
+          0: ANY_KW@1505..1508 "any" [] []
+      5: SEMICOLON@1508..1509 ";" [] []
+    17: TS_TYPE_ALIAS_DECLARATION@1509..1598
+      0: TYPE_KW@1509..1515 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@1515..1517
+        0: IDENT@1515..1517 "X3" [] []
+      2: TS_TYPE_PARAMETERS@1517..1521
+        0: L_ANGLE@1517..1518 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@1518..1519
+          0: TS_TYPE_PARAMETER@1518..1519
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@1518..1518
+            1: TS_TYPE_PARAMETER_NAME@1518..1519
+              0: IDENT@1518..1519 "T" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@1519..1521 ">" [] [Whitespace(" ")]
+      3: EQ@1521..1523 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@1523..1597
+        0: TS_REFERENCE_TYPE@1523..1525
+          0: JS_REFERENCE_IDENTIFIER@1523..1525
+            0: IDENT@1523..1525 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@1525..1533 "extends" [] [Whitespace(" ")]
+        2: TS_OBJECT_TYPE@1533..1586
+          0: L_CURLY@1533..1535 "{" [] [Whitespace(" ")]
+          1: TS_TYPE_MEMBER_LIST@1535..1584
+            0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@1535..1560
+              0: (empty)
+              1: JS_LITERAL_MEMBER_NAME@1535..1536
+                0: IDENT@1535..1536 "a" [] []
+              2: (empty)
+              3: TS_TYPE_ANNOTATION@1536..1558
+                0: COLON@1536..1538 ":" [] [Whitespace(" ")]
+                1: TS_FUNCTION_TYPE@1538..1558
+                  0: (empty)
+                  1: JS_PARAMETERS@1538..1551
+                    0: L_PAREN@1538..1539 "(" [] []
+                    1: JS_PARAMETER_LIST@1539..1549
+                      0: JS_FORMAL_PARAMETER@1539..1549
+                        0: JS_DECORATOR_LIST@1539..1539
+                        1: JS_IDENTIFIER_BINDING@1539..1540
+                          0: IDENT@1539..1540 "x" [] []
+                        2: (empty)
+                        3: TS_TYPE_ANNOTATION@1540..1549
+                          0: COLON@1540..1542 ":" [] [Whitespace(" ")]
+                          1: TS_INFER_TYPE@1542..1549
+                            0: INFER_KW@1542..1548 "infer" [] [Whitespace(" ")]
+                            1: TS_TYPE_PARAMETER_NAME@1548..1549
+                              0: IDENT@1548..1549 "U" [] []
+                            2: (empty)
+                        4: (empty)
+                    2: R_PAREN@1549..1551 ")" [] [Whitespace(" ")]
+                  2: FAT_ARROW@1551..1554 "=>" [] [Whitespace(" ")]
+                  3: TS_VOID_TYPE@1554..1558
+                    0: VOID_KW@1554..1558 "void" [] []
+              4: COMMA@1558..1560 "," [] [Whitespace(" ")]
+            1: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@1560..1584
+              0: (empty)
+              1: JS_LITERAL_MEMBER_NAME@1560..1561
+                0: IDENT@1560..1561 "b" [] []
+              2: (empty)
+              3: TS_TYPE_ANNOTATION@1561..1584
+                0: COLON@1561..1563 ":" [] [Whitespace(" ")]
+                1: TS_FUNCTION_TYPE@1563..1584
+                  0: (empty)
+                  1: JS_PARAMETERS@1563..1576
+                    0: L_PAREN@1563..1564 "(" [] []
+                    1: JS_PARAMETER_LIST@1564..1574
+                      0: JS_FORMAL_PARAMETER@1564..1574
+                        0: JS_DECORATOR_LIST@1564..1564
+                        1: JS_IDENTIFIER_BINDING@1564..1565
+                          0: IDENT@1564..1565 "x" [] []
+                        2: (empty)
+                        3: TS_TYPE_ANNOTATION@1565..1574
+                          0: COLON@1565..1567 ":" [] [Whitespace(" ")]
+                          1: TS_INFER_TYPE@1567..1574
+                            0: INFER_KW@1567..1573 "infer" [] [Whitespace(" ")]
+                            1: TS_TYPE_PARAMETER_NAME@1573..1574
+                              0: IDENT@1573..1574 "U" [] []
+                            2: (empty)
+                        4: (empty)
+                    2: R_PAREN@1574..1576 ")" [] [Whitespace(" ")]
+                  2: FAT_ARROW@1576..1579 "=>" [] [Whitespace(" ")]
+                  3: TS_VOID_TYPE@1579..1584
+                    0: VOID_KW@1579..1584 "void" [] [Whitespace(" ")]
+              4: (empty)
+          2: R_CURLY@1584..1586 "}" [] [Whitespace(" ")]
+        3: QUESTION@1586..1588 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@1588..1590
+          0: JS_REFERENCE_IDENTIFIER@1588..1590
+            0: IDENT@1588..1590 "U" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@1590..1592 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@1592..1597
+          0: NEVER_KW@1592..1597 "never" [] []
+      5: SEMICOLON@1597..1598 ";" [] []
+    18: TS_TYPE_ALIAS_DECLARATION@1598..1691
+      0: TYPE_KW@1598..1604 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@1604..1606
+        0: IDENT@1604..1606 "X1" [] []
+      2: TS_TYPE_PARAMETERS@1606..1637
+        0: L_ANGLE@1606..1607 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@1607..1635
+          0: TS_TYPE_PARAMETER@1607..1635
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@1607..1607
+            1: TS_TYPE_PARAMETER_NAME@1607..1609
+              0: IDENT@1607..1609 "T" [] [Whitespace(" ")]
+            2: TS_TYPE_CONSTRAINT_CLAUSE@1609..1635
+              0: EXTENDS_KW@1609..1617 "extends" [] [Whitespace(" ")]
+              1: TS_OBJECT_TYPE@1617..1635
+                0: L_CURLY@1617..1619 "{" [] [Whitespace(" ")]
+                1: TS_TYPE_MEMBER_LIST@1619..1634
+                  0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@1619..1627
+                    0: (empty)
+                    1: JS_LITERAL_MEMBER_NAME@1619..1620
+                      0: IDENT@1619..1620 "x" [] []
+                    2: (empty)
+                    3: TS_TYPE_ANNOTATION@1620..1625
+                      0: COLON@1620..1622 ":" [] [Whitespace(" ")]
+                      1: TS_ANY_TYPE@1622..1625
+                        0: ANY_KW@1622..1625 "any" [] []
+                    4: COMMA@1625..1627 "," [] [Whitespace(" ")]
+                  1: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@1627..1634
+                    0: (empty)
+                    1: JS_LITERAL_MEMBER_NAME@1627..1628
+                      0: IDENT@1627..1628 "y" [] []
+                    2: (empty)
+                    3: TS_TYPE_ANNOTATION@1628..1634
+                      0: COLON@1628..1630 ":" [] [Whitespace(" ")]
+                      1: TS_ANY_TYPE@1630..1634
+                        0: ANY_KW@1630..1634 "any" [] [Whitespace(" ")]
+                    4: (empty)
+                2: R_CURLY@1634..1635 "}" [] []
+            3: (empty)
+        2: R_ANGLE@1635..1637 ">" [] [Whitespace(" ")]
+      3: EQ@1637..1639 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@1639..1690
+        0: TS_REFERENCE_TYPE@1639..1641
+          0: JS_REFERENCE_IDENTIFIER@1639..1641
+            0: IDENT@1639..1641 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@1641..1649 "extends" [] [Whitespace(" ")]
+        2: TS_OBJECT_TYPE@1649..1676
+          0: L_CURLY@1649..1651 "{" [] [Whitespace(" ")]
+          1: TS_TYPE_MEMBER_LIST@1651..1674
+            0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@1651..1663
+              0: (empty)
+              1: JS_LITERAL_MEMBER_NAME@1651..1652
+                0: IDENT@1651..1652 "x" [] []
+              2: (empty)
+              3: TS_TYPE_ANNOTATION@1652..1661
+                0: COLON@1652..1654 ":" [] [Whitespace(" ")]
+                1: TS_INFER_TYPE@1654..1661
+                  0: INFER_KW@1654..1660 "infer" [] [Whitespace(" ")]
+                  1: TS_TYPE_PARAMETER_NAME@1660..1661
+                    0: IDENT@1660..1661 "X" [] []
+                  2: (empty)
+              4: COMMA@1661..1663 "," [] [Whitespace(" ")]
+            1: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@1663..1674
+              0: (empty)
+              1: JS_LITERAL_MEMBER_NAME@1663..1664
+                0: IDENT@1663..1664 "y" [] []
+              2: (empty)
+              3: TS_TYPE_ANNOTATION@1664..1674
+                0: COLON@1664..1666 ":" [] [Whitespace(" ")]
+                1: TS_INFER_TYPE@1666..1674
+                  0: INFER_KW@1666..1672 "infer" [] [Whitespace(" ")]
+                  1: TS_TYPE_PARAMETER_NAME@1672..1674
+                    0: IDENT@1672..1674 "Y" [] [Whitespace(" ")]
+                  2: (empty)
+              4: (empty)
+          2: R_CURLY@1674..1676 "}" [] [Whitespace(" ")]
+        3: QUESTION@1676..1678 "?" [] [Whitespace(" ")]
+        4: TS_TUPLE_TYPE@1678..1685
+          0: L_BRACK@1678..1679 "[" [] []
+          1: TS_TUPLE_TYPE_ELEMENT_LIST@1679..1683
+            0: TS_REFERENCE_TYPE@1679..1680
+              0: JS_REFERENCE_IDENTIFIER@1679..1680
+                0: IDENT@1679..1680 "X" [] []
+              1: (empty)
+            1: COMMA@1680..1682 "," [] [Whitespace(" ")]
+            2: TS_REFERENCE_TYPE@1682..1683
+              0: JS_REFERENCE_IDENTIFIER@1682..1683
+                0: IDENT@1682..1683 "Y" [] []
+              1: (empty)
+          2: R_BRACK@1683..1685 "]" [] [Whitespace(" ")]
+        5: COLON@1685..1687 ":" [] [Whitespace(" ")]
+        6: TS_ANY_TYPE@1687..1690
+          0: ANY_KW@1687..1690 "any" [] []
+      5: SEMICOLON@1690..1691 ";" [] []
+    19: TS_TYPE_ALIAS_DECLARATION@1691..1736
+      0: TYPE_KW@1691..1697 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@1697..1700
+        0: IDENT@1697..1700 "T62" [] []
+      2: TS_TYPE_PARAMETERS@1700..1704
+        0: L_ANGLE@1700..1701 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@1701..1702
+          0: TS_TYPE_PARAMETER@1701..1702
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@1701..1701
+            1: TS_TYPE_PARAMETER_NAME@1701..1702
+              0: IDENT@1701..1702 "T" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@1702..1704 ">" [] [Whitespace(" ")]
+      3: EQ@1704..1706 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@1706..1735
+        0: TS_REFERENCE_TYPE@1706..1708
+          0: JS_REFERENCE_IDENTIFIER@1706..1708
+            0: IDENT@1706..1708 "U" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@1708..1716 "extends" [] [Whitespace(" ")]
+        2: TS_ARRAY_TYPE@1716..1728
+          0: TS_PARENTHESIZED_TYPE@1716..1725
+            0: L_PAREN@1716..1717 "(" [] []
+            1: TS_INFER_TYPE@1717..1724
+              0: INFER_KW@1717..1723 "infer" [] [Whitespace(" ")]
+              1: TS_TYPE_PARAMETER_NAME@1723..1724
+                0: IDENT@1723..1724 "U" [] []
+              2: (empty)
+            2: R_PAREN@1724..1725 ")" [] []
+          1: L_BRACK@1725..1726 "[" [] []
+          2: R_BRACK@1726..1728 "]" [] [Whitespace(" ")]
+        3: QUESTION@1728..1730 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@1730..1732
+          0: JS_REFERENCE_IDENTIFIER@1730..1732
+            0: IDENT@1730..1732 "U" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@1732..1734 ":" [] [Whitespace(" ")]
+        6: TS_REFERENCE_TYPE@1734..1735
+          0: JS_REFERENCE_IDENTIFIER@1734..1735
+            0: IDENT@1734..1735 "U" [] []
+          1: (empty)
+      5: SEMICOLON@1735..1736 ";" [] []
+    20: TS_TYPE_ALIAS_DECLARATION@1736..1827
+      0: TYPE_KW@1736..1742 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@1742..1745
+        0: IDENT@1742..1745 "T63" [] []
+      2: TS_TYPE_PARAMETERS@1745..1749
+        0: L_ANGLE@1745..1746 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@1746..1747
+          0: TS_TYPE_PARAMETER@1746..1747
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@1746..1746
+            1: TS_TYPE_PARAMETER_NAME@1746..1747
+              0: IDENT@1746..1747 "T" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@1747..1749 ">" [] [Whitespace(" ")]
+      3: EQ@1749..1751 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@1751..1826
+        0: TS_REFERENCE_TYPE@1751..1753
+          0: JS_REFERENCE_IDENTIFIER@1751..1753
+            0: IDENT@1751..1753 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@1753..1761 "extends" [] [Whitespace(" ")]
+        2: TS_PARENTHESIZED_TYPE@1761..1809
+          0: L_PAREN@1761..1762 "(" [] []
+          1: TS_CONDITIONAL_TYPE@1762..1807
+            0: TS_PARENTHESIZED_TYPE@1762..1772
+              0: L_PAREN@1762..1763 "(" [] []
+              1: TS_INFER_TYPE@1763..1770
+                0: INFER_KW@1763..1769 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@1769..1770
+                  0: IDENT@1769..1770 "A" [] []
+                2: (empty)
+              2: R_PAREN@1770..1772 ")" [] [Whitespace(" ")]
+            1: EXTENDS_KW@1772..1780 "extends" [] [Whitespace(" ")]
+            2: TS_INFER_TYPE@1780..1788
+              0: INFER_KW@1780..1786 "infer" [] [Whitespace(" ")]
+              1: TS_TYPE_PARAMETER_NAME@1786..1788
+                0: IDENT@1786..1788 "B" [] [Whitespace(" ")]
+              2: (empty)
+            3: QUESTION@1788..1790 "?" [] [Whitespace(" ")]
+            4: TS_INFER_TYPE@1790..1798
+              0: INFER_KW@1790..1796 "infer" [] [Whitespace(" ")]
+              1: TS_TYPE_PARAMETER_NAME@1796..1798
+                0: IDENT@1796..1798 "C" [] [Whitespace(" ")]
+              2: (empty)
+            5: COLON@1798..1800 ":" [] [Whitespace(" ")]
+            6: TS_INFER_TYPE@1800..1807
+              0: INFER_KW@1800..1806 "infer" [] [Whitespace(" ")]
+              1: TS_TYPE_PARAMETER_NAME@1806..1807
+                0: IDENT@1806..1807 "D" [] []
+              2: (empty)
+          2: R_PAREN@1807..1809 ")" [] [Whitespace(" ")]
+        3: QUESTION@1809..1811 "?" [] [Whitespace(" ")]
+        4: TS_STRING_TYPE@1811..1818
+          0: STRING_KW@1811..1818 "string" [] [Whitespace(" ")]
+        5: COLON@1818..1820 ":" [] [Whitespace(" ")]
+        6: TS_NUMBER_TYPE@1820..1826
+          0: NUMBER_KW@1820..1826 "number" [] []
+      5: SEMICOLON@1826..1827 ";" [] []
+    21: TS_TYPE_ALIAS_DECLARATION@1827..1912
+      0: TYPE_KW@1827..1833 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@1833..1836
+        0: IDENT@1833..1836 "T75" [] []
+      2: TS_TYPE_PARAMETERS@1836..1840
+        0: L_ANGLE@1836..1837 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@1837..1838
+          0: TS_TYPE_PARAMETER@1837..1838
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@1837..1837
+            1: TS_TYPE_PARAMETER_NAME@1837..1838
+              0: IDENT@1837..1838 "T" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@1838..1840 ">" [] [Whitespace(" ")]
+      3: EQ@1840..1842 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@1842..1911
+        0: TS_REFERENCE_TYPE@1842..1844
+          0: JS_REFERENCE_IDENTIFIER@1842..1844
+            0: IDENT@1842..1844 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@1844..1852 "extends" [] [Whitespace(" ")]
+        2: TS_REFERENCE_TYPE@1852..1874
+          0: JS_REFERENCE_IDENTIFIER@1852..1855
+            0: IDENT@1852..1855 "T74" [] []
+          1: TS_TYPE_ARGUMENTS@1855..1874
+            0: L_ANGLE@1855..1856 "<" [] []
+            1: TS_TYPE_ARGUMENT_LIST@1856..1872
+              0: TS_INFER_TYPE@1856..1863
+                0: INFER_KW@1856..1862 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@1862..1863
+                  0: IDENT@1862..1863 "U" [] []
+                2: (empty)
+              1: COMMA@1863..1865 "," [] [Whitespace(" ")]
+              2: TS_INFER_TYPE@1865..1872
+                0: INFER_KW@1865..1871 "infer" [] [Whitespace(" ")]
+                1: TS_TYPE_PARAMETER_NAME@1871..1872
+                  0: IDENT@1871..1872 "U" [] []
+                2: (empty)
+            2: R_ANGLE@1872..1874 ">" [] [Whitespace(" ")]
+        3: QUESTION@1874..1876 "?" [] [Whitespace(" ")]
+        4: TS_UNION_TYPE@1876..1904
+          0: (empty)
+          1: TS_UNION_TYPE_VARIANT_LIST@1876..1904
+            0: TS_REFERENCE_TYPE@1876..1883
+              0: JS_REFERENCE_IDENTIFIER@1876..1879
+                0: IDENT@1876..1879 "T70" [] []
+              1: TS_TYPE_ARGUMENTS@1879..1883
+                0: L_ANGLE@1879..1880 "<" [] []
+                1: TS_TYPE_ARGUMENT_LIST@1880..1881
+                  0: TS_REFERENCE_TYPE@1880..1881
+                    0: JS_REFERENCE_IDENTIFIER@1880..1881
+                      0: IDENT@1880..1881 "U" [] []
+                    1: (empty)
+                2: R_ANGLE@1881..1883 ">" [] [Whitespace(" ")]
+            1: PIPE@1883..1885 "|" [] [Whitespace(" ")]
+            2: TS_REFERENCE_TYPE@1885..1892
+              0: JS_REFERENCE_IDENTIFIER@1885..1888
+                0: IDENT@1885..1888 "T72" [] []
+              1: TS_TYPE_ARGUMENTS@1888..1892
+                0: L_ANGLE@1888..1889 "<" [] []
+                1: TS_TYPE_ARGUMENT_LIST@1889..1890
+                  0: TS_REFERENCE_TYPE@1889..1890
+                    0: JS_REFERENCE_IDENTIFIER@1889..1890
+                      0: IDENT@1889..1890 "U" [] []
+                    1: (empty)
+                2: R_ANGLE@1890..1892 ">" [] [Whitespace(" ")]
+            3: PIPE@1892..1894 "|" [] [Whitespace(" ")]
+            4: TS_REFERENCE_TYPE@1894..1904
+              0: JS_REFERENCE_IDENTIFIER@1894..1897
+                0: IDENT@1894..1897 "T74" [] []
+              1: TS_TYPE_ARGUMENTS@1897..1904
+                0: L_ANGLE@1897..1898 "<" [] []
+                1: TS_TYPE_ARGUMENT_LIST@1898..1902
+                  0: TS_REFERENCE_TYPE@1898..1899
+                    0: JS_REFERENCE_IDENTIFIER@1898..1899
+                      0: IDENT@1898..1899 "U" [] []
+                    1: (empty)
+                  1: COMMA@1899..1901 "," [] [Whitespace(" ")]
+                  2: TS_REFERENCE_TYPE@1901..1902
+                    0: JS_REFERENCE_IDENTIFIER@1901..1902
+                      0: IDENT@1901..1902 "U" [] []
+                    1: (empty)
+                2: R_ANGLE@1902..1904 ">" [] [Whitespace(" ")]
+        5: COLON@1904..1906 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@1906..1911
+          0: NEVER_KW@1906..1911 "never" [] []
+      5: SEMICOLON@1911..1912 ";" [] []
+    22: TS_TYPE_ALIAS_DECLARATION@1912..2128
+      0: TYPE_KW@1912..1918 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@1918..1927
+        0: IDENT@1918..1927 "Jsonified" [] []
+      2: TS_TYPE_PARAMETERS@1927..1931
+        0: L_ANGLE@1927..1928 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@1928..1929
+          0: TS_TYPE_PARAMETER@1928..1929
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@1928..1928
+            1: TS_TYPE_PARAMETER_NAME@1928..1929
+              0: IDENT@1928..1929 "T" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@1929..1931 ">" [] [Whitespace(" ")]
+      3: EQ@1931..1933 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@1933..2127
+        0: TS_REFERENCE_TYPE@1933..1935
+          0: JS_REFERENCE_IDENTIFIER@1933..1935
+            0: IDENT@1933..1935 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@1935..1943 "extends" [] [Whitespace(" ")]
+        2: TS_UNION_TYPE@1943..1976
+          0: (empty)
+          1: TS_UNION_TYPE_VARIANT_LIST@1943..1976
+            0: TS_STRING_TYPE@1943..1950
+              0: STRING_KW@1943..1950 "string" [] [Whitespace(" ")]
+            1: PIPE@1950..1952 "|" [] [Whitespace(" ")]
+            2: TS_NUMBER_TYPE@1952..1959
+              0: NUMBER_KW@1952..1959 "number" [] [Whitespace(" ")]
+            3: PIPE@1959..1961 "|" [] [Whitespace(" ")]
+            4: TS_BOOLEAN_TYPE@1961..1969
+              0: BOOLEAN_KW@1961..1969 "boolean" [] [Whitespace(" ")]
+            5: PIPE@1969..1971 "|" [] [Whitespace(" ")]
+            6: TS_NULL_LITERAL_TYPE@1971..1976
+              0: NULL_KW@1971..1976 "null" [] [Whitespace(" ")]
+        3: QUESTION@1976..1978 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@1978..1979
+          0: JS_REFERENCE_IDENTIFIER@1978..1979
+            0: IDENT@1978..1979 "T" [] []
+          1: (empty)
+        5: COLON@1979..1986 ":" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+        6: TS_CONDITIONAL_TYPE@1986..2127
+          0: TS_REFERENCE_TYPE@1986..1988
+            0: JS_REFERENCE_IDENTIFIER@1986..1988
+              0: IDENT@1986..1988 "T" [] [Whitespace(" ")]
+            1: (empty)
+          1: EXTENDS_KW@1988..1996 "extends" [] [Whitespace(" ")]
+          2: TS_UNION_TYPE@1996..2017
+            0: (empty)
+            1: TS_UNION_TYPE_VARIANT_LIST@1996..2017
+              0: TS_UNDEFINED_TYPE@1996..2006
+                0: UNDEFINED_KW@1996..2006 "undefined" [] [Whitespace(" ")]
+              1: PIPE@2006..2008 "|" [] [Whitespace(" ")]
+              2: TS_REFERENCE_TYPE@2008..2017
+                0: JS_REFERENCE_IDENTIFIER@2008..2017
+                  0: IDENT@2008..2017 "Function" [] [Whitespace(" ")]
+                1: (empty)
+          3: QUESTION@2017..2019 "?" [] [Whitespace(" ")]
+          4: TS_NEVER_TYPE@2019..2024
+            0: NEVER_KW@2019..2024 "never" [] []
+          5: COLON@2024..2031 ":" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+          6: TS_CONDITIONAL_TYPE@2031..2127
+            0: TS_REFERENCE_TYPE@2031..2033
+              0: JS_REFERENCE_IDENTIFIER@2031..2033
+                0: IDENT@2031..2033 "T" [] [Whitespace(" ")]
+              1: (empty)
+            1: EXTENDS_KW@2033..2041 "extends" [] [Whitespace(" ")]
+            2: TS_OBJECT_TYPE@2041..2063
+              0: L_CURLY@2041..2043 "{" [] [Whitespace(" ")]
+              1: TS_TYPE_MEMBER_LIST@2043..2061
+                0: TS_METHOD_SIGNATURE_TYPE_MEMBER@2043..2061
+                  0: JS_LITERAL_MEMBER_NAME@2043..2049
+                    0: IDENT@2043..2049 "toJSON" [] []
+                  1: (empty)
+                  2: (empty)
+                  3: JS_PARAMETERS@2049..2051
+                    0: L_PAREN@2049..2050 "(" [] []
+                    1: JS_PARAMETER_LIST@2050..2050
+                    2: R_PAREN@2050..2051 ")" [] []
+                  4: TS_RETURN_TYPE_ANNOTATION@2051..2061
+                    0: COLON@2051..2053 ":" [] [Whitespace(" ")]
+                    1: TS_INFER_TYPE@2053..2061
+                      0: INFER_KW@2053..2059 "infer" [] [Whitespace(" ")]
+                      1: TS_TYPE_PARAMETER_NAME@2059..2061
+                        0: IDENT@2059..2061 "R" [] [Whitespace(" ")]
+                      2: (empty)
+                  5: (empty)
+              2: R_CURLY@2061..2063 "}" [] [Whitespace(" ")]
+            3: QUESTION@2063..2065 "?" [] [Whitespace(" ")]
+            4: TS_REFERENCE_TYPE@2065..2066
+              0: JS_REFERENCE_IDENTIFIER@2065..2066
+                0: IDENT@2065..2066 "R" [] []
+              1: (empty)
+            5: COLON@2066..2073 ":" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+            6: TS_CONDITIONAL_TYPE@2073..2127
+              0: TS_REFERENCE_TYPE@2073..2075
+                0: JS_REFERENCE_IDENTIFIER@2073..2075
+                  0: IDENT@2073..2075 "T" [] [Whitespace(" ")]
+                1: (empty)
+              1: EXTENDS_KW@2075..2083 "extends" [] [Whitespace(" ")]
+              2: TS_NON_PRIMITIVE_TYPE@2083..2090
+                0: OBJECT_KW@2083..2090 "object" [] [Whitespace(" ")]
+              3: QUESTION@2090..2092 "?" [] [Whitespace(" ")]
+              4: TS_REFERENCE_TYPE@2092..2110
+                0: JS_REFERENCE_IDENTIFIER@2092..2107
+                  0: IDENT@2092..2107 "JsonifiedObject" [] []
+                1: TS_TYPE_ARGUMENTS@2107..2110
+                  0: L_ANGLE@2107..2108 "<" [] []
+                  1: TS_TYPE_ARGUMENT_LIST@2108..2109
+                    0: TS_REFERENCE_TYPE@2108..2109
+                      0: JS_REFERENCE_IDENTIFIER@2108..2109
+                        0: IDENT@2108..2109 "T" [] []
+                      1: (empty)
+                  2: R_ANGLE@2109..2110 ">" [] []
+              5: COLON@2110..2113 ":" [Newline("\n")] [Whitespace(" ")]
+              6: TS_STRING_LITERAL_TYPE@2113..2127
+                0: JS_STRING_LITERAL@2113..2127 "\"what is this\"" [] []
+      5: SEMICOLON@2127..2128 ";" [] []
+    23: TS_TYPE_ALIAS_DECLARATION@2128..2191
+      0: TYPE_KW@2128..2134 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@2134..2137
+        0: IDENT@2134..2137 "T1" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@2137..2139 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@2139..2190
+        0: TS_REFERENCE_TYPE@2139..2142
+          0: JS_REFERENCE_IDENTIFIER@2139..2142
+            0: IDENT@2139..2142 "F1" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@2142..2150 "extends" [] [Whitespace(" ")]
+        2: TS_FUNCTION_TYPE@2150..2179
+          0: (empty)
+          1: JS_PARAMETERS@2150..2171
+            0: L_PAREN@2150..2151 "(" [] []
+            1: JS_PARAMETER_LIST@2151..2169
+              0: JS_REST_PARAMETER@2151..2169
+                0: JS_DECORATOR_LIST@2151..2151
+                1: DOT3@2151..2154 "..." [] []
+                2: JS_IDENTIFIER_BINDING@2154..2158
+                  0: IDENT@2154..2158 "args" [] []
+                3: TS_TYPE_ANNOTATION@2158..2169
+                  0: COLON@2158..2160 ":" [] [Whitespace(" ")]
+                  1: TS_PARENTHESIZED_TYPE@2160..2169
+                    0: L_PAREN@2160..2161 "(" [] []
+                    1: TS_INFER_TYPE@2161..2168
+                      0: INFER_KW@2161..2167 "infer" [] [Whitespace(" ")]
+                      1: TS_TYPE_PARAMETER_NAME@2167..2168
+                        0: IDENT@2167..2168 "T" [] []
+                      2: (empty)
+                    2: R_PAREN@2168..2169 ")" [] []
+            2: R_PAREN@2169..2171 ")" [] [Whitespace(" ")]
+          2: FAT_ARROW@2171..2174 "=>" [] [Whitespace(" ")]
+          3: TS_VOID_TYPE@2174..2179
+            0: VOID_KW@2174..2179 "void" [] [Whitespace(" ")]
+        3: QUESTION@2179..2181 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@2181..2183
+          0: JS_REFERENCE_IDENTIFIER@2181..2183
+            0: IDENT@2181..2183 "T" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@2183..2185 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@2185..2190
+          0: NEVER_KW@2185..2190 "never" [] []
+      5: SEMICOLON@2190..2191 ";" [] []
+    24: TS_TYPE_ALIAS_DECLARATION@2191..2256
+      0: TYPE_KW@2191..2197 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@2197..2200
+        0: IDENT@2197..2200 "T2" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@2200..2202 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@2202..2255
+        0: TS_REFERENCE_TYPE@2202..2205
+          0: JS_REFERENCE_IDENTIFIER@2202..2205
+            0: IDENT@2202..2205 "F1" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@2205..2213 "extends" [] [Whitespace(" ")]
+        2: TS_FUNCTION_TYPE@2213..2244
+          0: (empty)
+          1: JS_PARAMETERS@2213..2236
+            0: L_PAREN@2213..2214 "(" [] []
+            1: JS_PARAMETER_LIST@2214..2234
+              0: JS_FORMAL_PARAMETER@2214..2234
+                0: JS_DECORATOR_LIST@2214..2214
+                1: JS_IDENTIFIER_BINDING@2214..2218
+                  0: IDENT@2214..2218 "args" [] []
+                2: (empty)
+                3: TS_TYPE_ANNOTATION@2218..2234
+                  0: COLON@2218..2220 ":" [] [Whitespace(" ")]
+                  1: TS_TUPLE_TYPE@2220..2234
+                    0: L_BRACK@2220..2221 "[" [] []
+                    1: TS_TUPLE_TYPE_ELEMENT_LIST@2221..2233
+                      0: TS_REST_TUPLE_TYPE_ELEMENT@2221..2233
+                        0: DOT3@2221..2224 "..." [] []
+                        1: TS_PARENTHESIZED_TYPE@2224..2233
+                          0: L_PAREN@2224..2225 "(" [] []
+                          1: TS_INFER_TYPE@2225..2232
+                            0: INFER_KW@2225..2231 "infer" [] [Whitespace(" ")]
+                            1: TS_TYPE_PARAMETER_NAME@2231..2232
+                              0: IDENT@2231..2232 "T" [] []
+                            2: (empty)
+                          2: R_PAREN@2232..2233 ")" [] []
+                    2: R_BRACK@2233..2234 "]" [] []
+                4: (empty)
+            2: R_PAREN@2234..2236 ")" [] [Whitespace(" ")]
+          2: FAT_ARROW@2236..2239 "=>" [] [Whitespace(" ")]
+          3: TS_VOID_TYPE@2239..2244
+            0: VOID_KW@2239..2244 "void" [] [Whitespace(" ")]
+        3: QUESTION@2244..2246 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@2246..2248
+          0: JS_REFERENCE_IDENTIFIER@2246..2248
+            0: IDENT@2246..2248 "T" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@2248..2250 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@2250..2255
+          0: NEVER_KW@2250..2255 "never" [] []
+      5: SEMICOLON@2255..2256 ";" [] []
+    25: TS_TYPE_ALIAS_DECLARATION@2256..2315
+      0: TYPE_KW@2256..2262 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@2262..2264
+        0: IDENT@2262..2264 "T3" [] []
+      2: TS_TYPE_PARAMETERS@2264..2268
+        0: L_ANGLE@2264..2265 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@2265..2266
+          0: TS_TYPE_PARAMETER@2265..2266
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@2265..2265
+            1: TS_TYPE_PARAMETER_NAME@2265..2266
+              0: IDENT@2265..2266 "T" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@2266..2268 ">" [] [Whitespace(" ")]
+      3: EQ@2268..2270 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@2270..2314
+        0: TS_REFERENCE_TYPE@2270..2272
+          0: JS_REFERENCE_IDENTIFIER@2270..2272
+            0: IDENT@2270..2272 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@2272..2280 "extends" [] [Whitespace(" ")]
+        2: TS_REFERENCE_TYPE@2280..2300
+          0: JS_REFERENCE_IDENTIFIER@2280..2288
+            0: IDENT@2280..2288 "IsNumber" [] []
+          1: TS_TYPE_ARGUMENTS@2288..2300
+            0: L_ANGLE@2288..2289 "<" [] []
+            1: TS_TYPE_ARGUMENT_LIST@2289..2298
+              0: TS_PARENTHESIZED_TYPE@2289..2298
+                0: L_PAREN@2289..2290 "(" [] []
+                1: TS_INFER_TYPE@2290..2297
+                  0: INFER_KW@2290..2296 "infer" [] [Whitespace(" ")]
+                  1: TS_TYPE_PARAMETER_NAME@2296..2297
+                    0: IDENT@2296..2297 "N" [] []
+                  2: (empty)
+                2: R_PAREN@2297..2298 ")" [] []
+            2: R_ANGLE@2298..2300 ">" [] [Whitespace(" ")]
+        3: QUESTION@2300..2302 "?" [] [Whitespace(" ")]
+        4: TS_BOOLEAN_LITERAL_TYPE@2302..2307
+          0: TRUE_KW@2302..2307 "true" [] [Whitespace(" ")]
+        5: COLON@2307..2309 ":" [] [Whitespace(" ")]
+        6: TS_BOOLEAN_LITERAL_TYPE@2309..2314
+          0: FALSE_KW@2309..2314 "false" [] []
+      5: SEMICOLON@2314..2315 ";" [] []
+    26: TS_TYPE_ALIAS_DECLARATION@2315..2380
+      0: TYPE_KW@2315..2321 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@2321..2324
+        0: IDENT@2321..2324 "T4" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@2324..2326 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@2326..2379
+        0: TS_REFERENCE_TYPE@2326..2329
+          0: JS_REFERENCE_IDENTIFIER@2326..2329
+            0: IDENT@2326..2329 "F1" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@2329..2337 "extends" [] [Whitespace(" ")]
+        2: TS_FUNCTION_TYPE@2337..2368
+          0: (empty)
+          1: JS_PARAMETERS@2337..2360
+            0: L_PAREN@2337..2338 "(" [] []
+            1: JS_PARAMETER_LIST@2338..2358
+              0: JS_REST_PARAMETER@2338..2358
+                0: JS_DECORATOR_LIST@2338..2338
+                1: DOT3@2338..2341 "..." [] []
+                2: JS_IDENTIFIER_BINDING@2341..2345
+                  0: IDENT@2341..2345 "args" [] []
+                3: TS_TYPE_ANNOTATION@2345..2358
+                  0: COLON@2345..2347 ":" [] [Whitespace(" ")]
+                  1: TS_PARENTHESIZED_TYPE@2347..2358
+                    0: L_PAREN@2347..2348 "(" [] []
+                    1: TS_PARENTHESIZED_TYPE@2348..2357
+                      0: L_PAREN@2348..2349 "(" [] []
+                      1: TS_INFER_TYPE@2349..2356
+                        0: INFER_KW@2349..2355 "infer" [] [Whitespace(" ")]
+                        1: TS_TYPE_PARAMETER_NAME@2355..2356
+                          0: IDENT@2355..2356 "T" [] []
+                        2: (empty)
+                      2: R_PAREN@2356..2357 ")" [] []
+                    2: R_PAREN@2357..2358 ")" [] []
+            2: R_PAREN@2358..2360 ")" [] [Whitespace(" ")]
+          2: FAT_ARROW@2360..2363 "=>" [] [Whitespace(" ")]
+          3: TS_VOID_TYPE@2363..2368
+            0: VOID_KW@2363..2368 "void" [] [Whitespace(" ")]
+        3: QUESTION@2368..2370 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@2370..2372
+          0: JS_REFERENCE_IDENTIFIER@2370..2372
+            0: IDENT@2370..2372 "T" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@2372..2374 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@2374..2379
+          0: NEVER_KW@2374..2379 "never" [] []
+      5: SEMICOLON@2379..2380 ";" [] []
+    27: TS_TYPE_ALIAS_DECLARATION@2380..2447
+      0: TYPE_KW@2380..2386 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@2386..2389
+        0: IDENT@2386..2389 "T5" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@2389..2391 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@2391..2446
+        0: TS_REFERENCE_TYPE@2391..2394
+          0: JS_REFERENCE_IDENTIFIER@2391..2394
+            0: IDENT@2391..2394 "F1" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@2394..2402 "extends" [] [Whitespace(" ")]
+        2: TS_FUNCTION_TYPE@2402..2435
+          0: (empty)
+          1: JS_PARAMETERS@2402..2427
+            0: L_PAREN@2402..2403 "(" [] []
+            1: JS_PARAMETER_LIST@2403..2425
+              0: JS_FORMAL_PARAMETER@2403..2425
+                0: JS_DECORATOR_LIST@2403..2403
+                1: JS_IDENTIFIER_BINDING@2403..2407
+                  0: IDENT@2403..2407 "args" [] []
+                2: (empty)
+                3: TS_TYPE_ANNOTATION@2407..2425
+                  0: COLON@2407..2409 ":" [] [Whitespace(" ")]
+                  1: TS_TUPLE_TYPE@2409..2425
+                    0: L_BRACK@2409..2410 "[" [] []
+                    1: TS_TUPLE_TYPE_ELEMENT_LIST@2410..2424
+                      0: TS_REST_TUPLE_TYPE_ELEMENT@2410..2424
+                        0: DOT3@2410..2413 "..." [] []
+                        1: TS_PARENTHESIZED_TYPE@2413..2424
+                          0: L_PAREN@2413..2414 "(" [] []
+                          1: TS_PARENTHESIZED_TYPE@2414..2423
+                            0: L_PAREN@2414..2415 "(" [] []
+                            1: TS_INFER_TYPE@2415..2422
+                              0: INFER_KW@2415..2421 "infer" [] [Whitespace(" ")]
+                              1: TS_TYPE_PARAMETER_NAME@2421..2422
+                                0: IDENT@2421..2422 "T" [] []
+                              2: (empty)
+                            2: R_PAREN@2422..2423 ")" [] []
+                          2: R_PAREN@2423..2424 ")" [] []
+                    2: R_BRACK@2424..2425 "]" [] []
+                4: (empty)
+            2: R_PAREN@2425..2427 ")" [] [Whitespace(" ")]
+          2: FAT_ARROW@2427..2430 "=>" [] [Whitespace(" ")]
+          3: TS_VOID_TYPE@2430..2435
+            0: VOID_KW@2430..2435 "void" [] [Whitespace(" ")]
+        3: QUESTION@2435..2437 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@2437..2439
+          0: JS_REFERENCE_IDENTIFIER@2437..2439
+            0: IDENT@2437..2439 "T" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@2439..2441 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@2441..2446
+          0: NEVER_KW@2441..2446 "never" [] []
+      5: SEMICOLON@2446..2447 ";" [] []
+    28: TS_TYPE_ALIAS_DECLARATION@2447..2508
+      0: TYPE_KW@2447..2453 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@2453..2455
+        0: IDENT@2453..2455 "T6" [] []
+      2: TS_TYPE_PARAMETERS@2455..2459
+        0: L_ANGLE@2455..2456 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@2456..2457
+          0: TS_TYPE_PARAMETER@2456..2457
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@2456..2456
+            1: TS_TYPE_PARAMETER_NAME@2456..2457
+              0: IDENT@2456..2457 "T" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@2457..2459 ">" [] [Whitespace(" ")]
+      3: EQ@2459..2461 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@2461..2507
+        0: TS_REFERENCE_TYPE@2461..2463
+          0: JS_REFERENCE_IDENTIFIER@2461..2463
+            0: IDENT@2461..2463 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@2463..2471 "extends" [] [Whitespace(" ")]
+        2: TS_REFERENCE_TYPE@2471..2493
+          0: JS_REFERENCE_IDENTIFIER@2471..2479
+            0: IDENT@2471..2479 "IsNumber" [] []
+          1: TS_TYPE_ARGUMENTS@2479..2493
+            0: L_ANGLE@2479..2480 "<" [] []
+            1: TS_TYPE_ARGUMENT_LIST@2480..2491
+              0: TS_PARENTHESIZED_TYPE@2480..2491
+                0: L_PAREN@2480..2481 "(" [] []
+                1: TS_PARENTHESIZED_TYPE@2481..2490
+                  0: L_PAREN@2481..2482 "(" [] []
+                  1: TS_INFER_TYPE@2482..2489
+                    0: INFER_KW@2482..2488 "infer" [] [Whitespace(" ")]
+                    1: TS_TYPE_PARAMETER_NAME@2488..2489
+                      0: IDENT@2488..2489 "N" [] []
+                    2: (empty)
+                  2: R_PAREN@2489..2490 ")" [] []
+                2: R_PAREN@2490..2491 ")" [] []
+            2: R_ANGLE@2491..2493 ">" [] [Whitespace(" ")]
+        3: QUESTION@2493..2495 "?" [] [Whitespace(" ")]
+        4: TS_BOOLEAN_LITERAL_TYPE@2495..2500
+          0: TRUE_KW@2495..2500 "true" [] [Whitespace(" ")]
+        5: COLON@2500..2502 ":" [] [Whitespace(" ")]
+        6: TS_BOOLEAN_LITERAL_TYPE@2502..2507
+          0: FALSE_KW@2502..2507 "false" [] []
+      5: SEMICOLON@2507..2508 ";" [] []
+    29: TS_TYPE_ALIAS_DECLARATION@2508..2577
+      0: TYPE_KW@2508..2514 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@2514..2517
+        0: IDENT@2514..2517 "T7" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@2517..2519 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@2519..2576
+        0: TS_REFERENCE_TYPE@2519..2522
+          0: JS_REFERENCE_IDENTIFIER@2519..2522
+            0: IDENT@2519..2522 "F1" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@2522..2530 "extends" [] [Whitespace(" ")]
+        2: TS_FUNCTION_TYPE@2530..2565
+          0: (empty)
+          1: JS_PARAMETERS@2530..2557
+            0: L_PAREN@2530..2531 "(" [] []
+            1: JS_PARAMETER_LIST@2531..2555
+              0: JS_REST_PARAMETER@2531..2555
+                0: JS_DECORATOR_LIST@2531..2531
+                1: DOT3@2531..2534 "..." [] []
+                2: JS_IDENTIFIER_BINDING@2534..2538
+                  0: IDENT@2534..2538 "args" [] []
+                3: TS_TYPE_ANNOTATION@2538..2555
+                  0: COLON@2538..2540 ":" [] [Whitespace(" ")]
+                  1: TS_PARENTHESIZED_TYPE@2540..2555
+                    0: L_PAREN@2540..2541 "(" [] []
+                    1: TS_PARENTHESIZED_TYPE@2541..2554
+                      0: L_PAREN@2541..2542 "(" [] []
+                      1: TS_PARENTHESIZED_TYPE@2542..2553
+                        0: L_PAREN@2542..2543 "(" [] []
+                        1: TS_PARENTHESIZED_TYPE@2543..2552
+                          0: L_PAREN@2543..2544 "(" [] []
+                          1: TS_INFER_TYPE@2544..2551
+                            0: INFER_KW@2544..2550 "infer" [] [Whitespace(" ")]
+                            1: TS_TYPE_PARAMETER_NAME@2550..2551
+                              0: IDENT@2550..2551 "T" [] []
+                            2: (empty)
+                          2: R_PAREN@2551..2552 ")" [] []
+                        2: R_PAREN@2552..2553 ")" [] []
+                      2: R_PAREN@2553..2554 ")" [] []
+                    2: R_PAREN@2554..2555 ")" [] []
+            2: R_PAREN@2555..2557 ")" [] [Whitespace(" ")]
+          2: FAT_ARROW@2557..2560 "=>" [] [Whitespace(" ")]
+          3: TS_VOID_TYPE@2560..2565
+            0: VOID_KW@2560..2565 "void" [] [Whitespace(" ")]
+        3: QUESTION@2565..2567 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@2567..2569
+          0: JS_REFERENCE_IDENTIFIER@2567..2569
+            0: IDENT@2567..2569 "T" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@2569..2571 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@2571..2576
+          0: NEVER_KW@2571..2576 "never" [] []
+      5: SEMICOLON@2576..2577 ";" [] []
+    30: TS_TYPE_ALIAS_DECLARATION@2577..2648
+      0: TYPE_KW@2577..2583 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@2583..2586
+        0: IDENT@2583..2586 "T8" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@2586..2588 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@2588..2647
+        0: TS_REFERENCE_TYPE@2588..2591
+          0: JS_REFERENCE_IDENTIFIER@2588..2591
+            0: IDENT@2588..2591 "F1" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@2591..2599 "extends" [] [Whitespace(" ")]
+        2: TS_FUNCTION_TYPE@2599..2636
+          0: (empty)
+          1: JS_PARAMETERS@2599..2628
+            0: L_PAREN@2599..2600 "(" [] []
+            1: JS_PARAMETER_LIST@2600..2626
+              0: JS_FORMAL_PARAMETER@2600..2626
+                0: JS_DECORATOR_LIST@2600..2600
+                1: JS_IDENTIFIER_BINDING@2600..2604
+                  0: IDENT@2600..2604 "args" [] []
+                2: (empty)
+                3: TS_TYPE_ANNOTATION@2604..2626
+                  0: COLON@2604..2606 ":" [] [Whitespace(" ")]
+                  1: TS_TUPLE_TYPE@2606..2626
+                    0: L_BRACK@2606..2607 "[" [] []
+                    1: TS_TUPLE_TYPE_ELEMENT_LIST@2607..2625
+                      0: TS_REST_TUPLE_TYPE_ELEMENT@2607..2625
+                        0: DOT3@2607..2610 "..." [] []
+                        1: TS_PARENTHESIZED_TYPE@2610..2625
+                          0: L_PAREN@2610..2611 "(" [] []
+                          1: TS_PARENTHESIZED_TYPE@2611..2624
+                            0: L_PAREN@2611..2612 "(" [] []
+                            1: TS_PARENTHESIZED_TYPE@2612..2623
+                              0: L_PAREN@2612..2613 "(" [] []
+                              1: TS_PARENTHESIZED_TYPE@2613..2622
+                                0: L_PAREN@2613..2614 "(" [] []
+                                1: TS_INFER_TYPE@2614..2621
+                                  0: INFER_KW@2614..2620 "infer" [] [Whitespace(" ")]
+                                  1: TS_TYPE_PARAMETER_NAME@2620..2621
+                                    0: IDENT@2620..2621 "T" [] []
+                                  2: (empty)
+                                2: R_PAREN@2621..2622 ")" [] []
+                              2: R_PAREN@2622..2623 ")" [] []
+                            2: R_PAREN@2623..2624 ")" [] []
+                          2: R_PAREN@2624..2625 ")" [] []
+                    2: R_BRACK@2625..2626 "]" [] []
+                4: (empty)
+            2: R_PAREN@2626..2628 ")" [] [Whitespace(" ")]
+          2: FAT_ARROW@2628..2631 "=>" [] [Whitespace(" ")]
+          3: TS_VOID_TYPE@2631..2636
+            0: VOID_KW@2631..2636 "void" [] [Whitespace(" ")]
+        3: QUESTION@2636..2638 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@2638..2640
+          0: JS_REFERENCE_IDENTIFIER@2638..2640
+            0: IDENT@2638..2640 "T" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@2640..2642 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@2642..2647
+          0: NEVER_KW@2642..2647 "never" [] []
+      5: SEMICOLON@2647..2648 ";" [] []
+    31: TS_TYPE_ALIAS_DECLARATION@2648..2713
+      0: TYPE_KW@2648..2654 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@2654..2656
+        0: IDENT@2654..2656 "T9" [] []
+      2: TS_TYPE_PARAMETERS@2656..2660
+        0: L_ANGLE@2656..2657 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@2657..2658
+          0: TS_TYPE_PARAMETER@2657..2658
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@2657..2657
+            1: TS_TYPE_PARAMETER_NAME@2657..2658
+              0: IDENT@2657..2658 "T" [] []
+            2: (empty)
+            3: (empty)
+        2: R_ANGLE@2658..2660 ">" [] [Whitespace(" ")]
+      3: EQ@2660..2662 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@2662..2712
+        0: TS_REFERENCE_TYPE@2662..2664
+          0: JS_REFERENCE_IDENTIFIER@2662..2664
+            0: IDENT@2662..2664 "T" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@2664..2672 "extends" [] [Whitespace(" ")]
+        2: TS_REFERENCE_TYPE@2672..2698
+          0: JS_REFERENCE_IDENTIFIER@2672..2680
+            0: IDENT@2672..2680 "IsNumber" [] []
+          1: TS_TYPE_ARGUMENTS@2680..2698
+            0: L_ANGLE@2680..2681 "<" [] []
+            1: TS_TYPE_ARGUMENT_LIST@2681..2696
+              0: TS_PARENTHESIZED_TYPE@2681..2696
+                0: L_PAREN@2681..2682 "(" [] []
+                1: TS_PARENTHESIZED_TYPE@2682..2695
+                  0: L_PAREN@2682..2683 "(" [] []
+                  1: TS_PARENTHESIZED_TYPE@2683..2694
+                    0: L_PAREN@2683..2684 "(" [] []
+                    1: TS_PARENTHESIZED_TYPE@2684..2693
+                      0: L_PAREN@2684..2685 "(" [] []
+                      1: TS_INFER_TYPE@2685..2692
+                        0: INFER_KW@2685..2691 "infer" [] [Whitespace(" ")]
+                        1: TS_TYPE_PARAMETER_NAME@2691..2692
+                          0: IDENT@2691..2692 "N" [] []
+                        2: (empty)
+                      2: R_PAREN@2692..2693 ")" [] []
+                    2: R_PAREN@2693..2694 ")" [] []
+                  2: R_PAREN@2694..2695 ")" [] []
+                2: R_PAREN@2695..2696 ")" [] []
+            2: R_ANGLE@2696..2698 ">" [] [Whitespace(" ")]
+        3: QUESTION@2698..2700 "?" [] [Whitespace(" ")]
+        4: TS_BOOLEAN_LITERAL_TYPE@2700..2705
+          0: TRUE_KW@2700..2705 "true" [] [Whitespace(" ")]
+        5: COLON@2705..2707 ":" [] [Whitespace(" ")]
+        6: TS_BOOLEAN_LITERAL_TYPE@2707..2712
+          0: FALSE_KW@2707..2712 "false" [] []
+      5: SEMICOLON@2712..2713 ";" [] []
+    32: TS_TYPE_ALIAS_DECLARATION@2713..2836
+      0: TYPE_KW@2713..2719 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@2719..2726
+        0: IDENT@2719..2726 "Prepend" [] []
+      2: TS_TYPE_PARAMETERS@2726..2747
+        0: L_ANGLE@2726..2727 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@2727..2745
+          0: TS_TYPE_PARAMETER@2727..2728
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@2727..2727
+            1: TS_TYPE_PARAMETER_NAME@2727..2728
+              0: IDENT@2727..2728 "E" [] []
+            2: (empty)
+            3: (empty)
+          1: COMMA@2728..2730 "," [] [Whitespace(" ")]
+          2: TS_TYPE_PARAMETER@2730..2745
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@2730..2730
+            1: TS_TYPE_PARAMETER_NAME@2730..2732
+              0: IDENT@2730..2732 "T" [] [Whitespace(" ")]
+            2: TS_TYPE_CONSTRAINT_CLAUSE@2732..2745
+              0: EXTENDS_KW@2732..2740 "extends" [] [Whitespace(" ")]
+              1: TS_ARRAY_TYPE@2740..2745
+                0: TS_ANY_TYPE@2740..2743
+                  0: ANY_KW@2740..2743 "any" [] []
+                1: L_BRACK@2743..2744 "[" [] []
+                2: R_BRACK@2744..2745 "]" [] []
+            3: (empty)
+        2: R_ANGLE@2745..2747 ">" [] [Whitespace(" ")]
+      3: EQ@2747..2748 "=" [] []
+      4: TS_CONDITIONAL_TYPE@2748..2835
+        0: TS_PARENTHESIZED_TYPE@2748..2784
+          0: L_PAREN@2748..2754 "(" [Newline("\n"), Whitespace("    ")] []
+          1: TS_FUNCTION_TYPE@2754..2782
+            0: (empty)
+            1: JS_PARAMETERS@2754..2776
+              0: L_PAREN@2754..2755 "(" [] []
+              1: JS_PARAMETER_LIST@2755..2774
+                0: JS_FORMAL_PARAMETER@2755..2762
+                  0: JS_DECORATOR_LIST@2755..2755
+                  1: JS_IDENTIFIER_BINDING@2755..2759
+                    0: IDENT@2755..2759 "head" [] []
+                  2: (empty)
+                  3: TS_TYPE_ANNOTATION@2759..2762
+                    0: COLON@2759..2761 ":" [] [Whitespace(" ")]
+                    1: TS_REFERENCE_TYPE@2761..2762
+                      0: JS_REFERENCE_IDENTIFIER@2761..2762
+                        0: IDENT@2761..2762 "E" [] []
+                      1: (empty)
+                  4: (empty)
+                1: COMMA@2762..2764 "," [] [Whitespace(" ")]
+                2: JS_REST_PARAMETER@2764..2774
+                  0: JS_DECORATOR_LIST@2764..2764
+                  1: DOT3@2764..2767 "..." [] []
+                  2: JS_IDENTIFIER_BINDING@2767..2771
+                    0: IDENT@2767..2771 "args" [] []
+                  3: TS_TYPE_ANNOTATION@2771..2774
+                    0: COLON@2771..2773 ":" [] [Whitespace(" ")]
+                    1: TS_REFERENCE_TYPE@2773..2774
+                      0: JS_REFERENCE_IDENTIFIER@2773..2774
+                        0: IDENT@2773..2774 "T" [] []
+                      1: (empty)
+              2: R_PAREN@2774..2776 ")" [] [Whitespace(" ")]
+            2: FAT_ARROW@2776..2779 "=>" [] [Whitespace(" ")]
+            3: TS_ANY_TYPE@2779..2782
+              0: ANY_KW@2779..2782 "any" [] []
+          2: R_PAREN@2782..2784 ")" [] [Whitespace(" ")]
+        1: EXTENDS_KW@2784..2792 "extends" [] [Whitespace(" ")]
+        2: TS_PARENTHESIZED_TYPE@2792..2819
+          0: L_PAREN@2792..2793 "(" [] []
+          1: TS_FUNCTION_TYPE@2793..2818
+            0: (empty)
+            1: JS_PARAMETERS@2793..2812
+              0: L_PAREN@2793..2794 "(" [] []
+              1: JS_PARAMETER_LIST@2794..2810
+                0: JS_REST_PARAMETER@2794..2810
+                  0: JS_DECORATOR_LIST@2794..2794
+                  1: DOT3@2794..2797 "..." [] []
+                  2: JS_IDENTIFIER_BINDING@2797..2801
+                    0: IDENT@2797..2801 "args" [] []
+                  3: TS_TYPE_ANNOTATION@2801..2810
+                    0: COLON@2801..2803 ":" [] [Whitespace(" ")]
+                    1: TS_INFER_TYPE@2803..2810
+                      0: INFER_KW@2803..2809 "infer" [] [Whitespace(" ")]
+                      1: TS_TYPE_PARAMETER_NAME@2809..2810
+                        0: IDENT@2809..2810 "U" [] []
+                      2: (empty)
+              2: R_PAREN@2810..2812 ")" [] [Whitespace(" ")]
+            2: FAT_ARROW@2812..2815 "=>" [] [Whitespace(" ")]
+            3: TS_ANY_TYPE@2815..2818
+              0: ANY_KW@2815..2818 "any" [] []
+          2: R_PAREN@2818..2819 ")" [] []
+        3: QUESTION@2819..2826 "?" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@2826..2827
+          0: JS_REFERENCE_IDENTIFIER@2826..2827
+            0: IDENT@2826..2827 "U" [] []
+          1: (empty)
+        5: COLON@2827..2834 ":" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+        6: TS_REFERENCE_TYPE@2834..2835
+          0: JS_REFERENCE_IDENTIFIER@2834..2835
+            0: IDENT@2834..2835 "T" [] []
+          1: (empty)
+      5: SEMICOLON@2835..2836 ";" [] []
+  3: EOF@2836..2837 "" [Newline("\n")] []

--- a/crates/biome_js_parser/test_data/inline/ok/ts_infer_type_allowed.ts
+++ b/crates/biome_js_parser/test_data/inline/ok/ts_infer_type_allowed.ts
@@ -1,0 +1,51 @@
+type Args<F> = F extends (...args: infer A) => void ? A : never;
+type A = T extends import("test").C<infer P> ? P : never
+type A = T extends typeof Array<infer P> ? P : never
+type A = T extends { set(a: infer P): number } ? P : never
+type A = T extends { get(): infer P } ? P : never
+type A = T extends { method(this: infer P): number } ? P : never
+type valid9<T> = T extends Array<infer R> ? R : any;
+type ContentBetweenBrackets<S> = S extends `[${infer T}]` ? T : never;
+type WithSelectors<S> = S extends { getState: () => infer T }
+    ? S & { use: { [K in keyof T]: () => T[K] } }
+    : never;
+type A = MyType extends (OtherType extends infer T ? infer U : InnerFalse) ? OuterTrue : OuterFalse
+type Join<T extends unknown[], D extends string> =
+     T extends [] ? '' :
+     T extends [string | number | boolean | bigint] ? `${T[0]}` :
+     T extends [string | number | boolean | bigint, ...infer U] ? `${T[0]}${D}${Join<U, D>}` :
+     string;
+type MatchPair<S extends string> = S extends `[${infer A},${infer B}]` ? [A, B] : unknown;
+type FirstTwoAndRest<S extends string> = S extends `${infer A}${infer B}${infer R}` ? [`${A}${B}`, R] : unknown;
+type Trim<S extends string> =
+     S extends `${infer T} ` ? Trim<T> :
+     S;
+type Foo<T> = T extends `*${infer S}*` ? S : never;
+type Unpacked<T> = T extends (infer U)[] ? U :
+    T extends (...args: any[]) => infer U ? U :
+    T extends Promise<infer U> ? U :
+    T;
+type ArgumentType<T extends (x: any) => any> = T extends (a: infer A) => any ? A : any;
+type X3<T> = T extends { a: (x: infer U) => void, b: (x: infer U) => void } ? U : never;
+type X1<T extends { x: any, y: any }> = T extends { x: infer X, y: infer Y } ? [X, Y] : any;
+type T62<T> = U extends (infer U)[] ? U : U;
+type T63<T> = T extends ((infer A) extends infer B ? infer C : infer D) ? string : number;
+type T75<T> = T extends T74<infer U, infer U> ? T70<U> | T72<U> | T74<U, U> : never;
+type Jsonified<T> = T extends string | number | boolean | null ? T
+    : T extends undefined | Function ? never
+    : T extends { toJSON(): infer R } ? R
+    : T extends object ? JsonifiedObject<T>
+: "what is this";
+type T1 = F1 extends (...args: (infer T)) => void ? T : never;
+type T2 = F1 extends (args: [...(infer T)]) => void ? T : never;
+type T3<T> = T extends IsNumber<(infer N)> ? true : false;
+type T4 = F1 extends (...args: ((infer T))) => void ? T : never;
+type T5 = F1 extends (args: [...((infer T))]) => void ? T : never;
+type T6<T> = T extends IsNumber<((infer N))> ? true : false;
+type T7 = F1 extends (...args: ((((infer T))))) => void ? T : never;
+type T8 = F1 extends (args: [...((((infer T))))]) => void ? T : never;
+type T9<T> = T extends IsNumber<((((infer N))))> ? true : false;
+type Prepend<E, T extends any[]> =
+    ((head: E, ...args: T) => any) extends ((...args: infer U) => any)
+    ? U
+    : T;

--- a/crates/biome_js_parser/test_data/inline/ok/ts_inferred_type.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/ts_inferred_type.rast
@@ -9,121 +9,189 @@ JsModule {
             },
             type_parameters: missing (optional),
             eq_token: EQ@7..9 "=" [] [Whitespace(" ")],
-            ty: TsInferType {
-                infer_token: INFER_KW@9..15 "infer" [] [Whitespace(" ")],
-                name: TsTypeParameterName {
-                    ident_token: IDENT@15..16 "B" [] [],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@9..11 "A" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
                 },
-                constraint: missing (optional),
+                extends_token: EXTENDS_KW@11..19 "extends" [] [Whitespace(" ")],
+                extends_type: TsInferType {
+                    infer_token: INFER_KW@19..25 "infer" [] [Whitespace(" ")],
+                    name: TsTypeParameterName {
+                        ident_token: IDENT@25..27 "B" [] [Whitespace(" ")],
+                    },
+                    constraint: missing (optional),
+                },
+                question_mark_token: QUESTION@27..29 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@29..31 "B" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@31..33 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@33..38 "never" [] [],
+                },
             },
-            semicolon_token: SEMICOLON@16..17 ";" [] [],
+            semicolon_token: SEMICOLON@38..39 ";" [] [],
         },
         TsTypeAliasDeclaration {
-            type_token: TYPE_KW@17..23 "type" [Newline("\n")] [Whitespace(" ")],
+            type_token: TYPE_KW@39..45 "type" [Newline("\n")] [Whitespace(" ")],
             binding_identifier: TsIdentifierBinding {
-                name_token: IDENT@23..25 "B" [] [Whitespace(" ")],
+                name_token: IDENT@45..47 "B" [] [Whitespace(" ")],
             },
             type_parameters: missing (optional),
-            eq_token: EQ@25..27 "=" [] [Whitespace(" ")],
-            ty: TsObjectType {
-                l_curly_token: L_CURLY@27..29 "{" [] [Whitespace(" ")],
-                members: TsTypeMemberList [
-                    TsPropertySignatureTypeMember {
-                        readonly_token: missing (optional),
-                        name: JsLiteralMemberName {
-                            value: IDENT@29..30 "a" [] [],
-                        },
-                        optional_token: missing (optional),
-                        type_annotation: TsTypeAnnotation {
-                            colon_token: COLON@30..32 ":" [] [Whitespace(" ")],
-                            ty: TsInferType {
-                                infer_token: INFER_KW@32..38 "infer" [] [Whitespace(" ")],
-                                name: TsTypeParameterName {
-                                    ident_token: IDENT@38..39 "U" [] [],
-                                },
-                                constraint: missing (optional),
-                            },
-                        },
-                        separator_token: SEMICOLON@39..41 ";" [] [Whitespace(" ")],
+            eq_token: EQ@47..49 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@49..51 "A" [] [Whitespace(" ")],
                     },
-                    TsPropertySignatureTypeMember {
-                        readonly_token: missing (optional),
-                        name: JsLiteralMemberName {
-                            value: IDENT@41..42 "b" [] [],
-                        },
-                        optional_token: missing (optional),
-                        type_annotation: TsTypeAnnotation {
-                            colon_token: COLON@42..44 ":" [] [Whitespace(" ")],
-                            ty: TsInferType {
-                                infer_token: INFER_KW@44..50 "infer" [] [Whitespace(" ")],
-                                name: TsTypeParameterName {
-                                    ident_token: IDENT@50..51 "U" [] [],
-                                },
-                                constraint: missing (optional),
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@51..59 "extends" [] [Whitespace(" ")],
+                extends_type: TsObjectType {
+                    l_curly_token: L_CURLY@59..61 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [
+                        TsPropertySignatureTypeMember {
+                            readonly_token: missing (optional),
+                            name: JsLiteralMemberName {
+                                value: IDENT@61..62 "a" [] [],
                             },
+                            optional_token: missing (optional),
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@62..64 ":" [] [Whitespace(" ")],
+                                ty: TsInferType {
+                                    infer_token: INFER_KW@64..70 "infer" [] [Whitespace(" ")],
+                                    name: TsTypeParameterName {
+                                        ident_token: IDENT@70..71 "U" [] [],
+                                    },
+                                    constraint: missing (optional),
+                                },
+                            },
+                            separator_token: SEMICOLON@71..73 ";" [] [Whitespace(" ")],
                         },
-                        separator_token: missing (optional),
+                        TsPropertySignatureTypeMember {
+                            readonly_token: missing (optional),
+                            name: JsLiteralMemberName {
+                                value: IDENT@73..74 "b" [] [],
+                            },
+                            optional_token: missing (optional),
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@74..76 ":" [] [Whitespace(" ")],
+                                ty: TsInferType {
+                                    infer_token: INFER_KW@76..82 "infer" [] [Whitespace(" ")],
+                                    name: TsTypeParameterName {
+                                        ident_token: IDENT@82..83 "U" [] [],
+                                    },
+                                    constraint: missing (optional),
+                                },
+                            },
+                            separator_token: missing (optional),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@83..85 "}" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@85..87 "?" [] [Whitespace(" ")],
+                true_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@87..89 "U" [] [Whitespace(" ")],
                     },
-                ],
-                r_curly_token: R_CURLY@51..52 "}" [] [],
+                    type_arguments: missing (optional),
+                },
+                colon_token: COLON@89..91 ":" [] [Whitespace(" ")],
+                false_type: TsNeverType {
+                    never_token: NEVER_KW@91..96 "never" [] [],
+                },
             },
-            semicolon_token: SEMICOLON@52..53 ";" [] [],
+            semicolon_token: SEMICOLON@96..97 ";" [] [],
         },
     ],
-    eof_token: EOF@53..54 "" [Newline("\n")] [],
+    eof_token: EOF@97..98 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..54
+0: JS_MODULE@0..98
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..53
-    0: TS_TYPE_ALIAS_DECLARATION@0..17
+  2: JS_MODULE_ITEM_LIST@0..97
+    0: TS_TYPE_ALIAS_DECLARATION@0..39
       0: TYPE_KW@0..5 "type" [] [Whitespace(" ")]
       1: TS_IDENTIFIER_BINDING@5..7
         0: IDENT@5..7 "A" [] [Whitespace(" ")]
       2: (empty)
       3: EQ@7..9 "=" [] [Whitespace(" ")]
-      4: TS_INFER_TYPE@9..16
-        0: INFER_KW@9..15 "infer" [] [Whitespace(" ")]
-        1: TS_TYPE_PARAMETER_NAME@15..16
-          0: IDENT@15..16 "B" [] []
-        2: (empty)
-      5: SEMICOLON@16..17 ";" [] []
-    1: TS_TYPE_ALIAS_DECLARATION@17..53
-      0: TYPE_KW@17..23 "type" [Newline("\n")] [Whitespace(" ")]
-      1: TS_IDENTIFIER_BINDING@23..25
-        0: IDENT@23..25 "B" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@9..38
+        0: TS_REFERENCE_TYPE@9..11
+          0: JS_REFERENCE_IDENTIFIER@9..11
+            0: IDENT@9..11 "A" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@11..19 "extends" [] [Whitespace(" ")]
+        2: TS_INFER_TYPE@19..27
+          0: INFER_KW@19..25 "infer" [] [Whitespace(" ")]
+          1: TS_TYPE_PARAMETER_NAME@25..27
+            0: IDENT@25..27 "B" [] [Whitespace(" ")]
+          2: (empty)
+        3: QUESTION@27..29 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@29..31
+          0: JS_REFERENCE_IDENTIFIER@29..31
+            0: IDENT@29..31 "B" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@31..33 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@33..38
+          0: NEVER_KW@33..38 "never" [] []
+      5: SEMICOLON@38..39 ";" [] []
+    1: TS_TYPE_ALIAS_DECLARATION@39..97
+      0: TYPE_KW@39..45 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@45..47
+        0: IDENT@45..47 "B" [] [Whitespace(" ")]
       2: (empty)
-      3: EQ@25..27 "=" [] [Whitespace(" ")]
-      4: TS_OBJECT_TYPE@27..52
-        0: L_CURLY@27..29 "{" [] [Whitespace(" ")]
-        1: TS_TYPE_MEMBER_LIST@29..51
-          0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@29..41
-            0: (empty)
-            1: JS_LITERAL_MEMBER_NAME@29..30
-              0: IDENT@29..30 "a" [] []
-            2: (empty)
-            3: TS_TYPE_ANNOTATION@30..39
-              0: COLON@30..32 ":" [] [Whitespace(" ")]
-              1: TS_INFER_TYPE@32..39
-                0: INFER_KW@32..38 "infer" [] [Whitespace(" ")]
-                1: TS_TYPE_PARAMETER_NAME@38..39
-                  0: IDENT@38..39 "U" [] []
-                2: (empty)
-            4: SEMICOLON@39..41 ";" [] [Whitespace(" ")]
-          1: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@41..51
-            0: (empty)
-            1: JS_LITERAL_MEMBER_NAME@41..42
-              0: IDENT@41..42 "b" [] []
-            2: (empty)
-            3: TS_TYPE_ANNOTATION@42..51
-              0: COLON@42..44 ":" [] [Whitespace(" ")]
-              1: TS_INFER_TYPE@44..51
-                0: INFER_KW@44..50 "infer" [] [Whitespace(" ")]
-                1: TS_TYPE_PARAMETER_NAME@50..51
-                  0: IDENT@50..51 "U" [] []
-                2: (empty)
-            4: (empty)
-        2: R_CURLY@51..52 "}" [] []
-      5: SEMICOLON@52..53 ";" [] []
-  3: EOF@53..54 "" [Newline("\n")] []
+      3: EQ@47..49 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@49..96
+        0: TS_REFERENCE_TYPE@49..51
+          0: JS_REFERENCE_IDENTIFIER@49..51
+            0: IDENT@49..51 "A" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@51..59 "extends" [] [Whitespace(" ")]
+        2: TS_OBJECT_TYPE@59..85
+          0: L_CURLY@59..61 "{" [] [Whitespace(" ")]
+          1: TS_TYPE_MEMBER_LIST@61..83
+            0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@61..73
+              0: (empty)
+              1: JS_LITERAL_MEMBER_NAME@61..62
+                0: IDENT@61..62 "a" [] []
+              2: (empty)
+              3: TS_TYPE_ANNOTATION@62..71
+                0: COLON@62..64 ":" [] [Whitespace(" ")]
+                1: TS_INFER_TYPE@64..71
+                  0: INFER_KW@64..70 "infer" [] [Whitespace(" ")]
+                  1: TS_TYPE_PARAMETER_NAME@70..71
+                    0: IDENT@70..71 "U" [] []
+                  2: (empty)
+              4: SEMICOLON@71..73 ";" [] [Whitespace(" ")]
+            1: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@73..83
+              0: (empty)
+              1: JS_LITERAL_MEMBER_NAME@73..74
+                0: IDENT@73..74 "b" [] []
+              2: (empty)
+              3: TS_TYPE_ANNOTATION@74..83
+                0: COLON@74..76 ":" [] [Whitespace(" ")]
+                1: TS_INFER_TYPE@76..83
+                  0: INFER_KW@76..82 "infer" [] [Whitespace(" ")]
+                  1: TS_TYPE_PARAMETER_NAME@82..83
+                    0: IDENT@82..83 "U" [] []
+                  2: (empty)
+              4: (empty)
+          2: R_CURLY@83..85 "}" [] [Whitespace(" ")]
+        3: QUESTION@85..87 "?" [] [Whitespace(" ")]
+        4: TS_REFERENCE_TYPE@87..89
+          0: JS_REFERENCE_IDENTIFIER@87..89
+            0: IDENT@87..89 "U" [] [Whitespace(" ")]
+          1: (empty)
+        5: COLON@89..91 ":" [] [Whitespace(" ")]
+        6: TS_NEVER_TYPE@91..96
+          0: NEVER_KW@91..96 "never" [] []
+      5: SEMICOLON@96..97 ";" [] []
+  3: EOF@97..98 "" [Newline("\n")] []

--- a/crates/biome_js_parser/test_data/inline/ok/ts_inferred_type.ts
+++ b/crates/biome_js_parser/test_data/inline/ok/ts_inferred_type.ts
@@ -1,2 +1,2 @@
-type A = infer B;
-type B = { a: infer U; b: infer U};
+type A = A extends infer B ? B : never;
+type B = A extends { a: infer U; b: infer U} ? U : never;

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -38,6 +38,9 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Fix [#294](https://github.com/biomejs/biome/issues/294). [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type/) no longer reports false positives for return types. Contributed by @b4s36t4
 
 ### Parser
+
+- Enhance diagnostic for infer type handling in the parser. The 'infer' keyword can only be utilized within the 'extends' clause of a conditional type. Using it outside of this context will result in an error. Ensure that any type declarations using 'infer' are correctly placed within the conditional type structure to avoid parsing issues. Contributed by @denbezrukov
+
 ### VSCode
 
 ## 1.2.2 (2023-09-16)


### PR DESCRIPTION


## Summary

The 'infer' keyword can only be utilized within the 'extends' clause of a conditional type. Using it outside of this context will result in an error. Ensure that any type declarations using 'infer' are correctly placed within the conditional type structure to avoid parsing issues.

Added an error message from the typescript for such cases:
`'infer' declarations are only permitted in the 'extends' clause of a conditional type.`

Took test cases from the ts repo:
https://github.com/microsoft/TypeScript/blob/9cbcf010ce0701a25f01a2a074000db34f80cc17/tests/baselines/reference/inferTypes1.errors.txt#L124
https://github.com/microsoft/TypeScript/blob/9cbcf010ce0701a25f01a2a074000db34f80cc17/tests/baselines/reference/templateLiteralTypes1.errors.txt#L5


## Test Plan

`cargo test`
