### PR TITLE
docs: replace deprecated `indentSize` with `indentWidth`

### DIFF
--- a/website/src/content/docs/formatter/index.mdx
+++ b/website/src/content/docs/formatter/index.mdx
@@ -47,7 +47,7 @@ The following defaults are applied:
     "enabled": true,
     "formatWithErrors": false,
     "indentStyle": "tab",
-    "indentSize": 2,
+    "indentWidth": 2,
     "lineWidth": 80,
     "ignore": []
   }


### PR DESCRIPTION
In the formatter docs section, an example configuration is shown.

The property `indentSize` is used.
When I tried this option in my config, biome shows me an alert telling me that this property is deprecated, and I should use `indentWidth` instead.

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
Change an example configuration on the docs to one that is not deprecated.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
Try this with the latest version of biome and the warning message disappear.
<!-- What demonstrates that your implementation is correct? -->
