### PR TITLE
challenge(formatter): ignore embdedded languages and unstable syntaxes

### DIFF
--- a/crates/biome_formatter_test/src/diff_report.rs
+++ b/crates/biome_formatter_test/src/diff_report.rs
@@ -103,26 +103,35 @@ impl DiffReport {
     }
 
     fn is_ignored(file_name: &str) -> bool {
+        // ignore unstable syntaxes and embedded languages in template literals
         let patterns = [
             "arrows-bind",
             "async-do-expressions",
-            "async-do-expressions.js",
-            "decimal.js",
-            "do-expressions.js",
+            "async-do-expressions",
+            "decimal",
+            "do-expressions",
             "export-default-from",
-            "function-bind.js",
+            "function-bind",
             "module-blocks",
             "partial-application",
             "pipeline",
             "record",
-            "throw-expressions.js",
-            "v8intrinsic.js",
+            "throw-expressions",
+            "v8intrinsic",
             "v8_intrinsic",
             "bind-expressions",
             "destructuring-private-fields",
             "/do/",
             "export-extension",
             "js/tuple",
+            "deferred-import-evaluation", // `import defer` syntax
+            "source-phase-imports",       // `import source` syntax
+            "import-reflection",          // `import module` syntax
+            // embedded languages in template literals
+            "js/multiparser",
+            "js/range/issue-7082.js",
+            "js/template-literals/css-prop.js",
+            "js/template-literals/styled",
         ];
 
         patterns.iter().any(|pattern| file_name.contains(pattern))


### PR DESCRIPTION
## Summary

Embedded languages in template literals and unstable syntaxes are not part of the challenge.
