### PR TITLE
fix(lint): fix false-positives for `aria-label` and report cases where the `role` is implicit in `noSvgWithoutTitle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Fix [#727](https://github.com/biomejs/biome/issues/727). [noInferrableTypes](https://biomejs.dev/linter/rules/no-inferrable-types) now correctly keeps type annotations when the initialization expression is `null`. Contributed by @Conaclos
 
+- Fix [#784](https://github.com/biomejs/biome/issues/784), [noSvgWithoutTitle](https://biomejs.dev/linter/rules/no-svg-without-title) fixes false-positives to `aria-label` and reports svg's role attribute is other than `img`. Contributed by @unvalley
+
 ### Parser
 
 ### VSCode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Fix [#727](https://github.com/biomejs/biome/issues/727). [noInferrableTypes](https://biomejs.dev/linter/rules/no-inferrable-types) now correctly keeps type annotations when the initialization expression is `null`. Contributed by @Conaclos
 
-- Fix [#784](https://github.com/biomejs/biome/issues/784), [noSvgWithoutTitle](https://biomejs.dev/linter/rules/no-svg-without-title) fixes false-positives to `aria-label` and reports svg's role attribute is other than `img`. Contributed by @unvalley
+- Fix [#784](https://github.com/biomejs/biome/issues/784), [noSvgWithoutTitle](https://biomejs.dev/linter/rules/no-svg-without-title) fixes false-positives to `aria-label` and reports svg's role attribute is implicit. Contributed by @unvalley
 
 ### Parser
 

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_svg_without_title.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_svg_without_title.rs
@@ -62,6 +62,12 @@ declare_rule! {
     /// ```
     ///
     /// ```js
+    /// <svg role="img"  aria-labelledby="title">
+    ///     <span id="title">Pass</span>
+    /// </svg>
+    /// ```
+    ///
+    /// ```js
     /// <svg role="img" aria-label="title">
     ///     <span id="title">Pass</span>
     /// </svg>
@@ -108,7 +114,7 @@ impl Rule for NoSvgWithoutTitle {
         };
 
         let role_attribute_value = role_attribute.initializer()?.value().ok()?;
-        let Some(text) = role_attribute_value
+        let Some(role_attribute_text) = role_attribute_value
             .as_jsx_string()?
             .inner_string_text()
             .ok()
@@ -116,21 +122,22 @@ impl Rule for NoSvgWithoutTitle {
             return Some(());
         };
 
-        if text.to_lowercase() == "img" {
-            let [aria_label, aria_labelledby] = node
-                .attributes()
-                .find_by_names(["aria-label", "aria-labelledby"]);
-
-            let jsx_child_list = jsx_element.children();
-            let is_valid = is_valid_attribute_value(aria_label, &jsx_child_list).unwrap_or(false)
-                || is_valid_attribute_value(aria_labelledby, &jsx_child_list).unwrap_or(false);
-
-            if !is_valid {
-                return Some(());
+        match role_attribute_text.to_lowercase().as_str() {
+            "img" => {
+                let [aria_label, aria_labelledby] = node
+                    .attributes()
+                    .find_by_names(["aria-label", "aria-labelledby"]);
+                let is_valid_a11y_attribute = aria_label.is_some()
+                    || is_valid_attribute_value(aria_labelledby, &jsx_element.children())
+                        .unwrap_or(false);
+                if is_valid_a11y_attribute {
+                    return None;
+                }
+                Some(())
             }
-        };
-
-        None
+            // if not "img" role, the svg element should have a valid title element
+            _ => Some(()),
+        }
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_svg_without_title.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_svg_without_title.rs
@@ -62,7 +62,7 @@ declare_rule! {
     /// ```
     ///
     /// ```js
-    /// <svg role="img"  aria-labelledby="title">
+    /// <svg role="img" aria-labelledby="title">
     ///     <span id="title">Pass</span>
     /// </svg>
     /// ```

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_svg_without_title.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_svg_without_title.rs
@@ -135,8 +135,9 @@ impl Rule for NoSvgWithoutTitle {
                 }
                 Some(())
             }
-            // if not "img" role, the svg element should have a valid title element
-            _ => Some(()),
+            // if role attribute is empty, the svg element should have title element
+            "" => Some(()),
+            _ => None,
         }
     }
 

--- a/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/invalid.jsx
@@ -7,19 +7,10 @@
 	<svg role="img" title="title">
 		<span id="">foo</span>
 	</svg>
-	<svg role="img" aria-label="title">
-		<span>aria-label</span>
-	</svg>
 	<svg role="img" aria-labelledby="title">
 		<span id="">foo</span>
 	</svg>
 	<svg role="">
 		<span>implicit role</span>
-	</svg>
-	<svg role="presentation">
-		<span>presentation role without title</span>
-	</svg>
-	<svg role="button">
-		<span>button role without title</span>
 	</svg>
 </>;

