### PR TITLE
refactor(formatter): Use OnceCell in Memoized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 ### Configuration
 ### Editors
 ### Formatter
+
+#### Enhancements
+- Use `OnceCell` for the Memoized memory because that's what the `RefCell<Option>` implemented. Contributed by @denbezrukov
+
 ### JavaScript APIs
 ### Linter
 

--- a/crates/biome_formatter/src/format_extensions.rs
+++ b/crates/biome_formatter/src/format_extensions.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use std::cell::RefCell;
+use std::cell::OnceCell;
 use std::marker::PhantomData;
 use std::ops::Deref;
 
@@ -70,7 +70,7 @@ impl<T, Context> MemoizeFormat<Context> for T where T: Format<Context> {}
 #[derive(Debug)]
 pub struct Memoized<F, Context> {
     inner: F,
-    memory: RefCell<Option<FormatResult<Option<FormatElement>>>>,
+    memory: OnceCell<FormatResult<Option<FormatElement>>>,
     options: PhantomData<Context>,
 }
 
@@ -81,7 +81,7 @@ where
     fn new(inner: F) -> Self {
         Self {
             inner,
-            memory: RefCell::new(None),
+            memory: OnceCell::new(),
             options: PhantomData,
         }
     }
@@ -143,10 +143,7 @@ where
     ///
     /// ```
     pub fn inspect(&mut self, f: &mut Formatter<Context>) -> FormatResult<&[FormatElement]> {
-        let result = self
-            .memory
-            .get_mut()
-            .get_or_insert_with(|| f.intern(&self.inner));
+        let result = self.memory.get_or_init(|| f.intern(&self.inner));
 
         match result.as_ref() {
             Ok(Some(FormatElement::Interned(interned))) => Ok(interned.deref()),
@@ -162,8 +159,7 @@ where
     F: Format<Context>,
 {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        let mut memory = self.memory.borrow_mut();
-        let result = memory.get_or_insert_with(|| f.intern(&self.inner));
+        let result = self.memory.get_or_init(|| f.intern(&self.inner));
 
         match result {
             Ok(Some(elements)) => {

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -31,6 +31,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 ### Configuration
 ### Editors
 ### Formatter
+
+#### Enhancements
+- Use `OnceCell` for the Memoized memory because that's what the `RefCell<Option>` implemented. Contributed by @denbezrukov
+
 ### JavaScript APIs
 ### Linter
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Use OnceCell for the Memoized memory because that's what the RefCell<Option> implemented.

Thank to @MichaReiser 

## Test Plan

`cargo test`
