### PR TITLE
feat(cli): add --diagnostic-level option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Remove the CLI options from the `lsp-proxy`, as they were never meant to be passed to that command. Contributed by @ematipico
 
+- Add new `--diagnostic-level` option to let users control the level of diagnostics printed by the CLI. Possible values are: `"info"`, `"warn"`, `"hint"`. Contributed by @simonxabris
+
 #### Bug fixes
 
 - Fix the command `format`, now it returns a non-zero exit code when if there pending diffs. Contributed by @ematipico

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -74,7 +74,7 @@ pub struct CliOptions {
         fallback(Severity::default()),
         display_fallback
     )]
-    /// The level of diagnostics to show. In order, from the most verbose to the least verbose: info, warn, error.
+    /// The level of diagnostics to show. In order, from the lowest to the most important: info, warn, error. Passing `--diagnostic-level=error` will cause Biome to print only diagnostics that contain only errors.
     pub diagnostic_level: Severity,
 }
 

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -1,5 +1,6 @@
 use crate::logging::LoggingKind;
 use crate::LoggingLevel;
+use biome_diagnostics::Severity;
 use bpaf::Bpaf;
 use std::str::FromStr;
 
@@ -66,6 +67,17 @@ pub struct CliOptions {
         display_fallback
     )]
     pub log_kind: LoggingKind,
+
+    #[bpaf(
+        long("diagnostic-level"),
+        argument("info|warn|error"),
+        fallback(Severity::default()),
+        display_fallback
+    )]
+    /// The level of logging. In order, from the most verbose to the least verbose: debug, info, warn, error.
+    ///
+    /// The value `none` won't show any logging.
+    pub diagnostic_level: Severity,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -70,13 +70,11 @@ pub struct CliOptions {
 
     #[bpaf(
         long("diagnostic-level"),
-        argument("info|warning|error"),
+        argument("info|warn|error"),
         fallback(Severity::default()),
         display_fallback
     )]
-    /// The level of diagnostics to show. In order, from the most verbose to the least verbose: debug, info, warn, error.
-    ///
-    /// The value `none` won't show any logging.
+    /// The level of diagnostics to show. In order, from the most verbose to the least verbose: info, warn, error.
     pub diagnostic_level: Severity,
 }
 

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -70,11 +70,11 @@ pub struct CliOptions {
 
     #[bpaf(
         long("diagnostic-level"),
-        argument("info|warn|error"),
+        argument("info|warning|error"),
         fallback(Severity::default()),
         display_fallback
     )]
-    /// The level of logging. In order, from the most verbose to the least verbose: debug, info, warn, error.
+    /// The level of diagnostics to show. In order, from the most verbose to the least verbose: debug, info, warn, error.
     ///
     /// The value `none` won't show any logging.
     pub diagnostic_level: Severity,

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -572,7 +572,7 @@ fn process_messages(options: ProcessMessagesOptions) {
     }
 
     for diagnostic in diagnostics_to_print {
-        if diagnostic.severity() == *diagnostic_level {
+        if diagnostic.severity() >= *diagnostic_level {
             console.error(markup! {
                 {if verbose { PrintDiagnostic::verbose(&diagnostic) } else { PrintDiagnostic::simple(&diagnostic) }}
             });

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -103,6 +103,7 @@ pub(crate) fn traverse(
                     report: &mut report,
                     verbose: cli_options.verbose,
                     warnings: &mut warnings,
+                    diagnostic_level: &cli_options.diagnostic_level,
                 });
             })
             .expect("failed to spawn console thread");
@@ -278,6 +279,8 @@ struct ProcessMessagesOptions<'ctx> {
     report: &'ctx mut Report,
     /// Whether the console thread should print diagnostics in verbose mode
     verbose: bool,
+    /// The diagnostic level the console thread should print
+    diagnostic_level: &'ctx Severity,
 }
 
 /// This thread receives [Message]s from the workers through the `recv_msgs`
