### PR TITLE
fix(cli): `rage` command should not print any logs around servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### CLI
 
+#### Bug fixes
+
+- Fix `rage` command, now it doesn't print info about running servers. Contributed by @ematipico
+
 ### Configuration
 
 ### Editors

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -38,20 +38,21 @@ pub(crate) fn rage(session: CliSession, daemon_logs: bool) -> Result<(), CliDiag
     {WorkspaceRage(session.app.workspace.deref())}
     ));
 
-    match session.app.workspace.server_info() {
-        Some(_) if daemon_logs => {
-            session.app.console.log(markup!({
-                ConnectedClientServerLog(session.app.workspace.deref())
-            }));
+    if daemon_logs {
+        match session.app.workspace.server_info() {
+            Some(_) => {
+                session.app.console.log(markup!({
+                    ConnectedClientServerLog(session.app.workspace.deref())
+                }));
+            }
+            None => {
+                session
+                    .app
+                    .console
+                    .log(markup!("Discovering running Biome servers..."));
+                session.app.console.log(markup!({ RunningRomeServer }));
+            }
         }
-        None => {
-            session
-                .app
-                .console
-                .log(markup!("Discovering running Biome servers..."));
-            session.app.console.log(markup!({ RunningRomeServer }));
-        }
-        _ => {}
     }
     Ok(())
 }

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -20,6 +20,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### CLI
 
+#### Bug fixes
+
+- Fix `rage` command, now it doesn't print info about running servers. Contributed by @ematipico
+
 ### Configuration
 
 ### Editors


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

The `rage` command was still printing info around server info

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Tested locally, it works as expected now.

<!-- What demonstrates that your implementation is correct? -->
