### PR TITLE
fix(playground): indent width is not being applied

### DIFF
--- a/website/src/playground/workers/biomeWorker.ts
+++ b/website/src/playground/workers/biomeWorker.ts
@@ -84,7 +84,7 @@ self.addEventListener("message", async (e) => {
 					formatWithErrors: true,
 					lineWidth: lineWidth,
 					indentStyle: indentStyle === IndentStyle.Tab ? "tab" : "space",
-					indentSize: indentWidth,
+					indentWidth,
 				},
 
 				linter: {


### PR DESCRIPTION
## Summary

I was testing the formatter and realized that the indent width was not being applied


https://github.com/biomejs/biome/assets/78874691/7e657ad2-98ba-4ce6-be59-d3791aab62c9



## Test Plan

Manually tested the playground
