### PR TITLE
refactor(diagnostics): use `ParseDiagnostic`  instead

### DIFF
--- a/crates/biome_css_parser/src/syntax/parse_error.rs
+++ b/crates/biome_css_parser/src/syntax/parse_error.rs
@@ -4,11 +4,11 @@ use biome_parser::prelude::{ParseDiagnostic, ToDiagnostic};
 use biome_rowan::TextRange;
 
 pub(crate) fn expected_identifier(p: &CssParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("identifier", range).into_diagnostic(p)
+    expected_node("identifier", range, p)
 }
 
 pub(crate) fn expect_any_selector(p: &CssParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("selector", range).into_diagnostic(p)
+    expected_node("selector", range, p)
 }
 
 pub(crate) fn expect_any_sub_selector(p: &CssParser, range: TextRange) -> ParseDiagnostic {
@@ -21,19 +21,19 @@ pub(crate) fn expect_any_sub_selector(p: &CssParser, range: TextRange) -> ParseD
             "pseudo element selector",
         ],
         range,
+        p,
     )
-    .into_diagnostic(p)
 }
 
 pub(crate) fn expect_any_attribute_matcher_name(
     p: &CssParser,
     range: TextRange,
 ) -> ParseDiagnostic {
-    expected_any(&["identifier", "string literal"], range).into_diagnostic(p)
+    expected_any(&["identifier", "string literal"], range, p)
 }
 
 pub(crate) fn expect_any_attribute_modifier(p: &CssParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["s", "S", "i", "I"], range).into_diagnostic(p)
+    expected_any(&["s", "S", "i", "I"], range, p)
 }
 
 pub(crate) fn expect_any_pseudo_element(p: &CssParser, range: TextRange) -> ParseDiagnostic {
@@ -61,5 +61,5 @@ pub(crate) fn expect_any_pseudo_element(p: &CssParser, range: TextRange) -> Pars
 }
 
 pub(crate) fn expect_block(p: &CssParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("body", range).into_diagnostic(p)
+    expected_node("body", range, p)
 }

--- a/crates/biome_js_parser/src/syntax/assignment.rs
+++ b/crates/biome_js_parser/src/syntax/assignment.rs
@@ -235,7 +235,7 @@ impl ParseArrayPattern<AssignmentPatternWithDefault> for ArrayAssignmentPattern 
 
     #[inline]
     fn expected_element_error(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-        expected_any(&["assignment target", "rest element", "comma"], range).into_diagnostic(p)
+        expected_any(&["assignment target", "rest element", "comma"], range, p)
     }
 
     #[inline]
@@ -267,7 +267,7 @@ impl ParseObjectPattern for ObjectAssignmentPattern {
 
     #[inline]
     fn expected_property_pattern_error(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-        expected_any(&["assignment target", "rest property"], range).into_diagnostic(p)
+        expected_any(&["assignment target", "rest property"], range, p)
     }
 
     // test js property_assignment_target

--- a/crates/biome_js_parser/src/syntax/binding.rs
+++ b/crates/biome_js_parser/src/syntax/binding.rs
@@ -212,8 +212,8 @@ impl ParseArrayPattern<BindingPatternWithDefault> for ArrayBindingPattern {
                 "rest pattern",
             ],
             range,
+            p,
         )
-        .into_diagnostic(p)
     }
 
     #[inline]
@@ -246,7 +246,7 @@ impl ParseObjectPattern for ObjectBindingPattern {
 
     #[inline]
     fn expected_property_pattern_error(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-        expected_any(&["identifier", "member name", "rest pattern"], range).into_diagnostic(p)
+        expected_any(&["identifier", "member name", "rest pattern"], range, p)
     }
 
     // test js object_property_binding

--- a/crates/biome_js_parser/src/syntax/js_parse_error.rs
+++ b/crates/biome_js_parser/src/syntax/js_parse_error.rs
@@ -8,7 +8,7 @@ use biome_js_syntax::TextRange;
 use biome_parser::diagnostic::{expected_any, expected_node};
 
 pub(crate) fn expected_function_body(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("function body", range).into_diagnostic(p)
+    expected_node("function body", range, p)
 }
 
 pub(crate) fn expected_class_member_name(p: &JsParser, range: TextRange) -> ParseDiagnostic {
@@ -21,12 +21,12 @@ pub(crate) fn expected_class_member_name(p: &JsParser, range: TextRange) -> Pars
             "computed name",
         ],
         range,
+        p,
     )