@@ -295,6 +298,7 @@ fn process_messages(options: ProcessMessagesOptions) {
         report,
         verbose,
         warnings,
+        diagnostic_level,
     } = options;
 
     let mut paths: FxHashSet<String> = FxHashSet::default();
@@ -568,9 +572,11 @@ fn process_messages(options: ProcessMessagesOptions) {
     }
 
     for diagnostic in diagnostics_to_print {
-        console.error(markup! {
-            {if verbose { PrintDiagnostic::verbose(&diagnostic) } else { PrintDiagnostic::simple(&diagnostic) }}
-        });
+        if diagnostic.severity() == *diagnostic_level {
+            console.error(markup! {
+                {if verbose { PrintDiagnostic::verbose(&diagnostic) } else { PrintDiagnostic::simple(&diagnostic) }}
+            });
+        }
     }
 
     if mode.is_check() && total_skipped_suggested_fixes > 0 {

--- a/crates/biome_cli/tests/cases/diagnostics.rs
+++ b/crates/biome_cli/tests/cases/diagnostics.rs
@@ -1,0 +1,71 @@
+use crate::run_cli;
+use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
+use biome_console::{BufferConsole, LogLevel};
+use biome_fs::MemoryFileSystem;
+use biome_service::DynRef;
+use bpaf::Args;
+use std::path::Path;
+
+const TEST_CONTENTS: &str = "debugger;";
+
+#[test]
+fn logs_the_appropriate_messages_according_to_set_diagonstics_level() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let file_path = Path::new("biome.json");
+    fs.insert(
+        file_path.into(),
+        r#"{
+  "files": {
+    "include": ["test.js"]
+  },
+  "linter": {
+    "rules": {
+        "suspicious": {
+            "noDebugger": "warn"
+        }
+    }
+  }
+}
+
+"#
+        .as_bytes(),
+    );
+
+    let test = Path::new("test.js");
+    fs.insert(test.into(), TEST_CONTENTS.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("lint"),
+                ("--diagnostic-level=error"),
+                test.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    let messages = &console.out_buffer;
+
+    assert!(messages
+        .iter()
+        .filter(|m| m.level == LogLevel::Log)
+        .any(|m| {
+            let content = format!("{:?}", m.content);
+
+            !content.contains("noDebugger")
+        }));
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "logs_the_appropriate_messages_according_to_set_diagonstics_level",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/cases/mod.rs
+++ b/crates/biome_cli/tests/cases/mod.rs
@@ -3,6 +3,7 @@
 
 mod biome_json_support;
 mod config_extends;
+mod diagnostics;
 mod included_files;
 mod overrides_formatter;
 mod overrides_linter;

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/logs_the_appropriate_messages_according_to_set_diagonstics_level.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/logs_the_appropriate_messages_according_to_set_diagonstics_level.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "files": {
+    "include": ["test.js"]
+  },
+  "linter": {
+    "rules": {
+      "suspicious": {
+        "noDebugger": "warn"
+      }
+    }
+  }
+}
+```
+
+## `test.js`
+
+```js
+debugger;
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -77,8 +77,9 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
-                              verbose to the least verbose: info, warn, error.
+        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the lowest
+                              to the most important: info, warn, error. Passing `--diagnostic-level=error`
+                              will cause Biome to print only diagnostics that contain only errors.
                               [default: info]
 
 Available positional items:

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -77,6 +77,10 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
+        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
+                              the least verbose: debug, info, warn, error.
+                              The value `none` won't show any logging.
+                              [default: information]
 
 Available positional items:
     PATH                      Single file, single path or list of paths

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -77,10 +77,9 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
-                              the least verbose: debug, info, warn, error.
-                              The value `none` won't show any logging.
-                              [default: information]
+        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
+                              verbose to the least verbose: info, warn, error.
+                              [default: info]
 
 Available positional items:
     PATH                      Single file, single path or list of paths

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -79,6 +79,10 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
+        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
+                              the least verbose: debug, info, warn, error.
+                              The value `none` won't show any logging.
+                              [default: information]
 
 Available positional items:
     PATH                      Single file, single path or list of paths

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -79,8 +79,9 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
-                              verbose to the least verbose: info, warn, error.
+        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the lowest
+                              to the most important: info, warn, error. Passing `--diagnostic-level=error`
+                              will cause Biome to print only diagnostics that contain only errors.
                               [default: info]
 
 Available positional items:

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -79,10 +79,9 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
-                              the least verbose: debug, info, warn, error.
-                              The value `none` won't show any logging.
-                              [default: information]
+        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
+                              verbose to the least verbose: info, warn, error.
+                              [default: info]
 
 Available positional items:
     PATH                      Single file, single path or list of paths

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -73,10 +73,9 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
-                              the least verbose: debug, info, warn, error.
-                              The value `none` won't show any logging.
-                              [default: information]
+        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
+                              verbose to the least verbose: info, warn, error.
+                              [default: info]
 
 Available positional items:
     PATH                      Single file, single path or list of paths.

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -73,8 +73,9 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
-                              verbose to the least verbose: info, warn, error.
+        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the lowest
+                              to the most important: info, warn, error. Passing `--diagnostic-level=error`
+                              will cause Biome to print only diagnostics that contain only errors.
                               [default: info]
 
 Available positional items:

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -73,6 +73,10 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
+        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
+                              the least verbose: debug, info, warn, error.
+                              The value `none` won't show any logging.
+                              [default: information]
 
 Available positional items:
     PATH                      Single file, single path or list of paths.

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -46,8 +46,9 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
-                              verbose to the least verbose: info, warn, error.
+        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the lowest
+                              to the most important: info, warn, error. Passing `--diagnostic-level=error`
+                              will cause Biome to print only diagnostics that contain only errors.
                               [default: info]
 
 Available positional items:

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -46,6 +46,10 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
+        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
+                              the least verbose: debug, info, warn, error.
+                              The value `none` won't show any logging.
+                              [default: information]
 
 Available positional items:
     PATH                      Single file, single path or list of paths

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -46,10 +46,9 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
-                              the least verbose: debug, info, warn, error.
-                              The value `none` won't show any logging.
-                              [default: information]
+        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
+                              verbose to the least verbose: info, warn, error.
+                              [default: info]
 
 Available positional items:
     PATH                      Single file, single path or list of paths

