### PR TITLE
fix(lint/noMultipleSpacesInRegularExpressionLiterals): correctly handle spaces followed by a quantifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Fix [#294](https://github.com/biomejs/biome/issues/294). [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type/) no longer reports false positives for return types. Contributed by @b4s36t4
 
+- Fix [#383](https://github.com/biomejs/biome/issues/383). [noMultipleSpacesInRegularExpressionLiterals](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals) now provides correct code fixes when consecutive spaces are followed by a quantifier. Contributed by @Conaclos
+
 ### Parser
 
 - Enhance diagnostic for infer type handling in the parser. The 'infer' keyword can only be utilized within the 'extends' clause of a conditional type. Using it outside of this context will result in an error. Ensure that any type declarations using 'infer' are correctly placed within the conditional type structure to avoid parsing issues. Contributed by @denbezrukov

--- a/crates/biome_js_analyze/tests/specs/complexity/noMultipleSpacesInRegularExpressionLiterals/invalid.jsonc
+++ b/crates/biome_js_analyze/tests/specs/complexity/noMultipleSpacesInRegularExpressionLiterals/invalid.jsonc
@@ -4,5 +4,24 @@
 	"/foo   /;",
 	"/foo  bar/;",
 	"/foo   bar    baz/;",
-	"/foo [ba]r  b(a|z)/;"
+	"/foo [ba]r  b(a|z)/;",
+	"/foo  +/;",
+	"/foo  +?/;",
+	"/foo  */;",
+	"/foo  *?/;",
+	"/foo   */;",
+	"/foo  ?/;",
+	"/foo  {2}/;",
+	"/foo  {2}a{1,2}/;",
+	"/foo  {2,}/;",
+	"/foo  {,2}/;",
+	"/foo  {2,3}/;",
+	"/foo  +  *   *   {2,}/;",
+	// Malformed regexes
+	"/foo  {}/;",
+	"/foo  {,}/;",
+	"/foo  {,2}/;",
+	"/foo  {1 2}/;",
+	"/foo  {1/;",
+	"/foo  {1,2/;"
 ]

--- a/crates/biome_js_analyze/tests/specs/complexity/noMultipleSpacesInRegularExpressionLiterals/invalid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noMultipleSpacesInRegularExpressionLiterals/invalid.jsonc.snap
@@ -11,12 +11,14 @@ expression: invalid.jsonc
 ```
 invalid.jsonc:1:2 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
 
-  ! This regular expression contains unclear uses of multiple spaces.
+  ! This regular expression contains unclear uses of consecutive spaces.
   
   > 1 │ /   /;
       │  ^^^
   
-  i Suggested fix: It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {3}/
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
   
   - /···/;
   + /·{3}/;
@@ -33,12 +35,14 @@ invalid.jsonc:1:2 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  F
 ```
 invalid.jsonc:1:2 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
 
-  ! This regular expression contains unclear uses of multiple spaces.
+  ! This regular expression contains unclear uses of consecutive spaces.
   
   > 1 │ /  foo/;
       │  ^^
   
-  i Suggested fix: It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {2}/
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
   
   - /··foo/;
   + /·{2}foo/;
@@ -55,12 +59,14 @@ invalid.jsonc:1:2 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  F
 ```
 invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
 
-  ! This regular expression contains unclear uses of multiple spaces.
+  ! This regular expression contains unclear uses of consecutive spaces.
   
   > 1 │ /foo   /;
       │     ^^^
   
-  i Suggested fix: It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {3}/
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
   
   - /foo···/;
   + /foo·{3}/;
@@ -77,12 +83,14 @@ invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  F
 ```
 invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
 
-  ! This regular expression contains unclear uses of multiple spaces.
+  ! This regular expression contains unclear uses of consecutive spaces.
   
   > 1 │ /foo  bar/;
       │     ^^
   
-  i Suggested fix: It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {2}/
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
   
   - /foo··bar/;
   + /foo·{2}bar/;
@@ -99,12 +107,14 @@ invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  F
 ```
 invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
 
-  ! This regular expression contains unclear uses of multiple spaces.
+  ! This regular expression contains unclear uses of consecutive spaces.
   
   > 1 │ /foo   bar    baz/;
       │     ^^^^^^^^^^
   
-  i Suggested fix: It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {7}/
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
   
   - /foo···bar····baz/;
   + /foo·{3}bar·{4}baz/;
@@ -121,15 +131,414 @@ invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  F
 ```
 invalid.jsonc:1:11 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━
 
-  ! This regular expression contains unclear uses of multiple spaces.
+  ! This regular expression contains unclear uses of consecutive spaces.
   
   > 1 │ /foo [ba]r  b(a|z)/;
       │           ^^
   
-  i Suggested fix: It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {2}/
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
   
   - /foo·[ba]r··b(a|z)/;
   + /foo·[ba]r·{2}b(a|z)/;
+  
+
+```
+
+# Input
+```js
+/foo  +/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  +/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
+  
+  - /foo··+/;
+  + /foo·{2,}/;
+  
+
+```
+
+# Input
+```js
+/foo  +?/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  +?/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
+  
+  - /foo··+?/;
+  + /foo·{2,}?/;
+  
+
+```
+
+# Input
+```js
+/foo  */;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  */;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
+  
+  - /foo··*/;
+  + /foo·+/;
+  
+
+```
+
+# Input
+```js
+/foo  *?/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  *?/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
+  
+  - /foo··*?/;
+  + /foo·+?/;
+  
+
+```
+
+# Input
+```js
+/foo   */;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo   */;
+      │     ^^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
+  
+  - /foo···*/;
+  + /foo·{2,}/;
+  
+
+```
+
+# Input
+```js
+/foo  ?/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  ?/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
+  
+  - /foo··?/;
+  + /foo·{1,2}/;
+  
+
+```
+
+# Input
+```js
+/foo  {2}/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  {2}/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
+  
+  - /foo··{2}/;
+  + /foo·{3}/;
+  
+
+```
+
+# Input
+```js
+/foo  {2}a{1,2}/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  {2}a{1,2}/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
+  
+  - /foo··{2}a{1,2}/;
+  + /foo·{3}a{1,2}/;
+  
+
+```
+
+# Input
+```js
+/foo  {2,}/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  {2,}/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
+  
+  - /foo··{2,}/;
+  + /foo·{3,}/;
+  
+
+```
+
+# Input
+```js
+/foo  {,2}/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  {,2}/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+
+```
+
+# Input
+```js
+/foo  {2,3}/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  {2,3}/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
+  
+  - /foo··{2,3}/;
+  + /foo·{3,4}/;
+  
+
+```
+
+# Input
+```js
+/foo  +  *   *   {2,}/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  +  *   *   {2,}/;
+      │     ^^^^^^^^^^^^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+  i Suggested fix: Use a quantifier instead.
+  
+  - /foo··+··*···*···{2,}/;
+  + /foo·{2,}·+·{2,}·{4,}/;
+  
+
+```
+
+# Input
+```js
+/foo  {}/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  {}/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+
+```
+
+# Input
+```js
+/foo  {,}/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  {,}/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+
+```
+
+# Input
+```js
+/foo  {,2}/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  {,2}/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+
+```
+
+# Input
+```js
+/foo  {1 2}/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  {1 2}/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+
+```
+
+# Input
+```js
+/foo  {1/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  {1/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+
+```
+
+# Input
+```js
+/foo  {1,2/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:5 lint/complexity/noMultipleSpacesInRegularExpressionLiterals ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /foo  {1,2/;
+      │     ^^
+  
+  i It's hard to visually count the amount of spaces.
   
 
 ```

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -975,7 +975,7 @@ pub struct Complexity {
     #[bpaf(long("no-for-each"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_for_each: Option<RuleConfiguration>,
-    #[doc = "Disallow unclear usage of multiple space characters in regular expression literals"]
+    #[doc = "Disallow unclear usage of consecutive space characters in regular expression literals"]
     #[bpaf(
         long("no-multiple-spaces-in-regular-expression-literals"),
         argument("on|off|warn"),

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -288,7 +288,7 @@
 					]
 				},
 				"noMultipleSpacesInRegularExpressionLiterals": {
-					"description": "Disallow unclear usage of multiple space characters in regular expression literals",
+					"description": "Disallow unclear usage of consecutive space characters in regular expression literals",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -440,7 +440,7 @@ export interface Complexity {
 	 */
 	noForEach?: RuleConfiguration;
 	/**
-	 * Disallow unclear usage of multiple space characters in regular expression literals
+	 * Disallow unclear usage of consecutive space characters in regular expression literals
 	 */
 	noMultipleSpacesInRegularExpressionLiterals?: RuleConfiguration;
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -288,7 +288,7 @@
 					]
 				},
 				"noMultipleSpacesInRegularExpressionLiterals": {
-					"description": "Disallow unclear usage of multiple space characters in regular expression literals",
+					"description": "Disallow unclear usage of consecutive space characters in regular expression literals",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -62,6 +62,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Fix [#294](https://github.com/biomejs/biome/issues/294). [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type/) no longer reports false positives for return types. Contributed by @b4s36t4
 
+- Fix [#383](https://github.com/biomejs/biome/issues/383). [noMultipleSpacesInRegularExpressionLiterals](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals) now provides correct code fixes when consecutive spaces are followed by a quantifier. Contributed by @Conaclos
+
 ### Parser
 
 - Enhance diagnostic for infer type handling in the parser. The 'infer' keyword can only be utilized within the 'extends' clause of a conditional type. Using it outside of this context will result in an error. Ensure that any type declarations using 'infer' are correctly placed within the conditional type structure to avoid parsing issues. Contributed by @denbezrukov

--- a/website/src/content/docs/linter/rules/index.mdx
+++ b/website/src/content/docs/linter/rules/index.mdx
@@ -72,7 +72,7 @@ Disallow unnecessary boolean casts
 ### [noForEach](/linter/rules/no-for-each)
 Prefer <code>for...of</code> statement instead of <code>Array.forEach</code>.
 ### [noMultipleSpacesInRegularExpressionLiterals](/linter/rules/no-multiple-spaces-in-regular-expression-literals)
-Disallow unclear usage of multiple space characters in regular expression literals
+Disallow unclear usage of consecutive space characters in regular expression literals
 ### [noStaticOnlyClass](/linter/rules/no-static-only-class)
 This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace.
 ### [noUselessCatch](/linter/rules/no-useless-catch)

--- a/website/src/content/docs/linter/rules/no-multiple-spaces-in-regular-expression-literals.md
+++ b/website/src/content/docs/linter/rules/no-multiple-spaces-in-regular-expression-literals.md
@@ -8,7 +8,9 @@ title: noMultipleSpacesInRegularExpressionLiterals (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
-Disallow unclear usage of multiple space characters in regular expression literals
+Disallow unclear usage of consecutive space characters in regular expression literals
+
+Source: https://eslint.org/docs/latest/rules/no-regex-spaces/
 
 ## Examples
 
@@ -20,13 +22,15 @@ Disallow unclear usage of multiple space characters in regular expression litera
 
 <pre class="language-text"><code class="language-text">complexity/noMultipleSpacesInRegularExpressionLiterals.js:1:2 <a href="https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals">lint/complexity/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of multiple spaces.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of consecutive spaces.</span>
   
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>/   /
    <strong>   │ </strong> <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {3}/</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces.</span>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use a quantifier instead.</span>
   
     <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">/</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">/</span>
       <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">/</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: MediumSeaGreen;"><strong>{</strong></span><span style="color: MediumSeaGreen;"><strong>3</strong></span><span style="color: MediumSeaGreen;"><strong>}</strong></span><span style="color: MediumSeaGreen;">/</span>
@@ -35,81 +39,45 @@ Disallow unclear usage of multiple space characters in regular expression litera
 </code></pre>
 
 ```jsx
-/  foo/
-```
-
-<pre class="language-text"><code class="language-text">complexity/noMultipleSpacesInRegularExpressionLiterals.js:1:2 <a href="https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals">lint/complexity/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
-
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of multiple spaces.</span>
-  
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>/  foo/
-   <strong>   │ </strong> <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>2 │ </strong>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {2}/</span>
-  
-    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">/</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">f</span><span style="color: Tomato;">o</span><span style="color: Tomato;">o</span><span style="color: Tomato;">/</span>
-      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">/</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: MediumSeaGreen;"><strong>{</strong></span><span style="color: MediumSeaGreen;"><strong>2</strong></span><span style="color: MediumSeaGreen;"><strong>}</strong></span><span style="color: MediumSeaGreen;">f</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">/</span>
-    <strong>2</strong> <strong>2</strong><strong> │ </strong>  
-  
-</code></pre>
-
-```jsx
-/foo   /
+/foo  */
 ```
 
 <pre class="language-text"><code class="language-text">complexity/noMultipleSpacesInRegularExpressionLiterals.js:1:5 <a href="https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals">lint/complexity/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of multiple spaces.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of consecutive spaces.</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>/foo   /
-   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>2 │ </strong>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {3}/</span>
-  
-    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">/</span><span style="color: Tomato;">f</span><span style="color: Tomato;">o</span><span style="color: Tomato;">o</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">/</span>
-      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">/</span><span style="color: MediumSeaGreen;">f</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: MediumSeaGreen;"><strong>{</strong></span><span style="color: MediumSeaGreen;"><strong>3</strong></span><span style="color: MediumSeaGreen;"><strong>}</strong></span><span style="color: MediumSeaGreen;">/</span>
-    <strong>2</strong> <strong>2</strong><strong> │ </strong>  
-  
-</code></pre>
-
-```jsx
-/foo  bar/
-```
-
-<pre class="language-text"><code class="language-text">complexity/noMultipleSpacesInRegularExpressionLiterals.js:1:5 <a href="https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals">lint/complexity/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
-
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of multiple spaces.</span>
-  
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>/foo  bar/
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>/foo  */
    <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {2}/</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces.</span>
   
-    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">/</span><span style="color: Tomato;">f</span><span style="color: Tomato;">o</span><span style="color: Tomato;">o</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">b</span><span style="color: Tomato;">a</span><span style="color: Tomato;">r</span><span style="color: Tomato;">/</span>
-      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">/</span><span style="color: MediumSeaGreen;">f</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: MediumSeaGreen;"><strong>{</strong></span><span style="color: MediumSeaGreen;"><strong>2</strong></span><span style="color: MediumSeaGreen;"><strong>}</strong></span><span style="color: MediumSeaGreen;">b</span><span style="color: MediumSeaGreen;">a</span><span style="color: MediumSeaGreen;">r</span><span style="color: MediumSeaGreen;">/</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use a quantifier instead.</span>
+  
+    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">/</span><span style="color: Tomato;">f</span><span style="color: Tomato;">o</span><span style="color: Tomato;">o</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>*</strong></span><span style="color: Tomato;">/</span>
+      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">/</span><span style="color: MediumSeaGreen;">f</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: MediumSeaGreen;"><strong>+</strong></span><span style="color: MediumSeaGreen;">/</span>
     <strong>2</strong> <strong>2</strong><strong> │ </strong>  
   
 </code></pre>
 
 ```jsx
-/foo   bar    baz/
+/foo  {2,}bar   {3,5}baz/
 ```
 
 <pre class="language-text"><code class="language-text">complexity/noMultipleSpacesInRegularExpressionLiterals.js:1:5 <a href="https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals">lint/complexity/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of multiple spaces.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of consecutive spaces.</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>/foo   bar    baz/
-   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>/foo  {2,}bar   {3,5}baz/
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {7}/</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces.</span>
   
-    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">/</span><span style="color: Tomato;">f</span><span style="color: Tomato;">o</span><span style="color: Tomato;">o</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">b</span><span style="color: Tomato;">a</span><span style="color: Tomato;">r</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">b</span><span style="color: Tomato;">a</span><span style="color: Tomato;">z</span><span style="color: Tomato;">/</span>
-      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">/</span><span style="color: MediumSeaGreen;">f</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: MediumSeaGreen;"><strong>{</strong></span><span style="color: MediumSeaGreen;"><strong>3</strong></span><span style="color: MediumSeaGreen;"><strong>}</strong></span><span style="color: MediumSeaGreen;">b</span><span style="color: MediumSeaGreen;">a</span><span style="color: MediumSeaGreen;">r</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: MediumSeaGreen;"><strong>{</strong></span><span style="color: MediumSeaGreen;"><strong>4</strong></span><span style="color: MediumSeaGreen;"><strong>}</strong></span><span style="color: MediumSeaGreen;">b</span><span style="color: MediumSeaGreen;">a</span><span style="color: MediumSeaGreen;">z</span><span style="color: MediumSeaGreen;">/</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use a quantifier instead.</span>
+  
+    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">/</span><span style="color: Tomato;">f</span><span style="color: Tomato;">o</span><span style="color: Tomato;">o</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">{</span><span style="color: Tomato;"><strong>2</strong></span><span style="color: Tomato;">,</span><span style="color: Tomato;">}</span><span style="color: Tomato;">b</span><span style="color: Tomato;">a</span><span style="color: Tomato;">r</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">{</span><span style="color: Tomato;"><strong>3</strong></span><span style="color: Tomato;"><strong>,</strong></span><span style="color: Tomato;"><strong>5</strong></span><span style="color: Tomato;">}</span><span style="color: Tomato;">b</span><span style="color: Tomato;">a</span><span style="color: Tomato;">z</span><span style="color: Tomato;">/</span>
+      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">/</span><span style="color: MediumSeaGreen;">f</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: MediumSeaGreen;">{</span><span style="color: MediumSeaGreen;"><strong>3</strong></span><span style="color: MediumSeaGreen;">,</span><span style="color: MediumSeaGreen;">}</span><span style="color: MediumSeaGreen;">b</span><span style="color: MediumSeaGreen;">a</span><span style="color: MediumSeaGreen;">r</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: MediumSeaGreen;">{</span><span style="color: MediumSeaGreen;"><strong>5</strong></span><span style="color: MediumSeaGreen;"><strong>,</strong></span><span style="color: MediumSeaGreen;"><strong>7</strong></span><span style="color: MediumSeaGreen;">}</span><span style="color: MediumSeaGreen;">b</span><span style="color: MediumSeaGreen;">a</span><span style="color: MediumSeaGreen;">z</span><span style="color: MediumSeaGreen;">/</span>
     <strong>2</strong> <strong>2</strong><strong> │ </strong>  
   
 </code></pre>
@@ -120,13 +88,15 @@ Disallow unclear usage of multiple space characters in regular expression litera
 
 <pre class="language-text"><code class="language-text">complexity/noMultipleSpacesInRegularExpressionLiterals.js:1:11 <a href="https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals">lint/complexity/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of multiple spaces.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of consecutive spaces.</span>
   
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>/foo [ba]r  b(a|z)/
    <strong>   │ </strong>          <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {2}/</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces.</span>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use a quantifier instead.</span>
   
     <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">/</span><span style="color: Tomato;">f</span><span style="color: Tomato;">o</span><span style="color: Tomato;">o</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">[</span><span style="color: Tomato;">b</span><span style="color: Tomato;">a</span><span style="color: Tomato;">]</span><span style="color: Tomato;">r</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">b</span><span style="color: Tomato;">(</span><span style="color: Tomato;">a</span><span style="color: Tomato;">|</span><span style="color: Tomato;">z</span><span style="color: Tomato;">)</span><span style="color: Tomato;">/</span>
       <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">/</span><span style="color: MediumSeaGreen;">f</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">[</span><span style="color: MediumSeaGreen;">b</span><span style="color: MediumSeaGreen;">a</span><span style="color: MediumSeaGreen;">]</span><span style="color: MediumSeaGreen;">r</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: MediumSeaGreen;"><strong>{</strong></span><span style="color: MediumSeaGreen;"><strong>2</strong></span><span style="color: MediumSeaGreen;"><strong>}</strong></span><span style="color: MediumSeaGreen;">b</span><span style="color: MediumSeaGreen;">(</span><span style="color: MediumSeaGreen;">a</span><span style="color: MediumSeaGreen;">|</span><span style="color: MediumSeaGreen;">z</span><span style="color: MediumSeaGreen;">)</span><span style="color: MediumSeaGreen;">/</span>
@@ -141,15 +111,11 @@ Disallow unclear usage of multiple space characters in regular expression litera
 ```
 
 ```jsx
-/foo bar baz/
+/ foo bar baz /
 ```
 
 ```jsx
 /foo bar	baz/
-```
-
-```jsx
-/foo /
 ```
 
 ## Related links


### PR DESCRIPTION
## Summary

Fixes #383.

Also:
- Improve diagnostics
- Use standard `Range`

The ESLint rule ignores consecutive spaces followed by a quantifier.
I think it is more in line with the rule of updating the quantifier in order to avoid consecutive spaces.

## Test Plan

I added more tests, including malformed regexes.
