### PR TITLE
fix(cli): make `biome --version` exit with the correct exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Fix [#319](https://github.com/biomejs/biome/issues/319). The command `biome lint` now shows the correct options. Contributed by @ematipico
 
+- Fix [#312](https://github.com/biomejs/biome/issues/312). Running `biome --version` now exits with status code `0` instead of `1`. Contributed by @nhedger
+
 ### Configuration
 ### Editors
 ### Formatter

--- a/crates/biome_cli/src/main.rs
+++ b/crates/biome_cli/src/main.rs
@@ -49,7 +49,7 @@ fn main() -> ExitCode {
         Err(failure) => {
             return if let ParseFailure::Stdout(help, _) = &failure {
                 console.log(markup! {{help.to_string()}});
-                ExitCode::FAILURE
+                ExitCode::SUCCESS
             } else {
                 let diagnostic = CliDiagnostic::parse_error_bpaf(failure);
                 console.error(markup! { {PrintDiagnostic::simple(&diagnostic)}});


### PR DESCRIPTION
## Summary

This PR solves #312.

## Test Plan

See [this comment](https://github.com/biomejs/biome/issues/312#issuecomment-1728519726) for details.

- Running `biome --version` must exit with `0`

  ```bash
  biome --version
  echo $?
  ```

## Attention
When releasing the next version of CLI, we must update the [homebrew formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/b/biome.rb) that currently checks for exit code 1, so that it check for exit code 0.