### PR TITLE
fix(lint): fix `noConfusingVoidType` to accept generic types in a union type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Analyzer
 
+#### Bug fixes
+
+- Fix [#604](https://github.com/biomejs/biome/issues/604) which made [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type) report false positives when the `void` type is used in a generic type parameter. Contributed by @unvalley
+
 ### CLI
 
 ### Configuration

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_void_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_void_type.rs
@@ -1,17 +1,18 @@
 use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
-use biome_js_syntax::{AnyTsType, JsSyntaxKind};
+use biome_js_syntax::{JsLanguage, JsSyntaxKind, TsVoidType};
 use biome_rowan::{AstNode, SyntaxNode};
 
 declare_rule! {
     /// Disallow `void` type outside of generic or return types.
     ///
-    /// `void` in TypeScript refers to a function return that is meant to be ignored. Attempting to use a void type outside of a return type or generic type argument is often a sign of programmer error. void can also be misleading for other developers even if used correctly.
+    /// `void` in TypeScript refers to a function return that is meant to be ignored. Attempting to use a void type outside of a return type or generic type argument is often a sign of programmer error. `void` can also be misleading for other developers even if used correctly.
     ///
     /// > The `void` type means cannot be mixed with any other types, other than `never`, which accepts all types.
-    /// > If you think you need this then you probably want the undefined type instead.
+    /// > If you think you need this then you probably want the `undefined` type instead.
     ///
     /// ## Examples
+    ///
     /// ### Invalid
     ///
     /// ```ts,expect_diagnostic
@@ -53,55 +54,59 @@ declare_rule! {
     }
 }
 
-type Language = <AnyTsType as AstNode>::Language;
-
-// We only focus on union type
-pub enum VoidTypeIn {
+/// We only focus on union type
+pub enum VoidTypeContext {
     Union,
     Unknown,
 }
 
 impl Rule for NoConfusingVoidType {
-    type Query = Ast<AnyTsType>;
-    type State = VoidTypeIn;
+    type Query = Ast<TsVoidType>;
+    type State = VoidTypeContext;
     type Signals = Option<Self::State>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-
-        if let AnyTsType::TsVoidType(node) = node {
-            let result = node_in(node.syntax());
-            return result;
-        }
-
-        None
+        decide_void_type_context(node.syntax())
     }
+
     fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
         let node = ctx.query();
-        return Some(
-            RuleDiagnostic::new(
-                rule_category!(),
-                node.range(),
-                markup! {{match_message(state)}},
-            )
-            .note(markup! {
-                "Remove "<Emphasis>"void"</Emphasis>
-            }),
-        );
+        let message = match state {
+            VoidTypeContext::Union => "void is not valid as a constituent in a union type",
+            VoidTypeContext::Unknown => {
+                "void is only valid as a return type or a type argument in generic type"
+            }
+        };
+
+        Some(
+            RuleDiagnostic::new(rule_category!(), node.range(), markup! {{message}}).note(
+                markup! {
+                    "Remove "<Emphasis>"void"</Emphasis>
+                },
+            ),
+        )
     }
 }
 
