### PR TITLE
chore: remove `atty`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,6 @@ dependencies = [
 name = "biome_console"
 version = "0.0.1"
 dependencies = [
- "atty",
  "biome_markup",
  "biome_text_size",
  "schemars",
@@ -3606,7 +3605,6 @@ name = "xtask_coverage"
 version = "0.0.0"
 dependencies = [
  "ascii_table",
- "atty",
  "backtrace",
  "biome_console",
  "biome_diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ biome_text_size              = { version = "0.0.1", path = "./crates/biome_text_
 tests_macros                 = { path = "./crates/tests_macros" }
 
 # Crates needed in the workspace
-atty              = "0.2.14"
 bitflags          = "2.3.1"
 bpaf              = { version = "0.9.5", features = ["derive"] }
 countme           = "3.0.1"

--- a/crates/biome_console/Cargo.toml
+++ b/crates/biome_console/Cargo.toml
@@ -10,7 +10,6 @@ version              = "0.0.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atty            = { workspace = true }
 biome_markup    = { workspace = true }
 biome_text_size = { workspace = true }
 schemars        = { workspace = true, optional = true }

--- a/crates/biome_console/src/lib.rs
+++ b/crates/biome_console/src/lib.rs
@@ -1,6 +1,5 @@
-use atty::Stream;
 use std::io;
-use std::io::{Read, Stdin, Write};
+use std::io::{stderr, stdin, stdout, IsTerminal, Read, Stdin, Write};
 use std::panic::RefUnwindSafe;
 use termcolor::{ColorChoice, StandardStream};
 use write::Termcolor;
@@ -97,13 +96,13 @@ impl EnvConsole {
             ColorMode::Enabled => (ColorChoice::Always, ColorChoice::Always),
             ColorMode::Disabled => (ColorChoice::Never, ColorChoice::Never),
             ColorMode::Auto => {
-                let stdout = if atty::is(atty::Stream::Stdout) {
+                let stdout = if stdout().is_terminal() {
                     ColorChoice::Auto
                 } else {
                     ColorChoice::Never
                 };
 
-                let stderr = if atty::is(atty::Stream::Stderr) {
+                let stderr = if stderr().is_terminal() {
                     ColorChoice::Auto
                 } else {
                     ColorChoice::Never
@@ -169,7 +168,7 @@ impl Console for EnvConsole {
         //
         // Doing this check allows us to pipe stdin to rome, without expecting
         // user content when we call `read_to_string`
-        if atty::is(Stream::Stdin) {
+        if stdin().is_terminal() {
             return None;
         }
         let mut handle = self.r#in.lock();

--- a/crates/biome_js_parser/src/lexer/highlight.rs
+++ b/crates/biome_js_parser/src/lexer/highlight.rs
@@ -1,7 +1,7 @@
 use crate::*;
+use std::io::{stderr, stdout, IsTerminal};
 
 pub use ansi_term::{self, ANSIGenericString, Color, Style};
-use atty::is;
 
 /// A structure for syntax highlighting pieces of JavaScript source code
 /// using ANSI.
@@ -44,7 +44,7 @@ impl<'s> Highlighter<'s> {
     }
 
     fn check_terminal(&self) -> bool {
-        is(atty::Stream::Stderr) && is(atty::Stream::Stdout)
+        stderr().is_terminal() && stdout().is_terminal()
     }
 
     /// Reset the highlighter to the start of the source code

--- a/xtask/coverage/Cargo.toml
+++ b/xtask/coverage/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.0.0"
 
 [dependencies]
 ascii_table        = "4.0.2"
-atty               = { workspace = true }
 backtrace          = "0.3.65"
 biome_console      = { path = "../../crates/biome_console" }
 biome_diagnostics  = { path = "../../crates/biome_diagnostics" }

--- a/xtask/coverage/src/reporters.rs
+++ b/xtask/coverage/src/reporters.rs
@@ -1,14 +1,13 @@
 use crate::runner::{TestCaseFiles, TestRunOutcome, TestRunResult, TestSuite, TestSuiteInstance};
 use crate::{Summary, TestResults};
 use ascii_table::{Align, AsciiTable};
-use atty::Stream;
 use biome_diagnostics::termcolor::Buffer;
 use biome_diagnostics::{DiagnosticExt, Error};
 use colored::Colorize;
 use indicatif::ProgressBar;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::io::Write;
+use std::io::{stdout, IsTerminal, Write};
 use std::str::FromStr;
 use std::time::Instant;
 
@@ -186,7 +185,7 @@ impl Write for OutputTarget {
 
 impl SummaryReporter {
     pub fn new(detail_level: SummaryDetailLevel, output_target: OutputTarget) -> Self {
-        let buffer = if atty::is(Stream::Stdout) {
+        let buffer = if stdout().is_terminal() {
             Buffer::ansi()
         } else {
             // piping to a file


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

`atty` has become essentially obsolete because now Rust std has a built-in method: https://doc.rust-lang.org/std/io/trait.IsTerminal.html#tymethod.is_terminal

This PR removes it from the project

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

CI should pass

<!-- What demonstrates that your implementation is correct? -->