--- a/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/invalid.jsx
@@ -4,13 +4,22 @@
 		<title></title>
 		<circle />
 	</svg>
-	<svg role="img" aria-label="title">
-		<span id="">foo</span>
-	</svg>
 	<svg role="img" title="title">
 		<span id="">foo</span>
 	</svg>
+	<svg role="img" aria-label="title">
+		<span>aria-label</span>
+	</svg>
 	<svg role="img" aria-labelledby="title">
 		<span id="">foo</span>
+	</svg>
+	<svg role="">
+		<span>implicit role</span>
+	</svg>
+	<svg role="presentation">
+		<span>presentation role without title</span>
+	</svg>
+	<svg role="button">
+		<span>button role without title</span>
 	</svg>
 </>;

--- a/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/invalid.jsx.snap
@@ -10,14 +10,23 @@ expression: invalid.jsx
 		<title></title>
 		<circle />
 	</svg>
-	<svg role="img" aria-label="title">
-		<span id="">foo</span>
-	</svg>
 	<svg role="img" title="title">
 		<span id="">foo</span>
 	</svg>
+	<svg role="img" aria-label="title">
+		<span>aria-label</span>
+	</svg>
 	<svg role="img" aria-labelledby="title">
 		<span id="">foo</span>
+	</svg>
+	<svg role="">
+		<span>implicit role</span>
+	</svg>
+	<svg role="presentation">
+		<span>presentation role without title</span>
+	</svg>
+	<svg role="button">
+		<span>button role without title</span>
 	</svg>
 </>;
 
@@ -64,27 +73,10 @@ invalid.jsx:7:2 lint/a11y/noSvgWithoutTitle ━━━━━━━━━━━━
   
     5 │ 		<circle />
     6 │ 	</svg>
-  > 7 │ 	<svg role="img" aria-label="title">
-      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 7 │ 	<svg role="img" title="title">
+      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     8 │ 		<span id="">foo</span>
     9 │ 	</svg>
-  
-  i For accessibility purposes, SVGs should have an alternative text, provided via title element. If the svg element has role="img", you should add the aria-label or aria-labelledby attribute.
-  
-
-```
-
-```
-invalid.jsx:10:2 lint/a11y/noSvgWithoutTitle ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Alternative text title element cannot be empty
-  
-     8 │ 		<span id="">foo</span>
-     9 │ 	</svg>
-  > 10 │ 	<svg role="img" title="title">
-       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    11 │ 		<span id="">foo</span>
-    12 │ 	</svg>
   
   i For accessibility purposes, SVGs should have an alternative text, provided via title element. If the svg element has role="img", you should add the aria-label or aria-labelledby attribute.
   
@@ -96,12 +88,63 @@ invalid.jsx:13:2 lint/a11y/noSvgWithoutTitle ━━━━━━━━━━━�
 
   ! Alternative text title element cannot be empty
   
-    11 │ 		<span id="">foo</span>
+    11 │ 		<span>aria-label</span>
     12 │ 	</svg>
   > 13 │ 	<svg role="img" aria-labelledby="title">
        │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     14 │ 		<span id="">foo</span>
     15 │ 	</svg>
+  
+  i For accessibility purposes, SVGs should have an alternative text, provided via title element. If the svg element has role="img", you should add the aria-label or aria-labelledby attribute.
+  
+
+```
+
+```
+invalid.jsx:16:2 lint/a11y/noSvgWithoutTitle ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Alternative text title element cannot be empty
+  
+    14 │ 		<span id="">foo</span>
+    15 │ 	</svg>
+  > 16 │ 	<svg role="">
+       │ 	^^^^^^^^^^^^^
+    17 │ 		<span>implicit role</span>
+    18 │ 	</svg>
+  
+  i For accessibility purposes, SVGs should have an alternative text, provided via title element. If the svg element has role="img", you should add the aria-label or aria-labelledby attribute.
+  
+
+```
+
+```
+invalid.jsx:19:2 lint/a11y/noSvgWithoutTitle ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Alternative text title element cannot be empty
+  
+    17 │ 		<span>implicit role</span>
+    18 │ 	</svg>
+  > 19 │ 	<svg role="presentation">
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^
+    20 │ 		<span>presentation role without title</span>
+    21 │ 	</svg>
+  
+  i For accessibility purposes, SVGs should have an alternative text, provided via title element. If the svg element has role="img", you should add the aria-label or aria-labelledby attribute.
+  
+
+```
+
+```
+invalid.jsx:22:2 lint/a11y/noSvgWithoutTitle ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Alternative text title element cannot be empty
+  
+    20 │ 		<span>presentation role without title</span>
+    21 │ 	</svg>
+  > 22 │ 	<svg role="button">
+       │ 	^^^^^^^^^^^^^^^^^^^
+    23 │ 		<span>button role without title</span>
+    24 │ 	</svg>
   
   i For accessibility purposes, SVGs should have an alternative text, provided via title element. If the svg element has role="img", you should add the aria-label or aria-labelledby attribute.
   