-    .into_diagnostic(p)
 }
 
 pub(crate) fn expected_arrow_body(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["function body", "expression"], range).into_diagnostic(p)
+    expected_any(&["function body", "expression"], range, p)
 }
 
 pub(crate) fn expected_object_member(p: &JsParser, range: TextRange) -> ParseDiagnostic {
@@ -39,11 +39,11 @@ pub(crate) fn expected_object_member(p: &JsParser, range: TextRange) -> ParseDia
             "method",
         ],
         range,
+        p,
     )
-    .into_diagnostic(p)
 }
 pub(crate) fn expected_array_element(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["property", "expression", "method"], range).into_diagnostic(p)
+    expected_any(&["property", "expression", "method"], range, p)
 }
 
 pub(crate) fn expected_object_member_name(p: &JsParser, range: TextRange) -> ParseDiagnostic {
@@ -55,92 +55,92 @@ pub(crate) fn expected_object_member_name(p: &JsParser, range: TextRange) -> Par
             "computed property",
         ],
         range,
+        p,
     )
-    .into_diagnostic(p)
 }
 
 pub(crate) fn expected_block_statement(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("block statement", range).into_diagnostic(p)
+    expected_node("block statement", range, p)
 }
 
 pub(crate) fn expected_catch_clause(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("catch clause", range).into_diagnostic(p)
+    expected_node("catch clause", range, p)
 }
 
 pub(crate) fn expected_parameter(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("parameter", range).into_diagnostic(p)
+    expected_node("parameter", range, p)
 }
 
 pub(crate) fn expected_parameters(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("parenthesis '('", range).into_diagnostic(p)
+    expected_node("parenthesis '('", range, p)
 }
 
 pub(crate) fn expected_case_or_default(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["default", "case"], range).into_diagnostic(p)
+    expected_any(&["default", "case"], range, p)
 }
 
 pub(crate) fn expected_case(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("case", range).into_diagnostic(p)
+    expected_node("case", range, p)
 }
 
 pub(crate) fn expected_assignment_target(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["identifier", "assignment target"], range).into_diagnostic(p)
+    expected_any(&["identifier", "assignment target"], range, p)
 }
 
 pub(crate) fn expected_simple_assignment_target(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["identifier", "member expression"], range).into_diagnostic(p)
+    expected_any(&["identifier", "member expression"], range, p)
 }
 
 pub(crate) fn expected_identifier(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("identifier", range).into_diagnostic(p)
+    expected_node("identifier", range, p)
 }
 
 pub(crate) fn expected_statement(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("statement", range).into_diagnostic(p)
+    expected_node("statement", range, p)
 }
 
 pub(crate) fn expected_binding(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["identifier", "array pattern", "object pattern"], range).into_diagnostic(p)
+    expected_any(&["identifier", "array pattern", "object pattern"], range, p)
 }
 
 pub(crate) fn expected_class_member(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["property ", "method", "getter", "setter"], range).into_diagnostic(p)
+    expected_any(&["property ", "method", "getter", "setter"], range, p)
 }
 
 pub(crate) fn expected_class_parameters(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("class parameters", range).into_diagnostic(p)
+    expected_node("class parameters", range, p)
 }
 
 pub(crate) fn expected_constructor_parameters(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("constructor parameters", range).into_diagnostic(p)
+    expected_node("constructor parameters", range, p)
 }
 
 pub(crate) fn expected_class_method_body(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("class method body", range).into_diagnostic(p)
+    expected_node("class method body", range, p)
 }
 
 pub(crate) fn expected_module_source(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("string literal", range).into_diagnostic(p)
+    expected_node("string literal", range, p)
 }
 
 pub(crate) fn expected_named_import(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["namespace import", "named imports"], range).into_diagnostic(p)
