### PR TITLE
feat(lint): Implement `noImplicitAnyLet`

### DIFF
--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -97,6 +97,7 @@ define_categories! {
     "lint/nursery/noDuplicateJsonKeys": "https://biomejs.dev/linter/rules/no-duplicate-json-keys",
     "lint/nursery/noEmptyBlockStatements": "https://biomejs.dev/linter/rules/no-empty-block-statements",
     "lint/nursery/noEmptyCharacterClassInRegex": "https://biomejs.dev/linter/rules/no-empty-character-class-in-regex",
+    "lint/nursery/noImplicitAnyLet": "https://biomejs.dev/lint/rules/no-implicit-any-let",
     "lint/nursery/noInteractiveElementToNoninteractiveRole": "https://biomejs.dev/linter/rules/no-interactive-element-to-noninteractive-role",
     "lint/nursery/noInvalidNewBuiltin": "https://biomejs.dev/linter/rules/no-invalid-new-builtin",
     "lint/nursery/noMisleadingInstantiator": "https://biomejs.dev/linter/rules/no-misleading-instantiator",

--- a/crates/biome_js_analyze/src/analyzers/nursery.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery.rs
@@ -6,6 +6,7 @@ pub(crate) mod no_approximative_numeric_constant;
 pub(crate) mod no_default_export;
 pub(crate) mod no_empty_block_statements;
 pub(crate) mod no_empty_character_class_in_regex;
+pub(crate) mod no_implicit_any_let;
 pub(crate) mod no_misleading_instantiator;
 pub(crate) mod no_misrefactored_shorthand_assign;
 pub(crate) mod no_unused_private_class_members;
@@ -26,6 +27,7 @@ declare_group! {
             self :: no_default_export :: NoDefaultExport ,
             self :: no_empty_block_statements :: NoEmptyBlockStatements ,
             self :: no_empty_character_class_in_regex :: NoEmptyCharacterClassInRegex ,
+            self :: no_implicit_any_let :: NoImplicitAnyLet ,
             self :: no_misleading_instantiator :: NoMisleadingInstantiator ,
             self :: no_misrefactored_shorthand_assign :: NoMisrefactoredShorthandAssign ,
             self :: no_unused_private_class_members :: NoUnusedPrivateClassMembers ,

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_implicit_any_let.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_implicit_any_let.rs
@@ -5,7 +5,10 @@ use biome_js_syntax::{JsFileSource, JsVariableDeclaration, JsVariableDeclarator}
 declare_rule! {
     /// Disallow use of implicit `any` type on variable declarations.
     ///
-    /// Typescript variable declaration without any `type` or `initialization` can cause issue later in the code.
+    /// TypeScript variable declaration without any type annotation and initialization have the `any` type.
+    /// The any type in TypeScript is a dangerous “escape hatch” from the type system.
+    /// Using any disables many type checking rules and is generally best used only as a last resort or when prototyping code.
+    /// TypeScript’s `--noImplicitAny` compiler option doesn't report this case.
     ///
     ///
     ///

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_implicit_any_let.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_implicit_any_let.rs
@@ -1,0 +1,93 @@
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_console::markup;
+use biome_js_syntax::{JsFileSource, JsVariableDeclaration, JsVariableDeclarator};
+
+declare_rule! {
+    /// Disallow use of implicit `any` type on variable declarations.
+    ///
+    /// Typescript variable declaration without any `type` or `initialization` can cause issue later in the code.
+    ///
+    ///
+    ///
+    /// Source: https://www.typescriptlang.org/tsconfig#noImplicitAny
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```ts,expect_diagnostic
+    /// var a;
+    /// a = 2;
+    /// ````
+    ///
+    /// ```ts,expect_diagnostic
+    /// let b;
+    /// b = 1
+    /// ```
+    ///
+    /// ## Valid
+    ///
+    /// ```ts
+    /// var a = 1;
+    /// let a:number;
+    /// var b: number
+    /// var b =10;
+    /// ```
+    ///
+    pub(crate) NoImplicitAnyLet {
+        version: "next",
+        name: "noImplicitAnyLet",
+        recommended: true,
+    }
+}
+
+impl Rule for NoImplicitAnyLet {
+    type Query = Ast<JsVariableDeclaration>;
+    type State = JsVariableDeclarator;
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let source_type = ctx.source_type::<JsFileSource>().language();
+        let is_ts_source = source_type.is_typescript();
+        let node = ctx.query();
+        let is_declaration = source_type.is_definition_file();
+
+        if node.is_const() || is_declaration || !is_ts_source {
+            return None;
+        }
+
+        for declarator in node.declarators() {
+            let variable = declarator.ok()?;
+            let is_initialized = variable.initializer().is_some();
+            let is_type_annotated = variable.variable_annotation().is_some();
+            if !is_initialized && !is_type_annotated {
+                return Some(variable);
+            }
+        }
+
+        None
+    }
+
+    fn diagnostic(_: &RuleContext<Self>, node: &Self::State) -> Option<RuleDiagnostic> {
+        let variable = node
+            .id()
+            .ok()?
+            .as_any_js_binding()?
+            .as_js_identifier_binding()?
+            .name_token()
+            .ok()?;
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                variable.text_range(),
+                markup! {
+                    "This variable has implicitly the " <Emphasis>"any"</Emphasis> " type."
+                },
+            )
+            .note(markup! {
+                "Variable declarations without type annotation and initialization have implicitly the "<Emphasis>"any"</Emphasis>" type. Declare type or initialize the variable with some value."
+            }),
+        )
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noImplicitAnyLet/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImplicitAnyLet/invalid.ts
@@ -5,3 +5,11 @@ someVar1 = 123;
 var someVar1;
 someVar1 = '123';
 someVar1 = 123;
+
+let x = 0, y, z = 0;
+var x = 0, y, z = 0;
+for(let a = 0, b; a < 5; a++) {}
+
+function ex() {
+    let b;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noImplicitAnyLet/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImplicitAnyLet/invalid.ts
@@ -1,0 +1,7 @@
+let someVar1;
+someVar1 = '123';
+someVar1 = 123;
+
+var someVar1;
+someVar1 = '123';
+someVar1 = 123;

--- a/crates/biome_js_analyze/tests/specs/nursery/noImplicitAnyLet/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImplicitAnyLet/invalid.ts.snap
@@ -1,0 +1,124 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+---
+# Input
+```js
+let someVar1;
+someVar1 = '123';
+someVar1 = 123;
+
+var someVar1;
+someVar1 = '123';
+someVar1 = 123;
+
+let x = 0, y, z = 0;
+var x = 0, y, z = 0;
+for(let a = 0, b; a < 5; a++) {}
+
+function ex() {
+    let b;
+}
+
+```
+
+# Diagnostics
+```
+invalid.ts:1:5 lint/nursery/noImplicitAnyLet ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable has implicitly the any type.
+  
+  > 1 │ let someVar1;
+      │     ^^^^^^^^
+    2 │ someVar1 = '123';
+    3 │ someVar1 = 123;
+  
+  i Variable declarations without type annotation and initialization have implicitly the any type. Declare type or initialize the variable with some value.
+  
+
+```
+
+```
+invalid.ts:5:5 lint/nursery/noImplicitAnyLet ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable has implicitly the any type.
+  
+    3 │ someVar1 = 123;
+    4 │ 
+  > 5 │ var someVar1;
+      │     ^^^^^^^^
+    6 │ someVar1 = '123';
+    7 │ someVar1 = 123;
+  
+  i Variable declarations without type annotation and initialization have implicitly the any type. Declare type or initialize the variable with some value.
+  
+
+```
+
+```
+invalid.ts:9:12 lint/nursery/noImplicitAnyLet ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable has implicitly the any type.
+  
+     7 │ someVar1 = 123;
+     8 │ 
+   > 9 │ let x = 0, y, z = 0;
+       │            ^
+    10 │ var x = 0, y, z = 0;
+    11 │ for(let a = 0, b; a < 5; a++) {}
+  
+  i Variable declarations without type annotation and initialization have implicitly the any type. Declare type or initialize the variable with some value.
+  
+
+```
+
+```
+invalid.ts:10:12 lint/nursery/noImplicitAnyLet ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable has implicitly the any type.
+  
+     9 │ let x = 0, y, z = 0;
+  > 10 │ var x = 0, y, z = 0;
+       │            ^
+    11 │ for(let a = 0, b; a < 5; a++) {}
+    12 │ 
+  
+  i Variable declarations without type annotation and initialization have implicitly the any type. Declare type or initialize the variable with some value.
+  
+
+```
+
+```
+invalid.ts:11:16 lint/nursery/noImplicitAnyLet ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable has implicitly the any type.
+  
+     9 │ let x = 0, y, z = 0;
+    10 │ var x = 0, y, z = 0;
+  > 11 │ for(let a = 0, b; a < 5; a++) {}
+       │                ^
+    12 │ 
+    13 │ function ex() {
+  
+  i Variable declarations without type annotation and initialization have implicitly the any type. Declare type or initialize the variable with some value.
+  
+
+```
+
+```
+invalid.ts:14:9 lint/nursery/noImplicitAnyLet ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable has implicitly the any type.
+  
+    13 │ function ex() {
+  > 14 │     let b;
+       │         ^
+    15 │ }
+    16 │ 
+  
+  i Variable declarations without type annotation and initialization have implicitly the any type. Declare type or initialize the variable with some value.
+  
+
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/noImplicitAnyLet/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImplicitAnyLet/valid.ts
@@ -1,0 +1,6 @@
+/* should not generate diagnostics */
+
+let a: number;
+let b = 1
+var c : string;
+var d = "abn"

--- a/crates/biome_js_analyze/tests/specs/nursery/noImplicitAnyLet/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImplicitAnyLet/valid.ts
@@ -4,3 +4,7 @@ let a: number;
 let b = 1
 var c : string;
 var d = "abn"
+
+const x = 0;
+for(let y of xs) {}
+using z = f();

--- a/crates/biome_js_analyze/tests/specs/nursery/noImplicitAnyLet/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImplicitAnyLet/valid.ts.snap
@@ -1,0 +1,20 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```js
+/* should not generate diagnostics */
+
+let a: number;
+let b = 1
+var c : string;
+var d = "abn"
+
+const x = 0;
+for(let y of xs) {}
+using z = f();
+
+```
+
+

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -2625,6 +2625,10 @@ pub struct Nursery {
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_empty_character_class_in_regex: Option<RuleConfiguration>,
+    #[doc = "Disallow use of implicit any type on variable declarations."]
+    #[bpaf(long("no-implicit-any-let"), argument("on|off|warn"), optional, hide)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_implicit_any_let: Option<RuleConfiguration>,
     #[doc = "Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements."]
     #[bpaf(
         long("no-interactive-element-to-noninteractive-role"),
@@ -2634,10 +2638,6 @@ pub struct Nursery {
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_interactive_element_to_noninteractive_role: Option<RuleConfiguration>,
-    #[doc = "Restrict use of implicit any type in Typescript."]
-    #[bpaf(long("no-implicit-any-let"), argument("on|off|warn"), optional, hide)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_implicit_any_let: Option<RuleConfiguration>,
     #[doc = "Disallow new operators with global non-constructor functions."]
     #[bpaf(
         long("no-invalid-new-builtin"),
@@ -2765,6 +2765,9 @@ impl MergeWith<Nursery> for Nursery {
         if let Some(no_empty_character_class_in_regex) = other.no_empty_character_class_in_regex {
             self.no_empty_character_class_in_regex = Some(no_empty_character_class_in_regex);
         }
+        if let Some(no_implicit_any_let) = other.no_implicit_any_let {
+            self.no_implicit_any_let = Some(no_implicit_any_let);
+        }
         if let Some(no_interactive_element_to_noninteractive_role) =
             other.no_interactive_element_to_noninteractive_role
         {
@@ -2876,16 +2879,16 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
     ];
-    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 22] = [
+    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 23] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
@@ -2908,6 +2911,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended(&self) -> bool {
@@ -2949,89 +2953,94 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
             }
         }
-        if let Some(rule) = self.no_interactive_element_to_noninteractive_role.as_ref() {
+        if let Some(rule) = self.no_implicit_any_let.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
             }
         }
-        if let Some(rule) = self.no_invalid_new_builtin.as_ref() {
+        if let Some(rule) = self.no_interactive_element_to_noninteractive_role.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
             }
         }
-        if let Some(rule) = self.no_implicit_any_let.as_ref() {
+        if let Some(rule) = self.no_invalid_new_builtin.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
             }
         }
-        if let Some(rule) = self.no_misrefactored_shorthand_assign.as_ref() {
+        if let Some(rule) = self.no_misleading_instantiator.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
             }
         }
-        if let Some(rule) = self.no_this_in_static.as_ref() {
+        if let Some(rule) = self.no_misrefactored_shorthand_assign.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
             }
         }
-        if let Some(rule) = self.no_unused_imports.as_ref() {
+        if let Some(rule) = self.no_this_in_static.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.no_unused_private_class_members.as_ref() {
+        if let Some(rule) = self.no_unused_imports.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.no_useless_else.as_ref() {
+        if let Some(rule) = self.no_unused_private_class_members.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.no_useless_lone_block_statements.as_ref() {
+        if let Some(rule) = self.no_useless_else.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.use_aria_activedescendant_with_tabindex.as_ref() {
+        if let Some(rule) = self.no_useless_lone_block_statements.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.use_arrow_function.as_ref() {
+        if let Some(rule) = self.use_aria_activedescendant_with_tabindex.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.use_as_const_assertion.as_ref() {
+        if let Some(rule) = self.use_arrow_function.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.use_await.as_ref() {
+        if let Some(rule) = self.use_as_const_assertion.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_await.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.use_shorthand_assign.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+        if let Some(rule) = self.use_shorthand_assign.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
+            }
+        }
+        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
         index_set
@@ -3063,89 +3072,94 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
             }
         }
-        if let Some(rule) = self.no_interactive_element_to_noninteractive_role.as_ref() {
+        if let Some(rule) = self.no_implicit_any_let.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
             }
         }
-        if let Some(rule) = self.no_invalid_new_builtin.as_ref() {
+        if let Some(rule) = self.no_interactive_element_to_noninteractive_role.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
             }
         }
-        if let Some(rule) = self.no_implicit_any_let.as_ref() {
+        if let Some(rule) = self.no_invalid_new_builtin.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
             }
         }
-        if let Some(rule) = self.no_misrefactored_shorthand_assign.as_ref() {
+        if let Some(rule) = self.no_misleading_instantiator.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
             }
         }
-        if let Some(rule) = self.no_this_in_static.as_ref() {
+        if let Some(rule) = self.no_misrefactored_shorthand_assign.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
             }
         }
-        if let Some(rule) = self.no_unused_imports.as_ref() {
+        if let Some(rule) = self.no_this_in_static.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.no_unused_private_class_members.as_ref() {
+        if let Some(rule) = self.no_unused_imports.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.no_useless_else.as_ref() {
+        if let Some(rule) = self.no_unused_private_class_members.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.no_useless_lone_block_statements.as_ref() {
+        if let Some(rule) = self.no_useless_else.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.use_aria_activedescendant_with_tabindex.as_ref() {
+        if let Some(rule) = self.no_useless_lone_block_statements.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.use_arrow_function.as_ref() {
+        if let Some(rule) = self.use_aria_activedescendant_with_tabindex.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.use_as_const_assertion.as_ref() {
+        if let Some(rule) = self.use_arrow_function.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.use_await.as_ref() {
+        if let Some(rule) = self.use_as_const_assertion.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_await.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.use_shorthand_assign.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+        if let Some(rule) = self.use_shorthand_assign.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
+            }
+        }
+        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
         index_set
@@ -3161,7 +3175,7 @@ impl Nursery {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 11] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 22] {
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 23] {
         Self::ALL_RULES_AS_FILTERS
     }
     #[doc = r" Select preset rules"]
@@ -3189,10 +3203,10 @@ impl Nursery {
             "noDuplicateJsonKeys" => self.no_duplicate_json_keys.as_ref(),
             "noEmptyBlockStatements" => self.no_empty_block_statements.as_ref(),
             "noEmptyCharacterClassInRegex" => self.no_empty_character_class_in_regex.as_ref(),
+            "noImplicitAnyLet" => self.no_implicit_any_let.as_ref(),
             "noInteractiveElementToNoninteractiveRole" => {
                 self.no_interactive_element_to_noninteractive_role.as_ref()
             }
-            "noImplicitAnyLet" => self.no_implicit_any_let.as_ref(),
             "noInvalidNewBuiltin" => self.no_invalid_new_builtin.as_ref(),
             "noMisleadingInstantiator" => self.no_misleading_instantiator.as_ref(),
             "noMisrefactoredShorthandAssign" => self.no_misrefactored_shorthand_assign.as_ref(),

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -2634,6 +2634,10 @@ pub struct Nursery {
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_interactive_element_to_noninteractive_role: Option<RuleConfiguration>,
+    #[doc = "Restrict use of implicit any type in Typescript."]
+    #[bpaf(long("no-implicit-any-let"), argument("on|off|warn"), optional, hide)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_implicit_any_let: Option<RuleConfiguration>,
     #[doc = "Disallow new operators with global non-constructor functions."]
     #[bpaf(
         long("no-invalid-new-builtin"),
@@ -2830,12 +2834,13 @@ impl MergeWith<Nursery> for Nursery {
 }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
-    pub(crate) const GROUP_RULES: [&'static str; 22] = [
+    pub(crate) const GROUP_RULES: [&'static str; 23] = [
         "noApproximativeNumericConstant",
         "noDefaultExport",
         "noDuplicateJsonKeys",
         "noEmptyBlockStatements",
         "noEmptyCharacterClassInRegex",
+        "noImplicitAnyLet",
         "noInteractiveElementToNoninteractiveRole",
         "noInvalidNewBuiltin",
         "noMisleadingInstantiator",
@@ -2854,9 +2859,10 @@ impl Nursery {
         "useShorthandAssign",
         "useValidAriaRole",
     ];
-    const RECOMMENDED_RULES: [&'static str; 10] = [
+    const RECOMMENDED_RULES: [&'static str; 11] = [
         "noDuplicateJsonKeys",
         "noEmptyCharacterClassInRegex",
+        "noImplicitAnyLet",
         "noInvalidNewBuiltin",
         "noMisleadingInstantiator",
         "noUselessElse",
@@ -2866,9 +2872,10 @@ impl Nursery {
         "useGroupedTypeImport",
         "useValidAriaRole",
     ];
-    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 10] = [
+    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 11] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
@@ -2952,7 +2959,7 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
             }
         }
-        if let Some(rule) = self.no_misleading_instantiator.as_ref() {
+        if let Some(rule) = self.no_implicit_any_let.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
             }
@@ -3066,7 +3073,7 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
             }
         }
-        if let Some(rule) = self.no_misleading_instantiator.as_ref() {
+        if let Some(rule) = self.no_implicit_any_let.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
             }
@@ -3151,7 +3158,7 @@ impl Nursery {
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
     }
-    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 10] {
+    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 11] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
     pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 22] {
@@ -3185,6 +3192,7 @@ impl Nursery {
             "noInteractiveElementToNoninteractiveRole" => {
                 self.no_interactive_element_to_noninteractive_role.as_ref()
             }
+            "noImplicitAnyLet" => self.no_implicit_any_let.as_ref(),
             "noInvalidNewBuiltin" => self.no_invalid_new_builtin.as_ref(),
             "noMisleadingInstantiator" => self.no_misleading_instantiator.as_ref(),
             "noMisrefactoredShorthandAssign" => self.no_misrefactored_shorthand_assign.as_ref(),

--- a/crates/biome_service/src/configuration/parse/json/rules.rs
+++ b/crates/biome_service/src/configuration/parse/json/rules.rs
@@ -890,6 +890,13 @@ impl Deserializable for Nursery {
                                 diagnostics,
                             );
                         }
+                        "noImplicitAnyLet" => {
+                            result.no_implicit_any_let = Deserializable::deserialize(
+                                &value,
+                                "noImplicitAnyLet",
+                                diagnostics,
+                            );
+                        }
                         "noInteractiveElementToNoninteractiveRole" => {
                             result.no_interactive_element_to_noninteractive_role =
                                 Deserializable::deserialize(
@@ -1011,6 +1018,7 @@ impl Deserializable for Nursery {
                                     "noDuplicateJsonKeys",
                                     "noEmptyBlockStatements",
                                     "noEmptyCharacterClassInRegex",
+                                    "noImplicitAnyLet",
                                     "noInteractiveElementToNoninteractiveRole",
                                     "noInvalidNewBuiltin",
                                     "noMisleadingInstantiator",

--- a/crates/biome_service/tests/invalid/hooks_incorrect_options.json.snap
+++ b/crates/biome_service/tests/invalid/hooks_incorrect_options.json.snap
@@ -22,6 +22,7 @@ hooks_incorrect_options.json:6:5 deserialize ━━━━━━━━━━━�
   - noDuplicateJsonKeys
   - noEmptyBlockStatements
   - noEmptyCharacterClassInRegex
+  - noImplicitAnyLet
   - noInteractiveElementToNoninteractiveRole
   - noInvalidNewBuiltin
   - noMisleadingInstantiator

--- a/crates/biome_service/tests/invalid/hooks_missing_name.json.snap
+++ b/crates/biome_service/tests/invalid/hooks_missing_name.json.snap
@@ -22,6 +22,7 @@ hooks_missing_name.json:6:5 deserialize ━━━━━━━━━━━━━�
   - noDuplicateJsonKeys
   - noEmptyBlockStatements
   - noEmptyCharacterClassInRegex
+  - noImplicitAnyLet
   - noInteractiveElementToNoninteractiveRole
   - noInvalidNewBuiltin
   - noMisleadingInstantiator

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -1065,6 +1065,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noImplicitAnyLet": {
+					"description": "Disallow use of implicit any type on variable declarations.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noInteractiveElementToNoninteractiveRole": {
 					"description": "Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements.",
 					"anyOf": [

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -761,6 +761,10 @@ export interface Nursery {
 	 */
 	noInvalidNewBuiltin?: RuleConfiguration;
 	/**
+	 * Restrict use of implicit any type in Typescript.
+	 */
+	noImplicitAnyLet?: RuleConfiguration;
+	/**
 	 * Enforce proper usage of new and constructor.
 	 */
 	noMisleadingInstantiator?: RuleConfiguration;
@@ -1458,6 +1462,7 @@ export type Category =
 	| "lint/nursery/noDuplicateJsonKeys"
 	| "lint/nursery/noEmptyBlockStatements"
 	| "lint/nursery/noEmptyCharacterClassInRegex"
+	| "lint/nursery/noImplicitAnyLet"
 	| "lint/nursery/noInteractiveElementToNoninteractiveRole"
 	| "lint/nursery/noInvalidNewBuiltin"
 	| "lint/nursery/noMisleadingInstantiator"

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -753,6 +753,10 @@ export interface Nursery {
 	 */
 	noEmptyCharacterClassInRegex?: RuleConfiguration;
 	/**
+	 * Disallow use of implicit any type on variable declarations.
+	 */
+	noImplicitAnyLet?: RuleConfiguration;
+	/**
 	 * Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements.
 	 */
 	noInteractiveElementToNoninteractiveRole?: RuleConfiguration;
@@ -760,10 +764,6 @@ export interface Nursery {
 	 * Disallow new operators with global non-constructor functions.
 	 */
 	noInvalidNewBuiltin?: RuleConfiguration;
-	/**
-	 * Restrict use of implicit any type in Typescript.
-	 */
-	noImplicitAnyLet?: RuleConfiguration;
 	/**
 	 * Enforce proper usage of new and constructor.
 	 */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1065,6 +1065,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noImplicitAnyLet": {
+					"description": "Disallow use of implicit any type on variable declarations.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noInteractiveElementToNoninteractiveRole": {
 					"description": "Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements.",
 					"anyOf": [
@@ -1074,13 +1081,6 @@
 				},
 				"noInvalidNewBuiltin": {
 					"description": "Disallow new operators with global non-constructor functions.",
-					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
-						{ "type": "null" }
-					]
-				},
-				"noImplicitAnyLet": {
-					"description": "Restrict use of implicit any type in Typescript.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1079,6 +1079,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noImplicitAnyLet": {
+					"description": "Restrict use of implicit any type in Typescript.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noMisleadingInstantiator": {
 					"description": "Enforce proper usage of new and constructor.",
 					"anyOf": [

--- a/website/src/components/generated/NumberOfRules.astro
+++ b/website/src/components/generated/NumberOfRules.astro
@@ -1,2 +1,2 @@
 <!-- this file is auto generated, use `cargo lintdoc` to update it -->
- <p>Biome's linter has a total of <strong><a href='/linter/rules'>175 rules</a></strong><p>
+ <p>Biome's linter has a total of <strong><a href='/linter/rules'>176 rules</a></strong><p>

--- a/website/src/content/docs/linter/rules/index.mdx
+++ b/website/src/content/docs/linter/rules/index.mdx
@@ -220,6 +220,7 @@ Rules that belong to this group <strong>are not subject to semantic version</str
 | [noDuplicateJsonKeys](/linter/rules/no-duplicate-json-keys) | Disallow two keys with the same name inside a JSON object. |  |
 | [noEmptyBlockStatements](/linter/rules/no-empty-block-statements) | Disallow empty block statements and static blocks. |  |
 | [noEmptyCharacterClassInRegex](/linter/rules/no-empty-character-class-in-regex) | Disallow empty character classes in regular expression literals. |  |
+| [noImplicitAnyLet](/linter/rules/no-implicit-any-let) | Disallow use of implicit <code>any</code> type on variable declarations. |  |
 | [noInteractiveElementToNoninteractiveRole](/linter/rules/no-interactive-element-to-noninteractive-role) | Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements. |  |
 | [noInvalidNewBuiltin](/linter/rules/no-invalid-new-builtin) | Disallow <code>new</code> operators with global non-constructor functions. | <span aria-label="The rule has an unsafe fix" role="img" title="The rule has an unsafe fix">⚠️ </span> |
 | [noMisleadingInstantiator](/linter/rules/no-misleading-instantiator) | Enforce proper usage of <code>new</code> and <code>constructor</code>. |  |

--- a/website/src/content/docs/linter/rules/no-implicit-any-let.md
+++ b/website/src/content/docs/linter/rules/no-implicit-any-let.md
@@ -1,0 +1,69 @@
+---
+title: noImplicitAnyLet (since vnext)
+---
+
+**Diagnostic Category: `lint/nursery/noImplicitAnyLet`**
+
+:::caution
+This rule is part of the [nursery](/linter/rules/#nursery) group.
+:::
+
+Disallow use of implicit `any` type on variable declarations.
+
+Typescript variable declaration without any `type` or `initialization` can cause issue later in the code.
+
+Source: https://www.typescriptlang.org/tsconfig#noImplicitAny
+
+## Examples
+
+### Invalid
+
+```ts
+var a;
+a = 2;
+```
+
+<pre class="language-text"><code class="language-text">nursery/noImplicitAnyLet.js:1:5 <a href="https://biomejs.dev/lint/rules/no-implicit-any-let">lint/nursery/noImplicitAnyLet</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This variable has implicitly the </span><span style="color: Tomato;"><strong>any</strong></span><span style="color: Tomato;"> type.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>var a;
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>a = 2;
+    <strong>3 │ </strong>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Variable declarations without type annotation and initialization have implicitly the </span><span style="color: lightgreen;"><strong>any</strong></span><span style="color: lightgreen;"> type. Declare type or initialize the variable with some value.</span>
+  
+</code></pre>
+
+```ts
+let b;
+b = 1
+```
+
+<pre class="language-text"><code class="language-text">nursery/noImplicitAnyLet.js:1:5 <a href="https://biomejs.dev/lint/rules/no-implicit-any-let">lint/nursery/noImplicitAnyLet</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This variable has implicitly the </span><span style="color: Tomato;"><strong>any</strong></span><span style="color: Tomato;"> type.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>let b;
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>b = 1
+    <strong>3 │ </strong>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Variable declarations without type annotation and initialization have implicitly the </span><span style="color: lightgreen;"><strong>any</strong></span><span style="color: lightgreen;"> type. Declare type or initialize the variable with some value.</span>
+  
+</code></pre>
+
+## Valid
+
+```ts
+var a = 1;
+let a:number;
+var b: number
+var b =10;
+```
+
+## Related links
+
+- [Disable a rule](/linter/#disable-a-lint-rule)
+- [Rule options](/linter/#rule-options)

--- a/website/src/content/docs/linter/rules/no-implicit-any-let.md
+++ b/website/src/content/docs/linter/rules/no-implicit-any-let.md
@@ -10,7 +10,10 @@ This rule is part of the [nursery](/linter/rules/#nursery) group.
 
 Disallow use of implicit `any` type on variable declarations.
 
-Typescript variable declaration without any `type` or `initialization` can cause issue later in the code.
+TypeScript variable declaration without any type annotation and initialization have the `any` type.
+The any type in TypeScript is a dangerous “escape hatch” from the type system.
+Using any disables many type checking rules and is generally best used only as a last resort or when prototyping code.
+TypeScript’s `--noImplicitAny` compiler option doesn't report this case.
 
 Source: https://www.typescriptlang.org/tsconfig#noImplicitAny
 

--- a/website/src/frontend-scripts/index.ts
+++ b/website/src/frontend-scripts/index.ts
@@ -12,7 +12,7 @@ import { getCurrentTheme, matchesDark, setCurrentTheme } from "./util";
  */
 function randomShuffle<T>(array: T[]): T[] {
 	let count = array.length;
-	let index;
+	let index: number;
 	while (count) {
 		index = Math.floor(Math.random() * count--);
 		const temp = array[count]!;

--- a/website/src/frontend-scripts/toc.ts
+++ b/website/src/frontend-scripts/toc.ts
@@ -111,7 +111,7 @@ class Manager {
 
 		// Calculate when this heading ends. It's either at the beginning of the next heading, or page bottom.
 		const start = this.getHeadingTop(heading);
-		let end;
+		let end: number;
 
 		const nextHeading = headingElements[i + 1];
 		if (nextHeading) {

--- a/website/src/playground/tabs/FormatterCodeTab.tsx
+++ b/website/src/playground/tabs/FormatterCodeTab.tsx
@@ -48,7 +48,7 @@ export default function FormatterCodeTab({
 	prettier,
 	extensions,
 }: Props) {
-	let hint;
+	let hint: string | JSX.Element;
 	if (prettier.type === "SUCCESS") {
 		hint = calculateHint(prettier.code, biome);
 	} else {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

closes #389

closes #395

This implements a new rule to restrict the usage of variables without any type or initialisation in TS.

ref: https://www.typescriptlang.org/tsconfig#noImplicitAny

I have taken over #395. Thank you for the work @b4s36t4.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

All existing tests should pass. #395 has added some test cases for valid and invalid situation and I've improved them. 
In addition, I have corrected all the issues pointed out in #395 for now.