### PR TITLE
fix(project): change how `extends` should be applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   When `include` and `ignore` are both specified, `ignore` takes **precedence** over `include`
 
 
+### Bug fixes
+
+- Fix [#343](https://github.com/biomejs/biome/issues/343), `extends` was incorrectly applied to the `biome.json` file. Contributed by @ematipico
+
 ### Editors
 
 #### Bug fixes

--- a/crates/biome_cli/tests/cases/config_extends.rs
+++ b/crates/biome_cli/tests/cases/config_extends.rs
@@ -219,3 +219,50 @@ fn extends_resolves_when_using_config_path() {
         result,
     ));
 }
+
+#[test]
+fn applies_extended_values_in_current_config() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let format = Path::new("format.json");
+    fs.insert(
+        format.into(),
+        r#"{ "javascript": { "formatter": { "quoteStyle": "single" } } }"#,
+    );
+
+    let rome_json = Path::new("biome.json");
+    fs.insert(
+        rome_json.into(),
+        r#"{ "extends": ["format.json"], "formatter": { "lineWidth": 20 } }"#,
+    );
+
+    let test_file = Path::new("test.js");
+    fs.insert(
+        test_file.into(),
+        r#"debugger; const a = ["lorem", "ipsum"]; "#,
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                "--write",
+                test_file.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "applies_extended_values_in_current_config",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/applies_extended_values_in_current_config.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/applies_extended_values_in_current_config.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{ "extends": ["format.json"], "formatter": { "lineWidth": 20 } }
+```
+
+## `format.json`
+
+```json
+{ "javascript": { "formatter": { "quoteStyle": "single" } } }
+```
+
+## `test.js`
+
+```js
+debugger;
+const a = [
+	'lorem',
+	'ipsum',
+];
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -87,10 +87,11 @@ Available options:
         --formatter-enabled=<true|false>  Allow to enable or disable the formatter check.
         --linter-enabled=<true|false>  Allow to enable or disable the linter check.
         --organize-imports-enabled=<true|false>  Allow to enable or disable the organize imports.
-        --stdin-file-path=PATH  A file name with its extension to pass when reading from standard in,
-                              e.g. echo 'let a;' | biome check --stdin-file-path=file.js"
+        --stdin-file-path=PATH  Use this option when you want to format code piped from `stdin`, and
+                              print the output to `stdout`.
                               The file doesn't need to exist on disk, what matters is the extension of
-                              the file. Based on the extension, Biome will use the appropriate tool.
+                              the file. Based on the extension, Biome knows how to check the code.
+                              Example: `echo 'let a;' | biome check --stdin-file-path=file.js`
     -h, --help                Prints help information
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -88,10 +88,11 @@ Available options:
                               languages) files. Default to 2.
         --json-formatter-line-width=NUMBER  What's the max width of a line, applied to JSON (and its
                               super languages) files. Defaults to 80.
-        --stdin-file-path=PATH  A file name with its extension to pass when reading from standard in,
-                              e.g. echo 'let a;' | biome format --stdin-file-path=file.js".
+        --stdin-file-path=PATH  Use this option when you want to format code piped from `stdin`, and
+                              print the output to `stdout`.
                               The file doesn't need to exist on disk, what matters is the extension of
-                              the file. Based on the extension, Biome will use the appropriate tool.
+                              the file. Based on the extension, Biome knows how to format the code.
+                              Example: `echo 'let a;' | biome format --stdin-file-path=file.js`
         --write               Writes formatted files to file system.
     -h, --help                Prints help information
 

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -53,10 +53,11 @@ Available positional items:
 Available options:
         --apply               Apply safe fixes, formatting
         --apply-unsafe        Apply safe fixes and unsafe fixes, formatting and import sorting
-        --stdin-file-path=PATH  A file name with its extension to pass when reading from standard in,
-                              e.g. echo 'let a;' | biome lint --stdin-file-path=file.js"
+        --stdin-file-path=PATH  Use this option when you want to format code piped from `stdin`, and
+                              print the output to `stdout`.
                               The file doesn't need to exist on disk, what matters is the extension of