+    expected_any(&["namespace import", "named imports"], range, p)
 }
 
 pub(crate) fn expected_literal_export_name(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["string literal", "identifier"], range).into_diagnostic(p)
+    expected_any(&["string literal", "identifier"], range, p)
 }
 
 pub(crate) fn expected_export_clause(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["class", "function", "variable declaration"], range).into_diagnostic(p)
+    expected_any(&["class", "function", "variable declaration"], range, p)
 }
 
 pub(crate) fn expected_export_name_specifier(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("export name", range).into_diagnostic(p)
+    expected_node("export name", range, p)
 }
 
 pub(crate) fn expected_named_import_specifier(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("identifier", range).into_diagnostic(p)
+    expected_node("identifier", range, p)
 }
 
 pub(crate) fn duplicate_assertion_keys_error(
@@ -155,19 +155,19 @@ pub(crate) fn duplicate_assertion_keys_error(
 }
 
 pub(crate) fn expected_expression(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("expression", range).into_diagnostic(p)
+    expected_node("expression", range, p)
 }
 
 pub(crate) fn expected_expression_assignment(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["expression", "assignment"], range).into_diagnostic(p)
+    expected_any(&["expression", "assignment"], range, p)
 }
 
 pub(crate) fn expected_unary_expression(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("unary expression", range).into_diagnostic(p)
+    expected_node("unary expression", range, p)
 }
 
 pub(crate) fn expected_property_or_signature(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["property", "signature"], range).into_diagnostic(p)
+    expected_any(&["property", "signature"], range, p)
 }
 
 pub(crate) fn expected_declaration(p: &JsParser, range: TextRange) -> ParseDiagnostic {
@@ -181,15 +181,15 @@ pub(crate) fn expected_declaration(p: &JsParser, range: TextRange) -> ParseDiagn
             "type alias",
         ],
         range,
+        p,
     )
-    .into_diagnostic(p)
 }
 
 pub(crate) fn expected_export_default_declaration(
     p: &JsParser,
     range: TextRange,
 ) -> ParseDiagnostic {
-    let expected = if TypeScript.is_supported(p) {
+    if TypeScript.is_supported(p) {
         expected_any(
             &[
                 "class declaration",
@@ -197,12 +197,11 @@ pub(crate) fn expected_export_default_declaration(
                 "interface declaration",
             ],
             range,
+            p,
         )
     } else {
-        expected_any(&["class declaration", "function declaration"], range)
-    };
-
-    expected.into_diagnostic(p)
+        expected_any(&["class declaration", "function declaration"], range, p)
+    }
 }
 
 pub(crate) fn unexpected_body_inside_ambient_context(

--- a/crates/biome_js_parser/src/syntax/jsx/jsx_parse_errors.rs
+++ b/crates/biome_js_parser/src/syntax/jsx/jsx_parse_errors.rs
@@ -4,15 +4,15 @@ use biome_js_syntax::TextRange;
 use biome_parser::diagnostic::{expected_any, expected_node};
 
 pub(crate) fn jsx_expected_attribute(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("JSX attribute", range).into_diagnostic(p)
+    expected_node("JSX attribute", range, p)
 }
 
 pub(crate) fn jsx_expected_attribute_value(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("JSX attribute value", range).into_diagnostic(p)
+    expected_node("JSX attribute value", range, p)
 }
 
 pub(crate) fn jsx_expected_children(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["JSX Expression", "Element", "text"], range).into_diagnostic(p)
+    expected_any(&["JSX Expression", "Element", "text"], range, p)
 }
 
 pub(crate) fn jsx_expected_closing_tag(

--- a/crates/biome_js_parser/src/syntax/module.rs
+++ b/crates/biome_js_parser/src/syntax/module.rs
@@ -240,8 +240,8 @@ pub(crate) fn parse_import_or_import_equals_declaration(p: &mut JsParser) -> Par
             expected_any(
                 &["default import", "namespace import", "named import"],
                 range,
+                p,
             )
-            .into_diagnostic(p)
         });
 
         let end = p.cur_range().start();
