### PR TITLE
build: set `codegen-units = 1`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -89,4 +89,5 @@ rustflags = [
 ]
 
 [profile.release]
-lto = true
+codegen-units = 1
+lto           = true


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
`codegen-units = 1` flags usually optimizes performance, but the results are actually opaque. Do you think it's worth adding the flag? Downside of this flag is longer build time.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
- CI should pass
<!-- What demonstrates that your implementation is correct? -->
