### PR TITLE
Fix parsing `maxAllowedComplexity`

### DIFF
--- a/crates/biome_js_analyze/src/analyzers/complexity/no_excessive_cognitive_complexity.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_excessive_cognitive_complexity.rs
@@ -415,7 +415,7 @@ impl VisitNode<JsonLanguage> for ComplexityOptions {
         if name_text == "maxAllowedComplexity" {
             if let Some(value) = value
                 .as_json_number_value()
-                .and_then(|number_value| u8::from_str(&number_value.syntax().to_string()).ok())
+                .and_then(|number_value| u8::from_str(&number_value.text()).ok())
                 // Don't allow 0 or no code would pass.
                 // And don't allow MAX_SCORE or we can't detect exceeding it.
                 .filter(|&number| number > 0 && number < MAX_SCORE)


### PR DESCRIPTION
Fixes #643.

## Summary

So apparently there's a confusing behavior where the `SyntaxNode` of a `JsonNumberValue` may contain a trailing space. If it does, calling `.to_string()` on the syntax node will include the space, causing `u8::from_str()` to fail. Calling `.text()` directly on the value doesn't have this issue.

To be honest, it feels like this may be a workaround to a deeper issue, so I'm not entirely sure this is the right fix. Because of this, I also have not yet created a test for it. Is the possibility for trailing spaces in syntax nodes an expected behavior?

## Test Plan

I think an extra unit test should be created for this, since it's quite surprising behavior. But right now I'm more concerned about how similar issues could be prevented from (re)occurring. But the right action here depends on whether the spaces in syntax nodes are intentional or not.