### PR TITLE
fix: cargo build for publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,20 +3,42 @@
 We can use help in a bunch of areas and any help is greatly appreciated!
 
 # Table of Contents
-- [Asking Questions, Making Proposals](#asking-questions-making-proposals)
-- [Reporting Bugs](#reporting-bugs)
-- [Getting Started](#getting-started)
-- [Install the Required Tools](#install-the-required-tools)
-- [Crates Development](#crates-development)
-- [VS Code Extension Development](#vs-code-extension-development)
-- [IntelliJ Extension Development](#intellij-plugin-development)
-- [Node.js Development](#nodejs-development)
-- [Website Development](#website-development)
-- [Commit Messages](#commit-messages)
-- [Creating Pull Requests](#creating-pull-requests)
-- [Releasing](#releasing)
-- [Resources](#resources)
-- [Current Members](#current-members)
+- [🚀 Contributing](#-contributing)
+- [Table of Contents](#table-of-contents)
+  - [Asking questions, making proposals](#asking-questions-making-proposals)
+  - [Reporting bugs](#reporting-bugs)
+  - [Getting Started](#getting-started)
+  - [Install the required tools](#install-the-required-tools)
+  - [Crates development](#crates-development)
+    - [Analyzers and lint rules](#analyzers-and-lint-rules)
+    - [Parser](#parser)
+    - [Formatter](#formatter)
+    - [Testing](#testing)
+    - [Checks](#checks)
+      - [Generated files](#generated-files)
+        - [`cargo codegen grammar`](#cargo-codegen-grammar)
+        - [`cargo codegen test`](#cargo-codegen-test)
+        - [`cargo codegen analyzer`](#cargo-codegen-analyzer)
+    - [crate dependencies](#crate-dependencies)
+  - [Intellij plugin development](#intellij-plugin-development)
+    - [Running the plugin on IDEA](#running-the-plugin-on-idea)
+    - [Build the plugin](#build-the-plugin)
+    - [UI Testing intellij plugin](#ui-testing-intellij-plugin)
+  - [Node.js development](#nodejs-development)
+  - [Website development](#website-development)
+  - [Commit messages](#commit-messages)
+  - [Creating pull requests](#creating-pull-requests)
+    - [Changelog](#changelog)
+      - [Writing a changelog line](#writing-a-changelog-line)
+    - [Documentation](#documentation)
+    - [Magic comments](#magic-comments)
+    - [Versioning](#versioning)
+  - [Releasing](#releasing)
+  - [Resources](#resources)
+  - [Current Members](#current-members)
+    - [Lead team](#lead-team)
+    - [Core Contributors team](#core-contributors-team)
+    - [Maintainers team](#maintainers-team)
 
 ## Asking questions, making proposals
 
@@ -353,7 +375,7 @@ When releasing a new version of a Biome, follow these steps:
 
 1. [ ] Update `version` in [Biome's `package.json`](./packages/@biomejs/biome/package.json) if applicable.
 
-2. [ ] Update `version` in each published crates if applicable. (`Cargo.toml` and `crates/**/Cargo.toml`)
+2. [ ] **Update to the same `version` in all crates** if you publish crates. (`Cargo.toml` and `crates/**/Cargo.toml`)
 
 3. [ ] Linter rules have a `version` metadata directly defined in their implementation.
    This field is set to `next` for newly created rules.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "biome_analyze"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "biome_aria"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "biome_aria_metadata",
  "rustc-hash",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "biome_aria_metadata"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "case",
  "proc-macro2",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "biome_console"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_markup",
  "biome_text_size",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "biome_control_flow"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "biome_rowan",
  "rustc-hash",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "biome_css_factory"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_css_syntax",
  "biome_rowan",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "biome_css_parser"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_console",
  "biome_css_factory",
@@ -254,14 +254,14 @@ dependencies = [
 
 [[package]]
 name = "biome_css_syntax"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_rowan",
 ]
 
 [[package]]
 name = "biome_deserialize"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "biome_diagnostics"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "backtrace",
  "biome_console",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "biome_diagnostics_categories"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "quote",
  "schemars",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "biome_diagnostics_macros"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -322,7 +322,7 @@ version = "0.0.0"
 
 [[package]]
 name = "biome_formatter"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "biome_console",
  "biome_deserialize",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "biome_fs"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "biome_js_analyze"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "biome_analyze",
  "biome_aria",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "biome_js_factory"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_js_syntax",
  "biome_rowan",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "biome_js_formatter"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "biome_console",
  "biome_deserialize",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "biome_js_parser"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "biome_js_semantic"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "biome_js_syntax"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "biome_js_transform"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_analyze",
  "biome_console",
@@ -526,11 +526,11 @@ dependencies = [
 
 [[package]]
 name = "biome_js_unicode_table"
-version = "0.1.0"
+version = "0.3.0"
 
 [[package]]
 name = "biome_json_analyze"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "biome_analyze",
  "biome_console",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "biome_json_factory"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_json_syntax",
  "biome_rowan",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "biome_json_formatter"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_diagnostics",
  "biome_formatter",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "biome_json_parser"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "biome_json_syntax"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_rowan",
 ]
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "biome_markup"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "biome_parser"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "biome_rowan"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_text_edit",
  "biome_text_size",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "biome_suppression"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "biome_text_edit"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "biome_text_size",
  "schemars",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "biome_text_size"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,39 +27,39 @@ inherits = "release"
 
 [workspace.dependencies]
 # publish
-biome_analyze                = { version = "0.2.0", path = "./crates/biome_analyze" }
-biome_aria                   = { version = "0.2.0", path = "./crates/biome_aria" }
-biome_aria_metadata          = { version = "0.1.0", path = "./crates/biome_aria_metadata" }
-biome_console                = { version = "0.1.0", path = "./crates/biome_console" }
-biome_control_flow           = { version = "0.2.0", path = "./crates/biome_control_flow" }
-biome_css_factory            = { version = "0.1.0", path = "./crates/biome_css_factory" }
-biome_css_parser             = { version = "0.1.0", path = "./crates/biome_css_parser" }
-biome_css_syntax             = { version = "0.1.0", path = "./crates/biome_css_syntax" }
-biome_deserialize            = { version = "0.1.0", path = "./crates/biome_deserialize" }
-biome_diagnostics            = { version = "0.1.0", path = "./crates/biome_diagnostics" }
-biome_diagnostics_categories = { version = "0.2.0", path = "./crates/biome_diagnostics_categories" }
-biome_diagnostics_macros     = { version = "0.1.0", path = "./crates/biome_diagnostics_macros" }
-biome_formatter              = { version = "0.2.0", path = "./crates/biome_formatter" }
-biome_fs                     = { version = "0.1.0", path = "./crates/biome_fs" }
-biome_js_analyze             = { version = "0.2.0", path = "./crates/biome_js_analyze" }
-biome_js_factory             = { version = "0.1.0", path = "./crates/biome_js_factory" }
-biome_js_formatter           = { version = "0.2.0", path = "./crates/biome_js_formatter" }
-biome_js_parser              = { version = "0.1.0", path = "./crates/biome_js_parser" }
-biome_js_semantic            = { version = "0.2.0", path = "./crates/biome_js_semantic" }
-biome_js_syntax              = { version = "0.2.0", path = "./crates/biome_js_syntax" }
-biome_js_transform           = { version = "0.1.0", path = "./crates/biome_js_transform" }
-biome_js_unicode_table       = { version = "0.1.0", path = "./crates/biome_js_unicode_table" }
-biome_json_analyze           = { version = "0.2.0", path = "./crates/biome_json_analyze" }
-biome_json_factory           = { version = "0.1.0", path = "./crates/biome_json_factory" }
-biome_json_formatter         = { version = "0.1.0", path = "./crates/biome_json_formatter" }
-biome_json_parser            = { version = "0.1.0", path = "./crates/biome_json_parser" }
-biome_json_syntax            = { version = "0.1.0", path = "./crates/biome_json_syntax" }
-biome_markup                 = { version = "0.1.0", path = "./crates/biome_markup" }
-biome_parser                 = { version = "0.2.0", path = "./crates/biome_parser" }
-biome_rowan                  = { version = "0.1.0", path = "./crates/biome_rowan" }
-biome_suppression            = { version = "0.1.0", path = "./crates/biome_suppression" }
-biome_text_edit              = { version = "0.1.0", path = "./crates/biome_text_edit" }
-biome_text_size              = { version = "0.1.0", path = "./crates/biome_text_size" }
+biome_analyze                = { version = "0.3.0", path = "./crates/biome_analyze" }
+biome_aria                   = { version = "0.3.0", path = "./crates/biome_aria" }
+biome_aria_metadata          = { version = "0.3.0", path = "./crates/biome_aria_metadata" }
+biome_console                = { version = "0.3.0", path = "./crates/biome_console" }
+biome_control_flow           = { version = "0.3.0", path = "./crates/biome_control_flow" }
+biome_css_factory            = { version = "0.3.0", path = "./crates/biome_css_factory" }
+biome_css_parser             = { version = "0.3.0", path = "./crates/biome_css_parser" }
+biome_css_syntax             = { version = "0.3.0", path = "./crates/biome_css_syntax" }
+biome_deserialize            = { version = "0.3.0", path = "./crates/biome_deserialize" }
+biome_diagnostics            = { version = "0.3.0", path = "./crates/biome_diagnostics" }
+biome_diagnostics_categories = { version = "0.3.0", path = "./crates/biome_diagnostics_categories" }
+biome_diagnostics_macros     = { version = "0.3.0", path = "./crates/biome_diagnostics_macros" }
+biome_formatter              = { version = "0.3.0", path = "./crates/biome_formatter" }
+biome_fs                     = { version = "0.3.0", path = "./crates/biome_fs" }
+biome_js_analyze             = { version = "0.3.0", path = "./crates/biome_js_analyze" }
+biome_js_factory             = { version = "0.3.0", path = "./crates/biome_js_factory" }
+biome_js_formatter           = { version = "0.3.0", path = "./crates/biome_js_formatter" }
+biome_js_parser              = { version = "0.3.0", path = "./crates/biome_js_parser" }
+biome_js_semantic            = { version = "0.3.0", path = "./crates/biome_js_semantic" }
+biome_js_syntax              = { version = "0.3.0", path = "./crates/biome_js_syntax" }
+biome_js_transform           = { version = "0.3.0", path = "./crates/biome_js_transform" }
+biome_js_unicode_table       = { version = "0.3.0", path = "./crates/biome_js_unicode_table" }
+biome_json_analyze           = { version = "0.3.0", path = "./crates/biome_json_analyze" }
+biome_json_factory           = { version = "0.3.0", path = "./crates/biome_json_factory" }
+biome_json_formatter         = { version = "0.3.0", path = "./crates/biome_json_formatter" }
+biome_json_parser            = { version = "0.3.0", path = "./crates/biome_json_parser" }
+biome_json_syntax            = { version = "0.3.0", path = "./crates/biome_json_syntax" }
+biome_markup                 = { version = "0.3.0", path = "./crates/biome_markup" }
+biome_parser                 = { version = "0.3.0", path = "./crates/biome_parser" }
+biome_rowan                  = { version = "0.3.0", path = "./crates/biome_rowan" }
+biome_suppression            = { version = "0.3.0", path = "./crates/biome_suppression" }
+biome_text_edit              = { version = "0.3.0", path = "./crates/biome_text_edit" }
+biome_text_size              = { version = "0.3.0", path = "./crates/biome_text_size" }
 # not publish
 biome_cli            = { path = "./crates/biome_cli" }
 biome_flags          = { path = "./crates/biome_flags" }

--- a/crates/biome_analyze/Cargo.toml
+++ b/crates/biome_analyze/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_analyze"
 repository.workspace = true
-version              = "0.2.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_aria/Cargo.toml
+++ b/crates/biome_aria/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_aria"
 repository.workspace = true
-version              = "0.2.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_aria_metadata/Cargo.toml
+++ b/crates/biome_aria_metadata/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_aria_metadata"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_console/Cargo.toml
+++ b/crates/biome_console/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_console"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_control_flow/Cargo.toml
+++ b/crates/biome_control_flow/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_control_flow"
 repository.workspace = true
-version              = "0.2.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_css_factory/Cargo.toml
+++ b/crates/biome_css_factory/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_css_factory"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_css_parser/Cargo.toml
+++ b/crates/biome_css_parser/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_css_parser"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 [dependencies]
 biome_console          = { workspace = true }

--- a/crates/biome_css_syntax/Cargo.toml
+++ b/crates/biome_css_syntax/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_css_syntax"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_deserialize/Cargo.toml
+++ b/crates/biome_deserialize/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_deserialize"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_diagnostics/Cargo.toml
+++ b/crates/biome_diagnostics/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_diagnostics"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 [[example]]
 name = "cli"

--- a/crates/biome_diagnostics_categories/Cargo.toml
+++ b/crates/biome_diagnostics_categories/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_diagnostics_categories"
 repository.workspace = true
-version              = "0.2.0"
+version              = "0.3.0"
 
 [dependencies]
 schemars = { workspace = true, optional = true }

--- a/crates/biome_diagnostics_macros/Cargo.toml
+++ b/crates/biome_diagnostics_macros/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_diagnostics_macros"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 [lib]
 proc-macro = true

--- a/crates/biome_formatter/Cargo.toml
+++ b/crates/biome_formatter/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_formatter"
 repository.workspace = true
-version              = "0.2.0"
+version              = "0.3.0"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/biome_fs/Cargo.toml
+++ b/crates/biome_fs/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_fs"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_js_analyze"
 repository.workspace = true
-version              = "0.2.0"
+version              = "0.3.0"
 
 [dependencies]
 biome_analyze          = { workspace = true }

--- a/crates/biome_js_factory/Cargo.toml
+++ b/crates/biome_js_factory/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace    = true
 license.workspace    = true
 name                 = "biome_js_factory"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_js_formatter/Cargo.toml
+++ b/crates/biome_js_formatter/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_js_formatter"
 repository.workspace = true
-version              = "0.2.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_js_parser/Cargo.toml
+++ b/crates/biome_js_parser/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_js_parser"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 [dependencies]
 biome_console          = { workspace = true }

--- a/crates/biome_js_semantic/Cargo.toml
+++ b/crates/biome_js_semantic/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_js_semantic"
 repository.workspace = true
-version              = "0.2.0"
+version              = "0.3.0"
 
 [dependencies]
 biome_js_syntax = { workspace = true }

--- a/crates/biome_js_syntax/Cargo.toml
+++ b/crates/biome_js_syntax/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_js_syntax"
 repository.workspace = true
-version              = "0.2.0"
+version              = "0.3.0"
 
 [dependencies]
 biome_console     = { workspace = true }

--- a/crates/biome_js_transform/Cargo.toml
+++ b/crates/biome_js_transform/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_js_transform"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_js_unicode_table/Cargo.toml
+++ b/crates/biome_js_unicode_table/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_js_unicode_table"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 [dependencies]
 

--- a/crates/biome_json_analyze/Cargo.toml
+++ b/crates/biome_json_analyze/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_json_analyze"
 repository.workspace = true
-version              = "0.2.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_json_factory/Cargo.toml
+++ b/crates/biome_json_factory/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_json_factory"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_json_formatter/Cargo.toml
+++ b/crates/biome_json_formatter/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_json_formatter"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_json_parser/Cargo.toml
+++ b/crates/biome_json_parser/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_json_parser"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 [dependencies]
 biome_console          = { workspace = true }

--- a/crates/biome_json_syntax/Cargo.toml
+++ b/crates/biome_json_syntax/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_json_syntax"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_markup/Cargo.toml
+++ b/crates/biome_markup/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_markup"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 
 [lib]

--- a/crates/biome_parser/Cargo.toml
+++ b/crates/biome_parser/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_parser"
 repository.workspace = true
-version              = "0.2.0"
+version              = "0.3.0"
 
 
 [dependencies]

--- a/crates/biome_rowan/Cargo.toml
+++ b/crates/biome_rowan/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_rowan"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 [dependencies]
 biome_text_edit = { workspace = true }

--- a/crates/biome_suppression/Cargo.toml
+++ b/crates/biome_suppression/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_suppression"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 
 [dependencies]

--- a/crates/biome_text_edit/Cargo.toml
+++ b/crates/biome_text_edit/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_text_edit"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 [dependencies]
 biome_text_size = { workspace = true, features = ["serde"] }

--- a/crates/biome_text_size/Cargo.toml
+++ b/crates/biome_text_size/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace   = true
 license.workspace    = true
 name                 = "biome_text_size"
 repository.workspace = true
-version              = "0.1.0"
+version              = "0.3.0"
 
 [dependencies]
 schemars = { workspace = true, optional = true }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

In 1.3.0 release, we tried to publish crates but it failed. This is because all crate versions were not upgraded to the same version at once.

So, I upgraded all crate versions to `0.3.0`. In 1.4.0 release, crate publishing should be successful.  I also added a note about this in the CONTRIBUTION.md.



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I'll try to publish crates in 1.4.0 release.

<!-- What demonstrates that your implementation is correct? -->
