### PR TITLE
fix(workflow/release_lsp): added distributionFile parameter

### DIFF
--- a/.github/workflows/release_lsp.yml
+++ b/.github/workflows/release_lsp.yml
@@ -284,6 +284,7 @@ jobs:
     outputs:
       version: ${{ env.version }}
       prerelease: ${{ env.prerelease }}
+      filename: ${{ env.filename }}
 
     steps:
       - name: Checkout repository
@@ -309,6 +310,14 @@ jobs:
       - name: Build plugin
         working-directory: editors/intellij
         run: ./gradlew buildPlugin
+
+      - name: Get build file name
+        working-directory: editors/intellij
+        run: |
+          cd ./build/distributions
+          FILENAME=`ls *.zip`
+
+          echo "filename=${FILENAME}" >> $GITHUB_ENV
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -350,21 +359,21 @@ jobs:
           CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_CERTIFICATE_CHAIN }}
           PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
           PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_PRIVATE_KEY_PASSWORD }}
-        run: ./gradlew publishPlugin
+        run: ./gradlew publishPlugin -PdistributionFile=./build/distributions/${{ needs.build-intellij.outputs.filename }}
         working-directory: editors/intellij
 
       - name: Extract changelog
         run: |
-          bash scripts/print-changelog.sh ${{ needs.build.outputs.version }} >| ${{ github.workspace }}/RELEASE_NOTES
+          bash scripts/print-changelog.sh ${{ needs.build-intellij.outputs.version }} >| ${{ github.workspace }}/RELEASE_NOTES
       - name: Create GitHub release and tag
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: Intellij Plugin v${{ needs.build.outputs.version }}
-          tag_name: lsp-intellij/v${{ needs.build.outputs.version }}
+          name: Intellij Plugin v${{ needs.build-intellij.outputs.version }}
+          tag_name: lsp-intellij/v${{ needs.build-intellij.outputs.version }}
           draft: false
-          prerelease: ${{ needs.build.outputs.prerelease == 'true' }}
+          prerelease: ${{ needs.build-intellij.outputs.prerelease == 'true' }}
           body_path: ${{ github.workspace }}/RELEASE_NOTES
           files: |
             ./editors/intellij/build/distributions/Biome-*.zip


### PR DESCRIPTION
## Summary

Publish step need to know the build file to avoid create new zip 