### PR TITLE
feat(organize_imports): support `bun:`, `#`, absolute imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Import sorting is safe to apply now, and it will be applied when running `check --apply` instead of `check --apply-unsafe`.
 
+- Import sorting now handles Bun imports `bun:<name>`, absolute path imports `/<path>`, and [Node's subpath imports `#<name>`](https://nodejs.org/api/packages.html#subpath-imports). See [our documentation](https://biomejs.dev/analyzer/) for more details. Contributed by @Conaclos
+
 ### CLI
 
 #### Bug fixes

--- a/crates/biome_js_analyze/tests/specs/correctness/organizeImports/groups.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/organizeImports/groups.js
@@ -6,3 +6,6 @@ import assert from "node:assert";
 import aunt from "../aunt";
 import { VERSION } from "https://deno.land/std/version.ts";
 import { mock, test } from "node:test";
+import { expect } from "bun:test";
+import { internal } from "#internal";
+import { secret } from "/absolute/path";

--- a/crates/biome_js_analyze/tests/specs/correctness/organizeImports/groups.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/organizeImports/groups.js.snap
@@ -12,25 +12,35 @@ import assert from "node:assert";
 import aunt from "../aunt";
 import { VERSION } from "https://deno.land/std/version.ts";
 import { mock, test } from "node:test";
-
+import { expect } from "bun:test";
+import { internal } from "#internal";
+import { secret } from "/absolute/path";
 ```
 
 # Actions
 ```diff
-@@ -1,8 +1,8 @@
+@@ -1,11 +1,11 @@
+-import uncle from "../uncle";
+-import sibling from "./sibling";
++import { expect } from "bun:test";
 +import assert from "node:assert";
 +import { mock, test } from "node:test";
-+import express from "npm:express";
-+import { VERSION } from "https://deno.land/std/version.ts";
-+import aunt from "../aunt";
- import uncle from "../uncle";
- import sibling from "./sibling";
--import express from "npm:express";
- import imageUrl from "url:./image.png";
+ import express from "npm:express";
+-import imageUrl from "url:./image.png";
 -import assert from "node:assert";
 -import aunt from "../aunt";
--import { VERSION } from "https://deno.land/std/version.ts";
+ import { VERSION } from "https://deno.land/std/version.ts";
 -import { mock, test } from "node:test";
+-import { expect } from "bun:test";
++import { secret } from "/absolute/path";
+ import { internal } from "#internal";
+-import { secret } from "/absolute/path";
+\ No newline at end of file
++import aunt from "../aunt";
++import uncle from "../uncle";
++import sibling from "./sibling";
++import imageUrl from "url:./image.png";
+\ No newline at end of file
 
 ```
 

--- a/website/src/content/docs/analyzer/index.mdx
+++ b/website/src/content/docs/analyzer/index.mdx
@@ -23,12 +23,15 @@ This feature is enabled by default but can be opted-in/out via configuration:
 
 Import statements are sorted by "distance". Modules that are "farther" from the user are put on the top, modules "closer" to the user are put on the bottom:
 
-1. built-in Node.js modules that are explicitly imported using the `node:` protocol;
-2. modules imported via `npm:` protocol. This is a valid syntax when writing code run by Deno, for example;
-3. modules imported via URL;
-4. modules imported from libraries;
-5. modules imported via relative imports;
-6. modules that couldn't be identified by the previous criteria;
+1. modules imported via `bun:` protocol. This is applicable when writing code run by Bun;
+2. built-in Node.js modules that are explicitly imported using the `node:` protocol and common Node built-ins such as `assert`;
+3. modules imported via `npm:` protocol. This is applicable when writing code run by Deno;
+4. modules imported via URL;
+5. modules imported from libraries;
+6. modules imported via absolute imports;
+7. modules imported from a name prefixed by `#`. This is applicable when using [Node's subpath imports](https://nodejs.org/api/packages.html#subpath-imports);
+8. modules imported via relative imports;
+9. modules that couldn't be identified by the previous criteria;
 
 For example, given the following code:
 
@@ -41,15 +44,23 @@ import assert from "node:assert";
 import aunt from "../aunt";
 import { VERSION } from "https://deno.land/std/version.ts";
 import { mock, test } from "node:test";
+import { expect } from "bun:test";
+import { internal } from "#internal";
+import { secret } from "/absolute/path";
+import React from "react";
 ```
 
 They will be sorted like this:
 
 ```ts
+ import { expect } from "bun:test";
  import assert from "node:assert";
  import { mock, test } from "node:test";
  import express from "npm:express";
  import { VERSION } from "https://deno.land/std/version.ts";
+ import React from "react";
+ import { secret } from "/absolute/path";
+ import { internal } from "#internal";
  import aunt from "../aunt";
  import uncle from "../uncle";
  import sibling from "./sibling";

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -22,6 +22,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Import sorting is safe to apply now, and it will be applied when running `check --apply` instead of `check --apply-unsafe`.
 
+- Import sorting now handles Bun imports `bun:<name>`, absolute path imports `/<path>`, and [Node's subpath imports `#<name>`](https://nodejs.org/api/packages.html#subpath-imports). See [our documentation](https://biomejs.dev/analyzer/) for more details. Contributed by @Conaclos
+
 ### CLI
 
 #### Bug fixes


### PR DESCRIPTION
## Summary

Fix #449.

I added the following categories:

- `bun:`. Bunjs has recently gained a lot of traction. I think it could be great to handle `bun:` imports.
  I placed `bun:` imports just before `node:`. In this way we have a lexicographic order between `bun`, `node`, and `npm`.
- Absolute imports such as `/path`.
  I placed it just before the URLs.
- [Node's subpath import](https://nodejs.org/api/packages.html#subpath-imports) `#import`
  They are placed just after the libraries and just before the relative imports because they generally redirect to a relative path or a library.

I updated the related website page.

I noticed that we recognize implicitly exported node built-in modules as node modules. This contradicts what the documentation says: `built-in Node.js modules that are explicitly imported using the `node:` protocol;`. @arendjr what the expected behavior?

## Test Plan

Updated tests.
