### PR TITLE
refactor(lint/noUnusedLabels): make code fix safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   - [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
   - [useWhile](https://biomejs.dev/linter/rules/use-while)
 
+- [noUnusedLabels](https://biomejs.dev/linter/rules/no-unused-labels) no longer reports unbreakable labeled statements. Contributed by @Conaclos
+
 #### Bug fixes
 
 - Fix [#294](https://github.com/biomejs/biome/issues/294). [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type/) no longer reports false positives for return types. Contributed by @b4s36t4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   - [noNegationElse](https://biomejs.dev/linter/rules/no-negation-else)
   - [noUselessLabel](https://biomejs.dev/linter/rules/no-useless-label)
   - [noUselessTypeConstraint](https://biomejs.dev/linter/rules/no-useless-type-constraint)
+  - [noUnusedLabels](https://biomejs.dev/linter/rules/no-unused-labels)
   - [useConst](https://biomejs.dev/linter/rules/use-const)
   - [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
   - [useWhile](https://biomejs.dev/linter/rules/use-while)

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/invalid.js
@@ -1,27 +1,25 @@
-/*before*/ A /*inner*/: /*after*/ var foo = 0;
+/*before*/ A /*inner*/: /*after*/ while(true) {};
 
-B: {
+A: for (let i = 0; i < 10; ++i) {
 	foo();
 }
 
-C: for (let i = 0; i < 10; ++i) {
+A: {
 	foo();
 }
 
-D: var foo = 0;
-
-E: {
+A: {
 	foo();
 	bar();
 }
 
-F: for (var i = 0; i < 10; ++i) {
+A: for (var i = 0; i < 10; ++i) {
 	foo();
 	if (a) break;
 	bar();
 }
 
-G: for (var i = 0; i < 10; ++i) {
+A: for (var i = 0; i < 10; ++i) {
 	foo();
 	if (a) continue;
 	bar();
@@ -31,34 +29,30 @@ A: for (var i = 0; i < 10; ++i) {
 	H: break A;
 }
 
-I: {
+A: {
 	var I = 0;
 	console.log(I);
 }
 
-J: /* comment */ foo;
-
-K /* comment */: foo;
-
-L: {
+A: {
 	function f() {
-		L: {
-			break L;
+		A: {
+			break A;
 		}
 	}
 }
 
-M: {
+A: {
 	class X {
 		static {
-			M: {
-				break M;
+			B: {
+				break B;
 			}
 		}
 
 		method() {
-			M: {
-				break M;
+			B: {
+				break B;
 			}
 		}
 	}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/invalid.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
-assertion_line: 96
 expression: invalid.js
 ---
 # Input
@@ -92,7 +91,9 @@ invalid.js:1:12 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
     2 │ 
     3 │ B: {
   
-  i Suggested fix: Remove the unused label.
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
   
     1 │ /*before*/·A·/*inner*/:·/*after*/·var·foo·=·0;
       │            -----------------------            
@@ -111,7 +112,9 @@ invalid.js:3:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
     4 │ 	foo();
     5 │ }
   
-  i Suggested fix: Remove the unused label.
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
   
     3 │ B:·{
       │ --- 
@@ -130,7 +133,9 @@ invalid.js:7:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
     8 │ 	foo();
     9 │ }
   
-  i Suggested fix: Remove the unused label.
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
   
     7 │ C:·for·(let·i·=·0;·i·<·10;·++i)·{
       │ ---                              
@@ -149,7 +154,9 @@ invalid.js:11:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
     12 │ 
     13 │ E: {
   
-  i Suggested fix: Remove the unused label.
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
   
     11 │ D:·var·foo·=·0;
        │ ---            
@@ -168,7 +175,9 @@ invalid.js:13:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
     14 │ 	foo();
     15 │ 	bar();
   
-  i Suggested fix: Remove the unused label.
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
   
     13 │ E:·{
        │ --- 
@@ -187,7 +196,9 @@ invalid.js:18:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
     19 │ 	foo();
     20 │ 	if (a) break;
   
-  i Suggested fix: Remove the unused label.
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
   
     18 │ F:·for·(var·i·=·0;·i·<·10;·++i)·{
        │ ---                              
@@ -206,7 +217,9 @@ invalid.js:24:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
     25 │ 	foo();
     26 │ 	if (a) continue;
   
-  i Suggested fix: Remove the unused label.
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
   
     24 │ G:·for·(var·i·=·0;·i·<·10;·++i)·{
        │ ---                              
@@ -224,7 +237,9 @@ invalid.js:31:2 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
     32 │ }
     33 │ 
   
-  i Suggested fix: Remove the unused label.
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
   
     31 │ → H:·break·A;
        │   ---        
@@ -243,7 +258,9 @@ invalid.js:34:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
     35 │ 	var I = 0;
     36 │ 	console.log(I);
   
-  i Suggested fix: Remove the unused label.
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
   
     34 │ I:·{
        │ --- 
@@ -262,7 +279,9 @@ invalid.js:39:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
     40 │ 
     41 │ K /* comment */: foo;
   
-  i Suggested fix: Remove the unused label.
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
   
     39 │ J:·/*·comment·*/·foo;
        │ -----------------    
@@ -281,7 +300,9 @@ invalid.js:41:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
     42 │ 
     43 │ L: {
   
-  i Suggested fix: Remove the unused label.
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
   
     41 │ K·/*·comment·*/:·foo;
        │ -----------------    
@@ -300,7 +321,9 @@ invalid.js:43:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
     44 │ 	function f() {
     45 │ 		L: {
   
-  i Suggested fix: Remove the unused label.
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
   
     43 │ L:·{
        │ --- 
@@ -319,7 +342,9 @@ invalid.js:51:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
     52 │ 	class X {
     53 │ 		static {
   
-  i Suggested fix: Remove the unused label.
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
   
     51 │ M:·{
        │ --- 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/invalid.js.snap
@@ -4,30 +4,28 @@ expression: invalid.js
 ---
 # Input
 ```js
-/*before*/ A /*inner*/: /*after*/ var foo = 0;
+/*before*/ A /*inner*/: /*after*/ while(true) {};
 
-B: {
+A: for (let i = 0; i < 10; ++i) {
 	foo();
 }
 
-C: for (let i = 0; i < 10; ++i) {
+A: {
 	foo();
 }
 
-D: var foo = 0;
-
-E: {
+A: {
 	foo();
 	bar();
 }
 
-F: for (var i = 0; i < 10; ++i) {
+A: for (var i = 0; i < 10; ++i) {
 	foo();
 	if (a) break;
 	bar();
 }
 
-G: for (var i = 0; i < 10; ++i) {
+A: for (var i = 0; i < 10; ++i) {
 	foo();
 	if (a) continue;
 	bar();
@@ -37,34 +35,30 @@ A: for (var i = 0; i < 10; ++i) {
 	H: break A;
 }
 
-I: {
+A: {
 	var I = 0;
 	console.log(I);
 }
 
-J: /* comment */ foo;
-
-K /* comment */: foo;
-
-L: {
+A: {
 	function f() {
-		L: {
-			break L;
+		A: {
+			break A;
 		}
 	}
 }
 
-M: {
+A: {
 	class X {
 		static {
-			M: {
-				break M;
+			B: {
+				break B;
 			}
 		}
 
 		method() {
-			M: {
-				break M;
+			B: {
+				break B;
 			}
 		}
 	}
@@ -86,17 +80,17 @@ invalid.js:1:12 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
 
   ! Unused label.
   
-  > 1 │ /*before*/ A /*inner*/: /*after*/ var foo = 0;
+  > 1 │ /*before*/ A /*inner*/: /*after*/ while(true) {};
       │            ^
     2 │ 
-    3 │ B: {
+    3 │ A: for (let i = 0; i < 10; ++i) {
   
   i The label is not used by any break statement and continue statement.
   
   i Safe fix: Remove the unused label.
   
-    1 │ /*before*/·A·/*inner*/:·/*after*/·var·foo·=·0;
-      │            -----------------------            
+    1 │ /*before*/·A·/*inner*/:·/*after*/·while(true)·{};
+      │            -----------------------               
 
 ```
 
@@ -105,9 +99,9 @@ invalid.js:3:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
 
   ! Unused label.
   
-    1 │ /*before*/ A /*inner*/: /*after*/ var foo = 0;
+    1 │ /*before*/ A /*inner*/: /*after*/ while(true) {};
     2 │ 
-  > 3 │ B: {
+  > 3 │ A: for (let i = 0; i < 10; ++i) {
       │ ^
     4 │ 	foo();
     5 │ }
@@ -116,8 +110,8 @@ invalid.js:3:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
   
   i Safe fix: Remove the unused label.
   
-    3 │ B:·{
-      │ --- 
+    3 │ A:·for·(let·i·=·0;·i·<·10;·++i)·{
+      │ ---                              
 
 ```
 
@@ -128,7 +122,7 @@ invalid.js:7:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
   
     5 │ }
     6 │ 
-  > 7 │ C: for (let i = 0; i < 10; ++i) {
+  > 7 │ A: {
       │ ^
     8 │ 	foo();
     9 │ }
@@ -137,8 +131,8 @@ invalid.js:7:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
   
   i Safe fix: Remove the unused label.
   
-    7 │ C:·for·(let·i·=·0;·i·<·10;·++i)·{
-      │ ---                              
+    7 │ A:·{
+      │ --- 
 
 ```
 
@@ -149,204 +143,121 @@ invalid.js:11:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
   
      9 │ }
     10 │ 
-  > 11 │ D: var foo = 0;
+  > 11 │ A: {
        │ ^
-    12 │ 
-    13 │ E: {
+    12 │ 	foo();
+    13 │ 	bar();
   
   i The label is not used by any break statement and continue statement.
   
   i Safe fix: Remove the unused label.
   
-    11 │ D:·var·foo·=·0;
-       │ ---            
-
-```
-
-```
-invalid.js:13:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Unused label.
-  
-    11 │ D: var foo = 0;
-    12 │ 
-  > 13 │ E: {
-       │ ^
-    14 │ 	foo();
-    15 │ 	bar();
-  
-  i The label is not used by any break statement and continue statement.
-  
-  i Safe fix: Remove the unused label.
-  
-    13 │ E:·{
+    11 │ A:·{
        │ --- 
 
 ```
 
 ```
-invalid.js:18:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:16:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Unused label.
   
-    16 │ }
-    17 │ 
-  > 18 │ F: for (var i = 0; i < 10; ++i) {
+    14 │ }
+    15 │ 
+  > 16 │ A: for (var i = 0; i < 10; ++i) {
        │ ^
-    19 │ 	foo();
-    20 │ 	if (a) break;
+    17 │ 	foo();
+    18 │ 	if (a) break;
   
   i The label is not used by any break statement and continue statement.
   
   i Safe fix: Remove the unused label.
   
-    18 │ F:·for·(var·i·=·0;·i·<·10;·++i)·{
+    16 │ A:·for·(var·i·=·0;·i·<·10;·++i)·{
        │ ---                              
 
 ```
 
 ```
-invalid.js:24:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:22:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Unused label.
   
-    22 │ }
-    23 │ 
-  > 24 │ G: for (var i = 0; i < 10; ++i) {
+    20 │ }
+    21 │ 
+  > 22 │ A: for (var i = 0; i < 10; ++i) {
        │ ^
-    25 │ 	foo();
-    26 │ 	if (a) continue;
+    23 │ 	foo();
+    24 │ 	if (a) continue;
   
   i The label is not used by any break statement and continue statement.
   
   i Safe fix: Remove the unused label.
   
-    24 │ G:·for·(var·i·=·0;·i·<·10;·++i)·{
+    22 │ A:·for·(var·i·=·0;·i·<·10;·++i)·{
        │ ---                              
 
 ```
 
 ```
-invalid.js:31:2 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:32:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Unused label.
   
-    30 │ A: for (var i = 0; i < 10; ++i) {
-  > 31 │ 	H: break A;
-       │ 	^
-    32 │ }
-    33 │ 
-  
-  i The label is not used by any break statement and continue statement.
-  
-  i Safe fix: Remove the unused label.
-  
-    31 │ → H:·break·A;
-       │   ---        
-
-```
-
-```
-invalid.js:34:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Unused label.
-  
-    32 │ }
-    33 │ 
-  > 34 │ I: {
+    30 │ }
+    31 │ 
+  > 32 │ A: {
        │ ^
-    35 │ 	var I = 0;
-    36 │ 	console.log(I);
+    33 │ 	var I = 0;
+    34 │ 	console.log(I);
   
   i The label is not used by any break statement and continue statement.
   
   i Safe fix: Remove the unused label.
   
-    34 │ I:·{
+    32 │ A:·{
        │ --- 
 
 ```
 
 ```
-invalid.js:39:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:37:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Unused label.
   
-    37 │ }
-    38 │ 
-  > 39 │ J: /* comment */ foo;
+    35 │ }
+    36 │ 
+  > 37 │ A: {
        │ ^
-    40 │ 
-    41 │ K /* comment */: foo;
+    38 │ 	function f() {
+    39 │ 		A: {
   
   i The label is not used by any break statement and continue statement.
   
   i Safe fix: Remove the unused label.
   
-    39 │ J:·/*·comment·*/·foo;
-       │ -----------------    
-
-```
-
-```
-invalid.js:41:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Unused label.
-  
-    39 │ J: /* comment */ foo;
-    40 │ 
-  > 41 │ K /* comment */: foo;
-       │ ^
-    42 │ 
-    43 │ L: {
-  
-  i The label is not used by any break statement and continue statement.
-  
-  i Safe fix: Remove the unused label.
-  
-    41 │ K·/*·comment·*/:·foo;
-       │ -----------------    
-
-```
-
-```
-invalid.js:43:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Unused label.
-  
-    41 │ K /* comment */: foo;
-    42 │ 
-  > 43 │ L: {
-       │ ^
-    44 │ 	function f() {
-    45 │ 		L: {
-  
-  i The label is not used by any break statement and continue statement.
-  
-  i Safe fix: Remove the unused label.
-  
-    43 │ L:·{
+    37 │ A:·{
        │ --- 
 
 ```
 
 ```
-invalid.js:51:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:45:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Unused label.
   
-    49 │ }
-    50 │ 
-  > 51 │ M: {
+    43 │ }
+    44 │ 
+  > 45 │ A: {
        │ ^
-    52 │ 	class X {
-    53 │ 		static {
+    46 │ 	class X {
+    47 │ 		static {
   
   i The label is not used by any break statement and continue statement.
   
   i Safe fix: Remove the unused label.
   
-    51 │ M:·{
+    45 │ A:·{
        │ --- 
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/valid.js
@@ -5,9 +5,9 @@ A: {
 	bar();
 }
 
-B: for (let i = 0; i < 10; ++i) {
+A: for (let i = 0; i < 10; ++i) {
 	if (foo()) {
-		break B;
+		break A;
 	}
 	bar();
 }
@@ -47,3 +47,9 @@ A: {
 		bar();
 	}
 }
+
+// unbreakable statements
+
+A: var foo = 0;
+
+A: asserts(cond, "cond should hold");

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/valid.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
-assertion_line: 92
 expression: valid.js
 ---
 # Input
@@ -12,9 +11,9 @@ A: {
 	bar();
 }
 
-B: for (let i = 0; i < 10; ++i) {
+A: for (let i = 0; i < 10; ++i) {
 	if (foo()) {
-		break B;
+		break A;
 	}
 	bar();
 }
@@ -54,6 +53,12 @@ A: {
 		bar();
 	}
 }
+
+// unbreakable statements
+
+A: var foo = 0;
+
+A: asserts(cond, "cond should hold");
 
 ```
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -73,6 +73,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   - [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
   - [useWhile](https://biomejs.dev/linter/rules/use-while)
 
+- [noUnusedLabels](https://biomejs.dev/linter/rules/no-unused-labels) no longer reports unbreakable labeled statements. Contributed by @Conaclos
+
 #### Bug fixes
 
 - Fix [#294](https://github.com/biomejs/biome/issues/294). [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type/) no longer reports false positives for return types. Contributed by @b4s36t4

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -68,6 +68,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   - [noNegationElse](https://biomejs.dev/linter/rules/no-negation-else)
   - [noUselessLabel](https://biomejs.dev/linter/rules/no-useless-label)
   - [noUselessTypeConstraint](https://biomejs.dev/linter/rules/no-useless-type-constraint)
+  - [noUnusedLabels](https://biomejs.dev/linter/rules/no-unused-labels)
   - [useConst](https://biomejs.dev/linter/rules/use-const)
   - [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
   - [useWhile](https://biomejs.dev/linter/rules/use-while)

--- a/website/src/content/docs/linter/rules/no-unused-labels.md
+++ b/website/src/content/docs/linter/rules/no-unused-labels.md
@@ -18,7 +18,7 @@ Source: https://eslint.org/docs/latest/rules/no-unused-labels
 
 ### Invalid
 
-```js
+```jsx
 LOOP: for (const x of xs) {
     if (x > 0) {
         break;
@@ -46,12 +46,19 @@ LOOP: for (const x of xs) {
 
 ### Valid
 
-```js
+```jsx
 LOOP: for (const x of xs) {
     if (x > 0) {
         break LOOP;
     }
     f(x);
+}
+```
+
+```jsx
+function nonNegative(n) {
+    DEV: assert(n >= 0);
+    return n;
 }
 ```
 

--- a/website/src/content/docs/linter/rules/no-unused-labels.md
+++ b/website/src/content/docs/linter/rules/no-unused-labels.md
@@ -36,7 +36,9 @@ LOOP: for (const x of xs) {
     <strong>2 │ </strong>    if (x &gt; 0) {
     <strong>3 │ </strong>        break;
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove the unused </span><span style="color: rgb(38, 148, 255);"><strong>label</strong></span><span style="color: rgb(38, 148, 255);">.</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The label is not used by any </span><span style="color: rgb(38, 148, 255);"><strong>break</strong></span><span style="color: rgb(38, 148, 255);"> statement and continue statement.</span>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove the unused </span><span style="color: rgb(38, 148, 255);"><strong>label</strong></span><span style="color: rgb(38, 148, 255);">.</span>
   
 <strong>  </strong><strong>  1 │ </strong><span style="color: Tomato;">L</span><span style="color: Tomato;">O</span><span style="color: Tomato;">O</span><span style="color: Tomato;">P</span><span style="color: Tomato;">:</span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span>for<span style="opacity: 0.8;">·</span>(const<span style="opacity: 0.8;">·</span>x<span style="opacity: 0.8;">·</span>of<span style="opacity: 0.8;">·</span>xs)<span style="opacity: 0.8;">·</span>{
 <strong>  </strong><strong>    │ </strong><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>                     


### PR DESCRIPTION
## Summary

Make code fix of [noUnusedLabels](https://biomejs.dev/linter/rules/no-unused-labels).

I also improved the implementation by reducing the memory usage of the visitor.
The mutation also uses safer API.

By the way, I wonder if we should reduce the scope of the rule.
For now the rule applies to all labeled statements. However, there are some labeled statement that always unused by nature.
For example:

```js
function sqrt(n) {
    DEV: assert(n >= 0);
}
```

We could only report breakable statements (basically statement that can contain other statements)?
Non-breakable statements (and some breakable statements) are already covered by [noConfusingLabels](https://biomejs.dev/linter/rules/no-confusing-labels).
Any though?

## Test Plan

Tests updated.
