### PR TITLE
challenge(formatter): predictable order of type parameter modifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "smallvec",
  "tests_macros",
  "tracing",
  "unicode-width",

--- a/crates/biome_js_formatter/Cargo.toml
+++ b/crates/biome_js_formatter/Cargo.toml
@@ -25,6 +25,7 @@ biome_text_size              = { workspace = true }
 cfg-if                       = "1.0.0"
 schemars                     = { workspace = true, optional = true }
 serde                        = { workspace = true, features = ["derive"], optional = true }
+smallvec                     = { workspace = true }
 tracing                      = { workspace = true }
 unicode-width                = "0.1.9"
 

--- a/crates/biome_js_formatter/src/ts/lists/type_parameter_modifier_list.rs
+++ b/crates/biome_js_formatter/src/ts/lists/type_parameter_modifier_list.rs
@@ -1,5 +1,9 @@
 use crate::prelude::*;
-use biome_js_syntax::TsTypeParameterModifierList;
+use biome_js_syntax::{
+    AnyTsTypeParameterModifier, TsTypeParameterModifierList, TypeParameterModifiers,
+};
+use biome_rowan::AstNodeList;
+use smallvec::SmallVec;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatTsTypeParameterModifierList;
@@ -7,8 +11,18 @@ pub(crate) struct FormatTsTypeParameterModifierList;
 impl FormatRule<TsTypeParameterModifierList> for FormatTsTypeParameterModifierList {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsTypeParameterModifierList, f: &mut JsFormatter) -> FormatResult<()> {
+        let modifiers = sort_modifiers_by_precedence(node);
         f.join_with(&space())
-            .entries(node.iter().formatted())
+            .entries(modifiers.into_iter().formatted())
             .finish()
     }
+}
+
+/// This function consumes a list of modifiers and applies a predictable sorting.
+fn sort_modifiers_by_precedence(
+    list: &TsTypeParameterModifierList,
+) -> SmallVec<[AnyTsTypeParameterModifier; 3]> {
+    let mut result = list.iter().collect::<SmallVec<_>>();
+    result.sort_unstable_by_key(|node| TypeParameterModifiers::from(node));
+    result
 }

--- a/crates/biome_js_formatter/tests/specs/prettier/typescript/typeparams/const.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/prettier/typescript/typeparams/const.ts.snap
@@ -56,20 +56,7 @@ class _ {
  <const T extends U>() => {};
  (function <const T>() {});
  (function <const T extends U>() {});
-@@ -11,18 +11,18 @@
- class A<const T> {}
- class B<const T extends U> {}
- class C<T, const U> {}
--class D<const in T> {}
-+class D<in const T> {}
- class E<const in T> {}
- (class<const T> {});
- (class<const T extends U> {});
- (class<T, const U> {});
--(class<const in T> {});
-+(class<in const T> {});
- (class<const in T> {});
- 
+@@ -22,7 +22,7 @@
  interface I<const T> {}
  interface J<const T extends U> {}
  interface K<T, const U> {}
@@ -96,12 +83,12 @@ declare function d<const T>();
 class A<const T> {}
 class B<const T extends U> {}
 class C<T, const U> {}
-class D<in const T> {}
+class D<const in T> {}
 class E<const in T> {}
 (class<const T> {});
 (class<const T extends U> {});
 (class<T, const U> {});
-(class<in const T> {});
+(class<const in T> {});
 (class<const in T> {});
 
 interface I<const T> {}

--- a/crates/biome_js_syntax/src/modifier_ext.rs
+++ b/crates/biome_js_syntax/src/modifier_ext.rs
@@ -1,10 +1,10 @@
 use crate::{
     AnyJsMethodModifier, AnyJsPropertyModifier, AnyTsIndexSignatureModifier,
     AnyTsMethodSignatureModifier, AnyTsPropertyParameterModifier, AnyTsPropertySignatureModifier,
-    JsSyntaxKind, TsAccessibilityModifier,
+    AnyTsTypeParameterModifier, JsSyntaxKind, TsAccessibilityModifier,
 };
 
-/// Helpful data structure to make the order modifiers predictable inside the formatter
+/// Helpful data structure to make the order of modifiers predictable inside the formatter
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum Modifiers {
     // modifiers must be sorted by precedence.
@@ -84,6 +84,24 @@ impl From<&AnyTsPropertySignatureModifier> for Modifiers {
             AnyTsPropertySignatureModifier::TsAbstractModifier(_) => Modifiers::Abstract,
             AnyTsPropertySignatureModifier::TsOverrideModifier(_) => Modifiers::Override,
             AnyTsPropertySignatureModifier::TsReadonlyModifier(_) => Modifiers::Readonly,
+        }
+    }
+}
+
+/// Helpful data structure to make the order of type parameter modifiers predictable inside the formatter
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub enum TypeParameterModifiers {
+    Const,
+    In,
+    Out,
+}
+
+impl From<&AnyTsTypeParameterModifier> for TypeParameterModifiers {
+    fn from(modifier: &AnyTsTypeParameterModifier) -> Self {
+        match modifier {
+            AnyTsTypeParameterModifier::TsConstModifier(_) => Self::Const,
+            AnyTsTypeParameterModifier::TsInModifier(_) => Self::In,
+            AnyTsTypeParameterModifier::TsOutModifier(_) => Self::Out,
         }
     }
 }


### PR DESCRIPTION
## Summary

Fix #717

This PR adds a predictable order for Type parameter modifiers (`const`, `in`, `out`).

Prettier also format a bogus node (`const` is not allowed for type parameter of interfaces):

```ts
interface L<in const T> {}
```

Thus, Biome doesn't turn `in const` into `const in`.

## Test Plan

Updated prettier diff.

