### PR TITLE
chore: fix hook linting message grammar

### DIFF
--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
@@ -692,7 +692,7 @@ impl Rule for UseExhaustiveDependencies {
                     rule_category!(),
                     use_effect_range,
                     markup! {
-                        "This hook do not specify all of its dependencies."
+                        "This hook does not specify all of its dependencies."
                     },
                 );
 

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/checkHooksImportedFromReact.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/checkHooksImportedFromReact.js.snap
@@ -31,7 +31,7 @@ function MyComponent2() {
 ```
 checkHooksImportedFromReact.js:3:9 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     1 │ function MyComponent1() {
     2 │   let a = 1;

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/customHook.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/customHook.js.snap
@@ -22,7 +22,7 @@ function MyComponent() {
 ```
 customHook.js:5:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     3 │ function MyComponent() {
     4 │     let a = 1;
@@ -46,7 +46,7 @@ customHook.js:5:5 lint/correctness/useExhaustiveDependencies ━━━━━━�
 ```
 customHook.js:8:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
      6 │         console.log(a);
      7 │     });

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/extraDependenciesInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/extraDependenciesInvalid.js.snap
@@ -156,7 +156,7 @@ extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies ━�
 ```
 extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     26 │ function MyComponent1() {
     27 │   let someObj = getObj();

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.js.snap
@@ -136,7 +136,7 @@ function MyComponent13() {
 ```
 missingDependenciesInvalid.js:7:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     5 │     let a = 1;
     6 │     const b = a + 1;
@@ -160,7 +160,7 @@ missingDependenciesInvalid.js:7:5 lint/correctness/useExhaustiveDependencies ━
 ```
 missingDependenciesInvalid.js:7:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     5 │     let a = 1;
     6 │     const b = a + 1;
@@ -184,7 +184,7 @@ missingDependenciesInvalid.js:7:5 lint/correctness/useExhaustiveDependencies ━
 ```
 missingDependenciesInvalid.js:21:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     19 │   const deferredValue = useDeferredValue(value);
     20 │   const [isPending, startTransition] = useTransition();
@@ -208,7 +208,7 @@ missingDependenciesInvalid.js:21:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:21:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     19 │   const deferredValue = useDeferredValue(value);
     20 │   const [isPending, startTransition] = useTransition();
@@ -232,7 +232,7 @@ missingDependenciesInvalid.js:21:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:21:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     19 │   const deferredValue = useDeferredValue(value);
     20 │   const [isPending, startTransition] = useTransition();
@@ -256,7 +256,7 @@ missingDependenciesInvalid.js:21:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:21:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     19 │   const deferredValue = useDeferredValue(value);
     20 │   const [isPending, startTransition] = useTransition();
@@ -280,7 +280,7 @@ missingDependenciesInvalid.js:21:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:21:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     19 │   const deferredValue = useDeferredValue(value);
     20 │   const [isPending, startTransition] = useTransition();
@@ -304,7 +304,7 @@ missingDependenciesInvalid.js:21:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:21:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     19 │   const deferredValue = useDeferredValue(value);
     20 │   const [isPending, startTransition] = useTransition();
@@ -327,7 +327,7 @@ missingDependenciesInvalid.js:21:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:41:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     39 │ function MyComponent3() {
     40 │   let a = 1;
@@ -351,7 +351,7 @@ missingDependenciesInvalid.js:41:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:42:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     40 │   let a = 1;
     41 │   useEffect(() => console.log(a));
@@ -375,7 +375,7 @@ missingDependenciesInvalid.js:42:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:43:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     41 │   useEffect(() => console.log(a));
     42 │   useCallback(() => console.log(a));
@@ -399,7 +399,7 @@ missingDependenciesInvalid.js:43:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:44:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     42 │   useCallback(() => console.log(a));
     43 │   useMemo(() => console.log(a));
@@ -423,7 +423,7 @@ missingDependenciesInvalid.js:44:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:45:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     43 │   useMemo(() => console.log(a));
     44 │   useImperativeHandle(ref, () => console.log(a));
@@ -447,7 +447,7 @@ missingDependenciesInvalid.js:45:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:46:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     44 │   useImperativeHandle(ref, () => console.log(a));
     45 │   useLayoutEffect(() => console.log(a));
@@ -471,7 +471,7 @@ missingDependenciesInvalid.js:46:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:53:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     51 │ function MyComponent4() {
     52 │   let a = 1;
@@ -495,7 +495,7 @@ missingDependenciesInvalid.js:53:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:62:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     60 │ function MyComponent5() {
     61 │   let a = 1;
@@ -528,7 +528,7 @@ missingDependenciesInvalid.js:62:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:72:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     70 │ function MyComponent6() {
     71 │   let someObj = getObj();
@@ -552,7 +552,7 @@ missingDependenciesInvalid.js:72:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:78:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     77 │ const MyComponent7 = React.memo(function ({ a }) {
   > 78 │   useEffect(() => {
@@ -575,7 +575,7 @@ missingDependenciesInvalid.js:78:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:84:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     83 │ const MyComponent8 = React.memo(({ a }) => {
   > 84 │   useEffect(() => {
@@ -598,7 +598,7 @@ missingDependenciesInvalid.js:84:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:92:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     90 │ export function MyComponent9() {
     91 │   let a = 1;
@@ -622,7 +622,7 @@ missingDependenciesInvalid.js:92:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:99:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
      97 │ export default function MyComponent10() {
      98 │   let a = 1;
@@ -646,7 +646,7 @@ missingDependenciesInvalid.js:99:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:107:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     105 │ function MyComponent11() {
     106 │   let a = 1;
@@ -670,7 +670,7 @@ missingDependenciesInvalid.js:107:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:114:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     112 │ function MyComponent12() {
     113 │   let a = 1;
@@ -694,7 +694,7 @@ missingDependenciesInvalid.js:114:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:122:9 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook do not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies.
   
     120 │ function MyComponent13() {
     121 │   let a = 1;

--- a/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
+++ b/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
@@ -51,8 +51,8 @@ function component() {
 
 <pre class="language-text"><code class="language-text">correctness/useExhaustiveDependencies.js:5:5 <a href="https://biomejs.dev/linter/rules/use-exhaustive-dependencies">lint/correctness/useExhaustiveDependencies</a> ━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook do not specify all of its dependencies.</span>
   
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook does not specify all of its dependencies.</span>
     <strong>3 │ </strong>function component() {
     <strong>4 │ </strong>    let a = 1;
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>5 │ </strong>    useEffect(() =&gt; {
@@ -151,8 +151,8 @@ function component() {
 
 <pre class="language-text"><code class="language-text">correctness/useExhaustiveDependencies.js:6:5 <a href="https://biomejs.dev/linter/rules/use-exhaustive-dependencies">lint/correctness/useExhaustiveDependencies</a> ━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook do not specify all of its dependencies.</span>
   
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook does not specify all of its dependencies.</span>
     <strong>4 │ </strong>    let a = 1;
     <strong>5 │ </strong>    const b = a + 1;
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>6 │ </strong>    useEffect(() =&gt; {

--- a/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
+++ b/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
@@ -51,8 +51,8 @@ function component() {
 
 <pre class="language-text"><code class="language-text">correctness/useExhaustiveDependencies.js:5:5 <a href="https://biomejs.dev/linter/rules/use-exhaustive-dependencies">lint/correctness/useExhaustiveDependencies</a> ━━━━━━━━━━━━
 
-  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook does not specify all of its dependencies.</span>
+  
     <strong>3 │ </strong>function component() {
     <strong>4 │ </strong>    let a = 1;
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>5 │ </strong>    useEffect(() =&gt; {
@@ -151,8 +151,8 @@ function component() {
 
 <pre class="language-text"><code class="language-text">correctness/useExhaustiveDependencies.js:6:5 <a href="https://biomejs.dev/linter/rules/use-exhaustive-dependencies">lint/correctness/useExhaustiveDependencies</a> ━━━━━━━━━━━━
 
-  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook does not specify all of its dependencies.</span>
+  
     <strong>4 │ </strong>    let a = 1;
     <strong>5 │ </strong>    const b = a + 1;
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>6 │ </strong>    useEffect(() =&gt; {


### PR DESCRIPTION
## Summary

I noticed while working on a project that there was a slight grammar error in one of the newer rules. This PR fixes that and closes #579

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

Run linter over the following code, see new message:

```
import {useEffect} from "react";

const Comp = () => {
    const test = 0;

    useEffect(() => {console.log(test)}, []);

    return null;
}
```
