### PR TITLE
challenge(formatter): Implement `bracketSameLine` option to match Prettier

### DIFF
--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -80,30 +80,33 @@ const {a, b} = foo;
 "#;
 
 const APPLY_BRACKET_SAME_LINE_BEFORE: &str = r#"<Foo
-    className={style}
-    reallyLongAttributeName1={longComplexValue}
-    reallyLongAttributeName2={anotherLongValue}
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
 />;
 
 <Foo
-    className={style}
-    reallyLongAttributeName1={longComplexValue}
-    reallyLongAttributeName2={anotherLongValue}
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
 >
-    Hi
-</Foo>"#;
+	Hi
+</Foo>;
+"#;
 
 const APPLY_BRACKET_SAME_LINE_AFTER: &str = r#"<Foo
-    className={style}
-    reallyLongAttributeName1={longComplexValue}
-    reallyLongAttributeName2={anotherLongValue} />;
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+/>;
 
 <Foo
-    className={style}
-    reallyLongAttributeName1={longComplexValue}
-    reallyLongAttributeName2={anotherLongValue}>
-    Hi
-</Foo>"#;
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}>
+	Hi
+</Foo>;
+"#;
 
 // Without this, Test (windows-latest) fails with: `warning: constant `DEFAULT_CONFIGURATION_BEFORE` is never used`
 #[allow(dead_code)]

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -79,6 +79,32 @@ let foo = {a, b};
 const {a, b} = foo;
 "#;
 
+const APPLY_BRACKET_SAME_LINE_BEFORE: &str = r#"<Foo
+    className={style}
+    reallyLongAttributeName1={longComplexValue}
+    reallyLongAttributeName2={anotherLongValue}
+/>;
+
+<Foo
+    className={style}
+    reallyLongAttributeName1={longComplexValue}
+    reallyLongAttributeName2={anotherLongValue}
+>
+    Hi
+</Foo>"#;
+
+const APPLY_BRACKET_SAME_LINE_AFTER: &str = r#"<Foo
+    className={style}
+    reallyLongAttributeName1={longComplexValue}
+    reallyLongAttributeName2={anotherLongValue} />;
+
+<Foo
+    className={style}
+    reallyLongAttributeName1={longComplexValue}
+    reallyLongAttributeName2={anotherLongValue}>
+    Hi
+</Foo>"#;
+
 // Without this, Test (windows-latest) fails with: `warning: constant `DEFAULT_CONFIGURATION_BEFORE` is never used`
 #[allow(dead_code)]
 const DEFAULT_CONFIGURATION_BEFORE: &str = r#"function f() {
@@ -698,6 +724,51 @@ fn applies_custom_bracket_spacing() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "applies_custom_bracket_spacing",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn applies_custom_bracket_same_line() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("file.js");
+    fs.insert(file_path.into(), APPLY_BRACKET_SAME_LINE_BEFORE.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                ("--bracket-same-line"),
+                ("true"),
+                ("--write"),
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    let mut file = fs
+        .open(file_path)
+        .expect("formatting target file was removed by the CLI");
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .expect("failed to read file from memory FS");
+
+    assert_eq!(content, APPLY_BRACKET_SAME_LINE_AFTER);
+
+    drop(file);
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "applies_custom_bracket_same_line",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -39,6 +39,9 @@ The configuration that is contained inside the file `biome.json`
                               Defaults to "always".
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
+        --bracket-same-line=<true|false>  Whether to hug the closing bracket of multiline HTML/JSX tags
+                              to the end of the last line, rather than being alone on the following line.
+                              Defaults to false.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its super
                               languages) files.
         --javascript-formatter-indent-style=<tab|space>  The indent style applied to JavaScript (and

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -41,6 +41,9 @@ The configuration that is contained inside the file `biome.json`
                               Defaults to "always".
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
+        --bracket-same-line=<true|false>  Whether to hug the closing bracket of multiline HTML/JSX tags
+                              to the end of the last line, rather than being alone on the following line.
+                              Defaults to false.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its super
                               languages) files.
         --javascript-formatter-indent-style=<tab|space>  The indent style applied to JavaScript (and

--- a/crates/biome_cli/tests/snapshots/main_commands_format/applies_custom_bracket_same_line.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/applies_custom_bracket_same_line.snap
@@ -1,0 +1,29 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.js`
+
+```js
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+/>;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}>
+	Hi
+</Foo>;
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -28,6 +28,9 @@ Formatting options specific to the JavaScript files
                               Defaults to "always".
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
+        --bracket-same-line=<true|false>  Whether to hug the closing bracket of multiline HTML/JSX tags
+                              to the end of the last line, rather than being alone on the following line.
+                              Defaults to false.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its super
                               languages) files.
         --javascript-formatter-indent-style=<tab|space>  The indent style applied to JavaScript (and

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -165,6 +165,9 @@ pub struct JsFormatOptions {
     /// Whether to insert spaces around brackets in object literals. Defaults to true.
     bracket_spacing: BracketSpacing,
 
+    /// Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.
+    bracket_same_line: BracketSameLine,
+
     /// Information related to the current file
     source_type: JsFileSource,
 }
@@ -184,6 +187,7 @@ impl JsFormatOptions {
             semicolons: Semicolons::default(),
             arrow_parentheses: ArrowParentheses::default(),
             bracket_spacing: BracketSpacing::default(),
+            bracket_same_line: BracketSameLine::default(),
         }
     }
 
