### PR TITLE
docs: clarify `organizeImports` is opt-out

### DIFF
--- a/website/src/content/docs/analyzer/index.mdx
+++ b/website/src/content/docs/analyzer/index.mdx
@@ -9,7 +9,7 @@ Biome's analyzer provides a series of features that users can leverage.
 
 Biome allows to sort import statement using [natural ordering](https://en.wikipedia.org/wiki/Natural_sort_order).
 
-This feature is enabled by default but can be opted-in/out via configuration:
+This feature is enabled by default but can be opted-out via configuration:
 
 ```json
 {


### PR DESCRIPTION
## Summary

`organizeImports` is opt-out, not opt-in. This PR clarifies it.