### PR TITLE
feat(intellij): Manual config path specifying

### DIFF
--- a/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/BiomeUtils.kt
+++ b/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/BiomeUtils.kt
@@ -56,6 +56,16 @@ object BiomeUtils {
         return biomeBinFile?.path
     }
 
+    fun getBiomeConfigPath(project: Project): String? {
+        val configPath = BiomeSettings.getInstance(project).configPath
+
+        if (!configPath.isEmpty()) {
+            return configPath
+        }
+
+        return null
+    }
+
     fun createNodeCommandLine(project: Project, executable: String): GeneralCommandLine {
         val interpreter = NodeJsInterpreterManager.getInstance(project).interpreter
         if (interpreter !is NodeJsLocalInterpreter && interpreter !is WslNodeInterpreter) {

--- a/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/formatter/BiomeFormatterProvider.kt
+++ b/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/formatter/BiomeFormatterProvider.kt
@@ -32,7 +32,14 @@ class BiomeFormatterProvider : AsyncDocumentFormattingService() {
     override fun createFormattingTask(request: AsyncFormattingRequest): FormattingTask? {
         val ioFile = request.ioFile ?: return null
         val project = request.context.project
+        val configPath = BiomeUtils.getBiomeConfigPath(project)
+
         val params = SmartList("format", "--stdin-file-path", ioFile.path)
+
+        if (!configPath.isNullOrEmpty()) {
+            params.add("--config-path")
+            params.add(configPath)
+        }        
 
         val exePath = BiomeUtils.getBiomeExecutablePath(project)
 

--- a/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/lsp/BiomeLspServerSupportProvider.kt
+++ b/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/lsp/BiomeLspServerSupportProvider.kt
@@ -36,7 +36,13 @@ private class BiomeLspServerDescriptor(project: Project, val executable: String)
     ProjectWideLspServerDescriptor(project, "Biome") {
     override fun isSupportedFile(file: VirtualFile) = BiomeUtils.isSupportedFileType(file)
     override fun createCommandLine(): GeneralCommandLine {
-        val params = SmartList("lsp-proxy")
+				val configPath = BiomeUtils.getBiomeConfigPath(project)
+				val params = SmartList("lsp-proxy")
+
+				if (!configPath.isNullOrEmpty()) {
+					params.add("--config-path")
+					params.add(configPath)
+				}
 
         if (executable.isEmpty()) {
             throw ExecutionException(BiomeBundle.message("biome.language.server.not.found"))

--- a/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettings.kt
+++ b/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettings.kt
@@ -12,6 +12,11 @@ class BiomeSettings :
         set(value) {
             state.executablePath = value
         }
+    var configPath: String
+        get() = state.configPath ?: ""
+        set(value) {
+            state.configPath = value
+        }
 
     companion object {
         @JvmStatic

--- a/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettingsConfigurable.kt
+++ b/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettingsConfigurable.kt
@@ -25,6 +25,11 @@ class BiomeSettingsConfigurable(internal val project: Project) :
                     .bindText(settings::executablePath)
             }
 
+            row(BiomeBundle.message("biome.config.path.label")) {
+                textFieldWithBrowseButton(BiomeBundle.message("biome.config.path.label")) { fileChosen(it) }
+                    .bindText(settings::configPath)
+            }
+
             onApply {
                 biomeServerService.restartBiomeServer()
                 biomeServerService.notifyRestart()

--- a/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettingsState.kt
+++ b/editors/intellij/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettingsState.kt
@@ -8,4 +8,5 @@ import org.jetbrains.annotations.ApiStatus
 @ApiStatus.Internal
 class BiomeSettingsState : BaseState() {
     var executablePath by string()
+    var configPath by string()
 }

--- a/editors/intellij/src/main/resources/messages/BiomeBundle.properties
+++ b/editors/intellij/src/main/resources/messages/BiomeBundle.properties
@@ -1,5 +1,6 @@
 name=Biome
 biome.path.label=Biome CLI Path
+biome.config.path.label=biome.json Directory Path
 biome.settings.name=Biome Settings
 biome.formatting.failure=Formatting error
 biome.language.server.not.found=Biome language server is not found, make sure you have @biomejs/biome installed.


### PR DESCRIPTION
## Summary

I wanted to be able to specify my biome.json that gets executed, so I added an option for it in the UI 

<img width="1094" alt="image" src="https://github.com/biomejs/biome/assets/3316640/f20ed7a3-2429-4779-b723-97e9e18328f3">

If it isn't set, it uses the existing functionality to find the config file, and otherwise uses what was set here.

## Test Plan

I installed it on my IDE and specified a config directory in a different location and it used that config instead.