@@ -194,6 +198,11 @@ impl JsFormatOptions {
 
     pub fn with_bracket_spacing(mut self, bracket_spacing: BracketSpacing) -> Self {
         self.bracket_spacing = bracket_spacing;
+        self
+    }
+
+    pub fn with_bracket_same_line(mut self, bracket_same_line: BracketSameLine) -> Self {
+        self.bracket_same_line = bracket_same_line;
         self
     }
 
@@ -250,6 +259,10 @@ impl JsFormatOptions {
         self.bracket_spacing = bracket_spacing;
     }
 
+    pub fn set_bracket_same_line(&mut self, bracket_same_line: BracketSameLine) {
+        self.bracket_same_line = bracket_same_line;
+    }
+
     pub fn set_indent_style(&mut self, indent_style: IndentStyle) {
         self.indent_style = indent_style;
     }
@@ -292,6 +305,10 @@ impl JsFormatOptions {
 
     pub fn bracket_spacing(&self) -> BracketSpacing {
         self.bracket_spacing
+    }
+
+    pub fn bracket_same_line(&self) -> BracketSameLine {
+        self.bracket_same_line
     }
 
     pub fn quote_style(&self) -> QuoteStyle {
@@ -357,7 +374,8 @@ impl fmt::Display for JsFormatOptions {
         writeln!(f, "Trailing comma: {}", self.trailing_comma)?;
         writeln!(f, "Semicolons: {}", self.semicolons)?;
         writeln!(f, "Arrow parentheses: {}", self.arrow_parentheses)?;
-        writeln!(f, "Bracket spacing: {}", self.bracket_spacing.value())
+        writeln!(f, "Bracket spacing: {}", self.bracket_spacing.value())?;
+        writeln!(f, "Bracket same line: {}", self.bracket_same_line.value())
     }
 }
 
@@ -680,6 +698,33 @@ impl Default for BracketSpacing {
 }
 
 impl From<bool> for BracketSpacing {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    serde(rename_all = "camelCase")
+)]
+pub struct BracketSameLine(bool);
+
+impl BracketSameLine {
+    /// Return the boolean value for this [BracketSameLine]
+    pub fn value(&self) -> bool {
+        self.0
+    }
+}
+
+impl Default for BracketSameLine {
+    fn default() -> Self {
+        Self(false)
+    }
+}
+
+impl From<bool> for BracketSameLine {
     fn from(value: bool) -> Self {
         Self(value)
     }

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -703,7 +703,7 @@ impl From<bool> for BracketSpacing {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Copy, Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
@@ -715,12 +715,6 @@ impl BracketSameLine {
     /// Return the boolean value for this [BracketSameLine]
     pub fn value(&self) -> bool {
         self.0
-    }
-}
-
-impl Default for BracketSameLine {
-    fn default() -> Self {
-        Self(false)
     }
 }
 

--- a/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
+++ b/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
@@ -81,11 +81,12 @@ impl Format<JsFormatContext> for AnyJsxOpeningElement {
                         ]
                     )?;
 
-                    let bracket_same_line = attributes.is_empty() && !name_has_comments;
+                    let force_bracket_same_line = f.options().bracket_same_line().value();
+                    let wants_bracket_same_line = attributes.is_empty() && !name_has_comments;
 
                     if self.is_self_closing() {
                         write!(f, [soft_line_break_or_space(), format_close])
-                    } else if bracket_same_line {
+                    } else if force_bracket_same_line || wants_bracket_same_line {
                         write!(f, [format_close])
                     } else {
                         write!(f, [soft_line_break(), format_close])

--- a/crates/biome_js_formatter/tests/language.rs
+++ b/crates/biome_js_formatter/tests/language.rs
@@ -4,8 +4,8 @@ use biome_formatter::{
 use biome_formatter_test::TestFormatLanguage;
 use biome_js_formatter::context::trailing_comma::TrailingComma;
 use biome_js_formatter::context::{
-    ArrowParentheses, BracketSpacing, JsFormatContext, JsFormatOptions, QuoteProperties,
-    QuoteStyle, Semicolons,
+    ArrowParentheses, BracketSameLine, BracketSpacing, JsFormatContext, JsFormatOptions,
+    QuoteProperties, QuoteStyle, Semicolons,
 };
 use biome_js_formatter::{format_node, format_range, JsFormatLanguage};
 use biome_js_parser::{parse, JsParserOptions};
@@ -228,6 +228,9 @@ pub struct JsSerializableFormatOptions {
 
     /// Whether to insert spaces around brackets in object literals. Defaults to true.
     pub bracket_spacing: Option<bool>,
+
+    /// Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.
+    pub bracket_same_line: Option<bool>,
 }
 
 impl JsSerializableFormatOptions {
@@ -272,6 +275,10 @@ impl JsSerializableFormatOptions {
             .with_bracket_spacing(
                 self.bracket_spacing
                     .map_or_else(BracketSpacing::default, |value| value.into()),
+            )
+            .with_bracket_same_line(
+                self.bracket_same_line
+                    .map_or_else(BracketSameLine::default, |value| value.into()),
             )
     }
 }

--- a/crates/biome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
@@ -69,6 +69,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
@@ -40,6 +40,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/spaces.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/spaces.js.snap
@@ -33,6 +33,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/spread.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/spread.js.snap
@@ -33,6 +33,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js.snap
@@ -38,6 +38,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -69,6 +70,7 @@ Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -100,6 +102,7 @@ Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
@@ -49,6 +49,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -88,6 +89,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
@@ -37,6 +37,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -72,6 +73,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -63,6 +64,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
@@ -55,6 +55,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -100,6 +101,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
@@ -32,6 +32,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -60,6 +61,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -72,6 +72,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -144,6 +145,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
@@ -45,6 +45,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -81,6 +82,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/params.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/params.js.snap
@@ -354,6 +354,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -680,6 +681,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
@@ -30,6 +30,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -190,6 +190,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
@@ -32,6 +32,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -49,6 +50,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: false
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -56,6 +57,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: false
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -54,6 +55,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: false
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
@@ -32,6 +32,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -60,6 +61,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: false
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/bom_character.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/bom_character.js.snap
@@ -28,6 +28,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/call_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/call_expression.js.snap
@@ -75,6 +75,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/class/class.js.snap
@@ -98,6 +98,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/class/private_method.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/class/private_method.js.snap
@@ -44,6 +44,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/comments.js.snap
@@ -106,6 +106,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
@@ -293,6 +293,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
@@ -120,6 +120,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
@@ -120,6 +120,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
@@ -120,6 +120,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple.js.snap
@@ -76,6 +76,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple_call_decorator.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple_call_decorator.js.snap
@@ -76,6 +76,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_1.js.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_2.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_2.js.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_3.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_3.js.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_4.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_4.js.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/expression.js.snap
@@ -49,6 +49,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/multiline.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/multiline.js.snap
@@ -44,6 +44,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/each/each.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/each/each.js.snap
@@ -94,6 +94,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/export_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/export_bracket_spacing.js.snap
@@ -47,6 +47,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -95,6 +96,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: false
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
@@ -37,6 +37,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
@@ -28,6 +28,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
@@ -32,6 +32,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
@@ -36,6 +36,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
@@ -47,6 +47,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js.snap
@@ -33,6 +33,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -57,6 +58,7 @@ Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -81,6 +83,7 @@ Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
@@ -30,6 +30,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
@@ -62,6 +62,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
@@ -28,6 +28,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
@@ -37,6 +37,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -60,6 +61,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
@@ -140,6 +140,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
@@ -33,6 +33,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
@@ -33,6 +33,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
@@ -40,6 +40,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/static_member_regex.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/static_member_regex.js.snap
@@ -52,6 +52,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
@@ -32,6 +32,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
@@ -32,6 +32,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
@@ -61,6 +61,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
@@ -48,6 +48,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
@@ -42,6 +42,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
@@ -36,6 +36,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/function/function.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/function/function.js.snap
@@ -60,6 +60,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/function/function_args.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/function/function_args.js.snap
@@ -30,6 +30,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
@@ -44,6 +44,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/ident.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/ident.js.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
@@ -51,6 +51,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/import_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/import_bracket_spacing.js.snap
@@ -52,6 +52,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -93,6 +94,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: false
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/default_import.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/default_import.js.snap
@@ -39,6 +39,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/import_call.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/import_call.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
@@ -60,6 +60,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
@@ -28,6 +28,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js.snap
@@ -58,6 +58,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -117,6 +118,7 @@ Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -176,6 +178,7 @@ Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/indent-width/example-1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/indent-width/example-1.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -53,6 +54,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -81,6 +83,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/indent-width/example-2.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/indent-width/example-2.js.snap
@@ -45,6 +45,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -81,6 +82,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -117,6 +119,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/interpreter-with-trailing-spaces.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/interpreter-with-trailing-spaces.js.snap
@@ -30,6 +30,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/interpreter.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/interpreter.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
@@ -38,6 +38,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
@@ -44,6 +44,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/line-ending/line_ending.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/line-ending/line_ending.js.snap
@@ -45,6 +45,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -81,6 +82,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -117,6 +119,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/newlines.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/newlines.js.snap
@@ -106,6 +106,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/class.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/class.js.snap
@@ -146,6 +146,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -281,6 +282,7 @@ Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/issue2006.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/issue2006.js.snap
@@ -36,6 +36,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -63,6 +64,7 @@ Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/no-semi.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/no-semi.js.snap
@@ -108,6 +108,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -218,6 +219,7 @@ Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/private-field.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/private-field.js.snap
@@ -32,6 +32,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -55,6 +56,7 @@ Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons-asi.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons-asi.js.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -49,6 +50,7 @@ Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -53,6 +54,7 @@ Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/number/number.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/number/number.js.snap
@@ -30,6 +30,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/bracket-spacing/object_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/bracket-spacing/object_bracket_spacing.js.snap
@@ -50,6 +50,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -87,6 +88,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: false
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
@@ -47,6 +47,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/numeric-property.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/numeric-property.js.snap
@@ -65,6 +65,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/object.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/object.js.snap
@@ -60,6 +60,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/octal_literals_key.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/octal_literals_key.js.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/property_key.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/property_key.js.snap
@@ -36,6 +36,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
@@ -116,6 +116,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js.snap
@@ -37,6 +37,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -67,6 +68,7 @@ Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -97,6 +99,7 @@ Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
@@ -51,6 +51,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js.snap
@@ -36,6 +36,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
@@ -38,6 +38,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
@@ -36,6 +36,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/script.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/script.js.snap
@@ -32,6 +32,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
@@ -37,6 +37,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
@@ -42,6 +42,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
@@ -57,6 +57,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
@@ -45,6 +45,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
@@ -36,6 +36,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -97,6 +97,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/return.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/return.js.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
@@ -53,6 +53,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/statement.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/statement.js.snap
@@ -30,6 +30,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js.snap
@@ -47,6 +47,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/throw.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/throw.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
@@ -54,6 +54,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
@@ -54,6 +54,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/directives.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/directives.js.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -54,6 +55,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -77,6 +79,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/parentheses_token.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/parentheses_token.js.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -49,6 +50,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -69,6 +71,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/properties_quotes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/properties_quotes.js.snap
@@ -71,6 +71,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -134,6 +135,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -197,6 +199,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/string.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/string.js.snap
@@ -85,6 +85,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -172,6 +173,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js
@@ -259,6 +261,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/suppression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/suppression.js.snap
@@ -56,6 +56,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/template/template.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/template/template.js.snap
@@ -75,6 +75,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/with.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/with.js.snap
@@ -33,6 +33,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/script/script.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/script/script.js.snap
@@ -32,6 +32,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/script/script_with_bom.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/script/script_with_bom.js.snap
@@ -32,6 +32,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/script/with.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/script/with.js.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
@@ -57,6 +57,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/attributes.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/attributes.jsx.snap
@@ -104,6 +104,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx
@@ -1,0 +1,18 @@
+const a = <div></div>;
+
+<Foo
+    className={style}
+    reallyLongAttributeName1={longComplexValue}
+    reallyLongAttributeName2={anotherLongValue}
+/>;
+
+<Foo
+    className={style}
+    reallyLongAttributeName1={longComplexValue}
+    reallyLongAttributeName2={anotherLongValue}
+>
+    Hi
+</Foo>;
+
+<div className="hi" />;
+<div className="hi"></div>;

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
@@ -1,0 +1,109 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: jsx/bracket_same_line/bracket_same_line.jsx
+---
+
+# Input
+
+```jsx
+const a = <div></div>;
+
+<Foo
+    className={style}
+    reallyLongAttributeName1={longComplexValue}
+    reallyLongAttributeName2={anotherLongValue}
+/>;
+
+<Foo
+    className={style}
+    reallyLongAttributeName1={longComplexValue}
+    reallyLongAttributeName2={anotherLongValue}
+>
+    Hi
+</Foo>;
+
+<div className="hi" />;
+<div className="hi"></div>;
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+-----
+
+```jsx
+const a = <div></div>;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+/>;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+>
+	Hi
+</Foo>;
+
+<div className="hi" />;
+<div className="hi"></div>;
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: true
+-----
+
+```jsx
+const a = <div></div>;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+/>;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}>
+	Hi
+</Foo>;
+
+<div className="hi" />;
+<div className="hi"></div>;
+```
+
+

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/options.json
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"bracket_same_line": true
+		}
+	]
+}

--- a/crates/biome_js_formatter/tests/specs/jsx/comments.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/comments.jsx.snap
@@ -32,6 +32,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/conditional.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/conditional.jsx.snap
@@ -77,6 +77,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/element.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/element.jsx.snap
@@ -358,6 +358,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/fragment.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/fragment.jsx.snap
@@ -30,6 +30,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/new-lines.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/new-lines.jsx.snap
@@ -78,6 +78,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/quote_style/quote_style.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/quote_style/quote_style.jsx.snap
@@ -36,6 +36,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx
@@ -58,6 +59,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx
@@ -80,6 +82,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx
@@ -102,6 +105,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx
@@ -124,6 +128,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
@@ -49,6 +49,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/smoke.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/smoke.jsx.snap
@@ -28,6 +28,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/ts/arrow/arrow_parentheses.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow/arrow_parentheses.ts.snap
@@ -41,6 +41,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -73,6 +74,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: As needed
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
@@ -39,6 +39,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
@@ -33,6 +33,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
@@ -41,6 +41,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
@@ -49,6 +49,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
@@ -61,6 +61,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
@@ -42,6 +42,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/call_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/call_expression.ts.snap
@@ -51,6 +51,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/accessor.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/accessor.ts.snap
@@ -30,6 +30,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
@@ -35,6 +35,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
@@ -63,6 +63,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
@@ -30,6 +30,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/readonly_ambient_property.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/readonly_ambient_property.ts.snap
@@ -38,6 +38,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
@@ -39,6 +39,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -83,6 +84,7 @@ Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -127,6 +129,7 @@ Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/class.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/class.ts.snap
@@ -87,6 +87,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
@@ -73,6 +73,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
@@ -115,6 +115,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declare.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declare.ts.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/decoartors.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/decoartors.ts.snap
@@ -286,6 +286,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/decorators/class_members.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/decorators/class_members.ts.snap
@@ -120,6 +120,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts.snap
@@ -33,6 +33,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -57,6 +58,7 @@ Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -81,6 +83,7 @@ Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/expression_bracket_spacing.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/expression_bracket_spacing.ts.snap
@@ -95,6 +95,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -210,6 +211,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: false
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
@@ -132,6 +132,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
@@ -74,6 +74,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/function/parameters/function_parameters.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/function/parameters/function_parameters.ts.snap
@@ -61,6 +61,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -115,6 +116,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -166,6 +168,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/function/trailing_comma/function_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/function/trailing_comma/function_trailing_comma.ts.snap
@@ -65,6 +65,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -123,6 +124,7 @@ Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -181,6 +183,7 @@ Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
@@ -50,6 +50,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
@@ -32,6 +32,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/class.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/class.ts.snap
@@ -79,6 +79,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -149,6 +150,7 @@ Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/non-null.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/non-null.ts.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -53,6 +54,7 @@ Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/statements.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/statements.ts.snap
@@ -42,6 +42,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -74,6 +75,7 @@ Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/types.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/types.ts.snap
@@ -41,6 +41,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -77,6 +78,7 @@ Trailing comma: All
 Semicolons: As needed
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
@@ -50,6 +50,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -90,6 +91,7 @@ Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -130,6 +132,7 @@ Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
@@ -30,6 +30,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/parenthesis.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/parenthesis.ts.snap
@@ -37,6 +37,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
@@ -29,6 +29,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
@@ -40,6 +40,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/string/parameter_quotes.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/string/parameter_quotes.ts.snap
@@ -63,6 +63,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -117,6 +118,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -171,6 +173,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/suppressions.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/suppressions.ts.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/conditional.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/conditional.ts.snap
@@ -44,6 +44,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/import_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/import_type.ts.snap
@@ -34,6 +34,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
@@ -86,6 +86,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
@@ -35,6 +35,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
@@ -28,6 +28,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/template_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/template_type.ts.snap
@@ -31,6 +31,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
@@ -40,6 +40,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -70,6 +71,7 @@ Trailing comma: ES5
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts
@@ -100,6 +102,7 @@ Trailing comma: None
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/union_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/union_type.ts.snap
@@ -274,6 +274,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/tsx/smoke.tsx.snap
+++ b/crates/biome_js_formatter/tests/specs/tsx/smoke.tsx.snap
@@ -28,6 +28,7 @@ Trailing comma: All
 Semicolons: Always
 Arrow parentheses: Always
 Bracket spacing: true
+Bracket same line: false
 -----
 
 ```tsx

--- a/crates/biome_service/src/configuration/javascript/formatter.rs
+++ b/crates/biome_service/src/configuration/javascript/formatter.rs
@@ -40,6 +40,10 @@ pub struct JavascriptFormatter {
     #[bpaf(long("bracket-spacing"), argument("true|false"), optional)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bracket_spacing: Option<bool>,
+    /// Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.
+    #[bpaf(long("bracket-same-line"), argument("true|false"), optional)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bracket_same_line: Option<bool>,
 
     /// Control the formatter for JavaScript (and its super languages) files.
     #[bpaf(long("javascript-formatter-enabled"), argument("true|false"), optional)]
@@ -95,6 +99,9 @@ impl MergeWith<JavascriptFormatter> for JavascriptFormatter {
         }
         if let Some(bracket_spacing) = other.bracket_spacing {
             self.bracket_spacing = Some(bracket_spacing);
+        }
+        if let Some(bracket_same_line) = other.bracket_same_line {
+            self.bracket_same_line = Some(bracket_same_line);
         }
         if let Some(quote_properties) = other.quote_properties {
             self.quote_properties = Some(quote_properties);

--- a/crates/biome_service/src/configuration/parse/json/javascript/formatter.rs
+++ b/crates/biome_service/src/configuration/parse/json/javascript/formatter.rs
@@ -35,6 +35,7 @@ impl DeserializationVisitor for JavascriptFormatterVisitor {
             "semicolons",
             "arrowParentheses",
             "bracketSpacing",
+            "bracketSameLine",
             "enabled",
             "indentStyle",
             "indentSize",
@@ -74,6 +75,10 @@ impl DeserializationVisitor for JavascriptFormatterVisitor {
                 }
                 "bracketSpacing" => {
                     result.bracket_spacing =
+                        Deserializable::deserialize(&value, &key_text, diagnostics);
+                }
+                "bracketSameLine" => {
+                    result.bracket_same_line =
                         Deserializable::deserialize(&value, &key_text, diagnostics);
                 }
                 "enabled" => {

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -27,7 +27,8 @@ use biome_js_analyze::{
 };
 use biome_js_formatter::context::trailing_comma::TrailingComma;
 use biome_js_formatter::context::{
-    ArrowParentheses, BracketSpacing, JsFormatOptions, QuoteProperties, QuoteStyle, Semicolons,
+    ArrowParentheses, BracketSameLine, BracketSpacing, JsFormatOptions, QuoteProperties,
+    QuoteStyle, Semicolons,
 };
 use biome_js_formatter::format_node;
 use biome_js_parser::JsParserOptions;
@@ -53,6 +54,7 @@ pub struct JsFormatterSettings {
     pub semicolons: Option<Semicolons>,
     pub arrow_parentheses: Option<ArrowParentheses>,
     pub bracket_spacing: Option<BracketSpacing>,
+    pub bracket_same_line: Option<BracketSameLine>,
     pub line_ending: Option<LineEnding>,
     pub line_width: Option<LineWidth>,
     pub indent_width: Option<IndentWidth>,
@@ -125,7 +127,8 @@ impl Language for JsLanguage {
             .with_trailing_comma(language.trailing_comma.unwrap_or_default())
             .with_semicolons(language.semicolons.unwrap_or_default())
             .with_arrow_parentheses(language.arrow_parentheses.unwrap_or_default())
-            .with_bracket_spacing(language.bracket_spacing.unwrap_or_default());
+            .with_bracket_spacing(language.bracket_spacing.unwrap_or_default())
+            .with_bracket_same_line(language.bracket_same_line.unwrap_or_default());
 
         overrides.override_js_format_options(path, options)
     }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -269,6 +269,8 @@ impl From<JavascriptConfiguration> for LanguageSettings<JsLanguage> {
             language_setting.formatter.semicolons = formatter.semicolons;
             language_setting.formatter.arrow_parentheses = formatter.arrow_parentheses;
             language_setting.formatter.bracket_spacing = formatter.bracket_spacing.map(Into::into);
+            language_setting.formatter.bracket_same_line =
+                formatter.bracket_same_line.map(Into::into);
             language_setting.formatter.enabled = formatter.enabled;
             language_setting.formatter.line_width = formatter.line_width;
             language_setting.formatter.indent_width = formatter
@@ -517,6 +519,9 @@ impl OverrideSettings {
                 }
                 if let Some(bracket_spacing) = js_formatter.bracket_spacing {
                     options.set_bracket_spacing(bracket_spacing);
+                }
+                if let Some(bracket_same_line) = js_formatter.bracket_same_line {
+                    options.set_bracket_same_line(bracket_same_line);
                 }
             }
 

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -845,6 +845,10 @@
 						{ "type": "null" }
 					]
 				},
+				"bracketSameLine": {
+					"description": "Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.",
+					"type": ["boolean", "null"]
+				},
 				"bracketSpacing": {
 					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
 					"type": ["boolean", "null"]

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -230,6 +230,10 @@ export interface JavascriptFormatter {
 	 */
 	arrowParentheses?: ArrowParentheses;
 	/**
+	 * Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.
+	 */
+	bracketSameLine?: boolean;
+	/**
 	 * Whether to insert spaces around brackets in object literals. Defaults to true.
 	 */
 	bracketSpacing?: boolean;

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -845,6 +845,10 @@
 						{ "type": "null" }
 					]
 				},
+				"bracketSameLine": {
+					"description": "Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.",
+					"type": ["boolean", "null"]
+				},
 				"bracketSpacing": {
 					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
 					"type": ["boolean", "null"]

--- a/website/src/playground/PlaygroundLoader.tsx
+++ b/website/src/playground/PlaygroundLoader.tsx
@@ -338,6 +338,9 @@ function initState(
 			bracketSpacing:
 				searchParams.get("bracketSpacing") === "true" ??
 				defaultPlaygroundState.settings.bracketSpacing,
+			bracketSameLine:
+				searchParams.get("bracketSameLine") === "true" ??
+				defaultPlaygroundState.settings.bracketSameLine,
 			lintRules:
 				(searchParams.get("lintRules") as LintRules) ??
 				defaultPlaygroundState.settings.lintRules,

--- a/website/src/playground/tabs/SettingsTab.tsx
+++ b/website/src/playground/tabs/SettingsTab.tsx
@@ -46,6 +46,7 @@ export default function SettingsTab({
 			semicolons,
 			arrowParentheses,
 			bracketSpacing,
+			bracketSameLine,
 			lintRules,
 			enabledLinting,
 			importSortingEnabled,
@@ -93,6 +94,10 @@ export default function SettingsTab({
 	const setBracketSpacing = createPlaygroundSettingsSetter(
 		setPlaygroundState,
 		"bracketSpacing",
+	);
+	const setBracketSameLine = createPlaygroundSettingsSetter(
+		setPlaygroundState,
+		"bracketSameLine",
 	);
 	const setLintRules = createPlaygroundSettingsSetter(
 		setPlaygroundState,
@@ -259,6 +264,8 @@ export default function SettingsTab({
 				setArrowParentheses={setArrowParentheses}
 				bracketSpacing={bracketSpacing}
 				setBracketSpacing={setBracketSpacing}
+				bracketSameLine={bracketSameLine}
+				setBracketSameLine={setBracketSameLine}
 			/>
 			<LinterSettings
 				lintRules={lintRules}
@@ -590,6 +597,8 @@ function FormatterSettings({
 	setArrowParentheses,
 	bracketSpacing,
 	setBracketSpacing,
+	bracketSameLine,
+	setBracketSameLine,
 }: {
 	lineWidth: number;
 	setLineWidth: (value: number) => void;
@@ -611,6 +620,8 @@ function FormatterSettings({
 	setArrowParentheses: (value: ArrowParentheses) => void;
 	bracketSpacing: boolean;
 	setBracketSpacing: (value: boolean) => void;
+	bracketSameLine: boolean;
+	setBracketSameLine: (value: boolean) => void;
 }) {
 	return (
 		<>
@@ -736,6 +747,16 @@ function FormatterSettings({
 						type="checkbox"
 						checked={bracketSpacing}
 						onChange={(e) => setBracketSpacing(e.target.checked)}
+					/>
+				</div>
+				<div className="field-row">
+					<label htmlFor="bracketSameLine">Bracket Same Line</label>
+					<input
+						id="bracketSameLine"
+						name="bracketSameLine"
+						type="checkbox"
+						checked={bracketSameLine}
+						onChange={(e) => setBracketSameLine(e.target.checked)}
 					/>
 				</div>
 			</section>

--- a/website/src/playground/types.ts
+++ b/website/src/playground/types.ts
@@ -114,6 +114,7 @@ export interface PlaygroundSettings {
 	semicolons: Semicolons;
 	arrowParentheses: ArrowParentheses;
 	bracketSpacing: boolean;
+	bracketSameLine: boolean;
 	lintRules: LintRules;
 	enabledLinting: boolean;
 	importSortingEnabled: boolean;
@@ -159,6 +160,7 @@ export const defaultPlaygroundState: PlaygroundState = {
 		semicolons: Semicolons.Always,
 		arrowParentheses: ArrowParentheses.Always,
 		bracketSpacing: true,
+		bracketSameLine: false,
 		lintRules: LintRules.Recommended,
 		enabledLinting: true,
 		importSortingEnabled: true,

--- a/website/src/playground/workers/biomeWorker.ts
+++ b/website/src/playground/workers/biomeWorker.ts
@@ -74,6 +74,7 @@ self.addEventListener("message", async (e) => {
 				semicolons,
 				arrowParentheses,
 				bracketSpacing,
+				bracketSameLine,
 				importSortingEnabled,
 				unsafeParameterDecoratorsEnabled,
 				allowComments,
@@ -113,6 +114,7 @@ self.addEventListener("message", async (e) => {
 								? "always"
 								: "asNeeded",
 						bracketSpacing,
+						bracketSameLine,
 					},
 					parser: {
 						unsafeParameterDecoratorsEnabled,

--- a/website/src/playground/workers/prettierWorker.ts
+++ b/website/src/playground/workers/prettierWorker.ts
@@ -38,6 +38,7 @@ self.addEventListener("message", async (e) => {
 				semicolons,
 				arrowParentheses,
 				bracketSpacing,
+				bracketSameLine,
 			} = settings;
 			const code = e.data.code as string;
 			const filename = e.data.filename as string;
@@ -54,6 +55,7 @@ self.addEventListener("message", async (e) => {
 				semicolons,
 				arrowParentheses,
 				bracketSpacing,
+				bracketSameLine,
 			});
 
 			self.postMessage({
@@ -84,6 +86,7 @@ async function formatWithPrettier(
 		semicolons: Semicolons;
 		arrowParentheses: ArrowParentheses;
 		bracketSpacing: boolean;
+		bracketSameLine: boolean;
 	},
 ): Promise<PrettierOutput> {
 	try {
@@ -104,6 +107,7 @@ async function formatWithPrettier(
 					? "always"
 					: "avoid",
 			bracketSpacing: options.bracketSpacing,
+			bracketSameLine: options.bracketSameLine,
 		};
 
 		// @ts-expect-error


### PR DESCRIPTION
To review: I'd recommend just checking the first commit and the third one. The second is the one with all the snapshot file updates, and the fourth is just website codegen.

## Summary

This should be the last big option that Prettier supports that Biome doesn't (other than the Pragma options). All that this option does is force the closing bracket of a multiline opening JSX tag (or HTML/Vue, once those are supported) to hug onto the end of the last attribute line rather than get placed on its own line afterward.

For example:

```jsx
// Existing behavior. Now also the default, meaning `bracketSameLine: true`.
<Foo
  className={somethingReallyLongThatForcesThisToWrap}
  anotherReallyLongAttribute={withAValueThatsSurelyTooLong}
  soThatEverythingWraps
>
  Hello
</Foo>

<Foo
  selfClosingTags={likeThisOne}
  stillPlaceTheBracket={onItsOwnLine}
  toIndicateThat={itClosesItself}
/>
```

And with the option _disabled_, which is the new behavior:

```jsx
// New behavior, with `bracketSameLine: false`.
<Foo
  className={somethingReallyLongThatForcesThisToWrap}
  anotherReallyLongAttribute={withAValueThatsSurelyTooLong}
  soThatEverythingWraps>
  Hello
</Foo>

<Foo
  selfClosingTags={likeThisOne}
  stillPlaceTheBracket={onItsOwnLine}
  toIndicateThat={itClosesItself}
/>
```

## Test Plan

New snapshot test in the CLI and in `biome_js_formatter` checks that this option is being applied correctly.

All snapshots have also been updated with the additional configuration readout.