### PR TITLE
feat(biome_js_parser): allow newline between the `static` and the class member name

### DIFF
--- a/crates/biome_js_parser/src/syntax/class.rs
+++ b/crates/biome_js_parser/src/syntax/class.rs
@@ -1712,7 +1712,8 @@ pub(crate) fn is_nth_at_modifier(p: &mut JsParser, n: usize, constructor_paramet
         return false;
     }
 
-    if p.has_nth_preceding_line_break(n + 1) {
+    // The new line is allowed between the `static` and the member name.
+    if !matches!(p.nth(n), T![static]) && p.has_nth_preceding_line_break(n + 1) {
         return false;
     }
 
@@ -1737,6 +1738,13 @@ fn is_at_constructor(p: &JsParser, modifiers: &ClassMemberModifiers) -> bool {
 // class A { public() {} }
 // class A { static protected() {} }
 // class A { static }
+
+// test js class_member_modifiers_no_asi
+// class A {
+//   static
+//   foo() {}
+// }
+//
 
 /// Parses all possible modifiers regardless of what the current member is. It's up to the caller
 /// to create diagnostics for not allowed modifiers.

--- a/crates/biome_js_parser/test_data/inline/ok/class_member_modifiers_no_asi.js
+++ b/crates/biome_js_parser/test_data/inline/ok/class_member_modifiers_no_asi.js
@@ -1,0 +1,4 @@
+class A {
+  static
+  foo() {}
+}

--- a/crates/biome_js_parser/test_data/inline/ok/class_member_modifiers_no_asi.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/class_member_modifiers_no_asi.rast
@@ -1,0 +1,86 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsClassDeclaration {
+            decorators: JsDecoratorList [],
+            abstract_token: missing (optional),
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..8 "A" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            extends_clause: missing (optional),
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@8..9 "{" [] [],
+            members: JsClassMemberList [
+                JsMethodClassMember {
+                    modifiers: JsMethodModifierList [
+                        JsStaticModifier {
+                            modifier_token: STATIC_KW@9..18 "static" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                    ],
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@18..24 "foo" [Newline("\n"), Whitespace("  ")] [],
+                    },
+                    question_mark_token: missing (optional),
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@24..25 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@25..27 ")" [] [Whitespace(" ")],
+                    },
+                    return_type_annotation: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@27..28 "{" [] [],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@28..29 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@29..31 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@31..32 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..32
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..31
+    0: JS_CLASS_DECLARATION@0..31
+      0: JS_DECORATOR_LIST@0..0
+      1: (empty)
+      2: CLASS_KW@0..6 "class" [] [Whitespace(" ")]
+      3: JS_IDENTIFIER_BINDING@6..8
+        0: IDENT@6..8 "A" [] [Whitespace(" ")]
+      4: (empty)
+      5: (empty)
+      6: (empty)
+      7: L_CURLY@8..9 "{" [] []
+      8: JS_CLASS_MEMBER_LIST@9..29
+        0: JS_METHOD_CLASS_MEMBER@9..29
+          0: JS_METHOD_MODIFIER_LIST@9..18
+            0: JS_STATIC_MODIFIER@9..18
+              0: STATIC_KW@9..18 "static" [Newline("\n"), Whitespace("  ")] []
+          1: (empty)
+          2: (empty)
+          3: JS_LITERAL_MEMBER_NAME@18..24
+            0: IDENT@18..24 "foo" [Newline("\n"), Whitespace("  ")] []
+          4: (empty)
+          5: (empty)
+          6: JS_PARAMETERS@24..27
+            0: L_PAREN@24..25 "(" [] []
+            1: JS_PARAMETER_LIST@25..25
+            2: R_PAREN@25..27 ")" [] [Whitespace(" ")]
+          7: (empty)
+          8: JS_FUNCTION_BODY@27..29
+            0: L_CURLY@27..28 "{" [] []
+            1: JS_DIRECTIVE_LIST@28..28
+            2: JS_STATEMENT_LIST@28..28
+            3: R_CURLY@28..29 "}" [] []
+      9: R_CURLY@29..31 "}" [Newline("\n")] []
+  3: EOF@31..32 "" [Newline("\n")] []


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Playground: https://biomejs.dev/playground?indentWidth=4&code=YwBsAGEAcwBzACAAWAAgAHsACgAgACAAcwB0AGEAdABpAGMACgAgACAAYgBhAHIAKAApACAAewB9AAoAfQA%3D

```JavaScript
class X {
  static
  bar() {}
}
```

There is no ASI after the `static`. 
The newline is allowed between the `static` and the class member name.


## Test Plan

new inline test case added.
