### PR TITLE
docs: fix typo and improve readability in complexity/noBannedTypes rule

### DIFF
--- a/website/src/content/docs/linter/rules/no-banned-types.md
+++ b/website/src/content/docs/linter/rules/no-banned-types.md
@@ -47,8 +47,9 @@ const n: {} = 0
 
 To represent an empty object, you should use `{ [k: string]: never }` or `Record<string, never>`.
 
-To avoid any confusion, the rule forbids the use of the type `{}`,e except in two situation.
-In type constraints to restrict a generic type to non-nullable types:
+To avoid any confusion, the rule forbids the use of the type `{}`, except in two situations:
+
+1. In type constraints to restrict a generic type to non-nullable types:
 
 ```ts
 function f<T extends {}>(x: T) {
@@ -56,7 +57,7 @@ function f<T extends {}>(x: T) {
 }
 ```
 
-And in a type intersection to narrow a type to its non-nullable equivalent type:
+2. In a type intersection to narrow a type to its non-nullable equivalent type:
 
 ```ts
 type NonNullableMyType = MyType & {};


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Removes an extra `e` letter and proposes a change to improve the readability in the [`complexity/noBannedTypes`](https://biomejs.dev/linter/rules/no-banned-types) rule.

## Test Plan

N/A
