### PR TITLE
challenge(formatter): check if the third member of test call expression is appropriate

### DIFF
--- a/crates/biome_js_formatter/src/utils/test_call.rs
+++ b/crates/biome_js_formatter/src/utils/test_call.rs
@@ -366,7 +366,7 @@ fn contains_a_test_pattern(callee: &AnyJsExpression) -> SyntaxResult<bool> {
             Some("only" | "skip" | "step") => third.is_none(),
             Some("describe") => match third {
                 None => true,
-                Some("only") => true,
+                Some("only") => fourth.is_none(),
                 Some("parallel" | "serial") => match fourth {
                     None => true,
                     Some("only") => fifth.is_none(),

--- a/crates/biome_js_formatter/tests/specs/prettier/js/test-declarations/test_declarations.js.snap
+++ b/crates/biome_js_formatter/tests/specs/prettier/js/test-declarations/test_declarations.js.snap
@@ -223,18 +223,6 @@ it(
  
  // Should break
  
-@@ -152,10 +142,7 @@
-   () => {},
- );
- 
--test.describe.only.parallel(
--  "does something really long and complicated so I have to write a very long name for the test",
--  () => {},
--);
-+test.describe.only.parallel("does something really long and complicated so I have to write a very long name for the test", () => {});
- 
- test.describe.parallel.serial(
-   "does something really long and complicated so I have to write a very long name for the testThis is a very",
 ```
 
 # Output
@@ -384,7 +372,10 @@ xskip(
   () => {},
 );
 
-test.describe.only.parallel("does something really long and complicated so I have to write a very long name for the test", () => {});
+test.describe.only.parallel(
+  "does something really long and complicated so I have to write a very long name for the test",
+  () => {},
+);
 
 test.describe.parallel.serial(
   "does something really long and complicated so I have to write a very long name for the testThis is a very",
@@ -470,11 +461,11 @@ it(
   127:   "does something really long and complicated so I have to write a very long name for the test",
   134:   "does something really long and complicated so I have to write a very long name for the test",
   141:   "does something really long and complicated so I have to write a very long name for the test",
-  145: test.describe.only.parallel("does something really long and complicated so I have to write a very long name for the test", () => {});
-  148:   "does something really long and complicated so I have to write a very long name for the testThis is a very",
-  153:   "does something really long and complicated so I have to write a very long name for the test",
-  158:   "does something really long and complicated so I have to write a very long name for the test",
-  167:   does something really long and complicated so I have to write a very long name for the test`, () => {
+  146:   "does something really long and complicated so I have to write a very long name for the test",
+  151:   "does something really long and complicated so I have to write a very long name for the testThis is a very",
+  156:   "does something really long and complicated so I have to write a very long name for the test",
+  161:   "does something really long and complicated so I have to write a very long name for the test",
+  170:   does something really long and complicated so I have to write a very long name for the test`, () => {
 ```
 
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

I've added a implementation for checking if the third member of test call expression is appropriate. I will fix the other Prettier differences in [js/test-declarations/test_declarations.js](https://github.com/biomejs/biome/blob/main/crates/biome_js_formatter/report_incompatible.md#jstest-declarationstest_declarationsjs) in a separated pull request because I think this fix will be a bit large.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

`cargo test -p biome_js_formatter --test prettier_tests`
