### PR TITLE
fix(vscode): biome resolution

### DIFF
--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -248,24 +248,30 @@ async function getWorkspaceDependency(
 		// @biomejs/biome package, we need to create a custom require function that
 		// is scoped to @biomejs/biome. This allows us to reliably resolve the
 		// package regardless of the package manager used by the user.
-		const requireFromBiome = createRequire(
-			require.resolve("@biomejs/biome/package.json", {
-				paths: [workspaceFolder.uri.fsPath],
-			}),
-		);
-		const binaryPackage = dirname(
-			requireFromBiome.resolve(
-				`@biomejs/cli-${process.platform}-${process.arch}/package.json`,
-			),
-		);
+		try {
+			const requireFromBiome = createRequire(
+				require.resolve("@biomejs/biome/package.json", {
+					paths: [workspaceFolder.uri.fsPath],
+				}),
+			);
+			const binaryPackage = dirname(
+				requireFromBiome.resolve(
+					`@biomejs/cli-${process.platform}-${process.arch}/package.json`,
+				),
+			);
 
-		const biomePath = Uri.file(
-			`${binaryPackage}/biome${process.platform === "win32" ? ".exe" : ""}`,
-		);
+			const biomePath = Uri.file(
+				`${binaryPackage}/biome${process.platform === "win32" ? ".exe" : ""}`,
+			);
 
-		if (await fileExists(biomePath)) {
-			return biomePath.fsPath;
+			if (await fileExists(biomePath)) {
+				return biomePath.fsPath;
+			}
+		} catch {
+			return undefined;
 		}
+
+		return undefined;
 	}
 
 	window.showWarningMessage(

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -25,8 +25,8 @@ import { StatusBar } from "./statusBar";
 import { setContextValue } from "./utils";
 
 import resolveImpl = require("resolve/async");
-import type * as resolve from "resolve";
 import { createRequire } from "module";
+import type * as resolve from "resolve";
 
 const resolveAsync = promisify<string, resolve.AsyncOpts, string | undefined>(
 	resolveImpl,


### PR DESCRIPTION
## Summary

This PR attempts to fix recently reported issues regarding the Biome VS Code extension.

Instead of relying on the `node_modules/.bin` folder and a shell to run the biome CLI, this PR leverages Node's `createRequire` function to create a module resolver scoped to the `@biomejs/biome` npm package. This allows us to resolve `@biomejs/cli-*-*` packages reliably across package managers.

I'm hoping this will fix:

1. Spawn issues
2. Resolution when using pnpm

Related issues: https://github.com/biomejs/biome/issues/332, https://github.com/biomejs/biome/issues/293

## Test Plan

### NPM
- [x] npm on Linux
- [x] npm on macOS
- [x] npm on Windows

### PNPM
- [x] pnpm on Linux
- [x] pnpm on macOS
- [x] pnpm on Windows

### Yarn 3
- [x] yarn on Linux
- [x] yarn on macOS
- [x] yarn on Windows

### Bun
- [x] bun on Linux
- [x] bun on macOS
- [x] ~bun on Windows~ (not applicable)