### PR TITLE
refactor: use rustc-hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ name = "biome_aria"
 version = "0.1.0"
 dependencies = [
  "biome_aria_metadata",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -190,6 +191,7 @@ dependencies = [
  "libc",
  "mimalloc",
  "rayon",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tikv-jemallocator",
@@ -218,6 +220,7 @@ name = "biome_control_flow"
 version = "0.1.0"
 dependencies = [
  "biome_rowan",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -363,6 +366,7 @@ dependencies = [
  "indexmap",
  "parking_lot",
  "rayon",
+ "rustc-hash",
  "schemars",
  "serde",
  "tracing",
@@ -459,6 +463,7 @@ dependencies = [
  "indexmap",
  "quickcheck",
  "quickcheck_macros",
+ "rustc-hash",
  "schemars",
  "serde",
  "serde_json",
@@ -530,6 +535,7 @@ dependencies = [
  "biome_test_utils",
  "insta",
  "lazy_static",
+ "rustc-hash",
  "tests_macros",
 ]
 
@@ -604,6 +610,7 @@ dependencies = [
  "futures",
  "indexmap",
  "proptest",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tokio",
@@ -697,6 +704,7 @@ dependencies = [
  "dashmap",
  "indexmap",
  "insta",
+ "rustc-hash",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -305,8 +305,8 @@ The first step is to setup a struct to represent the rule configuration.
 ```rust,ignore
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReactExtensiveDependenciesOptions {
-    hooks_config: HashMap<String, ReactHookConfiguration>,
-    stable_config: HashSet<StableReactHookConfiguration>,
+    hooks_config: FxHashMap<String, ReactHookConfiguration>,
+    stable_config: FxHashSet<StableReactHookConfiguration>,
 }
 
 impl Rule for UseExhaustiveDependencies {

--- a/crates/biome_analyze/src/options.rs
+++ b/crates/biome_analyze/src/options.rs
@@ -1,6 +1,7 @@
+use rustc_hash::FxHashMap;
+
 use crate::{Rule, RuleKey};
 use std::any::{Any, TypeId};
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::path::PathBuf;
 
@@ -28,7 +29,7 @@ impl RuleOptions {
 
 /// A convenient new type data structure to insert and get rules
 #[derive(Debug, Default)]
-pub struct AnalyzerRules(HashMap<RuleKey, RuleOptions>);
+pub struct AnalyzerRules(FxHashMap<RuleKey, RuleOptions>);
 
 impl AnalyzerRules {
     /// It tracks the options of a specific rule

--- a/crates/biome_analyze/src/services.rs
+++ b/crates/biome_analyze/src/services.rs
@@ -1,9 +1,7 @@
 use crate::{RuleKey, TextRange};
 use biome_diagnostics::{Diagnostic, LineIndexBuf, Resource, Result, SourceCode};
-use std::{
-    any::{Any, TypeId},
-    collections::HashMap,
-};
+use rustc_hash::FxHashMap;
+use std::any::{Any, TypeId};
 
 #[derive(Debug, Diagnostic)]
 #[diagnostic(category = "internalError/io", tags(INTERNAL))]
@@ -43,7 +41,7 @@ pub trait FromServices: Sized {
 
 #[derive(Debug, Default)]
 pub struct ServiceBag {
-    services: HashMap<TypeId, Box<dyn Any>>,
+    services: FxHashMap<TypeId, Box<dyn Any>>,
 }
 
 impl ServiceBag {

--- a/crates/biome_aria/Cargo.toml
+++ b/crates/biome_aria/Cargo.toml
@@ -14,3 +14,4 @@ version              = "0.1.0"
 
 [dependencies]
 biome_aria_metadata = { workspace = true }
+rustc-hash          = { workspace = true }

--- a/crates/biome_aria/src/roles.rs
+++ b/crates/biome_aria/src/roles.rs
@@ -1,6 +1,6 @@
 use crate::{define_role, is_aria_property_valid};
 use biome_aria_metadata::AriaPropertiesEnum;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::fmt::Debug;
 use std::slice::Iter;
 use std::str::FromStr;
@@ -892,7 +892,7 @@ impl<'a> AriaRoles {
         &self,
         element: &str,
         // To generate `attributes`, you can use `biome_js_analyze::aria_services::AriaServices::extract_defined_attributes`
-        attributes: &HashMap<String, Vec<String>>,
+        attributes: &FxHashMap<String, Vec<String>>,
     ) -> Option<&'static dyn AriaRoleDefinition> {
         let result = match element {
             "article" => &ArticleRole as &dyn AriaRoleDefinition,
@@ -1023,7 +1023,7 @@ impl<'a> AriaRoles {
     pub fn is_not_interactive_element(
         &self,
         element_name: &str,
-        attributes: Option<HashMap<String, Vec<String>>>,
+        attributes: Option<FxHashMap<String, Vec<String>>>,
     ) -> bool {
         // <header> elements do not technically have semantics, unless the
         // element is a direct descendant of <body>, and this crate cannot
@@ -1125,7 +1125,7 @@ pub struct AriaRoles;
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
+    use rustc_hash::FxHashMap;
 
     use crate::AriaRoles;
 
@@ -1134,7 +1134,7 @@ mod test {
         let aria_roles = AriaRoles {};
         assert!(!aria_roles.is_not_interactive_element("header", None));
         assert!(!aria_roles.is_not_interactive_element("input", {
-            let mut attributes = HashMap::new();
+            let mut attributes = FxHashMap::default();
             attributes.insert("type".to_string(), vec!["search".to_string()]);
             Some(attributes)
         }));
@@ -1151,7 +1151,7 @@ mod test {
         assert!(aria_roles.is_not_interactive_element("h6", None));
         assert!(aria_roles.is_not_interactive_element("body", None));
         assert!(aria_roles.is_not_interactive_element("input", {
-            let mut attributes = HashMap::new();
+            let mut attributes = FxHashMap::default();
             attributes.insert("type".to_string(), vec!["hidden".to_string()]);
             Some(attributes)
         }));
@@ -1163,12 +1163,12 @@ mod test {
 
         // No attributes
         let implicit_role = aria_roles
-            .get_implicit_role("button", &HashMap::new())
+            .get_implicit_role("button", &FxHashMap::default())
             .unwrap();
         assert_eq!(implicit_role.type_name(), "biome_aria::roles::ButtonRole");
 
         // <input type="search">
-        let mut attributes = HashMap::new();
+        let mut attributes = FxHashMap::default();
         attributes.insert("type".to_string(), vec!["search".to_string()]);
         let implicit_role = aria_roles.get_implicit_role("input", &attributes).unwrap();
         assert_eq!(
@@ -1177,7 +1177,7 @@ mod test {
         );
 
         // <select name="animals" multiple size="4">
-        let mut attributes = HashMap::new();
+        let mut attributes = FxHashMap::default();
         attributes.insert("name".to_string(), vec!["animals".to_string()]);
         attributes.insert("multiple".to_string(), vec![String::new()]);
         attributes.insert("size".to_string(), vec!["4".to_string()]);

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -41,6 +41,7 @@ hdrhistogram         = { version = "7.5.0", default-features = false }
 indexmap             = { workspace = true }
 lazy_static          = { workspace = true }
 rayon                = "1.5.1"
+rustc-hash           = { workspace = true }
 serde                = { workspace = true, features = ["derive"] }
 serde_json           = { workspace = true }
 tokio                = { workspace = true, features = ["io-std", "io-util", "net", "time", "rt", "sync", "rt-multi-thread", "macros"] }

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -24,7 +24,7 @@ use crossbeam::{
     channel::{unbounded, Receiver, Sender},
     select,
 };
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 use std::{
     ffi::OsString,
     io,
@@ -297,7 +297,7 @@ fn process_messages(options: ProcessMessagesOptions) {
         warnings,
     } = options;
 
-    let mut paths: HashSet<String> = HashSet::new();
+    let mut paths: FxHashSet<String> = FxHashSet::default();
     let mut printed_diagnostics: u16 = 0;
     let mut not_printed_diagnostics = 0;
     let mut total_skipped_suggested_fixes = 0;

--- a/crates/biome_cli/src/metrics.rs
+++ b/crates/biome_cli/src/metrics.rs
@@ -1,6 +1,5 @@
 use std::{
     borrow::Cow,
-    collections::HashMap,
     hash::Hash,
     ops::Sub,
     ptr,
@@ -8,6 +7,7 @@ use std::{
 };
 
 use hdrhistogram::Histogram;
+use rustc_hash::FxHashMap;
 use std::sync::{Mutex, RwLock};
 use tracing::{span, subscriber::Interest, Level, Metadata, Subscriber};
 use tracing_subscriber::{
@@ -22,7 +22,7 @@ struct MetricsLayer;
 
 lazy_static::lazy_static! {
     /// Global storage for metrics data
-    static ref METRICS: RwLock<HashMap<CallsiteKey, Mutex<CallsiteEntry>>> = RwLock::default();
+    static ref METRICS: RwLock<FxHashMap<CallsiteKey, Mutex<CallsiteEntry>>> = RwLock::default();
 }
 
 /// Static pointer to the metadata of a callsite, used as a unique identifier

--- a/crates/biome_cli/src/reports/formatter.rs
+++ b/crates/biome_cli/src/reports/formatter.rs
@@ -1,5 +1,5 @@
+use rustc_hash::FxHashMap;
 use serde::Serialize;
-use std::collections::HashMap;
 
 #[derive(Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -8,7 +8,7 @@ pub struct FormatterReport {
     summary: Option<FormatterReportSummary>,
 
     /// The key is the path of the file
-    files: HashMap<String, FormatterReportFileDetail>,
+    files: FxHashMap<String, FormatterReportFileDetail>,
 }
 
 impl FormatterReport {

--- a/crates/biome_cli/src/reports/mod.rs
+++ b/crates/biome_cli/src/reports/mod.rs
@@ -4,8 +4,8 @@ use crate::reports::formatter::{FormatterReportFileDetail, FormatterReportSummar
 use biome_diagnostics::{Category, Severity};
 use biome_service::WorkspaceError;
 use formatter::FormatterReport;
+use rustc_hash::FxHashMap;
 use serde::Serialize;
-use std::collections::HashMap;
 
 #[derive(Debug, Default, Serialize)]
 pub struct Report {
@@ -15,7 +15,7 @@ pub struct Report {
     /// Diagnostics tracked during a generic traversal
     ///
     /// The key is the path of the file where the diagnostics occurred
-    diagnostics: HashMap<String, ReportErrorKind>,
+    diagnostics: FxHashMap<String, ReportErrorKind>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/biome_control_flow/Cargo.toml
+++ b/crates/biome_control_flow/Cargo.toml
@@ -14,3 +14,4 @@ version              = "0.1.0"
 
 [dependencies]
 biome_rowan = { workspace = true }
+rustc-hash  = { workspace = true }

--- a/crates/biome_control_flow/src/lib.rs
+++ b/crates/biome_control_flow/src/lib.rs
@@ -1,11 +1,9 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
-use std::{
-    collections::HashMap,
-    fmt::{self, Display, Formatter},
-};
+use std::fmt::{self, Display, Formatter};
 
 use biome_rowan::{Language, SyntaxElement, SyntaxNode};
+use rustc_hash::FxHashMap;
 
 pub mod builder;
 
@@ -180,7 +178,7 @@ impl<L: Language> Display for ControlFlowGraph<L> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         writeln!(fmt, "flowchart TB")?;
 
-        let mut links = HashMap::new();
+        let mut links = FxHashMap::default();
         for (id, block) in self.blocks.iter().enumerate() {
             if fmt.alternate() {
                 writeln!(fmt, "    subgraph block_{id}")?;

--- a/crates/biome_formatter/src/format_element/document.rs
+++ b/crates/biome_formatter/src/format_element/document.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use biome_rowan::TextSize;
 use rustc_hash::FxHashMap;
-use std::collections::HashMap;
 use std::ops::Deref;
 
 /// A formatted document.
@@ -133,7 +132,7 @@ impl std::fmt::Display for Document {
 #[derive(Clone, Default, Debug)]
 struct IrFormatContext {
     /// The interned elements that have been printed to this point
-    printed_interned_elements: HashMap<Interned, usize>,
+    printed_interned_elements: FxHashMap<Interned, usize>,
 }
 
 impl FormatContext for IrFormatContext {

--- a/crates/biome_fs/Cargo.toml
+++ b/crates/biome_fs/Cargo.toml
@@ -19,6 +19,7 @@ crossbeam         = "0.8.2"
 indexmap          = { workspace = true }
 parking_lot       = { version = "0.12.0", features = ["arc_lock"] }
 rayon             = "1.7.0"
+rustc-hash        = { workspace = true }
 schemars          = { workspace = true, optional = true }
 serde             = { workspace = true }
 tracing           = { workspace = true }

--- a/crates/biome_fs/src/fs/memory.rs
+++ b/crates/biome_fs/src/fs/memory.rs
@@ -1,5 +1,5 @@
-use std::collections::hash_map::Entry;
-use std::collections::{hash_map::IntoIter, HashMap};
+use rustc_hash::FxHashMap;
+use std::collections::hash_map::{Entry, IntoIter};
 use std::io;
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
@@ -16,8 +16,8 @@ use super::{BoxedTraversal, ErrorKind, File, FileSystemDiagnostic};
 
 /// Fully in-memory file system, stores the content of all known files in a hashmap
 pub struct MemoryFileSystem {
-    files: AssertUnwindSafe<RwLock<HashMap<PathBuf, FileEntry>>>,
-    errors: HashMap<PathBuf, ErrorEntry>,
+    files: AssertUnwindSafe<RwLock<FxHashMap<PathBuf, FileEntry>>>,
+    errors: FxHashMap<PathBuf, ErrorEntry>,
     allow_write: bool,
 }
 

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_nonoctal_decimal_escape.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_nonoctal_decimal_escape.rs
@@ -7,7 +7,8 @@ use biome_diagnostics::Applicability;
 use biome_js_factory::make;
 use biome_js_syntax::JsStringLiteralExpression;
 use biome_rowan::{AstNode, BatchMutationExt, TextRange};
-use std::{collections::HashSet, ops::Range};
+use rustc_hash::FxHashSet;
+use std::ops::Range;
 
 declare_rule! {
     /// Disallow `\8` and `\9` escape sequences in string literals.
@@ -166,7 +167,7 @@ impl Rule for NoNonoctalDecimalEscape {
             }
         }
 
-        let mut seen = HashSet::new();
+        let mut seen = FxHashSet::default();
         signals.retain(|rule_state| seen.insert(rule_state.diagnostics_text_range));
         signals
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_class_members.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_class_members.rs
@@ -1,5 +1,3 @@
-use std::collections::{HashMap, HashSet};
-
 use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 use biome_js_syntax::{
     AnyJsClassMemberName, JsClassMemberList, JsGetterClassMember, JsMethodClassMember,
@@ -7,6 +5,7 @@ use biome_js_syntax::{
 };
 use biome_rowan::{declare_node_union, AstNode};
 use biome_rowan::{AstNodeList, TokenText};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 declare_rule! {
     /// Disallow duplicate class members.
@@ -178,7 +177,8 @@ impl Rule for NoDuplicateClassMembers {
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let mut defined_members: HashMap<MemberState, HashSet<MemberType>> = HashMap::new();
+        let mut defined_members: FxHashMap<MemberState, FxHashSet<MemberType>> =
+            FxHashMap::default();
 
         let node = ctx.query();
         node.into_iter()
@@ -201,7 +201,10 @@ impl Rule for NoDuplicateClassMembers {
                         stored_members.insert(member_type);
                     }
                 } else {
-                    defined_members.insert(member_state, HashSet::from([member_type]));
+                    defined_members
+                        .entry(member_state)
+                        .or_default()
+                        .insert(member_type);
                 }
 
                 None

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_jsx_props.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_jsx_props.rs
@@ -4,7 +4,7 @@ use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::{AnyJsxAttribute, JsxAttribute};
 use biome_rowan::AstNode;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 declare_rule! {
     /// Prevents JSX properties to be assigned multiple times.
@@ -40,13 +40,13 @@ declare_rule! {
 impl Rule for NoDuplicateJsxProps {
     type Query = Ast<AnyJsxElement>;
     type State = (String, Vec<JsxAttribute>);
-    type Signals = HashMap<String, Vec<JsxAttribute>>;
+    type Signals = FxHashMap<String, Vec<JsxAttribute>>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
 
-        let mut defined_attributes: HashMap<String, Vec<JsxAttribute>> = HashMap::new();
+        let mut defined_attributes: FxHashMap<String, Vec<JsxAttribute>> = FxHashMap::default();
         for attribute in node.attributes() {
             if let AnyJsxAttribute::JsxAttribute(attr) = attribute {
                 if let Ok(name) = attr.name() {

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_object_keys.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_object_keys.rs
@@ -9,8 +9,8 @@ use biome_js_syntax::{
     JsMethodObjectMember, JsPropertyObjectMember, JsShorthandPropertyObjectMember, TextRange,
 };
 use biome_rowan::{AstNode, BatchMutationExt, TokenText};
+use rustc_hash::FxHashMap;
 use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::fmt::Display;
 
 use crate::JsRuleAction;
@@ -217,7 +217,7 @@ impl Rule for NoDuplicateObjectKeys {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
 
-        let mut defined_properties: HashMap<TokenText, DefinedProperty> = HashMap::new();
+        let mut defined_properties = FxHashMap::default();
         let mut signals: Self::Signals = Vec::new();
 
         for member_definition in node

--- a/crates/biome_js_analyze/src/aria_services.rs
+++ b/crates/biome_js_analyze/src/aria_services.rs
@@ -6,7 +6,7 @@ use biome_aria::iso::{countries, is_valid_country, is_valid_language, languages}
 use biome_aria::{AriaProperties, AriaRoles};
 use biome_js_syntax::{AnyJsRoot, AnyJsxAttribute, JsLanguage, JsSyntaxNode, JsxAttributeList};
 use biome_rowan::AstNode;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -41,14 +41,14 @@ impl AriaServices {
     }
 
     /// Parses a [JsxAttributeList] and extracts the names and values of each [JsxAttribute],
-    /// returning them as a [HashMap]. Attributes with no specified value are given a value of "true".
+    /// returning them as a [FxHashMap]. Attributes with no specified value are given a value of "true".
     /// If an attribute has multiple values, each value is stored as a separate item in the
-    /// [HashMap] under the same attribute name. Returns [None] if the parsing fails.
+    /// [FxHashMap] under the same attribute name. Returns [None] if the parsing fails.
     pub fn extract_attributes(
         &self,
         attribute_list: &JsxAttributeList,
-    ) -> Option<HashMap<String, Vec<String>>> {
-        let mut defined_attributes: HashMap<String, Vec<String>> = HashMap::new();
+    ) -> Option<FxHashMap<String, Vec<String>>> {
+        let mut defined_attributes: FxHashMap<String, Vec<String>> = FxHashMap::default();
         for attribute in attribute_list {
             if let AnyJsxAttribute::JsxAttribute(attr) = attribute {
                 let name = attr.name().ok()?.syntax().text_trimmed().to_string();

--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -1,5 +1,4 @@
 use crate::react::{is_react_call_api, ReactLibrary};
-use std::collections::{HashMap, HashSet};
 
 use biome_js_semantic::{Capture, Closure, ClosureExtensions, SemanticModel};
 use biome_js_syntax::{
@@ -9,6 +8,7 @@ use biome_js_syntax::{
     TextRange,
 };
 use biome_rowan::AstNode;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 
 /// Return result of [react_hook_with_dependency].
@@ -97,7 +97,7 @@ impl From<(usize, usize)> for ReactHookConfiguration {
 
 pub(crate) fn react_hook_configuration<'a>(
     call: &JsCallExpression,
-    hooks: &'a HashMap<String, ReactHookConfiguration>,
+    hooks: &'a FxHashMap<String, ReactHookConfiguration>,
 ) -> Option<&'a ReactHookConfiguration> {
     let name = call
         .callee()
@@ -137,7 +137,7 @@ const HOOKS_WITH_DEPS_API: [&str; 6] = [
 /// of all function that are considered hooks. See [ReactHookConfiguration].
 pub(crate) fn react_hook_with_dependency(
     call: &JsCallExpression,
-    hooks: &HashMap<String, ReactHookConfiguration>,
+    hooks: &FxHashMap<String, ReactHookConfiguration>,
     model: &SemanticModel,
 ) -> Option<ReactCallWithDependencyResult> {
     let expression = call.callee().ok()?;
@@ -209,7 +209,7 @@ impl StableReactHookConfiguration {
 /// ```
 pub fn is_binding_react_stable(
     binding: &AnyJsIdentifierBinding,
-    stable_config: &HashSet<StableReactHookConfiguration>,
+    stable_config: &FxHashSet<StableReactHookConfiguration>,
 ) -> bool {
     fn array_binding_declarator_index(
         binding: &AnyJsIdentifierBinding,
@@ -277,7 +277,7 @@ mod test {
             .unwrap();
         let set_name = AnyJsIdentifierBinding::cast(node).unwrap();
 
-        let config = HashSet::from_iter([
+        let config = FxHashSet::from_iter([
             StableReactHookConfiguration::new("useRef", None),
             StableReactHookConfiguration::new("useState", Some(1)),
         ]);

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
@@ -12,8 +12,9 @@ use biome_js_syntax::{
 use biome_json_syntax::{AnyJsonValue, JsonLanguage, JsonSyntaxNode};
 use biome_rowan::{AstNode, AstSeparatedList, SyntaxNode, SyntaxNodeCast};
 use bpaf::Bpaf;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
 #[cfg(feature = "schemars")]
@@ -165,13 +166,13 @@ declare_rule! {
 
 #[derive(Debug, Clone)]
 pub struct ReactExtensiveDependenciesOptions {
-    pub(crate) hooks_config: HashMap<String, ReactHookConfiguration>,
-    pub(crate) stable_config: HashSet<StableReactHookConfiguration>,
+    pub(crate) hooks_config: FxHashMap<String, ReactHookConfiguration>,
+    pub(crate) stable_config: FxHashSet<StableReactHookConfiguration>,
 }
 
 impl Default for ReactExtensiveDependenciesOptions {
     fn default() -> Self {
-        let hooks_config = HashMap::from_iter([
+        let hooks_config = FxHashMap::from_iter([
             ("useEffect".to_string(), (0, 1).into()),
             ("useLayoutEffect".to_string(), (0, 1).into()),
             ("useInsertionEffect".to_string(), (0, 1).into()),
@@ -201,7 +202,7 @@ impl Default for ReactExtensiveDependenciesOptions {
             ),
         ]);
 
-        let stable_config: HashSet<StableReactHookConfiguration> = HashSet::from_iter([
+        let stable_config = FxHashSet::from_iter([
             StableReactHookConfiguration::new("useState", Some(1)),
             StableReactHookConfiguration::new("useReducer", Some(1)),
             StableReactHookConfiguration::new("useTransition", Some(1)),

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_redeclare.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_redeclare.rs
@@ -8,7 +8,7 @@ use biome_js_syntax::{
     AnyTsType, TextRange, TsIndexSignatureParameter, TsIndexSignatureTypeMember, TsTypeMemberList,
 };
 use biome_rowan::AstNode;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 declare_rule! {
     /// Disallow variable, function, class, and type redeclarations in the same scope.
@@ -114,7 +114,7 @@ impl Rule for NoRedeclare {
 }
 
 fn check_redeclarations_in_single_scope(scope: &Scope, redeclarations: &mut Vec<Redeclaration>) {
-    let mut declarations = HashMap::<String, (TextRange, AnyJsBindingDeclaration)>::default();
+    let mut declarations = FxHashMap::<String, (TextRange, AnyJsBindingDeclaration)>::default();
     for binding in scope.bindings() {
         let id_binding = binding.tree();
 

--- a/crates/biome_js_analyze/src/syntax/correctness/no_duplicate_private_class_members.rs
+++ b/crates/biome_js_analyze/src/syntax/correctness/no_duplicate_private_class_members.rs
@@ -1,10 +1,9 @@
-use std::collections::{HashMap, HashSet};
-
 use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 
 use biome_diagnostics::category;
 use biome_js_syntax::{AnyJsClassMember, JsClassMemberList, TextRange};
 use biome_rowan::AstNode;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 declare_rule! {
     /// Catch a `SyntaxError` when defining duplicate private class members.
@@ -37,7 +36,7 @@ impl Rule for NoDuplicatePrivateClassMembers {
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let mut defined_members: HashMap<String, HashSet<MemberType>> = HashMap::new();
+        let mut defined_members: FxHashMap<String, FxHashSet<MemberType>> = FxHashMap::default();
 
         let node = ctx.query();
         node.into_iter()
@@ -65,7 +64,10 @@ impl Rule for NoDuplicatePrivateClassMembers {
                         stored_members.insert(member_type);
                     }
                 } else {
-                    defined_members.insert(member_name, HashSet::from([member_type]));
+                    defined_members
+                        .entry(member_name)
+                        .or_default()
+                        .insert(member_type);
                 }
 
                 None

--- a/crates/biome_js_parser/Cargo.toml
+++ b/crates/biome_js_parser/Cargo.toml
@@ -22,6 +22,7 @@ bitflags               = { workspace = true }
 cfg-if                 = "1.0.0"
 drop_bomb              = "0.1.5"
 indexmap               = { workspace = true }
+rustc-hash             = { workspace = true }
 schemars               = { workspace = true, optional = true }
 serde                  = { workspace = true, features = ["derive"] }
 serde_json             = { workspace = true }

--- a/crates/biome_js_parser/src/state.rs
+++ b/crates/biome_js_parser/src/state.rs
@@ -3,7 +3,7 @@ use biome_js_syntax::JsFileSource;
 use biome_rowan::{TextRange, TextSize};
 use bitflags::bitflags;
 use indexmap::IndexMap;
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 use std::ops::{Deref, DerefMut, Range};
 
 type LabelSet = IndexMap<String, LabelledItem>;
@@ -86,7 +86,7 @@ pub(crate) struct ParserState {
 
     /// Stores the token positions of all syntax that looks like an arrow expressions but aren't one.
     /// Optimization to reduce the back-tracking required when parsing parenthesized and arrow function expressions.
-    pub(crate) not_parenthesized_arrow: HashSet<TextSize>,
+    pub(crate) not_parenthesized_arrow: FxHashSet<TextSize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/biome_js_parser/src/syntax/module.rs
+++ b/crates/biome_js_parser/src/syntax/module.rs
@@ -36,7 +36,7 @@ use biome_parser::diagnostic::{expected_any, expected_node};
 use biome_parser::parse_lists::ParseSeparatedList;
 use biome_parser::parse_recovery::RecoveryResult;
 use biome_parser::ParserProgress;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use super::auxiliary::{is_nth_at_declaration_clause, parse_declaration_clause};
 
@@ -601,7 +601,7 @@ fn parse_import_assertion(p: &mut JsParser) -> ParsedSyntax {
 
 #[derive(Default)]
 struct ImportAssertionList {
-    assertion_keys: HashMap<String, TextRange>,
+    assertion_keys: FxHashMap<String, TextRange>,
 }
 
 impl ParseSeparatedList for ImportAssertionList {
@@ -641,7 +641,7 @@ impl ParseSeparatedList for ImportAssertionList {
 
 fn parse_import_assertion_entry(
     p: &mut JsParser,
-    seen_assertion_keys: &mut HashMap<String, TextRange>,
+    seen_assertion_keys: &mut FxHashMap<String, TextRange>,
 ) -> ParsedSyntax {
     let m = p.start();
     let key_range = p.cur_range();

--- a/crates/biome_js_semantic/src/semantic_model.rs
+++ b/crates/biome_js_semantic/src/semantic_model.rs
@@ -22,7 +22,7 @@ pub use closure::*;
 use rust_lapper::{Interval, Lapper};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::{
-    collections::{BTreeSet, HashSet, VecDeque},
+    collections::{BTreeSet, VecDeque},
     iter::FusedIterator,
     rc::Rc,
 };
@@ -41,7 +41,7 @@ pub use scope::*;
 #[derive(Default)]
 pub struct SemanticModelOptions {
     /// All the allowed globals names
-    pub globals: HashSet<String>,
+    pub globals: FxHashSet<String>,
 }
 
 /// Build the complete [SemanticModel] of a parsed file.

--- a/crates/biome_js_semantic/src/tests/assertions.rs
+++ b/crates/biome_js_semantic/src/tests/assertions.rs
@@ -8,7 +8,7 @@ use biome_js_parser::JsParserOptions;
 use biome_js_syntax::{AnyJsRoot, JsFileSource, JsSyntaxToken, TextRange, TextSize, WalkEvent};
 use biome_rowan::{AstNode, NodeOrToken};
 use rustc_hash::FxHashMap;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 /// This method helps testing scope resolution. It does this
 /// iterating [SemanticEventIterator] and storing where each scope start and end. Later it iterates
@@ -123,7 +123,7 @@ pub fn assert(code: &str, test_name: &str) {
 
     // Extract semantic events and index by range
 
-    let mut events_by_pos: HashMap<TextSize, Vec<SemanticEvent>> = HashMap::new();
+    let mut events_by_pos: FxHashMap<TextSize, Vec<SemanticEvent>> = FxHashMap::default();
     let mut scope_start_by_id: FxHashMap<usize, TextSize> = FxHashMap::default();
     for event in semantic_events(r.syntax()) {
         let pos = if let SemanticEvent::ScopeEnded {
@@ -446,7 +446,7 @@ impl SemanticAssertions {
         &self,
         code: &str,
         test_name: &str,
-        events_by_pos: HashMap<TextSize, Vec<SemanticEvent>>,
+        events_by_pos: FxHashMap<TextSize, Vec<SemanticEvent>>,
         scope_start: FxHashMap<usize, TextSize>,
     ) {
         // Check every declaration assertion is ok
@@ -824,7 +824,7 @@ fn show_unmatched_assertion(
 fn show_all_events<F>(
     test_name: &str,
     code: &str,
-    events_by_pos: HashMap<TextSize, Vec<SemanticEvent>>,
+    events_by_pos: FxHashMap<TextSize, Vec<SemanticEvent>>,
     f: F,
 ) where
     F: Fn(&SemanticEvent) -> bool,

--- a/crates/biome_json_analyze/Cargo.toml
+++ b/crates/biome_json_analyze/Cargo.toml
@@ -19,6 +19,7 @@ biome_diagnostics = { workspace = true }
 biome_json_syntax = { workspace = true }
 biome_rowan       = { workspace = true }
 lazy_static       = { workspace = true }
+rustc-hash        = { workspace = true }
 
 [dev-dependencies]
 biome_json_factory = { path = "../biome_json_factory" }

--- a/crates/biome_json_analyze/src/analyzers/nursery/no_duplicate_json_keys.rs
+++ b/crates/biome_json_analyze/src/analyzers/nursery/no_duplicate_json_keys.rs
@@ -2,7 +2,7 @@ use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnosti
 use biome_console::markup;
 use biome_json_syntax::{JsonMemberName, JsonObjectValue, TextRange};
 use biome_rowan::{AstNode, AstSeparatedList};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 declare_rule! {
     /// Disallow two keys with the same name inside a JSON object.
@@ -48,7 +48,7 @@ impl Rule for NoDuplicateJsonKeys {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let query = ctx.query();
-        let mut names = HashMap::<String, Vec<TextRange>>::new();
+        let mut names = FxHashMap::<String, Vec<TextRange>>::default();
         let mut original_key = None;
         for (index, member) in query.json_member_list().iter().flatten().enumerate() {
             let name = member.name().ok()?;

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -26,6 +26,7 @@ biome_service      = { workspace = true }
 biome_text_edit    = { workspace = true }
 futures            = "0.3"
 indexmap           = { workspace = true }
+rustc-hash         = { workspace = true }
 serde              = { workspace = true, features = ["derive"] }
 serde_json         = { workspace = true }
 tokio              = { workspace = true, features = ["rt", "io-std"] }

--- a/crates/biome_lsp/src/converters/line_index.rs
+++ b/crates/biome_lsp/src/converters/line_index.rs
@@ -1,23 +1,23 @@
 //! `LineIndex` maps flat `TextSize` offsets into `(Line, Column)`
 //! representation.
 
-use std::collections::HashMap;
 use std::mem;
 
 use crate::converters::{LineCol, WideChar, WideEncoding, WideLineCol};
 use biome_rowan::TextSize;
+use rustc_hash::FxHashMap;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct LineIndex {
     /// Offset the beginning of each line, zero-based.
     pub(crate) newlines: Vec<TextSize>,
     /// List of non-ASCII characters on each line.
-    pub(crate) line_wide_chars: HashMap<u32, Vec<WideChar>>,
+    pub(crate) line_wide_chars: FxHashMap<u32, Vec<WideChar>>,
 }
 
 impl LineIndex {
     pub fn new(text: &str) -> LineIndex {
-        let mut line_wide_chars = HashMap::default();
+        let mut line_wide_chars = FxHashMap::default();
         let mut wide_chars = Vec::new();
 
         let mut newlines = vec![TextSize::from(0)];

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -13,8 +13,8 @@ use biome_service::workspace::{RageEntry, RageParams, RageResult};
 use biome_service::{workspace, Workspace};
 use futures::future::ready;
 use futures::FutureExt;
+use rustc_hash::FxHashMap;
 use serde_json::json;
-use std::collections::HashMap;
 use std::panic::RefUnwindSafe;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -434,7 +434,7 @@ impl Drop for LSPServer {
 }
 
 /// Map of active sessions connected to a [ServerFactory].
-type Sessions = Arc<Mutex<HashMap<SessionKey, SessionHandle>>>;
+type Sessions = Arc<Mutex<FxHashMap<SessionKey, SessionHandle>>>;
 
 /// Helper method for wrapping a [Workspace] method in a `custom_method` for
 /// the [LSPServer]

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -15,8 +15,8 @@ use biome_service::{load_config, ConfigurationBasePath, Workspace};
 use biome_service::{DynRef, WorkspaceError};
 use futures::stream::futures_unordered::FuturesUnordered;
 use futures::StreamExt;
+use rustc_hash::FxHashMap;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
@@ -62,7 +62,7 @@ pub(crate) struct Session {
     /// File system to read files inside the workspace
     pub(crate) fs: DynRef<'static, dyn FileSystem>,
 
-    documents: RwLock<HashMap<lsp_types::Url, Document>>,
+    documents: RwLock<FxHashMap<lsp_types::Url, Document>>,
 
     pub(crate) cancellation: Arc<Notify>,
 }
@@ -104,7 +104,7 @@ pub(crate) type SessionHandle = Arc<Session>;
 /// instance and whether they are enabled or not
 #[derive(Default)]
 pub(crate) struct CapabilitySet {
-    registry: HashMap<&'static str, (&'static str, CapabilityStatus)>,
+    registry: FxHashMap<&'static str, (&'static str, CapabilityStatus)>,
 }
 
 /// Represents whether a capability is enabled or not, optionally holding the

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -37,6 +37,7 @@ biome_text_edit      = { workspace = true }
 bpaf                 = { workspace = true }
 dashmap              = { workspace = true }
 indexmap             = { workspace = true, features = ["serde"] }
+rustc-hash           = { workspace = true }
 schemars             = { workspace = true, features = ["indexmap1"], optional = true }
 serde                = { workspace = true, features = ["derive"] }
 serde_json           = { workspace = true, features = ["raw_value"] }

--- a/crates/biome_service/src/workspace_types.rs
+++ b/crates/biome_service/src/workspace_types.rs
@@ -1,8 +1,9 @@
 //! Utility functions to help with generating bindings for the [Workspace] API
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
 
 use biome_js_syntax::{AnyJsDeclaration, AnyTsTupleTypeElement};
+use rustc_hash::FxHashSet;
 use schemars::{
     gen::{SchemaGenerator, SchemaSettings},
     schema::{InstanceType, RootSchema, Schema, SchemaObject, SingleOrVec},
@@ -21,7 +22,7 @@ use biome_rowan::{AstSeparatedList, TriviaPieceKind};
 #[derive(Default)]
 pub struct ModuleQueue<'a> {
     /// Set of type names that have already been emitted
-    visited: HashSet<&'a str>,
+    visited: FxHashSet<&'a str>,
     /// Queue of type names and definitions that need to be generated
     queue: VecDeque<(&'a str, &'a SchemaObject)>,
 }
@@ -39,7 +40,7 @@ impl<'a> ModuleQueue<'a> {
         self.queue.pop_front()
     }
 
-    pub fn visited(&self) -> &HashSet<&'a str> {
+    pub fn visited(&self) -> &FxHashSet<&'a str> {
         &self.visited
     }
 }


### PR DESCRIPTION
## Summary

Use `FxHashSet` and `FxHasMap` where possible.
This is a basic tip to ensure efficient computation of hashes.

## Test Plan

Ci should pass. No perf regression should be noticed on benchmarks.
