### PR TITLE
feat(lint/useForOf): add rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### New features
 
+- Add [useForOf](https://biomejs.dev/linter/rules/use-for-of) rule.
+  The rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.
+  Contributed by @victor-teles
+
 #### Enhancement
 
 - Implements [#924](https://github.com/biomejs/biome/issues/924) and [#920](https://github.com/biomejs/biome/issues/920). [noUselessElse](https://biomejs.dev/linter/rules/no-useless-else) now ignores `else` clauses that follow at least one `if` statement that doesn't break early. Contributed by @Conaclos
@@ -226,12 +230,6 @@ The following rules are now deprecated:
 - Support more a11y roles and fix some methods for a11y lint rules Contributed @nissy-dev
 - Fix [#609](https://github.com/biomejs/biome/issues/609) `useExhaustiveDependencies`, by removing `useContext`, `useId` and `useSyncExternalStore` from the known hooks. Contributed by @msdlisper
 - Fix `useExhaustiveDependencies`, by removing `useContext`, `useId` and `useSyncExternalStore` from the known hooks. Contributed by @msdlisper
-
-#### New features
-
-- Add [useForOf](https://biomejs.dev/linter/rules/use-for-of) rule.
-  The rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.
-  Contributed by @victor-teles
 
 ### Parser
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,12 @@ The following rules are now deprecated:
 - Fix [#609](https://github.com/biomejs/biome/issues/609) `useExhaustiveDependencies`, by removing `useContext`, `useId` and `useSyncExternalStore` from the known hooks. Contributed by @msdlisper
 - Fix `useExhaustiveDependencies`, by removing `useContext`, `useId` and `useSyncExternalStore` from the known hooks. Contributed by @msdlisper
 
+#### New features
+
+- Add [useForOf](https://biomejs.dev/linter/rules/use-for-of) rule.
+  The rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.
+  Contributed by @victor-teles
+
 ### Parser
 
 #### Enhancements

--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -687,7 +687,7 @@ impl Rule for ExampleRule {
 The semantic model provides information about the references of a binding (variable) within a program, indicating if it is written (e.g., `const a = 4`), read (e.g., `const b = a`, where `a` is read), or exported.
 
 
-#### Using the Semantic<> in rule
+#### How to use the query `Semantic<>` in a lint rule
 
 We've a `for` loop and we need to identify the `i` variable usage:
 
@@ -698,7 +698,7 @@ for (let i = 0; i < array.length; i++) {
 ```
 
 To get started we need to create a new rule using the semantic type `type Query = Semantic<JsForStatement>;`
-With that we can now use the `ctx.model()` to get information about bindings present in the for loop.
+We can now use the `ctx.model()` to get information about bindings in the for loop.
 
 ```rust,ignore
 impl Rule for ForLoopCountReferences {

--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -689,7 +689,7 @@ The semantic model provides information about the references of a binding (varia
 
 #### How to use the query `Semantic<>` in a lint rule
 
-We've a `for` loop and we need to identify the `i` variable usage:
+We have a for loop that creates an index i, and we need to identify where this index is used inside the body of the loop
 
 ```js
 for (let i = 0; i < array.length; i++) {

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -109,6 +109,7 @@ define_categories! {
     "lint/nursery/noUselessLoneBlockStatements": "https://biomejs.dev/linter/rules/no-useless-lone-block-statements",
     "lint/nursery/useAwait": "https://biomejs.dev/linter/rules/use-await",
     "lint/nursery/useBiomeSuppressionComment": "https://biomejs.dev/linter/rules/use-biome-suppression-comment",
+    "lint/nursery/useForOf": "https://biomejs.dev/linter/rules/use-for-of",
     "lint/nursery/useGroupedTypeImport": "https://biomejs.dev/linter/rules/use-grouped-type-import",
     "lint/nursery/useImportRestrictions": "https://biomejs.dev/linter/rules/use-import-restrictions",
     "lint/nursery/useRegexLiterals": "https://biomejs.dev/linter/rules/use-regex-literals",

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery.rs
@@ -3,12 +3,14 @@
 use biome_analyze::declare_group;
 
 pub(crate) mod no_unused_imports;
+pub(crate) mod use_for_of;
 
 declare_group! {
     pub (crate) Nursery {
         name : "nursery" ,
         rules : [
             self :: no_unused_imports :: NoUnusedImports ,
+            self :: use_for_of :: UseForOf ,
         ]
      }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_for_of.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_for_of.rs
@@ -310,7 +310,7 @@ fn get_incrementable_like(node: AnyJsExpression) -> Option<AnyIncrementableLike>
 }
 
 impl AnyIncrementableLike {
-    ///Check whether expression is increment by one, like:
+    ///Check whether the current expression is increment by one, like:
     ///
     /// JsPostUpdateExpression: i++
     /// JsPreUpdateExpression: ++i

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_for_of.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_for_of.rs
@@ -1,0 +1,384 @@
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_console::markup;
+use biome_js_semantic::ReferencesExtensions;
+use biome_js_syntax::{
+    AnyJsExpression, AnyJsForInitializer, JsAssignmentExpression, JsAssignmentOperator,
+    JsBinaryExpression, JsBinaryOperator, JsForStatement, JsIdentifierBinding,
+    JsPostUpdateExpression, JsPostUpdateOperator, JsPreUpdateExpression, JsPreUpdateOperator,
+    JsSyntaxKind, JsSyntaxToken, JsUnaryOperator, JsVariableDeclarator,
+};
+use biome_rowan::{declare_node_union, AstNode, AstSeparatedList};
+
+use crate::{semantic_services::Semantic, utils::is_node_equal};
+
+declare_rule! {
+    /// This rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.
+    ///
+    ///
+    /// Source: https://typescript-eslint.io/rules/prefer-for-of/
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// for (let i = 0; i < array.length; i++) {
+    ///   console.log(array[i]);
+    /// }
+    /// ```
+    ///
+    /// ## Valid
+    ///
+    /// ```js
+    /// for (let i = 0; i < array.length; i++) {
+    ///    console.log(i, array[i]);
+    ///  }
+    /// ```
+    ///
+    /// ```js
+    /// for (let i = 0, j = 0; i < array.length; i++) {
+    ///    console.log(i, array[i]);
+    ///  }
+    /// ```
+    ///
+    /// ```js
+    /// for (let i = 1; i < array.length; i++) {
+    ///    console.log(i, array[i]);
+    ///  }
+    /// ```
+    ///
+    pub(crate) UseForOf {
+        version: "1.4.0",
+        name: "useForOf",
+        recommended: false,
+    }
+}
+
+declare_node_union! {
+    pub(crate) AnyIncrementableLike = JsPostUpdateExpression | JsPreUpdateExpression | JsAssignmentExpression
+}
+
+impl Rule for UseForOf {
+    type Query = Semantic<JsForStatement>;
+    type State = ();
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+        let model = ctx.model();
+        let initializer = node.initializer()?;
+
+        if !is_initializer_valid(&initializer)? {
+            return None;
+        }
+
+        let declarators = initializer.as_js_variable_declaration()?.declarators();
+        let initializer = declarators.first()?.ok()?;
+        let initializer_id = initializer.id().ok()?;
+        let test = node.test()?;
+        let binding = initializer_id
+            .as_any_js_binding()?
+            .as_js_identifier_binding()?;
+
+        if !is_test_valid(binding, &test)? {
+            return None;
+        }
+
+        if !is_update_valid(binding, node.update()?)? {
+            return None;
+        }
+
+        let body = node.body().ok()?;
+        let block = body.as_js_block_statement();
+        let references = get_initializer_references(block, binding, model);
+        let array_right = test.as_js_binary_expression()?.right().ok()?;
+        let array_used_in_for = array_right
+            .as_js_static_member_expression()?
+            .object()
+            .ok()?;
+
+        let index_only_used_with_array = |reference| {
+            let array_in_use = reference_being_used_by_array(reference, &array_used_in_for)
+                .is_some_and(|array_in_use| array_in_use);
+            let is_delete =
+                is_delete(reference, &array_used_in_for).is_some_and(|is_assignee| is_assignee);
+
+            array_in_use && !is_delete
+        };
+
+        if references.iter().all(index_only_used_with_array) {
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn diagnostic(node: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {
+        Some(RuleDiagnostic::new(
+            rule_category!(),
+            node.query().range(),
+            markup! {
+                "Use "<Emphasis>"for-of"</Emphasis>" loop instead of a "<Emphasis>"for loop"</Emphasis>"."
+            },
+        ))
+    }
+}
+
+/// Get initializer references taking scope to account (excluding initials `for` loop references)
+fn get_initializer_references(
+    block: Option<&biome_js_syntax::JsBlockStatement>,
+    binding: &biome_js_syntax::JsIdentifierBinding,
+    model: &biome_js_semantic::SemanticModel,
+) -> Vec<AnyJsExpression> {
+    let skip_references = {
+        if block.is_none() {
+            2
+        } else {
+            0
+        }
+    };
+
+    binding
+        .all_references(model)
+        .skip(skip_references)
+        .filter_map(|reference| {
+            if let Some(block) = block {
+                // If block is preset, we need to consider only references in this scope
+                if block.range().start() != reference.scope().range().start() {
+                    return None;
+                }
+            }
+
+            AnyJsExpression::cast(reference.syntax().parent()?)
+        })
+        .collect()
+}
+
+/// Ensure the `for` declaration is correctly initialized
+///
+/// ## Valid example
+/// for (let i = 0; i < array.length; i++)
+///
+/// ## Invalid examples
+/// for (let i = 0, x = 1; i < array.length; i++)
+///
+fn is_initializer_valid(initializer: &AnyJsForInitializer) -> Option<bool> {
+    let initializer_declarations = initializer.as_js_variable_declaration()?.declarators();
+    let initializer = initializer_declarations.first()?.ok()?;
+
+    if initializer_declarations.len() > 1 || !is_zero_initialized(&initializer)? {
+        return None;
+    }
+
+    Some(true)
+}
+
+/// Ensure the `for` test is correctly initialized
+///
+/// ## Valid example
+/// for (let i = 0; i < array.length; i++)
+///
+/// ## Invalid examples
+/// for (let i = 0; NOTI < array.length; i++)
+///
+fn is_test_valid(
+    initializer_binding: &JsIdentifierBinding,
+    test: &AnyJsExpression,
+) -> Option<bool> {
+    let test_binary_expression = test.as_js_binary_expression()?;
+    let left = test_binary_expression.left().ok()?;
+    let identifier_expression = left.as_js_identifier_expression()?;
+
+    if initializer_binding.name_token().ok()?.text_trimmed()
+        != identifier_expression
+            .name()
+            .ok()?
+            .value_token()
+            .ok()?
+            .text_trimmed()
+    {
+        return None;
+    }
+
+    if !is_less_than_length_expression(test_binary_expression)? {
+        return None;
+    }
+
+    Some(true)
+}
+
+/// Ensure the `for` update is correctly initialized
+///
+/// ## Valid example
+/// for (let i = 0; i < array.length; i++)
+///
+/// ## Invalid examples
+/// for (let i = 0; i < array.length; i--)
+///
+/// for (let i = 0; i < array.length; NOTI++)
+///
+fn is_update_valid(
+    initializer_binding: &JsIdentifierBinding,
+    update: AnyJsExpression,
+) -> Option<bool> {
+    let incrementable_like = get_incrementable_like(update)?;
+
+    if initializer_binding.name_token().ok()?.text_trimmed()
+        != incrementable_like.get_name_token()?.text_trimmed()
+    {
+        return None;
+    }
+
+    if !incrementable_like.is_increment_by_one()? {
+        return None;
+    }
+
+    Some(true)
+}
+
+fn reference_being_used_by_array(
+    expression: &AnyJsExpression,
+    array_used_in_for: &AnyJsExpression,
+) -> Option<bool> {
+    match expression.parent::<AnyJsExpression>()? {
+        AnyJsExpression::JsComputedMemberExpression(computed_member) => Some(is_node_equal(
+            computed_member.object().ok()?.syntax(),
+            array_used_in_for.syntax(),
+        )),
+        _ => Some(false),
+    }
+}
+
+fn is_delete(expression: &AnyJsExpression, array_used_in_for: &AnyJsExpression) -> Option<bool> {
+    let parent = expression.parent::<AnyJsExpression>()?;
+
+    match parent.parent::<AnyJsExpression>()? {
+        AnyJsExpression::JsUnaryExpression(unary_expression) => {
+            let is_delete = matches!(unary_expression.operator().ok()?, JsUnaryOperator::Delete);
+            let argument = unary_expression.argument().ok()?;
+            let argument = argument.as_js_computed_member_expression()?;
+            let same_reference =
+                is_node_equal(argument.object().ok()?.syntax(), array_used_in_for.syntax());
+
+            Some(is_delete && same_reference)
+        }
+        _ => Some(false),
+    }
+}
+
+fn is_less_than_length_expression(binary_expression: &JsBinaryExpression) -> Option<bool> {
+    let right = binary_expression.right().ok()?;
+    let static_member_expression = right.as_js_static_member_expression()?;
+    let object = static_member_expression.object().ok()?;
+    let member = static_member_expression.member().ok()?;
+    let member = member.as_js_name()?;
+    let operator = binary_expression.operator().ok()?;
+
+    Some(
+        matches!(operator, JsBinaryOperator::LessThan)
+            && member.value_token().ok()?.text() == "length"
+            && !matches!(object.syntax().kind(), JsSyntaxKind::JS_THIS_EXPRESSION),
+    )
+}
+
+fn is_zero_initialized(variable_declarator: &JsVariableDeclarator) -> Option<bool> {
+    let expression = variable_declarator.initializer()?.expression().ok()?;
+    let number_literal = expression
+        .as_any_js_literal_expression()?
+        .as_js_number_literal_expression()?;
+
+    let value = number_literal.value_token().ok()?;
+    let value = value.text_trimmed();
+
+    Some(value == "0")
+}
+
+fn get_incrementable_like(node: AnyJsExpression) -> Option<AnyIncrementableLike> {
+    match node {
+        AnyJsExpression::JsAssignmentExpression(expression) => {
+            Some(AnyIncrementableLike::JsAssignmentExpression(expression))
+        }
+        AnyJsExpression::JsPostUpdateExpression(expression) => {
+            Some(AnyIncrementableLike::JsPostUpdateExpression(expression))
+        }
+        AnyJsExpression::JsPreUpdateExpression(expression) => {
+            Some(AnyIncrementableLike::JsPreUpdateExpression(expression))
+        }
+        _ => None,
+    }
+}
+
+impl AnyIncrementableLike {
+    ///Check whether expression is increment by one, like:
+    ///
+    /// JsPostUpdateExpression: i++
+    /// JsPreUpdateExpression: ++i
+    /// JsAssignmentExpression(Binary): i = i + 1
+    /// JsAssignmentExpression(Shorthand): i += 1
+    fn is_increment_by_one(&self) -> Option<bool> {
+        match self {
+            AnyIncrementableLike::JsPostUpdateExpression(expression) => Some(matches!(
+                expression.operator().ok()?,
+                JsPostUpdateOperator::Increment
+            )),
+            AnyIncrementableLike::JsPreUpdateExpression(expression) => Some(matches!(
+                expression.operator().ok()?,
+                JsPreUpdateOperator::Increment
+            )),
+            AnyIncrementableLike::JsAssignmentExpression(expression) => {
+                let operator = expression.operator().ok()?;
+                let right = expression.right().ok()?;
+
+                if let Some(binary_expression) = JsBinaryExpression::cast_ref(right.syntax()) {
+                    let binary_right = binary_expression.right().ok()?;
+                    let number_literal = binary_right
+                        .as_any_js_literal_expression()?
+                        .as_js_number_literal_expression()?;
+
+                    let binary_value = number_literal.value_token().ok()?;
+                    let binary_value = binary_value.text_trimmed();
+
+                    if matches!(binary_expression.operator().ok()?, JsBinaryOperator::Plus)
+                        && binary_value == "1"
+                    {
+                        return Some(true);
+                    }
+                }
+
+                let number_literal = right
+                    .as_any_js_literal_expression()?
+                    .as_js_number_literal_expression()?;
+
+                let value = number_literal.value_token().ok()?;
+                let value = value.text_trimmed();
+
+                Some(matches!(operator, JsAssignmentOperator::AddAssign) && value == "1")
+            }
+        }
+    }
+
+    fn get_name_token(&self) -> Option<JsSyntaxToken> {
+        match self {
+            AnyIncrementableLike::JsPostUpdateExpression(expression) => expression
+                .operand()
+                .ok()?
+                .as_js_identifier_assignment()?
+                .name_token()
+                .ok(),
+            AnyIncrementableLike::JsPreUpdateExpression(expression) => expression
+                .operand()
+                .ok()?
+                .as_js_identifier_assignment()?
+                .name_token()
+                .ok(),
+            AnyIncrementableLike::JsAssignmentExpression(expression) => expression
+                .left()
+                .ok()?
+                .as_any_js_assignment()?
+                .as_js_identifier_assignment()?
+                .name_token()
+                .ok(),
+        }
+    }
+}

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_for_of.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_for_of.rs
@@ -1,11 +1,12 @@
 use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use biome_console::markup;
-use biome_js_semantic::ReferencesExtensions;
+use biome_js_semantic::{ReferencesExtensions, SemanticModel};
 use biome_js_syntax::{
-    AnyJsExpression, AnyJsForInitializer, JsAssignmentExpression, JsAssignmentOperator,
-    JsBinaryExpression, JsBinaryOperator, JsForStatement, JsIdentifierBinding,
-    JsIdentifierExpression, JsPostUpdateExpression, JsPostUpdateOperator, JsPreUpdateExpression,
-    JsPreUpdateOperator, JsSyntaxKind, JsSyntaxToken, JsUnaryOperator, JsVariableDeclarator,
+    AnyJsExpression, AnyJsForInitializer, AnyJsStatement, JsAssignmentExpression,
+    JsAssignmentOperator, JsBinaryExpression, JsBinaryOperator, JsForStatement,
+    JsIdentifierBinding, JsIdentifierExpression, JsPostUpdateExpression, JsPostUpdateOperator,
+    JsPreUpdateExpression, JsPreUpdateOperator, JsSyntaxKind, JsSyntaxToken, JsUnaryOperator,
+    JsVariableDeclarator,
 };
 use biome_rowan::{declare_node_union, AstNode, AstSeparatedList, TextRange};
 
@@ -89,10 +90,8 @@ impl Rule for UseForOf {
 
         let body = node.body().ok()?;
         let body_range = match body {
-            biome_js_syntax::AnyJsStatement::JsBlockStatement(block) => Some(block.range()),
-            biome_js_syntax::AnyJsStatement::JsExpressionStatement(statement) => {
-                Some(statement.range())
-            }
+            AnyJsStatement::JsBlockStatement(block) => Some(block.range()),
+            AnyJsStatement::JsExpressionStatement(statement) => Some(statement.range()),
             _ => None,
         }?;
 
@@ -138,8 +137,8 @@ impl Rule for UseForOf {
 /// - `Vec<AnyBindingExpression>`
 ///
 fn list_initializer_references(
-    model: &biome_js_semantic::SemanticModel,
-    binding: &biome_js_syntax::JsIdentifierBinding,
+    model: &SemanticModel,
+    binding: &JsIdentifierBinding,
     body_range: &TextRange,
 ) -> Vec<AnyBindingExpression> {
     binding

--- a/crates/biome_js_analyze/tests/specs/nursery/useForOf/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useForOf/invalid.js
@@ -1,0 +1,68 @@
+
+
+for (let i = 0; i < array.length; i++) {
+	console.log(array[i])
+}
+
+for (var a = 0; a < obj.arr.length; a++) {
+  console.log(obj.arr[a]);
+}
+
+for (var b = 0; b < arr.length; b++) console.log(arr[b]);
+
+for (let a = 0; a < arr.length; a++) {
+  console.log(arr[a]);
+}
+
+for (var b = 0; b < arr.length; b++) console?.log(arr[b]);
+
+
+for (let a = 0; a < arr.length; a++) {
+  console?.log(arr[a]);
+}
+
+for (let a = 0; a < arr.length; ++a) {
+  arr[a].whatever();
+}
+
+for (let x = 0; x < arr.length; x++) {
+	console.log(arr[x])
+}
+
+for (let x = 0; x < arr.length; x += 1) {
+	console.log(arr[x])
+}
+
+for (let x = 0; x < arr.length; x = x + 1) {}
+
+for (let shadow = 0; shadow < arr.length; shadow++) {
+  for (let shadow = 0; shadow < arr.length; shadow++) {}
+}
+
+for (let i = 0; i < arr.length; i++) {
+  obj[arr[i]] = 1;
+}
+
+for (let i = 0; i < arr.length; i++) {
+  delete obj[arr[i]];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  [obj[arr[i]]] = [1];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  [...obj[arr[i]]] = [1];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  ({ foo: obj[arr[i]] } = { foo: 1 });
+}
+
+for (let i = 0; i < this.item.length; ++i) {
+  this.item[i];
+}
+
+for (let i = 0; i < this.array.length; ++i) {
+  yield this.array[i];
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useForOf/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useForOf/invalid.js.snap
@@ -1,0 +1,402 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.js
+---
+# Input
+```js
+
+
+for (let i = 0; i < array.length; i++) {
+	console.log(array[i])
+}
+
+for (var a = 0; a < obj.arr.length; a++) {
+  console.log(obj.arr[a]);
+}
+
+for (var b = 0; b < arr.length; b++) console.log(arr[b]);
+
+for (let a = 0; a < arr.length; a++) {
+  console.log(arr[a]);
+}
+
+for (var b = 0; b < arr.length; b++) console?.log(arr[b]);
+
+
+for (let a = 0; a < arr.length; a++) {
+  console?.log(arr[a]);
+}
+
+for (let a = 0; a < arr.length; ++a) {
+  arr[a].whatever();
+}
+
+for (let x = 0; x < arr.length; x++) {
+	console.log(arr[x])
+}
+
+for (let x = 0; x < arr.length; x += 1) {
+	console.log(arr[x])
+}
+
+for (let x = 0; x < arr.length; x = x + 1) {}
+
+for (let shadow = 0; shadow < arr.length; shadow++) {
+  for (let shadow = 0; shadow < arr.length; shadow++) {}
+}
+
+for (let i = 0; i < arr.length; i++) {
+  obj[arr[i]] = 1;
+}
+
+for (let i = 0; i < arr.length; i++) {
+  delete obj[arr[i]];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  [obj[arr[i]]] = [1];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  [...obj[arr[i]]] = [1];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  ({ foo: obj[arr[i]] } = { foo: 1 });
+}
+
+for (let i = 0; i < this.item.length; ++i) {
+  this.item[i];
+}
+
+for (let i = 0; i < this.array.length; ++i) {
+  yield this.array[i];
+}
+
+```
+
+# Diagnostics
+```
+invalid.js:3:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+  > 3 │ for (let i = 0; i < array.length; i++) {
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 4 │ 	console.log(array[i])
+  > 5 │ }
+      │ ^
+    6 │ 
+    7 │ for (var a = 0; a < obj.arr.length; a++) {
+  
+
+```
+
+```
+invalid.js:7:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+     5 │ }
+     6 │ 
+   > 7 │ for (var a = 0; a < obj.arr.length; a++) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 8 │   console.log(obj.arr[a]);
+   > 9 │ }
+       │ ^
+    10 │ 
+    11 │ for (var b = 0; b < arr.length; b++) console.log(arr[b]);
+  
+
+```
+
+```
+invalid.js:11:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+     9 │ }
+    10 │ 
+  > 11 │ for (var b = 0; b < arr.length; b++) console.log(arr[b]);
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ for (let a = 0; a < arr.length; a++) {
+  
+
+```
+
+```
+invalid.js:13:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    11 │ for (var b = 0; b < arr.length; b++) console.log(arr[b]);
+    12 │ 
+  > 13 │ for (let a = 0; a < arr.length; a++) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 14 │   console.log(arr[a]);
+  > 15 │ }
+       │ ^
+    16 │ 
+    17 │ for (var b = 0; b < arr.length; b++) console?.log(arr[b]);
+  
+
+```
+
+```
+invalid.js:17:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    15 │ }
+    16 │ 
+  > 17 │ for (var b = 0; b < arr.length; b++) console?.log(arr[b]);
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    18 │ 
+  
+
+```
+
+```
+invalid.js:20:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+  > 20 │ for (let a = 0; a < arr.length; a++) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 21 │   console?.log(arr[a]);
+  > 22 │ }
+       │ ^
+    23 │ 
+    24 │ for (let a = 0; a < arr.length; ++a) {
+  
+
+```
+
+```
+invalid.js:24:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    22 │ }
+    23 │ 
+  > 24 │ for (let a = 0; a < arr.length; ++a) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 25 │   arr[a].whatever();
+  > 26 │ }
+       │ ^
+    27 │ 
+    28 │ for (let x = 0; x < arr.length; x++) {
+  
+
+```
+
+```
+invalid.js:28:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    26 │ }
+    27 │ 
+  > 28 │ for (let x = 0; x < arr.length; x++) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 29 │ 	console.log(arr[x])
+  > 30 │ }
+       │ ^
+    31 │ 
+    32 │ for (let x = 0; x < arr.length; x += 1) {
+  
+
+```
+
+```
+invalid.js:32:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    30 │ }
+    31 │ 
+  > 32 │ for (let x = 0; x < arr.length; x += 1) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 33 │ 	console.log(arr[x])
+  > 34 │ }
+       │ ^
+    35 │ 
+    36 │ for (let x = 0; x < arr.length; x = x + 1) {}
+  
+
+```
+
+```
+invalid.js:36:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    34 │ }
+    35 │ 
+  > 36 │ for (let x = 0; x < arr.length; x = x + 1) {}
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    37 │ 
+    38 │ for (let shadow = 0; shadow < arr.length; shadow++) {
+  
+
+```
+
+```
+invalid.js:38:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    36 │ for (let x = 0; x < arr.length; x = x + 1) {}
+    37 │ 
+  > 38 │ for (let shadow = 0; shadow < arr.length; shadow++) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 39 │   for (let shadow = 0; shadow < arr.length; shadow++) {}
+  > 40 │ }
+       │ ^
+    41 │ 
+    42 │ for (let i = 0; i < arr.length; i++) {
+  
+
+```
+
+```
+invalid.js:39:3 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    38 │ for (let shadow = 0; shadow < arr.length; shadow++) {
+  > 39 │   for (let shadow = 0; shadow < arr.length; shadow++) {}
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    40 │ }
+    41 │ 
+  
+
+```
+
+```
+invalid.js:42:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    40 │ }
+    41 │ 
+  > 42 │ for (let i = 0; i < arr.length; i++) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 43 │   obj[arr[i]] = 1;
+  > 44 │ }
+       │ ^
+    45 │ 
+    46 │ for (let i = 0; i < arr.length; i++) {
+  
+
+```
+
+```
+invalid.js:46:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    44 │ }
+    45 │ 
+  > 46 │ for (let i = 0; i < arr.length; i++) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 47 │   delete obj[arr[i]];
+  > 48 │ }
+       │ ^
+    49 │ 
+    50 │ for (let i = 0; i < arr.length; i++) {
+  
+
+```
+
+```
+invalid.js:50:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    48 │ }
+    49 │ 
+  > 50 │ for (let i = 0; i < arr.length; i++) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 51 │   [obj[arr[i]]] = [1];
+  > 52 │ }
+       │ ^
+    53 │ 
+    54 │ for (let i = 0; i < arr.length; i++) {
+  
+
+```
+
+```
+invalid.js:54:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    52 │ }
+    53 │ 
+  > 54 │ for (let i = 0; i < arr.length; i++) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 55 │   [...obj[arr[i]]] = [1];
+  > 56 │ }
+       │ ^
+    57 │ 
+    58 │ for (let i = 0; i < arr.length; i++) {
+  
+
+```
+
+```
+invalid.js:58:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    56 │ }
+    57 │ 
+  > 58 │ for (let i = 0; i < arr.length; i++) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 59 │   ({ foo: obj[arr[i]] } = { foo: 1 });
+  > 60 │ }
+       │ ^
+    61 │ 
+    62 │ for (let i = 0; i < this.item.length; ++i) {
+  
+
+```
+
+```
+invalid.js:62:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    60 │ }
+    61 │ 
+  > 62 │ for (let i = 0; i < this.item.length; ++i) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 63 │   this.item[i];
+  > 64 │ }
+       │ ^
+    65 │ 
+    66 │ for (let i = 0; i < this.array.length; ++i) {
+  
+
+```
+
+```
+invalid.js:66:1 lint/nursery/useForOf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use for-of loop instead of a for loop.
+  
+    64 │ }
+    65 │ 
+  > 66 │ for (let i = 0; i < this.array.length; ++i) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 67 │   yield this.array[i];
+  > 68 │ }
+       │ ^
+    69 │ 
+  
+
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/useForOf/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useForOf/valid.js
@@ -1,0 +1,140 @@
+/* should not generate diagnostics */
+
+for (let i = 0; i < array.length; i++) {
+	console.log(i);
+}
+
+for (let i = 0; i < arr1.length; i++) {
+  const x = arr1[i] === arr2[i];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  arr[i] = 0;
+}
+
+for (var c = 0; c < arr.length; c++) {
+  doMath(c);
+}
+
+for (var d = 0; d < arr.length; d++) doMath(d);
+
+for (var e = 0; e < arr.length; e++) {
+  if (e > 5) {
+    doMath(e);
+  }
+  console.log(arr[e]);
+}
+
+for (var f = 0; f <= 40; f++) {
+  doMath(f);
+}
+
+for (var g = 0; g <= 40; g++) doMath(g);
+
+for (var h = 0, len = arr.length; h < len; h++) {}
+
+for (var i = 0, len = arr.length; i < len; i++) arr[i];
+
+
+for (;;) {
+  if (m > 3) break;
+  console.log(m);
+  m++;
+}
+
+
+for (; n < 9; n++) {
+  console.log(n);
+}
+
+for (; o < arr.length; o++) {
+  console.log(arr[o]);
+}
+
+for (; x < arr.length; x++) {}
+
+for (let x = 0; ; x++) {}
+
+for (let x = 0; x < arr.length; ) {}
+
+for (let x = 0; NOTX < arr.length; x++) {}
+
+for (let x = 0; x < arr.length; NOTX++) {}
+
+for (let NOTX = 0; x < arr.length; x++) {}
+
+for (let x = 0; x < arr.length; x--) {}
+
+for (let x = 0; x <= arr.length; x++) {}
+
+for (let x = 1; x < arr.length; x++) {}
+
+for (let x = 0; x < arr.length(); x++) {}
+
+for (let x = 0; x < arr.length; x += 11) {}
+
+for (let x = arr.length; x > 1; x -= 1) {}
+
+for (let x = 0; x < arr.length; x *= 2) {}
+
+for (let x = 0; x < arr.length; x = x + 11) {}
+
+for (let x = 0; x < arr.length; x++) {
+  x++;
+}
+
+for (let x = 0; true; x++) {}
+
+for (var q in obj) {
+  if (obj.hasOwnProperty(q)) {
+    console.log(q);
+  }
+}
+
+for (var r of arr) {
+  console.log(r);
+}
+
+for (let x = 0; x < arr.length; x++) {
+  let y = arr[x + 1];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  delete arr[i];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  [arr[i]] = [1];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  [...arr[i]] = [1];
+}
+
+for (let i = 0; i < arr1?.length; i++) {
+  const x = arr1[i] === arr2[i];
+}
+
+for (let i = 0; i < arr?.length; i++) {
+  arr[i] = 0;
+}
+
+for (var c = 0; c < arr?.length; c++) {
+  doMath(c);
+}
+
+for (var d = 0; d < arr?.length; d++) doMath(d);
+
+for (var c = 0; c < arr.length; c++) {
+  doMath?.(c);
+}
+
+for (var d = 0; d < arr.length; d++) doMath?.(d);
+
+for (let i = 0; i < test.length; ++i) {
+  this[i];
+}
+
+for (let i = 0; i < this.length; ++i) {
+  yield this[i];
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useForOf/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useForOf/valid.js.snap
@@ -1,0 +1,150 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```js
+/* should not generate diagnostics */
+
+for (let i = 0; i < array.length; i++) {
+	console.log(i);
+}
+
+for (let i = 0; i < arr1.length; i++) {
+  const x = arr1[i] === arr2[i];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  arr[i] = 0;
+}
+
+for (var c = 0; c < arr.length; c++) {
+  doMath(c);
+}
+
+for (var d = 0; d < arr.length; d++) doMath(d);
+
+for (var e = 0; e < arr.length; e++) {
+  if (e > 5) {
+    doMath(e);
+  }
+  console.log(arr[e]);
+}
+
+for (var f = 0; f <= 40; f++) {
+  doMath(f);
+}
+
+for (var g = 0; g <= 40; g++) doMath(g);
+
+for (var h = 0, len = arr.length; h < len; h++) {}
+
+for (var i = 0, len = arr.length; i < len; i++) arr[i];
+
+
+for (;;) {
+  if (m > 3) break;
+  console.log(m);
+  m++;
+}
+
+
+for (; n < 9; n++) {
+  console.log(n);
+}
+
+for (; o < arr.length; o++) {
+  console.log(arr[o]);
+}
+
+for (; x < arr.length; x++) {}
+
+for (let x = 0; ; x++) {}
+
+for (let x = 0; x < arr.length; ) {}
+
+for (let x = 0; NOTX < arr.length; x++) {}
+
+for (let x = 0; x < arr.length; NOTX++) {}
+
+for (let NOTX = 0; x < arr.length; x++) {}
+
+for (let x = 0; x < arr.length; x--) {}
+
+for (let x = 0; x <= arr.length; x++) {}
+
+for (let x = 1; x < arr.length; x++) {}
+
+for (let x = 0; x < arr.length(); x++) {}
+
+for (let x = 0; x < arr.length; x += 11) {}
+
+for (let x = arr.length; x > 1; x -= 1) {}
+
+for (let x = 0; x < arr.length; x *= 2) {}
+
+for (let x = 0; x < arr.length; x = x + 11) {}
+
+for (let x = 0; x < arr.length; x++) {
+  x++;
+}
+
+for (let x = 0; true; x++) {}
+
+for (var q in obj) {
+  if (obj.hasOwnProperty(q)) {
+    console.log(q);
+  }
+}
+
+for (var r of arr) {
+  console.log(r);
+}
+
+for (let x = 0; x < arr.length; x++) {
+  let y = arr[x + 1];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  delete arr[i];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  [arr[i]] = [1];
+}
+
+for (let i = 0; i < arr.length; i++) {
+  [...arr[i]] = [1];
+}
+
+for (let i = 0; i < arr1?.length; i++) {
+  const x = arr1[i] === arr2[i];
+}
+
+for (let i = 0; i < arr?.length; i++) {
+  arr[i] = 0;
+}
+
+for (var c = 0; c < arr?.length; c++) {
+  doMath(c);
+}
+
+for (var d = 0; d < arr?.length; d++) doMath(d);
+
+for (var c = 0; c < arr.length; c++) {
+  doMath?.(c);
+}
+
+for (var d = 0; d < arr.length; d++) doMath?.(d);
+
+for (let i = 0; i < test.length; ++i) {
+  this[i];
+}
+
+for (let i = 0; i < this.length; ++i) {
+  yield this[i];
+}
+
+```
+
+

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -2812,6 +2812,10 @@ pub struct Nursery {
     #[bpaf(long("use-await"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_await: Option<RuleConfiguration>,
+    #[doc = "This rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated."]
+    #[bpaf(long("use-for-of"), argument("on|off|warn"), optional, hide)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_for_of: Option<RuleConfiguration>,
     #[doc = "Enforce the use of import type when an import only has specifiers with type qualifier."]
     #[bpaf(
         long("use-grouped-type-import"),
@@ -2868,6 +2872,9 @@ impl MergeWith<Nursery> for Nursery {
         if let Some(use_await) = other.use_await {
             self.use_await = Some(use_await);
         }
+        if let Some(use_for_of) = other.use_for_of {
+            self.use_for_of = Some(use_for_of);
+        }
         if let Some(use_grouped_type_import) = other.use_grouped_type_import {
             self.use_grouped_type_import = Some(use_grouped_type_import);
         }
@@ -2892,7 +2899,7 @@ impl MergeWith<Nursery> for Nursery {
 }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
-    pub(crate) const GROUP_RULES: [&'static str; 13] = [
+    pub(crate) const GROUP_RULES: [&'static str; 14] = [
         "noAriaHiddenOnFocusable",
         "noDefaultExport",
         "noDuplicateJsonKeys",
@@ -2902,6 +2909,7 @@ impl Nursery {
         "noUnusedPrivateClassMembers",
         "noUselessLoneBlockStatements",
         "useAwait",
+        "useForOf",
         "useGroupedTypeImport",
         "useImportRestrictions",
         "useRegexLiterals",
@@ -2920,10 +2928,10 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
     ];
-    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 13] = [
+    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 14] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
@@ -2937,6 +2945,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended(&self) -> bool {
@@ -2998,24 +3007,29 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_for_of.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.use_regex_literals.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+        if let Some(rule) = self.use_regex_literals.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
+            }
+        }
+        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
         index_set
@@ -3067,24 +3081,29 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_for_of.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.use_regex_literals.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+        if let Some(rule) = self.use_regex_literals.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
+            }
+        }
+        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
         index_set
@@ -3100,7 +3119,7 @@ impl Nursery {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 6] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 13] {
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 14] {
         Self::ALL_RULES_AS_FILTERS
     }
     #[doc = r" Select preset rules"]
@@ -3132,6 +3151,7 @@ impl Nursery {
             "noUnusedPrivateClassMembers" => self.no_unused_private_class_members.as_ref(),
             "noUselessLoneBlockStatements" => self.no_useless_lone_block_statements.as_ref(),
             "useAwait" => self.use_await.as_ref(),
+            "useForOf" => self.use_for_of.as_ref(),
             "useGroupedTypeImport" => self.use_grouped_type_import.as_ref(),
             "useImportRestrictions" => self.use_import_restrictions.as_ref(),
             "useRegexLiterals" => self.use_regex_literals.as_ref(),

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -2812,7 +2812,7 @@ pub struct Nursery {
     #[bpaf(long("use-await"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_await: Option<RuleConfiguration>,
-    #[doc = "This rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated."]
+    #[doc = "This rule recommends a for-of loop when in a for loop, the index used to extract an item from the iterated array."]
     #[bpaf(long("use-for-of"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_for_of: Option<RuleConfiguration>,

--- a/crates/biome_service/src/configuration/parse/json/rules.rs
+++ b/crates/biome_service/src/configuration/parse/json/rules.rs
@@ -959,6 +959,10 @@ impl Deserializable for Nursery {
                             result.use_await =
                                 Deserializable::deserialize(&value, "useAwait", diagnostics);
                         }
+                        "useForOf" => {
+                            result.use_for_of =
+                                Deserializable::deserialize(&value, "useForOf", diagnostics);
+                        }
                         "useGroupedTypeImport" => {
                             result.use_grouped_type_import = Deserializable::deserialize(
                                 &value,
@@ -1003,6 +1007,7 @@ impl Deserializable for Nursery {
                                     "noUnusedPrivateClassMembers",
                                     "noUselessLoneBlockStatements",
                                     "useAwait",
+                                    "useForOf",
                                     "useGroupedTypeImport",
                                     "useImportRestrictions",
                                     "useRegexLiterals",

--- a/crates/biome_service/tests/invalid/hooks_incorrect_options.json.snap
+++ b/crates/biome_service/tests/invalid/hooks_incorrect_options.json.snap
@@ -26,6 +26,7 @@ hooks_incorrect_options.json:6:5 deserialize ━━━━━━━━━━━�
   - noUnusedPrivateClassMembers
   - noUselessLoneBlockStatements
   - useAwait
+  - useForOf
   - useGroupedTypeImport
   - useImportRestrictions
   - useRegexLiterals

--- a/crates/biome_service/tests/invalid/hooks_missing_name.json.snap
+++ b/crates/biome_service/tests/invalid/hooks_missing_name.json.snap
@@ -26,6 +26,7 @@ hooks_missing_name.json:6:5 deserialize ━━━━━━━━━━━━━�
   - noUnusedPrivateClassMembers
   - noUselessLoneBlockStatements
   - useAwait
+  - useForOf
   - useGroupedTypeImport
   - useImportRestrictions
   - useRegexLiterals

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -1167,6 +1167,13 @@
 						{ "type": "null" }
 					]
 				},
+				"useForOf": {
+					"description": "This rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"useGroupedTypeImport": {
 					"description": "Enforce the use of import type when an import only has specifiers with type qualifier.",
 					"anyOf": [

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -818,7 +818,7 @@ export interface Nursery {
 	 */
 	useAwait?: RuleConfiguration;
 	/**
-	 * This rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.
+	 * This rule recommends a for-of loop when in a for loop, the index used to extract an item from the iterated array.
 	 */
 	useForOf?: RuleConfiguration;
 	/**

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -818,6 +818,10 @@ export interface Nursery {
 	 */
 	useAwait?: RuleConfiguration;
 	/**
+	 * This rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.
+	 */
+	useForOf?: RuleConfiguration;
+	/**
 	 * Enforce the use of import type when an import only has specifiers with type qualifier.
 	 */
 	useGroupedTypeImport?: RuleConfiguration;
@@ -1507,6 +1511,7 @@ export type Category =
 	| "lint/nursery/noUselessLoneBlockStatements"
 	| "lint/nursery/useAwait"
 	| "lint/nursery/useBiomeSuppressionComment"
+	| "lint/nursery/useForOf"
 	| "lint/nursery/useGroupedTypeImport"
 	| "lint/nursery/useImportRestrictions"
 	| "lint/nursery/useRegexLiterals"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1180,7 +1180,7 @@
 					]
 				},
 				"useForOf": {
-					"description": "This rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.",
+					"description": "This rule recommends a for-of loop when in a for loop, the index used to extract an item from the iterated array.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1179,6 +1179,13 @@
 						{ "type": "null" }
 					]
 				},
+				"useForOf": {
+					"description": "This rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"useGroupedTypeImport": {
 					"description": "Enforce the use of import type when an import only has specifiers with type qualifier.",
 					"anyOf": [

--- a/website/src/components/generated/NumberOfRules.astro
+++ b/website/src/components/generated/NumberOfRules.astro
@@ -1,2 +1,2 @@
 <!-- this file is auto generated, use `cargo lintdoc` to update it -->
- <p>Biome's linter has a total of <strong><a href='/linter/rules'>178 rules</a></strong><p>
+ <p>Biome's linter has a total of <strong><a href='/linter/rules'>179 rules</a></strong><p>

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -233,6 +233,12 @@ The following rules are now deprecated:
 - Fix [#609](https://github.com/biomejs/biome/issues/609) `useExhaustiveDependencies`, by removing `useContext`, `useId` and `useSyncExternalStore` from the known hooks. Contributed by @msdlisper
 - Fix `useExhaustiveDependencies`, by removing `useContext`, `useId` and `useSyncExternalStore` from the known hooks. Contributed by @msdlisper
 
+#### New features
+
+- Add [useForOf](https://biomejs.dev/linter/rules/use-for-of) rule.
+  The rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.
+  Contributed by @victor-teles
+
 ### Parser
 
 #### Enhancements

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -34,6 +34,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### New features
 
+- Add [useForOf](https://biomejs.dev/linter/rules/use-for-of) rule.
+  The rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.
+  Contributed by @victor-teles
+
 #### Enhancement
 
 - Implements [#924](https://github.com/biomejs/biome/issues/924) and [#920](https://github.com/biomejs/biome/issues/920). [noUselessElse](https://biomejs.dev/linter/rules/no-useless-else) now ignores `else` clauses that follow at least one `if` statement that doesn't break early. Contributed by @Conaclos
@@ -232,12 +236,6 @@ The following rules are now deprecated:
 - Support more a11y roles and fix some methods for a11y lint rules Contributed @nissy-dev
 - Fix [#609](https://github.com/biomejs/biome/issues/609) `useExhaustiveDependencies`, by removing `useContext`, `useId` and `useSyncExternalStore` from the known hooks. Contributed by @msdlisper
 - Fix `useExhaustiveDependencies`, by removing `useContext`, `useId` and `useSyncExternalStore` from the known hooks. Contributed by @msdlisper
-
-#### New features
-
-- Add [useForOf](https://biomejs.dev/linter/rules/use-for-of) rule.
-  The rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.
-  Contributed by @victor-teles
 
 ### Parser
 

--- a/website/src/content/docs/linter/rules/index.mdx
+++ b/website/src/content/docs/linter/rules/index.mdx
@@ -236,7 +236,7 @@ Rules that belong to this group <strong>are not subject to semantic version</str
 | [noUnusedPrivateClassMembers](/linter/rules/no-unused-private-class-members) | Disallow unused private class members | <span aria-label="The rule has an unsafe fix" role="img" title="The rule has an unsafe fix">⚠️ </span> |
 | [noUselessLoneBlockStatements](/linter/rules/no-useless-lone-block-statements) | Disallow unnecessary nested block statements. | <span aria-label="The rule has an unsafe fix" role="img" title="The rule has an unsafe fix">⚠️ </span> |
 | [useAwait](/linter/rules/use-await) | Ensure <code>async</code> functions utilize <code>await</code>. |  |
-| [useForOf](/linter/rules/use-for-of) | This rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated. |  |
+| [useForOf](/linter/rules/use-for-of) | This rule recommends a <code>for-of</code> loop when in a <code>for</code> loop, the index used to extract an item from the iterated array. |  |
 | [useGroupedTypeImport](/linter/rules/use-grouped-type-import) | Enforce the use of <code>import type</code> when an <code>import</code> only has specifiers with <code>type</code> qualifier. | <span aria-label="The rule has an unsafe fix" role="img" title="The rule has an unsafe fix">⚠️ </span> |
 | [useImportRestrictions](/linter/rules/use-import-restrictions) | Disallows package private imports. |  |
 | [useRegexLiterals](/linter/rules/use-regex-literals) | Enforce the use of the regular expression literals instead of the RegExp constructor if possible. | <span aria-label="The rule has an unsafe fix" role="img" title="The rule has an unsafe fix">⚠️ </span> |

--- a/website/src/content/docs/linter/rules/index.mdx
+++ b/website/src/content/docs/linter/rules/index.mdx
@@ -236,6 +236,7 @@ Rules that belong to this group <strong>are not subject to semantic version</str
 | [noUnusedPrivateClassMembers](/linter/rules/no-unused-private-class-members) | Disallow unused private class members | <span aria-label="The rule has an unsafe fix" role="img" title="The rule has an unsafe fix">⚠️ </span> |
 | [noUselessLoneBlockStatements](/linter/rules/no-useless-lone-block-statements) | Disallow unnecessary nested block statements. | <span aria-label="The rule has an unsafe fix" role="img" title="The rule has an unsafe fix">⚠️ </span> |
 | [useAwait](/linter/rules/use-await) | Ensure <code>async</code> functions utilize <code>await</code>. |  |
+| [useForOf](/linter/rules/use-for-of) | This rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated. |  |
 | [useGroupedTypeImport](/linter/rules/use-grouped-type-import) | Enforce the use of <code>import type</code> when an <code>import</code> only has specifiers with <code>type</code> qualifier. | <span aria-label="The rule has an unsafe fix" role="img" title="The rule has an unsafe fix">⚠️ </span> |
 | [useImportRestrictions](/linter/rules/use-import-restrictions) | Disallows package private imports. |  |
 | [useRegexLiterals](/linter/rules/use-regex-literals) | Enforce the use of the regular expression literals instead of the RegExp constructor if possible. | <span aria-label="The rule has an unsafe fix" role="img" title="The rule has an unsafe fix">⚠️ </span> |

--- a/website/src/content/docs/linter/rules/use-for-of.md
+++ b/website/src/content/docs/linter/rules/use-for-of.md
@@ -1,5 +1,5 @@
 ---
-title: useForOf (since v1.4.0)
+title: useForOf (since vnext)
 ---
 
 **Diagnostic Category: `lint/nursery/useForOf`**
@@ -8,7 +8,7 @@ title: useForOf (since v1.4.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
-This rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.
+This rule recommends a `for-of` loop when in a `for` loop, the index used to extract an item from the iterated array.
 
 Source: https://typescript-eslint.io/rules/prefer-for-of/
 
@@ -45,12 +45,6 @@ for (let i = 0; i < array.length; i++) {
 
 ```jsx
 for (let i = 0, j = 0; i < array.length; i++) {
-   console.log(i, array[i]);
- }
-```
-
-```jsx
-for (let i = 1; i < array.length; i++) {
    console.log(i, array[i]);
  }
 ```

--- a/website/src/content/docs/linter/rules/use-for-of.md
+++ b/website/src/content/docs/linter/rules/use-for-of.md
@@ -1,0 +1,61 @@
+---
+title: useForOf (since v1.4.0)
+---
+
+**Diagnostic Category: `lint/nursery/useForOf`**
+
+:::caution
+This rule is part of the [nursery](/linter/rules/#nursery) group.
+:::
+
+This rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.
+
+Source: https://typescript-eslint.io/rules/prefer-for-of/
+
+## Examples
+
+### Invalid
+
+```jsx
+for (let i = 0; i < array.length; i++) {
+  console.log(array[i]);
+}
+```
+
+<pre class="language-text"><code class="language-text">nursery/useForOf.js:1:1 <a href="https://biomejs.dev/linter/rules/use-for-of">lint/nursery/useForOf</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Use </span><span style="color: Orange;"><strong>for-of</strong></span><span style="color: Orange;"> loop instead of a </span><span style="color: Orange;"><strong>for loop</strong></span><span style="color: Orange;">.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>for (let i = 0; i &lt; array.length; i++) {
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>  console.log(array[i]);
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>}
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>4 │ </strong>
+  
+</code></pre>
+
+## Valid
+
+```jsx
+for (let i = 0; i < array.length; i++) {
+   console.log(i, array[i]);
+ }
+```
+
+```jsx
+for (let i = 0, j = 0; i < array.length; i++) {
+   console.log(i, array[i]);
+ }
+```
+
+```jsx
+for (let i = 1; i < array.length; i++) {
+   console.log(i, array[i]);
+ }
+```
+
+## Related links
+
+- [Disable a rule](/linter/#disable-a-lint-rule)
+- [Rule options](/linter/#rule-options)


### PR DESCRIPTION
## Summary

This PR implements `useForOf` lint rule and closes #49


| Configuration  |  |
| ------------- | ------------- |
| Recommended  | ❌  |
| Fixable  |  ❌  |

### About this rule

This rule recommends a for-of loop when the loop index is only used to read from an array that is being iterated.

- [x] Skip diagnostic for multi initializers
- [x] Skip diagnostic when the initializer index don't start with 0
- [x] Only diagnostic when the `update` is incremented by one
- [x] Skip diagnostic when the initializer is being referenced
- [x] Skip diagnostic for test that not using `< array.length`
- [x] Skip diagnostic for globalThis in `test` 
- [x] Changelog entry
- [x] Add a basic documentation about semantic model


## Test Plan

- Validate snapshot 😄
- Run default tests

I've removed one original test from eslint-typescript  valid scenario because it's seems not valid code at all:
If you think we still need it, please lets discuss it


### Invalid assignment
```js
for (let i = 0; i < arr.length; i++) {
  ({ foo: arr[i] }) = { foo: 0 };
} 
```

![image](https://github.com/biomejs/biome/assets/78874691/35e10166-c97d-4234-8c5b-9c3e8358b643)
