### PR TITLE
feat: deserializer POC

### DIFF
--- a/crates/biome_deserialize/src/diagnostics.rs
+++ b/crates/biome_deserialize/src/diagnostics.rs
@@ -158,3 +158,31 @@ impl Advices for DeserializationAdvice {
         Ok(())
     }
 }
+
+#[derive(Default)]
+pub struct DeserializationDiagnostics {
+    pub diagnostics: Vec<DeserializationDiagnostic>,
+    range: Option<TextRange>,
+}
+
+impl DeserializationDiagnostics {
+    pub fn set_range(&mut self, range: TextRange) {
+        self.range = Some(range);
+    }
+
+    pub fn report_incorrect_type(&mut self, _expected_type: impl Display) {
+        todo!();
+    }
+
+    pub fn report_unknown_key(&mut self, _allowed_keys: &[&str]) {
+        todo!();
+    }
+
+    pub fn report_unknown_variant(&mut self, _allowed_variants: &[&str]) {
+        todo!();
+    }
+
+    pub fn report_number_out_of_bounds(&mut self, _min: i64, _max: u64) {
+        todo!()
+    }
+}

--- a/crates/biome_deserialize/src/lib.rs
+++ b/crates/biome_deserialize/src/lib.rs
@@ -8,7 +8,7 @@ use biome_diagnostics::{Error, Severity};
 pub use diagnostics::{DeserializationAdvice, DeserializationDiagnostic};
 use std::fmt::Debug;
 pub use string_set::{deserialize_string_set, serialize_string_set, StringSet};
-pub use visitor::VisitNode;
+pub use visitor::*;
 
 /// A small type to interrogate the result of a JSON deserialization
 #[derive(Debug, Default)]

--- a/crates/biome_deserialize/src/lib.rs
+++ b/crates/biome_deserialize/src/lib.rs
@@ -5,7 +5,9 @@ pub mod json;
 pub mod string_set;
 
 use biome_diagnostics::{Error, Severity};
-pub use diagnostics::{DeserializationAdvice, DeserializationDiagnostic};
+pub use diagnostics::{
+    DeserializationAdvice, DeserializationDiagnostic, DeserializationDiagnostics,
+};
 use std::fmt::Debug;
 pub use string_set::{deserialize_string_set, serialize_string_set, StringSet};
 pub use visitor::*;

--- a/crates/biome_deserialize/src/visitor.rs
+++ b/crates/biome_deserialize/src/visitor.rs
@@ -1,5 +1,5 @@
 use crate::DeserializationDiagnostic;
