### PR TITLE
feat(css_parser): CSS Parser pseudo element selector #268

### DIFF
--- a/crates/biome_css_parser/src/lexer/mod.rs
+++ b/crates/biome_css_parser/src/lexer/mod.rs
@@ -2,6 +2,7 @@
 #[rustfmt::skip]
 mod tests;
 
+use crate::CssParserOptions;
 use biome_css_syntax::{CssSyntaxKind, CssSyntaxKind::*, TextLen, TextRange, TextSize, T};
 use biome_js_unicode_table::{is_id_continue, is_id_start, lookup_byte, Dispatch::*};
 use biome_parser::diagnostic::ParseDiagnostic;
@@ -52,6 +53,8 @@ pub(crate) struct CssLexer<'src> {
     current_flags: TokenFlags,
 
     diagnostics: Vec<ParseDiagnostic>,
+
+    config: CssParserOptions,
 }
 
 impl<'src> Lexer<'src> for CssLexer<'src> {
@@ -172,7 +175,12 @@ impl<'src> CssLexer<'src> {
             current_flags: TokenFlags::empty(),
             position: 0,
             diagnostics: vec![],
+            config: CssParserOptions::default(),
         }
+    }
+
+    pub(crate) fn with_config(self, config: CssParserOptions) -> Self {
+        Self { config, ..self }
     }
 
     fn text_position(&self) -> TextSize {
@@ -808,9 +816,10 @@ impl<'src> CssLexer<'src> {
     fn consume_slash(&mut self) -> CssSyntaxKind {
         self.assert_byte(b'/');
 
-        let start = self.text_position();
         match self.peek_byte() {
             Some(b'*') => {
+                let start = self.text_position();
+
                 // eat `/*`
                 self.advance(2);
 
@@ -851,7 +860,7 @@ impl<'src> CssLexer<'src> {
                     COMMENT
                 }
             }
-            Some(b'/') => {
+            Some(b'/') if self.config.allow_wrong_line_comments => {
                 self.advance(2);
 
                 while let Some(chr) = self.current_byte() {

--- a/crates/biome_css_parser/src/lexer/tests.rs
+++ b/crates/biome_css_parser/src/lexer/tests.rs
@@ -9,12 +9,14 @@ use std::time::Duration;
 use biome_css_syntax::CssSyntaxKind::EOF;
 use biome_parser::lexer::Lexer;
 use crate::lexer::CssLexContext;
+use crate::CssParserOptions;
 
 // Assert the result of lexing a piece of source code,
 // and make sure the tokens yielded are fully lossless and the source can be reconstructed from only the tokens
 macro_rules! assert_lex {
     ($src:expr, $($kind:ident:$len:expr $(,)?)*) => {{
-        let mut lexer = CssLexer::from_str($src);
+        let config = CssParserOptions::default().with_allow_wrong_line_comments();
+        let mut lexer = CssLexer::from_str($src).with_config(config);
         let mut idx = 0;
         let mut tok_idx = TextSize::default();
 
@@ -346,7 +348,7 @@ fn identifier() {
 }
 
 #[test]
-fn single_line_comments() {
+fn wrong_line_comments() {
     assert_lex! {
         "//abc
     ",

--- a/crates/biome_css_parser/src/parser.rs
+++ b/crates/biome_css_parser/src/parser.rs
@@ -14,12 +14,12 @@ pub(crate) struct CssParser<'source> {
 
 #[derive(Default, Debug, Clone, Copy)]
 pub struct CssParserOptions {
-    pub allow_single_line_comments: bool,
+    pub allow_wrong_line_comments: bool,
 }
 
 impl CssParserOptions {
-    pub fn with_allow_single_line_comments(mut self) -> Self {
-        self.allow_single_line_comments = true;
+    pub fn with_allow_wrong_line_comments(mut self) -> Self {
+        self.allow_wrong_line_comments = true;
         self
     }
 }

--- a/crates/biome_css_parser/src/token_source.rs
+++ b/crates/biome_css_parser/src/token_source.rs
@@ -26,7 +26,6 @@ pub(crate) struct CssTokenSource<'src> {
 
     /// Offset of the last cached lookahead token from the current [BufferedLexer] token.
     lookahead_offset: usize,
-    config: CssParserOptions,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -43,20 +42,15 @@ impl<'src> CssTokenSource<'src> {
             trivia_list: vec![],
             lookahead_offset: 0,
             non_trivia_lookahead: VecDeque::new(),
-            config: CssParserOptions::default(),
         }
-    }
-
-    pub(crate) fn with_config(self, config: CssParserOptions) -> Self {
-        Self { config, ..self }
     }
 
     /// Creates a new token source for the given string
     pub fn from_str(source: &'src str, config: CssParserOptions) -> Self {
-        let lexer = CssLexer::from_str(source);
+        let lexer = CssLexer::from_str(source).with_config(config);
 
         let buffered = BufferedLexer::new(lexer);
-        let mut source = CssTokenSource::new(buffered).with_config(config);
+        let mut source = CssTokenSource::new(buffered);
 
         source.next_non_trivia_token(CssLexContext::default(), true);
         source
@@ -77,13 +71,6 @@ impl<'src> CssTokenSource<'src> {
 
             match trivia_kind {
                 Err(_) => {
-                    // Not trivia
-                    break;
-                }
-                Ok(trivia_kind)
-                    if trivia_kind.is_single_line_comment()
-                        && !self.config.allow_single_line_comments =>
-                {
                     // Not trivia
                     break;
                 }

--- a/crates/biome_css_parser/tests/spec_test.rs
+++ b/crates/biome_css_parser/tests/spec_test.rs
@@ -37,9 +37,7 @@ pub fn run(test_case: &str, _snapshot_name: &str, test_directory: &str, outcome_
     let content = fs::read_to_string(test_case_path)
         .expect("Expected test path to be a readable file in UTF8 encoding");
 
-    let parse_config = CssParserOptions {
-        allow_single_line_comments: outcome_str == "allow_single_line_comments",
-    };
+    let parse_config = CssParserOptions::default().with_allow_wrong_line_comments();
     let parsed = parse_css(&content, parse_config);
     let formatted_ast = format!("{:#?}", parsed.tree());
 
@@ -140,7 +138,10 @@ pub fn quick_test() {
 :lang(fr-be, "de") > q {}
 
     "#;
-    let root = parse_css(code, CssParserOptions::default());
+    let root = parse_css(
+        code,
+        CssParserOptions::default().with_allow_wrong_line_comments(),
+    );
     let syntax = root.syntax();
     dbg!(&syntax, root.diagnostics(), root.has_errors());
 

--- a/xtask/bench/src/language.rs
+++ b/xtask/bench/src/language.rs
@@ -43,7 +43,7 @@ impl<'a> Parse<'a> {
             )),
             Parse::Css(code) => Parsed::Css(biome_css_parser::parse_css(
                 code,
-                CssParserOptions::default().with_allow_single_line_comments(),
+                CssParserOptions::default().with_allow_wrong_line_comments(),
             )),
         }
     }
@@ -67,7 +67,7 @@ impl<'a> Parse<'a> {
             Parse::Css(code) => Parsed::Css(biome_css_parser::parse_css_with_cache(
                 code,
                 cache,
-                CssParserOptions::default().with_allow_single_line_comments(),
+                CssParserOptions::default().with_allow_wrong_line_comments(),
             )),
         }
     }


### PR DESCRIPTION

## Summary
Current implementation is incorrect. Because now it makes incorrect the following comments:
`./*12321*/div {}` 

We need to rename the css config option to `allow wrong line comments for css` and check only `.div {}//comment` syntax.

## Test Plan

`cargo test -p biome_css_parser`
