### PR TITLE
refactor(lint/noUselessLabel): make code fix safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   The rule reports `else` clauses that can be omitted because their `if` branches break.
   Contributed by @Conaclos
 
+#### Enhancements
+
+- The following rules have now safe code fixes:
+
+  - [noUselessLabel](https://biomejs.dev/linter/rules/no-useless-label)
+
 #### Bug fixes
 
 - Fix [#294](https://github.com/biomejs/biome/issues/294). [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type/) no longer reports false positives for return types. Contributed by @b4s36t4

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_label.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_label.rs
@@ -122,7 +122,7 @@ impl Rule for NoUselessLabel {
         mutation.replace_token_discard_trivia(stmt_token, new_stmt_token);
         Some(JsRuleAction {
             category: ActionCategory::QuickFix,
-            applicability: Applicability::MaybeIncorrect,
+            applicability: Applicability::Always,
             message: markup! {"Remove the unnecessary "<Emphasis>"label"</Emphasis>".\nYou can achieve the same result without the label."}.to_owned(),
             mutation,
         })

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessLabel/invalid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessLabel/invalid.jsonc.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
-assertion_line: 96
 expression: invalid.jsonc
 ---
 # Input
@@ -17,7 +16,7 @@ invalid.jsonc:1:20 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: while (a) break A;
       │                    ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·while·(a)·break·A;
@@ -39,7 +38,7 @@ invalid.jsonc:1:30 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: while (a) { B: { continue A; } }
       │                              ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·while·(a)·{·B:·{·continue·A;·}·}
@@ -61,7 +60,7 @@ invalid.jsonc:1:42 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ X: while (x) { A: while (a) { B: { break A; break B; continue X; } } }
       │                                          ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ X:·while·(x)·{·A:·while·(a)·{·B:·{·break·A;·break·B;·continue·X;·}·}·}
@@ -83,7 +82,7 @@ invalid.jsonc:1:15 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: do { break A; } while (a);
       │               ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·do·{·break·A;·}·while·(a);
@@ -105,7 +104,7 @@ invalid.jsonc:1:21 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: for (;;) { break A; }
       │                     ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·for·(;;)·{·break·A;·}
@@ -127,7 +126,7 @@ invalid.jsonc:1:27 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: for (a in obj) { break A; }
       │                           ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·for·(a·in·obj)·{·break·A;·}
@@ -149,7 +148,7 @@ invalid.jsonc:1:27 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: for (a of ary) { break A; }
       │                           ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·for·(a·of·ary)·{·break·A;·}
@@ -171,7 +170,7 @@ invalid.jsonc:1:31 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: switch (a) { case 0: break A; }
       │                               ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·switch·(a)·{·case·0:·break·A;·}
@@ -193,7 +192,7 @@ invalid.jsonc:1:46 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ X: while (x) { A: switch (a) { case 0: break A; } }
       │                                              ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ X:·while·(x)·{·A:·switch·(a)·{·case·0:·break·A;·}·}
@@ -215,7 +214,7 @@ invalid.jsonc:1:44 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ X: switch (a) { case 0: A: while (b) break A; }
       │                                            ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ X:·switch·(a)·{·case·0:·A:·while·(b)·break·A;·}
@@ -237,7 +236,7 @@ invalid.jsonc:1:25 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: while (true) { break A; while (true) { break A; } }
       │                         ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·while·(true)·{·break·A;·while·(true)·{·break·A;·}·}
@@ -259,7 +258,7 @@ invalid.jsonc:1:34 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: while(true) { /*before*/break A; }
       │                                  ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·while(true)·{·/*before*/break·A;·}
@@ -281,7 +280,7 @@ invalid.jsonc:1:28 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: while(true) { break/**/ A; }
       │                            ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·while(true)·{·break/**/·A;·}
@@ -303,7 +302,7 @@ invalid.jsonc:1:32 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: while(true) { continue /**/ A; }
       │                                ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·while(true)·{·continue·/**/·A;·}
@@ -325,7 +324,7 @@ invalid.jsonc:1:28 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: while(true) { break /**/A; }
       │                            ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·while(true)·{·break·/**/A;·}
@@ -347,7 +346,7 @@ invalid.jsonc:1:30 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: while(true) { continue/**/A; }
       │                              ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·while(true)·{·continue/**/A;·}
@@ -369,7 +368,7 @@ invalid.jsonc:1:27 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: while(true) { continue A/*after*/; }
       │                           ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·while(true)·{·continue·A/*after*/;·}
@@ -393,7 +392,7 @@ invalid.jsonc:1:24 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
       │                        ^
     2 │  }
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·while(true)·{·break·A·//after
@@ -417,7 +416,7 @@ invalid.jsonc:1:24 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
       │                        ^
     2 │ foo() }
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·while(true)·{·break·A·/*after*/
@@ -439,7 +438,7 @@ invalid.jsonc:1:49 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: while(true) { while(true) { break A; } break A; }
       │                                                 ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·while(true)·{·while(true)·{·break·A;·}·break·A;·}
@@ -461,7 +460,7 @@ invalid.jsonc:1:58 lint/complexity/noUselessLabel  FIXABLE  ━━━━━━�
   > 1 │ A: while(true) { (() => { A: while(true) {} } )(); break A; }
       │                                                          ^
   
-  i Suggested fix: Remove the unnecessary label.
+  i Safe fix: Remove the unnecessary label.
     You can achieve the same result without the label.
   
     1 │ A:·while(true)·{·(()·=>·{·A:·while(true)·{}·}·)();·break·A;·}

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -46,6 +46,12 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   The rule reports `else` clauses that can be omitted because their `if` branches break.
   Contributed by @Conaclos
 
+#### Enhancements
+
+- The following rules have now safe code fixes:
+
+  - [noUselessLabel](https://biomejs.dev/linter/rules/no-useless-label)
+
 #### Bug fixes
 
 - Fix [#294](https://github.com/biomejs/biome/issues/294). [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type/) no longer reports false positives for return types. Contributed by @b4s36t4

--- a/website/src/content/docs/linter/rules/no-useless-label.md
+++ b/website/src/content/docs/linter/rules/no-useless-label.md
@@ -34,7 +34,7 @@ loop: while(a) {
     <strong>3 │ </strong>}
     <strong>4 │ </strong>
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove the unnecessary </span><span style="color: rgb(38, 148, 255);"><strong>label</strong></span><span style="color: rgb(38, 148, 255);">.
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove the unnecessary </span><span style="color: rgb(38, 148, 255);"><strong>label</strong></span><span style="color: rgb(38, 148, 255);">.
 </span><span style="color: rgb(38, 148, 255);">  </span><span style="color: rgb(38, 148, 255);">  </span><span style="color: rgb(38, 148, 255);">You can achieve the same result without the label.</span>
   
 <strong>  </strong><strong>  2 │ </strong><span style="opacity: 0.8;">·</span><span style="opacity: 0.8;">·</span><span style="opacity: 0.8;">·</span><span style="opacity: 0.8;">·</span>break<span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="color: Tomato;">l</span><span style="color: Tomato;">o</span><span style="color: Tomato;">o</span><span style="color: Tomato;">p</span>;


### PR DESCRIPTION
## Summary

The code fix of [noUselessLabel](https://biomejs.dev/linter/rules/no-useless-label) is now safe.
No bug was reported and this does not affect the behavior of the program.

## Test Plan

Updated tests.
