### PR TITLE
refactor(biome_js_analyze): enable clippy::needless_pass_by_value

### DIFF
--- a/crates/biome_js_analyze/src/analyzers/a11y/no_redundant_alt.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_redundant_alt.rs
@@ -94,16 +94,14 @@ impl Rule for NoRedundantAlt {
                 match value.expression().ok()? {
                     AnyJsExpression::AnyJsLiteralExpression(
                         AnyJsLiteralExpression::JsStringLiteralExpression(expr),
-                    ) => {
-                        is_redundant_alt(expr.inner_string_text().ok()?.to_string()).then_some(alt)
-                    }
+                    ) => is_redundant_alt(expr.inner_string_text().ok()?.text()).then_some(alt),
                     AnyJsExpression::JsTemplateExpression(expr) => {
                         let contain_redundant_alt =
                             expr.elements().into_iter().any(|template_element| {
                                 match template_element {
                                     AnyJsTemplateElement::JsTemplateChunkElement(node) => {
                                         node.template_chunk_token().ok().map_or(false, |token| {
-                                            is_redundant_alt(token.text_trimmed().to_string())
+                                            is_redundant_alt(token.text_trimmed())
                                         })
                                     }
                                     AnyJsTemplateElement::JsTemplateElement(_) => false,
@@ -117,8 +115,8 @@ impl Rule for NoRedundantAlt {
                 }
             }
             AnyJsxAttributeValue::JsxString(ref value) => {
-                let text = value.inner_string_text().ok()?.to_string();
-                is_redundant_alt(text).then_some(alt)
+                let inner_string_text = value.inner_string_text().ok()?;
+                is_redundant_alt(inner_string_text.text()).then_some(alt)
             }
         }
     }
@@ -141,7 +139,7 @@ impl Rule for NoRedundantAlt {
 
 const REDUNDANT_WORDS: [&str; 3] = ["image", "photo", "picture"];
 
-fn is_redundant_alt(alt: String) -> bool {
+fn is_redundant_alt(alt: &str) -> bool {
     REDUNDANT_WORDS
         .into_iter()
         .any(|word| alt.split_whitespace().any(|x| x.to_lowercase() == word))

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_valid_anchor.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_valid_anchor.rs
@@ -120,11 +120,11 @@ impl UseValidAnchorState {
         }
     }
 
-    fn range(&self) -> TextRange {
+    fn range(&self) -> &TextRange {
         match self {
             UseValidAnchorState::MissingHrefAttribute(range)
             | UseValidAnchorState::CantBeAnchor(range)
-            | UseValidAnchorState::IncorrectHref(range) => *range,
+            | UseValidAnchorState::IncorrectHref(range) => range,
         }
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_rename.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_rename.rs
@@ -4,8 +4,9 @@ use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
 use biome_js_syntax::{
+    AnyJsExportNamedSpecifier, AnyJsNamedImportSpecifier, AnyJsObjectBindingPatternMember,
     JsExportNamedFromSpecifier, JsExportNamedSpecifier, JsNamedImportSpecifier,
-    JsObjectBindingPatternProperty, JsSyntaxElement,
+    JsObjectBindingPatternProperty,
 };
 use biome_rowan::{declare_node_union, trim_leading_trivia_pieces, AstNode, BatchMutationExt};
 
@@ -136,18 +137,12 @@ impl Rule for NoUselessRename {
             JsRenaming::JsExportNamedSpecifier(x) => {
                 let replacing =
                     make::js_export_named_shorthand_specifier(x.local_name().ok()?).build();
-                mutation.replace_element(
-                    JsSyntaxElement::Node(x.syntax().clone()),
-                    JsSyntaxElement::Node(replacing.syntax().clone()),
-                );
+                mutation.replace_node(AnyJsExportNamedSpecifier::from(x.clone()), replacing.into());
             }
             JsRenaming::JsNamedImportSpecifier(x) => {
                 let replacing =
                     make::js_shorthand_named_import_specifier(x.local_name().ok()?).build();
-                mutation.replace_element(
-                    JsSyntaxElement::Node(x.syntax().clone()),
-                    JsSyntaxElement::Node(replacing.syntax().clone()),
-                );
+                mutation.replace_node(AnyJsNamedImportSpecifier::from(x.clone()), replacing.into());
             }
             JsRenaming::JsObjectBindingPatternProperty(x) => {
                 let mut replacing_builder = make::js_object_binding_pattern_shorthand_property(
@@ -156,9 +151,9 @@ impl Rule for NoUselessRename {
                 if let Some(init) = x.init() {
                     replacing_builder = replacing_builder.with_init(init);
                 }
-                mutation.replace_element(
-                    JsSyntaxElement::Node(x.syntax().clone()),
-                    JsSyntaxElement::Node(replacing_builder.build().syntax().clone()),
+                mutation.replace_node(
+                    AnyJsObjectBindingPatternMember::from(x.clone()),
+                    replacing_builder.build().into(),
                 );
             }
         }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_switch_case.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_switch_case.rs
@@ -135,6 +135,7 @@ impl Rule for NoUselessSwitchCase {
         let default_clause = ctx.query();
         let mut mutation = ctx.root().begin();
         let consequent = useless_case.consequent();
+        let useless_case = useless_case.clone();
         if consequent.len() > 0 {
             let default_clause_colon_token = default_clause.colon_token().ok()?;
             let new_default_clause = default_clause
@@ -145,11 +146,11 @@ impl Rule for NoUselessSwitchCase {
                 ));
             mutation.remove_node(default_clause.clone());
             mutation.replace_node(
-                AnyJsSwitchClause::from(useless_case.clone()),
+                AnyJsSwitchClause::from(useless_case),
                 new_default_clause.into(),
             );
         } else {
-            mutation.remove_node(useless_case.clone());
+            mutation.remove_node(useless_case);
         }
         Some(JsRuleAction {
             mutation,

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_switch_case.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_switch_case.rs
@@ -2,8 +2,8 @@ use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
-use biome_js_syntax::{JsCaseClause, JsDefaultClause};
-use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, Direction, SyntaxElement};
+use biome_js_syntax::{AnyJsSwitchClause, JsCaseClause, JsDefaultClause};
+use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, Direction};
 
 use crate::JsRuleAction;
 
@@ -144,9 +144,9 @@ impl Rule for NoUselessSwitchCase {
                     useless_case.colon_token().ok()?.trailing_trivia().pieces(),
                 ));
             mutation.remove_node(default_clause.clone());
-            mutation.replace_element(
-                SyntaxElement::Node(useless_case.syntax().clone()),
-                SyntaxElement::Node(new_default_clause.syntax().clone()),
+            mutation.replace_node(
+                AnyJsSwitchClause::from(useless_case.clone()),
+                new_default_clause.into(),
             );
         } else {
             mutation.remove_node(useless_case.clone());

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_literal_keys.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_literal_keys.rs
@@ -9,7 +9,8 @@ use biome_js_factory::make::{
     js_static_member_expression, token,
 };
 use biome_js_syntax::{
-    AnyJsComputedMember, AnyJsExpression, AnyJsLiteralExpression, AnyJsName, JsComputedMemberName,
+    AnyJsAssignment, AnyJsComputedMember, AnyJsExpression, AnyJsLiteralExpression,
+    AnyJsMemberExpression, AnyJsName, AnyJsObjectMemberName, JsComputedMemberName,
     JsLiteralMemberName, JsSyntaxKind, T,
 };
 use biome_js_unicode_table::is_js_ident;
@@ -128,9 +129,9 @@ impl Rule for UseLiteralKeys {
                             dot_token,
                             AnyJsName::JsName(member),
                         );
-                        mutation.replace_element(
-                            node.clone().into_syntax().into(),
-                            static_expression.into_syntax().into(),
+                        mutation.replace_node(
+                            AnyJsMemberExpression::from(node.clone()),
+                            static_expression.into(),
                         );
                     }
                     AnyJsComputedMember::JsComputedMemberAssignment(node) => {
@@ -139,9 +140,9 @@ impl Rule for UseLiteralKeys {
                             dot_token,
                             AnyJsName::JsName(member),
                         );
-                        mutation.replace_element(
-                            node.clone().into_syntax().into(),
-                            static_member.into_syntax().into(),
+                        mutation.replace_node(
+                            AnyJsAssignment::from(node.clone()),
+                            static_member.into(),
                         );
                     }
                 }
@@ -156,9 +157,9 @@ impl Rule for UseLiteralKeys {
                     make::js_string_literal(identifier)
                 };
                 let literal_member_name = js_literal_member_name(name_token);
-                mutation.replace_element(
-                    member.clone().into_syntax().into(),
-                    literal_member_name.into_syntax().into(),
+                mutation.replace_node(
+                    AnyJsObjectMemberName::from(member.clone()),
+                    literal_member_name.into(),
                 );
             }
         }

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_optional_chain.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_optional_chain.rs
@@ -567,8 +567,7 @@ impl LogicalOrLikeChain {
         if !is_right_empty_object {
             return None;
         }
-        let member =
-            LogicalOrLikeChain::get_chain_parent_member(AnyJsExpression::from(logical.clone()))?;
+        let member = LogicalOrLikeChain::get_chain_parent_member(logical)?;
         Some(LogicalOrLikeChain { member })
     }
 
@@ -576,7 +575,7 @@ impl LogicalOrLikeChain {
     /// E.g.
     /// `(foo ?? {}).bar` is inside `((foo ?? {}).bar || {}).baz;`
     fn is_inside_another_chain(&self) -> bool {
-        LogicalOrLikeChain::get_chain_parent(self.member.clone()).map_or(false, |parent| {
+        LogicalOrLikeChain::get_chain_parent(&self.member).map_or(false, |parent| {
             parent
                 .as_js_logical_expression()
                 .filter(|parent_expression| {
@@ -647,8 +646,8 @@ impl LogicalOrLikeChain {
     }
 
     /// Traversal by parent to find the parent member of a chain.
-    fn get_chain_parent_member(expression: AnyJsExpression) -> Option<AnyJsMemberExpression> {
-        iter::successors(expression.parent::<AnyJsExpression>(), |expression| {
+    fn get_chain_parent_member(logical: &JsLogicalExpression) -> Option<AnyJsMemberExpression> {
+        iter::successors(logical.parent::<AnyJsExpression>(), |expression| {
             if matches!(expression, AnyJsExpression::JsParenthesizedExpression(_)) {
                 expression.parent::<AnyJsExpression>()
             } else {
@@ -672,7 +671,7 @@ impl LogicalOrLikeChain {
 
     /// Traversal by parent to find the parent of a chain.
     /// This function is opposite to the `get_member` function.
-    fn get_chain_parent(expression: AnyJsMemberExpression) -> Option<AnyJsExpression> {
+    fn get_chain_parent(expression: &AnyJsMemberExpression) -> Option<AnyJsExpression> {
         iter::successors(expression.parent::<AnyJsExpression>(), |expression| {
             if matches!(
                 expression,

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_invalid_constructor_super.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_invalid_constructor_super.rs
@@ -61,10 +61,10 @@ pub(crate) enum NoInvalidConstructorSuperState {
 }
 
 impl NoInvalidConstructorSuperState {
-    fn range(&self) -> TextRange {
+    fn range(&self) -> &TextRange {
         match self {
-            NoInvalidConstructorSuperState::UnexpectedSuper(range) => *range,
-            NoInvalidConstructorSuperState::BadExtends { super_range, .. } => *super_range,
+            NoInvalidConstructorSuperState::UnexpectedSuper(range) => range,
+            NoInvalidConstructorSuperState::BadExtends { super_range, .. } => super_range,
         }
     }
 

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_self_assign.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_self_assign.rs
@@ -402,7 +402,7 @@ struct AnyJsAssignmentExpressionLikeIterator {
 }
 
 impl AnyJsAssignmentExpressionLikeIterator {
-    fn from_static_member_expression(source: JsStaticMemberExpression) -> SyntaxResult<Self> {
+    fn from_static_member_expression(source: &JsStaticMemberExpression) -> SyntaxResult<Self> {
         Ok(Self {
             source_member: source.member().map(AnyNameLike::from)?,
             source_object: source.object()?,
@@ -411,7 +411,7 @@ impl AnyJsAssignmentExpressionLikeIterator {
         })
     }
 
-    fn from_static_member_assignment(source: JsStaticMemberAssignment) -> SyntaxResult<Self> {
+    fn from_static_member_assignment(source: &JsStaticMemberAssignment) -> SyntaxResult<Self> {
         Ok(Self {
             source_member: source.member().map(AnyNameLike::from)?,
             source_object: source.object()?,
@@ -420,7 +420,7 @@ impl AnyJsAssignmentExpressionLikeIterator {
         })
     }
 
-    fn from_computed_member_assignment(source: JsComputedMemberAssignment) -> SyntaxResult<Self> {
+    fn from_computed_member_assignment(source: &JsComputedMemberAssignment) -> SyntaxResult<Self> {
         Ok(Self {
             source_member: source.member().and_then(|expression| match expression {
                 AnyJsExpression::JsIdentifierExpression(node) => {
@@ -435,7 +435,7 @@ impl AnyJsAssignmentExpressionLikeIterator {
         })
     }
 
-    fn from_computed_member_expression(source: JsComputedMemberExpression) -> SyntaxResult<Self> {
+    fn from_computed_member_expression(source: &JsComputedMemberExpression) -> SyntaxResult<Self> {
         Ok(Self {
             source_member: source.member().and_then(|expression| match expression {
                 AnyJsExpression::JsIdentifierExpression(node) => {
@@ -623,8 +623,10 @@ impl TryFrom<(AnyJsAssignmentPattern, AnyJsExpression)> for AnyAssignmentLike {
                 )),
                 AnyJsExpression::JsStaticMemberExpression(right),
             ) => AnyAssignmentLike::StaticExpression {
-                left: AnyJsAssignmentExpressionLikeIterator::from_static_member_assignment(left)?,
-                right: AnyJsAssignmentExpressionLikeIterator::from_static_member_expression(right)?,
+                left: AnyJsAssignmentExpressionLikeIterator::from_static_member_assignment(&left)?,
+                right: AnyJsAssignmentExpressionLikeIterator::from_static_member_expression(
+                    &right,
+                )?,
             },
 
             (
@@ -633,9 +635,11 @@ impl TryFrom<(AnyJsAssignmentPattern, AnyJsExpression)> for AnyAssignmentLike {
                 ),
                 AnyJsExpression::JsComputedMemberExpression(right),
             ) => AnyAssignmentLike::StaticExpression {
-                left: AnyJsAssignmentExpressionLikeIterator::from_computed_member_assignment(left)?,
+                left: AnyJsAssignmentExpressionLikeIterator::from_computed_member_assignment(
+                    &left,
+                )?,
                 right: AnyJsAssignmentExpressionLikeIterator::from_computed_member_expression(
-                    right,
+                    &right,
                 )?,
             },
             _ => AnyAssignmentLike::None,

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_misleading_instantiator.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_misleading_instantiator.rs
@@ -109,12 +109,12 @@ impl RuleState {
         }
     }
 
-    fn range(&self) -> TextRange {
+    fn range(&self) -> &TextRange {
         match self {
             RuleState::ClassMisleadingNew(range)
             | RuleState::InterfaceMisleadingNew(range)
             | RuleState::InterfaceMisleadingConstructor(range)
-            | RuleState::TypeAliasMisleadingConstructor(range) => *range,
+            | RuleState::TypeAliasMisleadingConstructor(range) => range,
         }
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_useless_else.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_useless_else.rs
@@ -153,12 +153,12 @@ impl Rule for NoUselessElse {
     fn action(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {
         let else_clause = ctx.query();
         let if_stmt = else_clause.parent::<JsIfStatement>()?;
-        if let Some(stmts_list) = JsStatementList::cast(if_stmt.syntax().parent()?) {
+        if let Some(stmts_list) = if_stmt.parent::<JsStatementList>() {
             let else_alternative = else_clause.alternate().ok()?;
             let if_pos = stmts_list
                 .iter()
                 .position(|x| x.syntax() == if_stmt.syntax())?;
-            let new_if_stmt = AnyJsStatement::JsIfStatement(if_stmt.clone().with_else_clause(None))
+            let new_if_stmt = AnyJsStatement::from(if_stmt.with_else_clause(None))
                 .with_trailing_trivia_pieces([])?;
             let prev_stmts = stmts_list.iter().take(if_pos).chain([new_if_stmt]);
             let next_stmts = stmts_list.iter().skip(if_pos + 1);

--- a/crates/biome_js_analyze/src/analyzers/style/use_block_statements.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_block_statements.rs
@@ -170,6 +170,7 @@ impl Rule for UseBlockStatements {
                 let mut leading_trivia = stmt
                     .syntax()
                     .first_leading_trivia()
+                    .as_ref()
                     .map(collect_to_first_newline)
                     .unwrap_or_else(Vec::new);
 
@@ -200,6 +201,7 @@ impl Rule for UseBlockStatements {
                     leading_trivia = node
                         .syntax()
                         .first_leading_trivia()
+                        .as_ref()
                         .map(collect_to_first_newline)
                         .unwrap_or_else(Vec::new);
                 }
@@ -290,7 +292,7 @@ impl Rule for UseBlockStatements {
 }
 
 /// Collect newline and comment trivia pieces in reverse order up to the first newline included
-fn collect_to_first_newline(trivia: JsSyntaxTrivia) -> Vec<SyntaxTriviaPiece<JsLanguage>> {
+fn collect_to_first_newline(trivia: &JsSyntaxTrivia) -> Vec<SyntaxTriviaPiece<JsLanguage>> {
     let mut has_newline = false;
     trivia
         .pieces()

--- a/crates/biome_js_analyze/src/analyzers/style/use_numeric_literals.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_numeric_literals.rs
@@ -90,7 +90,7 @@ impl Rule for UseNumericLiterals {
         let node = ctx.query();
         let mut mutation = ctx.root().begin();
         let number = call.to_numeric_literal()?;
-        let number = ast_utils::token_with_source_trivia(number, node);
+        let number = ast_utils::token_with_source_trivia(&number, node);
         mutation.replace_node_discard_trivia(
             AnyJsExpression::JsCallExpression(node.clone()),
             AnyJsExpression::AnyJsLiteralExpression(

--- a/crates/biome_js_analyze/src/analyzers/style/use_shorthand_array_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_shorthand_array_type.rs
@@ -58,7 +58,7 @@ declare_rule! {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 enum TsArrayKind {
     /// `Array<T>`
     Simple,
@@ -77,7 +77,7 @@ impl Rule for UseShorthandArrayType {
         let type_arguments = node.type_arguments()?;
 
         match get_array_kind_by_reference(node) {
-            Some(array_kind) => convert_to_array_type(type_arguments, array_kind),
+            Some(array_kind) => convert_to_array_type(&type_arguments, array_kind),
             None => None,
         }
     }
@@ -142,7 +142,7 @@ fn get_array_kind_by_reference(ty: &TsReferenceType) -> Option<TsArrayKind> {
 }
 
 fn convert_to_array_type(
-    type_arguments: TsTypeArguments,
+    type_arguments: &TsTypeArguments,
     array_kind: TsArrayKind,
 ) -> Option<AnyTsType> {
     if type_arguments.ts_type_argument_list().len() > 0 {
@@ -166,7 +166,7 @@ fn convert_to_array_type(
                     AnyTsType::TsReferenceType(ty) => match get_array_kind_by_reference(ty) {
                         Some(array_kind) => {
                             if let Some(type_arguments) = ty.type_arguments() {
-                                convert_to_array_type(type_arguments, array_kind)
+                                convert_to_array_type(&type_arguments, array_kind)
                             } else {
                                 Some(param)
                             }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_comment_text.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_comment_text.rs
@@ -86,8 +86,8 @@ impl Rule for NoCommentText {
         );
 
         mutation.replace_node(
-            AnyJsxChild::JsxText(node.clone()),
-            AnyJsxChild::JsxExpressionChild(
+            AnyJsxChild::from(node.clone()),
+            AnyJsxChild::from(
                 make::jsx_expression_child(
                     make::token(T!['{']).with_trailing_trivia([(
                         TriviaPieceKind::MultiLineComment,

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_double_equals.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_double_equals.rs
@@ -70,7 +70,7 @@ impl Rule for NoDoubleEquals {
         }
 
         // TODO: Implement SyntaxResult helpers to make this cleaner
-        if is_null_literal(n.left()) || is_null_literal(n.right()) {
+        if is_null_literal(&n.left()) || is_null_literal(&n.right()) {
             return None;
         }
 
@@ -117,7 +117,7 @@ impl Rule for NoDoubleEquals {
     }
 }
 
-fn is_null_literal(res: SyntaxResult<AnyJsExpression>) -> bool {
+fn is_null_literal(res: &SyntaxResult<AnyJsExpression>) -> bool {
     matches!(
         res,
         Ok(AnyJsExpression::AnyJsLiteralExpression(

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_object_keys.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_object_keys.rs
@@ -111,12 +111,12 @@ impl MemberDefinition {
 
     fn node(&self) -> AnyJsObjectMember {
         match self {
-            MemberDefinition::Getter(getter) => AnyJsObjectMember::from(getter.clone()),
-            MemberDefinition::Setter(setter) => AnyJsObjectMember::from(setter.clone()),
-            MemberDefinition::Method(method) => AnyJsObjectMember::from(method.clone()),
-            MemberDefinition::Property(property) => AnyJsObjectMember::from(property.clone()),
+            MemberDefinition::Getter(getter) => getter.clone().into(),
+            MemberDefinition::Setter(setter) => setter.clone().into(),
+            MemberDefinition::Method(method) => method.clone().into(),
+            MemberDefinition::Property(property) => property.clone().into(),
             MemberDefinition::ShorthandProperty(shorthand_property) => {
-                AnyJsObjectMember::from(shorthand_property.clone())
+                shorthand_property.clone().into()
             }
         }
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_unsafe_negation.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_unsafe_negation.rs
@@ -111,8 +111,8 @@ impl Rule for NoUnsafeNegation {
                     AnyJsExpression::JsParenthesizedExpression(next_parenthesis_expression),
                 );
                 mutation.replace_node(
-                    AnyJsExpression::JsInstanceofExpression(expr.clone()),
-                    AnyJsExpression::JsUnaryExpression(next_unary_expression),
+                    AnyJsExpression::from(expr.clone()),
+                    AnyJsExpression::from(next_unary_expression),
                 );
             }
             JsInOrInstanceOfExpression::JsInExpression(expr) => {
@@ -131,8 +131,8 @@ impl Rule for NoUnsafeNegation {
                     AnyJsExpression::JsParenthesizedExpression(next_parenthesis_expression),
                 );
                 mutation.replace_node(
-                    AnyJsExpression::JsInExpression(expr.clone()),
-                    AnyJsExpression::JsUnaryExpression(next_unary_expression),
+                    AnyJsExpression::from(expr.clone()),
+                    AnyJsExpression::from(next_unary_expression),
                 );
             }
         }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/no_aria_unsupported_elements.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/no_aria_unsupported_elements.rs
@@ -140,7 +140,7 @@ impl Rule for NoAriaUnsupportedElements {
         })?;
 
         let removed_attribute = attribute.to_string();
-        mutation.remove_node(attribute.clone());
+        mutation.remove_node(attribute);
 
         Some(JsRuleAction {
             category: ActionCategory::QuickFix,

--- a/crates/biome_js_analyze/src/assists/correctness/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assists/correctness/organize_imports.rs
@@ -96,18 +96,18 @@ impl Rule for OrganizeImports {
                 }
             }
 
-            // If this is the first import in the group save the leading trivia
-            // and slot index
-            if first_node.is_none() {
-                first_node = Some(import.clone());
-            }
-
             let source = match import.import_clause().ok()? {
                 AnyJsImportClause::JsImportBareClause(clause) => clause.source().ok()?,
                 AnyJsImportClause::JsImportDefaultClause(clause) => clause.source().ok()?,
                 AnyJsImportClause::JsImportNamedClause(clause) => clause.source().ok()?,
                 AnyJsImportClause::JsImportNamespaceClause(clause) => clause.source().ok()?,
             };
+
+            // If this is the first import in the group save the leading trivia
+            // and slot index
+            if first_node.is_none() {
+                first_node = Some(import.clone());
+            }
 
             let key = source.inner_string_text().ok()?;
             match nodes.entry(ImportKey(key)) {

--- a/crates/biome_js_analyze/src/assists/correctness/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assists/correctness/organize_imports.rs
@@ -87,7 +87,7 @@ impl Rule for OrganizeImports {
             let first_token = import.import_token().ok()?;
 
             // If this is not the first import in the group, check for a group break
-            if has_empty_line(first_token.leading_trivia()) {
+            if has_empty_line(&first_token.leading_trivia()) {
                 if let Some(first_node) = first_node.take() {
                     groups.push(ImportGroup {
                         first_node,
@@ -747,7 +747,7 @@ fn is_ascii_whitespace(piece: &SyntaxTriviaPiece<JsLanguage>) -> bool {
 }
 
 /// Returns true if the provided trivia contains an empty line (two consecutive newline pieces, ignoring whitespace)
-fn has_empty_line(trivia: SyntaxTrivia<JsLanguage>) -> bool {
+fn has_empty_line(trivia: &SyntaxTrivia<JsLanguage>) -> bool {
     let mut was_newline = false;
     trivia
         .pieces()

--- a/crates/biome_js_analyze/src/ast_utils.rs
+++ b/crates/biome_js_analyze/src/ast_utils.rs
@@ -4,7 +4,7 @@ use biome_rowan::{AstNode, TriviaPiece};
 /// Add any leading and trailing trivia from given source node to the token.
 ///
 /// Adds whitespace trivia if needed for safe replacement of source node.
-pub fn token_with_source_trivia<T>(token: JsSyntaxToken, source: &T) -> JsSyntaxToken
+pub fn token_with_source_trivia<T>(token: &JsSyntaxToken, source: &T) -> JsSyntaxToken
 where
     T: AstNode<Language = JsLanguage>,
 {

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::needless_pass_by_value)]
+
 use crate::suppression_action::apply_suppression_comment;
 use biome_analyze::{
     AnalysisFilter, Analyzer, AnalyzerContext, AnalyzerOptions, AnalyzerSignal, ControlFlow,

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(clippy::needless_pass_by_value)]
+#![warn(clippy::needless_pass_by_value, clippy::redundant_clone)]
 
 use crate::suppression_action::apply_suppression_comment;
 use biome_analyze::{

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(clippy::needless_pass_by_value, clippy::redundant_clone)]
+#![warn(clippy::needless_pass_by_value)]
 
 use crate::suppression_action::apply_suppression_comment;
 use biome_analyze::{

--- a/crates/biome_js_analyze/src/react.rs
+++ b/crates/biome_js_analyze/src/react.rs
@@ -5,7 +5,7 @@ pub mod hooks;
 use biome_js_semantic::{Binding, SemanticModel};
 use biome_js_syntax::{
     AnyJsCallArgument, AnyJsExpression, AnyJsMemberExpression, AnyJsNamedImportSpecifier,
-    JsCallExpression, JsIdentifierBinding, JsImport, JsImportNamedClause,
+    AnyJsObjectMember, JsCallExpression, JsIdentifierBinding, JsImport, JsImportNamedClause,
     JsNamedImportSpecifierList, JsNamedImportSpecifiers, JsObjectExpression,
     JsPropertyObjectMember, JsxMemberName, JsxReferenceIdentifier,
 };
@@ -102,13 +102,14 @@ impl ReactApiCall for ReactCreateElementCall {
         self.props.as_ref().and_then(|props| {
             let members = props.members();
             members.iter().find_map(|member| {
-                let member = member.ok()?;
-                let property = member.as_js_property_object_member()?;
+                let AnyJsObjectMember::JsPropertyObjectMember(property) = member.ok()? else {
+                    return None;
+                };
                 let property_name = property.name().ok()?;
 
                 let property_name = property_name.as_js_literal_member_name()?;
                 if property_name.name().ok()? == prop_name {
-                    Some(property.clone())
+                    Some(property)
                 } else {
                     None
                 }

--- a/crates/biome_js_analyze/src/react.rs
+++ b/crates/biome_js_analyze/src/react.rs
@@ -204,7 +204,7 @@ pub(crate) fn is_react_call_api(
             return false;
         }
         return match model.binding(&reference) {
-            Some(decl) => is_react_export(decl, lib),
+            Some(decl) => is_react_export(&decl, lib),
             None => reference.has_name(lib.global_name()),
         };
     }
@@ -212,7 +212,7 @@ pub(crate) fn is_react_call_api(
     if let Some(ident) = expr.as_js_reference_identifier() {
         return model
             .binding(&ident)
-            .and_then(|it| is_named_react_export(it, lib, api_name))
+            .and_then(|it| is_named_react_export(&it, lib, api_name))
             .unwrap_or(false);
     }
 
@@ -239,7 +239,7 @@ pub(crate) fn jsx_member_name_is_react_fragment(
 
     let lib = ReactLibrary::React;
     match model.binding(object) {
-        Some(declaration) => Some(is_react_export(declaration, lib)),
+        Some(declaration) => Some(is_react_export(&declaration, lib)),
         None => Some(object.value_token().ok()?.text_trimmed() == lib.global_name()),
     }
 }
@@ -255,7 +255,7 @@ pub(crate) fn jsx_reference_identifier_is_fragment(
     model: &SemanticModel,
 ) -> Option<bool> {
     match model.binding(name) {
-        Some(reference) => is_named_react_export(reference, ReactLibrary::React, "Fragment"),
+        Some(reference) => is_named_react_export(&reference, ReactLibrary::React, "Fragment"),
         None => {
             let value_token = name.value_token().ok()?;
             let is_fragment = value_token.text_trimmed() == "Fragment";
@@ -264,7 +264,7 @@ pub(crate) fn jsx_reference_identifier_is_fragment(
     }
 }
 
-fn is_react_export(binding: Binding, lib: ReactLibrary) -> bool {
+fn is_react_export(binding: &Binding, lib: ReactLibrary) -> bool {
     binding
         .syntax()
         .ancestors()
@@ -273,7 +273,7 @@ fn is_react_export(binding: Binding, lib: ReactLibrary) -> bool {
         .unwrap_or(false)
 }
 
-fn is_named_react_export(binding: Binding, lib: ReactLibrary, name: &str) -> Option<bool> {
+fn is_named_react_export(binding: &Binding, lib: ReactLibrary, name: &str) -> Option<bool> {
     let ident = JsIdentifierBinding::cast_ref(binding.syntax())?;
     let import_specifier = ident.parent::<AnyJsNamedImportSpecifier>()?;
     let name_token = match &import_specifier {

--- a/crates/biome_js_analyze/src/semantic_analyzers/a11y/use_button_type.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/a11y/use_button_type.rs
@@ -74,7 +74,7 @@ impl Rule for UseButtonType {
                         missing_prop: true,
                     });
                 };
-                inspect_jsx_type_attribute(attribute)
+                inspect_jsx_type_attribute(&attribute)
             }
             UseButtonTypeQuery::JsxOpeningElement(element) => {
                 let name = element.name().ok()?;
@@ -88,7 +88,7 @@ impl Rule for UseButtonType {
                         missing_prop: true,
                     });
                 };
-                inspect_jsx_type_attribute(attribute)
+                inspect_jsx_type_attribute(&attribute)
             }
             UseButtonTypeQuery::JsCallExpression(call_expression) => {
                 let model = ctx.model();
@@ -171,7 +171,7 @@ impl Rule for UseButtonType {
     }
 }
 
-fn inspect_jsx_type_attribute(attribute: JsxAttribute) -> Option<UseButtonTypeState> {
+fn inspect_jsx_type_attribute(attribute: &JsxAttribute) -> Option<UseButtonTypeState> {
     let Some(initializer) = attribute.initializer() else {
         return Some(UseButtonTypeState {
             range: attribute.range(),

--- a/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_useless_fragments.rs
@@ -230,28 +230,22 @@ impl Rule for NoUselessFragments {
             let child = node.children().first();
             if let Some(child) = child {
                 let new_node = match child {
-                    AnyJsxChild::JsxElement(node) => Some(
-                        jsx_tag_expression(AnyJsxTag::JsxElement(node))
-                            .syntax()
-                            .clone(),
-                    ),
-                    AnyJsxChild::JsxFragment(node) => Some(
-                        jsx_tag_expression(AnyJsxTag::JsxFragment(node))
-                            .syntax()
-                            .clone(),
-                    ),
+                    AnyJsxChild::JsxElement(node) => {
+                        Some(jsx_tag_expression(AnyJsxTag::JsxElement(node)).into_syntax())
+                    }
+                    AnyJsxChild::JsxFragment(node) => {
+                        Some(jsx_tag_expression(AnyJsxTag::JsxFragment(node)).into_syntax())
+                    }
                     AnyJsxChild::JsxSelfClosingElement(node) => Some(
-                        jsx_tag_expression(AnyJsxTag::JsxSelfClosingElement(node))
-                            .syntax()
-                            .clone(),
+                        jsx_tag_expression(AnyJsxTag::JsxSelfClosingElement(node)).into_syntax(),
                     ),
                     AnyJsxChild::JsxText(text) => {
                         let new_value = format!("\"{}\"", text.value_token().ok()?);
-                        Some(jsx_string(ident(&new_value)).syntax().clone())
+                        Some(jsx_string(ident(&new_value)).into_syntax())
                     }
                     AnyJsxChild::JsxExpressionChild(child) => {
                         child.expression().map(|expression| {
-                            js_expression_statement(expression).build().syntax().clone()
+                            js_expression_statement(expression).build().into_syntax()
                         })
                     }
 

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_constant_condition.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_constant_condition.rs
@@ -401,7 +401,7 @@ fn is_logical_identity(node: AnyJsExpression, operator: JsLogicalOperator) -> bo
     use JsLogicalOperator::*;
     match node.omit_parentheses() {
         AnyJsLiteralExpression(node) => {
-            let boolean_value = get_boolean_value(node);
+            let boolean_value = get_boolean_value(&node);
             operator == LogicalOr && boolean_value || (operator == LogicalAnd && !boolean_value)
         }
         JsUnaryExpression(node) => {
@@ -468,7 +468,7 @@ fn is_logical_identity(node: AnyJsExpression, operator: JsLogicalOperator) -> bo
     }
 }
 
-fn get_boolean_value(node: AnyJsLiteralExpression) -> bool {
+fn get_boolean_value(node: &AnyJsLiteralExpression) -> bool {
     use AnyJsLiteralExpression::*;
     match node {
         JsRegexLiteralExpression(_) => true,
@@ -499,7 +499,7 @@ mod tests {
             .find_map(|js_statement| js_statement.cast::<AnyJsLiteralExpression>());
 
         assert_eq!(
-            get_boolean_value(literal_expression.expect("Not found AnyLiteralExpression.")),
+            get_boolean_value(&literal_expression.expect("Not found AnyLiteralExpression.")),
             value
         );
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_constant_condition.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_constant_condition.rs
@@ -184,9 +184,10 @@ impl From<AnyJsStatement> for ConditionalStatement {
 // Gets a yield expression from the given statement
 fn get_yield_expression(stmt: &AnyJsStatement) -> Option<JsYieldExpression> {
     let stmt = stmt.as_js_expression_statement()?;
-    let expr = stmt.as_fields().expression.ok()?;
-    let expr = expr.as_js_yield_expression()?;
-    Some(expr.clone())
+    let Ok(AnyJsExpression::JsYieldExpression(expr)) = stmt.as_fields().expression else {
+        return None;
+    };
+    Some(expr)
 }
 
 fn get_statement_list(stmt: &AnyJsStatement) -> Option<JsStatementList> {

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_unused_variables.rs
@@ -110,7 +110,7 @@ pub enum SuggestedFix {
 }
 
 fn is_function_that_is_ok_parameter_not_be_used(
-    parent_function: Option<JsAnyParameterParentFunction>,
+    parent_function: &Option<JsAnyParameterParentFunction>,
 ) -> bool {
     matches!(
         parent_function,
@@ -152,14 +152,14 @@ fn suggested_fix_if_unused(binding: &AnyJsIdentifierBinding) -> Option<Suggested
         // Some parameters are ok to not be used
         AnyJsBindingDeclaration::TsPropertyParameter(_) => None,
         AnyJsBindingDeclaration::JsFormalParameter(parameter) => {
-            if is_function_that_is_ok_parameter_not_be_used(parameter.parent_function()) {
+            if is_function_that_is_ok_parameter_not_be_used(&parameter.parent_function()) {
                 None
             } else {
                 suggestion_for_binding(binding)
             }
         }
         AnyJsBindingDeclaration::JsRestParameter(parameter) => {
-            if is_function_that_is_ok_parameter_not_be_used(parameter.parent_function()) {
+            if is_function_that_is_ok_parameter_not_be_used(&parameter.parent_function()) {
                 None
             } else {
                 suggestion_for_binding(binding)

--- a/crates/biome_js_analyze/src/semantic_analyzers/security/no_dangerously_set_inner_html_with_children.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/security/no_dangerously_set_inner_html_with_children.rs
@@ -59,9 +59,9 @@ enum ChildrenKind {
 }
 
 impl ChildrenKind {
-    fn range(&self) -> TextRange {
+    fn range(&self) -> &TextRange {
         match self {
-            ChildrenKind::Prop(range) | ChildrenKind::Direct(range) => *range,
+            ChildrenKind::Prop(range) | ChildrenKind::Direct(range) => range,
         }
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/no_restricted_globals.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/no_restricted_globals.rs
@@ -153,7 +153,7 @@ impl Rule for NoRestrictedGlobals {
                 } else {
                     vec![]
                 };
-                is_restricted(text, binding, denied_globals.as_slice())
+                is_restricted(text, &binding, denied_globals.as_slice())
                     .map(|text| (token.text_trimmed_range(), text))
             })
             .collect()
@@ -175,7 +175,7 @@ impl Rule for NoRestrictedGlobals {
     }
 }
 
-fn is_restricted(name: &str, binding: Option<Binding>, denied_globals: &[&str]) -> Option<String> {
+fn is_restricted(name: &str, binding: &Option<Binding>, denied_globals: &[&str]) -> Option<String> {
     if binding.is_none() && (RESTRICTED_GLOBALS.contains(&name) || denied_globals.contains(&name)) {
         Some(name.to_string())
     } else {

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_duplicate_parameters.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_duplicate_parameters.rs
@@ -67,7 +67,7 @@ impl Rule for NoDuplicateParameters {
         // Traversing the parameters of the function in preorder and checking for duplicates,
         list.iter().find_map(|parameter| {
             let parameter = parameter.ok()?;
-            traverse_parameter(parameter, &mut set)
+            traverse_parameter(&parameter, &mut set)
         })
     }
 
@@ -89,7 +89,7 @@ impl Rule for NoDuplicateParameters {
 /// Traverse the parameter recursively and check if it is duplicated.
 /// Return `Some(JsIdentifierBinding)` if it is duplicated.
 fn traverse_parameter(
-    parameter: AnyParameter,
+    parameter: &AnyParameter,
     tracked_bindings: &mut FxHashSet<String>,
 ) -> Option<JsIdentifierBinding> {
     parameter

--- a/crates/biome_js_analyze/src/utils/rename.rs
+++ b/crates/biome_js_analyze/src/utils/rename.rs
@@ -369,8 +369,8 @@ mod tests {
         nok_rename_function_conflict, "function a() {} function b() {}",
     }
 
-    fn snap_diagnostic(test_name: &str, diagnostic: Error) {
-        let content = print_diagnostic_to_string(&diagnostic);
+    fn snap_diagnostic(test_name: &str, diagnostic: &Error) {
+        let content = print_diagnostic_to_string(diagnostic);
 
         insta::with_settings!({
             prepend_module_to_snapshot => false,
@@ -384,7 +384,7 @@ mod tests {
     fn cannot_find_declaration() {
         snap_diagnostic(
             "cannot_find_declaration",
-            RenameError::CannotFindDeclaration("async".to_string()).with_file_path("example.js"),
+            &RenameError::CannotFindDeclaration("async".to_string()).with_file_path("example.js"),
         )
     }
 
@@ -393,7 +393,7 @@ mod tests {
         let source_code = "async function f() {}";
         snap_diagnostic(
             "cannot_be_renamed",
-            RenameError::CannotBeRenamed {
+            &RenameError::CannotBeRenamed {
                 original_name: "async".to_string(),
                 original_range: TextRange::new(0.into(), 5.into()),
                 new_name: "await".to_string(),

--- a/crates/biome_js_analyze/src/utils/tests.rs
+++ b/crates/biome_js_analyze/src/utils/tests.rs
@@ -99,20 +99,16 @@ pub fn assert_remove_identifier_a_ok<Anc: AstNode<Language = JsLanguage> + Debug
     };
 
     let mut batch = r.tree().begin();
-    let batch_result =
-        if let Some(parameter) = node_to_remove.syntax().clone().cast::<JsFormalParameter>() {
-            batch.remove_js_formal_parameter(&parameter)
-        } else if let Some(declarator) = node_to_remove
-            .syntax()
-            .clone()
-            .cast::<JsVariableDeclarator>()
-        {
-            batch.remove_js_variable_declarator(&declarator)
-        } else if let Some(member) = node_to_remove.syntax().clone().cast::<AnyJsObjectMember>() {
-            batch.remove_js_object_member(&member)
-        } else {
-            panic!("Don't know how to remove this node: {:?}", node_to_remove);
-        };
+    let batch_result = if let Some(parameter) = JsFormalParameter::cast_ref(node_to_remove.syntax())
+    {
+        batch.remove_js_formal_parameter(&parameter)
+    } else if let Some(declarator) = JsVariableDeclarator::cast_ref(node_to_remove.syntax()) {
+        batch.remove_js_variable_declarator(&declarator)
+    } else if let Some(member) = AnyJsObjectMember::cast_ref(node_to_remove.syntax()) {
+        batch.remove_js_object_member(&member)
+    } else {
+        panic!("Don't know how to remove this node: {:?}", node_to_remove);
+    };
     assert!(batch_result);
     let root = batch.commit();
 

--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -193,9 +193,9 @@ impl Reference {
         matches!(self, Reference::Read { .. })
     }
 
-    pub fn range(&self) -> TextRange {
+    pub fn range(&self) -> &TextRange {
         match self {
-            Reference::Read { range, .. } | Reference::Write { range } => *range,
+            Reference::Read { range, .. } | Reference::Write { range } => range,
         }
     }
 }
@@ -743,7 +743,7 @@ impl SemanticEventExtractor {
                     for reference in references {
                         self.stash.push_back(SemanticEvent::UnresolvedReference {
                             is_read: reference.is_read(),
-                            range: reference.range(),
+                            range: *reference.range(),
                         });
                     }
                 }

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -52,6 +52,13 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 
 ### Editors
+
+#### Bug fixes
+
+- Fix [#404](https://github.com/biomejs/biome/issues/404). Biome intellij plugin now works on Windows. Contributed by @victor-teles
+
+- Fix [#402](https://github.com/biomejs/biome/issues/402). Biome `format` on intellij plugin now recognize biome.json. Contributed by @victor-teles
+
 ### Formatter
 
 #### Enhancements


### PR DESCRIPTION
## Summary

This PR enables Clippy [needless_pass_by_value](https://rust-lang.github.io/rust-clippy/master/#/needless_pass_by_value) only on the `biome_js_analyze crate`.

The rule detects parameter that can borrow instead of taking ownership of a value.
This enabled to detect unnecessary clones.

I plan to enable the rules on other crates.
Enabling the rule on a single crate allows demonstrating the interest of the rule and to refactor progressively.

## Test Plan

`just test`