### PR TITLE
fix: avoid escape for jsx

### DIFF
--- a/crates/biome_formatter/src/token/string.rs
+++ b/crates/biome_formatter/src/token/string.rs
@@ -133,7 +133,11 @@ impl Quote {
 ///
 /// By default the formatter uses `\n` as a newline. The function replaces
 /// `\r\n` with `\n`,
-pub fn normalize_string(raw_content: &str, preferred_quote: Quote) -> Cow<str> {
+pub fn normalize_string(
+    raw_content: &str,
+    preferred_quote: Quote,
+    is_escape_preserved: bool,
+) -> Cow<str> {
     let alternate_quote = preferred_quote.other();
 
     // A string should be manipulated only if its raw content contains backslash or quotes
@@ -196,6 +200,9 @@ pub fn normalize_string(raw_content: &str, preferred_quote: Quote) -> Cow<str> {
                         // escape removed: "\a" => "a"
                         // So we ignore the current slash and we continue
                         // to the next iteration
+                        if is_escape_preserved {
+                            reduced_string.push(current_char);
+                        }
                         continue;
                     }
                 } else {

--- a/crates/biome_js_formatter/src/utils/string_utils.rs
+++ b/crates/biome_js_formatter/src/utils/string_utils.rs
@@ -309,12 +309,16 @@ impl<'token> LiteralStringNormaliser<'token> {
 
     fn normalize_string(&self, string_information: &StringInformation) -> Cow<'token, str> {
         let raw_content = self.raw_content();
+        let is_escape_preserved = matches!(self.token.token.kind(), JSX_STRING_LITERAL);
 
         if matches!(self.token.parent_kind, StringLiteralParentKind::Directive) {
             return Cow::Borrowed(raw_content);
         }
-
-        normalize_string(raw_content, string_information.preferred_quote.into())
+        normalize_string(
+            raw_content,
+            string_information.preferred_quote.into(),
+            is_escape_preserved,
+        )
     }
 
     fn raw_content(&self) -> &'token str {

--- a/crates/biome_js_formatter/tests/specs/jsx/attribute_escape.jsx
+++ b/crates/biome_js_formatter/tests/specs/jsx/attribute_escape.jsx
@@ -1,0 +1,15 @@
+const a = () => {
+	const a = "\test";
+	const b = "\\test";
+	const c = "\\\test";
+	const d = "\\\\test";
+
+	return (
+		<>
+			<input name="pin" type="text" pattern="\d{4,4}" required />
+			<input name="\\pin" type="text" pattern="\d{4,4}" required />
+			<input name="\\\pin" type="text" pattern="\d{4,4}" required />
+			<input name="\\\\pin" type="text" pattern="\d{4,4}" required />
+		</>
+	);
+};

--- a/crates/biome_js_formatter/tests/specs/jsx/attribute_escape.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/attribute_escape.jsx.snap
@@ -1,0 +1,68 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 212
+info: jsx/attribute_escape.jsx
+---
+
+# Input
+
+```jsx
+const a = () => {
+	const a = "\test";
+	const b = "\\test";
+	const c = "\\\test";
+	const d = "\\\\test";
+
+	return (
+		<>
+			<input name="pin" type="text" pattern="\d{4,4}" required />
+			<input name="\\pin" type="text" pattern="\d{4,4}" required />
+			<input name="\\\pin" type="text" pattern="\d{4,4}" required />
+			<input name="\\\\pin" type="text" pattern="\d{4,4}" required />
+		</>
+	);
+};
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+-----
+
+```jsx
+const a = () => {
+	const a = "\test";
+	const b = "\\test";
+	const c = "\\\test";
+	const d = "\\\\test";
+
+	return (
+		<>
+			<input name="pin" type="text" pattern="\d{4,4}" required />
+			<input name="\\pin" type="text" pattern="\d{4,4}" required />
+			<input name="\\\pin" type="text" pattern="\d{4,4}" required />
+			<input name="\\\\pin" type="text" pattern="\d{4,4}" required />
+		</>
+	);
+};
+```
+
+

--- a/crates/biome_json_formatter/src/format_string.rs
+++ b/crates/biome_json_formatter/src/format_string.rs
@@ -16,7 +16,7 @@ impl Format<JsonFormatContext> for CleanedStringLiteralText<'_> {
         let content = self.token.text_trimmed();
         let raw_content = &content[1..content.len() - 1];
 
-        let text = match normalize_string(raw_content, Quote::Double) {
+        let text = match normalize_string(raw_content, Quote::Double, false) {
             Cow::Borrowed(_) => Cow::Borrowed(content),
             Cow::Owned(raw_content) => Cow::Owned(std::format!(
                 "{}{}{}",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
fix #826
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
`cargo test -p biome_js_formatter`
Check [this Prettier playground](https://prettier.io/playground/#N4Igxg9gdgLgprEAuc0DOMAEBDTBeTACgEp8A+TYAHSkypkigx3zpCvrgypAG4a6DdFgBGrHhw7xufAfUbMw49pKlcYPfrXnDMAE2WrV0jbKhyYAJzgwArpdqEL9ADxlnGmC4CWUAA62WFDYALZweDx+vjyYMACefuE88AAepph+2DDwDhEqesAALAA0hQC+MdYAjrbe1gYA9O7anq6+AUGhSSocUeYgsQndqemZ2XC5ElQFJeWVcDV1cI3NgvRt-oGYwWF5RlR9MfGJeSMxYzlQe9NFpRUD1bX1mE0eGx3bXdf7hwPHw3A0ucspdrjM7vNFs9Xi1XDDBMQtJgyrwQMUQBA-DBvOhkKBsJZLBAAO4ABQJCDQyBA2AANsTsHEqeiRJZsGAANY2ADKXQAMr44MgAGZ0tBwFlszk8zJgXwAc2QVlsEpA4pC3iVlhV6MBiUs3jCsDpABUJsEDVwRWLVWgFbS4ABFWwQeDW2ni9EAKzQKW59qdLrdSFFHtVNVdcFJRL8VJQ2DQAFooHBlss0SArNhvLSFQBhCAhELYal02kZu1QeUOgCC2QNIkCUYmApT7s9IAAFjAQrSAOqd7zSWVwbmUofeABuQ7i1LAaGZIEnKoAklA9AgYNywAasTX19z4g726q-ETxX22X5qWeuBNJ0L0b5xZYYNHsPLiyf0ZlLC-qSI2AiHA5Y-gasB9t4egwJ2yAABwAAzoo8Szvp+JYhja6IwEBkHQbBSAAEzorY4omkBcahh2cAhMBegbnofLYFWtgfnAABiECWMW2QKqWgQQCAZRlEAA), and see prettier and newly added test case snap are identical
<!-- What demonstrates that your implementation is correct? -->