--- a/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
@@ -29,11 +29,12 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
-                              the least verbose: debug, info, warn, error.
-                              The value `none` won't show any logging.
-                              [default: information]
-				-h, --help  Prints help information
+        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
+                              verbose to the least verbose: info, warn, error.
+                              [default: info]
+
+Available options:
+    -h, --help                Prints help information
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
@@ -7,34 +7,10 @@ expression: content
 ```block
 Acts as a server for the Language Server Protocol over stdin/stdout
 
-Usage: lsp-proxy
-
-Global options applied to all commands
-        --colors=<off|force>  Set the formatting mode for markup: "off" prints everything as plain text,
-                              "force" forces the formatting of markup using ANSI even if the console
-                              output is determined to be incompatible
-        --use-server          Connect to a running instance of the Biome daemon server.
-        --verbose             Print additional verbose advices on diagnostics
-        --config-path=PATH    Set the filesystem path to the directory of the biome.json configuration
-                              file
-        --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
-                              [default: 20]
-        --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
-        --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed
-                              during the execution of the command.
-        --error-on-warnings   Tell Biome to exit with an error code if some diagnostics emit warnings.
-        --log-level=<none|debug|info|warn|error>  The level of logging. In order, from the most verbose
-                              to the least verbose: debug, info, warn, error.
-                              The value `none` won't show any logging.
-                              [default: none]
-        --log-kind=<pretty|compact|json>  How the log should look like.
-                              [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
-                              verbose to the least verbose: info, warn, error.
-                              [default: info]
+Usage: lsp-proxy 
 
 Available options:
-    -h, --help                Prints help information
+    -h, --help  Prints help information
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
@@ -7,10 +7,33 @@ expression: content
 ```block
 Acts as a server for the Language Server Protocol over stdin/stdout
 
-Usage: lsp-proxy 
+Usage: lsp-proxy
 
