### PR TITLE
fix(biome_js_parser): report error when using u and v flag at the same time

### DIFF
--- a/crates/biome_js_parser/src/lexer/mod.rs
+++ b/crates/biome_js_parser/src/lexer/mod.rs
@@ -1453,11 +1453,8 @@ impl<'src> JsLexer<'src> {
     }
     #[inline]
     fn flag_uv_err(&self) -> ParseDiagnostic {
-        ParseDiagnostic::new(
-            "Invalid regex flag.",
-            self.position..self.position + 1,
-        )
-        .hint("The 'u' and 'v' regular expression flags cannot be enabled at the same time.")
+        ParseDiagnostic::new("Invalid regex flag.", self.position..self.position + 1)
+            .hint("The 'u' and 'v' regular expression flags cannot be enabled at the same time.")
     }
     #[inline]
     #[allow(clippy::many_single_char_names)]

--- a/crates/biome_js_parser/src/lexer/mod.rs
+++ b/crates/biome_js_parser/src/lexer/mod.rs
@@ -1446,10 +1446,18 @@ impl<'src> JsLexer<'src> {
     #[inline]
     fn flag_err(&self, flag: char) -> ParseDiagnostic {
         ParseDiagnostic::new(
-            format!("duplicate flag `{}`", flag),
+            format!("Duplicate flag `{}`.", flag),
             self.position..self.position + 1,
         )
-        .hint("this flag was already used")
+        .hint("This flag was already used.")
+    }
+    #[inline]
+    fn flag_uv_err(&self) -> ParseDiagnostic {
+        ParseDiagnostic::new(
+            "Invalid regex flag.",
+            self.position..self.position + 1,
+        )
+        .hint("The 'u' and 'v' regular expression flags cannot be enabled at the same time.")
     }
     #[inline]
     #[allow(clippy::many_single_char_names)]
@@ -1518,13 +1526,7 @@ impl<'src> JsLexer<'src> {
                                 }
                                 b'u' => {
                                     if flag.contains(RegexFlag::V) {
-                                        self.diagnostics.push(
-                                            ParseDiagnostic::new(
-                                                "invalid regex flag",
-                                                chr_start..self.position + 1,
-                                            )
-                                            .hint("The 'u' and 'v' regular expression flags cannot be enabled at the same time."),
-                                        );
+                                        self.diagnostics.push(self.flag_uv_err());
                                     }
                                     if flag.contains(RegexFlag::U) {
                                         self.diagnostics.push(self.flag_err('u'));
@@ -1545,13 +1547,7 @@ impl<'src> JsLexer<'src> {
                                 }
                                 b'v' => {
                                     if flag.contains(RegexFlag::U) {
-                                        self.diagnostics.push(
-                                            ParseDiagnostic::new(
-                                                "invalid regex flag",
-                                                chr_start..self.position + 1,
-                                            )
-                                            .hint("The 'u' and 'v' regular expression flags cannot be enabled at the same time."),
-                                        );
+                                        self.diagnostics.push(self.flag_uv_err());
                                     }
                                     if flag.contains(RegexFlag::V) {
                                         self.diagnostics.push(self.flag_err('v'));
@@ -1561,10 +1557,10 @@ impl<'src> JsLexer<'src> {
                                 _ if self.cur_ident_part().is_some() => {
                                     self.diagnostics.push(
                                         ParseDiagnostic::new(
-                                            "invalid regex flag",
+                                            "Invalid regex flag",
                                             chr_start..self.position + 1,
                                         )
-                                        .hint("this is not a valid regex flag"),
+                                        .hint("This is not a valid regex flag."),
                                     );
                                 }
                                 _ => break,

--- a/crates/biome_js_parser/src/lexer/mod.rs
+++ b/crates/biome_js_parser/src/lexer/mod.rs
@@ -1517,6 +1517,15 @@ impl<'src> JsLexer<'src> {
                                     flag |= RegexFlag::S;
                                 }
                                 b'u' => {
+                                    if flag.contains(RegexFlag::V) {
+                                        self.diagnostics.push(
+                                            ParseDiagnostic::new(
+                                                "invalid regex flag",
+                                                chr_start..self.position + 1,
+                                            )
+                                            .hint("The 'u' and 'v' regular expression flags cannot be enabled at the same time."),
+                                        );
+                                    }
                                     if flag.contains(RegexFlag::U) {
                                         self.diagnostics.push(self.flag_err('u'));
                                     }
@@ -1535,6 +1544,15 @@ impl<'src> JsLexer<'src> {
                                     flag |= RegexFlag::D;
                                 }
                                 b'v' => {
+                                    if flag.contains(RegexFlag::U) {
+                                        self.diagnostics.push(
+                                            ParseDiagnostic::new(
+                                                "invalid regex flag",
+                                                chr_start..self.position + 1,
+                                            )
+                                            .hint("The 'u' and 'v' regular expression flags cannot be enabled at the same time."),
+                                        );
+                                    }
                                     if flag.contains(RegexFlag::V) {
                                         self.diagnostics.push(self.flag_err('v'));
                                     }

--- a/crates/biome_js_parser/src/syntax/expr.rs
+++ b/crates/biome_js_parser/src/syntax/expr.rs
@@ -162,6 +162,10 @@ pub(crate) fn parse_expression_or_recover_to_next_statement(
 // 01n, 0_0, 01.2 // lexer errors
 // "test
 // continues" // unterminated string literal
+
+// test_err js regex
+// /[\p{Control}--[\t\n]]/vv;
+// /[\p{Control}--[\t\n]]/uv;
 pub(super) fn parse_literal_expression(p: &mut JsParser) -> ParsedSyntax {
     let literal_kind = match p.cur() {
         JsSyntaxKind::JS_NUMBER_LITERAL => {

--- a/crates/biome_js_parser/test_data/inline/err/regex.js
+++ b/crates/biome_js_parser/test_data/inline/err/regex.js
@@ -1,0 +1,2 @@
+/[\p{Control}--[\t\n]]/vv;
+/[\p{Control}--[\t\n]]/uv;

--- a/crates/biome_js_parser/test_data/inline/err/regex.rast
+++ b/crates/biome_js_parser/test_data/inline/err/regex.rast
@@ -1,0 +1,60 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExpressionStatement {
+            expression: JsRegexLiteralExpression {
+                value_token: JS_REGEX_LITERAL@0..25 "/[\\p{Control}--[\\t\\n]]/vv" [] [],
+            },
+            semicolon_token: SEMICOLON@25..26 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsRegexLiteralExpression {
+                value_token: JS_REGEX_LITERAL@26..52 "/[\\p{Control}--[\\t\\n]]/uv" [Newline("\n")] [],
+            },
+            semicolon_token: SEMICOLON@52..53 ";" [] [],
+        },
+    ],
+    eof_token: EOF@53..54 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..54
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..53
+    0: JS_EXPRESSION_STATEMENT@0..26
+      0: JS_REGEX_LITERAL_EXPRESSION@0..25
+        0: JS_REGEX_LITERAL@0..25 "/[\\p{Control}--[\\t\\n]]/vv" [] []
+      1: SEMICOLON@25..26 ";" [] []
+    1: JS_EXPRESSION_STATEMENT@26..53
+      0: JS_REGEX_LITERAL_EXPRESSION@26..52
+        0: JS_REGEX_LITERAL@26..52 "/[\\p{Control}--[\\t\\n]]/uv" [Newline("\n")] []
+      1: SEMICOLON@52..53 ";" [] []
+  3: EOF@53..54 "" [Newline("\n")] []
+--
+regex.js:1:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × duplicate flag `v`
+  
+  > 1 │ /[\p{Control}--[\t\n]]/vv;
+      │                         ^
+    2 │ /[\p{Control}--[\t\n]]/uv;
+    3 │ 
+  
+  i this flag was already used
+  
+--
+regex.js:2:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × invalid regex flag
+  
+    1 │ /[\p{Control}--[\t\n]]/vv;
+  > 2 │ /[\p{Control}--[\t\n]]/uv;
+      │                         ^
+    3 │ 
+  
+  i The 'u' and 'v' regular expression flags cannot be enabled at the same time.
+  
+--
+/[\p{Control}--[\t\n]]/vv;
+/[\p{Control}--[\t\n]]/uv;

--- a/crates/biome_js_parser/test_data/inline/err/regex.rast
+++ b/crates/biome_js_parser/test_data/inline/err/regex.rast
@@ -34,19 +34,19 @@ JsModule {
 --
 regex.js:1:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × duplicate flag `v`
+  × Duplicate flag `v`.
   
   > 1 │ /[\p{Control}--[\t\n]]/vv;
       │                         ^
     2 │ /[\p{Control}--[\t\n]]/uv;
     3 │ 
   
-  i this flag was already used
+  i This flag was already used.
   
 --
 regex.js:2:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × invalid regex flag
+  × Invalid regex flag.
   
     1 │ /[\p{Control}--[\t\n]]/vv;
   > 2 │ /[\p{Control}--[\t\n]]/uv;


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This is a follow up PR of #619 

Based on https://github.com/biomejs/biome/pull/619#issuecomment-1784409026, I modified the parser to report an error when the u and v flags are used at the same time.
This PR is a follow up PR, so I don't update changelog.



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added some parser tests.

<!-- What demonstrates that your implementation is correct? -->
