### PR TITLE
docs: add documentation for `setup-biome`

### DIFF
--- a/website/astro.config.ts
+++ b/website/astro.config.ts
@@ -205,7 +205,10 @@ export default defineConfig({
 				{
 					label: "Recipes",
 					items: [
-						{ label: "Continuous Integration", link: "/recipes/continuous-integration" },
+						{
+							label: "Continuous Integration",
+							link: "/recipes/continuous-integration",
+						},
 					],
 				},
 				{

--- a/website/astro.config.ts
+++ b/website/astro.config.ts
@@ -203,6 +203,12 @@ export default defineConfig({
 					],
 				},
 				{
+					label: "Recipes",
+					items: [
+						{ label: "Continuous Integration", link: "/recipes/continuous-integration" },
+					],
+				},
+				{
 					label: "Internals",
 					items: [
 						{ label: "Philosophy", link: "/internals/philosophy" },

--- a/website/src/content/docs/recipes/continuous-integration.mdx
+++ b/website/src/content/docs/recipes/continuous-integration.mdx
@@ -18,7 +18,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  quality:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 

--- a/website/src/content/docs/recipes/continuous-integration.mdx
+++ b/website/src/content/docs/recipes/continuous-integration.mdx
@@ -20,13 +20,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-     steps:
-       - name: Checkout 
-         uses: actions/checkout@v4
-       - name: Setup Biome
-         uses: biomejs/setup-biome@v1
-         with:
-           version: 1.2.2
-       - name: Run Biome
-         run: biome ci .
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v4
+      - name: Setup Biome
+        uses: biomejs/setup-biome@v1
+        with:
+          version: 1.2.2
+      - name: Run Biome
+        run: biome ci .
 ```

--- a/website/src/content/docs/recipes/continuous-integration.mdx
+++ b/website/src/content/docs/recipes/continuous-integration.mdx
@@ -1,0 +1,32 @@
+---
+title: Continuous Integration
+description: Using Biome in a CI environment
+---
+
+Running Biome in a CI environment is easy. Check out the following examples for some inspiration.
+
+## GitHub Actions
+
+We provides a first-party [GitHub Action](https://github.com/marketplace/actions/setup-biome) to setup Biome in your runner.
+Here's what a simple workflow might look like:
+
+```yaml
+name: Code quality
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+     steps:
+       - name: Checkout 
+         uses: actions/checkout@v4
+       - name: Setup Biome
+         uses: biomejs/setup-biome@v1
+         with:
+           version: 1.2.2
+       - name: Run Biome
+         run: biome ci .
+```


### PR DESCRIPTION
## Summary

This PR adds documentation for `setup-biome` and closes #380.

## Test Plan

- [x] Ensure that the example workflow works
