### PR TITLE
refactor(lint/useEnumInitializers): make code fix safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
   - [noUselessLabel](https://biomejs.dev/linter/rules/no-useless-label)
   - [noUselessTypeConstraint](https://biomejs.dev/linter/rules/no-useless-type-constraint)
+  - [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
 
 #### Bug fixes
 

--- a/crates/biome_js_analyze/src/analyzers/style/use_enum_initializers.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_enum_initializers.rs
@@ -179,7 +179,7 @@ impl Rule for UseEnumInitializers {
         if has_mutations {
             return Some(JsRuleAction {
                 category: ActionCategory::QuickFix,
-                applicability: Applicability::MaybeIncorrect,
+                applicability: Applicability::Always,
                 message: markup! { "Initialize all enum members." }.to_owned(),
                 mutation,
             });

--- a/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid.ts
@@ -45,3 +45,23 @@ export namespace A {
         }
     }
 }
+
+const RED = 0;
+export enum RgbColor {
+	Red = RED,
+	Green,
+	Blue,
+}
+
+export enum RgbColor2 {
+	Red = RED,
+	Green = 5,
+	Blue,
+}
+
+const GREEN = 0;
+export enum RgbColor3 {
+	Red,
+	Green = GREEN,
+	Blue,
+}

--- a/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid.ts.snap
@@ -52,6 +52,26 @@ export namespace A {
     }
 }
 
+const RED = 0;
+export enum RgbColor {
+	Red = RED,
+	Green,
+	Blue,
+}
+
+export enum RgbColor2 {
+	Red = RED,
+	Green = 5,
+	Blue,
+}
+
+const GREEN = 0;
+export enum RgbColor3 {
+	Red,
+	Green = GREEN,
+	Blue,
+}
+
 ```
 
 # Diagnostics
@@ -84,7 +104,7 @@ invalid.ts:1:13 lint/style/useEnumInitializers  FIXABLE  ━━━━━━━�
   
   i Allowing implicit initializations for enum members can cause bugs if enum declarations are modified over time.
   
-  i Suggested fix: Initialize all enum members.
+  i Safe fix: Initialize all enum members.
   
      1  1 │   export enum Status {
      2    │ - → Close,
@@ -174,7 +194,7 @@ invalid.ts:14:13 lint/style/useEnumInitializers  FIXABLE  ━━━━━━━�
   
   i Allowing implicit initializations for enum members can cause bugs if enum declarations are modified over time.
   
-  i Suggested fix: Initialize all enum members.
+  i Safe fix: Initialize all enum members.
   
     13 13 │   
     14 14 │   export enum Direction {
@@ -215,7 +235,7 @@ invalid.ts:21:13 lint/style/useEnumInitializers  FIXABLE  ━━━━━━━�
   
   i Allowing implicit initializations for enum members can cause bugs if enum declarations are modified over time.
   
-  i Suggested fix: Initialize all enum members.
+  i Safe fix: Initialize all enum members.
   
     24 │ → Blue·=·"Blue",
        │       +++++++++ 
@@ -315,7 +335,7 @@ invalid.ts:42:21 lint/style/useEnumInitializers  FIXABLE  ━━━━━━━�
   
   i Allowing implicit initializations for enum members can cause bugs if enum declarations are modified over time.
   
-  i Suggested fix: Initialize all enum members.
+  i Safe fix: Initialize all enum members.
   
     41 41 │       export namespace B {
     42 42 │           export enum Enum {
@@ -326,6 +346,108 @@ invalid.ts:42:21 lint/style/useEnumInitializers  FIXABLE  ━━━━━━━�
     45 45 │           }
     46 46 │       }
   
+
+```
+
+```
+invalid.ts:50:13 lint/style/useEnumInitializers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This enum declaration contains members that are implicitly initialized.
+  
+    49 │ const RED = 0;
+  > 50 │ export enum RgbColor {
+       │             ^^^^^^^^
+    51 │ 	Red = RED,
+    52 │ 	Green,
+  
+  i This enum member should be explicitly initialized.
+  
+    50 │ export enum RgbColor {
+    51 │ 	Red = RED,
+  > 52 │ 	Green,
+       │ 	^^^^^
+    53 │ 	Blue,
+    54 │ }
+  
+  i This enum member should be explicitly initialized.
+  
+    51 │ 	Red = RED,
+    52 │ 	Green,
+  > 53 │ 	Blue,
+       │ 	^^^^
+    54 │ }
+    55 │ 
+  
+  i Allowing implicit initializations for enum members can cause bugs if enum declarations are modified over time.
+  
+
+```
+
+```
+invalid.ts:56:13 lint/style/useEnumInitializers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This enum declaration contains members that are implicitly initialized.
+  
+    54 │ }
+    55 │ 
+  > 56 │ export enum RgbColor2 {
+       │             ^^^^^^^^^
+    57 │ 	Red = RED,
+    58 │ 	Green = 5,
+  
+  i This enum member should be explicitly initialized.
+  
+    57 │ 	Red = RED,
+    58 │ 	Green = 5,
+  > 59 │ 	Blue,
+       │ 	^^^^
+    60 │ }
+    61 │ 
+  
+  i Allowing implicit initializations for enum members can cause bugs if enum declarations are modified over time.
+  
+  i Safe fix: Initialize all enum members.
+  
+    59 │ → Blue·=·6,
+       │       ++++ 
+
+```
+
+```
+invalid.ts:63:13 lint/style/useEnumInitializers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This enum declaration contains members that are implicitly initialized.
+  
+    62 │ const GREEN = 0;
+  > 63 │ export enum RgbColor3 {
+       │             ^^^^^^^^^
+    64 │ 	Red,
+    65 │ 	Green = GREEN,
+  
+  i This enum member should be explicitly initialized.
+  
+    62 │ const GREEN = 0;
+    63 │ export enum RgbColor3 {
+  > 64 │ 	Red,
+       │ 	^^^
+    65 │ 	Green = GREEN,
+    66 │ 	Blue,
+  
+  i This enum member should be explicitly initialized.
+  
+    64 │ 	Red,
+    65 │ 	Green = GREEN,
+  > 66 │ 	Blue,
+       │ 	^^^^
+    67 │ }
+    68 │ 
+  
+  i Allowing implicit initializations for enum members can cause bugs if enum declarations are modified over time.
+  
+  i Safe fix: Initialize all enum members.
+  
+    64 │ → Red·=·0,
+       │      ++++ 
 
 ```
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -60,6 +60,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
   - [noUselessLabel](https://biomejs.dev/linter/rules/no-useless-label)
   - [noUselessTypeConstraint](https://biomejs.dev/linter/rules/no-useless-type-constraint)
+  - [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
 
 #### Bug fixes
 

--- a/website/src/content/docs/linter/rules/use-enum-initializers.md
+++ b/website/src/content/docs/linter/rules/use-enum-initializers.md
@@ -47,7 +47,7 @@ enum Version {
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Allowing implicit initializations for enum members can cause bugs if enum declarations are modified over time.</span>
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Initialize all enum members.</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Initialize all enum members.</span>
   
 <strong>  </strong><strong>  2 │ </strong><span style="opacity: 0.8;">·</span><span style="opacity: 0.8;">·</span><span style="opacity: 0.8;">·</span><span style="opacity: 0.8;">·</span>V1<span style="opacity: 0.8;"><span style="color: MediumSeaGreen;">·</span></span><span style="color: MediumSeaGreen;">=</span><span style="opacity: 0.8;"><span style="color: MediumSeaGreen;">·</span></span><span style="color: MediumSeaGreen;">0</span>,
 <strong>  </strong><strong>    │ </strong>      <span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span> 
@@ -80,7 +80,7 @@ enum Status {
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Allowing implicit initializations for enum members can cause bugs if enum declarations are modified over time.</span>
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Initialize all enum members.</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Initialize all enum members.</span>
   
 <strong>  </strong><strong>  3 │ </strong><span style="opacity: 0.8;">·</span><span style="opacity: 0.8;">·</span><span style="opacity: 0.8;">·</span><span style="opacity: 0.8;">·</span>Close<span style="opacity: 0.8;"><span style="color: MediumSeaGreen;">·</span></span><span style="color: MediumSeaGreen;">=</span><span style="opacity: 0.8;"><span style="color: MediumSeaGreen;">·</span></span><span style="color: MediumSeaGreen;">2</span>,
 <strong>  </strong><strong>    │ </strong>         <span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span> 
@@ -114,7 +114,7 @@ enum Color {
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Allowing implicit initializations for enum members can cause bugs if enum declarations are modified over time.</span>
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Initialize all enum members.</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Initialize all enum members.</span>
   
 <strong>  </strong><strong>  4 │ </strong><span style="opacity: 0.8;">·</span><span style="opacity: 0.8;">·</span><span style="opacity: 0.8;">·</span><span style="opacity: 0.8;">·</span>Blue<span style="opacity: 0.8;"><span style="color: MediumSeaGreen;">·</span></span><span style="color: MediumSeaGreen;">=</span><span style="opacity: 0.8;"><span style="color: MediumSeaGreen;">·</span></span><span style="color: MediumSeaGreen;">&quot;</span><span style="color: MediumSeaGreen;">B</span><span style="color: MediumSeaGreen;">l</span><span style="color: MediumSeaGreen;">u</span><span style="color: MediumSeaGreen;">e</span><span style="color: MediumSeaGreen;">&quot;</span>,
 <strong>  </strong><strong>    │ </strong>        <span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span> 


### PR DESCRIPTION
## Summary

No bugs were reported for [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers).
Moreover, its code fix doesn't change the program behavior.

## Test Plan

I updated the snapshots and added more tests.