### PR TITLE
fix(formatter): arrow function chain doesn't break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Apply the correct layout when the right hand of an assignment expression is a await expression or a yield expression. Contributed by @ematipico
-- Fix [#303](https://github.com/biomejs/biome/issues/303) Where neasted arrow functions doesn't break Contributed by @victor-teles
+- Fix [#303](https://github.com/biomejs/biome/issues/303), where nested arrow functions didn't break. Contributed by @victor-teles
 
 
 ### JavaScript APIs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Apply the correct layout when the right hand of an assignment expression is a await expression or a yield expression. Contributed by @ematipico
+- Fix [#303](https://github.com/biomejs/biome/issues/303) Where neasted arrow functions doesn't break Contributed by @victor-teles
+
 
 ### JavaScript APIs
 

--- a/crates/biome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -573,6 +573,10 @@ impl ArrowFunctionLayout {
                 {
                     should_break = should_break || should_break_chain(&current)?;
 
+                    if let Some(body) = JsArrowFunctionExpression::cast_ref(next.syntax()) {
+                        should_break = should_break || should_break_chain(&body)?;
+                    }
+
                     if head.is_none() {
                         head = Some(current);
                     } else {

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/params.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/params.js
@@ -319,3 +319,8 @@ foo(
       })
   ) => {}
 );
+
+export default (element) => async (Component, props, slotted, { client }) => {
+  delete props['class'];
+  if (!element.hasAttribute('ssr')) return;
+};

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/params.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/params.js.snap
@@ -328,6 +328,11 @@ foo(
   ) => {}
 );
 
+export default (element) => async (Component, props, slotted, { client }) => {
+  delete props['class'];
+  if (!element.hasAttribute('ssr')) return;
+};
+
 ```
 
 
@@ -651,6 +656,12 @@ foo(
 			}),
 	) => {},
 );
+
+export default (element) =>
+	async (Component, props, slotted, { client }) => {
+		delete props["class"];
+		if (!element.hasAttribute("ssr")) return;
+	};
 ```
 
 ## Output 2
@@ -969,6 +980,12 @@ foo(
 			}),
 	) => {},
 );
+
+export default element =>
+	async (Component, props, slotted, { client }) => {
+		delete props["class"];
+		if (!element.hasAttribute("ssr")) return;
+	};
 ```
 
 

--- a/crates/biome_js_formatter/tests/specs/prettier/js/arrows/issue-1389-curry.js.snap
+++ b/crates/biome_js_formatter/tests/specs/prettier/js/arrows/issue-1389-curry.js.snap
@@ -37,15 +37,7 @@ const makeSomeFunction2 =
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,6 +1,5 @@
- const foobar =
--  (argumentOne, argumentTwo, argumentThree) =>
--  (...restOfTheArguments) => {
-+  (argumentOne, argumentTwo, argumentThree) => (...restOfTheArguments) => {
-     return "baz";
-   };
- 
-@@ -9,10 +8,8 @@
+@@ -9,10 +9,8 @@
      return "baz";
    };
  
@@ -64,7 +56,8 @@ const makeSomeFunction2 =
 
 ```js
 const foobar =
-  (argumentOne, argumentTwo, argumentThree) => (...restOfTheArguments) => {
+  (argumentOne, argumentTwo, argumentThree) =>
+  (...restOfTheArguments) => {
     return "baz";
   };
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -29,7 +29,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Apply the correct layout when the right hand of an assignment expression is a await expression or a yield expression. Contributed by @ematipico
-- Fix [#303](https://github.com/biomejs/biome/issues/303) Where neasted arrow functions doesn't break Contributed by @victor-teles
+- Fix [#303](https://github.com/biomejs/biome/issues/303), where nested arrow functions didn't break. Contributed by @victor-teles
 
 
 ### JavaScript APIs

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -29,6 +29,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Apply the correct layout when the right hand of an assignment expression is a await expression or a yield expression. Contributed by @ematipico
+- Fix [#303](https://github.com/biomejs/biome/issues/303) Where neasted arrow functions doesn't break Contributed by @victor-teles
+
 
 ### JavaScript APIs
 


### PR DESCRIPTION
## Summary

This PR fixes #303

### About the resolution

When arrow functions returns another arrow function, we need to apply same break logic.

## Test Plan

- Validate snapshot 😄
- Added test case from issue
