### PR TITLE
chore: upgrade prettier to v3.1.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,8 +137,8 @@ importers:
         specifier: ^8.4.30
         version: 8.4.30
       prettier:
-        specifier: ^3.0.3
-        version: 3.0.3
+        specifier: ^3.1.0
+        version: 3.1.0
       react:
         specifier: ^17.0.2
         version: 17.0.2
@@ -6045,8 +6045,8 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier@3.0.3:
-    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
+  /prettier@3.1.0:
+    resolution: {integrity: sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true

--- a/website/package.json
+++ b/website/package.json
@@ -43,7 +43,7 @@
 		"mdast-util-to-hast": "^12.3.0",
 		"mermaid": "^9.4.3",
 		"postcss": "^8.4.30",
-		"prettier": "^3.0.3",
+		"prettier": "^3.1.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"rehype-autolink-headings": "^6.1.1",


### PR DESCRIPTION
## Summary
This PR will upgrade prettier to v3.1.0.

## Test Plan
Checked the operation of the changes in v3.1 on local playground.
<img width="1192" alt="image" src="https://github.com/biomejs/biome/assets/51070449/577a406b-e83a-4834-9e49-ae8196b050dd">
https://prettier.io/blog/2023/11/13/3.1.0#add-indentation-back-to-nested-ternaries-9559httpsgithubcomprettierprettierpull9559-by-rattrayalexhttpsgithubcomrattrayalex

Closes #852
