### PR TITLE
docs: fix link to technical principals

### DIFF
--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Let's say we want to create a new rule called `myRuleName`, which uses the seman
    }
    ```
 
-   While implementing the diagnostic, please keep [Biome's technical principals](https://biomejs.dev/#technical) in mind.
+   While implementing the diagnostic, please keep [Biome's technical principals](https://biomejs.dev/internals/philosophy/#technical) in mind.
    This function is called for every signal emitted by the `run` function, and it may return
    zero or one diagnostic.
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

There is a link to `Biome’s technical principals` in the documentation for[ biome_analyze](https://docs.rs/biome_analyze/latest/biome_analyze/#create-and-implement-the-rule), but I thought the link was set incorrectly, so I changed it. [new link](https://biomejs.dev/internals/philosophy/#technical)

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
