### PR TITLE
feat(cli): add `--config-path` to `lsp-proxy` and `start` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 ### CLI
 
 - Remove the CLI options from the `lsp-proxy`, as they were never meant to be passed to that command. Contributed by @ematipico
+- Add option `--config-path` to `lsp-proxy` and `start` commands. It's now possible to tell the Daemon server to load `biome.json` from a custom path. Contributed by @ematipico
 
 #### Bug fixes
 
@@ -33,10 +34,9 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Fix [#639](https://github.com/biomejs/biome/issues/639) by ignoring unused TypeScript's mapped key. Contributed by @Conaclos
-
 - Fix [#565](https://github.com/biomejs/biome/issues/565) by handling several `infer` with the same name in extends clauses of TypeScript's conditional types. Contributed by @Conaclos
-
 - Fix [#653](https://github.com/biomejs/biome/issues/653). [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) now correctly removes the entire line where the unused `import` is. Contributed by @Conaclos
+- Fix [#607](https://github.com/biomejs/biome/issues/609) `useExhaustiveDependencies`, ignore optional chaining, Contributed by @msdlisper
 
 ### Parser
 
@@ -86,7 +86,6 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Fix [#591](https://github.com/biomejs/biome/issues/591) which made [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare) report type parameters with identical names but in different method signatures. Contributed by @Conaclos
 - Support more a11y roles and fix some methods for a11y lint rules Contributed @nissy-dev
 - Fix [#609](https://github.com/biomejs/biome/issues/609) `useExhaustiveDependencies`, by removing `useContext`, `useId` and `useSyncExternalStore` from the known hooks. Contributed by @msdlisper
-- Fix [#607](https://github.com/biomejs/biome/issues/609) `useExhaustiveDependencies`, ignore optional chaining, Contributed by @msdlisper
 
 ### Parser
 

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ use biome_service::configuration::{
 use biome_service::Configuration;
 use bpaf::Bpaf;
 use std::ffi::OsString;
+use std::path::PathBuf;
 
 pub(crate) mod check;
 pub(crate) mod ci;
@@ -40,7 +41,11 @@ pub enum BiomeCommand {
     ),
     /// Start the Biome daemon server process
     #[bpaf(command)]
-    Start,
+    Start(
+        /// Allows to set a custom path when discovering the configuration file `biome.json`
+        #[bpaf(env("BIOME_CONFIG_PATH"), long("config-path"), argument("PATH"))]
+        Option<PathBuf>,
+    ),
 
     /// Stop the Biome daemon server process
     #[bpaf(command)]
@@ -186,7 +191,11 @@ pub enum BiomeCommand {
     Init,
     /// Acts as a server for the Language Server Protocol over stdin/stdout
     #[bpaf(command("lsp-proxy"))]
-    LspProxy,
+    LspProxy(
+        /// Allows to set a custom path when discovering the configuration file `biome.json`
+        #[bpaf(env("BIOME_CONFIG_PATH"), long("config-path"), argument("PATH"))]
+        Option<PathBuf>,
+    ),
     /// It updates the configuration when there are breaking changes
     #[bpaf(command)]
     Migrate(
@@ -200,6 +209,9 @@ pub enum BiomeCommand {
     RunServer {
         #[bpaf(long("stop-on-disconnect"), hide_usage)]
         stop_on_disconnect: bool,
+        /// Allows to set a custom path when discovering the configuration file `biome.json`
+        #[bpaf(env("BIOME_CONFIG_PATH"), long("config-path"), argument("PATH"))]
+        config_path: Option<PathBuf>,
     },
     #[bpaf(command("__print_socket"), hide)]
     PrintSocket,
@@ -215,8 +227,8 @@ impl BiomeCommand {
             | BiomeCommand::Ci { cli_options, .. }
             | BiomeCommand::Format { cli_options, .. }
             | BiomeCommand::Migrate(cli_options, _) => cli_options.colors.as_ref(),
-            BiomeCommand::LspProxy
-            | BiomeCommand::Start
+            BiomeCommand::LspProxy(_)
+            | BiomeCommand::Start(_)
             | BiomeCommand::Stop
             | BiomeCommand::Init
             | BiomeCommand::RunServer { .. }
@@ -234,9 +246,9 @@ impl BiomeCommand {
             | BiomeCommand::Format { cli_options, .. }
             | BiomeCommand::Migrate(cli_options, _) => cli_options.use_server,
             BiomeCommand::Init
-            | BiomeCommand::Start
+            | BiomeCommand::Start(_)
             | BiomeCommand::Stop
-            | BiomeCommand::LspProxy
+            | BiomeCommand::LspProxy(_)
             | BiomeCommand::RunServer { .. }
             | BiomeCommand::PrintSocket => false,
         }
@@ -255,10 +267,10 @@ impl BiomeCommand {
             | BiomeCommand::Migrate(cli_options, _) => cli_options.verbose,
             BiomeCommand::Version(_)
             | BiomeCommand::Rage(..)
-            | BiomeCommand::Start
+            | BiomeCommand::Start(_)
             | BiomeCommand::Stop
             | BiomeCommand::Init
-            | BiomeCommand::LspProxy
+            | BiomeCommand::LspProxy(_)
             | BiomeCommand::RunServer { .. }
             | BiomeCommand::PrintSocket => false,
         }
@@ -272,9 +284,9 @@ impl BiomeCommand {
             | BiomeCommand::Ci { cli_options, .. }
             | BiomeCommand::Migrate(cli_options, _) => cli_options.log_level.clone(),
             BiomeCommand::Version(_)
-            | BiomeCommand::LspProxy
+            | BiomeCommand::LspProxy(_)
             | BiomeCommand::Rage(..)
-            | BiomeCommand::Start
+            | BiomeCommand::Start(_)
             | BiomeCommand::Stop
             | BiomeCommand::Init
             | BiomeCommand::RunServer { .. }
@@ -290,8 +302,8 @@ impl BiomeCommand {
             | BiomeCommand::Migrate(cli_options, _) => cli_options.log_kind.clone(),
             BiomeCommand::Version(_)
             | BiomeCommand::Rage(..)
-            | BiomeCommand::LspProxy
-            | BiomeCommand::Start
+            | BiomeCommand::LspProxy(_)
+            | BiomeCommand::Start(_)
             | BiomeCommand::Stop
             | BiomeCommand::Init
             | BiomeCommand::RunServer { .. }

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -74,7 +74,7 @@ impl<'app> CliSession<'app> {
         let result = match command {
             BiomeCommand::Version(_) => commands::version::full_version(self),
             BiomeCommand::Rage(_, daemon_logs) => commands::rage::rage(self, daemon_logs),
-            BiomeCommand::Start => commands::daemon::start(self),
+            BiomeCommand::Start(config_path) => commands::daemon::start(self, config_path),
             BiomeCommand::Stop => commands::daemon::stop(self),
             BiomeCommand::Check {
                 apply,
@@ -165,13 +165,14 @@ impl<'app> CliSession<'app> {
                 },
             ),
             BiomeCommand::Init => commands::init::init(self),
-            BiomeCommand::LspProxy => commands::daemon::lsp_proxy(),
+            BiomeCommand::LspProxy(config_path) => commands::daemon::lsp_proxy(config_path),
             BiomeCommand::Migrate(cli_options, write) => {
                 commands::migrate::migrate(self, cli_options, write)
             }
-            BiomeCommand::RunServer { stop_on_disconnect } => {
-                commands::daemon::run_server(stop_on_disconnect)
-            }
+            BiomeCommand::RunServer {
+                stop_on_disconnect,
+                config_path,
+            } => commands::daemon::run_server(stop_on_disconnect, config_path),
             BiomeCommand::PrintSocket => commands::daemon::print_socket(),
         };
 

--- a/crates/biome_cli/src/main.rs
+++ b/crates/biome_cli/src/main.rs
@@ -37,8 +37,8 @@ fn main() -> ExitCode {
     match result {
         Err(termination) => {
             console.error(markup! {
-                        {if is_verbose { PrintDiagnostic::verbose(&termination) } else { PrintDiagnostic::simple(&termination) }}
-                    });
+                {if is_verbose { PrintDiagnostic::verbose(&termination) } else { PrintDiagnostic::simple(&termination) }}
+            });
             termination.report()
         }
         Ok(_) => ExitCode::SUCCESS,

--- a/crates/biome_cli/tests/main.rs
+++ b/crates/biome_cli/tests/main.rs
@@ -385,7 +385,7 @@ pub(crate) fn run_cli<'app>(
     };
 
     let factory = ServerFactory::default();
-    let connection = factory.create();
+    let connection = factory.create(None);
 
     let runtime = Runtime::new().expect("failed to create runtime");
 

--- a/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
@@ -7,10 +7,12 @@ expression: content
 ```block
 Acts as a server for the Language Server Protocol over stdin/stdout
 
-Usage: lsp-proxy 
+Usage: lsp-proxy [--config-path=PATH]
 
 Available options:
-    -h, --help  Prints help information
+        --config-path=PATH  Allows to set a custom path when discovering the configuration file `biome.json`
+                            [env:BIOME_CONFIG_PATH: N/A]
+    -h, --help              Prints help information
 
 ```
 

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -65,6 +65,8 @@ pub(crate) struct Session {
     documents: RwLock<FxHashMap<lsp_types::Url, Document>>,
 
     pub(crate) cancellation: Arc<Notify>,
+
+    pub(crate) config_path: Option<PathBuf>,
 }
 
 /// The parameters provided by the client in the "initialize" request
@@ -145,7 +147,12 @@ impl Session {
             extension_settings: config,
             fs: DynRef::Owned(Box::new(OsFileSystem)),
             cancellation,
+            config_path: None,
         }
+    }
+
+    pub(crate) fn set_config_path(&mut self, path: PathBuf) {
+        self.config_path = Some(path);
     }
 
     /// Initialize this session instance with the incoming initialization parameters from the client
@@ -389,9 +396,13 @@ impl Session {
     /// the root URI and update the workspace settings accordingly
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn load_workspace_settings(&self) {
-        let base_path = match self.base_path() {
-            None => ConfigurationBasePath::default(),
-            Some(path) => ConfigurationBasePath::Lsp(path),
+        let base_path = if let Some(config_path) = &self.config_path {
+            ConfigurationBasePath::FromUser(config_path.clone())
+        } else {
+            match self.base_path() {
+                None => ConfigurationBasePath::default(),
+                Some(path) => ConfigurationBasePath::Lsp(path),
+            }
         };
 
         let status = match load_config(&self.fs, base_path) {

--- a/crates/biome_lsp/tests/server.rs
+++ b/crates/biome_lsp/tests/server.rs
@@ -255,9 +255,9 @@ impl Server {
         .await
     }
 
-    /// Basic implementation of the `rome/shutdown` request for tests
-    async fn rome_shutdown(&mut self) -> Result<()> {
-        self.request::<_, ()>("biome/shutdown", "_rome_shutdown", ())
+    /// Basic implementation of the `biome/shutdown` request for tests
+    async fn biome_shutdown(&mut self) -> Result<()> {
+        self.request::<_, ()>("biome/shutdown", "_biome_shutdown", ())
             .await?
             .context("biome/shutdown returned None")?;
         Ok(())
@@ -323,7 +323,7 @@ where
 #[tokio::test]
 async fn basic_lifecycle() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -342,7 +342,7 @@ async fn basic_lifecycle() -> Result<()> {
 #[tokio::test]
 async fn document_lifecycle() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -473,7 +473,7 @@ async fn document_lifecycle() -> Result<()> {
 #[tokio::test]
 async fn document_no_extension() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -544,7 +544,7 @@ async fn document_no_extension() -> Result<()> {
 #[tokio::test]
 async fn pull_diagnostics() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -648,7 +648,7 @@ fn fixable_diagnostic(line: u32) -> Result<lsp::Diagnostic> {
 #[tokio::test]
 async fn pull_quick_fixes() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -779,7 +779,7 @@ async fn pull_quick_fixes() -> Result<()> {
 #[tokio::test]
 async fn pull_biome_quick_fixes_ignore_unsafe() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -861,7 +861,7 @@ async fn pull_biome_quick_fixes_ignore_unsafe() -> Result<()> {
 #[tokio::test]
 async fn pull_biome_quick_fixes() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -955,7 +955,7 @@ async fn pull_biome_quick_fixes() -> Result<()> {
 #[tokio::test]
 async fn pull_quick_fixes_include_unsafe() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1109,7 +1109,7 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
 #[tokio::test]
 async fn pull_diagnostics_for_rome_json() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1176,7 +1176,7 @@ async fn pull_diagnostics_for_rome_json() -> Result<()> {
 #[tokio::test]
 async fn no_code_actions_for_ignored_json_files() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1260,7 +1260,7 @@ async fn no_code_actions_for_ignored_json_files() -> Result<()> {
 #[tokio::test]
 async fn pull_code_actions_with_import_sorting() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1441,7 +1441,7 @@ if(a === -0) {}
 #[tokio::test]
 async fn pull_refactors() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1553,7 +1553,7 @@ async fn pull_refactors() -> Result<()> {
 #[tokio::test]
 async fn pull_fix_all() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1656,7 +1656,7 @@ async fn pull_fix_all() -> Result<()> {
 #[tokio::test]
 async fn change_document_remove_line() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1723,7 +1723,7 @@ isSpreadAssignment;
 #[tokio::test]
 async fn format_with_syntax_errors() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1772,7 +1772,7 @@ async fn format_with_syntax_errors() -> Result<()> {
 #[tokio::test]
 async fn server_shutdown() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create().into_inner();
+    let (service, client) = factory.create(None).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1785,7 +1785,7 @@ async fn server_shutdown() -> Result<()> {
     let cancellation = factory.cancellation();
     let cancellation = cancellation.notified();
 
-    server.rome_shutdown().await?;
+    server.biome_shutdown().await?;
 
     cancellation.await;
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -21,6 +21,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 ### CLI
 
 - Remove the CLI options from the `lsp-proxy`, as they were never meant to be passed to that command. Contributed by @ematipico
+- Add option `--config-path` to `lsp-proxy` and `start` commands. It's now possible to tell the Daemon server to load `biome.json` from a custom path. Contributed by @ematipico
 
 #### Bug fixes
 
@@ -39,10 +40,9 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Fix [#639](https://github.com/biomejs/biome/issues/639) by ignoring unused TypeScript's mapped key. Contributed by @Conaclos
-
 - Fix [#565](https://github.com/biomejs/biome/issues/565) by handling several `infer` with the same name in extends clauses of TypeScript's conditional types. Contributed by @Conaclos
-
 - Fix [#653](https://github.com/biomejs/biome/issues/653). [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) now correctly removes the entire line where the unused `import` is. Contributed by @Conaclos
+- Fix [#607](https://github.com/biomejs/biome/issues/609) `useExhaustiveDependencies`, ignore optional chaining, Contributed by @msdlisper
 
 ### Parser
 
@@ -92,7 +92,6 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Fix [#591](https://github.com/biomejs/biome/issues/591) which made [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare) report type parameters with identical names but in different method signatures. Contributed by @Conaclos
 - Support more a11y roles and fix some methods for a11y lint rules Contributed @nissy-dev
 - Fix [#609](https://github.com/biomejs/biome/issues/609) `useExhaustiveDependencies`, by removing `useContext`, `useId` and `useSyncExternalStore` from the known hooks. Contributed by @msdlisper
-- Fix [#607](https://github.com/biomejs/biome/issues/609) `useExhaustiveDependencies`, ignore optional chaining, Contributed by @msdlisper
 
 ### Parser
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Before, it *seemed* that we supported `--config-path`, but it's a mistake of the help command.

Although this is a feature that users require, so I added it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

This is a tricky one. So I plan to merge it, create a nightly release and ask users to test it.

<!-- What demonstrates that your implementation is correct? -->
