### PR TITLE
fix(workflow/release_lsp): added prerelease output

### DIFF
--- a/.github/workflows/release_lsp.yml
+++ b/.github/workflows/release_lsp.yml
@@ -279,6 +279,7 @@ jobs:
     needs: check
     env:
       version: ${{ needs.check.outputs.intellij_version }}
+      prerelease: ${{ needs.check.outputs.prerelease }}
 
     if: needs.check.outputs.intellij_version_changed == 'true' || needs.check.outputs.nightly == 'true'
     outputs:


### PR DESCRIPTION
## Summary

Added missing prerelease output to avoid create gh releases for nightly versions

