### PR TITLE
refactor(lint/useConst): make code fix safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
   - [noUselessLabel](https://biomejs.dev/linter/rules/no-useless-label)
   - [noUselessTypeConstraint](https://biomejs.dev/linter/rules/no-useless-type-constraint)
+  - [useConst](https://biomejs.dev/linter/rules/use-const)
   - [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
 
 #### Bug fixes

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_runs_linter_not_formatter_issue_3495.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_runs_linter_not_formatter_issue_3495.snap
@@ -34,7 +34,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 file.js:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This 'let' declares a variable which is never re-assigned.
+  × This let declares a variable which is never re-assigned.
   
   > 1 │ let a = !b || !c
       │ ^^^
@@ -44,7 +44,7 @@ file.js:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━�
   > 1 │ let a = !b || !c
       │     ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·a·=·!b·||·!c
   + const·a·=·!b·||·!c

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/no_var.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/no_var.rs
@@ -3,11 +3,11 @@ use biome_analyze::{context::RuleContext, declare_rule, ActionCategory, Rule, Ru
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
-use biome_js_syntax::{JsModule, JsScript, JsSyntaxKind};
+use biome_js_syntax::{AnyJsVariableDeclaration, JsModule, JsScript, JsSyntaxKind};
 
 use biome_rowan::{AstNode, BatchMutationExt};
 
-use super::use_const::{ConstBindings, VariableDeclaration};
+use super::use_const::ConstBindings;
 
 declare_rule! {
     /// Disallow the use of `var`
@@ -40,7 +40,7 @@ declare_rule! {
 }
 
 impl Rule for NoVar {
-    type Query = Semantic<VariableDeclaration>;
+    type Query = Semantic<AnyJsVariableDeclaration>;
     type State = ();
     type Signals = Option<Self::State>;
     type Options = ();

--- a/crates/biome_js_analyze/tests/specs/style/useConst/invalid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useConst/invalid.jsonc.snap
@@ -11,7 +11,7 @@ let x = 1; foo(x);
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let x = 1; foo(x);
       │ ^^^
@@ -21,7 +21,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let x = 1; foo(x);
       │     ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·x·=·1;·foo(x);
   + const·x·=·1;·foo(x);
@@ -38,7 +38,7 @@ for (let i in [1,2,3]) { foo(i); }
 ```
 invalid.jsonc:1:6 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ for (let i in [1,2,3]) { foo(i); }
       │      ^^^
@@ -48,7 +48,7 @@ invalid.jsonc:1:6 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ for (let i in [1,2,3]) { foo(i); }
       │          ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - for·(let·i·in·[1,2,3])·{·foo(i);·}
   + for·(const·i·in·[1,2,3])·{·foo(i);·}
@@ -65,7 +65,7 @@ for (let x of [1,2,3]) { foo(x); }
 ```
 invalid.jsonc:1:6 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ for (let x of [1,2,3]) { foo(x); }
       │      ^^^
@@ -75,7 +75,7 @@ invalid.jsonc:1:6 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ for (let x of [1,2,3]) { foo(x); }
       │          ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - for·(let·x·of·[1,2,3])·{·foo(x);·}
   + for·(const·x·of·[1,2,3])·{·foo(x);·}
@@ -92,7 +92,7 @@ invalid.jsonc:1:6 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:15 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ (function() { let x = 1; foo(x); })();
       │               ^^^
@@ -102,7 +102,7 @@ invalid.jsonc:1:15 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ (function() { let x = 1; foo(x); })();
       │                   ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - (function()·{·let·x·=·1;·foo(x);·})();
   + (function()·{·const·x·=·1;·foo(x);·})();
@@ -119,7 +119,7 @@ invalid.jsonc:1:15 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ (function() { for (let i in [1,2,3]) { foo(i); } })();
       │                    ^^^
@@ -129,7 +129,7 @@ invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ (function() { for (let i in [1,2,3]) { foo(i); } })();
       │                        ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - (function()·{·for·(let·i·in·[1,2,3])·{·foo(i);·}·})();
   + (function()·{·for·(const·i·in·[1,2,3])·{·foo(i);·}·})();
@@ -146,7 +146,7 @@ invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ (function() { for (let x of [1,2,3]) { foo(x); } })();
       │                    ^^^
@@ -156,7 +156,7 @@ invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ (function() { for (let x of [1,2,3]) { foo(x); } })();
       │                        ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - (function()·{·for·(let·x·of·[1,2,3])·{·foo(x);·}·})();
   + (function()·{·for·(const·x·of·[1,2,3])·{·foo(x);·}·})();
@@ -173,7 +173,7 @@ let f = (function() { let g = x; })(); f = 1;
 ```
 invalid.jsonc:1:23 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let f = (function() { let g = x; })(); f = 1;
       │                       ^^^
@@ -183,7 +183,7 @@ invalid.jsonc:1:23 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let f = (function() { let g = x; })(); f = 1;
       │                           ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·f·=·(function()·{·let·g·=·x;·})();·f·=·1;
   + let·f·=·(function()·{·const·g·=·x;·})();·f·=·1;
@@ -200,7 +200,7 @@ let x = 0; { let x = 1; foo(x); } x = 0;
 ```
 invalid.jsonc:1:14 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let x = 0; { let x = 1; foo(x); } x = 0;
       │              ^^^
@@ -210,7 +210,7 @@ invalid.jsonc:1:14 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let x = 0; { let x = 1; foo(x); } x = 0;
       │                  ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·x·=·0;·{·let·x·=·1;·foo(x);·}·x·=·0;
   + let·x·=·0;·{·const·x·=·1;·foo(x);·}·x·=·0;
@@ -227,7 +227,7 @@ for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }
 ```
 invalid.jsonc:1:32 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }
       │                                ^^^
@@ -237,7 +237,7 @@ invalid.jsonc:1:32 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }
       │                                    ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - for·(let·i·=·0;·i·<·10;·++i)·{·let·x·=·1;·foo(x);·}
   + for·(let·i·=·0;·i·<·10;·++i)·{·const·x·=·1;·foo(x);·}
@@ -254,7 +254,7 @@ for (let i in [1,2,3]) { let x = 1; foo(x); }
 ```
 invalid.jsonc:1:6 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ for (let i in [1,2,3]) { let x = 1; foo(x); }
       │      ^^^
@@ -264,7 +264,7 @@ invalid.jsonc:1:6 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ for (let i in [1,2,3]) { let x = 1; foo(x); }
       │          ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - for·(let·i·in·[1,2,3])·{·let·x·=·1;·foo(x);·}
   + for·(const·i·in·[1,2,3])·{·let·x·=·1;·foo(x);·}
@@ -275,7 +275,7 @@ invalid.jsonc:1:6 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:26 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ for (let i in [1,2,3]) { let x = 1; foo(x); }
       │                          ^^^
@@ -285,7 +285,7 @@ invalid.jsonc:1:26 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ for (let i in [1,2,3]) { let x = 1; foo(x); }
       │                              ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - for·(let·i·in·[1,2,3])·{·let·x·=·1;·foo(x);·}
   + for·(let·i·in·[1,2,3])·{·const·x·=·1;·foo(x);·}
@@ -302,7 +302,7 @@ var foo = function() { for (const b of c) { let a; a = 1; } };
 ```
 invalid.jsonc:1:45 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ var foo = function() { for (const b of c) { let a; a = 1; } };
       │                                             ^^^
@@ -324,7 +324,7 @@ var foo = function() { for (const b of c) { let a; ({a} = 1); } };
 ```
 invalid.jsonc:1:45 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ var foo = function() { for (const b of c) { let a; ({a} = 1); } };
       │                                             ^^^
@@ -346,7 +346,7 @@ let x; x = 0;
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let x; x = 0;
       │ ^^^
@@ -368,7 +368,7 @@ switch (a) { case 0: let x; x = 0; }
 ```
 invalid.jsonc:1:22 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ switch (a) { case 0: let x; x = 0; }
       │                      ^^^
@@ -390,7 +390,7 @@ invalid.jsonc:1:22 lint/style/useConst ━━━━━━━━━━━━━�
 ```
 invalid.jsonc:1:15 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ (function() { let x; x = 1; })();
       │               ^^^
@@ -412,7 +412,7 @@ let {a: {b, c}} = {a: {b: 1, c: 2}}
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ let {a: {b, c}} = {a: {b: 1, c: 2}}
       │ ^^^
@@ -427,7 +427,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let {a: {b, c}} = {a: {b: 1, c: 2}}
       │             ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·{a:·{b,·c}}·=·{a:·{b:·1,·c:·2}}
   + const·{a:·{b,·c}}·=·{a:·{b:·1,·c:·2}}
@@ -444,7 +444,7 @@ let {a = 0, b} = obj; foo(a, b);
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ let {a = 0, b} = obj; foo(a, b);
       │ ^^^
@@ -459,7 +459,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let {a = 0, b} = obj; foo(a, b);
       │             ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·{a·=·0,·b}·=·obj;·foo(a,·b);
   + const·{a·=·0,·b}·=·obj;·foo(a,·b);
@@ -476,7 +476,7 @@ let [a] = [1]
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let [a] = [1]
       │ ^^^
@@ -486,7 +486,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let [a] = [1]
       │      ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·[a]·=·[1]
   + const·[a]·=·[1]
@@ -503,7 +503,7 @@ let {a} = obj
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let {a} = obj
       │ ^^^
@@ -513,7 +513,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let {a} = obj
       │      ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·{a}·=·obj
   + const·{a}·=·obj
@@ -530,7 +530,7 @@ let a, b; ({a = 0, b} = obj); foo(a, b);
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ let a, b; ({a = 0, b} = obj); foo(a, b);
       │ ^^^
@@ -557,7 +557,7 @@ let x; function foo() { bar(x); } x = 0;
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let x; function foo() { bar(x); } x = 0;
       │ ^^^
@@ -579,7 +579,7 @@ invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━
 ```
 invalid.jsonc:1:24 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ /*eslint use-x:error*/ let x = 1
       │                        ^^^
@@ -589,7 +589,7 @@ invalid.jsonc:1:24 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ /*eslint use-x:error*/ let x = 1
       │                            ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - /*eslint·use-x:error*/·let·x·=·1
   + /*eslint·use-x:error*/·const·x·=·1
@@ -606,7 +606,7 @@ invalid.jsonc:1:24 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:26 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ /*eslint use-x:error*/ { let x = 1 }
       │                          ^^^
@@ -616,7 +616,7 @@ invalid.jsonc:1:26 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ /*eslint use-x:error*/ { let x = 1 }
       │                              ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - /*eslint·use-x:error*/·{·let·x·=·1·}
   + /*eslint·use-x:error*/·{·const·x·=·1·}
@@ -633,7 +633,7 @@ let { foo, bar } = baz;
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ let { foo, bar } = baz;
       │ ^^^
@@ -648,7 +648,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let { foo, bar } = baz;
       │            ^^^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·{·foo,·bar·}·=·baz;
   + const·{·foo,·bar·}·=·baz;
@@ -665,7 +665,7 @@ const x = [1,2]; let [,y] = x;
 ```
 invalid.jsonc:1:18 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ const x = [1,2]; let [,y] = x;
       │                  ^^^
@@ -675,7 +675,7 @@ invalid.jsonc:1:18 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ const x = [1,2]; let [,y] = x;
       │                        ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - const·x·=·[1,2];·let·[,y]·=·x;
   + const·x·=·[1,2];·const·[,y]·=·x;
@@ -692,7 +692,7 @@ const x = [1,2,3]; let [y,,z] = x;
 ```
 invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ const x = [1,2,3]; let [y,,z] = x;
       │                    ^^^
@@ -707,7 +707,7 @@ invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ const x = [1,2,3]; let [y,,z] = x;
       │                            ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - const·x·=·[1,2,3];·let·[y,,z]·=·x;
   + const·x·=·[1,2,3];·const·[y,,z]·=·x;
@@ -724,7 +724,7 @@ let predicate; [, {foo:returnType, predicate}] = foo();
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let predicate; [, {foo:returnType, predicate}] = foo();
       │ ^^^
@@ -746,7 +746,7 @@ let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();
       │ ^^^
@@ -768,7 +768,7 @@ let predicate; [, {foo:returnType, ...predicate} ] = foo();
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let predicate; [, {foo:returnType, ...predicate} ] = foo();
       │ ^^^
@@ -790,7 +790,7 @@ let x = 'x', y = 'y';
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ let x = 'x', y = 'y';
       │ ^^^
@@ -805,7 +805,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let x = 'x', y = 'y';
       │              ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·x·=·'x',·y·=·'y';
   + const·x·=·'x',·y·=·'y';
@@ -822,7 +822,7 @@ let x = 1, y = 'y'; let z = 1;
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ let x = 1, y = 'y'; let z = 1;
       │ ^^^
@@ -837,7 +837,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let x = 1, y = 'y'; let z = 1;
       │            ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·x·=·1,·y·=·'y';·let·z·=·1;
   + const·x·=·1,·y·=·'y';·let·z·=·1;
@@ -848,7 +848,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:21 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let x = 1, y = 'y'; let z = 1;
       │                     ^^^
@@ -858,7 +858,7 @@ invalid.jsonc:1:21 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let x = 1, y = 'y'; let z = 1;
       │                         ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·x·=·1,·y·=·'y';·let·z·=·1;
   + let·x·=·1,·y·=·'y';·const·z·=·1;
@@ -875,7 +875,7 @@ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
       │ ^^^
@@ -895,7 +895,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
       │             ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·{·a,·b,·c}·=·obj;·let·{·x,·y,·z}·=·anotherObj;·x·=·2;
   + const·{·a,·b,·c}·=·obj;·let·{·x,·y,·z}·=·anotherObj;·x·=·2;
@@ -912,7 +912,7 @@ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
       │ ^^^
@@ -927,7 +927,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
       │              ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·x·=·'x',·y·=·'y';·function·someFunc()·{·let·a·=·1,·b·=·2;·foo(a,·b)·}
   + const·x·=·'x',·y·=·'y';·function·someFunc()·{·let·a·=·1,·b·=·2;·foo(a,·b)·}
@@ -938,7 +938,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:45 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
       │                                             ^^^
@@ -953,7 +953,7 @@ invalid.jsonc:1:45 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
       │                                                        ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·x·=·'x',·y·=·'y';·function·someFunc()·{·let·a·=·1,·b·=·2;·foo(a,·b)·}
   + let·x·=·'x',·y·=·'y';·function·someFunc()·{·const·a·=·1,·b·=·2;·foo(a,·b)·}
@@ -970,7 +970,7 @@ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
       │ ^^^
@@ -980,7 +980,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
       │     ^^^^^^^^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·someFunc·=·()·=>·{·let·a·=·1,·b·=·2;·foo(a,·b)·}
   + const·someFunc·=·()·=>·{·let·a·=·1,·b·=·2;·foo(a,·b)·}
@@ -991,7 +991,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:24 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
       │                        ^^^
@@ -1006,7 +1006,7 @@ invalid.jsonc:1:24 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
       │                                   ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·someFunc·=·()·=>·{·let·a·=·1,·b·=·2;·foo(a,·b)·}
   + let·someFunc·=·()·=>·{·const·a·=·1,·b·=·2;·foo(a,·b)·}
@@ -1023,7 +1023,7 @@ invalid.jsonc:1:24 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:32 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ /*eslint no-undef-init:error*/ let foo = undefined;
       │                                ^^^
@@ -1033,7 +1033,7 @@ invalid.jsonc:1:32 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ /*eslint no-undef-init:error*/ let foo = undefined;
       │                                    ^^^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - /*eslint·no-undef-init:error*/·let·foo·=·undefined;
   + /*eslint·no-undef-init:error*/·const·foo·=·undefined;
@@ -1050,7 +1050,7 @@ let a = 1; class C { static { a; } }
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let a = 1; class C { static { a; } }
       │ ^^^
@@ -1060,7 +1060,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let a = 1; class C { static { a; } }
       │     ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·a·=·1;·class·C·{·static·{·a;·}·}
   + const·a·=·1;·class·C·{·static·{·a;·}·}
@@ -1077,7 +1077,7 @@ class C { static { a; } } let a = 1;
 ```
 invalid.jsonc:1:27 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ class C { static { a; } } let a = 1;
       │                           ^^^
@@ -1087,7 +1087,7 @@ invalid.jsonc:1:27 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ class C { static { a; } } let a = 1;
       │                               ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - class·C·{·static·{·a;·}·}·let·a·=·1;
   + class·C·{·static·{·a;·}·}·const·a·=·1;
@@ -1104,7 +1104,7 @@ class C { static { let a = 1; } }
 ```
 invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ class C { static { let a = 1; } }
       │                    ^^^
@@ -1114,7 +1114,7 @@ invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ class C { static { let a = 1; } }
       │                        ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - class·C·{·static·{·let·a·=·1;·}·}
   + class·C·{·static·{·const·a·=·1;·}·}
@@ -1131,7 +1131,7 @@ class C { static { if (foo) { let a = 1; } } }
 ```
 invalid.jsonc:1:31 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ class C { static { if (foo) { let a = 1; } } }
       │                               ^^^
@@ -1141,7 +1141,7 @@ invalid.jsonc:1:31 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ class C { static { if (foo) { let a = 1; } } }
       │                                   ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - class·C·{·static·{·if·(foo)·{·let·a·=·1;·}·}·}
   + class·C·{·static·{·if·(foo)·{·const·a·=·1;·}·}·}
@@ -1158,7 +1158,7 @@ class C { static { let a = 1; if (foo) { a; } } }
 ```
 invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ class C { static { let a = 1; if (foo) { a; } } }
       │                    ^^^
@@ -1168,7 +1168,7 @@ invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ class C { static { let a = 1; if (foo) { a; } } }
       │                        ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - class·C·{·static·{·let·a·=·1;·if·(foo)·{·a;·}·}·}
   + class·C·{·static·{·const·a·=·1;·if·(foo)·{·a;·}·}·}
@@ -1185,7 +1185,7 @@ class C { static { if (foo) { let a; a = 1; } } }
 ```
 invalid.jsonc:1:31 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ class C { static { if (foo) { let a; a = 1; } } }
       │                               ^^^
@@ -1207,7 +1207,7 @@ class C { static { let a; a = 1; } }
 ```
 invalid.jsonc:1:20 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ class C { static { let a; a = 1; } }
       │                    ^^^
@@ -1229,7 +1229,7 @@ class C { static { let { a, b } = foo; } }
 ```
 invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ class C { static { let { a, b } = foo; } }
       │                    ^^^
@@ -1244,7 +1244,7 @@ invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ class C { static { let { a, b } = foo; } }
       │                             ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - class·C·{·static·{·let·{·a,·b·}·=·foo;·}·}
   + class·C·{·static·{·const·{·a,·b·}·=·foo;·}·}
@@ -1261,7 +1261,7 @@ class C { static { let a, b; ({ a, b } = foo); } }
 ```
 invalid.jsonc:1:20 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ class C { static { let a, b; ({ a, b } = foo); } }
       │                    ^^^
@@ -1288,7 +1288,7 @@ class C { static { let a; let b; ({ a, b } = foo); } }
 ```
 invalid.jsonc:1:20 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ class C { static { let a; let b; ({ a, b } = foo); } }
       │                    ^^^
@@ -1304,7 +1304,7 @@ invalid.jsonc:1:20 lint/style/useConst ━━━━━━━━━━━━━�
 ```
 invalid.jsonc:1:27 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ class C { static { let a; let b; ({ a, b } = foo); } }
       │                           ^^^
@@ -1326,7 +1326,7 @@ class C { static { let a; a = 0; console.log(a); } }
 ```
 invalid.jsonc:1:20 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ class C { static { let a; a = 0; console.log(a); } }
       │                    ^^^
@@ -1348,7 +1348,7 @@ let { itemId, list } = {}, obj = []; console.log(itemId, list, obj);
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ let { itemId, list } = {}, obj = []; console.log(itemId, list, obj);
       │ ^^^
@@ -1368,7 +1368,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let { itemId, list } = {}, obj = []; console.log(itemId, list, obj);
       │                            ^^^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·{·itemId,·list·}·=·{},·obj·=·[];·console.log(itemId,·list,·obj);
   + const·{·itemId,·list·}·=·{},·obj·=·[];·console.log(itemId,·list,·obj);
@@ -1385,7 +1385,7 @@ let [ itemId, list ] = [], obj = []; console.log(itemId, list, obj);
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares some variables which are never re-assigned.
+  ! This let declares some variables which are never re-assigned.
   
   > 1 │ let [ itemId, list ] = [], obj = []; console.log(itemId, list, obj);
       │ ^^^
@@ -1405,7 +1405,7 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ let [ itemId, list ] = [], obj = []; console.log(itemId, list, obj);
       │                            ^^^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - let·[·itemId,·list·]·=·[],·obj·=·[];·console.log(itemId,·list,·obj);
   + const·[·itemId,·list·]·=·[],·obj·=·[];·console.log(itemId,·list,·obj);
@@ -1422,7 +1422,7 @@ class C { static { () => a; let a = 1; } };
 ```
 invalid.jsonc:1:29 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ class C { static { () => a; let a = 1; } };
       │                             ^^^
@@ -1432,7 +1432,7 @@ invalid.jsonc:1:29 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
   > 1 │ class C { static { () => a; let a = 1; } };
       │                                 ^
   
-  i Suggested fix: Use 'const' instead.
+  i Safe fix: Use const instead.
   
   - class·C·{·static·{·()·=>·a;·let·a·=·1;·}·};
   + class·C·{·static·{·()·=>·a;·const·a·=·1;·}·};
@@ -1449,7 +1449,7 @@ let x; function foo() { bar(x); } x = 0;
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This 'let' declares a variable which is never re-assigned.
+  ! This let declares a variable which is never re-assigned.
   
   > 1 │ let x; function foo() { bar(x); } x = 0;
       │ ^^^

--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -340,12 +340,7 @@ impl SemanticEventExtractor {
                 .parent::<JsVariableDeclaration>()?
                 .is_var(),
             Some(JsSyntaxKind::JS_FOR_VARIABLE_DECLARATION) => {
-                declarator
-                    .parent::<JsForVariableDeclaration>()?
-                    .kind_token()
-                    .ok()?
-                    .kind()
-                    == JsSyntaxKind::VAR_KW
+                declarator.parent::<JsForVariableDeclaration>()?.is_var()
             }
             _ => false,
         };

--- a/crates/biome_js_syntax/src/stmt_ext.rs
+++ b/crates/biome_js_syntax/src/stmt_ext.rs
@@ -55,9 +55,8 @@ impl JsVariableDeclaration {
     }
 
     pub fn variable_kind(&self) -> SyntaxResult<JsVariableKind> {
-        let token_kind = self.kind().map(|t| t.kind())?;
-
-        Ok(match token_kind {
+        let kind_token = self.kind()?;
+        Ok(match kind_token.kind() {
             T![const] => JsVariableKind::Const,
             T![let] => JsVariableKind::Let,
             T![var] => JsVariableKind::Var,
@@ -84,9 +83,8 @@ impl JsForVariableDeclaration {
     }
 
     pub fn variable_kind(&self) -> SyntaxResult<JsVariableKind> {
-        let token_kind = self.kind_token().map(|t| t.kind())?;
-
-        Ok(match token_kind {
+        let kind_token = self.kind_token()?;
+        Ok(match kind_token.kind() {
             T![const] => JsVariableKind::Const,
             T![let] => JsVariableKind::Let,
             T![var] => JsVariableKind::Var,
@@ -101,10 +99,32 @@ declare_node_union! {
 }
 
 impl AnyJsVariableDeclaration {
+    /// Whether the declaration is a const declaration
+    pub fn is_const(&self) -> bool {
+        self.variable_kind() == Ok(JsVariableKind::Const)
+    }
+
+    /// Whether the declaration is a let declaration
+    pub fn is_let(&self) -> bool {
+        self.variable_kind() == Ok(JsVariableKind::Let)
+    }
+
+    /// Whether the declaration is a var declaration
+    pub fn is_var(&self) -> bool {
+        self.variable_kind() == Ok(JsVariableKind::Var)
+    }
+
     pub fn variable_kind(&self) -> SyntaxResult<JsVariableKind> {
         match self {
             AnyJsVariableDeclaration::JsForVariableDeclaration(decl) => decl.variable_kind(),
             AnyJsVariableDeclaration::JsVariableDeclaration(decl) => decl.variable_kind(),
+        }
+    }
+
+    pub fn kind_token(&self) -> Option<SyntaxToken> {
+        match self {
+            AnyJsVariableDeclaration::JsVariableDeclaration(x) => x.kind().ok(),
+            AnyJsVariableDeclaration::JsForVariableDeclaration(x) => x.kind_token().ok(),
         }
     }
 }

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -60,6 +60,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
   - [noUselessLabel](https://biomejs.dev/linter/rules/no-useless-label)
   - [noUselessTypeConstraint](https://biomejs.dev/linter/rules/no-useless-type-constraint)
+  - [useConst](https://biomejs.dev/linter/rules/use-const)
   - [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
 
 #### Bug fixes

--- a/website/src/content/docs/linter/rules/use-const.md
+++ b/website/src/content/docs/linter/rules/use-const.md
@@ -21,7 +21,7 @@ console.log(a);
 
 <pre class="language-text"><code class="language-text">style/useConst.js:1:1 <a href="https://biomejs.dev/linter/rules/use-const">lint/style/useConst</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This 'let' declares a variable which is never re-assigned.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This </span><span style="color: Tomato;"><strong>let</strong></span><span style="color: Tomato;"> declares a variable which is never re-assigned.</span>
   
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>let a = 3;
    <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
@@ -35,7 +35,7 @@ console.log(a);
     <strong>2 │ </strong>console.log(a);
     <strong>3 │ </strong>
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use 'const' instead.</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>const</strong></span><span style="color: rgb(38, 148, 255);"> instead.</span>
   
     <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>l</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">a</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">=</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">3</span><span style="color: Tomato;">;</span>
       <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;"><strong>c</strong></span><span style="color: MediumSeaGreen;"><strong>o</strong></span><span style="color: MediumSeaGreen;"><strong>n</strong></span><span style="color: MediumSeaGreen;"><strong>s</strong></span><span style="color: MediumSeaGreen;"><strong>t</strong></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">a</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">=</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">3</span><span style="color: MediumSeaGreen;">;</span>
@@ -53,7 +53,7 @@ for (let a of [1, 2, 3]) {
 
 <pre class="language-text"><code class="language-text">style/useConst.js:2:6 <a href="https://biomejs.dev/linter/rules/use-const">lint/style/useConst</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This 'let' declares a variable which is never re-assigned.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This </span><span style="color: Tomato;"><strong>let</strong></span><span style="color: Tomato;"> declares a variable which is never re-assigned.</span>
   
     <strong>1 │ </strong>// `a` is redefined (not reassigned) on each loop step.
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>for (let a of [1, 2, 3]) {
@@ -69,7 +69,7 @@ for (let a of [1, 2, 3]) {
     <strong>3 │ </strong>    console.log(a);
     <strong>4 │ </strong>}
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use 'const' instead.</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>const</strong></span><span style="color: rgb(38, 148, 255);"> instead.</span>
   
     <strong>1</strong> <strong>1</strong><strong> │ </strong>  // `a` is redefined (not reassigned) on each loop step.
     <strong>2</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">f</span><span style="color: Tomato;">o</span><span style="color: Tomato;">r</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">(</span><span style="color: Tomato;"><strong>l</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">a</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">o</span><span style="color: Tomato;">f</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">[</span><span style="color: Tomato;">1</span><span style="color: Tomato;">,</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">2</span><span style="color: Tomato;">,</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">3</span><span style="color: Tomato;">]</span><span style="color: Tomato;">)</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">{</span>
@@ -88,7 +88,7 @@ for (let a in [1, 2, 3]) {
 
 <pre class="language-text"><code class="language-text">style/useConst.js:2:6 <a href="https://biomejs.dev/linter/rules/use-const">lint/style/useConst</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This 'let' declares a variable which is never re-assigned.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This </span><span style="color: Tomato;"><strong>let</strong></span><span style="color: Tomato;"> declares a variable which is never re-assigned.</span>
   
     <strong>1 │ </strong>// `a` is redefined (not reassigned) on each loop step.
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>for (let a in [1, 2, 3]) {
@@ -104,7 +104,7 @@ for (let a in [1, 2, 3]) {
     <strong>3 │ </strong>    console.log(a);
     <strong>4 │ </strong>}
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use 'const' instead.</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>const</strong></span><span style="color: rgb(38, 148, 255);"> instead.</span>
   
     <strong>1</strong> <strong>1</strong><strong> │ </strong>  // `a` is redefined (not reassigned) on each loop step.
     <strong>2</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">f</span><span style="color: Tomato;">o</span><span style="color: Tomato;">r</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">(</span><span style="color: Tomato;"><strong>l</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">a</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">i</span><span style="color: Tomato;">n</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">[</span><span style="color: Tomato;">1</span><span style="color: Tomato;">,</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">2</span><span style="color: Tomato;">,</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">3</span><span style="color: Tomato;">]</span><span style="color: Tomato;">)</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">{</span>
@@ -124,7 +124,7 @@ let a = 3;
 
 <pre class="language-text"><code class="language-text">style/useConst.js:1:1 <a href="https://biomejs.dev/linter/rules/use-const">lint/style/useConst</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This 'let' declares a variable which is never re-assigned.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This </span><span style="color: Tomato;"><strong>let</strong></span><span style="color: Tomato;"> declares a variable which is never re-assigned.</span>
   
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>let a = 3;
    <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
@@ -138,7 +138,7 @@ let a = 3;
     <strong>2 │ </strong>{
     <strong>3 │ </strong>    let a = 4;
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use 'const' instead.</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>const</strong></span><span style="color: rgb(38, 148, 255);"> instead.</span>
   
     <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>l</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">a</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">=</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">3</span><span style="color: Tomato;">;</span>
       <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;"><strong>c</strong></span><span style="color: MediumSeaGreen;"><strong>o</strong></span><span style="color: MediumSeaGreen;"><strong>n</strong></span><span style="color: MediumSeaGreen;"><strong>s</strong></span><span style="color: MediumSeaGreen;"><strong>t</strong></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">a</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">=</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">3</span><span style="color: MediumSeaGreen;">;</span>


### PR DESCRIPTION
## Summary

The code fix of [useConst](https://biomejs.dev/linter/rules/use-const) seems pretty stable. No bug was reported since several versions. The code fix of the equivalent ESLint rule is safe. Thus, I think it is time to make the code fix of `useCOnst` safe.

I also take the opportunity to reduplicate some code, and improving the diagnostic using `Emphasis`.

## Test Plan

Updated tests.
