### PR TITLE
refactor(lint/noUselessTypeCOnstraint): add required trailing comma in arrow functions

### DIFF
--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessTypeConstraint/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessTypeConstraint/invalid.ts
@@ -15,3 +15,6 @@ const QuuxAny = <T extends any>() => {};
 function QuuzAny<T extends any>() {}
 
 function commented<T /*a*/ extends /*b*/ any /*c*/>() {}
+
+const A = <T extends unknown>() => {}
+const B = <T extends unknown = unknown>() => {}

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessTypeConstraint/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessTypeConstraint/invalid.ts.snap
@@ -22,6 +22,9 @@ function QuuzAny<T extends any>() {}
 
 function commented<T /*a*/ extends /*b*/ any /*c*/>() {}
 
+const A = <T extends unknown>() => {}
+const B = <T extends unknown = unknown>() => {}
+
 ```
 
 # Diagnostics
@@ -158,6 +161,7 @@ invalid.ts:17:28 lint/complexity/noUselessTypeConstraint  FIXABLE  ━━━━�
   > 17 │ function commented<T /*a*/ extends /*b*/ any /*c*/>() {}
        │                            ^^^^^^^^^^^^^^^^^
     18 │ 
+    19 │ const A = <T extends unknown>() => {}
   
   i All types are subtypes of any and unknown.
   
@@ -165,6 +169,46 @@ invalid.ts:17:28 lint/complexity/noUselessTypeConstraint  FIXABLE  ━━━━�
   
     17 │ function·commented<T·/*a*/·extends·/*b*/·any·/*c*/>()·{}
        │                           ------------------------      
+
+```
+
+```
+invalid.ts:19:14 lint/complexity/noUselessTypeConstraint  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Constraining a type parameter to any or unknown is useless.
+  
+    17 │ function commented<T /*a*/ extends /*b*/ any /*c*/>() {}
+    18 │ 
+  > 19 │ const A = <T extends unknown>() => {}
+       │              ^^^^^^^^^^^^^^^
+    20 │ const B = <T extends unknown = unknown>() => {}
+    21 │ 
+  
+  i All types are subtypes of any and unknown.
+  
+  i Safe fix: Remove the constraint.
+  
+    19 │ const·A·=·<T·extends·unknown>()·=>·{}
+       │             ----------------         
+
+```
+
+```
+invalid.ts:20:14 lint/complexity/noUselessTypeConstraint  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Constraining a type parameter to any or unknown is useless.
+  
+    19 │ const A = <T extends unknown>() => {}
+  > 20 │ const B = <T extends unknown = unknown>() => {}
+       │              ^^^^^^^^^^^^^^^
+    21 │ 
+  
+  i All types are subtypes of any and unknown.
+  
+  i Safe fix: Remove the constraint.
+  
+    20 │ const·B·=·<T·extends·unknown·=·unknown>()·=>·{}
+       │              ----------------                  
 
 ```
 

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessTypeConstraint/invalid.tsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessTypeConstraint/invalid.tsx
@@ -1,0 +1,3 @@
+const A = <T extends unknown>() => {}
+const B = <T extends unknown = unknown>() => {}
+const A = <T extends unknown, U>() => {}

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessTypeConstraint/invalid.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessTypeConstraint/invalid.tsx.snap
@@ -1,0 +1,73 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.tsx
+---
+# Input
+```js
+const A = <T extends unknown>() => {}
+const B = <T extends unknown = unknown>() => {}
+const A = <T extends unknown, U>() => {}
+```
+
+# Diagnostics
+```
+invalid.tsx:1:14 lint/complexity/noUselessTypeConstraint  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Constraining a type parameter to any or unknown is useless.
+  
+  > 1 │ const A = <T extends unknown>() => {}
+      │              ^^^^^^^^^^^^^^^
+    2 │ const B = <T extends unknown = unknown>() => {}
+    3 │ const A = <T extends unknown, U>() => {}
+  
+  i All types are subtypes of any and unknown.
+  
+  i Safe fix: Remove the constraint.
+  
+    1   │ - const·A·=·<T·extends·unknown>()·=>·{}
+      1 │ + const·A·=·<T,>()·=>·{}
+    2 2 │   const B = <T extends unknown = unknown>() => {}
+    3 3 │   const A = <T extends unknown, U>() => {}
+  
+
+```
+
+```
+invalid.tsx:2:14 lint/complexity/noUselessTypeConstraint  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Constraining a type parameter to any or unknown is useless.
+  
+    1 │ const A = <T extends unknown>() => {}
+  > 2 │ const B = <T extends unknown = unknown>() => {}
+      │              ^^^^^^^^^^^^^^^
+    3 │ const A = <T extends unknown, U>() => {}
+  
+  i All types are subtypes of any and unknown.
+  
+  i Safe fix: Remove the constraint.
+  
+    2 │ const·B·=·<T·extends·unknown·=·unknown>()·=>·{}
+      │              ----------------                  
+
+```
+
+```
+invalid.tsx:3:14 lint/complexity/noUselessTypeConstraint  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Constraining a type parameter to any or unknown is useless.
+  
+    1 │ const A = <T extends unknown>() => {}
+    2 │ const B = <T extends unknown = unknown>() => {}
+  > 3 │ const A = <T extends unknown, U>() => {}
+      │              ^^^^^^^^^^^^^^^
+  
+  i All types are subtypes of any and unknown.
+  
+  i Safe fix: Remove the constraint.
+  
+    3 │ const·A·=·<T·extends·unknown,·U>()·=>·{}
+      │             ----------------            
+
+```
+
+


### PR DESCRIPTION
## Summary

This Pr updates the code action by adding a mandatory trailing comma in type parameter lists of arrow functions in some specific cases.

## Test Plan

I added tests.
