### PR TITLE
challenge(formatter): add `bracketSpacing` option matching Prettier's setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### New features
 
 - Add a new option [`--line-ending`](https://biomejs.dev/reference/configuration/#formatterlineending). This option allows changing the type of line endings. Contributed by @SuperchupuDev
+- Added a new option called `--bracket-spacing` to the formatter. This option allows you to control whether spaces are inserted around the brackets of object literals. [#627](https://github.com/biomejs/biome/issues/627). Contributed by @faultyserver
 
 #### Bug fixes
 
@@ -88,10 +89,6 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Fix [#592](https://github.com/biomejs/biome/issues/592), by changing binary resolution in the IntelliJ plugin. Contributed by @Joshuabaker2
 
 ### Formatter
-
-#### New Features
-
-- Added a new option called `--bracket-spacing` to the formatter. This option allows you to control whether spaces are inserted around the brackets of object literals. [#627](https://github.com/rome/tools/issues/627)
 
 #### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Formatter
 
+#### New Features
+
+- Added a new option called `--bracket-spacing` to the formatter. This option allows you to control whether spaces are inserted around the brackets of object literals. [#627](https://github.com/rome/tools/issues/627)
+
 #### Bug fixes
 
 - Apply the correct layout when the right hand of an assignment expression is a await expression or a yield expression. Contributed by @ematipico

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -69,6 +69,16 @@ action => {};
 (action = 1) => {};
 "#;
 
+const APPLY_BRACKET_SPACING_BEFORE: &str = r#"import { Foo } from 'bar';
+let foo = { a, b };
+const { a, b } = foo;
+"#;
+
+const APPLY_BRACKET_SPACING_AFTER: &str = r#"import {Foo} from 'bar';
+let foo = {a, b};
+const {a, b} = foo;
+"#;
+
 // Without this, Test (windows-latest) fails with: `warning: constant `DEFAULT_CONFIGURATION_BEFORE` is never used`
 #[allow(dead_code)]
 const DEFAULT_CONFIGURATION_BEFORE: &str = r#"function f() {
@@ -643,6 +653,51 @@ fn applies_custom_arrow_parentheses() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "applies_custom_arrow_parentheses",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn applies_custom_bracket_spacing() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("file.js");
+    fs.insert(file_path.into(), APPLY_BRACKET_SPACING_BEFORE.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                ("--bracket-spacing"),
+                ("false"),
+                ("--write"),
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    let mut file = fs
+        .open(file_path)
+        .expect("formatting target file was removed by the CLI");
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .expect("failed to read file from memory FS");
+
+    assert_eq!(content, APPLY_BRACKET_SPACING_AFTER);
+
+    drop(file);
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "applies_custom_bracket_spacing",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -69,12 +69,12 @@ action => {};
 (action = 1) => {};
 "#;
 
-const APPLY_BRACKET_SPACING_BEFORE: &str = r#"import { Foo } from 'bar';
+const APPLY_BRACKET_SPACING_BEFORE: &str = r#"import { Foo } from "bar";
 let foo = { a, b };
 const { a, b } = foo;
 "#;
 
-const APPLY_BRACKET_SPACING_AFTER: &str = r#"import {Foo} from 'bar';
+const APPLY_BRACKET_SPACING_AFTER: &str = r#"import {Foo} from "bar";
 let foo = {a, b};
 const {a, b} = foo;
 "#;

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -37,8 +37,8 @@ The configuration that is contained inside the file `biome.json`
                               only in for statements where it is necessary because of ASI.
         --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow functions.
                               Defaults to "always".
-        --bracket-spacing=BOOLEAN  Whether to insert spaces around brackets in object literals. Defaults
-                              to true.
+        --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
+                              Defaults to true.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its super
                               languages) files.
         --javascript-formatter-indent-style=<tab|space>  The indent style applied to JavaScript (and

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -37,6 +37,8 @@ The configuration that is contained inside the file `biome.json`
                               only in for statements where it is necessary because of ASI.
         --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow functions.
                               Defaults to "always".
+        --bracket-spacing=BOOLEAN  Whether to insert spaces around brackets in object literals. Defaults
+                              to true.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its super
                               languages) files.
         --javascript-formatter-indent-style=<tab|space>  The indent style applied to JavaScript (and

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -39,6 +39,8 @@ The configuration that is contained inside the file `biome.json`
                               only in for statements where it is necessary because of ASI.
         --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow functions.
                               Defaults to "always".
+        --bracket-spacing=BOOLEAN  Whether to insert spaces around brackets in object literals. Defaults
+                              to true.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its super
                               languages) files.
         --javascript-formatter-indent-style=<tab|space>  The indent style applied to JavaScript (and

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -39,8 +39,8 @@ The configuration that is contained inside the file `biome.json`
                               only in for statements where it is necessary because of ASI.
         --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow functions.
                               Defaults to "always".
-        --bracket-spacing=BOOLEAN  Whether to insert spaces around brackets in object literals. Defaults
-                              to true.
+        --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
+                              Defaults to true.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its super
                               languages) files.
         --javascript-formatter-indent-style=<tab|space>  The indent style applied to JavaScript (and

--- a/crates/biome_cli/tests/snapshots/main_commands_format/applies_custom_bracket_spacing.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/applies_custom_bracket_spacing.snap
@@ -1,0 +1,20 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.js`
+
+```js
+import {Foo} from "bar";
+let foo = {a, b};
+const {a, b} = foo;
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -26,8 +26,8 @@ Formatting options specific to the JavaScript files
                               only in for statements where it is necessary because of ASI.
         --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow functions.
                               Defaults to "always".
-        --bracket-spacing=BOOLEAN  Whether to insert spaces around brackets in object literals. Defaults
-                              to true.
+        --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
+                              Defaults to true.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its super
                               languages) files.
         --javascript-formatter-indent-style=<tab|space>  The indent style applied to JavaScript (and

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -26,6 +26,8 @@ Formatting options specific to the JavaScript files
                               only in for statements where it is necessary because of ASI.
         --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow functions.
                               Defaults to "always".
+        --bracket-spacing=BOOLEAN  Whether to insert spaces around brackets in object literals. Defaults
+                              to true.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its super
                               languages) files.
         --javascript-formatter-indent-style=<tab|space>  The indent style applied to JavaScript (and

--- a/crates/biome_formatter/src/builders.rs
+++ b/crates/biome_formatter/src/builders.rs
@@ -601,6 +601,32 @@ pub const fn space() -> Space {
     Space
 }
 
+/// Optionally inserts a single space if the given condition is true.
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::format;
+/// use biome_formatter::prelude::*;
+///
+/// # fn main() -> FormatResult<()> {
+/// let elements = format!(SimpleFormatContext::default(), [text("a"), conditional_space(true), text("b")])?;
+/// let nospace = format!(SimpleFormatContext::default(), [text("a"), conditional_space(false), text("b")])?;
+///
+/// assert_eq!("a b", elements.print()?.as_code());
+/// assert_eq!("ab", nospace.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn conditional_space(should_insert: bool) -> Option<Space> {
+    if should_insert {
+        Some(Space)
+    } else {
+        None
+    }
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Space;
 
@@ -1044,6 +1070,110 @@ pub fn soft_block_indent<Context>(content: &impl Format<Context>) -> BlockIndent
     BlockIndent {
         content: Argument::new(content),
         mode: IndentMode::Soft,
+    }
+}
+
+/// Conditionally adds spaces around the content if its enclosing group fits
+/// within a single line and the caller suggests that the space should be added.
+/// Otherwise indents the content and separates it by line breaks.
+///
+/// # Examples
+///
+/// Adds line breaks and indents the content if the enclosing group doesn't fit on the line.
+///
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn main() -> FormatResult<()> {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(10).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let elements = format!(context, [
+///     group(&format_args![
+///         text("{"),
+///         soft_block_indent_with_conditional_space(&format_args![
+///             text("aPropertyThatExceeds"),
+///             text(":"),
+///             space(),
+///             text("'line width'"),
+///         ], false),
+///         text("}")
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "{\n\taPropertyThatExceeds: 'line width'\n}",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Adds spaces around the content if the caller requests it and the group fits on the line.
+///
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn main() -> FormatResult<()> {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         text("{"),
+///         soft_block_indent_with_conditional_space(&format_args![
+///             text("a"),
+///             text(":"),
+///             space(),
+///             text("5"),
+///         ], true),
+///         text("}")
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "{ a: 5 }",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Does not add spaces around the content if the caller denies it and the group fits on the line.
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn main() -> FormatResult<()> {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         text("{"),
+///         soft_block_indent_with_conditional_space(&format_args![
+///             text("a"),
+///             text(":"),
+///             space(),
+///             text("5"),
+///         ], false),
+///         text("}")
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "{a: 5}",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+pub fn soft_block_indent_with_conditional_space<Context>(
+    content: &impl Format<Context>,
+    should_add_space: bool,
+) -> BlockIndent<Context> {
+    if should_add_space {
+        soft_space_or_block_indent(content)
+    } else {
+        soft_block_indent(content)
     }
 }
 

--- a/crates/biome_formatter/src/builders.rs
+++ b/crates/biome_formatter/src/builders.rs
@@ -610,8 +610,8 @@ pub const fn space() -> Space {
 /// use biome_formatter::prelude::*;
 ///
 /// # fn main() -> FormatResult<()> {
-/// let elements = format!(SimpleFormatContext::default(), [text("a"), conditional_space(true), text("b")])?;
-/// let nospace = format!(SimpleFormatContext::default(), [text("a"), conditional_space(false), text("b")])?;
+/// let elements = format!(SimpleFormatContext::default(), [text("a"), maybe_space(true), text("b")])?;
+/// let nospace = format!(SimpleFormatContext::default(), [text("a"), maybe_space(false), text("b")])?;
 ///
 /// assert_eq!("a b", elements.print()?.as_code());
 /// assert_eq!("ab", nospace.print()?.as_code());
@@ -619,7 +619,7 @@ pub const fn space() -> Space {
 /// # }
 /// ```
 #[inline]
-pub fn conditional_space(should_insert: bool) -> Option<Space> {
+pub fn maybe_space(should_insert: bool) -> Option<Space> {
     if should_insert {
         Some(Space)
     } else {
@@ -1094,7 +1094,7 @@ pub fn soft_block_indent<Context>(content: &impl Format<Context>) -> BlockIndent
 /// let elements = format!(context, [
 ///     group(&format_args![
 ///         text("{"),
-///         soft_block_indent_with_conditional_space(&format_args![
+///         soft_block_indent_with_maybe_space(&format_args![
 ///             text("aPropertyThatExceeds"),
 ///             text(":"),
 ///             space(),
@@ -1122,7 +1122,7 @@ pub fn soft_block_indent<Context>(content: &impl Format<Context>) -> BlockIndent
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         text("{"),
-///         soft_block_indent_with_conditional_space(&format_args![
+///         soft_block_indent_with_maybe_space(&format_args![
 ///             text("a"),
 ///             text(":"),
 ///             space(),
@@ -1149,7 +1149,7 @@ pub fn soft_block_indent<Context>(content: &impl Format<Context>) -> BlockIndent
 /// let elements = format!(SimpleFormatContext::default(), [
 ///     group(&format_args![
 ///         text("{"),
-///         soft_block_indent_with_conditional_space(&format_args![
+///         soft_block_indent_with_maybe_space(&format_args![
 ///             text("a"),
 ///             text(":"),
 ///             space(),
@@ -1166,7 +1166,7 @@ pub fn soft_block_indent<Context>(content: &impl Format<Context>) -> BlockIndent
 /// # Ok(())
 /// # }
 /// ```
-pub fn soft_block_indent_with_conditional_space<Context>(
+pub fn soft_block_indent_with_maybe_space<Context>(
     content: &impl Format<Context>,
     should_add_space: bool,
 ) -> BlockIndent<Context> {

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -162,6 +162,9 @@ pub struct JsFormatOptions {
     /// Whether to add non-necessary parentheses to arrow functions. Defaults to "always".
     arrow_parentheses: ArrowParentheses,
 
+    /// Whether to insert spaces around brackets in object literals. Defaults to true.
+    bracket_spacing: BracketSpacing,
+
     /// Information related to the current file
     source_type: JsFileSource,
 }
@@ -180,11 +183,17 @@ impl JsFormatOptions {
             trailing_comma: TrailingComma::default(),
             semicolons: Semicolons::default(),
             arrow_parentheses: ArrowParentheses::default(),
+            bracket_spacing: BracketSpacing::default(),
         }
     }
 
     pub fn with_arrow_parentheses(mut self, arrow_parentheses: ArrowParentheses) -> Self {
         self.arrow_parentheses = arrow_parentheses;
+        self
+    }
+
+    pub fn with_bracket_spacing(mut self, bracket_spacing: BracketSpacing) -> Self {
+        self.bracket_spacing = bracket_spacing;
         self
     }
 
@@ -237,6 +246,10 @@ impl JsFormatOptions {
         self.arrow_parentheses = arrow_parentheses;
     }
 
+    pub fn set_bracket_spacing(&mut self, bracket_spacing: BracketSpacing) {
+        self.bracket_spacing = bracket_spacing;
+    }
+
     pub fn set_indent_style(&mut self, indent_style: IndentStyle) {
         self.indent_style = indent_style;
     }
@@ -275,6 +288,10 @@ impl JsFormatOptions {
 
     pub fn arrow_parentheses(&self) -> ArrowParentheses {
         self.arrow_parentheses
+    }
+
+    pub fn bracket_spacing(&self) -> BracketSpacing {
+        self.bracket_spacing
     }
 
     pub fn quote_style(&self) -> QuoteStyle {
@@ -339,7 +356,8 @@ impl fmt::Display for JsFormatOptions {
         writeln!(f, "Quote properties: {}", self.quote_properties)?;
         writeln!(f, "Trailing comma: {}", self.trailing_comma)?;
         writeln!(f, "Semicolons: {}", self.semicolons)?;
-        writeln!(f, "Arrow parentheses: {}", self.arrow_parentheses)
+        writeln!(f, "Arrow parentheses: {}", self.arrow_parentheses)?;
+        writeln!(f, "Bracket spacing: {}", self.bracket_spacing.value())
     }
 }
 
@@ -637,5 +655,32 @@ impl Deserializable for ArrowParentheses {
                 None
             }
         }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    serde(rename_all = "camelCase")
+)]
+pub struct BracketSpacing(bool);
+
+impl BracketSpacing {
+    /// Return the boolean value for this [BracketSpacing]
+    pub fn value(&self) -> bool {
+        self.0
+    }
+}
+
+impl Default for BracketSpacing {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
+impl From<bool> for BracketSpacing {
+    fn from(value: bool) -> Self {
+        Self(value)
     }
 }

--- a/crates/biome_js_formatter/src/js/module/export_named_clause.rs
+++ b/crates/biome_js_formatter/src/js/module/export_named_clause.rs
@@ -34,7 +34,7 @@ impl FormatNodeRule<JsExportNamedClause> for FormatJsExportNamedClause {
             let should_insert_space_around_brackets = f.options().bracket_spacing().value();
             write!(
                 f,
-                [group(&soft_block_indent_with_conditional_space(
+                [group(&soft_block_indent_with_maybe_space(
                     &specifiers.format(),
                     should_insert_space_around_brackets
                 ),)]

--- a/crates/biome_js_formatter/src/js/module/export_named_clause.rs
+++ b/crates/biome_js_formatter/src/js/module/export_named_clause.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{format_args, write};
+use biome_formatter::write;
 
 use crate::utils::FormatStatementSemicolon;
 
@@ -31,12 +31,13 @@ impl FormatNodeRule<JsExportNamedClause> for FormatJsExportNamedClause {
                 [format_dangling_comments(node.syntax()).with_block_indent()]
             )?;
         } else {
+            let should_insert_space_around_brackets = f.options().bracket_spacing().value();
             write!(
                 f,
-                [group(&format_args![
-                    soft_line_indent_or_space(&specifiers.format()),
-                    soft_line_break_or_space(),
-                ])]
+                [group(&soft_block_indent_with_conditional_space(
+                    &specifiers.format(),
+                    should_insert_space_around_brackets
+                ),)]
             )?;
         }
 

--- a/crates/biome_js_formatter/src/js/module/export_named_from_clause.rs
+++ b/crates/biome_js_formatter/src/js/module/export_named_from_clause.rs
@@ -37,7 +37,7 @@ impl FormatNodeRule<JsExportNamedFromClause> for FormatJsExportNamedFromClause {
                 write!(
                     f,
                     [
-                        conditional_space(should_insert_space_around_brackets),
+                        maybe_space(should_insert_space_around_brackets),
                         node.format()
                     ]
                 )?;
@@ -46,7 +46,7 @@ impl FormatNodeRule<JsExportNamedFromClause> for FormatJsExportNamedFromClause {
                     write!(f, [format_removed(&separator)])?;
                 }
 
-                write!(f, [conditional_space(should_insert_space_around_brackets)])?;
+                write!(f, [maybe_space(should_insert_space_around_brackets)])?;
             }
             _ => {
                 if specifiers.syntax().has_leading_newline() {
@@ -54,7 +54,7 @@ impl FormatNodeRule<JsExportNamedFromClause> for FormatJsExportNamedFromClause {
                 } else {
                     write!(
                         f,
-                        [group(&soft_block_indent_with_conditional_space(
+                        [group(&soft_block_indent_with_maybe_space(
                             &specifiers.format(),
                             should_insert_space_around_brackets
                         )),]

--- a/crates/biome_js_formatter/src/js/module/export_named_from_clause.rs
+++ b/crates/biome_js_formatter/src/js/module/export_named_from_clause.rs
@@ -21,6 +21,7 @@ impl FormatNodeRule<JsExportNamedFromClause> for FormatJsExportNamedFromClause {
             assertion,
             semicolon_token,
         } = node.as_fields();
+        let should_insert_space_around_brackets = f.options().bracket_spacing().value();
 
         if let Some(type_token) = &type_token {
             write!(f, [type_token.format(), space()])?;
@@ -33,13 +34,19 @@ impl FormatNodeRule<JsExportNamedFromClause> for FormatJsExportNamedFromClause {
                 node: Ok(node),
                 trailing_separator: Ok(separator),
             }) if specifiers.len() == 1 && !f.comments().has_comments(node.syntax()) => {
-                write!(f, [space(), node.format()])?;
+                write!(
+                    f,
+                    [
+                        conditional_space(should_insert_space_around_brackets),
+                        node.format()
+                    ]
+                )?;
 
                 if let Some(separator) = separator {
                     write!(f, [format_removed(&separator)])?;
                 }
 
-                write!(f, [space()])?;
+                write!(f, [conditional_space(should_insert_space_around_brackets)])?;
             }
             _ => {
                 if specifiers.syntax().has_leading_newline() {
@@ -47,7 +54,10 @@ impl FormatNodeRule<JsExportNamedFromClause> for FormatJsExportNamedFromClause {
                 } else {
                     write!(
                         f,
-                        [group(&soft_space_or_block_indent(&specifiers.format())),]
+                        [group(&soft_block_indent_with_conditional_space(
+                            &specifiers.format(),
+                            should_insert_space_around_brackets
+                        )),]
                     )?;
                 };
             }

--- a/crates/biome_js_formatter/src/js/module/import_assertion.rs
+++ b/crates/biome_js_formatter/src/js/module/import_assertion.rs
@@ -36,7 +36,7 @@ impl FormatNodeRule<JsImportAssertion> for FormatJsImportAssertion {
                     assertion_kind.format(),
                     space(),
                     l_curly_token.format(),
-                    group(&soft_block_indent_with_conditional_space(
+                    group(&soft_block_indent_with_maybe_space(
                         &assertions.format(),
                         should_insert_space_around_brackets
                     )),

--- a/crates/biome_js_formatter/src/js/module/import_assertion.rs
+++ b/crates/biome_js_formatter/src/js/module/import_assertion.rs
@@ -28,6 +28,7 @@ impl FormatNodeRule<JsImportAssertion> for FormatJsImportAssertion {
                 ]
             )
         } else {
+            let should_insert_space_around_brackets = f.options().bracket_spacing().value();
             write!(
                 f,
                 [
@@ -35,7 +36,10 @@ impl FormatNodeRule<JsImportAssertion> for FormatJsImportAssertion {
                     assertion_kind.format(),
                     space(),
                     l_curly_token.format(),
-                    group(&soft_space_or_block_indent(&assertions.format())),
+                    group(&soft_block_indent_with_conditional_space(
+                        &assertions.format(),
+                        should_insert_space_around_brackets
+                    )),
                     r_curly_token.format()
                 ]
             )

--- a/crates/biome_js_formatter/src/js/module/import_named_clause.rs
+++ b/crates/biome_js_formatter/src/js/module/import_named_clause.rs
@@ -79,7 +79,7 @@ impl FormatNodeRule<JsImportNamedClause> for FormatJsImportNamedClause {
                                     f,
                                     [
                                         l_curly_token.format(),
-                                        conditional_space(should_insert_space_around_brackets),
+                                        maybe_space(should_insert_space_around_brackets),
                                         specifier.format(),
                                     ]
                                 )?;
@@ -91,7 +91,7 @@ impl FormatNodeRule<JsImportNamedClause> for FormatJsImportNamedClause {
                                 write!(
                                     f,
                                     [
-                                        conditional_space(should_insert_space_around_brackets),
+                                        maybe_space(should_insert_space_around_brackets),
                                         r_curly_token.format()
                                     ]
                                 )

--- a/crates/biome_js_formatter/src/js/module/import_named_clause.rs
+++ b/crates/biome_js_formatter/src/js/module/import_named_clause.rs
@@ -72,13 +72,29 @@ impl FormatNodeRule<JsImportNamedClause> for FormatJsImportNamedClause {
                                     specifiers: _,
                                     r_curly_token,
                                 } = specifiers.as_fields();
-                                write!(f, [l_curly_token.format(), space(), specifier.format(),])?;
+                                let should_insert_space_around_brackets =
+                                    f.options().bracket_spacing().value();
+
+                                write!(
+                                    f,
+                                    [
+                                        l_curly_token.format(),
+                                        conditional_space(should_insert_space_around_brackets),
+                                        specifier.format(),
+                                    ]
+                                )?;
 
                                 if let Some(separator) = separator {
                                     format_removed(separator).fmt(f)?;
                                 }
 
-                                write!(f, [space(), r_curly_token.format()])
+                                write!(
+                                    f,
+                                    [
+                                        conditional_space(should_insert_space_around_brackets),
+                                        r_curly_token.format()
+                                    ]
+                                )
                             }
                         }
                         (

--- a/crates/biome_js_formatter/src/js/module/named_import_specifiers.rs
+++ b/crates/biome_js_formatter/src/js/module/named_import_specifiers.rs
@@ -23,9 +23,13 @@ impl FormatNodeRule<JsNamedImportSpecifiers> for FormatJsNamedImportSpecifiers {
                 [format_dangling_comments(node.syntax()).with_soft_block_indent()]
             )?;
         } else {
+            let should_insert_space_around_brackets = f.options().bracket_spacing().value();
             write!(
                 f,
-                [group(&soft_space_or_block_indent(&specifiers.format()))]
+                [group(&soft_block_indent_with_conditional_space(
+                    &specifiers.format(),
+                    should_insert_space_around_brackets
+                ))]
             )?;
         }
 

--- a/crates/biome_js_formatter/src/js/module/named_import_specifiers.rs
+++ b/crates/biome_js_formatter/src/js/module/named_import_specifiers.rs
@@ -26,7 +26,7 @@ impl FormatNodeRule<JsNamedImportSpecifiers> for FormatJsNamedImportSpecifiers {
             let should_insert_space_around_brackets = f.options().bracket_spacing().value();
             write!(
                 f,
-                [group(&soft_block_indent_with_conditional_space(
+                [group(&soft_block_indent_with_maybe_space(
                     &specifiers.format(),
                     should_insert_space_around_brackets
                 ))]

--- a/crates/biome_js_formatter/src/ts/auxiliary/property_signature_type_member.rs
+++ b/crates/biome_js_formatter/src/ts/auxiliary/property_signature_type_member.rs
@@ -25,7 +25,7 @@ impl FormatNodeRule<TsPropertySignatureTypeMember> for FormatTsPropertySignature
             f,
             [
                 readonly_token.format(),
-                space(),
+                conditional_space(readonly_token.is_some()),
                 name.format(),
                 optional_token.format(),
                 type_annotation.format(),

--- a/crates/biome_js_formatter/src/ts/auxiliary/property_signature_type_member.rs
+++ b/crates/biome_js_formatter/src/ts/auxiliary/property_signature_type_member.rs
@@ -25,7 +25,7 @@ impl FormatNodeRule<TsPropertySignatureTypeMember> for FormatTsPropertySignature
             f,
             [
                 readonly_token.format(),
-                conditional_space(readonly_token.is_some()),
+                maybe_space(readonly_token.is_some()),
                 name.format(),
                 optional_token.format(),
                 type_annotation.format(),

--- a/crates/biome_js_formatter/src/ts/types/mapped_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/mapped_type.rs
@@ -79,11 +79,16 @@ impl FormatNodeRule<TsMappedType> for FormatTsMappedType {
             )
         });
 
+        let should_insert_space_around_brackets = f.options().bracket_spacing().value();
         write!(
             f,
             [
                 &l_curly_token.format(),
-                group(&soft_space_or_block_indent(&format_inner)).should_expand(should_expand),
+                group(&soft_block_indent_with_conditional_space(
+                    &format_inner,
+                    should_insert_space_around_brackets
+                ))
+                .should_expand(should_expand),
                 r_curly_token.format(),
             ]
         )

--- a/crates/biome_js_formatter/src/ts/types/mapped_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/mapped_type.rs
@@ -84,7 +84,7 @@ impl FormatNodeRule<TsMappedType> for FormatTsMappedType {
             f,
             [
                 &l_curly_token.format(),
-                group(&soft_block_indent_with_conditional_space(
+                group(&soft_block_indent_with_maybe_space(
                     &format_inner,
                     should_insert_space_around_brackets
                 ))

--- a/crates/biome_js_formatter/src/utils/object_like.rs
+++ b/crates/biome_js_formatter/src/utils/object_like.rs
@@ -60,10 +60,15 @@ impl Format<JsFormatContext> for JsObjectLike {
                 [format_dangling_comments(self.syntax()).with_block_indent(),]
             )?;
         } else {
+            let should_insert_space_around_brackets = f.options().bracket_spacing().value();
             let should_expand = self.members_have_leading_newline();
             write!(
                 f,
-                [group(&soft_space_or_block_indent(&members)).should_expand(should_expand)]
+                [group(&soft_block_indent_with_conditional_space(
+                    &members,
+                    should_insert_space_around_brackets
+                ))
+                .should_expand(should_expand)]
             )?;
         }
 

--- a/crates/biome_js_formatter/src/utils/object_like.rs
+++ b/crates/biome_js_formatter/src/utils/object_like.rs
@@ -64,7 +64,7 @@ impl Format<JsFormatContext> for JsObjectLike {
             let should_expand = self.members_have_leading_newline();
             write!(
                 f,
-                [group(&soft_block_indent_with_conditional_space(
+                [group(&soft_block_indent_with_maybe_space(
                     &members,
                     should_insert_space_around_brackets
                 ))

--- a/crates/biome_js_formatter/src/utils/object_pattern_like.rs
+++ b/crates/biome_js_formatter/src/utils/object_pattern_like.rs
@@ -161,12 +161,14 @@ impl JsObjectPatternLike {
 
 impl Format<JsFormatContext> for JsObjectPatternLike {
     fn fmt(&self, f: &mut Formatter<JsFormatContext>) -> FormatResult<()> {
+        let should_insert_space_around_brackets = f.options().bracket_spacing().value();
         let format_properties = format_with(|f| {
             write!(
                 f,
-                [soft_space_or_block_indent(&format_with(
-                    |f| self.write_properties(f)
-                ))]
+                [soft_block_indent_with_conditional_space(
+                    &format_with(|f| self.write_properties(f)),
+                    should_insert_space_around_brackets
+                )]
             )
         });
 

--- a/crates/biome_js_formatter/src/utils/object_pattern_like.rs
+++ b/crates/biome_js_formatter/src/utils/object_pattern_like.rs
@@ -165,7 +165,7 @@ impl Format<JsFormatContext> for JsObjectPatternLike {
         let format_properties = format_with(|f| {
             write!(
                 f,
-                [soft_block_indent_with_conditional_space(
+                [soft_block_indent_with_maybe_space(
                     &format_with(|f| self.write_properties(f)),
                     should_insert_space_around_brackets
                 )]

--- a/crates/biome_js_formatter/tests/language.rs
+++ b/crates/biome_js_formatter/tests/language.rs
@@ -224,6 +224,9 @@ pub struct JsSerializableFormatOptions {
 
     /// Whether to add non-necessary parentheses to arrow functions. Defaults to "always".
     pub arrow_parentheses: Option<JsSerializableArrowParentheses>,
+
+    /// Whether to insert spaces around brackets in object literals. Defaults to true.
+    pub bracket_spacing: Option<bool>,
 }
 
 impl JsSerializableFormatOptions {

--- a/crates/biome_js_formatter/tests/language.rs
+++ b/crates/biome_js_formatter/tests/language.rs
@@ -4,7 +4,8 @@ use biome_formatter::{
 use biome_formatter_test::TestFormatLanguage;
 use biome_js_formatter::context::trailing_comma::TrailingComma;
 use biome_js_formatter::context::{
-    ArrowParentheses, JsFormatContext, JsFormatOptions, QuoteProperties, QuoteStyle, Semicolons,
+    ArrowParentheses, BracketSpacing, JsFormatContext, JsFormatOptions, QuoteProperties,
+    QuoteStyle, Semicolons,
 };
 use biome_js_formatter::{format_node, format_range, JsFormatLanguage};
 use biome_js_parser::{parse, JsParserOptions};
@@ -267,6 +268,10 @@ impl JsSerializableFormatOptions {
             .with_arrow_parentheses(
                 self.arrow_parentheses
                     .map_or_else(|| ArrowParentheses::Always, |value| value.into()),
+            )
+            .with_bracket_spacing(
+                self.bracket_spacing
+                    .map_or_else(BracketSpacing::default, |value| value.into()),
             )
     }
 }

--- a/crates/biome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
@@ -68,6 +68,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
@@ -39,6 +39,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/spaces.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/spaces.js.snap
@@ -32,6 +32,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/spread.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/spread.js.snap
@@ -32,6 +32,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js.snap
@@ -37,6 +37,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -67,6 +68,7 @@ Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -97,6 +99,7 @@ Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
@@ -48,6 +48,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -86,6 +87,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
@@ -36,6 +36,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -70,6 +71,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -61,6 +62,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
@@ -54,6 +54,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -98,6 +99,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
@@ -31,6 +31,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -58,6 +59,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -71,6 +71,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -142,6 +143,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
@@ -44,6 +44,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -79,6 +80,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/params.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/params.js.snap
@@ -353,6 +353,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -678,6 +679,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
@@ -29,6 +29,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -189,6 +189,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
@@ -31,6 +31,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
@@ -35,4 +35,23 @@ Bracket spacing: true
 function foo([foo, /* not used */ /* not used */ ,]) {}
 ```
 
+## Output 2
+
+-----
+Indent style: Tab
+Indent width: 2
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: false
+-----
+
+```js
+function foo([foo, /* not used */ /* not used */ ,]) {}
+```
+
 

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
@@ -40,6 +40,7 @@ function foo([foo, /* not used */ /* not used */ ,]) {}
 -----
 Indent style: Tab
 Indent width: 2
+Line ending: LF
 Line width: 80
 Quote style: Double Quotes
 JSX quote style: Double Quotes

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
@@ -47,6 +47,7 @@ let [
 -----
 Indent style: Tab
 Indent width: 2
+Line ending: LF
 Line width: 80
 Quote style: Double Quotes
 JSX quote style: Double Quotes

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
@@ -42,4 +42,28 @@ let [
 ] = e;
 ```
 
+## Output 2
+
+-----
+Indent style: Tab
+Indent width: 2
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: false
+-----
+
+```js
+[a = "b"] = c;
+let [a = "b"] = c;
+let [
+	aaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbb,
+	cccccccccccccccccccc = dddddddddddddddddddd,
+] = e;
+```
+
 

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
@@ -40,4 +40,26 @@ let abcde = "very long value that will cause a line break",
 	fghij = "this should end up on the next line";
 ```
 
+## Output 2
+
+-----
+Indent style: Tab
+Indent width: 2
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: false
+-----
+
+```js
+let x = y;
+
+let abcde = "very long value that will cause a line break",
+	fghij = "this should end up on the next line";
+```
+
 

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
@@ -45,6 +45,7 @@ let abcde = "very long value that will cause a line break",
 -----
 Indent style: Tab
 Indent width: 2
+Line ending: LF
 Line width: 80
 Quote style: Double Quotes
 JSX quote style: Double Quotes

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
@@ -46,4 +46,31 @@ let {
 } = h;
 ```
 
+## Output 2
+
+-----
+Indent style: Tab
+Indent width: 2
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: false
+-----
+
+```js
+let {a} = b;
+let {d, b: c} = d;
+let {x, y = c, z: pp = f, ...g} = h;
+let {
+	aaaaaaaaaaaaaaaaaaaa,
+	bbbbbbbbbbbbbbbbbbbb = cccccccccccccccccccc,
+	dddddddddddddddddddd: eeeeeeeeeeeeeeeeeeee = ffffffffffffffffffff,
+	...gggggggggggggggggggg
+} = h;
+```
+
 

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
@@ -31,6 +31,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
@@ -51,6 +51,7 @@ let {
 -----
 Indent style: Tab
 Indent width: 2
+Line ending: LF
 Line width: 80
 Quote style: Double Quotes
 JSX quote style: Double Quotes

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/options.json
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"bracket_spacing": false
+		}
+	]
+}

--- a/crates/biome_js_formatter/tests/specs/js/module/bom_character.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/bom_character.js.snap
@@ -27,6 +27,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/call_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/call_expression.js.snap
@@ -74,6 +74,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/class/class.js.snap
@@ -97,6 +97,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/class/private_method.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/class/private_method.js.snap
@@ -43,6 +43,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/comments.js.snap
@@ -105,6 +105,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
@@ -292,6 +292,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
@@ -119,6 +119,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
@@ -119,6 +119,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
@@ -119,6 +119,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple.js.snap
@@ -75,6 +75,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple_call_decorator.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple_call_decorator.js.snap
@@ -75,6 +75,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_1.js.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_2.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_2.js.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_3.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_3.js.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_4.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_4.js.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/expression.js.snap
@@ -48,6 +48,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/multiline.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/multiline.js.snap
@@ -43,6 +43,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/each/each.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/each/each.js.snap
@@ -93,6 +93,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/export_bracket_spacing.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/export_bracket_spacing.js
@@ -1,0 +1,20 @@
+export {a,
+    b as c
+} from "fancy" assert { type: "json"}
+
+
+export {
+    lorem_lorem_lorem_lorem_lorem_lorem_lorem_lorem_lorem,
+    lorem_lorem_lorem_lorem_lorem_ as ipsum_ipsum_ipsum_ipsum_ipsum_ipsum_
+} from "fancy" assert { type: "json", "type2": "json", type23: "json", "type24": "json"}
+
+
+export { loooooooooooooooooooooooooooooooooooooooooooooooooong } from "loooooooooooooooooooooooooooooooooooooooooooooong"
+
+export { loooooooooooooooooooooooooooooooooooooooooooooooooong, } from "loooooooooooooooooooooooooooooooooooooooooooooong"
+
+export { 
+// comment 
+loooooooooooooooooooooooooooooooooooooooooooooooooong } from "loooooooooooooooooooooooooooooooooooooooooooooong"
+
+export { a as b } from "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"

--- a/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/export_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/export_bracket_spacing.js.snap
@@ -38,6 +38,7 @@ export { a as b } from "looooooooooooooooooooooooooooooooooooooooooooooooooooooo
 -----
 Indent style: Tab
 Indent width: 2
+Line ending: LF
 Line width: 80
 Quote style: Double Quotes
 JSX quote style: Double Quotes
@@ -85,6 +86,7 @@ export { a as b } from "looooooooooooooooooooooooooooooooooooooooooooooooooooooo
 -----
 Indent style: Tab
 Indent width: 2
+Line ending: LF
 Line width: 80
 Quote style: Double Quotes
 JSX quote style: Double Quotes

--- a/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/export_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/export_bracket_spacing.js.snap
@@ -1,0 +1,130 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/export/bracket-spacing/export_bracket_spacing.js
+---
+
+# Input
+
+```js
+export {a,
+    b as c
+} from "fancy" assert { type: "json"}
+
+
+export {
+    lorem_lorem_lorem_lorem_lorem_lorem_lorem_lorem_lorem,
+    lorem_lorem_lorem_lorem_lorem_ as ipsum_ipsum_ipsum_ipsum_ipsum_ipsum_
+} from "fancy" assert { type: "json", "type2": "json", type23: "json", "type24": "json"}
+
+
+export { loooooooooooooooooooooooooooooooooooooooooooooooooong } from "loooooooooooooooooooooooooooooooooooooooooooooong"
+
+export { loooooooooooooooooooooooooooooooooooooooooooooooooong, } from "loooooooooooooooooooooooooooooooooooooooooooooong"
+
+export { 
+// comment 
+loooooooooooooooooooooooooooooooooooooooooooooooooong } from "loooooooooooooooooooooooooooooooooooooooooooooong"
+
+export { a as b } from "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+-----
+
+```js
+export { a, b as c } from "fancy" assert { type: "json" };
+
+export {
+	lorem_lorem_lorem_lorem_lorem_lorem_lorem_lorem_lorem,
+	lorem_lorem_lorem_lorem_lorem_ as ipsum_ipsum_ipsum_ipsum_ipsum_ipsum_,
+} from "fancy" assert {
+	type: "json",
+	"type2": "json",
+	type23: "json",
+	"type24": "json",
+};
+
+export { loooooooooooooooooooooooooooooooooooooooooooooooooong } from "loooooooooooooooooooooooooooooooooooooooooooooong";
+
+export { loooooooooooooooooooooooooooooooooooooooooooooooooong } from "loooooooooooooooooooooooooooooooooooooooooooooong";
+
+export {
+	// comment
+	loooooooooooooooooooooooooooooooooooooooooooooooooong,
+} from "loooooooooooooooooooooooooooooooooooooooooooooong";
+
+export { a as b } from "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+```
+
+# Lines exceeding max width of 80 characters
+```
+   13: export { loooooooooooooooooooooooooooooooooooooooooooooooooong } from "loooooooooooooooooooooooooooooooooooooooooooooong";
+   15: export { loooooooooooooooooooooooooooooooooooooooooooooooooong } from "loooooooooooooooooooooooooooooooooooooooooooooong";
+   22: export { a as b } from "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Indent width: 2
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: false
+-----
+
+```js
+export {a, b as c} from "fancy" assert {type: "json"};
+
+export {
+	lorem_lorem_lorem_lorem_lorem_lorem_lorem_lorem_lorem,
+	lorem_lorem_lorem_lorem_lorem_ as ipsum_ipsum_ipsum_ipsum_ipsum_ipsum_,
+} from "fancy" assert {
+	type: "json",
+	"type2": "json",
+	type23: "json",
+	"type24": "json",
+};
+
+export {loooooooooooooooooooooooooooooooooooooooooooooooooong} from "loooooooooooooooooooooooooooooooooooooooooooooong";
+
+export {loooooooooooooooooooooooooooooooooooooooooooooooooong} from "loooooooooooooooooooooooooooooooooooooooooooooong";
+
+export {
+	// comment
+	loooooooooooooooooooooooooooooooooooooooooooooooooong,
+} from "loooooooooooooooooooooooooooooooooooooooooooooong";
+
+export {a as b} from "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+```
+
+# Lines exceeding max width of 80 characters
+```
+   13: export {loooooooooooooooooooooooooooooooooooooooooooooooooong} from "loooooooooooooooooooooooooooooooooooooooooooooong";
+   15: export {loooooooooooooooooooooooooooooooooooooooooooooooooong} from "loooooooooooooooooooooooooooooooooooooooooooooong";
+   22: export {a as b} from "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+```
+
+

--- a/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/options.json
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"bracket_spacing": false
+		}
+	]
+}

--- a/crates/biome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
@@ -36,6 +36,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
@@ -27,6 +27,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
@@ -31,6 +31,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
@@ -35,6 +35,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
@@ -46,6 +46,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js.snap
@@ -32,6 +32,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -55,6 +56,7 @@ Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -78,6 +80,7 @@ Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
@@ -29,6 +29,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
@@ -61,6 +61,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
@@ -27,6 +27,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
@@ -36,6 +36,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -58,6 +59,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
@@ -139,6 +139,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
@@ -32,6 +32,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
@@ -32,6 +32,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
@@ -39,6 +39,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/static_member_regex.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/static_member_regex.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: js/module/expression/member-chain/static_member-regex.js
+info: js/module/expression/member-chain/static_member_regex.js
 ---
 
 # Input
@@ -51,6 +51,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
@@ -31,6 +31,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
@@ -31,6 +31,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
@@ -60,6 +60,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
@@ -47,6 +47,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
@@ -41,6 +41,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
@@ -35,6 +35,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/function/function.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/function/function.js.snap
@@ -59,6 +59,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/function/function_args.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/function/function_args.js.snap
@@ -29,6 +29,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
@@ -43,6 +43,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/ident.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/ident.js.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
@@ -50,6 +50,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/import_bracket_spacing.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/import_bracket_spacing.js
@@ -1,0 +1,24 @@
+import {
+	a,
+	b,
+	c,
+} from "D";
+
+import {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	b,
+	c, } from "W";
+
+import TheDefault, {  named} from 'foo';
+
+import {  named} from 'foo' assert {
+
+    type :   "json"
+};
+
+import "very_long_import_very_long_import_very" assert {
+    // something good is here
+    "type": /****/ "json"
+        }
+
+import(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, {assert: {type:'json'}})

--- a/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/import_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/import_bracket_spacing.js.snap
@@ -43,6 +43,7 @@ import(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 -----
 Indent style: Tab
 Indent width: 2
+Line ending: LF
 Line width: 80
 Quote style: Double Quotes
 JSX quote style: Double Quotes
@@ -83,6 +84,7 @@ import(
 -----
 Indent style: Tab
 Indent width: 2
+Line ending: LF
 Line width: 80
 Quote style: Double Quotes
 JSX quote style: Double Quotes

--- a/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/import_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/import_bracket_spacing.js.snap
@@ -1,0 +1,121 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/import/bracket-spacing/import_bracket_spacing.js
+---
+
+# Input
+
+```js
+import {
+	a,
+	b,
+	c,
+} from "D";
+
+import {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	b,
+	c, } from "W";
+
+import TheDefault, {  named} from 'foo';
+
+import {  named} from 'foo' assert {
+
+    type :   "json"
+};
+
+import "very_long_import_very_long_import_very" assert {
+    // something good is here
+    "type": /****/ "json"
+        }
+
+import(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, {assert: {type:'json'}})
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+-----
+
+```js
+import { a, b, c } from "D";
+
+import { adsadasdasdasdasdasdasdasdasdasdas, b, c } from "W";
+
+import TheDefault, { named } from "foo";
+
+import { named } from "foo" assert { type: "json" };
+
+import "very_long_import_very_long_import_very" assert {
+	// something good is here
+	"type": /****/ "json",
+};
+
+import(
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+	{ assert: { type: "json" } }
+);
+```
+
+# Lines exceeding max width of 80 characters
+```
+   15: 	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Indent width: 2
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: false
+-----
+
+```js
+import {a, b, c} from "D";
+
+import {adsadasdasdasdasdasdasdasdasdasdas, b, c} from "W";
+
+import TheDefault, {named} from "foo";
+
+import {named} from "foo" assert {type: "json"};
+
+import "very_long_import_very_long_import_very" assert {
+	// something good is here
+	"type": /****/ "json",
+};
+
+import(
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+	{assert: {type: "json"}}
+);
+```
+
+# Lines exceeding max width of 80 characters
+```
+   15: 	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+```
+
+

--- a/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/options.json
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"bracket_spacing": false
+		}
+	]
+}

--- a/crates/biome_js_formatter/tests/specs/js/module/import/default_import.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/default_import.js.snap
@@ -38,6 +38,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/import_call.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/import_call.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
@@ -59,6 +59,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
@@ -27,6 +27,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js.snap
@@ -57,6 +57,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -115,6 +116,7 @@ Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -173,6 +175,7 @@ Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/indent-width/example-1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/indent-width/example-1.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -51,6 +52,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -78,6 +80,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/indent-width/example-2.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/indent-width/example-2.js.snap
@@ -44,6 +44,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -79,6 +80,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -114,6 +116,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/interpreter-with-trailing-spaces.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/interpreter-with-trailing-spaces.js.snap
@@ -29,6 +29,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/interpreter.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/interpreter.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
@@ -37,6 +37,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
@@ -43,6 +43,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/line-ending/line_ending.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/line-ending/line_ending.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: "js\\module\\line-ending\\line_ending.js"
+info: js/module/line-ending/line_ending.js
 ---
 
 # Input
@@ -44,6 +44,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -79,6 +80,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -114,6 +116,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/newlines.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/newlines.js.snap
@@ -105,6 +105,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/class.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/class.js.snap
@@ -145,6 +145,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -279,6 +280,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/issue2006.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/issue2006.js.snap
@@ -35,6 +35,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -61,6 +62,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/no-semi.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/no-semi.js.snap
@@ -107,6 +107,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -216,6 +217,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/private-field.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/private-field.js.snap
@@ -31,6 +31,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -53,6 +54,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons-asi.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons-asi.js.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -47,6 +48,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -51,6 +52,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/number/number.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/number/number.js.snap
@@ -29,6 +29,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/bracket-spacing/object_bracket_spacing.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/bracket-spacing/object_bracket_spacing.js
@@ -1,0 +1,22 @@
+let a = {
+	...spread,
+
+	foo() {
+	},
+
+	*foo() {
+	},
+	...spread,
+}
+
+const x = { apple: "banna"};
+
+const y = {
+	apple: "banana",
+};
+
+({a, b, c} = {a: 'apple', b: 'banana', c: 'coconut'});
+
+({
+	a, b, c
+} = {a: 'apple', b: 'banana', c: 'coconut' });

--- a/crates/biome_js_formatter/tests/specs/js/module/object/bracket-spacing/object_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/bracket-spacing/object_bracket_spacing.js.snap
@@ -41,6 +41,7 @@ const y = {
 -----
 Indent style: Tab
 Indent width: 2
+Line ending: LF
 Line width: 80
 Quote style: Double Quotes
 JSX quote style: Double Quotes
@@ -77,6 +78,7 @@ const y = {
 -----
 Indent style: Tab
 Indent width: 2
+Line ending: LF
 Line width: 80
 Quote style: Double Quotes
 JSX quote style: Double Quotes

--- a/crates/biome_js_formatter/tests/specs/js/module/object/bracket-spacing/object_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/bracket-spacing/object_bracket_spacing.js.snap
@@ -1,0 +1,111 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/object/bracket-spacing/object_bracket_spacing.js
+---
+
+# Input
+
+```js
+let a = {
+	...spread,
+
+	foo() {
+	},
+
+	*foo() {
+	},
+	...spread,
+}
+
+const x = { apple: "banna"};
+
+const y = {
+	apple: "banana",
+};
+
+({a, b, c} = {a: 'apple', b: 'banana', c: 'coconut'});
+
+({
+	a, b, c
+} = {a: 'apple', b: 'banana', c: 'coconut' });
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+-----
+
+```js
+let a = {
+	...spread,
+
+	foo() {},
+
+	*foo() {},
+	...spread,
+};
+
+const x = { apple: "banna" };
+
+const y = {
+	apple: "banana",
+};
+
+({ a, b, c } = { a: "apple", b: "banana", c: "coconut" });
+
+({ a, b, c } = { a: "apple", b: "banana", c: "coconut" });
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Indent width: 2
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: false
+-----
+
+```js
+let a = {
+	...spread,
+
+	foo() {},
+
+	*foo() {},
+	...spread,
+};
+
+const x = {apple: "banna"};
+
+const y = {
+	apple: "banana",
+};
+
+({a, b, c} = {a: "apple", b: "banana", c: "coconut"});
+
+({a, b, c} = {a: "apple", b: "banana", c: "coconut"});
+```
+
+

--- a/crates/biome_js_formatter/tests/specs/js/module/object/bracket-spacing/options.json
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/bracket-spacing/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"bracket_spacing": false
+		}
+	]
+}

--- a/crates/biome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
@@ -46,6 +46,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/numeric-property.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/numeric-property.js.snap
@@ -64,6 +64,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/object.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/object.js.snap
@@ -59,6 +59,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/octal_literals_key.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/octal_literals_key.js.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/property_key.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/property_key.js.snap
@@ -35,6 +35,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
@@ -115,6 +115,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js.snap
@@ -36,6 +36,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -65,6 +66,7 @@ Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -94,6 +96,7 @@ Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
@@ -50,6 +50,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js.snap
@@ -35,6 +35,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
@@ -37,6 +37,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
@@ -35,6 +35,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/script.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/script.js.snap
@@ -31,6 +31,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
@@ -36,6 +36,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
@@ -41,6 +41,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
@@ -56,6 +56,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
@@ -44,6 +44,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
@@ -35,6 +35,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -96,6 +96,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/return.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/return.js.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
@@ -52,6 +52,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/statement.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/statement.js.snap
@@ -29,6 +29,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js.snap
@@ -46,6 +46,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/throw.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/throw.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
@@ -53,6 +53,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
@@ -53,6 +53,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/directives.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/directives.js.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -52,6 +53,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -74,6 +76,7 @@ Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/parentheses_token.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/parentheses_token.js.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -47,6 +48,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -66,6 +68,7 @@ Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/properties_quotes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/properties_quotes.js.snap
@@ -70,6 +70,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -132,6 +133,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -194,6 +196,7 @@ Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/string.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/string.js.snap
@@ -84,6 +84,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -170,6 +171,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js
@@ -256,6 +258,7 @@ Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/suppression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/suppression.js.snap
@@ -55,6 +55,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/template/template.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/template/template.js.snap
@@ -74,6 +74,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/with.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/with.js.snap
@@ -32,6 +32,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/script/script.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/script/script.js.snap
@@ -31,6 +31,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/script/script_with_bom.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/script/script_with_bom.js.snap
@@ -31,6 +31,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/script/with.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/script/with.js.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
@@ -56,6 +56,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/attributes.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/attributes.jsx.snap
@@ -103,6 +103,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/comments.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/comments.jsx.snap
@@ -31,6 +31,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/conditional.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/conditional.jsx.snap
@@ -76,6 +76,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/element.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/element.jsx.snap
@@ -357,6 +357,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/fragment.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/fragment.jsx.snap
@@ -29,6 +29,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/new-lines.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/new-lines.jsx.snap
@@ -77,6 +77,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/quote_style/quote_style.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/quote_style/quote_style.jsx.snap
@@ -35,6 +35,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx
@@ -56,6 +57,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx
@@ -77,6 +79,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx
@@ -98,6 +101,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx
@@ -119,6 +123,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
@@ -48,6 +48,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/smoke.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/smoke.jsx.snap
@@ -27,6 +27,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/ts/arrow/arrow_parentheses.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow/arrow_parentheses.ts.snap
@@ -40,6 +40,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -71,6 +72,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
@@ -38,6 +38,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
@@ -32,6 +32,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
@@ -40,6 +40,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
@@ -48,6 +48,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
@@ -60,6 +60,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
@@ -41,6 +41,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/call_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/call_expression.ts.snap
@@ -50,6 +50,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/accessor.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/accessor.ts.snap
@@ -29,6 +29,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
@@ -34,6 +34,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
@@ -62,6 +62,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
@@ -29,6 +29,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/readonly_ambient_property.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/readonly_ambient_property.ts.snap
@@ -37,6 +37,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
@@ -38,6 +38,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -81,6 +82,7 @@ Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -124,6 +126,7 @@ Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/class.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/class.ts.snap
@@ -86,6 +86,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
@@ -72,6 +72,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
@@ -114,6 +114,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declare.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declare.ts.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/decoartors.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/decoartors.ts.snap
@@ -285,6 +285,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/decorators/class_members.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/decorators/class_members.ts.snap
@@ -119,6 +119,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts.snap
@@ -32,6 +32,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -55,6 +56,7 @@ Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -78,6 +80,7 @@ Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/expression_bracket_spacing.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/expression_bracket_spacing.ts
@@ -1,0 +1,68 @@
+import * as assert from "assert";
+
+type W = { a: string; b: symbol; c: symbol;d: symbol;e: symbol;f: symbol;g: symbol; };
+type X = { a: string; b: symbol; }
+type Z = {
+    a: string
+    b: symbol
+}
+type A = {
+    a: string
+}
+
+type OptionsFlags
+    <Type> =
+    {
+  +
+        readonly [Property
+        in
+        keyof
+            Type
+        as              string]
+        -?: boolean;
+};
+
+
+type TupleA
+    = [     string      ]
+
+type TupleB = [   ...string[  ]     ]
+
+type TupleC = [ surname  ?:
+    string[],
+    ...name: string[],  ]
+
+type TupleD = [
+    address: string,
+    address2: string,
+    address3: string,
+    address4: string,
+    address5: string,
+    surname  ?:
+    string[],
+    ...name: string[],  ]
+
+type PA = (
+    string
+    )
+
+
+type FunctionType = <Aaaaaaaaaaaaaaaaaaaaa,bvvvvvvvvvvvvvvvvvvvvvv,ceeeeeee,deeeeeeeeeeeeee,deeeeeeeeeeeeeee,deeeeeeeeeeeeeeee,deeeeeeeewweeeeee,>(Lorem: string, ipsum: symbol,  dolor: number, sit: boolean, amet: string, consectetur: symbol) => {
+    Lorem: string, ipsum: symbol, dolor: number, sit: boolean, amet: string, consectetur: symbol
+}
+
+type ShortFunctionType = <A,B,C,D,E,>(Lorem: string, ipsum: symbol,  dolor: number, sit: boolean, amet: string, consectetur: symbol) => {
+    a: string;
+}
+
+function test(a: string):
+    a is  string   { return true }
+
+
+type AbstractCompositeThingamabobberFactoryProvider = string;
+
+type ConstructorType = new ( options: { a: string, b: AbstractCompositeThingamabobberFactoryProvider },
+) => {};
+
+type GenericTypeExpression<A extends { a: string }> = Foo<A, {  bar: string }>;
+type GenericTypeExpression<A extends { a: string }> = AbstractCompositeThingamabobberFactoryProvider<{  bar: string, foo: symbol; baz: number; zzz: boolean }>;

--- a/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/expression_bracket_spacing.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/expression_bracket_spacing.ts.snap
@@ -86,6 +86,7 @@ type GenericTypeExpression<A extends { a: string }> = AbstractCompositeThingamab
 -----
 Indent style: Tab
 Indent width: 2
+Line ending: LF
 Line width: 80
 Quote style: Double Quotes
 JSX quote style: Double Quotes
@@ -200,6 +201,7 @@ type GenericTypeExpression<A extends { a: string }> =
 -----
 Indent style: Tab
 Indent width: 2
+Line ending: LF
 Line width: 80
 Quote style: Double Quotes
 JSX quote style: Double Quotes

--- a/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/expression_bracket_spacing.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/expression_bracket_spacing.ts.snap
@@ -1,0 +1,312 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: ts/expression/bracket-spacing/expression_bracket_spacing.ts
+---
+
+# Input
+
+```ts
+import * as assert from "assert";
+
+type W = { a: string; b: symbol; c: symbol;d: symbol;e: symbol;f: symbol;g: symbol; };
+type X = { a: string; b: symbol; }
+type Z = {
+    a: string
+    b: symbol
+}
+type A = {
+    a: string
+}
+
+type OptionsFlags
+    <Type> =
+    {
+  +
+        readonly [Property
+        in
+        keyof
+            Type
+        as              string]
+        -?: boolean;
+};
+
+
+type TupleA
+    = [     string      ]
+
+type TupleB = [   ...string[  ]     ]
+
+type TupleC = [ surname  ?:
+    string[],
+    ...name: string[],  ]
+
+type TupleD = [
+    address: string,
+    address2: string,
+    address3: string,
+    address4: string,
+    address5: string,
+    surname  ?:
+    string[],
+    ...name: string[],  ]
+
+type PA = (
+    string
+    )
+
+
+type FunctionType = <Aaaaaaaaaaaaaaaaaaaaa,bvvvvvvvvvvvvvvvvvvvvvv,ceeeeeee,deeeeeeeeeeeeee,deeeeeeeeeeeeeee,deeeeeeeeeeeeeeee,deeeeeeeewweeeeee,>(Lorem: string, ipsum: symbol,  dolor: number, sit: boolean, amet: string, consectetur: symbol) => {
+    Lorem: string, ipsum: symbol, dolor: number, sit: boolean, amet: string, consectetur: symbol
+}
+
+type ShortFunctionType = <A,B,C,D,E,>(Lorem: string, ipsum: symbol,  dolor: number, sit: boolean, amet: string, consectetur: symbol) => {
+    a: string;
+}
+
+function test(a: string):
+    a is  string   { return true }
+
+
+type AbstractCompositeThingamabobberFactoryProvider = string;
+
+type ConstructorType = new ( options: { a: string, b: AbstractCompositeThingamabobberFactoryProvider },
+) => {};
+
+type GenericTypeExpression<A extends { a: string }> = Foo<A, {  bar: string }>;
+type GenericTypeExpression<A extends { a: string }> = AbstractCompositeThingamabobberFactoryProvider<{  bar: string, foo: symbol; baz: number; zzz: boolean }>;
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+-----
+
+```ts
+import * as assert from "assert";
+
+type W = {
+	a: string;
+	b: symbol;
+	c: symbol;
+	d: symbol;
+	e: symbol;
+	f: symbol;
+	g: symbol;
+};
+type X = { a: string; b: symbol };
+type Z = {
+	a: string;
+	b: symbol;
+};
+type A = {
+	a: string;
+};
+
+type OptionsFlags<Type> = {
+	+readonly [Property in keyof Type as string]-?: boolean;
+};
+
+type TupleA = [string];
+
+type TupleB = [...string[]];
+
+type TupleC = [surname?: string[], ...name: string[]];
+
+type TupleD = [
+	address: string,
+	address2: string,
+	address3: string,
+	address4: string,
+	address5: string,
+	surname?: string[],
+	...name: string[],
+];
+
+type PA = string;
+
+type FunctionType = <
+	Aaaaaaaaaaaaaaaaaaaaa,
+	bvvvvvvvvvvvvvvvvvvvvvv,
+	ceeeeeee,
+	deeeeeeeeeeeeee,
+	deeeeeeeeeeeeeee,
+	deeeeeeeeeeeeeeee,
+	deeeeeeeewweeeeee,
+>(
+	Lorem: string,
+	ipsum: symbol,
+	dolor: number,
+	sit: boolean,
+	amet: string,
+	consectetur: symbol,
+) => {
+	Lorem: string;
+	ipsum: symbol;
+	dolor: number;
+	sit: boolean;
+	amet: string;
+	consectetur: symbol;
+};
+
+type ShortFunctionType = <A, B, C, D, E>(
+	Lorem: string,
+	ipsum: symbol,
+	dolor: number,
+	sit: boolean,
+	amet: string,
+	consectetur: symbol,
+) => {
+	a: string;
+};
+
+function test(a: string): a is string {
+	return true;
+}
+
+type AbstractCompositeThingamabobberFactoryProvider = string;
+
+type ConstructorType = new (options: {
+	a: string;
+	b: AbstractCompositeThingamabobberFactoryProvider;
+}) => {};
+
+type GenericTypeExpression<A extends { a: string }> = Foo<A, { bar: string }>;
+type GenericTypeExpression<A extends { a: string }> =
+	AbstractCompositeThingamabobberFactoryProvider<{
+		bar: string;
+		foo: symbol;
+		baz: number;
+		zzz: boolean;
+	}>;
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Indent width: 2
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: false
+-----
+
+```ts
+import * as assert from "assert";
+
+type W = {
+	a: string;
+	b: symbol;
+	c: symbol;
+	d: symbol;
+	e: symbol;
+	f: symbol;
+	g: symbol;
+};
+type X = {a: string; b: symbol};
+type Z = {
+	a: string;
+	b: symbol;
+};
+type A = {
+	a: string;
+};
+
+type OptionsFlags<Type> = {
+	+readonly [Property in keyof Type as string]-?: boolean;
+};
+
+type TupleA = [string];
+
+type TupleB = [...string[]];
+
+type TupleC = [surname?: string[], ...name: string[]];
+
+type TupleD = [
+	address: string,
+	address2: string,
+	address3: string,
+	address4: string,
+	address5: string,
+	surname?: string[],
+	...name: string[],
+];
+
+type PA = string;
+
+type FunctionType = <
+	Aaaaaaaaaaaaaaaaaaaaa,
+	bvvvvvvvvvvvvvvvvvvvvvv,
+	ceeeeeee,
+	deeeeeeeeeeeeee,
+	deeeeeeeeeeeeeee,
+	deeeeeeeeeeeeeeee,
+	deeeeeeeewweeeeee,
+>(
+	Lorem: string,
+	ipsum: symbol,
+	dolor: number,
+	sit: boolean,
+	amet: string,
+	consectetur: symbol,
+) => {
+	Lorem: string;
+	ipsum: symbol;
+	dolor: number;
+	sit: boolean;
+	amet: string;
+	consectetur: symbol;
+};
+
+type ShortFunctionType = <A, B, C, D, E>(
+	Lorem: string,
+	ipsum: symbol,
+	dolor: number,
+	sit: boolean,
+	amet: string,
+	consectetur: symbol,
+) => {
+	a: string;
+};
+
+function test(a: string): a is string {
+	return true;
+}
+
+type AbstractCompositeThingamabobberFactoryProvider = string;
+
+type ConstructorType = new (options: {
+	a: string;
+	b: AbstractCompositeThingamabobberFactoryProvider;
+}) => {};
+
+type GenericTypeExpression<A extends {a: string}> = Foo<A, {bar: string}>;
+type GenericTypeExpression<A extends {a: string}> =
+	AbstractCompositeThingamabobberFactoryProvider<{
+		bar: string;
+		foo: symbol;
+		baz: number;
+		zzz: boolean;
+	}>;
+```
+
+

--- a/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/options.json
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"bracket_spacing": false
+		}
+	]
+}

--- a/crates/biome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
@@ -131,6 +131,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
@@ -73,6 +73,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/function/parameters/function_parameters.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/function/parameters/function_parameters.ts.snap
@@ -60,6 +60,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -113,6 +114,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -163,6 +165,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/function/trailing_comma/function_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/function/trailing_comma/function_trailing_comma.ts.snap
@@ -64,6 +64,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -121,6 +122,7 @@ Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -178,6 +180,7 @@ Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
@@ -49,6 +49,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
@@ -31,6 +31,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/class.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/class.ts.snap
@@ -78,6 +78,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -147,6 +148,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/non-null.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/non-null.ts.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -51,6 +52,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/statements.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/statements.ts.snap
@@ -41,6 +41,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -72,6 +73,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/types.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/types.ts.snap
@@ -40,6 +40,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -75,6 +76,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
@@ -49,6 +49,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -88,6 +89,7 @@ Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -127,6 +129,7 @@ Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
@@ -29,6 +29,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/parenthesis.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/parenthesis.ts.snap
@@ -36,6 +36,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
@@ -28,6 +28,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
@@ -39,6 +39,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/string/parameter_quotes.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/string/parameter_quotes.ts.snap
@@ -62,6 +62,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -115,6 +116,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -168,6 +170,7 @@ Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/suppressions.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/suppressions.ts.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/conditional.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/conditional.ts.snap
@@ -43,6 +43,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/import_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/import_type.ts.snap
@@ -33,6 +33,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
@@ -85,6 +85,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
@@ -34,6 +34,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
@@ -27,6 +27,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/template_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/template_type.ts.snap
@@ -30,6 +30,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
@@ -39,6 +39,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -68,6 +69,7 @@ Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts
@@ -97,6 +99,7 @@ Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/union_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/union_type.ts.snap
@@ -273,6 +273,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/tsx/smoke.tsx.snap
+++ b/crates/biome_js_formatter/tests/specs/tsx/smoke.tsx.snap
@@ -27,6 +27,7 @@ Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
+Bracket spacing: true
 -----
 
 ```tsx

--- a/crates/biome_service/src/configuration/javascript/formatter.rs
+++ b/crates/biome_service/src/configuration/javascript/formatter.rs
@@ -37,7 +37,7 @@ pub struct JavascriptFormatter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arrow_parentheses: Option<ArrowParentheses>,
     /// Whether to insert spaces around brackets in object literals. Defaults to true.
-    #[bpaf(long("bracket-spacing"), argument("BOOLEAN"), optional)]
+    #[bpaf(long("bracket-spacing"), argument("true|false"), optional)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bracket_spacing: Option<bool>,
 

--- a/crates/biome_service/src/configuration/javascript/formatter.rs
+++ b/crates/biome_service/src/configuration/javascript/formatter.rs
@@ -36,6 +36,10 @@ pub struct JavascriptFormatter {
     #[bpaf(long("arrow-parentheses"), argument("always|as-needed"), optional)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arrow_parentheses: Option<ArrowParentheses>,
+    /// Whether to insert spaces around brackets in object literals. Defaults to true.
+    #[bpaf(long("bracket-spacing"), argument("BOOLEAN"), optional)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bracket_spacing: Option<bool>,
 
     /// Control the formatter for JavaScript (and its super languages) files.
     #[bpaf(long("javascript-formatter-enabled"), argument("true|false"), optional)]
@@ -88,6 +92,9 @@ impl MergeWith<JavascriptFormatter> for JavascriptFormatter {
     fn merge_with(&mut self, other: JavascriptFormatter) {
         if let Some(arrow_parentheses) = other.arrow_parentheses {
             self.arrow_parentheses = Some(arrow_parentheses);
+        }
+        if let Some(bracket_spacing) = other.bracket_spacing {
+            self.bracket_spacing = Some(bracket_spacing);
         }
         if let Some(quote_properties) = other.quote_properties {
             self.quote_properties = Some(quote_properties);

--- a/crates/biome_service/src/configuration/parse/json/javascript/formatter.rs
+++ b/crates/biome_service/src/configuration/parse/json/javascript/formatter.rs
@@ -34,6 +34,7 @@ impl DeserializationVisitor for JavascriptFormatterVisitor {
             "trailingComma",
             "semicolons",
             "arrowParentheses",
+            "bracketSpacing",
             "enabled",
             "indentStyle",
             "indentSize",
@@ -69,6 +70,10 @@ impl DeserializationVisitor for JavascriptFormatterVisitor {
                 }
                 "arrowParentheses" => {
                     result.arrow_parentheses =
+                        Deserializable::deserialize(&value, &key_text, diagnostics);
+                }
+                "bracketSpacing" => {
+                    result.bracket_spacing =
                         Deserializable::deserialize(&value, &key_text, diagnostics);
                 }
                 "enabled" => {

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -26,10 +26,9 @@ use biome_js_analyze::{
     analyze, analyze_with_inspect_matcher, visit_registry, ControlFlowGraph, RuleError,
 };
 use biome_js_formatter::context::trailing_comma::TrailingComma;
-use biome_js_formatter::context::ArrowParentheses;
-use biome_js_formatter::context::JsFormatOptions;
-use biome_js_formatter::context::Semicolons;
-use biome_js_formatter::context::{QuoteProperties, QuoteStyle};
+use biome_js_formatter::context::{
+    ArrowParentheses, BracketSpacing, JsFormatOptions, QuoteProperties, QuoteStyle, Semicolons,
+};
 use biome_js_formatter::format_node;
 use biome_js_parser::JsParserOptions;
 use biome_js_semantic::{semantic_model, SemanticModelOptions};
@@ -53,6 +52,7 @@ pub struct JsFormatterSettings {
     pub trailing_comma: Option<TrailingComma>,
     pub semicolons: Option<Semicolons>,
     pub arrow_parentheses: Option<ArrowParentheses>,
+    pub bracket_spacing: Option<BracketSpacing>,
     pub line_ending: Option<LineEnding>,
     pub line_width: Option<LineWidth>,
     pub indent_width: Option<IndentWidth>,
@@ -124,7 +124,8 @@ impl Language for JsLanguage {
             .with_quote_properties(language.quote_properties.unwrap_or_default())
             .with_trailing_comma(language.trailing_comma.unwrap_or_default())
             .with_semicolons(language.semicolons.unwrap_or_default())
-            .with_arrow_parentheses(language.arrow_parentheses.unwrap_or_default());
+            .with_arrow_parentheses(language.arrow_parentheses.unwrap_or_default())
+            .with_bracket_spacing(language.bracket_spacing.unwrap_or_default());
 
         overrides.override_js_format_options(path, options)
     }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -268,6 +268,7 @@ impl From<JavascriptConfiguration> for LanguageSettings<JsLanguage> {
             language_setting.formatter.trailing_comma = formatter.trailing_comma;
             language_setting.formatter.semicolons = formatter.semicolons;
             language_setting.formatter.arrow_parentheses = formatter.arrow_parentheses;
+            language_setting.formatter.bracket_spacing = formatter.bracket_spacing.map(Into::into);
             language_setting.formatter.enabled = formatter.enabled;
             language_setting.formatter.line_width = formatter.line_width;
             language_setting.formatter.indent_width = formatter
@@ -513,6 +514,9 @@ impl OverrideSettings {
                 }
                 if let Some(arrow_parentheses) = js_formatter.arrow_parentheses {
                     options.set_arrow_parentheses(arrow_parentheses);
+                }
+                if let Some(bracket_spacing) = js_formatter.bracket_spacing {
+                    options.set_bracket_spacing(bracket_spacing);
                 }
             }
 

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -845,6 +845,10 @@
 						{ "type": "null" }
 					]
 				},
+				"bracketSpacing": {
+					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
+					"type": ["boolean", "null"]
+				},
 				"enabled": {
 					"description": "Control the formatter for JavaScript (and its super languages) files.",
 					"type": ["boolean", "null"]

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -230,6 +230,10 @@ export interface JavascriptFormatter {
 	 */
 	arrowParentheses?: ArrowParentheses;
 	/**
+	 * Whether to insert spaces around brackets in object literals. Defaults to true.
+	 */
+	bracketSpacing?: boolean;
+	/**
 	 * Control the formatter for JavaScript (and its super languages) files.
 	 */
 	enabled?: boolean;

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -845,6 +845,10 @@
 						{ "type": "null" }
 					]
 				},
+				"bracketSpacing": {
+					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
+					"type": ["boolean", "null"]
+				},
 				"enabled": {
 					"description": "Control the formatter for JavaScript (and its super languages) files.",
 					"type": ["boolean", "null"]

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -95,6 +95,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Formatter
 
+#### New Features
+
+- Added a new option called `--bracket-spacing` to the formatter. This option allows you to control whether spaces are inserted around the brackets of object literals. [#627](https://github.com/rome/tools/issues/627)
+
 #### Bug fixes
 
 - Apply the correct layout when the right hand of an assignment expression is a await expression or a yield expression. Contributed by @ematipico

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -38,6 +38,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### New features
 
 - Add a new option [`--line-ending`](https://biomejs.dev/reference/configuration/#formatterlineending). This option allows changing the type of line endings. Contributed by @SuperchupuDev
+- Added a new option called `--bracket-spacing` to the formatter. This option allows you to control whether spaces are inserted around the brackets of object literals. [#627](https://github.com/biomejs/biome/issues/627). Contributed by @faultyserver
 
 #### Bug fixes
 
@@ -94,10 +95,6 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Fix [#592](https://github.com/biomejs/biome/issues/592), by changing binary resolution in the IntelliJ plugin. Contributed by @Joshuabaker2
 
 ### Formatter
-
-#### New Features
-
-- Added a new option called `--bracket-spacing` to the formatter. This option allows you to control whether spaces are inserted around the brackets of object literals. [#627](https://github.com/rome/tools/issues/627)
 
 #### Bug fixes
 

--- a/website/src/playground/PlaygroundLoader.tsx
+++ b/website/src/playground/PlaygroundLoader.tsx
@@ -335,6 +335,9 @@ function initState(
 			arrowParentheses:
 				(searchParams.get("arrowParentheses") as ArrowParentheses) ??
 				defaultPlaygroundState.settings.arrowParentheses,
+			bracketSpacing:
+				(searchParams.get("bracketSpacing") === "true") ??
+				defaultPlaygroundState.settings.bracketSpacing,
 			lintRules:
 				(searchParams.get("lintRules") as LintRules) ??
 				defaultPlaygroundState.settings.lintRules,

--- a/website/src/playground/PlaygroundLoader.tsx
+++ b/website/src/playground/PlaygroundLoader.tsx
@@ -336,7 +336,7 @@ function initState(
 				(searchParams.get("arrowParentheses") as ArrowParentheses) ??
 				defaultPlaygroundState.settings.arrowParentheses,
 			bracketSpacing:
-				(searchParams.get("bracketSpacing") === "true") ??
+				searchParams.get("bracketSpacing") === "true" ??
 				defaultPlaygroundState.settings.bracketSpacing,
 			lintRules:
 				(searchParams.get("lintRules") as LintRules) ??

--- a/website/src/playground/tabs/SettingsTab.tsx
+++ b/website/src/playground/tabs/SettingsTab.tsx
@@ -45,6 +45,7 @@ export default function SettingsTab({
 			trailingComma,
 			semicolons,
 			arrowParentheses,
+			bracketSpacing,
 			lintRules,
 			enabledLinting,
 			importSortingEnabled,
@@ -88,6 +89,10 @@ export default function SettingsTab({
 	const setArrowParentheses = createPlaygroundSettingsSetter(
 		setPlaygroundState,
 		"arrowParentheses",
+	);
+	const setBracketSpacing = createPlaygroundSettingsSetter(
+		setPlaygroundState,
+		"bracketSpacing",
 	);
 	const setLintRules = createPlaygroundSettingsSetter(
 		setPlaygroundState,
@@ -252,6 +257,8 @@ export default function SettingsTab({
 				setSemicolons={setSemicolons}
 				arrowParentheses={arrowParentheses}
 				setArrowParentheses={setArrowParentheses}
+				bracketSpacing={bracketSpacing}
+				setBracketSpacing={setBracketSpacing}
 			/>
 			<LinterSettings
 				lintRules={lintRules}
@@ -581,6 +588,8 @@ function FormatterSettings({
 	setSemicolons,
 	arrowParentheses,
 	setArrowParentheses,
+	bracketSpacing,
+	setBracketSpacing,
 }: {
 	lineWidth: number;
 	setLineWidth: (value: number) => void;
@@ -600,6 +609,8 @@ function FormatterSettings({
 	setSemicolons: (value: Semicolons) => void;
 	arrowParentheses: ArrowParentheses;
 	setArrowParentheses: (value: ArrowParentheses) => void;
+	bracketSpacing: boolean;
+	setBracketSpacing: (value: boolean) => void;
 }) {
 	return (
 		<>
@@ -716,6 +727,18 @@ function FormatterSettings({
 						<option value={ArrowParentheses.Always}>Always</option>
 						<option value={ArrowParentheses.AsNeeded}>As needed</option>
 					</select>
+				</div>
+				<div className="field-row">
+					<label htmlFor="bracketSpacing">Bracket Spacing</label>
+					<input
+						id="bracketSpacing"
+						name="bracketSpacing"
+						type="checkbox"
+						checked={bracketSpacing}
+						onChange={(e) =>
+							setBracketSpacing(e.target.checked)
+						}
+					/>
 				</div>
 			</section>
 		</>

--- a/website/src/playground/tabs/SettingsTab.tsx
+++ b/website/src/playground/tabs/SettingsTab.tsx
@@ -735,9 +735,7 @@ function FormatterSettings({
 						name="bracketSpacing"
 						type="checkbox"
 						checked={bracketSpacing}
-						onChange={(e) =>
-							setBracketSpacing(e.target.checked)
-						}
+						onChange={(e) => setBracketSpacing(e.target.checked)}
 					/>
 				</div>
 			</section>

--- a/website/src/playground/types.ts
+++ b/website/src/playground/types.ts
@@ -113,6 +113,7 @@ export interface PlaygroundSettings {
 	trailingComma: TrailingComma;
 	semicolons: Semicolons;
 	arrowParentheses: ArrowParentheses;
+	bracketSpacing: boolean;
 	lintRules: LintRules;
 	enabledLinting: boolean;
 	importSortingEnabled: boolean;
@@ -157,6 +158,7 @@ export const defaultPlaygroundState: PlaygroundState = {
 		trailingComma: TrailingComma.All,
 		semicolons: Semicolons.Always,
 		arrowParentheses: ArrowParentheses.Always,
+		bracketSpacing: true,
 		lintRules: LintRules.Recommended,
 		enabledLinting: true,
 		importSortingEnabled: true,

--- a/website/src/playground/workers/biomeWorker.ts
+++ b/website/src/playground/workers/biomeWorker.ts
@@ -73,6 +73,7 @@ self.addEventListener("message", async (e) => {
 				trailingComma,
 				semicolons,
 				arrowParentheses,
+				bracketSpacing,
 				importSortingEnabled,
 				unsafeParameterDecoratorsEnabled,
 				allowComments,
@@ -111,6 +112,7 @@ self.addEventListener("message", async (e) => {
 							arrowParentheses === ArrowParentheses.Always
 								? "always"
 								: "asNeeded",
+						bracketSpacing,
 					},
 					parser: {
 						unsafeParameterDecoratorsEnabled,

--- a/website/src/playground/workers/prettierWorker.ts
+++ b/website/src/playground/workers/prettierWorker.ts
@@ -37,6 +37,7 @@ self.addEventListener("message", async (e) => {
 				trailingComma,
 				semicolons,
 				arrowParentheses,
+				bracketSpacing,
 			} = settings;
 			const code = e.data.code as string;
 			const filename = e.data.filename as string;
@@ -52,6 +53,7 @@ self.addEventListener("message", async (e) => {
 				trailingComma,
 				semicolons,
 				arrowParentheses,
+				bracketSpacing,
 			});
 
 			self.postMessage({
@@ -81,6 +83,7 @@ async function formatWithPrettier(
 		trailingComma: TrailingComma;
 		semicolons: Semicolons;
 		arrowParentheses: ArrowParentheses;
+		bracketSpacing: boolean;
 	},
 ): Promise<PrettierOutput> {
 	try {
@@ -100,6 +103,7 @@ async function formatWithPrettier(
 				options.arrowParentheses === ArrowParentheses.Always
 					? "always"
 					: "avoid",
+			bracketSpacing: options.bracketSpacing,
 		};
 
 		// @ts-expect-error


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a new `bracketSpacing` option for the js formatter which matches [Prettier's equivalent option](https://prettier.io/docs/en/options#bracket-spacing). This option controls whether spaces are inserted around "object-like literals", meaning object expressions, named import/export specifier lists, import assertions, and type expressions.

The following is a case that should cover pretty much every variation that this option affects:

```typescript
import {a, b, c} from "foo" assert {type: "json"};

type X = {a: string};
type Y = {
  a: string;
};

const {a, b} = {a, b};
let {foo, bar, baz, zzz, andareallylongname} = {
  foo,
  bar,
  baz,
  zzz,
  andareallylongname,
};

export {a, b as car};

type Foo<A extends {type: string}> = A<{type: B}>;
```

With `bracketSpacing: false`, this code should [appear unchanged after formatting](http://localhost:4321/playground/?indentStyle=space&bracketSpacing=false&code=aQBtAHAAbwByAHQAIAB7AGEALAAgAGIALAAgAGMAfQAgAGYAcgBvAG0AIAAnAGYAbwBvACcAIABhAHMAcwBlAHIAdAAgAHsAdAB5AHAAZQA6ACAAJwBqAHMAbwBuACcAfQA7AAoACgB0AHkAcABlACAAWAAgAD0AIAB7AGEAOgAgAHMAdAByAGkAbgBnAH0AOwAKAHQAeQBwAGUAIABZACAAPQAgAHsACgAgACAAYQA6ACAAcwB0AHIAaQBuAGcACgB9AAoACgBjAG8AbgBzAHQAIAB7AGEALAAgAGIAfQAgAD0AIAB7AGEALAAgAGIAfQA7AAoAbABlAHQAIAB7AGYAbwBvACwAIABiAGEAcgAsACAAYgBhAHoALAAgAHoAegB6ACwAIABhAG4AZABhAHIAZQBhAGwAbAB5AGwAbwBuAGcAbgBhAG0AZQB9ACAAPQAgAHsAZgBvAG8ALAAgAGIAYQByACwAIABiAGEAegAsACAAegB6AHoALAAgAGEAbgBkAGEAcgBlAGEAbABsAHkAbABvAG4AZwBuAGEAbQBlAH0AOwAKAAoAZQB4AHAAbwByAHQAIAB7AGEALAAgAGIAIABhAHMAIABjAGEAcgB9ADsACgAKAHQAeQBwAGUAIABGAG8AbwA8AEEAIABlAHgAdABlAG4AZABzACAAewB0AHkAcABlADoAIABzAHQAcgBpAG4AZwB9AD4AIAA9ACAAQQA8AHsAdAB5AHAAZQA6ACAAQgB9AD4AOwA%3D).

By default, `bracketSpacing` is left as `true`, just like in Prettier, and users will have to explicitly disable it to see any changes from their current formatting.

The goal of adding this option is to ease adoption from existing Prettier users. While Biome does not (and I'm assuming won't) aim to have perfect parity with Prettier's features, bracket spacing is a commonly-set option, and one that causes a massive diff for large codebases.

Not much other discussion has happened on this option, other than this post from a little over a month ago: https://github.com/biomejs/biome/discussions/392.

### Implementation Notes

I'm both relatively new to Rust and completely new to this project, so I looked for inspiration on how to add an option by finding a [previous addition, `arrowParentheses`](https://github.com/rome/tools/pull/4667), and copying over the plumbing, then implementing the feature, and finally adding the relevant tests.

I decided to use a plain `bool` value for the option rather than a string/enum only because that's what Prettier does. If a string value would be preferred, I'm happy to change it to match those as well.

## Test Plan

`cargo test` with a bunch of new snapshots. A [local playground link with the sample code above](http://localhost:4321/playground/?indentStyle=space&bracketSpacing=false&code=aQBtAHAAbwByAHQAIAB7AGEALAAgAGIALAAgAGMAfQAgAGYAcgBvAG0AIAAnAGYAbwBvACcAIABhAHMAcwBlAHIAdAAgAHsAdAB5AHAAZQA6ACAAJwBqAHMAbwBuACcAfQA7AAoACgB0AHkAcABlACAAWAAgAD0AIAB7AGEAOgAgAHMAdAByAGkAbgBnAH0AOwAKAHQAeQBwAGUAIABZACAAPQAgAHsACgAgACAAYQA6ACAAcwB0AHIAaQBuAGcACgB9AAoACgBjAG8AbgBzAHQAIAB7AGEALAAgAGIAfQAgAD0AIAB7AGEALAAgAGIAfQA7AAoAbABlAHQAIAB7AGYAbwBvACwAIABiAGEAcgAsACAAYgBhAHoALAAgAHoAegB6ACwAIABhAG4AZABhAHIAZQBhAGwAbAB5AGwAbwBuAGcAbgBhAG0AZQB9ACAAPQAgAHsAZgBvAG8ALAAgAGIAYQByACwAIABiAGEAegAsACAAegB6AHoALAAgAGEAbgBkAGEAcgBlAGEAbABsAHkAbABvAG4AZwBuAGEAbQBlAH0AOwAKAAoAZQB4AHAAbwByAHQAIAB7AGEALAAgAGIAIABhAHMAIABjAGEAcgB9ADsACgAKAHQAeQBwAGUAIABGAG8AbwA8AEEAIABlAHgAdABlAG4AZABzACAAewB0AHkAcABlADoAIABzAHQAcgBpAG4AZwB9AD4AIAA9ACAAQQA8AHsAdAB5AHAAZQA6ACAAQgB9AD4AOwA%3D) also demonstrates the behavior.
