### PR TITLE
fix(intellij): binary resolution on windows

### DIFF
--- a/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/BiomeUtils.kt
+++ b/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/BiomeUtils.kt
@@ -44,7 +44,7 @@ object BiomeUtils {
         val executablePath = BiomeSettings.getInstance(project).executablePath
         val biomeBinFile = directoryManager.nodeModulesDirs
             .asSequence()
-            .mapNotNull { it.findFileByRelativePath(".bin/biome") }
+            .mapNotNull { it.findFileByRelativePath("@biomejs/biome/bin/biome") }
             .filter { it.isValid }
             .firstOrNull()
 


### PR DESCRIPTION
## Summary

fixes  #552 

### The problem

On `mac` the node_modules/.bin/biome resolves to a node script
```javascript
#!/usr/bin/env node
const { platform, arch, env, version, release } = process;

const PLATFORMS = {
...
```

On windows it's shell script
```
#!/bin/sh
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")

case `uname` in
    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
esac

if [ -x "$basedir/node" ]; then
  exec "$basedir/node"  "$basedir/../@biomejs/biome/bin/biome" "$@"
else 
  exec node  "$basedir/../@biomejs/biome/bin/biome" "$@"
fi
```

## Solution

Point direct to `@biomejs/biome/bin/biome` node script path


## Test Plan

Tested on a Windows VM
