### PR TITLE
docs: fix link to playground instrunctions

### DIFF
--- a/crates/biome_js_formatter/src/lib.rs
+++ b/crates/biome_js_formatter/src/lib.rs
@@ -85,7 +85,7 @@
 //! 4. Use the [playground](https://biomejs.dev/playground/) to inspect the code that you want to format.
 //! It helps you to understand which nodes need to be implemented/modified
 //! in order to implement formatting. Alternatively, you can locally run the playground by following
-//! the [playground instructions](https://github.com/biomejs/biome/blob/main/website/playground/README.md).
+//! the [playground instructions](https://github.com/biomejs/biome/blob/main/website/README.md).
 //! 5. Use the `quick_test.rs` file in `tests/` directory.
 //! function to test you snippet straight from your IDE, without running the whole test suite. The test
 //! is ignored on purpose, so you won't need to worry about the CI breaking.


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

In the documentation of [biome_js_formatter](https://docs.rs/biome_js_formatter/latest/biome_js_formatter/#best-practices), the link of `playground instructions` which is linked to [biomejs/src/website/playground/README.md](https://github.com/biomejs/biome/blob/main/website/playground/README.md) gives 404 error and doesn't exists, even in the oldest [commit](https://github.com/biomejs/biome/tree/cdaded93a386dc07a8d11c705ebe24de8d045cb3/website/src/playground).

Probably [biomejs/src/website/playground/README.md](https://github.com/biomejs/biome/blob/main/website/README.md) is a correct link which gives the instruction below

> If you want to work on the playground, additional artifacts are required and the following command must be used instead:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