-use biome_rowan::{Language, SyntaxNode};
+use biome_rowan::{Language, SyntaxNode, TextRange, TokenText};
 
 /// Generic trait to implement when resolving the configuration from a generic language
 pub trait VisitNode<L: Language>: Sized {
@@ -69,5 +69,150 @@ impl<L: Language> VisitNode<L> for () {
         _diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
         Some(())
+    }
+}
+
+pub trait NodeVisitor<L: DeserializableLanguage> {
+    fn visit_unit(&mut self, range: TextRange, diagnostics: &mut Vec<DeserializationDiagnostic>) {
+        self.fallback_on_error(range, diagnostics)
+    }
+
+    fn visit_bool(
+        &mut self,
+        _value: bool,
+        range: TextRange,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) {
+        self.fallback_on_error(range, diagnostics)
+    }
+
+    fn visit_str(
+        &mut self,
+        _value: &str,
+        range: TextRange,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) {
+        self.fallback_on_error(range, diagnostics)
+    }
+
+    fn visit_map(
+        &mut self,
+        _members: impl Iterator<Item = (SyntaxNode<L>, SyntaxNode<L>)>,
+        range: TextRange,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) {
+        self.fallback_on_error(range, diagnostics)
+    }
+
+    fn visit_array(
+        &mut self,
+        _items: impl Iterator<Item = SyntaxNode<L>>,
+        range: TextRange,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) {
+        self.fallback_on_error(range, diagnostics)
+    }
+
+    fn fallback_on_error(
+        &self,
+        range: TextRange,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) {
+        diagnostics.push(DeserializationDiagnostic::new("unsupported value").with_range(range))
+    }
+}
+
+pub trait Acceptable<L: Language> {
+    fn deserialize(
+        &mut self,
+        value: SyntaxNode<L>,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    );
+}
+
+impl<L: DeserializableLanguage, T: NodeVisitor<L>> Acceptable<L> for T {
+    fn deserialize(
+        &mut self,
+        value: SyntaxNode<L>,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) {
+        L::deserialize(self, value, diagnostics)
+    }
+}
+
+pub trait DeserializableLanguage: Language {
+    fn deserialize(
+        visitor: &mut impl NodeVisitor<Self>,
+        value: SyntaxNode<Self>,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    );
+
+    fn map_to_str(value: SyntaxNode<Self>) -> Option<TokenText>;
+}
+
+impl<L: DeserializableLanguage> NodeVisitor<L> for bool {
+    fn visit_bool(
+        &mut self,
+        value: bool,
+        _range: TextRange,
+        _diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) {
+        *self = value;
+    }
+
+    fn fallback_on_error(
+        &self,
+        range: TextRange,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) {
+        diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
+            "boolean", range,
+        ))
+    }
+}
+
+impl<L: DeserializableLanguage> NodeVisitor<L> for String {
+    fn visit_str(
+        &mut self,
+        value: &str,
+        _range: TextRange,
+        _diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) {
+        *self = value.to_string();
+    }
+
+    fn fallback_on_error(
+        &self,
+        range: TextRange,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) {
+        diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
+            "string", range,
+        ))
+    }
+}
+
+impl<L: DeserializableLanguage, T: Default + NodeVisitor<L>> NodeVisitor<L> for Vec<T> {
+    fn visit_array(
+        &mut self,
+        values: impl Iterator<Item = SyntaxNode<L>>,
+        _range: TextRange,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) {
+        for value in values {
+            let mut element = T::default();
+            element.deserialize(value, diagnostics);
+            self.push(element);
+        }
+    }
+
+    fn fallback_on_error(
+        &self,
+        range: TextRange,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) {
+        diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
+            "array", range,
+        ))
     }
 }


### PR DESCRIPTION
This PR presents a POC to write for write once deserialization code for biome configurations.
To demonstrate the feasibility of this, I only wrote the serialization of the configuration of `useNamingConvention` rule.

POC v1 is in commit 1.
POC v2 is in commit 2.

The system relies on two main traits defined in `biome_deserialize::visitor`:

- `NodeVisitor` (`DeserializationVisitor` in POC v2) which allows visiting a value (array, map, boolean ,string, ...)
- `DeserializableLanguage` that implements the specific code for every language

`NodeVisitor` is implemented by `bool`, `String`, `Vec<T>`, `NamingConventionOptions` and `EnumMemberCase`.
`DeserializableLanguage` is implemented by `JsonLanguage` (see `biome_deserialize::json`).

`DeserializableLanguage` requires the implementation of a method named `deserailize_value` that takes a visitor and a value (synatx node) as parameters.
An implantation of this method has to call the corresponding `visit_` method of the given visitor according to the type of the given node.

For convenience, the POC v2 provides a third trait named `Desrializable` with a method `desrializable`. The trait is implemented by `SyntaxNode<L>`.

In contrast to the first POC, POC v2, the visitor is not implemented for the instance of a type, but for the type itself. Instead of modifying the visited instance, it produces an instance of the visited type. This removes the constraint to have types that implement `Default`. This also provides a cleaner way to deserialize enums and other values.

POC v2 also introduces a new struct `DeserializationDiagnostics` that simplifies creation of a diagnostic and ensure that users use a curated list of diagnostics.

In comparison to the previous approach we can easily add a config language by implementing `DeserializableLanguage`.
We also avoids leaking representation information outside a type. Only the type know how deserialize itself.