### PR TITLE
refactor(lint/noUnusedVariables): report unused type params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - [noUnusedLabels](https://biomejs.dev/linter/rules/no-unused-labels) no longer reports unbreakable labeled statements. Contributed by @Conaclos
 
+- [noUnusedVariables](https://biomejs.dev/linter/rules/no-unused-variables) now reports unused TypeScript's type parameters. Contributed by @Conaclos
+
 #### Bug fixes
 
 - Fix [#294](https://github.com/biomejs/biome/issues/294). [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type/) no longer reports false positives for return types. Contributed by @b4s36t4

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
@@ -438,7 +438,10 @@ fn capture_needs_to_be_in_the_dependency_list(
         | AnyJsBindingDeclaration::TsEnumDeclaration(_)
         | AnyJsBindingDeclaration::TsTypeAliasDeclaration(_)
         | AnyJsBindingDeclaration::TsInterfaceDeclaration(_)
-        | AnyJsBindingDeclaration::TsModuleDeclaration(_) => None,
+        | AnyJsBindingDeclaration::TsModuleDeclaration(_)
+        | AnyJsBindingDeclaration::TsInferType(_)
+        | AnyJsBindingDeclaration::TsMappedType(_)
+        | AnyJsBindingDeclaration::TsTypeParameter(_) => None,
 
         // Variable declarators are stable if ...
         AnyJsBindingDeclaration::JsVariableDeclarator(declarator) => {
@@ -479,8 +482,7 @@ fn capture_needs_to_be_in_the_dependency_list(
         | AnyJsBindingDeclaration::TsDeclareFunctionExportDefaultDeclaration(_)
         | AnyJsBindingDeclaration::JsCatchDeclaration(_) => Some(capture),
 
-        // This should not be unreachable because of the test
-        // if the capture is imported
+        // This should be unreachable because of the test if the capture is imported
         AnyJsBindingDeclaration::JsImportDefaultClause(_)
         | AnyJsBindingDeclaration::JsImportNamespaceClause(_)
         | AnyJsBindingDeclaration::JsShorthandNamedImportSpecifier(_)

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
@@ -820,7 +820,11 @@ impl Named {
             AnyJsBindingDeclaration::JsShorthandNamedImportSpecifier(_) => {
                 Some(Named::ImportSource)
             }
-            AnyJsBindingDeclaration::JsBogusNamedImportSpecifier(_) => None,
+            AnyJsBindingDeclaration::JsBogusNamedImportSpecifier(_)
+            // Type parameters should be handled at call site
+            | AnyJsBindingDeclaration::TsInferType(_)
+            | AnyJsBindingDeclaration::TsMappedType(_)
+            | AnyJsBindingDeclaration::TsTypeParameter(_) => None,
         }
     }
 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidTypeParam.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidTypeParam.ts
@@ -1,0 +1,5 @@
+export function f<T>() {}
+export class C<T> {}
+export type Alias<T> = number
+export type Mapped<T> = { [K in keyof T]: number }
+export type Inferred<T> = T extends (infer I)[] ? number : never;

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidTypeParam.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidTypeParam.ts.snap
@@ -1,0 +1,133 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidTypeParam.ts
+---
+# Input
+```js
+export function f<T>() {}
+export class C<T> {}
+export type Alias<T> = number
+export type Mapped<T> = { [K in keyof T]: number }
+export type Inferred<T> = T extends (infer I)[] ? number : never;
+```
+
+# Diagnostics
+```
+invalidTypeParam.ts:1:19 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This type parameter is unused.
+  
+  > 1 │ export function f<T>() {}
+      │                   ^
+    2 │ export class C<T> {}
+    3 │ export type Alias<T> = number
+  
+  i Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend T with an underscore.
+  
+    1   │ - export·function·f<T>()·{}
+      1 │ + export·function·f<_T>()·{}
+    2 2 │   export class C<T> {}
+    3 3 │   export type Alias<T> = number
+  
+
+```
+
+```
+invalidTypeParam.ts:2:16 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This type parameter is unused.
+  
+    1 │ export function f<T>() {}
+  > 2 │ export class C<T> {}
+      │                ^
+    3 │ export type Alias<T> = number
+    4 │ export type Mapped<T> = { [K in keyof T]: number }
+  
+  i Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend T with an underscore.
+  
+    1 1 │   export function f<T>() {}
+    2   │ - export·class·C<T>·{}
+      2 │ + export·class·C<_T>·{}
+    3 3 │   export type Alias<T> = number
+    4 4 │   export type Mapped<T> = { [K in keyof T]: number }
+  
+
+```
+
+```
+invalidTypeParam.ts:3:19 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This type parameter is unused.
+  
+    1 │ export function f<T>() {}
+    2 │ export class C<T> {}
+  > 3 │ export type Alias<T> = number
+      │                   ^
+    4 │ export type Mapped<T> = { [K in keyof T]: number }
+    5 │ export type Inferred<T> = T extends (infer I)[] ? number : never;
+  
+  i Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend T with an underscore.
+  
+    1 1 │   export function f<T>() {}
+    2 2 │   export class C<T> {}
+    3   │ - export·type·Alias<T>·=·number
+      3 │ + export·type·Alias<_T>·=·number
+    4 4 │   export type Mapped<T> = { [K in keyof T]: number }
+    5 5 │   export type Inferred<T> = T extends (infer I)[] ? number : never;
+  
+
+```
+
+```
+invalidTypeParam.ts:4:28 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable is unused.
+  
+    2 │ export class C<T> {}
+    3 │ export type Alias<T> = number
+  > 4 │ export type Mapped<T> = { [K in keyof T]: number }
+      │                            ^
+    5 │ export type Inferred<T> = T extends (infer I)[] ? number : never;
+  
+  i Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend K with an underscore.
+  
+    2 2 │   export class C<T> {}
+    3 3 │   export type Alias<T> = number
+    4   │ - export·type·Mapped<T>·=·{·[K·in·keyof·T]:·number·}
+      4 │ + export·type·Mapped<T>·=·{·[_K·in·keyof·T]:·number·}
+    5 5 │   export type Inferred<T> = T extends (infer I)[] ? number : never;
+  
+
+```
+
+```
+invalidTypeParam.ts:5:44 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable is unused.
+  
+    3 │ export type Alias<T> = number
+    4 │ export type Mapped<T> = { [K in keyof T]: number }
+  > 5 │ export type Inferred<T> = T extends (infer I)[] ? number : never;
+      │                                            ^
+  
+  i Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend I with an underscore.
+  
+    3 3 │   export type Alias<T> = number
+    4 4 │   export type Mapped<T> = { [K in keyof T]: number }
+    5   │ - export·type·Inferred<T>·=·T·extends·(infer·I)[]·?·number·:·never;
+      5 │ + export·type·Inferred<T>·=·T·extends·(infer·_I)[]·?·number·:·never;
+  
+
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validTypeParam.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validTypeParam.ts
@@ -1,0 +1,10 @@
+export function f<T extends U, U>(a: T) {
+    return a;
+}
+export class C<T1, T2> {
+    readonly prop: T1;
+    method(a: T2) { return a; }
+}
+export type Alias<T> = { arr: T[] };
+export type Mapped = { [K in keyof number]: K };
+export type Inferred<T> = T extends (infer I)[] ? Set<I> : Set<unknown>;

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validTypeParam.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validTypeParam.ts.snap
@@ -1,0 +1,19 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validTypeParam.ts
+---
+# Input
+```js
+export function f<T extends U, U>(a: T) {
+    return a;
+}
+export class C<T1, T2> {
+    readonly prop: T1;
+    method(a: T2) { return a; }
+}
+export type Alias<T> = { arr: T[] };
+export type Mapped = { [K in keyof number]: K };
+export type Inferred<T> = T extends (infer I)[] ? Set<I> : Set<unknown>;
+```
+
+

--- a/crates/biome_js_syntax/src/binding_ext.rs
+++ b/crates/biome_js_syntax/src/binding_ext.rs
@@ -11,10 +11,10 @@ use crate::{
     TsConstructSignatureTypeMember, TsConstructorSignatureClassMember, TsConstructorType,
     TsDeclareFunctionDeclaration, TsDeclareFunctionExportDefaultDeclaration, TsEnumDeclaration,
     TsFunctionType, TsIdentifierBinding, TsImportEqualsDeclaration, TsIndexSignatureClassMember,
-    TsIndexSignatureParameter, TsInterfaceDeclaration, TsMethodSignatureClassMember,
-    TsMethodSignatureTypeMember, TsModuleDeclaration, TsPropertyParameter,
-    TsSetterSignatureClassMember, TsSetterSignatureTypeMember, TsTypeAliasDeclaration,
-    TsTypeParameterName,
+    TsIndexSignatureParameter, TsInferType, TsInterfaceDeclaration, TsMappedType,
+    TsMethodSignatureClassMember, TsMethodSignatureTypeMember, TsModuleDeclaration,
+    TsPropertyParameter, TsSetterSignatureClassMember, TsSetterSignatureTypeMember,
+    TsTypeAliasDeclaration, TsTypeParameter, TsTypeParameterName,
 };
 use biome_rowan::{declare_node_union, AstNode, SyntaxResult};
 
@@ -25,6 +25,8 @@ declare_node_union! {
         // parameters
             | JsFormalParameter | JsRestParameter | JsBogusParameter
             | TsIndexSignatureParameter | TsPropertyParameter
+        // type parameter
+            | TsInferType | TsMappedType | TsTypeParameter
         // functions
             | JsFunctionDeclaration | JsFunctionExpression
             | TsDeclareFunctionDeclaration
@@ -163,20 +165,18 @@ declare_node_union! {
 }
 
 fn declaration(node: &JsSyntaxNode) -> Option<AnyJsBindingDeclaration> {
-    use JsSyntaxKind::*;
-    let parent = node.parent()?;
-    let possible_declarator = parent.ancestors().find(|x| {
+    let possible_declarator = node.ancestors().skip(1).find(|x| {
         !matches!(
             x.kind(),
-            JS_BINDING_PATTERN_WITH_DEFAULT
-                | JS_OBJECT_BINDING_PATTERN
-                | JS_OBJECT_BINDING_PATTERN_REST
-                | JS_OBJECT_BINDING_PATTERN_PROPERTY
-                | JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST
-                | JS_OBJECT_BINDING_PATTERN_SHORTHAND_PROPERTY
-                | JS_ARRAY_BINDING_PATTERN
-                | JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST
-                | JS_ARRAY_BINDING_PATTERN_REST_ELEMENT
+            JsSyntaxKind::JS_BINDING_PATTERN_WITH_DEFAULT
+                | JsSyntaxKind::JS_OBJECT_BINDING_PATTERN
+                | JsSyntaxKind::JS_OBJECT_BINDING_PATTERN_REST
+                | JsSyntaxKind::JS_OBJECT_BINDING_PATTERN_PROPERTY
+                | JsSyntaxKind::JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST
+                | JsSyntaxKind::JS_OBJECT_BINDING_PATTERN_SHORTHAND_PROPERTY
+                | JsSyntaxKind::JS_ARRAY_BINDING_PATTERN
+                | JsSyntaxKind::JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST
+                | JsSyntaxKind::JS_ARRAY_BINDING_PATTERN_REST_ELEMENT
         )
     })?;
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -52,6 +52,13 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 
 ### Editors
+
+#### Bug fixes
+
+- Fix [#404](https://github.com/biomejs/biome/issues/404). Biome intellij plugin now works on Windows. Contributed by @victor-teles
+
+- Fix [#402](https://github.com/biomejs/biome/issues/402). Biome `format` on intellij plugin now recognize biome.json. Contributed by @victor-teles
+
 ### Formatter
 
 #### Enhancements
@@ -101,6 +108,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   - [useWhile](https://biomejs.dev/linter/rules/use-while)
 
 - [noUnusedLabels](https://biomejs.dev/linter/rules/no-unused-labels) no longer reports unbreakable labeled statements. Contributed by @Conaclos
+
+- [noUnusedVariables](https://biomejs.dev/linter/rules/no-unused-variables) now reports unused TypeScript's type parameters. Contributed by @Conaclos
 
 #### Bug fixes
 

--- a/website/src/content/docs/linter/rules/no-unused-variables.md
+++ b/website/src/content/docs/linter/rules/no-unused-variables.md
@@ -137,6 +137,28 @@ const foo = () => {
   
 </code></pre>
 
+```ts
+export function f<T>() {}
+```
+
+<pre class="language-text"><code class="language-text">correctness/noUnusedVariables.js:1:19 <a href="https://biomejs.dev/linter/rules/no-unused-variables">lint/correctness/noUnusedVariables</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">This type parameter is unused.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>export function f&lt;T&gt;() {}
+   <strong>   │ </strong>                  <strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Unused variables usually are result of incomplete refactoring, typos and other source of bugs.</span>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Unsafe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">If this is intentional, prepend </span><span style="color: rgb(38, 148, 255);"><strong>T</strong></span><span style="color: rgb(38, 148, 255);"> with an underscore.</span>
+  
+    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">e</span><span style="color: Tomato;">x</span><span style="color: Tomato;">p</span><span style="color: Tomato;">o</span><span style="color: Tomato;">r</span><span style="color: Tomato;">t</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">f</span><span style="color: Tomato;">u</span><span style="color: Tomato;">n</span><span style="color: Tomato;">c</span><span style="color: Tomato;">t</span><span style="color: Tomato;">i</span><span style="color: Tomato;">o</span><span style="color: Tomato;">n</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">f</span><span style="color: Tomato;">&lt;</span><span style="color: Tomato;"><strong>T</strong></span><span style="color: Tomato;">&gt;</span><span style="color: Tomato;">(</span><span style="color: Tomato;">)</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">{</span><span style="color: Tomato;">}</span>
+      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">e</span><span style="color: MediumSeaGreen;">x</span><span style="color: MediumSeaGreen;">p</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">r</span><span style="color: MediumSeaGreen;">t</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">f</span><span style="color: MediumSeaGreen;">u</span><span style="color: MediumSeaGreen;">n</span><span style="color: MediumSeaGreen;">c</span><span style="color: MediumSeaGreen;">t</span><span style="color: MediumSeaGreen;">i</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">n</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">f</span><span style="color: MediumSeaGreen;">&lt;</span><span style="color: MediumSeaGreen;"><strong>_</strong></span><span style="color: MediumSeaGreen;"><strong>T</strong></span><span style="color: MediumSeaGreen;">&gt;</span><span style="color: MediumSeaGreen;">(</span><span style="color: MediumSeaGreen;">)</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">{</span><span style="color: MediumSeaGreen;">}</span>
+    <strong>2</strong> <strong>2</strong><strong> │ </strong>  
+  
+</code></pre>
+
 # Valid
 
 ```jsx


### PR DESCRIPTION
## Summary

This PR enhances [noUnusedVariables](https://biomejs.dev/linter/rules/no-unused-variables) by handling unused type parameters.

## Test Plan

New tests added.