@@ -626,7 +626,7 @@ impl ParseSeparatedList for ImportAssertionList {
                 STMT_RECOVERY_SET.union(token_set![T![,], T!['}']]),
             )
             .enable_recovery_on_line_break(),
-            |p, range| expected_node("import assertion entry", range).into_diagnostic(p),
+            |p, range| expected_node("import assertion entry", range, p),
         )
     }
 
@@ -662,9 +662,11 @@ fn parse_import_assertion_entry(
             p.bump_remap(T![ident]);
         }
         T![:] => {
-            p.error(
-                expected_any(&["identifier", "string literal"], p.cur_range()).into_diagnostic(p),
-            );
+            p.error(expected_any(
+                &["identifier", "string literal"],
+                p.cur_range(),
+                p,
+            ));
         }
         _ => {
             m.abandon(p);

--- a/crates/biome_js_parser/src/syntax/typescript/ts_parse_error.rs
+++ b/crates/biome_js_parser/src/syntax/typescript/ts_parse_error.rs
@@ -5,7 +5,7 @@ use biome_parser::diagnostic::{expected_any, expected_node};
 use biome_rowan::TextRange;
 
 pub(crate) fn expected_ts_enum_member(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["identifier", "string literal", "computed name"], range).into_diagnostic(p)
+    expected_any(&["identifier", "string literal", "computed name"], range, p)
 }
 
 pub(crate) fn unexpected_abstract_member_with_body(
@@ -122,11 +122,11 @@ pub(crate) fn ts_set_accessor_return_type_error(
 }
 
 pub(crate) fn expected_ts_type(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("type", range).into_diagnostic(p)
+    expected_node("type", range, p)
 }
 
 pub(crate) fn expected_ts_type_parameter(p: &JsParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("type parameter", range).into_diagnostic(p)
+    expected_node("type parameter", range, p)
 }
 
 pub(crate) fn infer_not_allowed(p: &JsParser, range: TextRange) -> ParseDiagnostic {

--- a/crates/biome_json_parser/src/syntax.rs
+++ b/crates/biome_json_parser/src/syntax.rs
@@ -334,9 +334,9 @@ fn parse_rest(p: &mut JsonParser, value: ParsedSyntax) {
 }
 
 fn expected_value(p: &JsonParser, range: TextRange) -> ParseDiagnostic {
-    expected_any(&["array", "object", "literal"], range).into_diagnostic(p)
+    expected_any(&["array", "object", "literal"], range, p)
 }
 
 fn expected_property(p: &JsonParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("property", range).into_diagnostic(p)
+    expected_node("property", range, p)
 }

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -2752,6 +2752,9 @@ impl MergeWith<Nursery> for Nursery {
         if let Some(no_misrefactored_shorthand_assign) = other.no_misrefactored_shorthand_assign {
             self.no_misrefactored_shorthand_assign = Some(no_misrefactored_shorthand_assign);
         }
+        if let Some(no_this_in_static) = other.no_this_in_static {
+            self.no_this_in_static = Some(no_this_in_static);
+        }
         if let Some(no_unused_imports) = other.no_unused_imports {
             self.no_unused_imports = Some(no_unused_imports);
         }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

I removed some indirection and deleted a struct that we don't need anymore. Now we use `ParseDiagnostic` directly to emit messages from the parsing phase.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current snapshots should stay the same and tests should pass.

<!-- What demonstrates that your implementation is correct? -->
