### PR TITLE
feat(lint/noDefaultExport): add rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Linter
 
+#### New features
+
+- Add [noDefaultExport](https://biomejs.dev/linter/rules/no-default-export) which disallows `export default`. Contributed by @Conaclos
+
 #### Bug fixes
 
 - Fix [#639](https://github.com/biomejs/biome/issues/639) by ignoring unused TypeScript's mapped key. Contributed by @Conaclos

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -93,6 +93,7 @@ define_categories! {
     "lint/correctness/useValidForDirection": "https://biomejs.dev/linter/rules/use-valid-for-direction",
     "lint/correctness/useYield": "https://biomejs.dev/linter/rules/use-yield",
     "lint/nursery/noApproximativeNumericConstant": "https://biomejs.dev/linter/rules/no-approximative-numeric-constant",
+    "lint/nursery/noDefaultExport": "https://biomejs.dev/lint/rules/no-default-export",
     "lint/nursery/noDuplicateJsonKeys": "https://biomejs.dev/linter/rules/no-duplicate-json-keys",
     "lint/nursery/noEmptyBlockStatements": "https://biomejs.dev/linter/rules/no-empty-block-statements",
     "lint/nursery/noEmptyCharacterClassInRegex": "https://biomejs.dev/linter/rules/no-empty-character-class-in-regex",

--- a/crates/biome_js_analyze/src/analyzers/nursery.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery.rs
@@ -3,6 +3,7 @@
 use biome_analyze::declare_group;
 
 pub(crate) mod no_approximative_numeric_constant;
+pub(crate) mod no_default_export;
 pub(crate) mod no_empty_block_statements;
 pub(crate) mod no_empty_character_class_in_regex;
 pub(crate) mod no_misleading_instantiator;
@@ -22,6 +23,7 @@ declare_group! {
         name : "nursery" ,
         rules : [
             self :: no_approximative_numeric_constant :: NoApproximativeNumericConstant ,
+            self :: no_default_export :: NoDefaultExport ,
             self :: no_empty_block_statements :: NoEmptyBlockStatements ,
             self :: no_empty_character_class_in_regex :: NoEmptyCharacterClassInRegex ,
             self :: no_misleading_instantiator :: NoMisleadingInstantiator ,

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_default_export.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_default_export.rs
@@ -1,0 +1,120 @@
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_console::markup;
+use biome_js_syntax::AnyJsExportClause;
+use biome_rowan::{AstNode, AstSeparatedList, TextRange};
+
+declare_rule! {
+    /// Disallow default exports.
+    ///
+    /// Default exports cannot be easily discovered inside an editor:
+    /// They cannot be suggested by the editor when the user tries to import a name.
+    ///
+    /// Also, default exports don't encourage consistency over a code base:
+    /// the module that imports the default export must choose a name.
+    /// It is likely that different modules use different names.
+    ///
+    /// Moreover, default exports encourage exporting an object that acts as a namespace.
+    /// This is a legacy pattern used to mimic CommonJS modules.
+    ///
+    /// For all these reasons, a team may want to disallow default exports.
+    ///
+    /// Note that this rule disallows only default exports in EcmaScript Module.
+    /// It ignores CommonJS default exports.
+    ///
+    /// Source: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// export default function f() {};
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// export default class C {};
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// export default {
+    ///     f() {},
+    ///     g() {},
+    /// };
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// export { X as default };
+    /// ```
+    ///
+    /// ## Valid
+    ///
+    /// ```js
+    /// export function f () {};
+    /// export class C {};
+    /// export { default as X } from "mod";
+    /// ```
+    ///
+    /// ```cjs
+    /// module.exports = class {};
+    /// ```
+    ///
+    pub(crate) NoDefaultExport {
+        version: "next",
+        name: "noDefaultExport",
+        recommended: false,
+    }
+}
+
+impl Rule for NoDefaultExport {
+    type Query = Ast<AnyJsExportClause>;
+    type State = TextRange;
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let export_clause = ctx.query();
+        match export_clause {
+            AnyJsExportClause::JsExportDefaultDeclarationClause(clause) => {
+                Some(clause.default_token().ok()?.text_trimmed_range())
+            }
+            AnyJsExportClause::JsExportDefaultExpressionClause(clause) => {
+                Some(clause.default_token().ok()?.text_trimmed_range())
+            }
+            AnyJsExportClause::JsExportNamedClause(clause) => clause
+                .specifiers()
+                .iter()
+                .filter_map(|x| x.ok()?.as_js_export_named_specifier()?.exported_name().ok())
+                .find(|x| x.is_default())
+                .map(|x| x.range()),
+            AnyJsExportClause::JsExportNamedFromClause(clause) => clause
+                .specifiers()
+                .iter()
+                .filter_map(|x| x.ok()?.export_as()?.exported_name().ok())
+                .find(|x| x.is_default())
+                .map(|x| x.range()),
+            AnyJsExportClause::AnyJsDeclarationClause(_)
+            | AnyJsExportClause::JsExportFromClause(_)
+            | AnyJsExportClause::TsExportAsNamespaceClause(_)
+            | AnyJsExportClause::TsExportAssignmentClause(_)
+            | AnyJsExportClause::TsExportDeclareClause(_) => None,
+        }
+    }
+
+    fn diagnostic(_ctx: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                range,
+                markup! {
+                    "Avoid "<Emphasis>"default"</Emphasis>" exports."
+                },
+            )
+            .note(markup ! {
+                "Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base."
+            })
+            .note(markup! {
+                "Use a named export instead."
+            }),
+        )
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noDefaultExport/invalid.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noDefaultExport/invalid.json
@@ -1,0 +1,14 @@
+
+[
+    "export default function f() {};",
+    "export default class C {};",
+    "export default function () {};",
+    "export default class {};",
+    "export default X;",
+    "export default { f() {} };",
+    "export { X as default };",
+    "export { X as 'default' };",
+    "export { default } from './module';",
+    "export { X as default } from './module';",
+    "export { X as 'default' } from './module';"
+]

--- a/crates/biome_js_analyze/tests/specs/nursery/noDefaultExport/invalid.json.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noDefaultExport/invalid.json.snap
@@ -1,0 +1,220 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.json
+---
+# Input
+```js
+export default function f() {};
+```
+
+# Diagnostics
+```
+invalid.json:1:8 lint/nursery/noDefaultExport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid default exports.
+  
+  > 1 │ export default function f() {};
+      │        ^^^^^^^
+  
+  i Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.
+  
+  i Use a named export instead.
+  
+
+```
+
+# Input
+```js
+export default class C {};
+```
+
+# Diagnostics
+```
+invalid.json:1:8 lint/nursery/noDefaultExport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid default exports.
+  
+  > 1 │ export default class C {};
+      │        ^^^^^^^
+  
+  i Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.
+  
+  i Use a named export instead.
+  
+
+```
+
+# Input
+```js
+export default function () {};
+```
+
+# Diagnostics
+```
+invalid.json:1:8 lint/nursery/noDefaultExport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid default exports.
+  
+  > 1 │ export default function () {};
+      │        ^^^^^^^
+  
+  i Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.
+  
+  i Use a named export instead.
+  
+
+```
+
+# Input
+```js
+export default class {};
+```
+
+# Diagnostics
+```
+invalid.json:1:8 lint/nursery/noDefaultExport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid default exports.
+  
+  > 1 │ export default class {};
+      │        ^^^^^^^
+  
+  i Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.
+  
+  i Use a named export instead.
+  
+
+```
+
+# Input
+```js
+export default X;
+```
+
+# Diagnostics
+```
+invalid.json:1:8 lint/nursery/noDefaultExport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid default exports.
+  
+  > 1 │ export default X;
+      │        ^^^^^^^
+  
+  i Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.
+  
+  i Use a named export instead.
+  
+
+```
+
+# Input
+```js
+export default { f() {} };
+```
+
+# Diagnostics
+```
+invalid.json:1:8 lint/nursery/noDefaultExport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid default exports.
+  
+  > 1 │ export default { f() {} };
+      │        ^^^^^^^
+  
+  i Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.
+  
+  i Use a named export instead.
+  
+
+```
+
+# Input
+```js
+export { X as default };
+```
+
+# Diagnostics
+```
+invalid.json:1:15 lint/nursery/noDefaultExport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid default exports.
+  
+  > 1 │ export { X as default };
+      │               ^^^^^^^
+  
+  i Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.
+  
+  i Use a named export instead.
+  
+
+```
+
+# Input
+```js
+export { X as 'default' };
+```
+
+# Diagnostics
+```
+invalid.json:1:15 lint/nursery/noDefaultExport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid default exports.
+  
+  > 1 │ export { X as 'default' };
+      │               ^^^^^^^^^
+  
+  i Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.
+  
+  i Use a named export instead.
+  
+
+```
+
+# Input
+```js
+export { default } from './module';
+```
+
+# Input
+```js
+export { X as default } from './module';
+```
+
+# Diagnostics
+```
+invalid.json:1:15 lint/nursery/noDefaultExport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid default exports.
+  
+  > 1 │ export { X as default } from './module';
+      │               ^^^^^^^
+  
+  i Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.
+  
+  i Use a named export instead.
+  
+
+```
+
+# Input
+```js
+export { X as 'default' } from './module';
+```
+
+# Diagnostics
+```
+invalid.json:1:15 lint/nursery/noDefaultExport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid default exports.
+  
+  > 1 │ export { X as 'default' } from './module';
+      │               ^^^^^^^^^
+  
+  i Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.
+  
+  i Use a named export instead.
+  
+
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/noDefaultExport/valid.cjs
+++ b/crates/biome_js_analyze/tests/specs/nursery/noDefaultExport/valid.cjs
@@ -1,0 +1,3 @@
+module.exports = class {};
+exports = function () {};
+module.exports.A = class A {};

--- a/crates/biome_js_analyze/tests/specs/nursery/noDefaultExport/valid.cjs.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noDefaultExport/valid.cjs.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.cjs
+---
+# Input
+```js
+module.exports = class {};
+exports = function () {};
+module.exports.A = class A {};
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/noDefaultExport/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noDefaultExport/valid.js
@@ -1,0 +1,6 @@
+export Default from "mod";
+export const CONSTANT = 'foo';
+export function f() {};
+export class C {};
+export { CONSTANT as DUPLICATE_CONSTANT };
+export { default as X } from "mod";

--- a/crates/biome_js_analyze/tests/specs/nursery/noDefaultExport/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noDefaultExport/valid.js.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```js
+export Default from "mod";
+export const CONSTANT = 'foo';
+export function f() {};
+export class C {};
+export { CONSTANT as DUPLICATE_CONSTANT };
+export { default as X } from "mod";
+```
+
+

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -2594,6 +2594,10 @@ pub struct Nursery {
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_approximative_numeric_constant: Option<RuleConfiguration>,
+    #[doc = "Disallow default exports."]
+    #[bpaf(long("no-default-export"), argument("on|off|warn"), optional, hide)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_default_export: Option<RuleConfiguration>,
     #[doc = "Disallow two keys with the same name inside a JSON object."]
     #[bpaf(
         long("no-duplicate-json-keys"),
@@ -2745,6 +2749,9 @@ impl MergeWith<Nursery> for Nursery {
         if let Some(no_approximative_numeric_constant) = other.no_approximative_numeric_constant {
             self.no_approximative_numeric_constant = Some(no_approximative_numeric_constant);
         }
+        if let Some(no_default_export) = other.no_default_export {
+            self.no_default_export = Some(no_default_export);
+        }
         if let Some(no_duplicate_json_keys) = other.no_duplicate_json_keys {
             self.no_duplicate_json_keys = Some(no_duplicate_json_keys);
         }
@@ -2823,8 +2830,9 @@ impl MergeWith<Nursery> for Nursery {
 }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
-    pub(crate) const GROUP_RULES: [&'static str; 21] = [
+    pub(crate) const GROUP_RULES: [&'static str; 22] = [
         "noApproximativeNumericConstant",
+        "noDefaultExport",
         "noDuplicateJsonKeys",
         "noEmptyBlockStatements",
         "noEmptyCharacterClassInRegex",
@@ -2859,18 +2867,18 @@ impl Nursery {
         "useValidAriaRole",
     ];
     const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 10] = [
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
     ];
-    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 21] = [
+    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 22] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
@@ -2892,6 +2900,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended(&self) -> bool {
@@ -2913,104 +2922,109 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
             }
         }
-        if let Some(rule) = self.no_duplicate_json_keys.as_ref() {
+        if let Some(rule) = self.no_default_export.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
             }
         }
-        if let Some(rule) = self.no_empty_block_statements.as_ref() {
+        if let Some(rule) = self.no_duplicate_json_keys.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
             }
         }
-        if let Some(rule) = self.no_empty_character_class_in_regex.as_ref() {
+        if let Some(rule) = self.no_empty_block_statements.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
             }
         }
-        if let Some(rule) = self.no_interactive_element_to_noninteractive_role.as_ref() {
+        if let Some(rule) = self.no_empty_character_class_in_regex.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
             }
         }
-        if let Some(rule) = self.no_invalid_new_builtin.as_ref() {
+        if let Some(rule) = self.no_interactive_element_to_noninteractive_role.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
             }
         }