-fn node_in(node: &SyntaxNode<Language>) -> Option<VoidTypeIn> {
+fn decide_void_type_context(node: &SyntaxNode<JsLanguage>) -> Option<VoidTypeContext> {
     for parent in node.parent()?.ancestors() {
         match parent.kind() {
+            JsSyntaxKind::TS_UNION_TYPE_VARIANT_LIST => {
+                // checks if the union type contains generic type
+                for children in parent.descendants() {
+                    if children.kind() == JsSyntaxKind::TS_TYPE_ARGUMENT_LIST {
+                        return None;
+                    }
+                }
+            }
+
             // (string | void)
-            // string | void
             // string & void
             // arg: void
             // fn<T = void>() {}
             JsSyntaxKind::TS_PARENTHESIZED_TYPE
-            | JsSyntaxKind::TS_UNION_TYPE_VARIANT_LIST
             | JsSyntaxKind::TS_INTERSECTION_TYPE_ELEMENT_LIST
             | JsSyntaxKind::TS_TYPE_ANNOTATION
             | JsSyntaxKind::TS_DEFAULT_TYPE_CLAUSE => {
@@ -109,7 +114,7 @@ fn node_in(node: &SyntaxNode<Language>) -> Option<VoidTypeIn> {
             }
 
             JsSyntaxKind::TS_UNION_TYPE => {
-                return Some(VoidTypeIn::Union);
+                return Some(VoidTypeContext::Union);
             }
 
             // function fn(this: void) {}
@@ -124,17 +129,9 @@ fn node_in(node: &SyntaxNode<Language>) -> Option<VoidTypeIn> {
                 return None;
             }
 
-            _ => return Some(VoidTypeIn::Unknown),
+            _ => return Some(VoidTypeContext::Unknown),
         }
     }
 
-    Some(VoidTypeIn::Unknown)
-}
-
-fn match_message(node: &VoidTypeIn) -> String {
-    if matches!(node, VoidTypeIn::Union) {
-        return "void is not valid as a constituent in a union type".into();
-    }
-
-    "void is only valid as a return type or a type argument in generic type".into()
+    Some(VoidTypeContext::Unknown)
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_void_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_void_type.rs
@@ -45,7 +45,6 @@ declare_rule! {
     ///
     /// ```ts
     /// function printArg<T = void>(arg: T) {}
-    /// printArg<void>(undefined);
     /// ```
     pub(crate) NoConfusingVoidType {
         version: "1.2.0",

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/invalid.ts
@@ -1,21 +1,45 @@
-type PossibleValues = string | number | void;
-type MorePossibleValues = string | ((number & any) | (string | void));
-
-function logSomething(thing: void) {}
-function printArg<T = void>(arg: T) {}
-logAndReturn<void>(undefined);
-
-let voidPromise: Promise<void> = new Promise<void>(() => { });
-let voidMap: Map<string, void> = new Map<string, void>();
+// ref: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-invalid-void-type.test.ts
+function takeVoid(thing: void) {}
+const arrowGeneric = <T extends void>(arg: T) => {};
+const arrowGeneric2 = <T extends void = void>(arg: T) => {};
+function functionGeneric<T extends void>(arg: T) {}
+function functionGeneric2<T extends void = void>(arg: T) {}
+declare function functionDeclaration<T extends void>(arg: T): void;
+declare function functionDeclaration2<T extends void = void>(arg: T): void;
+functionGeneric<void>(undefined);
+declare function voidArray(args: void[]): void[];
+let value = undefined as void;
+let value = <void>undefined;
+function takesThings(...things: void[]): void {}
+type KeyofVoid = keyof void;
 
 interface Interface {
-	prop: void;
+  lambda: () => void;
+  voidProp: void;
 }
 
-class MyClass {
-	private readonly propName: void;
+class ClassName {
+  private readonly propName: void;
+}
+let letVoid: void;
+type VoidType = void;
+class OtherClassName {
+  private propName: VoidType;
 }
 
-let foo: void;
-let bar = 1 as unknown as void;
-let baz = 1 as unknown as void | string;
+type UnionType = string | number | void;
+type UnionType = string | ((number & any) | (string | void));
+declare function test(): number | void;
+declare function test<T extends number | void>(): T;
+type IntersectionType = string & number & void;
+
+type MappedType<T> = {
+  [K in keyof T]: void;
+};
+
+type ConditionalType<T> = {
+  [K in keyof T]: T[K] extends string ? void : string;
+};
+type ManyVoid = readonly void[];
+function foo(arr: readonly void[]) {}
+type invalidVoidUnion = void | Map<string, number>;

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/invalid.ts.snap
@@ -4,40 +4,370 @@ expression: invalid.ts
 ---
 # Input
 ```js
-type PossibleValues = string | number | void;
-type MorePossibleValues = string | ((number & any) | (string | void));
-
-function logSomething(thing: void) {}
-function printArg<T = void>(arg: T) {}
-logAndReturn<void>(undefined);
-
-let voidPromise: Promise<void> = new Promise<void>(() => { });
-let voidMap: Map<string, void> = new Map<string, void>();
+// ref: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-invalid-void-type.test.ts
+function takeVoid(thing: void) {}
+const arrowGeneric = <T extends void>(arg: T) => {};
+const arrowGeneric2 = <T extends void = void>(arg: T) => {};
+function functionGeneric<T extends void>(arg: T) {}
+function functionGeneric2<T extends void = void>(arg: T) {}
+declare function functionDeclaration<T extends void>(arg: T): void;
+declare function functionDeclaration2<T extends void = void>(arg: T): void;
+functionGeneric<void>(undefined);
+declare function voidArray(args: void[]): void[];
+let value = undefined as void;
+let value = <void>undefined;
+function takesThings(...things: void[]): void {}
+type KeyofVoid = keyof void;
 
 interface Interface {
-	prop: void;
+  lambda: () => void;
+  voidProp: void;
 }
 
-class MyClass {
-	private readonly propName: void;
+class ClassName {
+  private readonly propName: void;
+}
+let letVoid: void;
+type VoidType = void;
+class OtherClassName {
+  private propName: VoidType;
 }
 
-let foo: void;
-let bar = 1 as unknown as void;
-let baz = 1 as unknown as void | string;
+type UnionType = string | number | void;
+type UnionType = string | ((number & any) | (string | void));
+declare function test(): number | void;
+declare function test<T extends number | void>(): T;
+type IntersectionType = string & number & void;
+
+type MappedType<T> = {
+  [K in keyof T]: void;
+};
+
+type ConditionalType<T> = {
+  [K in keyof T]: T[K] extends string ? void : string;
+};
+type ManyVoid = readonly void[];
+function foo(arr: readonly void[]) {}
+type invalidVoidUnion = void | Map<string, number>;
 
 ```
 
 # Diagnostics
 ```
-invalid.ts:1:41 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:2:26 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    1 │ // ref: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-invalid-void-type.test.ts
+  > 2 │ function takeVoid(thing: void) {}
+      │                          ^^^^
+    3 │ const arrowGeneric = <T extends void>(arg: T) => {};
+    4 │ const arrowGeneric2 = <T extends void = void>(arg: T) => {};
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:3:33 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    1 │ // ref: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-invalid-void-type.test.ts
+    2 │ function takeVoid(thing: void) {}
+  > 3 │ const arrowGeneric = <T extends void>(arg: T) => {};
+      │                                 ^^^^
+    4 │ const arrowGeneric2 = <T extends void = void>(arg: T) => {};
+    5 │ function functionGeneric<T extends void>(arg: T) {}
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:4:34 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    2 │ function takeVoid(thing: void) {}
+    3 │ const arrowGeneric = <T extends void>(arg: T) => {};
+  > 4 │ const arrowGeneric2 = <T extends void = void>(arg: T) => {};
+      │                                  ^^^^
+    5 │ function functionGeneric<T extends void>(arg: T) {}
+    6 │ function functionGeneric2<T extends void = void>(arg: T) {}
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:5:36 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    3 │ const arrowGeneric = <T extends void>(arg: T) => {};
+    4 │ const arrowGeneric2 = <T extends void = void>(arg: T) => {};
+  > 5 │ function functionGeneric<T extends void>(arg: T) {}
+      │                                    ^^^^
+    6 │ function functionGeneric2<T extends void = void>(arg: T) {}
+    7 │ declare function functionDeclaration<T extends void>(arg: T): void;
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:6:37 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    4 │ const arrowGeneric2 = <T extends void = void>(arg: T) => {};
+    5 │ function functionGeneric<T extends void>(arg: T) {}
+  > 6 │ function functionGeneric2<T extends void = void>(arg: T) {}
+      │                                     ^^^^
+    7 │ declare function functionDeclaration<T extends void>(arg: T): void;
+    8 │ declare function functionDeclaration2<T extends void = void>(arg: T): void;
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:7:48 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    5 │ function functionGeneric<T extends void>(arg: T) {}
+    6 │ function functionGeneric2<T extends void = void>(arg: T) {}
+  > 7 │ declare function functionDeclaration<T extends void>(arg: T): void;
+      │                                                ^^^^
+    8 │ declare function functionDeclaration2<T extends void = void>(arg: T): void;
+    9 │ functionGeneric<void>(undefined);
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:8:49 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+     6 │ function functionGeneric2<T extends void = void>(arg: T) {}
+     7 │ declare function functionDeclaration<T extends void>(arg: T): void;
+   > 8 │ declare function functionDeclaration2<T extends void = void>(arg: T): void;
+       │                                                 ^^^^
+     9 │ functionGeneric<void>(undefined);
+    10 │ declare function voidArray(args: void[]): void[];
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:9:17 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+     7 │ declare function functionDeclaration<T extends void>(arg: T): void;
+     8 │ declare function functionDeclaration2<T extends void = void>(arg: T): void;
+   > 9 │ functionGeneric<void>(undefined);
+       │                 ^^^^
+    10 │ declare function voidArray(args: void[]): void[];
+    11 │ let value = undefined as void;
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:10:34 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+     8 │ declare function functionDeclaration2<T extends void = void>(arg: T): void;
+     9 │ functionGeneric<void>(undefined);
+  > 10 │ declare function voidArray(args: void[]): void[];
+       │                                  ^^^^
+    11 │ let value = undefined as void;
+    12 │ let value = <void>undefined;
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:10:43 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+     8 │ declare function functionDeclaration2<T extends void = void>(arg: T): void;
+     9 │ functionGeneric<void>(undefined);
+  > 10 │ declare function voidArray(args: void[]): void[];
+       │                                           ^^^^
+    11 │ let value = undefined as void;
+    12 │ let value = <void>undefined;
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:11:26 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+     9 │ functionGeneric<void>(undefined);
+    10 │ declare function voidArray(args: void[]): void[];
+  > 11 │ let value = undefined as void;
+       │                          ^^^^
+    12 │ let value = <void>undefined;
+    13 │ function takesThings(...things: void[]): void {}
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:12:14 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    10 │ declare function voidArray(args: void[]): void[];
+    11 │ let value = undefined as void;
+  > 12 │ let value = <void>undefined;
+       │              ^^^^
+    13 │ function takesThings(...things: void[]): void {}
+    14 │ type KeyofVoid = keyof void;
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:13:33 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    11 │ let value = undefined as void;
+    12 │ let value = <void>undefined;
+  > 13 │ function takesThings(...things: void[]): void {}
+       │                                 ^^^^
+    14 │ type KeyofVoid = keyof void;
+    15 │ 
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:14:24 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    12 │ let value = <void>undefined;
+    13 │ function takesThings(...things: void[]): void {}
+  > 14 │ type KeyofVoid = keyof void;
+       │                        ^^^^
+    15 │ 
+    16 │ interface Interface {
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:18:13 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    16 │ interface Interface {
+    17 │   lambda: () => void;
+  > 18 │   voidProp: void;
+       │             ^^^^
+    19 │ }
+    20 │ 
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:22:30 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    21 │ class ClassName {
+  > 22 │   private readonly propName: void;
+       │                              ^^^^
+    23 │ }
+    24 │ let letVoid: void;
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:24:14 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    22 │   private readonly propName: void;
+    23 │ }
+  > 24 │ let letVoid: void;
+       │              ^^^^
+    25 │ type VoidType = void;
+    26 │ class OtherClassName {
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:25:17 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    23 │ }
+    24 │ let letVoid: void;
+  > 25 │ type VoidType = void;
+       │                 ^^^^
+    26 │ class OtherClassName {
+    27 │   private propName: VoidType;
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:30:36 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! void is not valid as a constituent in a union type
   
-  > 1 │ type PossibleValues = string | number | void;
-      │                                         ^^^^
-    2 │ type MorePossibleValues = string | ((number & any) | (string | void));
-    3 │ 
+    28 │ }
+    29 │ 
+  > 30 │ type UnionType = string | number | void;
+       │                                    ^^^^
+    31 │ type UnionType = string | ((number & any) | (string | void));
+    32 │ declare function test(): number | void;
   
   i Remove void
   
@@ -45,15 +375,15 @@ invalid.ts:1:41 lint/suspicious/noConfusingVoidType ━━━━━━━━━�
 ```
 
 ```
-invalid.ts:2:64 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:31:55 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! void is not valid as a constituent in a union type
   
-    1 │ type PossibleValues = string | number | void;
-  > 2 │ type MorePossibleValues = string | ((number & any) | (string | void));
-      │                                                                ^^^^
-    3 │ 
-    4 │ function logSomething(thing: void) {}
+    30 │ type UnionType = string | number | void;
+  > 31 │ type UnionType = string | ((number & any) | (string | void));
+       │                                                       ^^^^
+    32 │ declare function test(): number | void;
+    33 │ declare function test<T extends number | void>(): T;
   
   i Remove void
   
@@ -61,97 +391,132 @@ invalid.ts:2:64 lint/suspicious/noConfusingVoidType ━━━━━━━━━�
 ```
 
 ```
-invalid.ts:4:30 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! void is only valid as a return type or a type argument in generic type
-  
-    2 │ type MorePossibleValues = string | ((number & any) | (string | void));
-    3 │ 
-  > 4 │ function logSomething(thing: void) {}
-      │                              ^^^^
-    5 │ function printArg<T = void>(arg: T) {}
-    6 │ logAndReturn<void>(undefined);
-  
-  i Remove void
-  
-
-```
-
-```
-invalid.ts:12:8 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! void is only valid as a return type or a type argument in generic type
-  
-    11 │ interface Interface {
-  > 12 │ 	prop: void;
-       │ 	      ^^^^
-    13 │ }
-    14 │ 
-  
-  i Remove void
-  
-
-```
-
-```
-invalid.ts:16:29 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! void is only valid as a return type or a type argument in generic type
-  
-    15 │ class MyClass {
-  > 16 │ 	private readonly propName: void;
-       │ 	                           ^^^^
-    17 │ }
-    18 │ 
-  
-  i Remove void
-  
-
-```
-
-```
-invalid.ts:19:10 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! void is only valid as a return type or a type argument in generic type
-  
-    17 │ }
-    18 │ 
-  > 19 │ let foo: void;
-       │          ^^^^
-    20 │ let bar = 1 as unknown as void;
-    21 │ let baz = 1 as unknown as void | string;
-  
-  i Remove void
-  
-
-```
-
-```
-invalid.ts:20:27 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! void is only valid as a return type or a type argument in generic type
-  
-    19 │ let foo: void;
-  > 20 │ let bar = 1 as unknown as void;
-       │                           ^^^^
-    21 │ let baz = 1 as unknown as void | string;
-    22 │ 
-  
-  i Remove void
-  
-
-```
-
-```
-invalid.ts:21:27 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:32:35 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! void is not valid as a constituent in a union type
   
-    19 │ let foo: void;
-    20 │ let bar = 1 as unknown as void;
-  > 21 │ let baz = 1 as unknown as void | string;
-       │                           ^^^^
-    22 │ 
+    30 │ type UnionType = string | number | void;
+    31 │ type UnionType = string | ((number & any) | (string | void));
+  > 32 │ declare function test(): number | void;
+       │                                   ^^^^
+    33 │ declare function test<T extends number | void>(): T;
+    34 │ type IntersectionType = string & number & void;
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:33:42 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is not valid as a constituent in a union type
+  
+    31 │ type UnionType = string | ((number & any) | (string | void));
+    32 │ declare function test(): number | void;
+  > 33 │ declare function test<T extends number | void>(): T;
+       │                                          ^^^^
+    34 │ type IntersectionType = string & number & void;
+    35 │ 
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:34:43 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    32 │ declare function test(): number | void;
+    33 │ declare function test<T extends number | void>(): T;
+  > 34 │ type IntersectionType = string & number & void;
+       │                                           ^^^^
+    35 │ 
+    36 │ type MappedType<T> = {
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:37:19 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    36 │ type MappedType<T> = {
+  > 37 │   [K in keyof T]: void;
+       │                   ^^^^
+    38 │ };
+    39 │ 
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:41:41 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    40 │ type ConditionalType<T> = {
+  > 41 │   [K in keyof T]: T[K] extends string ? void : string;
+       │                                         ^^^^
+    42 │ };
+    43 │ type ManyVoid = readonly void[];
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:43:26 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    41 │   [K in keyof T]: T[K] extends string ? void : string;
+    42 │ };
+  > 43 │ type ManyVoid = readonly void[];
+       │                          ^^^^
+    44 │ function foo(arr: readonly void[]) {}
+    45 │ type invalidVoidUnion = void | Map<string, number>;
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:44:28 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is only valid as a return type or a type argument in generic type
+  
+    42 │ };
+    43 │ type ManyVoid = readonly void[];
+  > 44 │ function foo(arr: readonly void[]) {}
+       │                            ^^^^
+    45 │ type invalidVoidUnion = void | Map<string, number>;
+    46 │ 
+  
+  i Remove void
+  
+
+```
+
+```
+invalid.ts:45:25 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! void is not valid as a constituent in a union type
+  
+    43 │ type ManyVoid = readonly void[];
+    44 │ function foo(arr: readonly void[]) {}
+  > 45 │ type invalidVoidUnion = void | Map<string, number>;
+       │                         ^^^^
+    46 │ 
   
   i Remove void
   

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts
@@ -7,3 +7,8 @@ let voidPromise: Promise<void> = new Promise<void>(() => { });
 let voidMap: Map<string, void> = new Map<string, void>();
 
 type FallbackHandler = (error?: Error) => void;
+
+async function fn(fn: () => Promise<void> | void) {
+  await fn();
+  return "ok";
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts
@@ -1,14 +1,40 @@
-function Foo(): void {}
-function doSomething(this: void) {}
-function printArg<T = void>(arg: T) {}
-logAndReturn<void>(undefined);
-
-let voidPromise: Promise<void> = new Promise<void>(() => { });
+// ref: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-invalid-void-type.test.ts
+function func(): void {}
+type NormalType = () => void;
+let normalArrow = (): void => {};
+let ughThisThing = void 0;
+function takeThing(thing: undefined) {}
+takeThing(void 0);
+let voidPromise: Promise<void> = new Promise<void>(() => {});
 let voidMap: Map<string, void> = new Map<string, void>();
 
-type FallbackHandler = (error?: Error) => void;
+function returnsVoidPromiseDirectly(): Promise<void> {
+  return Promise.resolve();
+}
 
-async function fn(fn: () => Promise<void> | void) {
-  await fn();
-  return "ok";
+async function returnsVoidPromiseAsync(): Promise<void> {}
+type UnionType = string | number;
+type GenericVoid = Generic<void>;
+type Generic<T> = [T];
+type voidPromiseUnion = void | Promise<void>;
+type promiseNeverUnion = Promise<void> | never;
+const arrowGeneric1 = <T = void,>(arg: T) => {};
+declare function functionDeclaration1<T = void>(arg: T): void;
+
+type Allowed<T> = [T];
+type Banned<T> = [T];
+type AllowedVoid = Allowed<void>;
+type AllowedVoid = Ex.Mx.Tx<void>;
+type voidPromiseUnion = void | Promise<void>;
+type promiseVoidUnion = Promise<void> | void;
+
+async function foo(bar: () => void | Promise<void>) {
+  await bar();
+}
+type promiseNeverUnion = Promise<void> | never;
+type voidPromiseNeverUnion = void | Promise<void> | never;
+
+class Test {
+  public static helper(this: void) {}
+  method(this: void) {}
 }

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts.snap
@@ -13,6 +13,12 @@ let voidPromise: Promise<void> = new Promise<void>(() => { });
 let voidMap: Map<string, void> = new Map<string, void>();
 
 type FallbackHandler = (error?: Error) => void;
+
+async function fn(fn: () => Promise<void> | void) {
+  await fn();
+  return "ok";
+}
+
 ```
 
 

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts.snap
@@ -4,19 +4,45 @@ expression: valid.ts
 ---
 # Input
 ```js
-function Foo(): void {}
-function doSomething(this: void) {}
-function printArg<T = void>(arg: T) {}
-logAndReturn<void>(undefined);
-
-let voidPromise: Promise<void> = new Promise<void>(() => { });
+// ref: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-invalid-void-type.test.ts
+function func(): void {}
+type NormalType = () => void;
+let normalArrow = (): void => {};
+let ughThisThing = void 0;
+function takeThing(thing: undefined) {}
+takeThing(void 0);
+let voidPromise: Promise<void> = new Promise<void>(() => {});
 let voidMap: Map<string, void> = new Map<string, void>();
 
-type FallbackHandler = (error?: Error) => void;
+function returnsVoidPromiseDirectly(): Promise<void> {
+  return Promise.resolve();
+}
 
-async function fn(fn: () => Promise<void> | void) {
-  await fn();
-  return "ok";
+async function returnsVoidPromiseAsync(): Promise<void> {}
+type UnionType = string | number;
+type GenericVoid = Generic<void>;
+type Generic<T> = [T];
+type voidPromiseUnion = void | Promise<void>;
+type promiseNeverUnion = Promise<void> | never;
+const arrowGeneric1 = <T = void,>(arg: T) => {};
+declare function functionDeclaration1<T = void>(arg: T): void;
+
+type Allowed<T> = [T];
+type Banned<T> = [T];
+type AllowedVoid = Allowed<void>;
+type AllowedVoid = Ex.Mx.Tx<void>;
+type voidPromiseUnion = void | Promise<void>;
+type promiseVoidUnion = Promise<void> | void;
+
+async function foo(bar: () => void | Promise<void>) {
+  await bar();
+}
+type promiseNeverUnion = Promise<void> | never;
+type voidPromiseNeverUnion = void | Promise<void> | never;
+
+class Test {
+  public static helper(this: void) {}
+  method(this: void) {}
 }
 
 ```

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -18,6 +18,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Analyzer
 
+#### Bug fixes
+
+- Fix [#604](https://github.com/biomejs/biome/issues/604) which made [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type) report false positives when the `void` type is used in a generic type parameter. Contributed by @unvalley
+
 ### CLI
 
 ### Configuration

--- a/website/src/content/docs/linter/rules/no-confusing-void-type.md
+++ b/website/src/content/docs/linter/rules/no-confusing-void-type.md
@@ -100,7 +100,6 @@ function doSomething(this: void) {}
 
 ```ts
 function printArg<T = void>(arg: T) {}
-printArg<void>(undefined);
 ```
 
 ## Related links

--- a/website/src/content/docs/linter/rules/no-confusing-void-type.md
+++ b/website/src/content/docs/linter/rules/no-confusing-void-type.md
@@ -10,10 +10,10 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Disallow `void` type outside of generic or return types.
 
-`void` in TypeScript refers to a function return that is meant to be ignored. Attempting to use a void type outside of a return type or generic type argument is often a sign of programmer error. void can also be misleading for other developers even if used correctly.
+`void` in TypeScript refers to a function return that is meant to be ignored. Attempting to use a void type outside of a return type or generic type argument is often a sign of programmer error. `void` can also be misleading for other developers even if used correctly.
 
 >The `void` type means cannot be mixed with any other types, other than `never`, which accepts all types.
-If you think you need this then you probably want the undefined type instead.
+If you think you need this then you probably want the `undefined` type instead.
 
 
 ## Examples


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
Closes #604

Fix `noConfusingVoidType` 
- to accept generic types in a union type: #604 
- to report void used in generic function type argument: to pass test

## Test Plan
`cargo test -p biome_js_analyze no_confusing_void_type`

~~Existing test plans should pass, and add a test case that filed on #604~~
Update test cases by referencing typescript-eslint no-invalid-void-type test cases.


<!-- What demonstrates that your implementation is correct? -->
