### PR TITLE
reafctor(js_analyze): move  in utils::batch

### DIFF
--- a/crates/biome_js_analyze/src/analyzers/correctness/no_unnecessary_continue.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_unnecessary_continue.rs
@@ -6,7 +6,7 @@ use biome_diagnostics::Applicability;
 use biome_js_syntax::{JsContinueStatement, JsLabeledStatement, JsSyntaxKind, JsSyntaxNode};
 use biome_rowan::{AstNode, BatchMutationExt};
 
-use crate::{utils, JsRuleAction};
+use crate::{utils::batch::JsBatchMutation, JsRuleAction};
 
 declare_rule! {
     /// Avoid using unnecessary `continue`.
@@ -105,7 +105,7 @@ impl Rule for NoUnnecessaryContinue {
     fn action(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {
         let node = ctx.query();
         let mut mutation = ctx.root().begin();
-        utils::remove_statement(&mut mutation, node)?;
+        mutation.remove_statement(node.clone().into());
         Some(JsRuleAction {
             category: ActionCategory::QuickFix,
             applicability: Applicability::MaybeIncorrect,

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_debugger.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_debugger.rs
@@ -6,7 +6,7 @@ use biome_diagnostics::Applicability;
 use biome_js_syntax::JsDebuggerStatement;
 use biome_rowan::{AstNode, BatchMutationExt};
 
-use crate::{utils, JsRuleAction};
+use crate::{utils::batch::JsBatchMutation, JsRuleAction};
 
 declare_rule! {
     /// Disallow the use of `debugger`
@@ -60,7 +60,7 @@ impl Rule for NoDebugger {
         let node = ctx.query();
 
         let mut mutation = ctx.root().begin();
-        utils::remove_statement(&mut mutation, node)?;
+        mutation.remove_statement(node.clone().into());
 
         Some(JsRuleAction {
             category: ActionCategory::QuickFix,

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_object_keys.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_object_keys.rs
@@ -306,7 +306,7 @@ impl Rule for NoDuplicateObjectKeys {
         PropertyConflict(_, member_definition): &Self::State,
     ) -> Option<JsRuleAction> {
         let mut batch = ctx.root().begin();
-        batch.remove_js_object_member(&member_definition.node());
+        batch.remove_js_object_member(member_definition.node());
         Some(JsRuleAction {
             category: biome_analyze::ActionCategory::QuickFix,
             // The property initialization could contain side effects

--- a/crates/biome_js_analyze/src/utils.rs
+++ b/crates/biome_js_analyze/src/utils.rs
@@ -1,9 +1,5 @@
-use biome_js_factory::make;
-use biome_js_syntax::{
-    inner_string_text, AnyJsExpression, AnyJsStatement, JsBinaryExpression, JsLanguage,
-    JsModuleItemList, JsStatementList, JsSyntaxNode, T,
-};
-use biome_rowan::{AstNode, BatchMutation, Direction, WalkEvent};
+use biome_js_syntax::{inner_string_text, AnyJsExpression, JsBinaryExpression, JsSyntaxNode};
+use biome_rowan::{AstNode, Direction, WalkEvent};
 use std::iter;
 
 pub mod batch;
@@ -42,27 +38,6 @@ impl<'a> Iterator for InterpretEscapedString<'a> {
 ///
 pub(crate) fn escape_string(s: &str) -> Result<String, EscapeError> {
     (InterpretEscapedString { s: s.chars() }).collect()
-}
-
-/// Utility function to remove a statement node from a syntax tree, by either
-/// removing the node from its parent if said parent is a statement list or
-/// module item list, or by replacing the statement node with an empty statement
-pub(crate) fn remove_statement<N>(mutation: &mut BatchMutation<JsLanguage>, node: &N) -> Option<()>
-where
-    N: AstNode<Language = JsLanguage> + Into<AnyJsStatement>,
-{
-    let parent = node.syntax().parent()?;
-
-    if JsStatementList::can_cast(parent.kind()) || JsModuleItemList::can_cast(parent.kind()) {
-        mutation.remove_node(node.clone());
-    } else {
-        mutation.replace_node(
-            node.clone().into(),
-            AnyJsStatement::JsEmptyStatement(make::js_empty_statement(make::token(T![;]))),
-        );
-    }
-
-    Some(())
 }
 
 /// Verifies that both nodes are equal by checking their descendants (nodes included) kinds

--- a/crates/biome_js_analyze/src/utils/tests.rs
+++ b/crates/biome_js_analyze/src/utils/tests.rs
@@ -105,7 +105,7 @@ pub fn assert_remove_identifier_a_ok<Anc: AstNode<Language = JsLanguage> + Debug
     } else if let Some(declarator) = JsVariableDeclarator::cast_ref(node_to_remove.syntax()) {
         batch.remove_js_variable_declarator(&declarator)
     } else if let Some(member) = AnyJsObjectMember::cast_ref(node_to_remove.syntax()) {
-        batch.remove_js_object_member(&member)
+        batch.remove_js_object_member(member)
     } else {
         panic!("Don't know how to remove this node: {:?}", node_to_remove);
     };


### PR DESCRIPTION
## Summary

This is a minor change: move `remove_statement` from `utils` to `utils::batch` where other related utils are placed.

## Test Plan

Tests should pass.