-        if let Some(rule) = self.no_misleading_instantiator.as_ref() {
+        if let Some(rule) = self.no_invalid_new_builtin.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
             }
         }
-        if let Some(rule) = self.no_misrefactored_shorthand_assign.as_ref() {
+        if let Some(rule) = self.no_misleading_instantiator.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
             }
         }
-        if let Some(rule) = self.no_this_in_static.as_ref() {
+        if let Some(rule) = self.no_misrefactored_shorthand_assign.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
             }
         }
-        if let Some(rule) = self.no_unused_imports.as_ref() {
+        if let Some(rule) = self.no_this_in_static.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
             }
         }
-        if let Some(rule) = self.no_unused_private_class_members.as_ref() {
+        if let Some(rule) = self.no_unused_imports.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.no_useless_else.as_ref() {
+        if let Some(rule) = self.no_unused_private_class_members.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.no_useless_lone_block_statements.as_ref() {
+        if let Some(rule) = self.no_useless_else.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.use_aria_activedescendant_with_tabindex.as_ref() {
+        if let Some(rule) = self.no_useless_lone_block_statements.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.use_arrow_function.as_ref() {
+        if let Some(rule) = self.use_aria_activedescendant_with_tabindex.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.use_as_const_assertion.as_ref() {
+        if let Some(rule) = self.use_arrow_function.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.use_await.as_ref() {
+        if let Some(rule) = self.use_as_const_assertion.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_await.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_shorthand_assign.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+        if let Some(rule) = self.use_shorthand_assign.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
+            }
+        }
+        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
         index_set
@@ -3022,104 +3036,109 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
             }
         }
-        if let Some(rule) = self.no_duplicate_json_keys.as_ref() {
+        if let Some(rule) = self.no_default_export.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
             }
         }
-        if let Some(rule) = self.no_empty_block_statements.as_ref() {
+        if let Some(rule) = self.no_duplicate_json_keys.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
             }
         }
-        if let Some(rule) = self.no_empty_character_class_in_regex.as_ref() {
+        if let Some(rule) = self.no_empty_block_statements.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
             }
         }
