### PR TITLE
fix(lint/noUnusedImports): handle typeof of an imported type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Fix [#548](https://github.com/biomejs/biome/issues/548) which made [noSelfAssign](https://biomejs.dev/linter/rules/no-self-assign) panic.
+
 - Fix [#555](https://github.com/biomejs/biome/issues/555), by correctly map `globals` into the workspace.
 
+- Fix [#557](https://github.com/biomejs/biome/issues/557) which made [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) report imported types used in `typeof` expression. Contributed by @Conaclos
 
 ## 1.3.0 (2022-10-19)
 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidtypeof.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidtypeof.ts
@@ -1,0 +1,3 @@
+interface I {}
+
+export declare const x: typeof I;

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidtypeof.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidtypeof.ts.snap
@@ -1,0 +1,29 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidtypeof.ts
+---
+# Input
+```js
+interface I {}
+
+export declare const x: typeof I;
+
+```
+
+# Diagnostics
+```
+invalidtypeof.ts:1:11 lint/correctness/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This interface is unused.
+  
+  > 1 │ interface I {}
+      │           ^
+    2 │ 
+    3 │ export declare const x: typeof I;
+  
+  i Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+  
+
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/noUnusedImports/issue557.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUnusedImports/issue557.ts
@@ -1,0 +1,3 @@
+// See https://github.com/biomejs/biome/issues/557
+import type Type from "mod";
+export const a: typeof Type = {};

--- a/crates/biome_js_analyze/tests/specs/nursery/noUnusedImports/issue557.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUnusedImports/issue557.ts.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue557.ts
+---
+# Input
+```js
+// See https://github.com/biomejs/biome/issues/557
+import type Type from "mod";
+export const a: typeof Type = {};
+```
+
+

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -54,8 +54,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Fix [#548](https://github.com/biomejs/biome/issues/548) which made [noSelfAssign](https://biomejs.dev/linter/rules/no-self-assign) panic.
+
 - Fix [#555](https://github.com/biomejs/biome/issues/555), by correctly map `globals` into the workspace.
 
+- Fix [#557](https://github.com/biomejs/biome/issues/557) which made [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) report imported types used in `typeof` expression. Contributed by @Conaclos
 
 ## 1.3.0 (2022-10-19)
 


### PR DESCRIPTION
## Summary

Fix #557 

As indicated in the issue, `typeof` can be applied to both a value and an **imported type**.

```ts
import { type A, B } from "";
class C {};
interfcae D {}
typeof A; // valid `A` is an imported type
typeof B;
typeof C;
typeof D; // Invalid `D` is a type but is not imported.
```

## Test Plan

New tests added.