### PR TITLE
docs: `npx biome` -> `npx @biomejs/biome`

### DIFF
--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -613,7 +613,7 @@ If you don't define this variable, Biome will automatically detect the correct b
 
 ```
 # Nix derivation example; the binary path comes from "${pkgs.biome}/bin/biome"
-BIOME_BINARY=/nix/store/68fyfw1hidsqkal1839whi3nzgvqv4pa-biome-1.0.0/bin/biome npx biome format .
+BIOME_BINARY=/nix/store/68fyfw1hidsqkal1839whi3nzgvqv4pa-biome-1.0.0/bin/biome npx @biomejs/biome format .
 ```
 
 ## Useful information


### PR DESCRIPTION
## Summary
In #400, it says that the npm package is `@biomejs/biome`, not `biome`.