--- a/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/invalid.jsx.snap
@@ -13,20 +13,11 @@ expression: invalid.jsx
 	<svg role="img" title="title">
 		<span id="">foo</span>
 	</svg>
-	<svg role="img" aria-label="title">
-		<span>aria-label</span>
-	</svg>
 	<svg role="img" aria-labelledby="title">
 		<span id="">foo</span>
 	</svg>
 	<svg role="">
 		<span>implicit role</span>
-	</svg>
-	<svg role="presentation">
-		<span>presentation role without title</span>
-	</svg>
-	<svg role="button">
-		<span>button role without title</span>
 	</svg>
 </>;
 
@@ -84,67 +75,33 @@ invalid.jsx:7:2 lint/a11y/noSvgWithoutTitle ━━━━━━━━━━━━
 ```
 
 ```
+invalid.jsx:10:2 lint/a11y/noSvgWithoutTitle ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Alternative text title element cannot be empty
+  
+     8 │ 		<span id="">foo</span>
+     9 │ 	</svg>
+  > 10 │ 	<svg role="img" aria-labelledby="title">
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    11 │ 		<span id="">foo</span>
+    12 │ 	</svg>
+  
+  i For accessibility purposes, SVGs should have an alternative text, provided via title element. If the svg element has role="img", you should add the aria-label or aria-labelledby attribute.
+  
+
+```
+
+```
 invalid.jsx:13:2 lint/a11y/noSvgWithoutTitle ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Alternative text title element cannot be empty
   
-    11 │ 		<span>aria-label</span>
+    11 │ 		<span id="">foo</span>
     12 │ 	</svg>
-  > 13 │ 	<svg role="img" aria-labelledby="title">
-       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    14 │ 		<span id="">foo</span>
-    15 │ 	</svg>
-  
-  i For accessibility purposes, SVGs should have an alternative text, provided via title element. If the svg element has role="img", you should add the aria-label or aria-labelledby attribute.
-  
-
-```
-
-```
-invalid.jsx:16:2 lint/a11y/noSvgWithoutTitle ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Alternative text title element cannot be empty
-  
-    14 │ 		<span id="">foo</span>
-    15 │ 	</svg>
-  > 16 │ 	<svg role="">
+  > 13 │ 	<svg role="">
        │ 	^^^^^^^^^^^^^
-    17 │ 		<span>implicit role</span>
-    18 │ 	</svg>
-  
-  i For accessibility purposes, SVGs should have an alternative text, provided via title element. If the svg element has role="img", you should add the aria-label or aria-labelledby attribute.
-  
-
-```
-
-```
-invalid.jsx:19:2 lint/a11y/noSvgWithoutTitle ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Alternative text title element cannot be empty
-  
-    17 │ 		<span>implicit role</span>
-    18 │ 	</svg>
-  > 19 │ 	<svg role="presentation">
-       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^
-    20 │ 		<span>presentation role without title</span>
-    21 │ 	</svg>
-  
-  i For accessibility purposes, SVGs should have an alternative text, provided via title element. If the svg element has role="img", you should add the aria-label or aria-labelledby attribute.
-  
-
-```
-
-```
-invalid.jsx:22:2 lint/a11y/noSvgWithoutTitle ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Alternative text title element cannot be empty
-  
-    20 │ 		<span>presentation role without title</span>
-    21 │ 	</svg>
-  > 22 │ 	<svg role="button">
-       │ 	^^^^^^^^^^^^^^^^^^^
-    23 │ 		<span>button role without title</span>
-    24 │ 	</svg>
+    14 │ 		<span>implicit role</span>
+    15 │ 	</svg>
   
   i For accessibility purposes, SVGs should have an alternative text, provided via title element. If the svg element has role="img", you should add the aria-label or aria-labelledby attribute.
   

--- a/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/valid.jsx
@@ -37,12 +37,4 @@
 		<title>implicit role</title>
 		<span>Pass</span>
 	</svg>
-	<svg role="presentation">
-		<title>presentation role with title</title>
-		<span id="sample">Pass</span>
-	</svg>
-	<svg role="button">
-		<title>button role with title</title>
-		<span id="sample">Pass</span>
-	</svg>
 </>;

--- a/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/valid.jsx
@@ -22,12 +22,27 @@
 		<title id="title">Pass</title>
 	</svg>
 	<svg role="img" aria-label="title">
