### PR TITLE
feat(js_formatter): es5 trailing comma revision

### DIFF
--- a/crates/biome_js_formatter/src/ts/lists/tuple_type_element_list.rs
+++ b/crates/biome_js_formatter/src/ts/lists/tuple_type_element_list.rs
@@ -9,7 +9,7 @@ impl FormatRule<TsTupleTypeElementList> for FormatTsTupleTypeElementList {
     type Context = JsFormatContext;
 
     fn fmt(&self, node: &TsTupleTypeElementList, f: &mut JsFormatter) -> FormatResult<()> {
-        let trailing_separator = FormatTrailingComma::All.trailing_separator(f.options());
+        let trailing_separator = FormatTrailingComma::ES5.trailing_separator(f.options());
 
         f.join_with(&soft_line_break_or_space())
             .entries(

--- a/crates/biome_js_formatter/src/ts/lists/type_parameter_list.rs
+++ b/crates/biome_js_formatter/src/ts/lists/type_parameter_list.rs
@@ -19,7 +19,7 @@ impl FormatRule<TsTypeParameterList> for FormatTsTypeParameterList {
         let trailing_separator = if node.len() == 1 && node.trailing_separator().is_some() {
             TrailingSeparator::Mandatory
         } else {
-            FormatTrailingComma::All.trailing_separator(f.options())
+            FormatTrailingComma::ES5.trailing_separator(f.options())
         };
 
         f.join_with(&soft_line_break_or_space())

--- a/crates/biome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
@@ -92,12 +92,12 @@ Bracket same line: false
 class C<
 	longlonglonglonglonglonglongT1,
 	longlonglonglonglonglonglongT2,
-	longlonglonglonglonglonglongT3
+	longlonglonglonglonglonglongT3,
 > {
 	one<
 		longlonglonglonglonglonglongT1,
 		longlonglonglonglonglonglongT2,
-		longlonglonglonglonglonglongT3
+		longlonglonglonglonglonglongT3,
 	>(
 		adsadasdasdasdasdasdasdasdasdasdas1,
 		dsadsadasdasdasdasdasdasdasd2,
@@ -106,7 +106,7 @@ class C<
 	two<
 		longlonglonglonglonglonglongT1,
 		longlonglonglonglonglonglongT2,
-		longlonglonglonglonglonglongT3
+		longlonglonglonglonglonglongT3,
 	>(
 		adsadasdasdasdasdasdasdasdasdasdas1,
 		dsadsadasdasdasdasdasdasdasd2,

--- a/crates/biome_js_formatter/tests/specs/ts/function/trailing_comma/function_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/function/trailing_comma/function_trailing_comma.ts.snap
@@ -131,7 +131,7 @@ Bracket same line: false
 function test<
 	longlonglonglonglonglonglongT1,
 	longlonglonglonglonglonglongT2,
-	longlonglonglonglonglonglongT3
+	longlonglonglonglonglonglongT3,
 >(
 	longlonglonglonglonglonglongItem1,
 	longlonglonglonglonglonglongItem2,
@@ -140,7 +140,7 @@ function test<
 const test1 = <
 	longlonglonglonglonglonglongT1,
 	longlonglonglonglonglonglongT2,
-	longlonglonglonglonglonglongT3
+	longlonglonglonglonglonglongT3,
 >(
 	longlonglonglonglonglonglongItem1,
 	longlonglonglonglonglonglongItem2,

--- a/crates/biome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
@@ -100,7 +100,7 @@ const obj = {
 	one<
 		longlonglonglonglonglonglongT1,
 		longlonglonglonglonglonglongT2,
-		longlonglonglonglonglonglongT3
+		longlonglonglonglonglonglongT3,
 	>(
 		adsadasdasdasdasdasdasdasdasdasdas1,
 		dsadsadasdasdasdasdasdasdasd2,
@@ -109,7 +109,7 @@ const obj = {
 	two<
 		longlonglonglonglonglonglongT1,
 		longlonglonglonglonglonglongT2,
-		longlonglonglonglonglonglongT3
+		longlonglonglonglonglonglongT3,
 	>(
 		adsadasdasdasdasdasdasdasdasdasdas1,
 		dsadsadasdasdasdasdasdasdasd2,

--- a/crates/biome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
@@ -78,13 +78,13 @@ Bracket same line: false
 type A = [
 	adsadasdasdasdasdasdasdasdasdasdas,
 	dsadsadasdasdasdasdasdasdasd,
-	dsadsadasdasdasdasdasdasdasd
+	dsadsadasdasdasdasdasdasdasd,
 ];
 
 interface C<
 	adsadasdasdasdasdasdasdasdasdasdas,
 	dsadsadasdasdasdasdasdasdasd,
-	dsadsadasdasdasdasdasdasdasd
+	dsadsadasdasdasdasdasdasdasd,
 > {}
 ```
 


### PR DESCRIPTION
## Summary

Follow the [change introduced by Prettier 3.0](https://prettier.io/blog/2023/07/05/3.0.0#print-trailing-comma-in-type-parameters-and-tuple-types-when---trailing-commaes5-14086httpsgithubcomprettierprettierpull14086-14085httpsgithubcomprettierprettierpull14085-by-fiskerhttpsgithubcomfisker) by adding trailing comma in ES5 mode. Note that this is listed under `Flow` breaking change, however, this also affect TypeScript.

## Test Plan

Updated snapshots.
