### PR TITLE
refactor(lint/noExplicitAny): ignore type constraint clauses

### DIFF
--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_explicit_any.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_explicit_any.rs
@@ -1,7 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
-use biome_js_syntax::TsAnyType;
+use biome_js_syntax::{TsAnyType, TsTypeConstraintClause};
 use biome_rowan::AstNode;
 
 declare_rule! {
@@ -12,6 +12,9 @@ declare_rule! {
     ///
     /// TypeScript's `--noImplicitAny` compiler option prevents an implied `any`,
     /// but doesn't prevent `any` from being explicitly used the way this rule does.
+    ///
+    /// Sometimes you can use the type `unknown` instead of the type `any`.
+    /// It also accepts any value, however it requires to check that a property exists before calling it.
     ///
     /// Source: https://typescript-eslint.io/rules/no-explicit-any
     ///
@@ -41,7 +44,7 @@ declare_rule! {
     /// ```
     ///
     /// ```ts
-    /// class SomeClass {
+    /// class SomeClass<T extends any> {
     ///   message: Array<Array<unknown>>;
     /// }
     /// ```
@@ -64,8 +67,15 @@ impl Rule for NoExplicitAny {
     type Signals = Option<Self::State>;
     type Options = ();
 
-    fn run(_: &RuleContext<Self>) -> Self::Signals {
-        Some(())
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+        if TsTypeConstraintClause::can_cast(node.syntax().parent()?.kind()) {
+            // Ignore `<T extends any>`.
+            // This use is inoffensive and already triggers the rule `noUselessTypeConstraint`.
+            None
+        } else {
+            Some(())
+        }
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/tests/specs/suspicious/noExplicitAny/validTypeConstraints.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noExplicitAny/validTypeConstraints.ts
@@ -1,0 +1,1 @@
+function f<T extends any>() {}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noExplicitAny/validTypeConstraints.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noExplicitAny/validTypeConstraints.ts.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validTypeConstraints.ts
+---
+# Input
+```js
+function f<T extends any>() {}
+```
+
+

--- a/website/src/content/docs/linter/rules/no-explicit-any.md
+++ b/website/src/content/docs/linter/rules/no-explicit-any.md
@@ -16,6 +16,9 @@ Using `any` disables many type checking rules and is generally best used only as
 TypeScript's `--noImplicitAny` compiler option prevents an implied `any`,
 but doesn't prevent `any` from being explicitly used the way this rule does.
 
+Sometimes you can use the type `unknown` instead of the type `any`.
+It also accepts any value, however it requires to check that a property exists before calling it.
+
 Source: https://typescript-eslint.io/rules/no-explicit-any
 
 ## Examples
@@ -82,7 +85,7 @@ let variable2 = 1;
 ```
 
 ```ts
-class SomeClass {
+class SomeClass<T extends any> {
   message: Array<Array<unknown>>;
 }
 ```


### PR DESCRIPTION
## Summary

The following code trigger both `noUslessTypeConstraint` and `noExplicitAny`:

```ts
function f<T extends any>(x: T): void {}
```

Extending `any` is not dangerous. Thus, this PR ignores this use of `any`.
This improves user experience by reporting this code a single time.

## Test Plan

Test added.
