### PR TITLE
fix(vscode): unknown command when running biome with space separated username or directories

### DIFF
--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -351,7 +351,7 @@ async function getSocket(
 	outputChannel: OutputChannel,
 	command: string,
 ): Promise<string> {
-	const process = spawn(command, ["__print_socket"], {
+	const process = spawn(`"${command}"`, ["__print_socket"], {
 		stdio: [null, "pipe", "pipe"],
 		shell: true,
 	});


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Issue in VSCode Extension
### Biome VSCode extension fail to run Biome when user has username/directories with SPACE character
Related with [#429 ] issue. I just found that `function getSocket` at `main.ts` creating process with command of path into Biome binary file. However, the command would fail when user has space at their username/directory (in my case, windows path). So I'm just add double quotations mark in the command.

before
```
async function getSocket(
        outputChannel: OutputChannel,
        command: string,
): Promise<string> {
        const process = spawn(command, ["__print_socket"], {
                stdio: [null, "pipe", "pipe"],
                shell: true,
        });
```

after
```
async function getSocket(
        outputChannel: OutputChannel,
        command: string,
): Promise<string> {
        const process = spawn(`"${command}"`, ["__print_socket"], {
                stdio: [null, "pipe", "pipe"],
                shell: true,
        });
```

And the extension just work as it should be,