-        if let Some(rule) = self.no_interactive_element_to_noninteractive_role.as_ref() {
+        if let Some(rule) = self.no_empty_character_class_in_regex.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
             }
         }
-        if let Some(rule) = self.no_invalid_new_builtin.as_ref() {
+        if let Some(rule) = self.no_interactive_element_to_noninteractive_role.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
             }
         }
-        if let Some(rule) = self.no_misleading_instantiator.as_ref() {
+        if let Some(rule) = self.no_invalid_new_builtin.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
             }
         }
-        if let Some(rule) = self.no_misrefactored_shorthand_assign.as_ref() {
+        if let Some(rule) = self.no_misleading_instantiator.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
             }
         }
-        if let Some(rule) = self.no_this_in_static.as_ref() {
+        if let Some(rule) = self.no_misrefactored_shorthand_assign.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
             }
         }
-        if let Some(rule) = self.no_unused_imports.as_ref() {
+        if let Some(rule) = self.no_this_in_static.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
             }
         }
-        if let Some(rule) = self.no_unused_private_class_members.as_ref() {
+        if let Some(rule) = self.no_unused_imports.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.no_useless_else.as_ref() {
+        if let Some(rule) = self.no_unused_private_class_members.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.no_useless_lone_block_statements.as_ref() {
+        if let Some(rule) = self.no_useless_else.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.use_aria_activedescendant_with_tabindex.as_ref() {
+        if let Some(rule) = self.no_useless_lone_block_statements.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.use_arrow_function.as_ref() {
+        if let Some(rule) = self.use_aria_activedescendant_with_tabindex.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.use_as_const_assertion.as_ref() {
+        if let Some(rule) = self.use_arrow_function.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.use_await.as_ref() {
+        if let Some(rule) = self.use_as_const_assertion.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_await.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_shorthand_assign.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+        if let Some(rule) = self.use_shorthand_assign.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
+            }
+        }
+        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
         index_set
@@ -3135,7 +3154,7 @@ impl Nursery {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 10] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 21] {
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 22] {
         Self::ALL_RULES_AS_FILTERS
     }
     #[doc = r" Select preset rules"]
@@ -3159,6 +3178,7 @@ impl Nursery {
     pub(crate) fn get_rule_configuration(&self, rule_name: &str) -> Option<&RuleConfiguration> {
         match rule_name {
             "noApproximativeNumericConstant" => self.no_approximative_numeric_constant.as_ref(),
+            "noDefaultExport" => self.no_default_export.as_ref(),
             "noDuplicateJsonKeys" => self.no_duplicate_json_keys.as_ref(),
             "noEmptyBlockStatements" => self.no_empty_block_statements.as_ref(),
             "noEmptyCharacterClassInRegex" => self.no_empty_character_class_in_regex.as_ref(),

--- a/crates/biome_service/src/configuration/parse/json/rules.rs
+++ b/crates/biome_service/src/configuration/parse/json/rules.rs
@@ -783,6 +783,11 @@ impl VisitNode<JsonLanguage> for Nursery {
                 )?;
                 self.no_approximative_numeric_constant = Some(configuration);
             }
+            "noDefaultExport" => {
+                let mut configuration = RuleConfiguration::default();
+                configuration.map_rule_configuration(&value, "noDefaultExport", diagnostics)?;
+                self.no_default_export = Some(configuration);
+            }
             "noDuplicateJsonKeys" => {
                 let mut configuration = RuleConfiguration::default();
                 configuration.map_rule_configuration(&value, "noDuplicateJsonKeys", diagnostics)?;
@@ -930,6 +935,7 @@ impl VisitNode<JsonLanguage> for Nursery {
                         "recommended",
                         "all",
                         "noApproximativeNumericConstant",
+                        "noDefaultExport",
                         "noDuplicateJsonKeys",
                         "noEmptyBlockStatements",
                         "noEmptyCharacterClassInRegex",

--- a/crates/biome_service/tests/invalid/hooks_incorrect_options.json.snap
+++ b/crates/biome_service/tests/invalid/hooks_incorrect_options.json.snap
@@ -18,6 +18,7 @@ hooks_incorrect_options.json:6:5 deserialize ━━━━━━━━━━━�
   - recommended
   - all
   - noApproximativeNumericConstant
+  - noDefaultExport
   - noDuplicateJsonKeys
   - noEmptyBlockStatements
   - noEmptyCharacterClassInRegex

--- a/crates/biome_service/tests/invalid/hooks_missing_name.json.snap
+++ b/crates/biome_service/tests/invalid/hooks_missing_name.json.snap
@@ -18,6 +18,7 @@ hooks_missing_name.json:6:5 deserialize ━━━━━━━━━━━━━�
   - recommended
   - all
   - noApproximativeNumericConstant
+  - noDefaultExport
   - noDuplicateJsonKeys
   - noEmptyBlockStatements
   - noEmptyCharacterClassInRegex

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -1037,6 +1037,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noDefaultExport": {
+					"description": "Disallow default exports.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noDuplicateJsonKeys": {
 					"description": "Disallow two keys with the same name inside a JSON object.",
 					"anyOf": [

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -737,6 +737,10 @@ export interface Nursery {
 	 */
 	noApproximativeNumericConstant?: RuleConfiguration;
 	/**
+	 * Disallow default exports.
+	 */
+	noDefaultExport?: RuleConfiguration;
+	/**
 	 * Disallow two keys with the same name inside a JSON object.
 	 */
 	noDuplicateJsonKeys?: RuleConfiguration;
@@ -1450,6 +1454,7 @@ export type Category =
 	| "lint/correctness/useValidForDirection"
 	| "lint/correctness/useYield"
 	| "lint/nursery/noApproximativeNumericConstant"
+	| "lint/nursery/noDefaultExport"
 	| "lint/nursery/noDuplicateJsonKeys"
 	| "lint/nursery/noEmptyBlockStatements"
 	| "lint/nursery/noEmptyCharacterClassInRegex"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1037,6 +1037,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noDefaultExport": {
+					"description": "Disallow default exports.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noDuplicateJsonKeys": {
 					"description": "Disallow two keys with the same name inside a JSON object.",
 					"anyOf": [

--- a/website/src/components/generated/NumberOfRules.astro
+++ b/website/src/components/generated/NumberOfRules.astro
@@ -1,2 +1,2 @@
 <!-- this file is auto generated, use `cargo lintdoc` to update it -->
- <p>Biome's linter has a total of <strong><a href='/linter/rules'>174 rules</a></strong><p>
+ <p>Biome's linter has a total of <strong><a href='/linter/rules'>175 rules</a></strong><p>

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -43,6 +43,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Linter
 
+#### New features
+
+- Add [noDefaultExport](https://biomejs.dev/linter/rules/no-default-export) which disallows `export default`. Contributed by @Conaclos
+
 #### Bug fixes
 
 - Fix [#639](https://github.com/biomejs/biome/issues/639) by ignoring unused TypeScript's mapped key. Contributed by @Conaclos

--- a/website/src/content/docs/linter/rules/index.mdx
+++ b/website/src/content/docs/linter/rules/index.mdx
@@ -216,6 +216,7 @@ Rules that belong to this group <strong>are not subject to semantic version</str
 | Rule name | Properties |  Description |
 | --- | --- | --- |
 | [noApproximativeNumericConstant](/linter/rules/no-approximative-numeric-constant) | Usually, the definition in the standard library is more precise than what people come up with or the used constant exceeds the maximum precision of the number type. |  |
+| [noDefaultExport](/linter/rules/no-default-export) | Disallow default exports. |  |
 | [noDuplicateJsonKeys](/linter/rules/no-duplicate-json-keys) | Disallow two keys with the same name inside a JSON object. |  |
 | [noEmptyBlockStatements](/linter/rules/no-empty-block-statements) | Disallow empty block statements and static blocks. |  |
 | [noEmptyCharacterClassInRegex](/linter/rules/no-empty-character-class-in-regex) | Disallow empty character classes in regular expression literals. |  |

--- a/website/src/content/docs/linter/rules/no-default-export.md
+++ b/website/src/content/docs/linter/rules/no-default-export.md
@@ -1,0 +1,125 @@
+---
+title: noDefaultExport (since vnext)
+---
+
+**Diagnostic Category: `lint/nursery/noDefaultExport`**
+
+:::caution
+This rule is part of the [nursery](/linter/rules/#nursery) group.
+:::
+
+Disallow default exports.
+
+Default exports cannot be easily discovered inside an editor:
+They cannot be suggested by the editor when the user tries to import a name.
+
+Also, default exports don't encourage consistency over a code base:
+the module that imports the default export must choose a name.
+It is likely that different modules use different names.
+
+Moreover, default exports encourage exporting an object that acts as a namespace.
+This is a legacy pattern used to mimic CommonJS modules.
+
+For all these reasons, a team may want to disallow default exports.
+
+Note that this rule disallows only default exports in EcmaScript Module.
+It ignores CommonJS default exports.
+
+Source: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md
+
+## Examples
+
+### Invalid
+
+```jsx
+export default function f() {};
+```
+
+<pre class="language-text"><code class="language-text">nursery/noDefaultExport.js:1:8 <a href="https://biomejs.dev/lint/rules/no-default-export">lint/nursery/noDefaultExport</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Avoid </span><span style="color: Orange;"><strong>default</strong></span><span style="color: Orange;"> exports.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>export default function f() {};
+   <strong>   │ </strong>       <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.</span>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Use a named export instead.</span>
+  
+</code></pre>
+
+```jsx
+export default class C {};
+```
+
+<pre class="language-text"><code class="language-text">nursery/noDefaultExport.js:1:8 <a href="https://biomejs.dev/lint/rules/no-default-export">lint/nursery/noDefaultExport</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Avoid </span><span style="color: Orange;"><strong>default</strong></span><span style="color: Orange;"> exports.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>export default class C {};
+   <strong>   │ </strong>       <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.</span>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Use a named export instead.</span>
+  
+</code></pre>
+
+```jsx
+export default {
+    f() {},
+    g() {},
+};
+```
+
+<pre class="language-text"><code class="language-text">nursery/noDefaultExport.js:1:8 <a href="https://biomejs.dev/lint/rules/no-default-export">lint/nursery/noDefaultExport</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Avoid </span><span style="color: Orange;"><strong>default</strong></span><span style="color: Orange;"> exports.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>export default {
+   <strong>   │ </strong>       <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>    f() {},
+    <strong>3 │ </strong>    g() {},
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.</span>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Use a named export instead.</span>
+  
+</code></pre>
+
+```jsx
+export { X as default };
+```
+
+<pre class="language-text"><code class="language-text">nursery/noDefaultExport.js:1:15 <a href="https://biomejs.dev/lint/rules/no-default-export">lint/nursery/noDefaultExport</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Avoid </span><span style="color: Orange;"><strong>default</strong></span><span style="color: Orange;"> exports.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>export { X as default };
+   <strong>   │ </strong>              <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Default exports cannot be easily discovered inside an editor and don't encourage the use of consistent names through a code base.</span>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Use a named export instead.</span>
+  
+</code></pre>
+
+## Valid
+
+```jsx
+export function f () {};
+export class C {};
+export { default as X } from "mod";
+```
+
+```js
+module.exports = class {};
+```
+
+## Related links
+
+- [Disable a rule](/linter/#disable-a-lint-rule)
+- [Rule options](/linter/#rule-options)


### PR DESCRIPTION
## Summary

Implement [no-default-export](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md).

This is a rule often recommended in code styles. For example the Google's TypeScript code style [discourages the use of default exports](https://google.github.io/styleguide/tsguide.html#exports).

## Test Plan

Unit tests and doc tests should pass.
