### PR TITLE
fix(js_formatter): Avoid double-printing the first leading comments in arrow chains

### DIFF
--- a/crates/biome_js_formatter/tests/quick_test.rs
+++ b/crates/biome_js_formatter/tests/quick_test.rs
@@ -14,30 +14,7 @@ mod language {
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
     let src = r#"
-    /**
- * Curried function that ends with a BEM CSS Selector
- *
- * @param {String} block - the BEM Block you'd like to select.
- * @returns {Function}
- */
-export const bem =
-	(block) =>
-	/**
-	 * @param {String} [element] - the BEM Element within that block; if undefined, selects the block itself.
-	 * @returns {Function}
-	 */
-	(element) =>
-	/**
-	 * @param {?String} [modifier] - the BEM Modifier for the Block or Element; if undefined, selects the Block or Element unmodified.
-	 * @returns {String}
-	 */
-	(modifier) =>
-		[
-			".",
-			css(block),
-			element ? `__${css(element)}` : "",
-			modifier ? `--${css(modifier)}` : "",
-		].join("");
+    foo( /*hi*/(a) => (b) => {})
     "#;
     let syntax = JsFileSource::tsx();
     let tree = parse(


### PR DESCRIPTION
[Playground Example](https://biomejs.dev/playground?code=ZgBvAG8AKAAgAC8AKgBoAGkAKgAvACAAKABwAGEAcgBhAG0AZQB0AGUAcgAxACAAKQAgAD0APgAgAHsAYwBvAG4AcwB0ACAAYQAgAD0AIAAnAGgAZQBsAGwAbwAnADsAfQApAAoAZgBvAG8AKAAgAC8AKgBoAGkAKgAvACgAYQApACAAPQA%2BACAAKABiACkAIAA9AD4AIAB7AH0AKQAKAAoAZgBvAG8AKAAgAC8AKgBoAGkAKgAvACgAcABhAHIAYQBtAGUAdABlAHIAMQApACAAPQA%2BACAAKABwAGEAcgBhAG0AZQB0AGUAcgAyACkAIAA9AD4AIAAoAHAAYQByAGEAbQBlAHQAZQByADMAKQAgAD0APgAgACgAcABhAHIAYQBtAGUAdABlAHIANAApACAAPQA%2BACAAKABwAGEAcgBhAG0AZQB0AGUAcgA1ACkAIAA9AD4AIAB7AGMAbwBuAHMAdAAgAGEAIAA9ACAAJwBoAGUAbABsAG8AJwA7AH0AKQA%3D).

## Summary

`ArrowChain` is a special case of `FormatJsArrowFunctionExpression` that handles formatting all of the nested arrow functions inside of it as a single node point. The top formatting node handles formatting comments, just like any other formatting node, but because all of the other arrow expressions are handled _within_ that node, the chain must print all of their leading comments manually.

However, the logic just used a loop and checked each arrow for a leading comment to then print it out if it exists. This included the first arrow expression in the chain as well, meaning the comment would be double printed; once by the parent Format node, and again by the inner loop.

This PR updates the logic to skip printing the leading comment for the first arrow in the chain, leaving it to only be printed once by the parent Format node.

```typescript
// Input
foo( /*hi*/(a) => (b) => {});

// Output, before
foo(/*hi*/ /*hi*/ (a) => (b) => {});

// Output, after
foo(/*hi*/ (a) => (b) => {});
```

Closes #921.

## Test Plan

There aren't any tests that currently cover this case, but since it's just a minor fix to the logic I think it's okay to not have an additional test just for it. It should get handled implicitly by most of the other tests with comments around arrow chains.
