### PR TITLE
refactor(js_formatter): adjust mandatory trailing comma in arrow functions

### DIFF
--- a/crates/biome_js_formatter/src/ts/lists/type_parameter_list.rs
+++ b/crates/biome_js_formatter/src/ts/lists/type_parameter_list.rs
@@ -20,9 +20,9 @@ impl FormatRule<TsTypeParameterList> for FormatTsTypeParameterList {
             && !f.options().source_type().variant().is_standard()
             && node.syntax().grand_parent().kind()
                 == Some(JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION)
-            // Ignore Type parameter with an `extends`` clause.
+            // Ignore Type parameter with an `extends`` clause or a default type.
             && !node.first().and_then(|param| param.ok())
-                .is_some_and(|type_parameter| type_parameter.constraint().is_some())
+                .is_some_and(|type_parameter| type_parameter.constraint().is_some() || type_parameter.default().is_some())
         {
             TrailingSeparator::Mandatory
         } else {

--- a/crates/biome_js_formatter/tests/specs/tsx/type_param.tsx
+++ b/crates/biome_js_formatter/tests/specs/tsx/type_param.tsx
@@ -3,6 +3,8 @@
 <const T,>() => {};
 <T extends U,>() => {};
 <const T extends U,>() => {};
+<T = T,>() => {};
+<const T = T,>() => {};
 <T, U,>() => {};
 <const T, const U,>() => {};
 

--- a/crates/biome_js_formatter/tests/specs/tsx/type_param.tsx.snap
+++ b/crates/biome_js_formatter/tests/specs/tsx/type_param.tsx.snap
@@ -11,6 +11,8 @@ info: tsx/type_param.tsx
 <const T,>() => {};
 <T extends U,>() => {};
 <const T extends U,>() => {};
+<T = T,>() => {};
+<const T = T,>() => {};
 <T, U,>() => {};
 <const T, const U,>() => {};
 
@@ -49,6 +51,8 @@ Bracket same line: false
 <const T,>() => {};
 <T extends U>() => {};
 <const T extends U>() => {};
+<T = T>() => {};
+<const T = T>() => {};
 <T, U>() => {};
 <const T, const U>() => {};
 


### PR DESCRIPTION
## Summary

This is a follow-up of #872.

This PR make us slightly diverges from Prettier by keeping the original intent of Prettier: disambiguating type parameter list of arrow function from JSX.
Prettier seems to forget that the presence of a default type is enough to disambiguate an arrow function from a JSX element.
Thus, in this specific case the trailing comma is not mandatory.

```tsx
<T = unknown>() => {};
```

```diff
// -- Prettier
// ++ Biome
- <T = unknown,>() => {};
+ <T = unknown>() => {}; 
```

## Test Plan

I added a test case.