### PR TITLE
docs(lint/useNamingConvention): type prop and method names in camelCase

### DIFF
--- a/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
@@ -115,9 +115,9 @@ declare_rule! {
     ///
     /// - A class name is in [`PascalCase`].
     ///
-    /// - A static property name and a static getter name are in [`camelCase`] or [`CONSTANT_CASE`].
+    /// - Static property and static getter names are in [`camelCase`] or [`CONSTANT_CASE`].
     ///
-    /// - A class property name and a class method name are in [`camelCase`].
+    /// - Class property and method names are in [`camelCase`].
     ///
     /// ```js
     /// class Person {
@@ -133,11 +133,11 @@ declare_rule! {
     ///
     /// ### TypeScript `type` aliases and `interface`
     ///
-    /// - A `type` alias and an interface name are in [`PascalCase`].
+    /// - A `type` alias or an interface name are in [`PascalCase`].
     ///
-    /// - A property name and a method name in a type or interface are in [`camelCase`] or [`CONSTANT_CASE`].
+    /// - Property and method names in a type are in [`camelCase`].
     ///
-    /// - A `readonly` property name and a getter name can also be in [`CONSTANT_CASE`].
+    /// - `readonly` property and getter names can also be in [`CONSTANT_CASE`].
     ///
     /// ```ts
     /// type Named = {
@@ -262,7 +262,7 @@ declare_rule! {
     /// ### enumMemberCase
     ///
     /// By default, the rule enforces the naming convention followed by the [TypeScript Compiler team](https://www.typescriptlang.org/docs/handbook/enums.html):
-    /// an `enum` member has to be in [`PascalCase`].
+    /// an `enum` member is in [`PascalCase`].
     ///
     /// You can enforce another convention by setting `enumMemberCase` option.
     /// The supported cases are: [`PascalCase`], [`CONSTANT_CASE`], and [`camelCase`].

--- a/website/src/content/docs/linter/rules/use-naming-convention.md
+++ b/website/src/content/docs/linter/rules/use-naming-convention.md
@@ -120,10 +120,10 @@ enum Status {
 - A class name is in [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case).
 
 
-- A static property name and a static getter name are in [`camelCase`](https://en.wikipedia.org/wiki/Camel_case) or [`CONSTANT_CASE`](https://en.wikipedia.org/wiki/Snake_case).
+- Static property and static getter names are in [`camelCase`](https://en.wikipedia.org/wiki/Camel_case) or [`CONSTANT_CASE`](https://en.wikipedia.org/wiki/Snake_case).
 
 
-- A class property name and a class method name are in [`camelCase`](https://en.wikipedia.org/wiki/Camel_case).
+- Class property and method names are in [`camelCase`](https://en.wikipedia.org/wiki/Camel_case).
 
 
 
@@ -141,13 +141,13 @@ class Person {
 
 ### TypeScript `type` aliases and `interface`
 
-- A `type` alias and an interface name are in [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case).
+- A `type` alias or an interface name are in [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case).
 
 
-- A property name and a method name in a type or interface are in [`camelCase`](https://en.wikipedia.org/wiki/Camel_case) or [`CONSTANT_CASE`](https://en.wikipedia.org/wiki/Snake_case).
+- Property and method names in a type are in [`camelCase`](https://en.wikipedia.org/wiki/Camel_case).
 
 
-- A `readonly` property name and a getter name can also be in [`CONSTANT_CASE`](https://en.wikipedia.org/wiki/Snake_case).
+- `readonly` property and getter names can also be in [`CONSTANT_CASE`](https://en.wikipedia.org/wiki/Snake_case).
 
 
 
@@ -324,7 +324,7 @@ Default: `true`
 ### enumMemberCase
 
 By default, the rule enforces the naming convention followed by the [TypeScript Compiler team](https://www.typescriptlang.org/docs/handbook/enums.html):
-an `enum` member has to be in [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case).
+an `enum` member is in [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case).
 
 You can enforce another convention by setting `enumMemberCase` option.
 The supported cases are: [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case), [`CONSTANT_CASE`](https://en.wikipedia.org/wiki/Snake_case), and [`camelCase`](https://en.wikipedia.org/wiki/Camel_case).


### PR DESCRIPTION


## Summary

Fix an error in documentation.

## Test Plan

No change.
