### PR TITLE
refactor: enable more Clippy rules

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -64,6 +64,7 @@ rustflags = [
   "-Wclippy::invalid_upcast_comparisons",
   "-Wclippy::iter_not_returning_iterator",
   "-Wclippy::large_stack_arrays",
+  "-Wclippy::large_types_passed_by_value",
   "-Wclippy::macro_use_imports",
   "-Wclippy::manual_ok_or",
   "-Wclippy::manual_string_new",
@@ -78,9 +79,11 @@ rustflags = [
   "-Wclippy::ref_option_ref",
   "-Wclippy::stable_sort_primitive",
   "-Wclippy::unnecessary_box_returns",
+  "-Wclippy::unnecessary_box_returns",
   "-Wclippy::unnecessary_join",
   "-Wclippy::unnested_or_patterns",
   "-Wclippy::verbose_bit_mask",
+  "-Wclippy::unreadable_literal",
   "-Wclippy::zero_sized_map_values",
 ]
 

--- a/crates/biome_css_parser/src/lexer/mod.rs
+++ b/crates/biome_css_parser/src/lexer/mod.rs
@@ -456,9 +456,9 @@ impl<'src> Lexer<'src> {
                                 // If this number is zero
                                 0 => REPLACEMENT_CHARACTER,
                                 // or is for a surrogate
-                                55296..=57343 => REPLACEMENT_CHARACTER,
+                                55_296..=57_343 => REPLACEMENT_CHARACTER,
                                 // or is greater than the maximum allowed code point
-                                1114112.. => REPLACEMENT_CHARACTER,
+                                1_114_112.. => REPLACEMENT_CHARACTER,
                                 _ => char::from_u32(hex).unwrap_or(REPLACEMENT_CHARACTER),
                             };
 

--- a/crates/biome_diagnostics/src/display.rs
+++ b/crates/biome_diagnostics/src/display.rs
@@ -709,7 +709,7 @@ mod tests {
         fn record(&self, visitor: &mut dyn Visit) -> io::Result<()> {
             let backtrace = from_value(json!([
                 {
-                    "ip": 0x0f0f0f0f,
+                    "ip": 0x0f0f_0f0f,
                     "symbols": [
                         {
                             "name": "crate::module::function",

--- a/crates/biome_js_parser/src/lexer/mod.rs
+++ b/crates/biome_js_parser/src/lexer/mod.rs
@@ -668,7 +668,7 @@ impl<'src> Lexer<'src> {
         };
 
         match u32::from_str_radix(digits_str, 16) {
-            Ok(digits) if digits <= 0x10FFFF => {
+            Ok(digits) if digits <= 0x10_FFFF => {
                 let res = std::char::from_u32(digits);
                 if let Some(chr) = res {
                     Ok(chr)

--- a/crates/biome_markup/src/lib.rs
+++ b/crates/biome_markup/src/lib.rs
@@ -157,7 +157,7 @@ pub fn markup(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                 }
                 _ => abort!(group.span(), "unexpected token"),
             },
-            _ => abort!(token.span(), "unexpected token"),
+            TokenTree::Ident(_) => abort!(token.span(), "unexpected token"),
         }
     }
 


### PR DESCRIPTION
## Summary

This enables the 3 following clippy rules:
- [large_types_passed_by_value](https://rust-lang.github.io/rust-clippy/master/#/large_types_passed_by_value?levels=allow,deny,none&groups=pedantic) reports large copyable types passed by value (we had no instance of this)
- [unnecessary_box_returns](https://rust-lang.github.io/rust-clippy/master/#/unnecessary_box_returns?levels=allow,deny,none&groups=pedantic) reports useless boxing (we had no instance of this)
- [unreadable_literal](https://rust-lang.github.io/rust-clippy/master/#/unreadable_literal) that ensures grouping of digit for better readability.

## Test Plan

`cargo test`, `just lint`, `cargo build`, `just codegen`.
