### PR TITLE
feat(cli): add `biome rage --daemon-logs` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Add option `--indent-width`, and deprecated the option `--indent-size`. Contributed by @ematipico
 - Add option `--javascript-formatter-indent-width`, and deprecated the option `--javascript-formatter-indent-size`. Contributed by @ematipico
 - Add option `--json-formatter-indent-width`, and deprecated the option `--json-formatter-indent-size`. Contributed by @ematipico
+- Add option `--daemon-logs` to `biome rage`. The `--daemon-logs` command is required to view Biome daemon server logs.  Contributed by @unvalley
 
 #### Enhancements
 - Deprecated the environment variable `ROME_BINARY`. Contributed by @ematipico

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Add option `--indent-width`, and deprecated the option `--indent-size`. Contributed by @ematipico
 - Add option `--javascript-formatter-indent-width`, and deprecated the option `--javascript-formatter-indent-size`. Contributed by @ematipico
 - Add option `--json-formatter-indent-width`, and deprecated the option `--json-formatter-indent-size`. Contributed by @ematipico
-- Add option `--daemon-logs` to `biome rage`. The `--daemon-logs` command is required to view Biome daemon server logs.  Contributed by @unvalley
+- Add option `--daemon-logs` to `biome rage`. The option is required to view Biome daemon server logs.  Contributed by @unvalley
 
 #### Enhancements
 - Deprecated the environment variable `ROME_BINARY`. Contributed by @ematipico

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -33,7 +33,7 @@ pub enum BiomeCommand {
     /// Prints information for debugging
     Rage(
         #[bpaf(external(cli_options), hide_usage)] CliOptions,
-        /// Prints information for debugging in details
+        /// Prints the Biome daemon server logs
         #[bpaf(long("daemon-logs"), switch)]
         bool,
     ),

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -31,7 +31,12 @@ pub enum BiomeCommand {
 
     #[bpaf(command)]
     /// Prints information for debugging
-    Rage(#[bpaf(external(cli_options), hide_usage)] CliOptions),
+    Rage(
+        #[bpaf(external(cli_options), hide_usage)] CliOptions,
+        /// Prints information for debugging in details
+        #[bpaf(long("daemon-logs"), switch)]
+        bool,
+    ),
     /// Start the Biome daemon server process
     #[bpaf(command)]
     Start,
@@ -199,7 +204,7 @@ impl BiomeCommand {
     pub const fn get_color(&self) -> Option<&ColorsArg> {
         match self {
             BiomeCommand::Version(cli_options) => cli_options.colors.as_ref(),
-            BiomeCommand::Rage(cli_options) => cli_options.colors.as_ref(),
+            BiomeCommand::Rage(cli_options, ..) => cli_options.colors.as_ref(),
             BiomeCommand::Start => None,
             BiomeCommand::Stop => None,
             BiomeCommand::Check { cli_options, .. } => cli_options.colors.as_ref(),
@@ -217,7 +222,7 @@ impl BiomeCommand {
     pub const fn should_use_server(&self) -> bool {
         match self {
             BiomeCommand::Version(cli_options) => cli_options.use_server,
-            BiomeCommand::Rage(cli_options) => cli_options.use_server,
+            BiomeCommand::Rage(cli_options, ..) => cli_options.use_server,
             BiomeCommand::Start => false,
             BiomeCommand::Stop => false,
             BiomeCommand::Check { cli_options, .. } => cli_options.use_server,
@@ -239,7 +244,7 @@ impl BiomeCommand {
     pub fn is_verbose(&self) -> bool {
         match self {
             BiomeCommand::Version(_) => false,
-            BiomeCommand::Rage(_) => false,
+            BiomeCommand::Rage(_, ..) => false,
             BiomeCommand::Start => false,
             BiomeCommand::Stop => false,
             BiomeCommand::Check { cli_options, .. } => cli_options.verbose,

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -244,7 +244,7 @@ impl BiomeCommand {
     pub fn is_verbose(&self) -> bool {
         match self {
             BiomeCommand::Version(_) => false,
-            BiomeCommand::Rage(_, ..) => false,
+            BiomeCommand::Rage(..) => false,
             BiomeCommand::Start => false,
             BiomeCommand::Stop => false,
             BiomeCommand::Check { cli_options, .. } => cli_options.verbose,

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -71,7 +71,7 @@ impl<'app> CliSession<'app> {
 
         let result = match command {
             BiomeCommand::Version(_) => commands::version::full_version(self),
-            BiomeCommand::Rage(_) => commands::rage::rage(self),
+            BiomeCommand::Rage(_, daemon_logs) => commands::rage::rage(self, daemon_logs),
             BiomeCommand::Start => commands::daemon::start(self),
             BiomeCommand::Stop => commands::daemon::stop(self),
             BiomeCommand::Check {

--- a/crates/biome_cli/src/main.rs
+++ b/crates/biome_cli/src/main.rs
@@ -38,9 +38,8 @@ fn main() -> ExitCode {
             match result {
                 Err(termination) => {
                     console.error(markup! {
-						{if is_verbose { PrintDiagnostic::verbose(&termination) } else { PrintDiagnostic::simple(&termination) }}
-            		});
-
+                        {if is_verbose { PrintDiagnostic::verbose(&termination) } else { PrintDiagnostic::simple(&termination) }}
+                    });
                     termination.report()
                 }
                 Ok(_) => ExitCode::SUCCESS,

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -1,0 +1,33 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+# Emitted Messages
+
+```block
+Prints information for debugging
+
+Usage: rage [--daemon-logs]
+
+Global options applied to all commands
+        --colors=<off|force>  Set the formatting mode for markup: "off" prints everything as plain text,
+                              "force" forces the formatting of markup using ANSI even if the console
+                              output is determined to be incompatible
+        --use-server          Connect to a running instance of the Biome daemon server.
+        --verbose             Print additional verbose advices on diagnostics
+        --config-path=PATH    Set the filesystem path to the directory of the biome.json configuration
+                              file
+        --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
+                              [default: 20]
+        --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
+        --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed
+                              during the execution of the command.
+        --error-on-warnings   Tell Biome to exit with an error code if some diagnostics emit warnings.
+
+Available options:
+        --daemon-logs         Prints information for debugging in details
+    -h, --help                Prints help information
+
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -25,7 +25,7 @@ Global options applied to all commands
         --error-on-warnings   Tell Biome to exit with an error code if some diagnostics emit warnings.
 
 Available options:
-        --daemon-logs         Prints information for debugging in details
+        --daemon-logs         Prints the Biome daemon server logs
     -h, --help                Prints help information
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
@@ -32,6 +32,9 @@ Server:
 
 Workspace:
   Open Documents:               0
+```
+
+```block
 
 Biome Server Log:
 

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -474,7 +474,7 @@ macro_rules! workspace_method {
 /// for each incoming connection accepted by the server
 #[derive(Default)]
 pub struct ServerFactory {
-    /// Synchronisation primitive used to broadcast a shutdown signal to all
+    /// Synchronization primitive used to broadcast a shutdown signal to all
     /// active connections
     cancellation: Arc<Notify>,
     /// Optional [Workspace] instance shared between all clients. Currently

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -37,6 +37,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Add option `--indent-width`, and deprecated the option `--indent-size`. Contributed by @ematipico
 - Add option `--javascript-formatter-indent-width`, and deprecated the option `--javascript-formatter-indent-size`. Contributed by @ematipico
 - Add option `--json-formatter-indent-width`, and deprecated the option `--json-formatter-indent-size`. Contributed by @ematipico
+- Add option `--daemon-logs` to `biome rage`. The `--daemon-logs` command is required to view Biome daemon server logs.  Contributed by @unvalley
 
 #### Enhancements
 - Deprecated the environment variable `ROME_BINARY`. Contributed by @ematipico

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -37,7 +37,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Add option `--indent-width`, and deprecated the option `--indent-size`. Contributed by @ematipico
 - Add option `--javascript-formatter-indent-width`, and deprecated the option `--javascript-formatter-indent-size`. Contributed by @ematipico
 - Add option `--json-formatter-indent-width`, and deprecated the option `--json-formatter-indent-size`. Contributed by @ematipico
-- Add option `--daemon-logs` to `biome rage`. The `--daemon-logs` command is required to view Biome daemon server logs.  Contributed by @unvalley
+- Add option `--daemon-logs` to `biome rage`. The option is required to view Biome daemon server logs.  Contributed by @unvalley
 
 #### Enhancements
 - Deprecated the environment variable `ROME_BINARY`. Contributed by @ematipico

--- a/xtask/codegen/src/main.rs
+++ b/xtask/codegen/src/main.rs
@@ -115,7 +115,7 @@ SUBCOMMANDS:
 	aria            Generate aria bindings for lint rules
 	analyzer        Generate factory functions for the analyzer and the configuration of the analyzers
 	configuration    Generate the part of the configuration that depends on some metadata
-	schema          Generate the JSON schema for the Rome configuration file format
+	schema          Generate the JSON schema for the Biome configuration file format
 	bindings        Generate TypeScript definitions for the JavaScript bindings to the Workspace API
 	grammar         Transforms ungram files into AST
 	formatter       Generates formatters for each language


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds option `--daemon-logs` to `biome rage`.
The `--daemon-logs` option is required to view Biome daemon server logs.
And the diff contains some tiny typo fixes.
Closes #296 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
`just test-crate biome_cli`
