### PR TITLE
fix(biome_aria): add more a11y roles and fix get_role method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Fix [#595](https://github.com/biomejs/biome/issues/595) by updating unsafe-apply logic to avoid unexpected errors in [noUselessFragments](https://biomejs.dev/linter/rules/no-useless-fragments/). Contributed by @nissy-dev
 
 - Fix [#591](https://github.com/biomejs/biome/issues/591) which made [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare) report type parameters with identical names but in different method signatures. Contributed by @Conaclos
+- Support more a11y roles and fix some methods for a11y lint rules Contributed @nissy-dev
 
 ### Parser
 

--- a/crates/biome_aria/src/roles.rs
+++ b/crates/biome_aria/src/roles.rs
@@ -423,6 +423,14 @@ define_role! {
 }
 
 define_role! {
+    /// https://www.w3.org/TR/wai-aria-1.2/#note
+    NoteRole {
+        PROPS: [],
+        ROLES: ["section"],
+    }
+}
+
+define_role! {
     /// https://www.w3.org/TR/wai-aria-1.1/#progressbar
     ProgressBarRole {
         PROPS: [("aria-valuenow", true), ("aria-valuemin", true), ("aria-valuemax", true)],
@@ -465,6 +473,15 @@ define_role! {
 }
 
 define_role! {
+    /// https://w3c.github.io/aria/#search
+    SearchRole {
+        PROPS: [],
+        ROLES: ["landmark"],
+        CONCEPTS: &[("search", &[])],
+    }
+}
+
+define_role! {
     /// https://www.w3.org/TR/wai-aria-1.1/#searchbox
     SearchboxRole {
         PROPS: [
@@ -489,6 +506,14 @@ define_role! {
 }
 
 define_role! {
+    /// https://www.w3.org/TR/wai-aria-1.2/#tablist
+    TabListRole {
+        PROPS: [("aria-multiselectable", false), ("aria-orientation", false)],
+        ROLES: ["composite"],
+    }
+}
+
+define_role! {
     /// https://www.w3.org/TR/wai-aria-1.1/#table
     TableRole {
         PROPS: [("aria-colcount", false), ("aria-rowcount", false)],
@@ -498,10 +523,10 @@ define_role! {
 }
 
 define_role! {
-    /// https://www.w3.org/TR/wai-aria-1.1/#tablelist
-    TableListRole {
-        PROPS: [("aria-level", false), ("aria-multiselectable", false), ("aria-orientation", false)],
-        ROLES: ["composite"],
+    /// https://www.w3.org/TR/wai-aria-1.1/#tabpanel
+    TabPanelRole {
+        PROPS: [],
+        ROLES: ["section"],
     }
 }
 
@@ -539,10 +564,34 @@ define_role! {
 }
 
 define_role! {
+    /// https://www.w3.org/TR/wai-aria-1.2/#tooltip
+    TooltipRole {
+        PROPS: [],
+        ROLES: ["section"],
+    }
+}
+
+define_role! {
     /// https://www.w3.org/TR/wai-aria-1.1/#tree
     TreeRole {
         PROPS: [("aria-multiselectable", false), ("aria-required", false)],
         ROLES: ["select"],
+    }
+}
+
+define_role! {
+    /// https://www.w3.org/TR/wai-aria-1.1/#treegrid
+    TreeGridRole {
+        PROPS: [],
+        ROLES: ["grid", "tree"],
+    }
+}
+
+define_role! {
+    /// https://www.w3.org/TR/wai-aria-1.1/#treeitem
+    TreeItemRole {
+        PROPS: [("aria-expanded", false), ("aria-haspopup", false)],
+        ROLES: ["listitem", "option"],
     }
 }
 
@@ -597,6 +646,14 @@ define_role! {
         PROPS: [],
         ROLES: ["section"],
         CONCEPTS: &[("del", &[])],
+    }
+}
+
+define_role! {
+    /// https://www.w3.org/TR/wai-aria-1.2/#directory
+    DirectoryRole {
+        PROPS: [],
+        ROLES: ["list"],
     }
 }
 
@@ -676,6 +733,14 @@ define_role! {
         PROPS: [],
         ROLES: ["section"],
         CONCEPTS: &[("time", &[])],
+    }
+}
+
+define_role! {
+    /// https://www.w3.org/TR/wai-aria-1.2/#timer
+    TimerRole {
+        PROPS: [],
+        ROLES: ["status"],
     }
 }
 
@@ -790,6 +855,7 @@ impl<'a> AriaRoles {
         "row",
         "rowgroup",
         "rowheader",
+        "search",
         "searchbox",
         "table",
         "term",
@@ -808,6 +874,7 @@ impl<'a> AriaRoles {
     ];
 
     /// It returns the metadata of a role, if it exits.
+    /// These roles don't include abstract roles.
     ///
     /// ## Examples
     ///
@@ -824,62 +891,87 @@ impl<'a> AriaRoles {
     /// ```
     pub fn get_role(&self, role: &str) -> Option<&'static dyn AriaRoleDefinition> {
         let result = match role {
-            "button" => &ButtonRole as &dyn AriaRoleDefinition,
-            "checkbox" => &CheckboxRole as &dyn AriaRoleDefinition,
-            "radio" => &RadioRole as &dyn AriaRoleDefinition,
-            "switch" => &SwitchRole as &dyn AriaRoleDefinition,
-            "option" => &OptionRole as &dyn AriaRoleDefinition,
-            "combobox" => &ComboBoxRole as &dyn AriaRoleDefinition,
-            "heading" => &HeadingRole as &dyn AriaRoleDefinition,
-            "spinbutton" => &SpinButtonRole as &dyn AriaRoleDefinition,
-            "slider" => &SliderRole as &dyn AriaRoleDefinition,
-            "separator" => &SeparatorRole as &dyn AriaRoleDefinition,
-            "scrollbar" => &ScollbarRole as &dyn AriaRoleDefinition,
-            "article" => &ArticleRole as &dyn AriaRoleDefinition,
-            "dialog" => &DialogRole as &dyn AriaRoleDefinition,
             "alert" => &AlertRole as &dyn AriaRoleDefinition,
             "alertdialog" => &AlertDialogRole as &dyn AriaRoleDefinition,
             "application" => &ApplicationRole as &dyn AriaRoleDefinition,
+            "article" => &ArticleRole as &dyn AriaRoleDefinition,
             "banner" => &BannerRole as &dyn AriaRoleDefinition,
+            "blockquote" => &BlockQuoteRole as &dyn AriaRoleDefinition,
+            "button" => &ButtonRole as &dyn AriaRoleDefinition,
+            "caption" => &CaptionRole as &dyn AriaRoleDefinition,
             "cell" => &CellRole as &dyn AriaRoleDefinition,
+            "checkbox" => &CheckboxRole as &dyn AriaRoleDefinition,
+            "code" => &CodeRole as &dyn AriaRoleDefinition,
             "columnheader" => &ColumnHeaderRole as &dyn AriaRoleDefinition,
+            "combobox" => &ComboBoxRole as &dyn AriaRoleDefinition,
+            "complementary" => &ComplementaryRole as &dyn AriaRoleDefinition,
+            "contentinfo" => &ContentInfoRole as &dyn AriaRoleDefinition,
             "definition" => &DefinitionRole as &dyn AriaRoleDefinition,
+            "delete" => &DeletionRole as &dyn AriaRoleDefinition,
+            "dialog" => &DialogRole as &dyn AriaRoleDefinition,
+            "directory" => &DirectoryRole as &dyn AriaRoleDefinition,
+            "document" => &DocumentRole as &dyn AriaRoleDefinition,
+            "emphasis" => &EmphasisRole as &dyn AriaRoleDefinition,
             "feed" => &FeedRole as &dyn AriaRoleDefinition,
             "figure" => &FigureRole as &dyn AriaRoleDefinition,
             "form" => &FormRole as &dyn AriaRoleDefinition,
+            "generic" => &GenericRole as &dyn AriaRoleDefinition,
             "grid" => &GridRole as &dyn AriaRoleDefinition,
             "gridcell" => &GridCellRole as &dyn AriaRoleDefinition,
             "group" => &GroupRole as &dyn AriaRoleDefinition,
+            "heading" => &HeadingRole as &dyn AriaRoleDefinition,
             "img" => &ImgRole as &dyn AriaRoleDefinition,
+            "insertion" => &InsertionRole as &dyn AriaRoleDefinition,
             "link" => &LinkRole as &dyn AriaRoleDefinition,
             "list" => &ListRole as &dyn AriaRoleDefinition,
             "listbox" => &ListBoxRole as &dyn AriaRoleDefinition,
             "listitem" => &ListItemRole as &dyn AriaRoleDefinition,
             "log" => &LogRole as &dyn AriaRoleDefinition,
             "main" => &MainRole as &dyn AriaRoleDefinition,
-            "menubar" => &MenubarRole as &dyn AriaRoleDefinition,
+            "marquee" => &MarqueeRole as &dyn AriaRoleDefinition,
+            "math" => &MathRole as &dyn AriaRoleDefinition,
             "menu" => &MenuRole as &dyn AriaRoleDefinition,
+            "menubar" => &MenubarRole as &dyn AriaRoleDefinition,
             "menuitem" => &MenuItemRole as &dyn AriaRoleDefinition,
             "menuitemcheckbox" => &MenuItemCheckboxRole as &dyn AriaRoleDefinition,
             "menuitemradio" => &MenuItemRadioRole as &dyn AriaRoleDefinition,
+            "meter" => &MeterRole as &dyn AriaRoleDefinition,
             "navigation" => &NavigationRole as &dyn AriaRoleDefinition,
+            "note" => &NoteRole as &dyn AriaRoleDefinition,
+            "option" => &OptionRole as &dyn AriaRoleDefinition,
+            "paragraph" => &ParagraphRole as &dyn AriaRoleDefinition,
+            "presentation" => &PresentationRole as &dyn AriaRoleDefinition,
             "progressbar" => &ProgressBarRole as &dyn AriaRoleDefinition,
+            "radio" => &RadioRole as &dyn AriaRoleDefinition,
             "radiogroup" => &RadiogroupRole as &dyn AriaRoleDefinition,
+            "region" => &RegionRole as &dyn AriaRoleDefinition,
             "row" => &RowRole as &dyn AriaRoleDefinition,
             "rowgroup" => &RowGroupRole as &dyn AriaRoleDefinition,
             "rowheader" => &RowHeaderRole as &dyn AriaRoleDefinition,
+            "search" => &SearchRole as &dyn AriaRoleDefinition,
             "searchbox" => &SearchboxRole as &dyn AriaRoleDefinition,
+            "separator" => &SeparatorRole as &dyn AriaRoleDefinition,
+            "slider" => &SliderRole as &dyn AriaRoleDefinition,
+            "spinbutton" => &SpinButtonRole as &dyn AriaRoleDefinition,
+            "scrollbar" => &ScollbarRole as &dyn AriaRoleDefinition,
+            "status" => &StatusRole as &dyn AriaRoleDefinition,
+            "strong" => &StrongRole as &dyn AriaRoleDefinition,
+            "subscript" => &SubScriptRole as &dyn AriaRoleDefinition,
+            "superscript" => &SuperScriptRole as &dyn AriaRoleDefinition,
+            "switch" => &SwitchRole as &dyn AriaRoleDefinition,
             "tab" => &TabRole as &dyn AriaRoleDefinition,
             "table" => &TableRole as &dyn AriaRoleDefinition,
-            "tablelist" => &TableListRole as &dyn AriaRoleDefinition,
+            "tablist" => &TabListRole as &dyn AriaRoleDefinition,
+            "tabpanel" => &TabPanelRole as &dyn AriaRoleDefinition,
             "term" => &TermRole as &dyn AriaRoleDefinition,
             "textbox" => &TextboxRole as &dyn AriaRoleDefinition,
+            "time" => &TimeRole as &dyn AriaRoleDefinition,
+            "timer" => &TimerRole as &dyn AriaRoleDefinition,
             "toolbar" => &ToolbarRole as &dyn AriaRoleDefinition,
+            "tooltip" => &TooltipRole as &dyn AriaRoleDefinition,
             "tree" => &TreeRole as &dyn AriaRoleDefinition,
-            "region" => &RegionRole as &dyn AriaRoleDefinition,
-            "presentation" => &PresentationRole as &dyn AriaRoleDefinition,
-            "document" => &DocumentRole as &dyn AriaRoleDefinition,
-            "generic" => &GenericRole as &dyn AriaRoleDefinition,
+            "treegrid" => &TreeGridRole as &dyn AriaRoleDefinition,
+            "treeitem" => &TreeItemRole as &dyn AriaRoleDefinition,
             _ => return None,
         };
         Some(result)
@@ -912,6 +1004,7 @@ impl<'a> AriaRoles {
             "html" => &DocumentRole as &dyn AriaRoleDefinition,
             "ins" => &InsertionRole as &dyn AriaRoleDefinition,
             "main" => &MainRole as &dyn AriaRoleDefinition,
+            "marquee" => &MarqueeRole as &dyn AriaRoleDefinition,
             "math" => &MathRole as &dyn AriaRoleDefinition,
             "menu" => &ListRole as &dyn AriaRoleDefinition,
             "meter" => &MeterRole as &dyn AriaRoleDefinition,
@@ -922,6 +1015,7 @@ impl<'a> AriaRoles {
             "output" => &StatusRole as &dyn AriaRoleDefinition,
             "p" => &ParagraphRole as &dyn AriaRoleDefinition,
             "progress" => &ProgressBarRole as &dyn AriaRoleDefinition,
+            "search" => &SearchRole as &dyn AriaRoleDefinition,
             "strong" => &StrongRole as &dyn AriaRoleDefinition,
             "sub" => &SubScriptRole as &dyn AriaRoleDefinition,
             "sup" => &SuperScriptRole as &dyn AriaRoleDefinition,
@@ -1083,6 +1177,7 @@ impl<'a> AriaRoles {
                 "row" => &RowRole as &dyn AriaRoleDefinitionWithConcepts,
                 "rowgroup" => &RowGroupRole as &dyn AriaRoleDefinitionWithConcepts,
                 "rowheader" => &RowHeaderRole as &dyn AriaRoleDefinitionWithConcepts,
+                "search" => &SearchboxRole as &dyn AriaRoleDefinitionWithConcepts,
                 "searchbox" => &SearchboxRole as &dyn AriaRoleDefinitionWithConcepts,
                 "table" => &TableRole as &dyn AriaRoleDefinitionWithConcepts,
                 "term" => &TermRole as &dyn AriaRoleDefinitionWithConcepts,

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -45,6 +45,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Fix [#595](https://github.com/biomejs/biome/issues/595) by updating unsafe-apply logic to avoid unexpected errors in [noUselessFragments](https://biomejs.dev/linter/rules/no-useless-fragments/). Contributed by @nissy-dev
 
 - Fix [#591](https://github.com/biomejs/biome/issues/591) which made [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare) report type parameters with identical names but in different method signatures. Contributed by @Conaclos
+- Support more a11y roles and fix some methods for a11y lint rules Contributed @nissy-dev
 
 ### Parser
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Part of #553

Some a11y roles were missing in biome_aria, so they were added. And, I fixed that the `get_role` method return all roles except abstract roles. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

passing all current tests would be enough.

<!-- What demonstrates that your implementation is correct? -->