-                              the file. Based on the extension, Biome will use the appropriate tool.
+                              the file. Based on the extension, Biome knows how to lint the code.
+                              Example: `echo 'let a;' | biome lint --stdin-file-path=file.js`
     -h, --help                Prints help information
 
 ```

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_excessive_complexity.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_excessive_complexity.rs
@@ -373,7 +373,7 @@ pub struct ComplexityScore {
 }
 
 /// Options for the rule `noNestedModuleImports`.
-#[derive(Deserialize, Serialize, Debug, Clone, Bpaf)]
+#[derive(Deserialize, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ComplexityOptions {

--- a/crates/biome_js_analyze/src/options.rs
+++ b/crates/biome_js_analyze/src/options.rs
@@ -22,7 +22,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-#[derive(Default, Deserialize, Serialize, Debug, Clone, Bpaf)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, untagged)]
 pub enum PossibleOptions {

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
@@ -195,7 +195,7 @@ impl Default for ReactExtensiveDependenciesOptions {
 }
 
 /// Options for the rule `useExhaustiveDependencies` and `useHookAtTopLevel`
-#[derive(Default, Deserialize, Serialize, Debug, Clone, Bpaf)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct HooksOptions {
@@ -212,7 +212,7 @@ impl FromStr for HooksOptions {
     }
 }
 
-#[derive(Default, Deserialize, Serialize, Debug, Clone, Bpaf)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Hooks {

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/no_restricted_globals.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/no_restricted_globals.rs
@@ -59,7 +59,7 @@ declare_rule! {
 const RESTRICTED_GLOBALS: [&str; 2] = ["event", "error"];
 
 /// Options for the rule `noRestrictedGlobals`.
-#[derive(Default, Deserialize, Serialize, Debug, Clone, Bpaf)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RestrictedGlobalsOptions {

--- a/crates/biome_service/src/configuration/formatter.rs
+++ b/crates/biome_service/src/configuration/formatter.rs
@@ -126,6 +126,15 @@ impl MergeWith<FormatterConfiguration> for FormatterConfiguration {
             self.include = Some(include)
         }
     }
+
+    fn merge_with_if_not_default(&mut self, other: FormatterConfiguration)
+    where
+        FormatterConfiguration: Default,
+    {
+        if other != FormatterConfiguration::default() {
+            self.merge_with(other)
+        }
+    }
 }
 
 impl TryFrom<FormatterConfiguration> for FormatSettings {

--- a/crates/biome_service/src/configuration/javascript/formatter.rs
+++ b/crates/biome_service/src/configuration/javascript/formatter.rs
@@ -124,4 +124,13 @@ impl MergeWith<JavascriptFormatter> for JavascriptFormatter {
             self.line_width = Some(line_width);
         }
     }
+
+    fn merge_with_if_not_default(&mut self, other: JavascriptFormatter)
+    where
+        JavascriptFormatter: Default,
+    {
+        if other != JavascriptFormatter::default() {
+            self.merge_with(other)
+        }
+    }
 }

--- a/crates/biome_service/src/configuration/javascript/mod.rs
+++ b/crates/biome_service/src/configuration/javascript/mod.rs
@@ -42,6 +42,20 @@ impl MergeWith<JavascriptConfiguration> for JavascriptConfiguration {
             formatter.merge_with(other_formatter);
         }
     }
+
+    fn merge_with_if_not_default(&mut self, other: JavascriptConfiguration)
+    where
+        JavascriptConfiguration: Default,
+    {
+        if let Some(other_formatter) = other.formatter {
+            if other_formatter != JavascriptFormatter::default() {
+                let formatter = self
+                    .formatter
+                    .get_or_insert_with(JavascriptFormatter::default);
+                formatter.merge_with(other_formatter);
+            }
+        }
+    }
 }
 
 impl MergeWith<Option<JavascriptFormatter>> for JavascriptConfiguration {
@@ -51,6 +65,20 @@ impl MergeWith<Option<JavascriptFormatter>> for JavascriptConfiguration {
                 .formatter
                 .get_or_insert_with(JavascriptFormatter::default);
             formatter.merge_with(other_formatter);
+        }
+    }
+
+    fn merge_with_if_not_default(&mut self, other: Option<JavascriptFormatter>)
+    where
+        Option<JavascriptFormatter>: Default,
+    {
+        if let Some(other_formatter) = other {
+            if other_formatter != JavascriptFormatter::default() {
+                let formatter = self
+                    .formatter
+                    .get_or_insert_with(JavascriptFormatter::default);
+                formatter.merge_with(other_formatter);
+            }
         }
     }
 }
@@ -94,6 +122,20 @@ impl MergeWith<JavascriptParser> for JavascriptParser {
         if let Some(unsafe_parameter_decorators_enabled) = other.unsafe_parameter_decorators_enabled
         {
             self.unsafe_parameter_decorators_enabled = Some(unsafe_parameter_decorators_enabled);
+        }
+    }
+
+    fn merge_with_if_not_default(&mut self, other: JavascriptParser)
+    where
+        JavascriptParser: Default,
+    {
+        if other != JavascriptParser::default() {
+            if let Some(unsafe_parameter_decorators_enabled) =
+                other.unsafe_parameter_decorators_enabled
+            {
+                self.unsafe_parameter_decorators_enabled =
+                    Some(unsafe_parameter_decorators_enabled);
+            }
         }
     }
 }

--- a/crates/biome_service/src/configuration/json.rs
+++ b/crates/biome_service/src/configuration/json.rs
@@ -35,6 +35,15 @@ impl MergeWith<JsonConfiguration> for JsonConfiguration {
             formatter.merge_with(other_formatter);
         }
     }
+
+    fn merge_with_if_not_default(&mut self, other: JsonConfiguration)
+    where
+        JsonConfiguration: Default,
+    {
+        if other != JsonConfiguration::default() {
+            self.merge_with(other)
+        }
+    }
 }
 
 /// Options that changes how the JSON parser behaves
@@ -64,6 +73,15 @@ impl MergeWith<JsonParser> for JsonParser {
         }
         if let Some(allow_trailing_commas) = other.allow_trailing_commas {
             self.allow_trailing_commas = Some(allow_trailing_commas);
+        }
+    }
+
+    fn merge_with_if_not_default(&mut self, other: JsonParser)
+    where
+        JsonParser: Default,
+    {
+        if other != JsonParser::default() {
+            self.merge_with(other)
         }
     }
 }
@@ -127,6 +145,15 @@ impl MergeWith<JsonFormatter> for JsonFormatter {
             self.line_width = Some(line_width);
         }
     }
+
+    fn merge_with_if_not_default(&mut self, other: JsonFormatter)
+    where
+        JsonFormatter: Default,
+    {
+        if other != JsonFormatter::default() {
+            self.merge_with(other)
+        }
+    }
 }
 
 impl MergeWith<Option<JsonFormatter>> for JsonConfiguration {
@@ -134,6 +161,18 @@ impl MergeWith<Option<JsonFormatter>> for JsonConfiguration {
         if let Some(other_formatter) = other {
             let formatter = self.formatter.get_or_insert_with(JsonFormatter::default);
             formatter.merge_with(other_formatter);
+        }
+    }
+
+    fn merge_with_if_not_default(&mut self, other: Option<JsonFormatter>)
+    where
+        Option<JsonFormatter>: Default,
+    {
+        if let Some(other_formatter) = other {
+            if other_formatter != JsonFormatter::default() {
+                let formatter = self.formatter.get_or_insert_with(JsonFormatter::default);
+                formatter.merge_with(other_formatter);
+            }
         }
     }
 }

--- a/crates/biome_service/src/configuration/linter/mod.rs
+++ b/crates/biome_service/src/configuration/linter/mod.rs
@@ -15,7 +15,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-#[derive(Deserialize, Serialize, Debug, Clone, Bpaf)]
+#[derive(Deserialize, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct LinterConfiguration {
@@ -46,6 +46,15 @@ impl MergeWith<LinterConfiguration> for LinterConfiguration {
     fn merge_with(&mut self, other: LinterConfiguration) {
         if let Some(enabled) = other.enabled {
             self.enabled = Some(enabled);
+        }
+    }
+
+    fn merge_with_if_not_default(&mut self, other: LinterConfiguration)
+    where
+        LinterConfiguration: Default,
+    {
+        if other != LinterConfiguration::default() {
+            self.merge_with(other)
         }
     }
 }
@@ -121,7 +130,7 @@ impl TryFrom<LinterConfiguration> for LinterSettings {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, Bpaf)]
+#[derive(Deserialize, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, untagged)]
 pub enum RuleConfiguration {
@@ -214,7 +223,7 @@ impl FromStr for RulePlainConfiguration {
     }
 }
 
-#[derive(Default, Deserialize, Serialize, Debug, Clone, Bpaf)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RuleWithOptions {

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -8,7 +8,7 @@ use indexmap::IndexSet;
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-#[derive(Deserialize, Serialize, Debug, Clone, Bpaf)]
+#[derive(Deserialize, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Rules {
@@ -340,7 +340,7 @@ impl Rules {
         enabled_rules.difference(&disabled_rules).copied().collect()
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
@@ -950,7 +950,7 @@ impl A11y {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
@@ -1450,7 +1450,7 @@ impl Complexity {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
@@ -2135,7 +2135,7 @@ impl Correctness {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
@@ -2720,7 +2720,7 @@ impl Nursery {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
@@ -2816,7 +2816,7 @@ impl Performance {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
@@ -2949,7 +2949,7 @@ impl Security {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
@@ -3587,7 +3587,7 @@ impl Style {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]

--- a/crates/biome_service/src/configuration/merge.rs
+++ b/crates/biome_service/src/configuration/merge.rs
@@ -1,5 +1,8 @@
 /// Simple trait to merge two types of the same type
-pub trait MergeWith<T> {
+pub trait MergeWith<T>
+where
+    T: Default + PartialEq,
+{
     /// Merges one type with another
     fn merge_with(&mut self, other: T);
 
@@ -7,6 +10,33 @@ pub trait MergeWith<T> {
     fn merge_with_if(&mut self, other: T, condition: bool) {
         if condition {
             self.merge_with(other)
+        }
+    }
+
+    /// Merges `other` only if its value is not equal to its [Default].
+    fn merge_with_if_not_default(&mut self, other: T)
+    where
+        T: Default;
+}
+
+impl<M> MergeWith<Option<M>> for M
+where
+    M: MergeWith<M> + Default + PartialEq,
+{
+    fn merge_with(&mut self, other: Option<M>) {
+        if let Some(other) = other {
+            self.merge_with(other);
+        }
+    }
+
+    fn merge_with_if_not_default(&mut self, other: Option<M>)
+    where
+        M: Default,
+    {
+        if let Some(other) = other {
+            if other != M::default() {
+                self.merge_with(other);
+            }
         }
     }
 }

--- a/crates/biome_service/src/configuration/organize_imports.rs
+++ b/crates/biome_service/src/configuration/organize_imports.rs
@@ -59,6 +59,15 @@ impl MergeWith<OrganizeImports> for OrganizeImports {
             self.ignore = Some(ignore)
         }
     }
+
+    fn merge_with_if_not_default(&mut self, other: OrganizeImports)
+    where
+        OrganizeImports: Default,
+    {
+        if other != OrganizeImports::default() {
+            self.merge_with(other)
+        }
+    }
 }
 
 impl TryFrom<OrganizeImports> for OrganizeImportsSettings {

--- a/crates/biome_service/src/configuration/vcs.rs
+++ b/crates/biome_service/src/configuration/vcs.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 const GIT_IGNORE_FILE_NAME: &str = ".gitignore";
 
 /// Set of properties to integrate Biome with a VCS software.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, Bpaf)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Bpaf, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct VcsConfiguration {
@@ -62,9 +62,18 @@ impl MergeWith<VcsConfiguration> for VcsConfiguration {
             self.root = Some(root);
         }
     }
+
+    fn merge_with_if_not_default(&mut self, other: VcsConfiguration)
+    where
+        VcsConfiguration: Default,
+    {
+        if other != VcsConfiguration::default() {
+            self.merge_with(other)
+        }
+    }
 }
 
-#[derive(Debug, Default, Deserialize, Clone, Serialize)]
+#[derive(Debug, Default, Deserialize, Clone, Serialize, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub enum VcsClientKind {

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -85,6 +85,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   When `include` and `ignore` are both specified, `ignore` takes **precedence** over `include`
 
 
+### Bug fixes
+
+- Fix [#343](https://github.com/biomejs/biome/issues/343), `extends` was incorrectly applied to the `biome.json` file. Contributed by @ematipico
+
 ### Editors
 
 #### Bug fixes

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -159,7 +159,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
         use bpaf::Bpaf;
         use biome_diagnostics::{Category, Severity};
 
-        #[derive(Deserialize, Serialize, Debug, Clone, Bpaf)]
+        #[derive(Deserialize, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
         #[cfg_attr(feature = "schema", derive(JsonSchema))]
         #[serde(rename_all = "camelCase", deny_unknown_fields)]
         pub struct Rules {
@@ -478,7 +478,7 @@ fn generate_struct(group: &str, rules: &BTreeMap<&'static str, RuleMetadata>) ->
         )
     };
     quote! {
-        #[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf)]
+        #[derive(Deserialize, Default, Serialize, Debug, Clone, Bpaf, Eq, PartialEq)]
         #[cfg_attr(feature = "schema", derive(JsonSchema))]
         #[serde(rename_all = "camelCase", default)]
         /// A list of rules that belong to this group


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/343

When I implemented the feature, I implemented it with an incorrect assumption, where `extends` would override the current configuration.

Instead, `extends` should be computed first, and then on top of the result, we should apply the options of `biome.json` file. 

To achieve this, I had to create a new method called `merge_if_not_default`. This was needed to avoid default values overriding what was computed from the `extends`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added a new test case, similar to the one of the issue that is closed. The snapshot shows that Biome format the code that correct options.

<!-- What demonstrates that your implementation is correct? -->
