### PR TITLE
ci(release_lsp): remove unknown job dependency

### DIFF
--- a/.github/workflows/release_lsp.yml
+++ b/.github/workflows/release_lsp.yml
@@ -276,7 +276,7 @@ jobs:
   build-intellij:
     name: Build Intellij LSP
     runs-on: ubuntu-latest
-    needs: [check, test-ui-intellij]
+    needs: [check]
     env:
       version: ${{ needs.check.outputs.intellij_version }}
       prerelease: ${{ needs.check.outputs.prerelease }}


### PR DESCRIPTION
The `test-ui-intellij` job does not exist and makes the workflow fail because it appears in the `needs` of the `build-intellij` job.
