### PR TITLE
ci(release_cli): add homebrew formula bumper

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -206,6 +206,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Bump Homebrew formula
+        if: needs.build.outputs.prerelease != 'true'
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{ secrets.HOMEBREW_BUMP_PR_TOKEN }}
+          formula: biome
+
       - name: Extract changelog
         run: |
           bash scripts/print-changelog.sh ${{ needs.build.outputs.version }} >| ${{ github.workspace }}/RELEASE_NOTES

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -210,6 +210,7 @@ jobs:
         if: needs.build.outputs.prerelease != 'true'
         uses: dawidd6/action-homebrew-bump-formula@v3
         with:
+          org: biomejs
           token: ${{ secrets.HOMEBREW_BUMP_PR_TOKEN }}
           formula: biome
 


### PR DESCRIPTION
## Summary

Solves #568 

This PR extends the `release_cli` workflow to automatically create a version bump PR on homebrew when we publish a new stable version of the CLI.

@biomejs/core-contributors Because the GitHub Action creates a fork (in the biomejs org) and a pull request, we will need to use a personal access token with the following permissions: `public_repo` and `workflow`. Can any of you guys create such PAT and add it as a secret on this repository with the name `HOMEBREW_BUMP_PR_TOKEN`?