-Available options:
-    -h, --help  Prints help information
+Global options applied to all commands
+        --colors=<off|force>  Set the formatting mode for markup: "off" prints everything as plain text,
+                              "force" forces the formatting of markup using ANSI even if the console
+                              output is determined to be incompatible
+        --use-server          Connect to a running instance of the Biome daemon server.
+        --verbose             Print additional verbose advices on diagnostics
+        --config-path=PATH    Set the filesystem path to the directory of the biome.json configuration
+                              file
+        --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
+                              [default: 20]
+        --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
+        --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed
+                              during the execution of the command.
+        --error-on-warnings   Tell Biome to exit with an error code if some diagnostics emit warnings.
+        --log-level=<none|debug|info|warn|error>  The level of logging. In order, from the most verbose
+                              to the least verbose: debug, info, warn, error.
+                              The value `none` won't show any logging.
+                              [default: none]
+        --log-kind=<pretty|compact|json>  How the log should look like.
+                              [default: pretty]
+        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
+                              the least verbose: debug, info, warn, error.
+                              The value `none` won't show any logging.
+                              [default: information]
+				-h, --help  Prints help information
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
@@ -29,6 +29,10 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
+        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
+                              the least verbose: debug, info, warn, error.
+                              The value `none` won't show any logging.
+                              [default: information]
 
 Available options:
         --write               Writes the new configuration file to disk

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
@@ -29,8 +29,9 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
-                              verbose to the least verbose: info, warn, error.
+        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the lowest
+                              to the most important: info, warn, error. Passing `--diagnostic-level=error`
+                              will cause Biome to print only diagnostics that contain only errors.
                               [default: info]
 
 Available options:

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
@@ -29,10 +29,9 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
-                              the least verbose: debug, info, warn, error.
-                              The value `none` won't show any logging.
-                              [default: information]
+        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
+                              verbose to the least verbose: info, warn, error.
+                              [default: info]
 
 Available options:
         --write               Writes the new configuration file to disk

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -29,6 +29,10 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
+        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
+                              the least verbose: debug, info, warn, error.
+                              The value `none` won't show any logging.
+                              [default: information]
 
 Available options:
         --daemon-logs         Prints the Biome daemon server logs

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -29,10 +29,9 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of logging. In order, from the most verbose to
-                              the least verbose: debug, info, warn, error.
-                              The value `none` won't show any logging.
-                              [default: information]
+        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
+                              verbose to the least verbose: info, warn, error.
+                              [default: info]
 
 Available options:
         --daemon-logs         Prints the Biome daemon server logs

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -29,8 +29,9 @@ Global options applied to all commands
                               [default: none]
         --log-kind=<pretty|compact|json>  How the log should look like.
                               [default: pretty]
-        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the most
-                              verbose to the least verbose: info, warn, error.
+        --diagnostic-level=<info|warn|error>  The level of diagnostics to show. In order, from the lowest
+                              to the most important: info, warn, error. Passing `--diagnostic-level=error`
+                              will cause Biome to print only diagnostics that contain only errors.
                               [default: info]
 
 Available options:

--- a/crates/biome_diagnostics/src/diagnostic.rs
+++ b/crates/biome_diagnostics/src/diagnostic.rs
@@ -142,7 +142,7 @@ impl FromStr for Severity {
             "warning" => Ok(Self::Warning),
             "error" => Ok(Self::Error),
             "fatal" => Ok(Self::Fatal),
-            _ => Err("Unexpected value".to_string()),
+            v => Err(format!("Found unexpected value ({}), valid values are: hint, information, warning, error, fatal.", v)),
         }
     }
 }

