### PR TITLE
fix(intellij): binary resolution execution sequence

### DIFF
--- a/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/BiomeUtils.kt
+++ b/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/BiomeUtils.kt
@@ -42,17 +42,18 @@ object BiomeUtils {
     fun getBiomeExecutablePath(project: Project): String? {
         val directoryManager = NodeModulesDirectoryManager.getInstance(project)
         val executablePath = BiomeSettings.getInstance(project).executablePath
+
+        if (!executablePath.isEmpty()) {
+            return executablePath
+        }
+
         val biomeBinFile = directoryManager.nodeModulesDirs
             .asSequence()
             .mapNotNull { it.findFileByRelativePath("@biomejs/biome/bin/biome") }
             .filter { it.isValid }
             .firstOrNull()
 
-        if (executablePath.isEmpty()) {
-            return biomeBinFile?.path
-        }
-
-        return executablePath
+        return biomeBinFile?.path
     }
 
     fun createNodeCommandLine(project: Project, executable: String): GeneralCommandLine {


### PR DESCRIPTION
## Summary

Fixes https://github.com/biomejs/biome/issues/592

### The problem
A previous fix modified the packager check to check for a specific package manager which caused crashes in some setup (for example, with Yarn PnP). The packager check is not needed however, when an executable path is manually specified in the plugin settings. 

### The solution
The logic of the code is the same, I just moved the early return of the executable path to before we do the check for the package using a package manager, which avoids using a package manager at all to find the executable, thereby avoiding the crash.