### PR TITLE
fix(website): remove formatter options from biome lint

### DIFF
--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -275,40 +275,6 @@ Run various checks on a set of files.
   The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reasons. Defaults to 1 MiB
 - **`    --files-ignore-unknown`**=_`<true|false>`_ &mdash; 
   Tells Biome to not emit diagnostics when handling files that doesn't know
-- **`    --indent-style`**=_`<tab|space>`_ &mdash; 
-  The indent style.
-- **`    --indent-size`**=_`NUMBER`_ &mdash; 
-  The size of the indentation, 2 by default
-- **`    --line-width`**=_`NUMBER`_ &mdash; 
-  What's the max width of a line. Defaults to 80.
-- **`    --quote-style`**=_`<double|single>`_ &mdash; 
-  The type of quotes used in JavaScript code. Defaults to double.
-- **`    --jsx-quote-style`**=_`<double|single>`_ &mdash; 
-  The type of quotes used in JSX. Defaults to double.
-- **`    --quote-properties`**=_`<preserve|as-needed>`_ &mdash; 
-  When properties in objects are quoted. Defaults to asNeeded.
-- **`    --trailing-comma`**=_`<all|es5|none>`_ &mdash; 
-  Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "all".
-- **`    --semicolons`**=_`<always|as-needed>`_ &mdash; 
-  Whether the formatter prints semicolons for all statements or only in for statements where it is necessary because of ASI.
-- **`    --arrow-parentheses`**=_`<always|as-needed>`_ &mdash; 
-  Whether to add non-necessary parentheses to arrow functions. Defaults to "always".
-- **`    --javascript-formatter-enabled`**=_`<true|false>`_ &mdash; 
-  Control the formatter for JavaScript (and its super languages) files.
-- **`    --javascript-formatter-indent-style`**=_`<tab|space>`_ &mdash; 
-  The indent style applied to JavaScript (and its super languages) files.
-- **`    --javascript-formatter-indent-size`**=_`NUMBER`_ &mdash; 
-  The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.
-- **`    --javascript-formatter-line-width`**=_`NUMBER`_ &mdash; 
-  What's the max width of a line, applied to JavaScript (and its super languages) files. Defaults to 80.
-- **`    --json-formatter-enabled`**=_`<true|false>`_ &mdash; 
-  Control the formatter for JSON (and its super languages) files.
-- **`    --json-formatter-indent-style`**=_`<tab|space>`_ &mdash; 
-  The indent style applied to JSON (and its super languages) files.
-- **`    --json-formatter-indent-size`**=_`NUMBER`_ &mdash; 
-  The size of the indentation applied to JSON (and its super languages) files. Default to 2.
-- **`    --json-formatter-line-width`**=_`NUMBER`_ &mdash; 
-  What's the max width of a line, applied to JSON (and its super languages) files. Defaults to 80.
 
 
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Removes `biome formatter` options from `biome lint` help from website.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
