### PR TITLE
refactor(json_deserailize): remove `visit_member_name`

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_configuration/incorrect_rule_name.snap
+++ b/crates/biome_cli/tests/snapshots/main_configuration/incorrect_rule_name.snap
@@ -84,4 +84,53 @@ biome.json:6:13 deserialize ━━━━━━━━━━━━━━━━━�
 
 ```
 
+```block
+biome.json:9:13 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Found an unknown key `what_the_hell`.
+  
+     7 │         },
+     8 │         "style": {
+   > 9 │             "what_the_hell": "off"
+       │             ^^^^^^^^^^^^^^^
+    10 │         }
+    11 │     }
+  
+  i Accepted keys
+  
+  - recommended
+  - all
+  - noArguments
+  - noCommaOperator
+  - noImplicitBoolean
+  - noInferrableTypes
+  - noNamespace
+  - noNegationElse
+  - noNonNullAssertion
+  - noParameterAssign
+  - noParameterProperties
+  - noRestrictedGlobals
+  - noShoutyConstants
+  - noUnusedTemplateLiteral
+  - noVar
+  - useBlockStatements
+  - useCollapsedElseIf
+  - useConst
+  - useDefaultParameterLast
+  - useEnumInitializers
+  - useExponentiationOperator
+  - useFragmentSyntax
+  - useLiteralEnumMembers
+  - useNamingConvention
+  - useNumericLiterals
+  - useSelfClosingElements
+  - useShorthandArrayType
+  - useSingleCaseStatement
+  - useSingleVarDeclarator
+  - useTemplate
+  - useWhile
+  
+
+```
+
 

--- a/crates/biome_deserialize/src/visitor.rs
+++ b/crates/biome_deserialize/src/visitor.rs
@@ -3,21 +3,14 @@ use biome_rowan::{Language, SyntaxNode};
 
 /// Generic trait to implement when resolving the configuration from a generic language
 pub trait VisitNode<L: Language>: Sized {
-    /// Called when visiting the key of a member
-    fn visit_member_name(
+    /// Called when visiting a value that is not a list or a map.
+    /// A value can be a string, an integer, a boolean.
+    fn visit_value(
         &mut self,
         _node: &SyntaxNode<L>,
         _diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        unimplemented!("you should implement visit_member_name")
-    }
-    /// Called when visiting the value of a member
-    fn visit_member_value(
-        &mut self,
-        _node: &SyntaxNode<L>,
-        _diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        unimplemented!("you should implement visit_member_value")
+        unimplemented!("you should implement visit_value")
     }
 
     /// Called when visiting a list of key-value.
@@ -42,32 +35,5 @@ pub trait VisitNode<L: Language>: Sized {
         _diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
         unimplemented!("you should implement visit_array_member")
-    }
-}
-
-impl<L: Language> VisitNode<L> for () {
-    fn visit_map(
-        &mut self,
-        _key: &SyntaxNode<L>,
-        _value: &SyntaxNode<L>,
-        _diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        Some(())
-    }
-
-    fn visit_member_name(
-        &mut self,
-        _node: &SyntaxNode<L>,
-        _diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        Some(())
-    }
-
-    fn visit_member_value(
-        &mut self,
-        _node: &SyntaxNode<L>,
-        _diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        Some(())
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_excessive_cognitive_complexity.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_excessive_cognitive_complexity.rs
@@ -4,7 +4,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_deserialize::{
-    json::{has_only_known_keys, VisitJsonNode},
+    json::{report_unknown_map_key, VisitJsonNode},
     DeserializationDiagnostic, VisitNode,
 };
 use biome_js_syntax::{
@@ -398,23 +398,20 @@ impl FromStr for ComplexityOptions {
     }
 }
 
-impl VisitNode<JsonLanguage> for ComplexityOptions {
-    fn visit_member_name(
-        &mut self,
-        node: &JsonSyntaxNode,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(node, &["maxAllowedComplexity"], diagnostics)
-    }
+impl ComplexityOptions {
+    const ALLOWED_KEYS: &'static [&'static str] = &["maxAllowedComplexity"];
+}
 
+impl VisitNode<JsonLanguage> for ComplexityOptions {
     fn visit_map(
         &mut self,
         key: &JsonSyntaxNode,
         value: &JsonSyntaxNode,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         if name_text == "maxAllowedComplexity" {
             if let Some(value) = value
                 .as_json_number_value()
@@ -433,6 +430,8 @@ impl VisitNode<JsonLanguage> for ComplexityOptions {
                     .with_range(value.range()),
                 );
             }
+        } else {
+            report_unknown_map_key(&name, Self::ALLOWED_KEYS, diagnostics);
         }
         Some(())
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
@@ -2,7 +2,7 @@ use crate::react::hooks::*;
 use crate::semantic_services::Semantic;
 use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use biome_console::markup;
-use biome_deserialize::json::{has_only_known_keys, VisitJsonNode};
+use biome_deserialize::json::{report_unknown_map_key, VisitJsonNode};
 use biome_deserialize::{DeserializationDiagnostic, VisitNode};
 use biome_js_semantic::{Capture, SemanticModel};
 use biome_js_syntax::{
@@ -229,6 +229,10 @@ pub struct HooksOptions {
     pub hooks: Vec<Hooks>,
 }
 
+impl HooksOptions {
+    const ALLOWED_KEYS: &'static [&'static str] = &["hooks"];
+}
+
 impl FromStr for HooksOptions {
     type Err = ();
 
@@ -255,26 +259,19 @@ pub struct Hooks {
 }
 
 impl Hooks {
-    const KNOWN_KEYS: &'static [&'static str] = &["name", "closureIndex", "dependenciesIndex"];
+    const ALLOWED_KEYS: &'static [&'static str] = &["name", "closureIndex", "dependenciesIndex"];
 }
 
 impl VisitNode<JsonLanguage> for Hooks {
-    fn visit_member_name(
-        &mut self,
-        node: &JsonSyntaxNode,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(node, Hooks::KNOWN_KEYS, diagnostics)
-    }
-
     fn visit_map(
         &mut self,
         key: &JsonSyntaxNode,
         value: &JsonSyntaxNode,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         match name_text {
             "name" => {
                 self.name = self.map_to_string(&value, name_text, diagnostics)?;
@@ -294,7 +291,9 @@ impl VisitNode<JsonLanguage> for Hooks {
                 self.dependencies_index =
                     self.map_to_usize(&value, name_text, usize::MAX, diagnostics);
             }
-            _ => {}
+            _ => {
+                report_unknown_map_key(&name, Self::ALLOWED_KEYS, diagnostics);
+            }
         }
 
         Some(())
@@ -310,22 +309,15 @@ impl FromStr for Hooks {
 }
 
 impl VisitNode<JsonLanguage> for HooksOptions {
-    fn visit_member_name(
-        &mut self,
-        node: &JsonSyntaxNode,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(node, &["hooks"], diagnostics)
-    }
-
     fn visit_map(
         &mut self,
         key: &JsonSyntaxNode,
         value: &JsonSyntaxNode,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         if name_text == "hooks" {
             let array = value.as_json_array_value()?;
             if array.elements().len() < 1 {
@@ -342,6 +334,8 @@ impl VisitNode<JsonLanguage> for HooksOptions {
                 hooks.map_to_object(&element, "hooks", diagnostics)?;
                 self.hooks.push(hooks);
             }
+        } else {
+            report_unknown_map_key(&name, Self::ALLOWED_KEYS, diagnostics);
         }
         Some(())
     }

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -537,13 +537,14 @@ impl ArrowParentheses {
     }
 }
 
+// Required by [Bpaf]
 impl FromStr for ArrowParentheses {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "as-needed" | "AsNeeded" => Ok(Self::AsNeeded),
-            "always" | "Always" => Ok(Self::Always),
+            "as-needed" => Ok(Self::AsNeeded),
+            "always" => Ok(Self::Always),
             _ => Err("Value not supported for Arrow parentheses. Supported values are 'as-needed' and 'always'."),
         }
     }

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -1,6 +1,6 @@
 use crate::comments::{FormatJsLeadingComment, JsCommentStyle, JsComments};
 use crate::context::trailing_comma::TrailingComma;
-use biome_deserialize::json::with_only_known_variants;
+use biome_deserialize::json::report_unknown_variant;
 use biome_deserialize::{DeserializationDiagnostic, VisitNode};
 use biome_formatter::printer::PrinterOptions;
 use biome_formatter::token::string::Quote;
@@ -9,8 +9,8 @@ use biome_formatter::{
     LineWidth, TransformSourceMap,
 };
 use biome_js_syntax::{AnyJsFunctionBody, JsFileSource, JsLanguage};
-use biome_json_syntax::JsonLanguage;
-use biome_rowan::SyntaxNode;
+use biome_json_syntax::{JsonLanguage, JsonStringValue};
+use biome_rowan::{AstNode, SyntaxNode};
 use std::fmt;
 use std::fmt::Debug;
 use std::rc::Rc;
@@ -328,8 +328,6 @@ impl fmt::Display for QuoteStyle {
 }
 
 impl QuoteStyle {
-    pub(crate) const KNOWN_VALUES: &'static [&'static str] = &["double", "single"];
-
     pub fn as_char(&self) -> char {
         match self {
             QuoteStyle::Double => '"',
@@ -376,23 +374,27 @@ impl QuoteStyle {
 impl From<QuoteStyle> for Quote {
     fn from(quote: QuoteStyle) -> Self {
         match quote {
-            QuoteStyle::Double => Quote::Double,
-            QuoteStyle::Single => Quote::Single,
+            QuoteStyle::Double => Self::Double,
+            QuoteStyle::Single => Self::Single,
         }
     }
 }
 
+impl QuoteStyle {
+    const ALLOWED_VARIANTS: &'static [&'static str] = &["double", "single"];
+}
+
 impl VisitNode<JsonLanguage> for QuoteStyle {
-    fn visit_member_value(
+    fn visit_value(
         &mut self,
         node: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let node = with_only_known_variants(node, QuoteStyle::KNOWN_VALUES, diagnostics)?;
-        if node.inner_string_text().ok()?.text() == "single" {
-            *self = QuoteStyle::Single;
+        let node = JsonStringValue::cast_ref(node)?;
+        if let Ok(value) = node.inner_string_text().ok()?.text().parse::<Self>() {
+            *self = value;
         } else {
-            *self = QuoteStyle::Double;
+            report_unknown_variant(&node, Self::ALLOWED_VARIANTS, diagnostics);
         }
         Some(())
     }
@@ -433,20 +435,20 @@ impl fmt::Display for QuoteProperties {
 }
 
 impl QuoteProperties {
-    pub(crate) const KNOWN_VALUES: &'static [&'static str] = &["preserve", "asNeeded"];
+    const ALLOWED_VARIANTS: &'static [&'static str] = &["preserve", "asNeeded"];
 }
 
 impl VisitNode<JsonLanguage> for QuoteProperties {
-    fn visit_member_value(
+    fn visit_value(
         &mut self,
         node: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let node = with_only_known_variants(node, QuoteProperties::KNOWN_VALUES, diagnostics)?;
-        if node.inner_string_text().ok()?.text() == "asNeeded" {
-            *self = QuoteProperties::AsNeeded;
-        } else {
-            *self = QuoteProperties::Preserve;
+        let node = JsonStringValue::cast_ref(node)?;
+        match node.inner_string_text().ok()?.text() {
+            "asNeeded" => *self = Self::AsNeeded,
+            "preserve" => *self = Self::Preserve,
+            _ => report_unknown_variant(&node, Self::ALLOWED_VARIANTS, diagnostics),
         }
         Some(())
     }
@@ -465,8 +467,6 @@ pub enum Semicolons {
 }
 
 impl Semicolons {
-    pub(crate) const KNOWN_VALUES: &'static [&'static str] = &["always", "asNeeded"];
-
     pub const fn is_as_needed(&self) -> bool {
         matches!(self, Self::AsNeeded)
     }
@@ -497,17 +497,21 @@ impl fmt::Display for Semicolons {
     }
 }
 
+impl Semicolons {
+    const ALLOWED_VARIANTS: &'static [&'static str] = &["always", "asNeeded"];
+}
+
 impl VisitNode<JsonLanguage> for Semicolons {
-    fn visit_member_value(
+    fn visit_value(
         &mut self,
         node: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let node = with_only_known_variants(node, Semicolons::KNOWN_VALUES, diagnostics)?;
-        if node.inner_string_text().ok()?.text() == "asNeeded" {
-            *self = Semicolons::AsNeeded;
-        } else {
-            *self = Semicolons::Always;
+        let node = JsonStringValue::cast_ref(node)?;
+        match node.inner_string_text().ok()?.text() {
+            "asNeeded" => *self = Self::AsNeeded,
+            "always" => *self = Self::Always,
+            _ => report_unknown_variant(&node, Self::ALLOWED_VARIANTS, diagnostics),
         }
         Some(())
     }
@@ -526,8 +530,6 @@ pub enum ArrowParentheses {
 }
 
 impl ArrowParentheses {
-    pub(crate) const KNOWN_VALUES: &'static [&'static str] = &["always", "asNeeded"];
-
     pub const fn is_as_needed(&self) -> bool {
         matches!(self, Self::AsNeeded)
     }
@@ -543,8 +545,8 @@ impl FromStr for ArrowParentheses {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "as-needed" => Ok(Self::AsNeeded),
-            "always" => Ok(Self::Always),
+            "as-needed" | "AsNeeded" => Ok(Self::AsNeeded),
+            "always" | "Always" => Ok(Self::Always),
             _ => Err("Value not supported for Arrow parentheses. Supported values are 'as-needed' and 'always'."),
         }
     }
@@ -559,17 +561,21 @@ impl fmt::Display for ArrowParentheses {
     }
 }
 
+impl ArrowParentheses {
+    const ALLOWED_VARIANTS: &'static [&'static str] = &["asNeeded", "always"];
+}
+
 impl VisitNode<JsonLanguage> for ArrowParentheses {
-    fn visit_member_value(
+    fn visit_value(
         &mut self,
         node: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let node = with_only_known_variants(node, ArrowParentheses::KNOWN_VALUES, diagnostics)?;
-        if node.inner_string_text().ok()?.text() == "asNeeded" {
-            *self = ArrowParentheses::AsNeeded;
-        } else {
-            *self = ArrowParentheses::Always;
+        let node = JsonStringValue::cast_ref(node)?;
+        match node.inner_string_text().ok()?.text() {
+            "asNeeded" => *self = Self::AsNeeded,
+            "always" => *self = Self::Always,
+            _ => report_unknown_variant(&node, Self::ALLOWED_VARIANTS, diagnostics),
         }
         Some(())
     }

--- a/crates/biome_js_formatter/src/context/trailing_comma.rs
+++ b/crates/biome_js_formatter/src/context/trailing_comma.rs
@@ -90,9 +90,9 @@ impl FromStr for TrailingComma {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "es5" | "ES5" => Ok(Self::Es5),
-            "all" | "All" => Ok(Self::All),
-            "none" | "None" => Ok(Self::None),
+            "es5" => Ok(Self::Es5),
+            "all" => Ok(Self::All),
+            "none" => Ok(Self::None),
             // TODO: replace this error with a diagnostic
             _ => Err("Value not supported for TrailingComma"),
         }
@@ -116,17 +116,8 @@ impl VisitNode<JsonLanguage> for TrailingComma {
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
         let node = with_only_known_variants(node, TrailingComma::KNOWN_VALUES, diagnostics)?;
-        match node.inner_string_text().ok()?.text() {
-            "all" => {
-                *self = TrailingComma::All;
-            }
-            "es5" => {
-                *self = TrailingComma::Es5;
-            }
-            "none" => {
-                *self = TrailingComma::None;
-            }
-            _ => {}
+        if let Ok(value) = node.inner_string_text().ok()?.text().parse::<Self>() {
+            *self = value;
         }
         Some(())
     }

--- a/crates/biome_js_formatter/src/context/trailing_comma.rs
+++ b/crates/biome_js_formatter/src/context/trailing_comma.rs
@@ -1,12 +1,12 @@
 use crate::prelude::*;
 use crate::{JsFormatContext, JsFormatOptions};
-use biome_deserialize::json::with_only_known_variants;
+use biome_deserialize::json::report_unknown_variant;
 use biome_deserialize::{DeserializationDiagnostic, VisitNode};
 use biome_formatter::formatter::Formatter;
 use biome_formatter::prelude::{if_group_breaks, text};
 use biome_formatter::write;
 use biome_formatter::{Format, FormatResult};
-use biome_json_syntax::JsonLanguage;
+use biome_json_syntax::{JsonLanguage, JsonStringValue};
 use biome_rowan::SyntaxNode;
 use std::fmt;
 use std::str::FromStr;
@@ -72,8 +72,6 @@ pub enum TrailingComma {
 }
 
 impl TrailingComma {
-    pub(crate) const KNOWN_VALUES: &'static [&'static str] = &["all", "es5", "none"];
-
     pub const fn is_es5(&self) -> bool {
         matches!(self, TrailingComma::Es5)
     }
@@ -90,9 +88,9 @@ impl FromStr for TrailingComma {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "es5" => Ok(Self::Es5),
-            "all" => Ok(Self::All),
-            "none" => Ok(Self::None),
+            "es5" | "ES5" => Ok(Self::Es5),
+            "all" | "All" => Ok(Self::All),
+            "none" | "None" => Ok(Self::None),
             // TODO: replace this error with a diagnostic
             _ => Err("Value not supported for TrailingComma"),
         }
@@ -109,15 +107,21 @@ impl fmt::Display for TrailingComma {
     }
 }
 
+impl TrailingComma {
+    const ALLOWED_VARIANTS: &'static [&'static str] = &["all", "es5", "none"];
+}
+
 impl VisitNode<JsonLanguage> for TrailingComma {
-    fn visit_member_value(
+    fn visit_value(
         &mut self,
         node: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let node = with_only_known_variants(node, TrailingComma::KNOWN_VALUES, diagnostics)?;
+        let node = JsonStringValue::cast_ref(node)?;
         if let Ok(value) = node.inner_string_text().ok()?.text().parse::<Self>() {
             *self = value;
+        } else {
+            report_unknown_variant(&node, Self::ALLOWED_VARIANTS, diagnostics);
         }
         Some(())
     }

--- a/crates/biome_service/src/configuration/formatter.rs
+++ b/crates/biome_service/src/configuration/formatter.rs
@@ -62,16 +62,6 @@ impl FormatterConfiguration {
     pub const fn is_disabled(&self) -> bool {
         matches!(self.enabled, Some(false))
     }
-    pub(crate) const KNOWN_KEYS: &'static [&'static str] = &[
-        "enabled",
-        "formatWithErrors",
-        "indentStyle",
-        "indentSize",
-        "indentWidth",
-        "lineWidth",
-        "ignore",
-        "include",
-    ];
 }
 
 impl Default for FormatterConfiguration {
@@ -227,10 +217,6 @@ pub enum PlainIndentStyle {
     Tab,
     /// Space
     Space,
-}
-
-impl PlainIndentStyle {
-    pub(crate) const KNOWN_VALUES: &'static [&'static str] = &["tab", "space"];
 }
 
 impl FromStr for PlainIndentStyle {

--- a/crates/biome_service/src/configuration/formatter.rs
+++ b/crates/biome_service/src/configuration/formatter.rs
@@ -89,8 +89,9 @@ impl Default for FormatterConfiguration {
     }
 }
 
+/// Required by [Bpaf].
 impl FromStr for FormatterConfiguration {
-    type Err = String;
+    type Err = &'static str;
 
     fn from_str(_s: &str) -> Result<Self, Self::Err> {
         Ok(Self::default())
@@ -233,13 +234,13 @@ impl PlainIndentStyle {
 }
 
 impl FromStr for PlainIndentStyle {
-    type Err = String;
+    type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "tab" => Ok(PlainIndentStyle::Tab),
             "space" => Ok(PlainIndentStyle::Space),
-            _ => Err("Unsupported value for this option".to_string()),
+            _ => Err("Unsupported value for this option"),
         }
     }
 }

--- a/crates/biome_service/src/configuration/javascript/formatter.rs
+++ b/crates/biome_service/src/configuration/javascript/formatter.rs
@@ -75,22 +75,6 @@ pub struct JavascriptFormatter {
     pub line_width: Option<LineWidth>,
 }
 
-impl JavascriptFormatter {
-    pub(crate) const KNOWN_KEYS: &'static [&'static str] = &[
-        "quoteStyle",
-        "jsxQuoteStyle",
-        "quoteProperties",
-        "trailingComma",
-        "semicolons",
-        "arrowParentheses",
-        "enabled",
-        "indentStyle",
-        "indentSize",
-        "indentWidth",
-        "lineWidth",
-    ];
-}
-
 impl MergeWith<JavascriptFormatter> for JavascriptFormatter {
     fn merge_with(&mut self, other: JavascriptFormatter) {
         if let Some(arrow_parentheses) = other.arrow_parentheses {

--- a/crates/biome_service/src/configuration/javascript/mod.rs
+++ b/crates/biome_service/src/configuration/javascript/mod.rs
@@ -84,9 +84,6 @@ impl MergeWith<Option<JavascriptFormatter>> for JavascriptConfiguration {
 }
 
 impl JavascriptConfiguration {
-    pub(crate) const KNOWN_KEYS: &'static [&'static str] =
-        &["formatter", "globals", "organizeImports", "parser"];
-
     pub fn with_formatter() -> Self {
         Self {
             formatter: Some(JavascriptFormatter::default()),
@@ -111,10 +108,6 @@ pub struct JavascriptParser {
     ///
     /// These decorators belong to an old proposal, and they are subject to change.
     pub unsafe_parameter_decorators_enabled: Option<bool>,
-}
-
-impl JavascriptParser {
-    pub(crate) const KNOWN_KEYS: &'static [&'static str] = &["unsafeParameterDecoratorsEnabled"];
 }
 
 impl MergeWith<JavascriptParser> for JavascriptParser {

--- a/crates/biome_service/src/configuration/json.rs
+++ b/crates/biome_service/src/configuration/json.rs
@@ -20,10 +20,6 @@ pub struct JsonConfiguration {
     pub formatter: Option<JsonFormatter>,
 }
 
-impl JsonConfiguration {
-    pub const KNOWN_KEYS: &'static [&'static str] = &["parser", "formatter"];
-}
-
 impl MergeWith<JsonConfiguration> for JsonConfiguration {
     fn merge_with(&mut self, other: JsonConfiguration) {
         if let Some(other_parser) = other.parser {
@@ -59,11 +55,6 @@ pub struct JsonParser {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Allow parsing trailing commas in `.json` files
     pub allow_trailing_commas: Option<bool>,
-}
-
-impl JsonParser {
-    pub(crate) const KNOWN_KEYS: &'static [&'static str] =
-        &["allowComments", "allowTrailingCommas"];
 }
 
 impl MergeWith<JsonParser> for JsonParser {
@@ -118,16 +109,6 @@ pub struct JsonFormatter {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[bpaf(long("json-formatter-line-width"), argument("NUMBER"), optional)]
     pub line_width: Option<LineWidth>,
-}
-
-impl JsonFormatter {
-    pub(crate) const KNOWN_KEYS: &'static [&'static str] = &[
-        "enabled",
-        "indentStyle",
-        "indentSize",
-        "indentWidth",
-        "lineWidth",
-    ];
 }
 
 impl MergeWith<JsonFormatter> for JsonFormatter {

--- a/crates/biome_service/src/configuration/linter/mod.rs
+++ b/crates/biome_service/src/configuration/linter/mod.rs
@@ -64,8 +64,6 @@ impl LinterConfiguration {
     pub const fn is_disabled(&self) -> bool {
         matches!(self.enabled, Some(false))
     }
-    pub(crate) const KNOWN_KEYS: &'static [&'static str] =
-        &["enabled", "rules", "include", "ignore"];
 }
 
 impl Default for LinterConfiguration {
@@ -179,10 +177,6 @@ pub enum RulePlainConfiguration {
     Warn,
     Error,
     Off,
-}
-
-impl RulePlainConfiguration {
-    pub(crate) const KNOWN_KEYS: &'static [&'static str] = &["warn", "error", "off"];
 }
 
 impl FromStr for RulePlainConfiguration {

--- a/crates/biome_service/src/configuration/mod.rs
+++ b/crates/biome_service/src/configuration/mod.rs
@@ -122,18 +122,6 @@ impl Default for Configuration {
 }
 
 impl Configuration {
-    const KNOWN_KEYS: &'static [&'static str] = &[
-        "vcs",
-        "files",
-        "linter",
-        "formatter",
-        "javascript",
-        "json",
-        "$schema",
-        "organizeImports",
-        "extends",
-        "overrides",
-    ];
     pub fn is_formatter_disabled(&self) -> bool {
         self.formatter
             .as_ref()
@@ -390,10 +378,6 @@ pub struct FilesConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[bpaf(long("files-ignore-unknown"), argument("true|false"), optional)]
     pub ignore_unknown: Option<bool>,
-}
-
-impl FilesConfiguration {
-    const KNOWN_KEYS: &'static [&'static str] = &["maxSize", "ignore", "include", "ignoreUnknown"];
 }
 
 impl MergeWith<FilesConfiguration> for FilesConfiguration {

--- a/crates/biome_service/src/configuration/mod.rs
+++ b/crates/biome_service/src/configuration/mod.rs
@@ -156,10 +156,7 @@ impl Configuration {
     }
 
     pub fn is_vcs_disabled(&self) -> bool {
-        self.vcs
-            .as_ref()
-            .map(|f| matches!(f.enabled, Some(false)))
-            .unwrap_or(true)
+        self.vcs.as_ref().map(|f| f.is_disabled()).unwrap_or(true)
     }
 }
 

--- a/crates/biome_service/src/configuration/overrides.rs
+++ b/crates/biome_service/src/configuration/overrides.rs
@@ -91,18 +91,6 @@ pub struct OverridePattern {
     pub organize_imports: Option<OverrideOrganizeImportsConfiguration>,
 }
 
-impl OverridePattern {
-    pub const KNOWN_KEYS: &'static [&'static str] = &[
-        "ignore",
-        "include",
-        "formatter",
-        "linter",
-        "organizeImports",
-        "javascript",
-        "json",
-    ];
-}
-
 impl FromStr for OverridePattern {
     type Err = String;
 
@@ -236,17 +224,6 @@ pub struct OverrideFormatterConfiguration {
     pub line_width: Option<LineWidth>,
 }
 
-impl OverrideFormatterConfiguration {
-    pub(crate) const KNOWN_KEYS: &'static [&'static str] = &[
-        "enabled",
-        "formatWithErrors",
-        "indentStyle",
-        "indentSize",
-        "indentWidth",
-        "lineWidth",
-    ];
-}
-
 impl MergeWith<OverrideFormatterConfiguration> for OverrideFormatterConfiguration {
     fn merge_with(&mut self, other: OverrideFormatterConfiguration) {
         if let Some(enabled) = other.enabled {
@@ -296,10 +273,6 @@ pub struct OverrideLinterConfiguration {
     pub rules: Option<Rules>,
 }
 
-impl OverrideLinterConfiguration {
-    pub(crate) const KNOWN_KEYS: &'static [&'static str] = &["enabled", "rules"];
-}
-
 impl MergeWith<OverrideLinterConfiguration> for OverrideLinterConfiguration {
     fn merge_with(&mut self, other: OverrideLinterConfiguration) {
         if let Some(enabled) = other.enabled {
@@ -328,10 +301,6 @@ pub struct OverrideOrganizeImportsConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[bpaf(hide)]
     pub enabled: Option<bool>,
-}
-
-impl OverrideOrganizeImportsConfiguration {
-    pub(crate) const KNOWN_KEYS: &'static [&'static str] = &["enabled"];
 }
 
 impl MergeWith<OverrideOrganizeImportsConfiguration> for OverrideOrganizeImportsConfiguration {

--- a/crates/biome_service/src/configuration/parse/json/formatter.rs
+++ b/crates/biome_service/src/configuration/parse/json/formatter.rs
@@ -1,28 +1,34 @@
 use crate::configuration::{FormatterConfiguration, PlainIndentStyle};
 use biome_console::markup;
-use biome_deserialize::json::{has_only_known_keys, with_only_known_variants, VisitJsonNode};
+use biome_deserialize::json::{report_unknown_map_key, report_unknown_variant, VisitJsonNode};
 use biome_deserialize::{DeserializationDiagnostic, StringSet, VisitNode};
 use biome_formatter::LineWidth;
-use biome_json_syntax::{JsonLanguage, JsonSyntaxNode};
+use biome_json_syntax::{JsonLanguage, JsonStringValue};
 use biome_rowan::{AstNode, SyntaxNode};
 
-impl VisitNode<JsonLanguage> for FormatterConfiguration {
-    fn visit_member_name(
-        &mut self,
-        node: &JsonSyntaxNode,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(node, FormatterConfiguration::KNOWN_KEYS, diagnostics)
-    }
+impl FormatterConfiguration {
+    const ALLOWED_KEYS: &'static [&'static str] = &[
+        "enabled",
+        "formatWithErrors",
+        "indentStyle",
+        "indentSize",
+        "indentWidth",
+        "lineWidth",
+        "ignore",
+        "include",
+    ];
+}
 
+impl VisitNode<JsonLanguage> for FormatterConfiguration {
     fn visit_map(
         &mut self,
         key: &SyntaxNode<JsonLanguage>,
         value: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         match name_text {
             "enabled" => {
                 self.enabled = self.map_to_boolean(&value, name_text, diagnostics);
@@ -55,7 +61,6 @@ impl VisitNode<JsonLanguage> for FormatterConfiguration {
             }
             "lineWidth" => {
                 let line_width = self.map_to_u16(&value, name_text, LineWidth::MAX, diagnostics)?;
-
                 self.line_width = Some(match LineWidth::try_from(line_width) {
                     Ok(result) => result,
                     Err(err) => {
@@ -73,21 +78,29 @@ impl VisitNode<JsonLanguage> for FormatterConfiguration {
             "formatWithErrors" => {
                 self.format_with_errors = self.map_to_boolean(&value, name_text, diagnostics);
             }
-            _ => {}
+            _ => {
+                report_unknown_map_key(&name, Self::ALLOWED_KEYS, diagnostics);
+            }
         }
         Some(())
     }
 }
 
+impl PlainIndentStyle {
+    const ALLOWED_VARIANTS: &'static [&'static str] = &["tab", "space"];
+}
+
 impl VisitNode<JsonLanguage> for PlainIndentStyle {
-    fn visit_member_value(
+    fn visit_value(
         &mut self,
         node: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let node = with_only_known_variants(node, PlainIndentStyle::KNOWN_VALUES, diagnostics)?;
+        let node = JsonStringValue::cast_ref(node)?;
         if let Ok(value) = node.inner_string_text().ok()?.text().parse::<Self>() {
             *self = value;
+        } else {
+            report_unknown_variant(&node, Self::ALLOWED_VARIANTS, diagnostics);
         }
         Some(())
     }

--- a/crates/biome_service/src/configuration/parse/json/formatter.rs
+++ b/crates/biome_service/src/configuration/parse/json/formatter.rs
@@ -89,10 +89,8 @@ impl VisitNode<JsonLanguage> for PlainIndentStyle {
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
         let node = with_only_known_variants(node, PlainIndentStyle::KNOWN_VALUES, diagnostics)?;
-        if node.inner_string_text().ok()? == "space" {
-            *self = PlainIndentStyle::Space;
-        } else {
-            *self = PlainIndentStyle::Tab;
+        if let Ok(value) = node.inner_string_text().ok()?.text().parse::<Self>() {
+            *self = value;
         }
         Some(())
     }

--- a/crates/biome_service/src/configuration/parse/json/formatter.rs
+++ b/crates/biome_service/src/configuration/parse/json/formatter.rs
@@ -23,7 +23,6 @@ impl VisitNode<JsonLanguage> for FormatterConfiguration {
     ) -> Option<()> {
         let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
         let name_text = name.text();
-
         match name_text {
             "enabled" => {
                 self.enabled = self.map_to_boolean(&value, name_text, diagnostics);
@@ -38,7 +37,6 @@ impl VisitNode<JsonLanguage> for FormatterConfiguration {
                     .map_to_index_set_string(&value, name_text, diagnostics)
                     .map(StringSet::new);
             }
-
             "indentStyle" => {
                 let mut indent_style = PlainIndentStyle::default();
                 indent_style.map_to_known_string(&value, name_text, diagnostics)?;
@@ -77,7 +75,6 @@ impl VisitNode<JsonLanguage> for FormatterConfiguration {
             }
             _ => {}
         }
-
         Some(())
     }
 }

--- a/crates/biome_service/src/configuration/parse/json/javascript/mod.rs
+++ b/crates/biome_service/src/configuration/parse/json/javascript/mod.rs
@@ -2,42 +2,37 @@ mod formatter;
 
 use crate::configuration::javascript::{JavascriptOrganizeImports, JavascriptParser};
 use crate::configuration::{JavascriptConfiguration, JavascriptFormatter};
-use biome_deserialize::json::{has_only_known_keys, VisitJsonNode};
+use biome_deserialize::json::{report_unknown_map_key, VisitJsonNode};
 use biome_deserialize::{DeserializationDiagnostic, StringSet, VisitNode};
 use biome_json_syntax::{JsonLanguage, JsonSyntaxNode};
 use biome_rowan::SyntaxNode;
 
-impl VisitNode<JsonLanguage> for JavascriptConfiguration {
-    fn visit_member_name(
-        &mut self,
-        node: &JsonSyntaxNode,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(node, JavascriptConfiguration::KNOWN_KEYS, diagnostics)
-    }
+impl JavascriptConfiguration {
+    const ALLOWED_KEYS: &'static [&'static str] =
+        &["formatter", "globals", "organizeImports", "parser"];
+}
 
+impl VisitNode<JsonLanguage> for JavascriptConfiguration {
     fn visit_map(
         &mut self,
         key: &SyntaxNode<JsonLanguage>,
         value: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
-
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         match name_text {
             "formatter" => {
                 let mut javascript_formatter = JavascriptFormatter::default();
                 javascript_formatter.map_to_object(&value, name_text, diagnostics)?;
                 self.formatter = Some(javascript_formatter);
             }
-
             "parser" => {
                 let mut parser = JavascriptParser::default();
                 parser.map_to_object(&value, name_text, diagnostics)?;
                 self.parser = Some(parser);
             }
-
             "globals" => {
                 self.globals = self
                     .map_to_index_set_string(&value, name_text, diagnostics)
@@ -48,7 +43,9 @@ impl VisitNode<JsonLanguage> for JavascriptConfiguration {
                 javascript_organize_imports.map_to_object(&value, name_text, diagnostics)?;
                 self.organize_imports = Some(javascript_organize_imports);
             }
-            _ => {}
+            _ => {
+                report_unknown_map_key(&name, Self::ALLOWED_KEYS, diagnostics);
+            }
         }
 
         Some(())
@@ -66,26 +63,25 @@ impl VisitNode<JsonLanguage> for JavascriptOrganizeImports {
     }
 }
 
-impl VisitNode<JsonLanguage> for JavascriptParser {
-    fn visit_member_name(
-        &mut self,
-        node: &JsonSyntaxNode,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(node, JavascriptParser::KNOWN_KEYS, diagnostics)
-    }
+impl JavascriptParser {
+    const ALLOWED_KEYS: &'static [&'static str] = &["unsafeParameterDecoratorsEnabled"];
+}
 
+impl VisitNode<JsonLanguage> for JavascriptParser {
     fn visit_map(
         &mut self,
         key: &SyntaxNode<JsonLanguage>,
         value: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         if name_text == "unsafeParameterDecoratorsEnabled" {
             self.unsafe_parameter_decorators_enabled =
                 self.map_to_boolean(&value, name_text, diagnostics);
+        } else {
+            report_unknown_map_key(&name, Self::ALLOWED_KEYS, diagnostics);
         }
 
         Some(())

--- a/crates/biome_service/src/configuration/parse/json/organize_imports.rs
+++ b/crates/biome_service/src/configuration/parse/json/organize_imports.rs
@@ -1,26 +1,23 @@
 use crate::configuration::organize_imports::OrganizeImports;
-use biome_deserialize::json::{has_only_known_keys, VisitJsonNode};
+use biome_deserialize::json::{report_unknown_map_key, VisitJsonNode};
 use biome_deserialize::{DeserializationDiagnostic, StringSet, VisitNode};
-use biome_json_syntax::{JsonLanguage, JsonSyntaxNode};
+use biome_json_syntax::JsonLanguage;
 use biome_rowan::SyntaxNode;
 
-impl VisitNode<JsonLanguage> for OrganizeImports {
-    fn visit_member_name(
-        &mut self,
-        node: &JsonSyntaxNode,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(node, &["enabled", "include", "ignore"], diagnostics)
-    }
+impl OrganizeImports {
+    const ALLOWED_KEYS: &'static [&'static str] = &["enabled", "ignore", "include"];
+}
 
+impl VisitNode<JsonLanguage> for OrganizeImports {
     fn visit_map(
         &mut self,
         key: &SyntaxNode<JsonLanguage>,
         value: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         match name_text {
             "enabled" => {
                 self.enabled = self.map_to_boolean(&value, name_text, diagnostics);
@@ -35,7 +32,9 @@ impl VisitNode<JsonLanguage> for OrganizeImports {
                     .map_to_index_set_string(&value, name_text, diagnostics)
                     .map(StringSet::new);
             }
-            _ => {}
+            _ => {
+                report_unknown_map_key(&name, Self::ALLOWED_KEYS, diagnostics);
+            }
         }
 
         Some(())

--- a/crates/biome_service/src/configuration/parse/json/rules.rs
+++ b/crates/biome_service/src/configuration/parse/json/rules.rs
@@ -3,41 +3,20 @@
 use crate::configuration::linter::*;
 use crate::configuration::parse::json::linter::are_recommended_and_all_correct;
 use crate::Rules;
-use biome_deserialize::json::{has_only_known_keys, VisitJsonNode};
+use biome_deserialize::json::{report_unknown_map_key, VisitJsonNode};
 use biome_deserialize::{DeserializationDiagnostic, VisitNode};
 use biome_json_syntax::JsonLanguage;
 use biome_rowan::SyntaxNode;
 impl VisitNode<JsonLanguage> for Rules {
-    fn visit_member_name(
-        &mut self,
-        node: &SyntaxNode<JsonLanguage>,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(
-            node,
-            &[
-                "recommended",
-                "all",
-                "a11y",
-                "complexity",
-                "correctness",
-                "nursery",
-                "performance",
-                "security",
-                "style",
-                "suspicious",
-            ],
-            diagnostics,
-        )
-    }
     fn visit_map(
         &mut self,
         key: &SyntaxNode<JsonLanguage>,
         value: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         match name_text {
             "recommended" => {
                 self.recommended = Some(self.map_to_boolean(&value, name_text, diagnostics)?);
@@ -101,60 +80,38 @@ impl VisitNode<JsonLanguage> for Rules {
                     self.suspicious = Some(visitor);
                 }
             }
-            _ => {}
+            _ => {
+                report_unknown_map_key(
+                    &name,
+                    &[
+                        "recommended",
+                        "all",
+                        "a11y",
+                        "complexity",
+                        "correctness",
+                        "nursery",
+                        "performance",
+                        "security",
+                        "style",
+                        "suspicious",
+                    ],
+                    diagnostics,
+                );
+            }
         }
         Some(())
     }
 }
 impl VisitNode<JsonLanguage> for A11y {
-    fn visit_member_name(
-        &mut self,
-        node: &SyntaxNode<JsonLanguage>,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(
-            node,
-            &[
-                "recommended",
-                "all",
-                "noAccessKey",
-                "noAriaUnsupportedElements",
-                "noAutofocus",
-                "noBlankTarget",
-                "noDistractingElements",
-                "noHeaderScope",
-                "noNoninteractiveElementToInteractiveRole",
-                "noNoninteractiveTabindex",
-                "noPositiveTabindex",
-                "noRedundantAlt",
-                "noRedundantRoles",
-                "noSvgWithoutTitle",
-                "useAltText",
-                "useAnchorContent",
-                "useAriaPropsForRole",
-                "useButtonType",
-                "useHeadingContent",
-                "useHtmlLang",
-                "useIframeTitle",
-                "useKeyWithClickEvents",
-                "useKeyWithMouseEvents",
-                "useMediaCaption",
-                "useValidAnchor",
-                "useValidAriaProps",
-                "useValidAriaValues",
-                "useValidLang",
-            ],
-            diagnostics,
-        )
-    }
     fn visit_map(
         &mut self,
         key: &SyntaxNode<JsonLanguage>,
         value: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         match name_text {
             "recommended" => {
                 self.recommended = Some(self.map_to_boolean(&value, name_text, diagnostics)?);
@@ -316,56 +273,56 @@ impl VisitNode<JsonLanguage> for A11y {
                 configuration.map_rule_configuration(&value, "useValidLang", diagnostics)?;
                 self.use_valid_lang = Some(configuration);
             }
-            _ => {}
+            _ => {
+                report_unknown_map_key(
+                    &name,
+                    &[
+                        "recommended",
+                        "all",
+                        "noAccessKey",
+                        "noAriaUnsupportedElements",
+                        "noAutofocus",
+                        "noBlankTarget",
+                        "noDistractingElements",
+                        "noHeaderScope",
+                        "noNoninteractiveElementToInteractiveRole",
+                        "noNoninteractiveTabindex",
+                        "noPositiveTabindex",
+                        "noRedundantAlt",
+                        "noRedundantRoles",
+                        "noSvgWithoutTitle",
+                        "useAltText",
+                        "useAnchorContent",
+                        "useAriaPropsForRole",
+                        "useButtonType",
+                        "useHeadingContent",
+                        "useHtmlLang",
+                        "useIframeTitle",
+                        "useKeyWithClickEvents",
+                        "useKeyWithMouseEvents",
+                        "useMediaCaption",
+                        "useValidAnchor",
+                        "useValidAriaProps",
+                        "useValidAriaValues",
+                        "useValidLang",
+                    ],
+                    diagnostics,
+                );
+            }
         }
         Some(())
     }
 }
 impl VisitNode<JsonLanguage> for Complexity {
-    fn visit_member_name(
-        &mut self,
-        node: &SyntaxNode<JsonLanguage>,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(
-            node,
-            &[
-                "recommended",
-                "all",
-                "noBannedTypes",
-                "noExcessiveCognitiveComplexity",
-                "noExtraBooleanCast",
-                "noForEach",
-                "noMultipleSpacesInRegularExpressionLiterals",
-                "noStaticOnlyClass",
-                "noUselessCatch",
-                "noUselessConstructor",
-                "noUselessEmptyExport",
-                "noUselessFragments",
-                "noUselessLabel",
-                "noUselessRename",
-                "noUselessSwitchCase",
-                "noUselessThisAlias",
-                "noUselessTypeConstraint",
-                "noVoid",
-                "noWith",
-                "useFlatMap",
-                "useLiteralKeys",
-                "useOptionalChain",
-                "useSimpleNumberKeys",
-                "useSimplifiedLogicExpression",
-            ],
-            diagnostics,
-        )
-    }
     fn visit_map(
         &mut self,
         key: &SyntaxNode<JsonLanguage>,
         value: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         match name_text {
             "recommended" => {
                 self.recommended = Some(self.map_to_boolean(&value, name_text, diagnostics)?);
@@ -507,65 +464,52 @@ impl VisitNode<JsonLanguage> for Complexity {
                 )?;
                 self.use_simplified_logic_expression = Some(configuration);
             }
-            _ => {}
+            _ => {
+                report_unknown_map_key(
+                    &name,
+                    &[
+                        "recommended",
+                        "all",
+                        "noBannedTypes",
+                        "noExcessiveCognitiveComplexity",
+                        "noExtraBooleanCast",
+                        "noForEach",
+                        "noMultipleSpacesInRegularExpressionLiterals",
+                        "noStaticOnlyClass",
+                        "noUselessCatch",
+                        "noUselessConstructor",
+                        "noUselessEmptyExport",
+                        "noUselessFragments",
+                        "noUselessLabel",
+                        "noUselessRename",
+                        "noUselessSwitchCase",
+                        "noUselessThisAlias",
+                        "noUselessTypeConstraint",
+                        "noVoid",
+                        "noWith",
+                        "useFlatMap",
+                        "useLiteralKeys",
+                        "useOptionalChain",
+                        "useSimpleNumberKeys",
+                        "useSimplifiedLogicExpression",
+                    ],
+                    diagnostics,
+                );
+            }
         }
         Some(())
     }
 }
 impl VisitNode<JsonLanguage> for Correctness {
-    fn visit_member_name(
-        &mut self,
-        node: &SyntaxNode<JsonLanguage>,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(
-            node,
-            &[
-                "recommended",
-                "all",
-                "noChildrenProp",
-                "noConstAssign",
-                "noConstantCondition",
-                "noConstructorReturn",
-                "noEmptyPattern",
-                "noGlobalObjectCalls",
-                "noInnerDeclarations",
-                "noInvalidConstructorSuper",
-                "noNewSymbol",
-                "noNonoctalDecimalEscape",
-                "noPrecisionLoss",
-                "noRenderReturnValue",
-                "noSelfAssign",
-                "noSetterReturn",
-                "noStringCaseMismatch",
-                "noSwitchDeclarations",
-                "noUndeclaredVariables",
-                "noUnnecessaryContinue",
-                "noUnreachable",
-                "noUnreachableSuper",
-                "noUnsafeFinally",
-                "noUnsafeOptionalChaining",
-                "noUnusedLabels",
-                "noUnusedVariables",
-                "noVoidElementsWithChildren",
-                "noVoidTypeReturn",
-                "useExhaustiveDependencies",
-                "useHookAtTopLevel",
-                "useIsNan",
-                "useValidForDirection",
-                "useYield",
-            ],
-            diagnostics,
-        )
-    }
     fn visit_map(
         &mut self,
         key: &SyntaxNode<JsonLanguage>,
         value: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         match name_text {
             "recommended" => {
                 self.recommended = Some(self.map_to_boolean(&value, name_text, diagnostics)?);
@@ -768,52 +712,61 @@ impl VisitNode<JsonLanguage> for Correctness {
                 configuration.map_rule_configuration(&value, "useYield", diagnostics)?;
                 self.use_yield = Some(configuration);
             }
-            _ => {}
+            _ => {
+                report_unknown_map_key(
+                    &name,
+                    &[
+                        "recommended",
+                        "all",
+                        "noChildrenProp",
+                        "noConstAssign",
+                        "noConstantCondition",
+                        "noConstructorReturn",
+                        "noEmptyPattern",
+                        "noGlobalObjectCalls",
+                        "noInnerDeclarations",
+                        "noInvalidConstructorSuper",
+                        "noNewSymbol",
+                        "noNonoctalDecimalEscape",
+                        "noPrecisionLoss",
+                        "noRenderReturnValue",
+                        "noSelfAssign",
+                        "noSetterReturn",
+                        "noStringCaseMismatch",
+                        "noSwitchDeclarations",
+                        "noUndeclaredVariables",
+                        "noUnnecessaryContinue",
+                        "noUnreachable",
+                        "noUnreachableSuper",
+                        "noUnsafeFinally",
+                        "noUnsafeOptionalChaining",
+                        "noUnusedLabels",
+                        "noUnusedVariables",
+                        "noVoidElementsWithChildren",
+                        "noVoidTypeReturn",
+                        "useExhaustiveDependencies",
+                        "useHookAtTopLevel",
+                        "useIsNan",
+                        "useValidForDirection",
+                        "useYield",
+                    ],
+                    diagnostics,
+                );
+            }
         }
         Some(())
     }
 }
 impl VisitNode<JsonLanguage> for Nursery {
-    fn visit_member_name(
-        &mut self,
-        node: &SyntaxNode<JsonLanguage>,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(
-            node,
-            &[
-                "recommended",
-                "all",
-                "noApproximativeNumericConstant",
-                "noDuplicateJsonKeys",
-                "noEmptyBlockStatements",
-                "noEmptyCharacterClassInRegex",
-                "noInteractiveElementToNoninteractiveRole",
-                "noInvalidNewBuiltin",
-                "noMisleadingInstantiator",
-                "noMisrefactoredShorthandAssign",
-                "noThisInStatic",
-                "noUnusedImports",
-                "noUselessElse",
-                "noUselessLoneBlockStatements",
-                "useAriaActivedescendantWithTabindex",
-                "useArrowFunction",
-                "useAsConstAssertion",
-                "useGroupedTypeImport",
-                "useImportRestrictions",
-                "useShorthandAssign",
-            ],
-            diagnostics,
-        )
-    }
     fn visit_map(
         &mut self,
         key: &SyntaxNode<JsonLanguage>,
         value: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         match name_text {
             "recommended" => {
                 self.recommended = Some(self.map_to_boolean(&value, name_text, diagnostics)?);
@@ -951,31 +904,48 @@ impl VisitNode<JsonLanguage> for Nursery {
                 configuration.map_rule_configuration(&value, "useShorthandAssign", diagnostics)?;
                 self.use_shorthand_assign = Some(configuration);
             }
-            _ => {}
+            _ => {
+                report_unknown_map_key(
+                    &name,
+                    &[
+                        "recommended",
+                        "all",
+                        "noApproximativeNumericConstant",
+                        "noDuplicateJsonKeys",
+                        "noEmptyBlockStatements",
+                        "noEmptyCharacterClassInRegex",
+                        "noInteractiveElementToNoninteractiveRole",
+                        "noInvalidNewBuiltin",
+                        "noMisleadingInstantiator",
+                        "noMisrefactoredShorthandAssign",
+                        "noThisInStatic",
+                        "noUnusedImports",
+                        "noUselessElse",
+                        "noUselessLoneBlockStatements",
+                        "useAriaActivedescendantWithTabindex",
+                        "useArrowFunction",
+                        "useAsConstAssertion",
+                        "useGroupedTypeImport",
+                        "useImportRestrictions",
+                        "useShorthandAssign",
+                    ],
+                    diagnostics,
+                );
+            }
         }
         Some(())
     }
 }
 impl VisitNode<JsonLanguage> for Performance {
-    fn visit_member_name(
-        &mut self,
-        node: &SyntaxNode<JsonLanguage>,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(
-            node,
-            &["recommended", "all", "noAccumulatingSpread", "noDelete"],
-            diagnostics,
-        )
-    }
     fn visit_map(
         &mut self,
         key: &SyntaxNode<JsonLanguage>,
         value: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         match name_text {
             "recommended" => {
                 self.recommended = Some(self.map_to_boolean(&value, name_text, diagnostics)?);
@@ -997,36 +967,27 @@ impl VisitNode<JsonLanguage> for Performance {
                 configuration.map_rule_configuration(&value, "noDelete", diagnostics)?;
                 self.no_delete = Some(configuration);
             }
-            _ => {}
+            _ => {
+                report_unknown_map_key(
+                    &name,
+                    &["recommended", "all", "noAccumulatingSpread", "noDelete"],
+                    diagnostics,
+                );
+            }
         }
         Some(())
     }
 }
 impl VisitNode<JsonLanguage> for Security {
-    fn visit_member_name(
-        &mut self,
-        node: &SyntaxNode<JsonLanguage>,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(
-            node,
-            &[
-                "recommended",
-                "all",
-                "noDangerouslySetInnerHtml",
-                "noDangerouslySetInnerHtmlWithChildren",
-            ],
-            diagnostics,
-        )
-    }
     fn visit_map(
         &mut self,
         key: &SyntaxNode<JsonLanguage>,
         value: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         match name_text {
             "recommended" => {
                 self.recommended = Some(self.map_to_boolean(&value, name_text, diagnostics)?);
@@ -1052,63 +1013,32 @@ impl VisitNode<JsonLanguage> for Security {
                 )?;
                 self.no_dangerously_set_inner_html_with_children = Some(configuration);
             }
-            _ => {}
+            _ => {
+                report_unknown_map_key(
+                    &name,
+                    &[
+                        "recommended",
+                        "all",
+                        "noDangerouslySetInnerHtml",
+                        "noDangerouslySetInnerHtmlWithChildren",
+                    ],
+                    diagnostics,
+                );
+            }
         }
         Some(())
     }
 }
 impl VisitNode<JsonLanguage> for Style {
-    fn visit_member_name(
-        &mut self,
-        node: &SyntaxNode<JsonLanguage>,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(
-            node,
-            &[
-                "recommended",
-                "all",
-                "noArguments",
-                "noCommaOperator",
-                "noImplicitBoolean",
-                "noInferrableTypes",
-                "noNamespace",
-                "noNegationElse",
-                "noNonNullAssertion",
-                "noParameterAssign",
-                "noParameterProperties",
-                "noRestrictedGlobals",
-                "noShoutyConstants",
-                "noUnusedTemplateLiteral",
-                "noVar",
-                "useBlockStatements",
-                "useCollapsedElseIf",
-                "useConst",
-                "useDefaultParameterLast",
-                "useEnumInitializers",
-                "useExponentiationOperator",
-                "useFragmentSyntax",
-                "useLiteralEnumMembers",
-                "useNamingConvention",
-                "useNumericLiterals",
-                "useSelfClosingElements",
-                "useShorthandArrayType",
-                "useSingleCaseStatement",
-                "useSingleVarDeclarator",
-                "useTemplate",
-                "useWhile",
-            ],
-            diagnostics,
-        )
-    }
     fn visit_map(
         &mut self,
         key: &SyntaxNode<JsonLanguage>,
         value: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         match name_text {
             "recommended" => {
                 self.recommended = Some(self.map_to_boolean(&value, name_text, diagnostics)?);
@@ -1297,75 +1227,59 @@ impl VisitNode<JsonLanguage> for Style {
                 configuration.map_rule_configuration(&value, "useWhile", diagnostics)?;
                 self.use_while = Some(configuration);
             }
-            _ => {}
+            _ => {
+                report_unknown_map_key(
+                    &name,
+                    &[
+                        "recommended",
+                        "all",
+                        "noArguments",
+                        "noCommaOperator",
+                        "noImplicitBoolean",
+                        "noInferrableTypes",
+                        "noNamespace",
+                        "noNegationElse",
+                        "noNonNullAssertion",
+                        "noParameterAssign",
+                        "noParameterProperties",
+                        "noRestrictedGlobals",
+                        "noShoutyConstants",
+                        "noUnusedTemplateLiteral",
+                        "noVar",
+                        "useBlockStatements",
+                        "useCollapsedElseIf",
+                        "useConst",
+                        "useDefaultParameterLast",
+                        "useEnumInitializers",
+                        "useExponentiationOperator",
+                        "useFragmentSyntax",
+                        "useLiteralEnumMembers",
+                        "useNamingConvention",
+                        "useNumericLiterals",
+                        "useSelfClosingElements",
+                        "useShorthandArrayType",
+                        "useSingleCaseStatement",
+                        "useSingleVarDeclarator",
+                        "useTemplate",
+                        "useWhile",
+                    ],
+                    diagnostics,
+                );
+            }
         }
         Some(())
     }
 }
 impl VisitNode<JsonLanguage> for Suspicious {
-    fn visit_member_name(
-        &mut self,
-        node: &SyntaxNode<JsonLanguage>,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<()> {
-        has_only_known_keys(
-            node,
-            &[
-                "recommended",
-                "all",
-                "noArrayIndexKey",
-                "noAssignInExpressions",
-                "noAsyncPromiseExecutor",
-                "noCatchAssign",
-                "noClassAssign",
-                "noCommentText",
-                "noCompareNegZero",
-                "noConfusingLabels",
-                "noConfusingVoidType",
-                "noConsoleLog",
-                "noConstEnum",
-                "noControlCharactersInRegex",
-                "noDebugger",
-                "noDoubleEquals",
-                "noDuplicateCase",
-                "noDuplicateClassMembers",
-                "noDuplicateJsxProps",
-                "noDuplicateObjectKeys",
-                "noDuplicateParameters",
-                "noEmptyInterface",
-                "noExplicitAny",
-                "noExtraNonNullAssertion",
-                "noFallthroughSwitchClause",
-                "noFunctionAssign",
-                "noGlobalIsFinite",
-                "noGlobalIsNan",
-                "noImportAssign",
-                "noLabelVar",
-                "noPrototypeBuiltins",
-                "noRedeclare",
-                "noRedundantUseStrict",
-                "noSelfCompare",
-                "noShadowRestrictedNames",
-                "noSparseArray",
-                "noUnsafeDeclarationMerging",
-                "noUnsafeNegation",
-                "useDefaultSwitchClauseLast",
-                "useGetterReturn",
-                "useIsArray",
-                "useNamespaceKeyword",
-                "useValidTypeof",
-            ],
-            diagnostics,
-        )
-    }
     fn visit_map(
         &mut self,
         key: &SyntaxNode<JsonLanguage>,
         value: &SyntaxNode<JsonLanguage>,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
-        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
-        let name_text = name.text();
+        let (name, value) = self.get_key_and_value(key, value)?;
+        let name_text = name.inner_string_text().ok()?;
+        let name_text = name_text.text();
         match name_text {
             "recommended" => {
                 self.recommended = Some(self.map_to_boolean(&value, name_text, diagnostics)?);
@@ -1626,7 +1540,57 @@ impl VisitNode<JsonLanguage> for Suspicious {
                 configuration.map_rule_configuration(&value, "useValidTypeof", diagnostics)?;
                 self.use_valid_typeof = Some(configuration);
             }
-            _ => {}
+            _ => {
+                report_unknown_map_key(
+                    &name,
+                    &[
+                        "recommended",
+                        "all",
+                        "noArrayIndexKey",
+                        "noAssignInExpressions",
+                        "noAsyncPromiseExecutor",
+                        "noCatchAssign",
+                        "noClassAssign",
+                        "noCommentText",
+                        "noCompareNegZero",
+                        "noConfusingLabels",
+                        "noConfusingVoidType",
+                        "noConsoleLog",
+                        "noConstEnum",
+                        "noControlCharactersInRegex",
+                        "noDebugger",
+                        "noDoubleEquals",
+                        "noDuplicateCase",
+                        "noDuplicateClassMembers",
+                        "noDuplicateJsxProps",
+                        "noDuplicateObjectKeys",
+                        "noDuplicateParameters",
+                        "noEmptyInterface",
+                        "noExplicitAny",
+                        "noExtraNonNullAssertion",
+                        "noFallthroughSwitchClause",
+                        "noFunctionAssign",
+                        "noGlobalIsFinite",
+                        "noGlobalIsNan",
+                        "noImportAssign",
+                        "noLabelVar",
+                        "noPrototypeBuiltins",
+                        "noRedeclare",
+                        "noRedundantUseStrict",
+                        "noSelfCompare",
+                        "noShadowRestrictedNames",
+                        "noSparseArray",
+                        "noUnsafeDeclarationMerging",
+                        "noUnsafeNegation",
+                        "useDefaultSwitchClauseLast",
+                        "useGetterReturn",
+                        "useIsArray",
+                        "useNamespaceKeyword",
+                        "useValidTypeof",
+                    ],
+                    diagnostics,
+                );
+            }
         }
         Some(())
     }

--- a/crates/biome_service/src/configuration/vcs.rs
+++ b/crates/biome_service/src/configuration/vcs.rs
@@ -83,8 +83,6 @@ pub enum VcsClientKind {
 }
 
 impl VcsClientKind {
-    pub const KNOWN_VALUES: &'static [&'static str] = &["git"];
-
     pub const fn ignore_file(&self) -> &'static str {
         match self {
             VcsClientKind::Git => GIT_IGNORE_FILE_NAME,
@@ -101,9 +99,4 @@ impl FromStr for VcsClientKind {
             _ => Err("Value not supported for VcsClientKind"),
         }
     }
-}
-
-impl VcsConfiguration {
-    pub const KNOWN_KEYS: &'static [&'static str] =
-        &["clientKind", "enabled", "useIgnoreFile", "root"];
 }


### PR DESCRIPTION
## Summary

- rename `visit_member_value` to `visit_value`
- remove `visit_member_name`

The removal of `visit_member_name` allowed the removal of `has_only_known_keys`.
This utility function is now replaced by `report_unknown_map_key`.
It is called in `visit_map` when an unknown key is detected.

I also replaced `has_only_known_variants` with `report_unknown_variant`.
It is called in `visit_value` when an unknown variant is found.

## Test Plan

Ci should pass.

A CLI snapshot was updated because it now correctly report an unknown rule name.