--- a/crates/biome_diagnostics/src/diagnostic.rs
+++ b/crates/biome_diagnostics/src/diagnostic.rs
@@ -137,12 +137,14 @@ impl FromStr for Severity {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "hint" => Ok(Self::Hint),
-            "information" => Ok(Self::Information),
-            "warning" => Ok(Self::Warning),
+            "hint" => Ok(Self::Information),
+            "info" => Ok(Self::Information),
+            "warn" => Ok(Self::Warning),
             "error" => Ok(Self::Error),
-            "fatal" => Ok(Self::Fatal),
-            v => Err(format!("Found unexpected value ({}), valid values are: hint, information, warning, error, fatal.", v)),
+            v => Err(format!(
+                "Found unexpected value ({}), valid values are: info, warn, error.",
+                v
+            )),
         }
     }
 }
@@ -151,8 +153,8 @@ impl Display for Severity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Hint => write!(f, "hint"),
-            Self::Information => write!(f, "information"),
-            Self::Warning => write!(f, "warning"),
+            Self::Information => write!(f, "info"),
+            Self::Warning => write!(f, "warn"),
             Self::Error => write!(f, "error"),
             Self::Fatal => write!(f, "fatal"),
         }

--- a/crates/biome_diagnostics/src/diagnostic.rs
+++ b/crates/biome_diagnostics/src/diagnostic.rs
@@ -1,4 +1,9 @@
-use std::{convert::Infallible, fmt::Debug, io};
+use std::{
+    convert::Infallible,
+    fmt::{Debug, Display},
+    io,
+    str::FromStr,
+};
 
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
@@ -107,7 +112,9 @@ pub trait Diagnostic: Debug {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default,
+)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 /// The severity to associate to a diagnostic.
@@ -115,6 +122,7 @@ pub enum Severity {
     /// Reports a hint.
     Hint,
     /// Reports an information.
+    #[default]
     Information,
     /// Reports a warning.
     Warning,
@@ -122,6 +130,33 @@ pub enum Severity {
     Error,
     /// Reports a crash.
     Fatal,
+}
+
+impl FromStr for Severity {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "hint" => Ok(Self::Hint),
+            "information" => Ok(Self::Information),
+            "warning" => Ok(Self::Warning),
+            "error" => Ok(Self::Error),
+            "fatal" => Ok(Self::Fatal),
+            _ => Err("Unexpected value".to_string()),
+        }
+    }
+}
+
+impl Display for Severity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Hint => write!(f, "hint"),
+            Self::Information => write!(f, "information"),
+            Self::Warning => write!(f, "warning"),
+            Self::Error => write!(f, "error"),
+            Self::Fatal => write!(f, "fatal"),
+        }
+    }
 }
 
 /// Internal enum used to automatically generate bit offsets for [DiagnosticTags]

--- a/crates/biome_diagnostics/src/diagnostic.rs
+++ b/crates/biome_diagnostics/src/diagnostic.rs
@@ -152,7 +152,7 @@ impl FromStr for Severity {
 impl Display for Severity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Hint => write!(f, "hint"),
+            Self::Hint => write!(f, "info"),
             Self::Information => write!(f, "info"),
             Self::Warning => write!(f, "warn"),
             Self::Error => write!(f, "error"),

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -22,6 +22,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Remove the CLI options from the `lsp-proxy`, as they were never meant to be passed to that command. Contributed by @ematipico
 
+- Add new `--diagnostic-level` option to let users control the level of diagnostics printed by the CLI. Possible values are: `"info"`, `"warn"`, `"hint"`. Contributed by @simonxabris
+
 #### Bug fixes
 
 - Fix the command `format`, now it returns a non-zero exit code when if there pending diffs. Contributed by @ematipico


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Adds the `--diagnostic-level` option to the CLI as described in issue #671.

A question regarding the implementation is what should be the default diagnostic level that should be used if it's not explicitly specified in the CLI options. For now I made [`Information` as the default](https://github.com/simonxabris/biome/blob/9649022b6a77597fe7ae040a787f7021e91da69f/crates/biome_diagnostics/src/diagnostic.rs#L121-L133). 
## Test Plan

Now this is where I have some question as I don't have much experience with rust testing and the output was quite hard to decipher.

I guess some of the snapshots have to be updated, as for example the `--help` commands output now displays the `--diagnostic-level` option, but there are other snapshots that fail and I can't actually determine why,  so I'll need some help with how to take care of those.
