### PR TITLE
fix(lint/noRedeclare): don't report type params of method signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,11 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Fix [#557](https://github.com/biomejs/biome/issues/557) which made [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) report imported types used in `typeof` expression. Contributed by @Conaclos
+
 - Fix [#576](https://github.com/biomejs/biome/issues/576) by removing some erroneous logic in [noSelfAssign](https://biomejs.dev/linter/rules/no-self-assign/). Contributed by @ematipico
+
+- Fix [#591](https://github.com/biomejs/biome/issues/591) which made [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare) report type parameters with identical names but in different method signatures. Contributed by @Conaclos
+
 ### Parser
 
 ### VSCode

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/validMethodTypeParam.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/validMethodTypeParam.ts
@@ -1,0 +1,14 @@
+interface I {
+	get<T>(f: T): T;
+	post<T>(g: T): T;
+}
+
+type A = {
+	get<T>(f: T): T;
+	post<T>(g: T): T;
+}
+
+declare class C {
+	get<T>(f: T): T;
+	post<T>(g: T): T;
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/validMethodTypeParam.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/validMethodTypeParam.ts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validMethodTypeParam.ts
+---
+# Input
+```js
+interface I {
+	get<T>(f: T): T;
+	post<T>(g: T): T;
+}
+
+type A = {
+	get<T>(f: T): T;
+	post<T>(g: T): T;
+}
+
+declare class C {
+	get<T>(f: T): T;
+	post<T>(g: T): T;
+}
+
+```
+
+

--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -324,7 +324,9 @@ impl SemanticEventExtractor {
             | TS_ENUM_DECLARATION
             | TS_TYPE_ALIAS_DECLARATION
             | TS_DECLARE_FUNCTION_DECLARATION
-            | TS_DECLARE_FUNCTION_EXPORT_DEFAULT_DECLARATION => {
+            | TS_DECLARE_FUNCTION_EXPORT_DEFAULT_DECLARATION
+            | TS_METHOD_SIGNATURE_CLASS_MEMBER
+            | TS_METHOD_SIGNATURE_TYPE_MEMBER => {
                 self.push_scope(
                     node.text_range(),
                     ScopeHoisting::DontHoistDeclarationsToParent,
@@ -602,6 +604,8 @@ impl SemanticEventExtractor {
             | JS_STATIC_INITIALIZATION_BLOCK_CLASS_MEMBER
             | TS_DECLARE_FUNCTION_DECLARATION
             | TS_DECLARE_FUNCTION_EXPORT_DEFAULT_DECLARATION
+            | TS_METHOD_SIGNATURE_CLASS_MEMBER
+            | TS_METHOD_SIGNATURE_TYPE_MEMBER
             | TS_INTERFACE_DECLARATION
             | TS_ENUM_DECLARATION
             | TS_TYPE_ALIAS_DECLARATION

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -33,7 +33,11 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Fix [#557](https://github.com/biomejs/biome/issues/557) which made [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) report imported types used in `typeof` expression. Contributed by @Conaclos
+
 - Fix [#576](https://github.com/biomejs/biome/issues/576) by removing some erroneous logic in [noSelfAssign](https://biomejs.dev/linter/rules/no-self-assign/). Contributed by @ematipico
+
+- Fix [#591](https://github.com/biomejs/biome/issues/591) which made [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare) report type parameters with identical names but in different method signatures. Contributed by @Conaclos
+
 ### Parser
 
 ### VSCode


### PR DESCRIPTION
## Summary

Fix #591.

The PR now create dedicated scope for method signatures. This is already done for function signatures and regular methods.

## Test Plan

Regression tests added.
