### PR TITLE
doc(ja): translate `404 page` into Japanese

### DIFF
--- a/website/src/content/config.ts
+++ b/website/src/content/config.ts
@@ -1,7 +1,8 @@
-import { docsSchema } from "@astrojs/starlight/schema";
+import { docsSchema, i18nSchema } from "@astrojs/starlight/schema";
 // src/content/config.ts
 import { defineCollection } from "astro:content";
 
 export const collections = {
 	docs: defineCollection({ schema: docsSchema() }),
+	i18n: defineCollection({ type: "data", schema: i18nSchema() }),
 };

--- a/website/src/content/docs/ja/404.md
+++ b/website/src/content/docs/ja/404.md
@@ -1,0 +1,8 @@
+---
+title: '404'
+template: splash
+editUrl: false
+hero:
+  title: '404'
+  tagline: お探しのページが見つかりません。URLを確認するか検索バーを使用してみてください。
+---

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,5 @@
+{
+	"rewrites": [
+		{ "source": "/(?<lang>[^/]*)/(.*)", "destination": "/$lang/404/" }
+	]
+}

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,5 @@
 {
-	"rewrites": [
-		{ "source": "/(?<lang>[^/]*)/(.*)", "destination": "/$lang/404/" }
+	"routes": [
+		{ "src": "/(?<lang>[^/]*)/(.*)", "dest": "/$lang/404/", "status": 404 }
 	]
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Partial work of #880. 404 page

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
I made an issue https://github.com/withastro/starlight/issues/1154 about 404 page in starlight issue since 404 page is a special case. Looks like what we need to do to show 404 page is that make `ja/404.md` and setup `vercel.json`. Not 100% sure if this would work so if we have the website preview, we should def check it out.
<!-- What demonstrates that your implementation is correct? -->
