### PR TITLE
feat(cli): help with colours

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dc3b1bd654a8d16eea03586c3eee8ffd25c7f242b9eae9730cc442834fe56d9"
 dependencies = [
  "bpaf_derive",
+ "owo-colors",
+ "supports-color",
 ]
 
 [[package]]
@@ -1739,6 +1741,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2089,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
@@ -2809,6 +2823,16 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
 
 [[package]]
 name = "syn"

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -34,7 +34,7 @@ biome_rowan          = { workspace = true }
 biome_service        = { workspace = true }
 biome_text_edit      = { workspace = true }
 biome_text_size      = { workspace = true }
-bpaf                 = { workspace = true }
+bpaf                 = { workspace = true, features = ["bright-color"] }
 crossbeam            = "0.8.1"
 dashmap              = { workspace = true }
 hdrhistogram         = { version = "7.5.0", default-features = false }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

I have always been on the fence with this one, but I decided to let it go! 

So far, we have been running `bpaf` using its API `run_inner`. This API is usually meant for testing, not for production. The reason why I was using this internal API is because I wanted to catch the error and decorate it with our diagnostics:


![Screenshot 2023-11-02 at 16 21 44](https://github.com/biomejs/biome/assets/602478/7860c731-daca-45b1-9cdb-db6017befa0b)


With this PR, we get the current changes:


![Screenshot 2023-11-02 at 16 15 59](https://github.com/biomejs/biome/assets/602478/c92ee5fe-ac80-439e-b0a1-568de785c183)
![Screenshot 2023-11-02 at 16 16 22](https://github.com/biomejs/biome/assets/602478/6b07e946-c0c3-4d62-a8de-608534b30a87)


Another reason why I want to try to apply this change is because I want to implement [auto completion](https://github.com/pacak/bpaf#dynamic-shell-completion), and that requires more control by `bpaf`.


@biomejs/core-contributors @biomejs/maintainers what do you think?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
