### PR TITLE
refactor: warn clippy::trivially_copy_pass_by_ref

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -78,7 +78,7 @@ rustflags = [
   "-Wclippy::ref_binding_to_reference",
   "-Wclippy::ref_option_ref",
   "-Wclippy::stable_sort_primitive",
-  "-Wclippy::unnecessary_box_returns",
+  "-Wclippy::trivially_copy_pass_by_ref",
   "-Wclippy::unnecessary_box_returns",
   "-Wclippy::unnecessary_join",
   "-Wclippy::unnested_or_patterns",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 allow-dbg-in-tests = true
+trivial-copy-size-limit = 4

--- a/crates/biome_formatter/src/comments/map.rs
+++ b/crates/biome_formatter/src/comments/map.rs
@@ -621,7 +621,7 @@ impl PartIndex {
         Self(NonZeroU32::try_from(value as u32 + 1).unwrap())
     }
 
-    fn value(&self) -> usize {
+    fn value(self) -> usize {
         (u32::from(self.0) - 1) as usize
     }
 
@@ -629,7 +629,7 @@ impl PartIndex {
         *self = self.incremented();
     }
 
-    fn incremented(&self) -> PartIndex {
+    fn incremented(self) -> PartIndex {
         PartIndex(NonZeroU32::new(self.0.get() + 1).unwrap())
     }
 }

--- a/crates/biome_formatter/src/printer/line_suffixes.rs
+++ b/crates/biome_formatter/src/printer/line_suffixes.rs
@@ -32,7 +32,7 @@ impl<'a> LineSuffixes<'a> {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub(super) enum LineSuffixEntry<'a> {
     /// A line suffix to print
     Suffix(&'a FormatElement),

--- a/crates/biome_formatter/src/printer/mod.rs
+++ b/crates/biome_formatter/src/printer/mod.rs
@@ -757,7 +757,7 @@ enum Indention {
 }
 
 impl Indention {
-    const fn is_empty(&self) -> bool {
+    const fn is_empty(self) -> bool {
         matches!(self, Indention::Level(0))
     }
 
@@ -767,18 +767,18 @@ impl Indention {
     }
 
     /// Returns the indention level
-    fn level(&self) -> u16 {
+    fn level(self) -> u16 {
         match self {
-            Indention::Level(count) => *count,
-            Indention::Align { level: indent, .. } => *indent,
+            Indention::Level(count) => count,
+            Indention::Align { level: indent, .. } => indent,
         }
     }
 
     /// Returns the number of trailing align spaces or 0 if none
-    fn align(&self) -> u8 {
+    fn align(self) -> u8 {
         match self {
             Indention::Level(_) => 0,
-            Indention::Align { align, .. } => (*align).into(),
+            Indention::Align { align, .. } => align.into(),
         }
     }
 

--- a/crates/biome_js_analyze/src/analyzers/style/use_numeric_literals.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_numeric_literals.rs
@@ -181,7 +181,7 @@ impl Radix {
         })
     }
 
-    fn prefix(&self) -> &'static str {
+    fn prefix(self) -> &'static str {
         match self {
             Radix::Binary => "0b",
             Radix::Octal => "0o",
@@ -189,7 +189,7 @@ impl Radix {
         }
     }
 
-    fn description(&self) -> &'static str {
+    fn description(self) -> &'static str {
         match self {
             Radix::Binary => "binary",
             Radix::Octal => "octal",

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
@@ -68,7 +68,7 @@ impl Rule for NoUndeclaredVariables {
                     return None;
                 }
 
-                if is_global(text, source_type) {
+                if is_global(text, *source_type) {
                     return None;
                 }
 
@@ -90,7 +90,7 @@ impl Rule for NoUndeclaredVariables {
     }
 }
 
-fn is_global(reference_name: &str, source_type: &JsFileSource) -> bool {
+fn is_global(reference_name: &str, source_type: JsFileSource) -> bool {
     ES_2021.binary_search(&reference_name).is_ok()
         || BROWSER.binary_search(&reference_name).is_ok()
         || NODE.binary_search(&reference_name).is_ok()

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
@@ -456,6 +456,7 @@ const fn default_strict_case() -> bool {
     true
 }
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
 const fn is_default_strict_case(strict_case: &bool) -> bool {
     *strict_case == default_strict_case()
 }

--- a/crates/biome_js_formatter/src/context/trailing_comma.rs
+++ b/crates/biome_js_formatter/src/context/trailing_comma.rs
@@ -22,7 +22,7 @@ pub(crate) enum FormatTrailingComma {
 
 impl FormatTrailingComma {
     /// This function returns corresponding [TrailingSeparator] for [format_separated] function.
-    pub fn trailing_separator(&self, options: &JsFormatOptions) -> TrailingSeparator {
+    pub fn trailing_separator(self, options: &JsFormatOptions) -> TrailingSeparator {
         if options.trailing_comma.is_none() {
             return TrailingSeparator::Omit;
         }

--- a/crates/biome_js_formatter/src/js/declarations/function_declaration.rs
+++ b/crates/biome_js_formatter/src/js/declarations/function_declaration.rs
@@ -161,7 +161,7 @@ impl FormatFunction {
     pub(crate) fn fmt_with_options(
         &self,
         f: &mut JsFormatter,
-        options: &FormatFunctionOptions,
+        options: FormatFunctionOptions,
     ) -> FormatResult<()> {
         if let Some(async_token) = self.async_token() {
             write!(f, [async_token.format(), space()])?;
@@ -248,7 +248,7 @@ impl FormatFunction {
 
 impl Format<JsFormatContext> for FormatFunction {
     fn fmt(&self, f: &mut JsFormatter) -> FormatResult<()> {
-        self.fmt_with_options(f, &FormatFunctionOptions::default())?;
+        self.fmt_with_options(f, FormatFunctionOptions::default())?;
         Ok(())
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -48,7 +48,7 @@ impl FormatNodeRule<JsArrowFunctionExpression> for FormatJsArrowFunctionExpressi
         f: &mut JsFormatter,
     ) -> FormatResult<()> {
         let layout =
-            ArrowFunctionLayout::for_arrow(node.clone(), f.context().comments(), &self.options)?;
+            ArrowFunctionLayout::for_arrow(node.clone(), f.context().comments(), self.options)?;
 
         match layout {
             ArrowFunctionLayout::Chain(chain) => {
@@ -555,7 +555,7 @@ impl ArrowFunctionLayout {
     fn for_arrow(
         arrow: JsArrowFunctionExpression,
         comments: &JsComments,
-        options: &FormatJsArrowFunctionExpressionOptions,
+        options: FormatJsArrowFunctionExpressionOptions,
     ) -> SyntaxResult<ArrowFunctionLayout> {
         let mut head = None;
         let mut middle = Vec::new();
@@ -589,7 +589,7 @@ impl ArrowFunctionLayout {
                             middle,
                             tail: current,
                             expand_signatures: should_break,
-                            options: *options,
+                            options,
                         }),
                     }
                 }

--- a/crates/biome_js_formatter/src/js/expressions/function_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/function_expression.rs
@@ -24,7 +24,7 @@ impl FormatRuleWithOptions<JsFunctionExpression> for FormatJsFunctionExpression 
 
 impl FormatNodeRule<JsFunctionExpression> for FormatJsFunctionExpression {
     fn fmt_fields(&self, node: &JsFunctionExpression, f: &mut JsFormatter) -> FormatResult<()> {
-        FormatFunction::from(node.clone()).fmt_with_options(f, &self.options)?;
+        FormatFunction::from(node.clone()).fmt_with_options(f, self.options)?;
         Ok(())
     }
 

--- a/crates/biome_js_formatter/src/js/lists/template_element_list.rs
+++ b/crates/biome_js_formatter/src/js/lists/template_element_list.rs
@@ -252,12 +252,12 @@ pub struct TemplateElementIndention(u32);
 
 impl TemplateElementIndention {
     /// Returns the indention level
-    pub(crate) fn level(&self, tab_width: TabWidth) -> u32 {
+    pub(crate) fn level(self, tab_width: TabWidth) -> u32 {
         self.0 / u32::from(u8::from(tab_width))
     }
 
     /// Returns the number of space indents on top of the indent level
-    pub(crate) fn align(&self, tab_width: TabWidth) -> u8 {
+    pub(crate) fn align(self, tab_width: TabWidth) -> u8 {
         (self.0 % u32::from(u8::from(tab_width))) as u8
     }
 

--- a/crates/biome_js_formatter/src/jsx/lists/child_list.rs
+++ b/crates/biome_js_formatter/src/jsx/lists/child_list.rs
@@ -414,7 +414,7 @@ pub enum JsxChildListLayout {
 }
 
 impl JsxChildListLayout {
-    const fn is_multiline(&self) -> bool {
+    const fn is_multiline(self) -> bool {
         matches!(self, JsxChildListLayout::Multiline)
     }
 }
@@ -467,7 +467,7 @@ enum WordSeparator {
 
 impl WordSeparator {
     /// Returns if formatting this separator will result in a child that expands
-    fn will_break(&self) -> bool {
+    fn will_break(self) -> bool {
         matches!(
             self,
             WordSeparator::EndOfText {

--- a/crates/biome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/biome_js_formatter/src/utils/binary_like_expression.rs
@@ -711,7 +711,7 @@ pub(crate) enum BinaryLikeOperator {
 }
 
 impl BinaryLikeOperator {
-    pub const fn precedence(&self) -> OperatorPrecedence {
+    pub const fn precedence(self) -> OperatorPrecedence {
         match self {
             BinaryLikeOperator::Logical(logical) => logical.precedence(),
             BinaryLikeOperator::Binary(binary) => binary.precedence(),
@@ -721,7 +721,7 @@ impl BinaryLikeOperator {
         }
     }
 
-    pub const fn is_remainder(&self) -> bool {
+    pub const fn is_remainder(self) -> bool {
         matches!(
             self,
             BinaryLikeOperator::Binary(JsBinaryOperator::Remainder)

--- a/crates/biome_js_formatter/src/utils/conditional.rs
+++ b/crates/biome_js_formatter/src/utils/conditional.rs
@@ -239,7 +239,7 @@ impl FormatRule<AnyJsConditional> for FormatJsAnyConditionalRule {
 
 impl FormatJsAnyConditionalRule {
     fn layout(
-        &self,
+        self,
         conditional: &AnyJsConditional,
         source_type: JsFileSource,
     ) -> ConditionalLayout {
@@ -300,7 +300,7 @@ impl FormatJsAnyConditionalRule {
     /// ).member
     /// ```
     fn should_extra_indent(
-        &self,
+        self,
         conditional: &AnyJsConditional,
         layout: &ConditionalLayout,
     ) -> bool {
@@ -476,7 +476,7 @@ impl FormatJsAnyConditionalRule {
 
     /// Returns `true` if this is the root conditional expression and the parent is a [JsStaticMemberExpression].
     fn is_parent_static_member_expression(
-        &self,
+        self,
         conditional: &AnyJsConditional,
         layout: &ConditionalLayout,
     ) -> bool {
@@ -634,10 +634,10 @@ pub enum ConditionalJsxChain {
 }
 
 impl ConditionalJsxChain {
-    pub const fn is_chain(&self) -> bool {
+    pub const fn is_chain(self) -> bool {
         matches!(self, ConditionalJsxChain::Chain)
     }
-    pub const fn is_no_chain(&self) -> bool {
+    pub const fn is_no_chain(self) -> bool {
         matches!(self, ConditionalJsxChain::NoChain)
     }
 }

--- a/crates/biome_js_parser/src/lexer/mod.rs
+++ b/crates/biome_js_parser/src/lexer/mod.rs
@@ -122,11 +122,11 @@ bitflags! {
 }
 
 impl TokenFlags {
-    pub const fn has_preceding_line_break(&self) -> bool {
+    pub const fn has_preceding_line_break(self) -> bool {
         self.contains(TokenFlags::PRECEDING_LINE_BREAK)
     }
 
-    pub const fn has_unicode_escape(&self) -> bool {
+    pub const fn has_unicode_escape(self) -> bool {
         self.contains(TokenFlags::UNICODE_ESCAPE)
     }
 }

--- a/crates/biome_js_parser/src/parser.rs
+++ b/crates/biome_js_parser/src/parser.rs
@@ -44,7 +44,7 @@ impl<'source> JsParser<'source> {
         let source = JsTokenSource::from_str(source);
 
         JsParser {
-            state: ParserState::new(&source_type),
+            state: ParserState::new(source_type),
             source_type,
             context: ParserContext::default(),
             source,

--- a/crates/biome_js_parser/src/state.rs
+++ b/crates/biome_js_parser/src/state.rs
@@ -33,15 +33,15 @@ pub(crate) enum ExportDefaultItemKind {
 }
 
 impl ExportDefaultItemKind {
-    pub(crate) fn is_overload(&self) -> bool {
+    pub(crate) fn is_overload(self) -> bool {
         matches!(self, ExportDefaultItemKind::FunctionOverload)
     }
 
-    pub(crate) fn is_function_declaration(&self) -> bool {
+    pub(crate) fn is_function_declaration(self) -> bool {
         matches!(self, ExportDefaultItemKind::FunctionDeclaration)
     }
 
-    pub(crate) fn is_interface(&self) -> bool {
+    pub(crate) fn is_interface(self) -> bool {
         matches!(self, ExportDefaultItemKind::Interface)
     }
 }
@@ -97,7 +97,7 @@ pub(crate) enum StrictMode {
 }
 
 impl ParserState {
-    pub fn new(source_type: &JsFileSource) -> Self {
+    pub fn new(source_type: JsFileSource) -> Self {
         let mut state = ParserState {
             parsing_context: ParsingContextFlags::TOP_LEVEL,
             label_set: IndexMap::new(),

--- a/crates/biome_js_parser/src/syntax/class.rs
+++ b/crates/biome_js_parser/src/syntax/class.rs
@@ -205,7 +205,7 @@ enum ClassKind {
 }
 
 impl ClassKind {
-    fn is_id_optional(&self) -> bool {
+    fn is_id_optional(self) -> bool {
         matches!(self, ClassKind::Expression | ClassKind::ExportDefault)
     }
 }
@@ -1912,14 +1912,14 @@ enum ModifierKind {
 }
 
 impl ModifierKind {
-    const fn is_ts_modifier(&self) -> bool {
+    const fn is_ts_modifier(self) -> bool {
         !matches!(
             self,
             ModifierKind::Static | ModifierKind::Accessor | ModifierKind::Decorator
         )
     }
 
-    const fn as_syntax_kind(&self) -> JsSyntaxKind {
+    const fn as_syntax_kind(self) -> JsSyntaxKind {
         match self {
             ModifierKind::Declare => TS_DECLARE_MODIFIER,
             ModifierKind::Abstract => TS_ABSTRACT_MODIFIER,
@@ -1934,7 +1934,7 @@ impl ModifierKind {
         }
     }
 
-    const fn as_flags(&self) -> ModifierFlags {
+    const fn as_flags(self) -> ModifierFlags {
         match self {
             ModifierKind::Declare => ModifierFlags::DECLARE,
             ModifierKind::Abstract => ModifierFlags::ABSTRACT,

--- a/crates/biome_js_parser/src/syntax/expr.rs
+++ b/crates/biome_js_parser/src/syntax/expr.rs
@@ -84,18 +84,18 @@ impl ExpressionContext {
     }
 
     /// Returns true if object expressions or object patterns are valid in this context
-    pub(crate) const fn is_object_expression_allowed(&self) -> bool {
+    pub(crate) const fn is_object_expression_allowed(self) -> bool {
         self.0
             .contains(ExpressionContextFlags::ALLOW_OBJECT_EXPRESSION)
     }
 
     /// Returns `true` if the expression parsing includes binary in expressions.
-    pub(crate) const fn is_in_included(&self) -> bool {
+    pub(crate) const fn is_in_included(self) -> bool {
         self.0.contains(ExpressionContextFlags::INCLUDE_IN)
     }
 
     /// Returns `true` if currently parsing a decorator expression `@<expr>`.
-    pub(crate) const fn is_in_decorator(&self) -> bool {
+    pub(crate) const fn is_in_decorator(self) -> bool {
         self.0.contains(ExpressionContextFlags::IN_DECORATOR)
     }
 

--- a/crates/biome_js_parser/src/syntax/function.rs
+++ b/crates/biome_js_parser/src/syntax/function.rs
@@ -147,7 +147,7 @@ enum AmbientFunctionKind {
 }
 
 impl AmbientFunctionKind {
-    const fn is_export_default(&self) -> bool {
+    const fn is_export_default(self) -> bool {
         matches!(self, AmbientFunctionKind::ExportDefault)
     }
 }
@@ -163,19 +163,19 @@ enum FunctionKind {
 }
 
 impl FunctionKind {
-    const fn is_export_default(&self) -> bool {
+    const fn is_export_default(self) -> bool {
         matches!(self, FunctionKind::ExportDefault)
     }
 
-    fn is_id_optional(&self) -> bool {
+    fn is_id_optional(self) -> bool {
         matches!(self, FunctionKind::Expression | FunctionKind::ExportDefault)
     }
 
-    fn is_expression(&self) -> bool {
+    fn is_expression(self) -> bool {
         matches!(self, FunctionKind::Expression)
     }
 
-    fn is_in_single_statement_context(&self) -> bool {
+    fn is_in_single_statement_context(self) -> bool {
         matches!(
             self,
             FunctionKind::Declaration {
@@ -516,7 +516,7 @@ pub(crate) enum Ambiguity {
 }
 
 impl Ambiguity {
-    fn is_disallowed(&self) -> bool {
+    fn is_disallowed(self) -> bool {
         matches!(self, Ambiguity::Disallowed)
     }
 }
@@ -1056,32 +1056,32 @@ pub(crate) enum ParameterContext {
 }
 
 impl ParameterContext {
-    pub fn is_any_setter(&self) -> bool {
+    pub fn is_any_setter(self) -> bool {
         self.is_setter() || self.is_class_setter()
     }
 
-    pub fn is_setter(&self) -> bool {
-        self == &ParameterContext::Setter
+    pub fn is_setter(self) -> bool {
+        self == ParameterContext::Setter
     }
 
-    pub fn is_class_setter(&self) -> bool {
-        self == &ParameterContext::ClassSetter
+    pub fn is_class_setter(self) -> bool {
+        self == ParameterContext::ClassSetter
     }
 
-    pub fn is_class_method_implementation(&self) -> bool {
-        self == &ParameterContext::ClassImplementation
+    pub fn is_class_method_implementation(self) -> bool {
+        self == ParameterContext::ClassImplementation
     }
 
-    pub fn is_any_class_method(&self) -> bool {
+    pub fn is_any_class_method(self) -> bool {
         self.is_class_method_implementation() || self.is_class_setter()
     }
 
-    pub fn is_parameter_property(&self) -> bool {
-        self == &ParameterContext::ParameterProperty
+    pub fn is_parameter_property(self) -> bool {
+        self == ParameterContext::ParameterProperty
     }
 
-    pub fn is_arrow_function(&self) -> bool {
-        self == &ParameterContext::Arrow
+    pub fn is_arrow_function(self) -> bool {
+        self == ParameterContext::Arrow
     }
 }
 

--- a/crates/biome_js_parser/src/syntax/stmt.rs
+++ b/crates/biome_js_parser/src/syntax/stmt.rs
@@ -138,11 +138,11 @@ pub(crate) enum StatementContext {
 }
 
 impl StatementContext {
-    pub(crate) fn is_single_statement(&self) -> bool {
+    pub(crate) fn is_single_statement(self) -> bool {
         !matches!(self, StatementContext::StatementList)
     }
 
-    pub(crate) fn is_statement_list(&self) -> bool {
+    pub(crate) fn is_statement_list(self) -> bool {
         matches!(self, StatementContext::StatementList)
     }
 }

--- a/crates/biome_js_parser/src/syntax/typescript/types.rs
+++ b/crates/biome_js_parser/src/syntax/typescript/types.rs
@@ -81,19 +81,19 @@ impl TypeContext {
         self.and(TypeContext::IN_CONDITIONAL_EXTENDS, allow)
     }
 
-    pub(crate) const fn is_conditional_type_allowed(&self) -> bool {
+    pub(crate) const fn is_conditional_type_allowed(self) -> bool {
         !self.contains(TypeContext::DISALLOW_CONDITIONAL_TYPES)
     }
 
-    pub(crate) const fn is_in_out_modifier_allowed(&self) -> bool {
+    pub(crate) const fn is_in_out_modifier_allowed(self) -> bool {
         self.contains(TypeContext::ALLOW_IN_OUT_MODIFIER)
     }
 
-    pub(crate) const fn is_const_modifier_allowed(&self) -> bool {
+    pub(crate) const fn is_const_modifier_allowed(self) -> bool {
         self.contains(TypeContext::ALLOW_CONST_MODIFIER)
     }
 
-    pub(crate) const fn in_conditional_extends(&self) -> bool {
+    pub(crate) const fn in_conditional_extends(self) -> bool {
         self.contains(TypeContext::IN_CONDITIONAL_EXTENDS)
     }
 
@@ -387,10 +387,10 @@ impl ClassMemberModifierList {
         self.0.push(modifier);
     }
 
-    fn find(&self, modifier_kind: &TypeParameterModifierKind) -> Option<&TypeParameterModifier> {
+    fn find(&self, modifier_kind: TypeParameterModifierKind) -> Option<&TypeParameterModifier> {
         self.0
             .iter()
-            .find(|predicate| predicate.kind == *modifier_kind)
+            .find(|predicate| predicate.kind == modifier_kind)
     }
 }
 
@@ -439,7 +439,7 @@ fn parse_ts_type_parameter_modifiers(p: &mut JsParser, context: TypeContext) -> 
         }
 
         // check for duplicate modifiers
-        if let Some(existing_modifier) = modifiers.find(&modifier_kind) {
+        if let Some(existing_modifier) = modifiers.find(modifier_kind) {
             p.error(modifier_already_seen(
                 p,
                 text_range,
@@ -450,7 +450,7 @@ fn parse_ts_type_parameter_modifiers(p: &mut JsParser, context: TypeContext) -> 
         }
 
         // check for modifier precedence
-        if let Some(ts_out_modifier) = modifiers.find(&TypeParameterModifierKind::Out) {
+        if let Some(ts_out_modifier) = modifiers.find(TypeParameterModifierKind::Out) {
             if modifier_kind == TypeParameterModifierKind::In {
                 p.error(modifier_must_precede_modifier(
                     p,
@@ -592,7 +592,7 @@ enum IntersectionOrUnionType {
 
 impl IntersectionOrUnionType {
     #[inline]
-    fn operator(&self) -> JsSyntaxKind {
+    fn operator(self) -> JsSyntaxKind {
         match self {
             IntersectionOrUnionType::Union => T![|],
             IntersectionOrUnionType::Intersection => T![&],
@@ -600,7 +600,7 @@ impl IntersectionOrUnionType {
     }
 
     #[inline]
-    fn list_kind(&self) -> JsSyntaxKind {
+    fn list_kind(self) -> JsSyntaxKind {
         match self {
             IntersectionOrUnionType::Union => TS_UNION_TYPE_VARIANT_LIST,
             IntersectionOrUnionType::Intersection => TS_INTERSECTION_TYPE_ELEMENT_LIST,
@@ -608,7 +608,7 @@ impl IntersectionOrUnionType {
     }
 
     #[inline]
-    fn kind(&self) -> JsSyntaxKind {
+    fn kind(self) -> JsSyntaxKind {
         match self {
             IntersectionOrUnionType::Union => TS_UNION_TYPE,
             IntersectionOrUnionType::Intersection => TS_INTERSECTION_TYPE,
@@ -616,7 +616,7 @@ impl IntersectionOrUnionType {
     }
 
     #[inline]
-    fn parse_element(&self, p: &mut JsParser, context: TypeContext) -> ParsedSyntax {
+    fn parse_element(self, p: &mut JsParser, context: TypeContext) -> ParsedSyntax {
         match self {
             IntersectionOrUnionType::Union => parse_ts_intersection_type_or_higher(p, context),
             IntersectionOrUnionType::Intersection => parse_ts_primary_type(p, context),

--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -401,19 +401,19 @@ impl SemanticEventExtractor {
             JS_VARIABLE_DECLARATOR => {
                 if let Some(true) = is_var {
                     let hoisted_scope_id = self.scope_index_to_hoist_declarations(0);
-                    self.push_binding_into_scope(hoisted_scope_id, &name_token, &parent_kind);
+                    self.push_binding_into_scope(hoisted_scope_id, &name_token, parent_kind);
                 } else {
-                    self.push_binding_into_scope(None, &name_token, &parent_kind);
+                    self.push_binding_into_scope(None, &name_token, parent_kind);
                 };
                 self.export_variable_declarator(node, &parent);
             }
             JS_FUNCTION_DECLARATION | JS_FUNCTION_EXPORT_DEFAULT_DECLARATION => {
                 let hoisted_scope_id = self.scope_index_to_hoist_declarations(1);
-                self.push_binding_into_scope(hoisted_scope_id, &name_token, &parent_kind);
+                self.push_binding_into_scope(hoisted_scope_id, &name_token, parent_kind);
                 self.export_function_declaration(node, &parent);
             }
             JS_CLASS_EXPRESSION | JS_FUNCTION_EXPRESSION => {
-                self.push_binding_into_scope(None, &name_token, &parent_kind);
+                self.push_binding_into_scope(None, &name_token, parent_kind);
                 self.export_declaration_expression(node, &parent);
             }
             JS_CLASS_DECLARATION
@@ -425,7 +425,7 @@ impl SemanticEventExtractor {
             | TS_TYPE_ALIAS_DECLARATION => {
                 let parent_scope = self.scopes.get(self.scopes.len() - 2);
                 let parent_scope = parent_scope.map(|scope| scope.scope_id);
-                self.push_binding_into_scope(parent_scope, &name_token, &parent_kind);
+                self.push_binding_into_scope(parent_scope, &name_token, parent_kind);
                 self.export_declaration(node, &parent);
             }
             JS_BINDING_PATTERN_WITH_DEFAULT
@@ -437,7 +437,7 @@ impl SemanticEventExtractor {
             | JS_ARRAY_BINDING_PATTERN
             | JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST
             | JS_ARRAY_BINDING_PATTERN_REST_ELEMENT => {
-                self.push_binding_into_scope(None, &name_token, &parent_kind);
+                self.push_binding_into_scope(None, &name_token, parent_kind);
 
                 let possible_declarator = parent.ancestors().find(|x| {
                     !matches!(
@@ -459,7 +459,7 @@ impl SemanticEventExtractor {
                 }
             }
             _ => {
-                self.push_binding_into_scope(None, &name_token, &parent_kind);
+                self.push_binding_into_scope(None, &name_token, parent_kind);
             }
         }
 
@@ -622,7 +622,7 @@ impl SemanticEventExtractor {
             let parent_kind = infer.syntax().parent().map(|parent| parent.kind());
 
             if let (Some(name_token), Some(parent_kind)) = (name_token, parent_kind) {
-                self.push_binding_into_scope(None, &name_token, &parent_kind);
+                self.push_binding_into_scope(None, &name_token, parent_kind);
             }
         }
     }
@@ -827,7 +827,7 @@ impl SemanticEventExtractor {
         &mut self,
         hoisted_scope_id: Option<usize>,
         name_token: &JsSyntaxToken,
-        declaration_kind: &JsSyntaxKind,
+        declaration_kind: JsSyntaxKind,
     ) {
         let name = name_token.token_text_trimmed();
         let declaration_range = name_token.text_range();
@@ -840,7 +840,7 @@ impl SemanticEventExtractor {
                 name.clone(),
                 BindingInfo {
                     text_range: declaration_range,
-                    declaration_kind: *declaration_kind,
+                    declaration_kind,
                 },
             )
             .map(|shadowed_range| (name.clone(), shadowed_range));

--- a/crates/biome_json_parser/src/syntax.rs
+++ b/crates/biome_json_parser/src/syntax.rs
@@ -90,28 +90,28 @@ enum SequenceKind {
 }
 
 impl SequenceKind {
-    const fn node_kind(&self) -> JsonSyntaxKind {
+    const fn node_kind(self) -> JsonSyntaxKind {
         match self {
             SequenceKind::Array => JSON_ARRAY_VALUE,
             SequenceKind::Object => JSON_OBJECT_VALUE,
         }
     }
 
-    const fn list_kind(&self) -> JsonSyntaxKind {
+    const fn list_kind(self) -> JsonSyntaxKind {
         match self {
             SequenceKind::Array => JSON_ARRAY_ELEMENT_LIST,
             SequenceKind::Object => JSON_MEMBER_LIST,
         }
     }
 
-    const fn open_paren(&self) -> JsonSyntaxKind {
+    const fn open_paren(self) -> JsonSyntaxKind {
         match self {
             SequenceKind::Array => T!['['],
             SequenceKind::Object => T!['{'],
         }
     }
 
-    const fn close_paren(&self) -> JsonSyntaxKind {
+    const fn close_paren(self) -> JsonSyntaxKind {
         match self {
             SequenceKind::Array => T![']'],
             SequenceKind::Object => T!['}'],

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -55,7 +55,7 @@ pub fn generate_ast(mode: Mode, language_kind_list: Vec<String>) -> Result<()> {
         );
         let mut ast = load_ast(kind);
         ast.sort();
-        generate_syntax(ast, &mode, kind)?;
+        generate_syntax(ast, mode, kind)?;
     }
 
     Ok(())
@@ -69,7 +69,7 @@ pub(crate) fn load_ast(language: LanguageKind) -> AstSrc {
     }
 }
 
-pub(crate) fn generate_syntax(ast: AstSrc, mode: &Mode, language_kind: LanguageKind) -> Result<()> {
+pub(crate) fn generate_syntax(ast: AstSrc, mode: Mode, language_kind: LanguageKind) -> Result<()> {
     let syntax_generated_path = project_root()
         .join("crates")
         .join(language_kind.syntax_crate_name())
@@ -299,8 +299,8 @@ fn classify_node_rule(grammar: &Grammar, rule: &Rule) -> NodeRuleClassification 
     }
 }
 
-fn clean_token_name(grammar: &Grammar, token: &Token) -> String {
-    let mut name = grammar[*token].name.clone();
+fn clean_token_name(grammar: &Grammar, token: Token) -> String {
+    let mut name = grammar[token].name.clone();
 
     // These tokens, when parsed to proc_macro2::TokenStream, generates a stream of bytes
     // that can't be recognized by [quote].
@@ -338,7 +338,7 @@ fn handle_rule(
             fields.push(field);
         }
         Rule::Token(token) => {
-            let name = clean_token_name(grammar, token);
+            let name = clean_token_name(grammar, *token);
 
             if name == "''" {
                 // array hole
@@ -449,7 +449,7 @@ fn handle_tokens_in_unions(
     let mut token_kinds = vec![];
     for rule in rule.iter() {
         match rule {
-            Rule::Token(token) => token_kinds.push(clean_token_name(grammar, token)),
+            Rule::Token(token) => token_kinds.push(clean_token_name(grammar, *token)),
             _ => return false,
         }
     }

--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -763,7 +763,7 @@ fn name_to_module(kind: &NodeKind, in_name: &str, language: LanguageKind) -> Nod
 }
 
 impl LanguageKind {
-    fn formatter_ident(&self) -> Ident {
+    fn formatter_ident(self) -> Ident {
         let name = match self {
             LanguageKind::Js => "JsFormatter",
             LanguageKind::Css => "CssFormatter",
@@ -773,7 +773,7 @@ impl LanguageKind {
         Ident::new(name, Span::call_site())
     }
 
-    fn format_context_ident(&self) -> Ident {
+    fn format_context_ident(self) -> Ident {
         let name = match self {
             LanguageKind::Js => "JsFormatContext",
             LanguageKind::Css => "CssFormatContext",

--- a/xtask/codegen/src/generate_bindings.rs
+++ b/xtask/codegen/src/generate_bindings.rs
@@ -408,7 +408,7 @@ pub(crate) fn generate_workspace_bindings(mode: Mode) -> Result<()> {
     let printed = formatted.print().unwrap();
     let code = printed.into_code();
 
-    update(&bindings_path, &code, &mode)?;
+    update(&bindings_path, &code, mode)?;
 
     Ok(())
 }

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -331,19 +331,19 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
     update(
         &config_root.join("rules.rs"),
         &xtask::reformat(configuration)?,
-        &mode,
+        mode,
     )?;
 
     update(
         &config_parsing_root.join("rules.rs"),
         &xtask::reformat(visitors)?,
-        &mode,
+        mode,
     )?;
 
     update(
         &push_rules_directory.join("generated.rs"),
         &xtask::reformat(push_rules)?,
-        &mode,
+        mode,
     )?;
 
     Ok(())

--- a/xtask/codegen/src/generate_nodes.rs
+++ b/xtask/codegen/src/generate_nodes.rs
@@ -84,7 +84,7 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
 
                 let is_list = match field {
                     Field::Node { ty, .. } => ast.is_list(ty),
-                    _ => false,
+                    Field::Token { .. } => false,
                 };
 
                 let string_name = name.to_string();

--- a/xtask/codegen/src/generate_schema.rs
+++ b/xtask/codegen/src/generate_schema.rs
@@ -20,8 +20,8 @@ pub(crate) fn generate_configuration_schema(mode: Mode) -> Result<()> {
             .print()
             .unwrap();
 
-    update(&schema_path_vscode, formatted.as_code(), &mode)?;
-    update(&schema_path_npm, formatted.as_code(), &mode)?;
+    update(&schema_path_vscode, formatted.as_code(), mode)?;
+    update(&schema_path_npm, formatted.as_code(), mode)?;
 
     Ok(())
 }

--- a/xtask/codegen/src/lib.rs
+++ b/xtask/codegen/src/lib.rs
@@ -73,11 +73,11 @@ impl FromStr for LanguageKind {
 }
 
 impl LanguageKind {
-    pub(crate) fn syntax_crate_ident(&self) -> Ident {
+    pub(crate) fn syntax_crate_ident(self) -> Ident {
         Ident::new(self.syntax_crate_name(), Span::call_site())
     }
 
-    pub(crate) fn syntax_kind(&self) -> TokenStream {
+    pub(crate) fn syntax_kind(self) -> TokenStream {
         match self {
             LanguageKind::Js => quote! { JsSyntaxKind },
             LanguageKind::Css => quote! { CssSyntaxKind },
@@ -85,7 +85,7 @@ impl LanguageKind {
         }
     }
 
-    pub(crate) fn syntax_node(&self) -> TokenStream {
+    pub(crate) fn syntax_node(self) -> TokenStream {
         match self {
             LanguageKind::Js => quote! { JsSyntaxNode },
             LanguageKind::Css => quote! { CssSyntaxNode },
@@ -93,7 +93,7 @@ impl LanguageKind {
         }
     }
 
-    pub(crate) fn syntax_element(&self) -> TokenStream {
+    pub(crate) fn syntax_element(self) -> TokenStream {
         match self {
             LanguageKind::Js => quote! { JsSyntaxElement },
             LanguageKind::Css => quote! { CssSyntaxElement },
@@ -101,7 +101,7 @@ impl LanguageKind {
         }
     }
 
-    pub(crate) fn syntax_token(&self) -> TokenStream {
+    pub(crate) fn syntax_token(self) -> TokenStream {
         match self {
             LanguageKind::Js => quote! { JsSyntaxToken },
             LanguageKind::Css => quote! { CssSyntaxToken },
@@ -109,7 +109,7 @@ impl LanguageKind {
         }
     }
 
-    pub(crate) fn syntax_element_children(&self) -> TokenStream {
+    pub(crate) fn syntax_element_children(self) -> TokenStream {
         match self {
             LanguageKind::Js => quote! { JsSyntaxElementChildren },
             LanguageKind::Css => quote! { CssSyntaxElementChildren },
@@ -117,7 +117,7 @@ impl LanguageKind {
         }
     }
 
-    pub(crate) fn syntax_list(&self) -> TokenStream {
+    pub(crate) fn syntax_list(self) -> TokenStream {
         match self {
             LanguageKind::Js => quote! { JsSyntaxList },
             LanguageKind::Css => quote! { CssSyntaxList },
@@ -125,7 +125,7 @@ impl LanguageKind {
         }
     }
 
-    pub(crate) fn language(&self) -> TokenStream {
+    pub(crate) fn language(self) -> TokenStream {
         match self {
             LanguageKind::Js => quote! { JsLanguage },
             LanguageKind::Css => quote! { CssLanguage },
@@ -133,7 +133,7 @@ impl LanguageKind {
         }
     }
 
-    pub fn formatter_crate_name(&self) -> &'static str {
+    pub fn formatter_crate_name(self) -> &'static str {
         match self {
             LanguageKind::Js => "biome_js_formatter",
             LanguageKind::Css => "rome_css_formatter",
@@ -141,7 +141,7 @@ impl LanguageKind {
         }
     }
 
-    pub fn syntax_crate_name(&self) -> &'static str {
+    pub fn syntax_crate_name(self) -> &'static str {
         match self {
             LanguageKind::Js => "biome_js_syntax",
             LanguageKind::Css => "biome_css_syntax",
@@ -149,7 +149,7 @@ impl LanguageKind {
         }
     }
 
-    pub fn factory_crate_name(&self) -> &'static str {
+    pub fn factory_crate_name(self) -> &'static str {
         match self {
             LanguageKind::Js => "biome_js_factory",
             LanguageKind::Css => "biome_css_factory",
@@ -160,7 +160,7 @@ impl LanguageKind {
 
 /// A helper to update file on disk if it has changed.
 /// With verify = false,
-pub fn update(path: &Path, contents: &str, mode: &Mode) -> Result<UpdateResult> {
+pub fn update(path: &Path, contents: &str, mode: Mode) -> Result<UpdateResult> {
     match fs2::read_to_string(path) {
         Ok(old_contents) if old_contents == contents => {
             return Ok(UpdateResult::NotUpdated);
@@ -168,7 +168,7 @@ pub fn update(path: &Path, contents: &str, mode: &Mode) -> Result<UpdateResult> 
         _ => (),
     }
 
-    if *mode == Mode::Verify {
+    if mode == Mode::Verify {
         anyhow::bail!("`{}` is not up-to-date", path.display());
     }
 

--- a/xtask/codegen/src/parser_tests.rs
+++ b/xtask/codegen/src/parser_tests.rs
@@ -64,14 +64,14 @@ pub fn generate_parser_tests(mode: Mode) -> Result<()> {
                     .join(name)
                     .with_extension(test.language.extension()),
             };
-            if let crate::UpdateResult::Updated = update(&path, &test.text, &mode)? {
+            if let crate::UpdateResult::Updated = update(&path, &test.text, mode)? {
                 some_file_was_updated = true;
             }
 
             if let Some(options) = &test.options {
                 let path = tests_dir.join(name).with_extension("options.json");
 
-                if let crate::UpdateResult::Updated = update(&path, options, &mode)? {
+                if let crate::UpdateResult::Updated = update(&path, options, mode)? {
                     some_file_was_updated = true;
                 }
             }


### PR DESCRIPTION
## Summary

This enables the following clippy rule:
- [trivially_copy_pass_by_ref](https://rust-lang.github.io/rust-clippy/master/#/trivially_copy_pass_by_ref) that ensures that copyable small types are passed by value.

The idea of the rule is to prevent the use of a reference for a small copyable type. These types can generally be passed via a register instead of the stack.

I also set the `trivial-copy-size-limit` option to `4` bytes to avoid warning against 8 byte copyable types. If we removes existing references to its types, we observe a regression.   

## Test Plan

`cargo test`, `just lint`, `cargo build`, `just codegen`.