-		<span id="title">Pass</span>
+		<span>Pass</span>
+	</svg>
+	<svg role="img" aria-label="title">
+		<span id="sample">Pass</span>
 	</svg>
 	<svg role="img" aria-labelledby="title">
 		<title id="title">Pass</title>
 	</svg>
 	<svg role="img" aria-labelledby="title">
 		<span id="title">Pass</span>
+	</svg>
+	<svg role="">
+		<title>implicit role</title>
+		<span>Pass</span>
+	</svg>
+	<svg role="presentation">
+		<title>presentation role with title</title>
+		<span id="sample">Pass</span>
+	</svg>
+	<svg role="button">
+		<title>button role with title</title>
+		<span id="sample">Pass</span>
 	</svg>
 </>;

--- a/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/valid.jsx.snap
@@ -43,14 +43,6 @@ expression: valid.jsx
 		<title>implicit role</title>
 		<span>Pass</span>
 	</svg>
-	<svg role="presentation">
-		<title>presentation role with title</title>
-		<span id="sample">Pass</span>
-	</svg>
-	<svg role="button">
-		<title>button role with title</title>
-		<span id="sample">Pass</span>
-	</svg>
 </>;
 
 ```

--- a/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/valid.jsx.snap
@@ -28,13 +28,28 @@ expression: valid.jsx
 		<title id="title">Pass</title>
 	</svg>
 	<svg role="img" aria-label="title">
-		<span id="title">Pass</span>
+		<span>Pass</span>
+	</svg>
+	<svg role="img" aria-label="title">
+		<span id="sample">Pass</span>
 	</svg>
 	<svg role="img" aria-labelledby="title">
 		<title id="title">Pass</title>
 	</svg>
 	<svg role="img" aria-labelledby="title">
 		<span id="title">Pass</span>
+	</svg>
+	<svg role="">
+		<title>implicit role</title>
+		<span>Pass</span>
+	</svg>
+	<svg role="presentation">
+		<title>presentation role with title</title>
+		<span id="sample">Pass</span>
+	</svg>
+	<svg role="button">
+		<title>button role with title</title>
+		<span id="sample">Pass</span>
 	</svg>
 </>;
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -60,7 +60,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Fix [#727](https://github.com/biomejs/biome/issues/727). [noInferrableTypes](https://biomejs.dev/linter/rules/no-inferrable-types) now correctly keeps type annotations when the initialization expression is `null`. Contributed by @Conaclos
 
-- Fix [#784](https://github.com/biomejs/biome/issues/784), [noSvgWithoutTitle](https://biomejs.dev/linter/rules/no-svg-without-title) fixes false-positives to `aria-label` and reports svg's role attribute is other than `img`. Contributed by @unvalley
+- Fix [#784](https://github.com/biomejs/biome/issues/784), [noSvgWithoutTitle](https://biomejs.dev/linter/rules/no-svg-without-title) fixes false-positives to `aria-label` and reports svg's role attribute is implicit. Contributed by @unvalley
 
 ### Parser
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -60,6 +60,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Fix [#727](https://github.com/biomejs/biome/issues/727). [noInferrableTypes](https://biomejs.dev/linter/rules/no-inferrable-types) now correctly keeps type annotations when the initialization expression is `null`. Contributed by @Conaclos
 
+- Fix [#784](https://github.com/biomejs/biome/issues/784), [noSvgWithoutTitle](https://biomejs.dev/linter/rules/no-svg-without-title) fixes false-positives to `aria-label` and reports svg's role attribute is other than `img`. Contributed by @unvalley
+
 ### Parser
 
 ### VSCode

--- a/website/src/content/docs/linter/rules/no-svg-without-title.md
+++ b/website/src/content/docs/linter/rules/no-svg-without-title.md
@@ -93,6 +93,12 @@ To make svg accessible, the following methods are available:
 ```
 
 ```jsx
+<svg role="img"  aria-labelledby="title">
+    <span id="title">Pass</span>
+</svg>
+```
+
+```jsx
 <svg role="img" aria-label="title">
     <span id="title">Pass</span>
 </svg>

--- a/website/src/content/docs/linter/rules/no-svg-without-title.md
+++ b/website/src/content/docs/linter/rules/no-svg-without-title.md
@@ -93,7 +93,7 @@ To make svg accessible, the following methods are available:
 ```
 
 ```jsx
-<svg role="img"  aria-labelledby="title">
+<svg role="img" aria-labelledby="title">
     <span id="title">Pass</span>
 </svg>
 ```


### PR DESCRIPTION
## Summary

Closes #784 
This PR does
- fix false-positives for `aria-label`. It does not require that title children having `id`.
- reports when `<svg>`'s `role` attribute is implicit (empty)
  - e.g. `<svg role="">` is invalid if there is no `<title>` in child.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added some test cases
- to accept `aria-label` without inner element's `id` consistency
- to report the case if svg's `role` attribute is implicit