### PR TITLE
fix(website): fix fragile blog links

### DIFF
--- a/website/src/components/PostsList.astro
+++ b/website/src/components/PostsList.astro
@@ -19,12 +19,12 @@ const posts = (await getCollection("blog")).sort(
     posts.map(async (post) => (
       <article>
         <h2>
-          <a href={`blog/${post.slug}`}>{post.data.title}</a>
+          <a href={`/blog/${post.slug}`}>{post.data.title}</a>
         </h2>
         <BlogPostInfo post={post.data} />
         <Fragment set:html={post.data.summary} />
         <p>
-          <a href={`blog/${post.slug}`}>Read more</a>
+          <a href={`/blog/${post.slug}`}>Read more</a>
         </p>
       </article>
     ))


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

- Closes #964 

This PR changes the start of the `PostsList.astro` component's blog links to `/blog/`, making it work properly with and without a trailing slash.

## Test Plan

Tested using the explanation/test plan from the associated issue, clicking on any blog post from `https://biomejs.dev/blog` or `https://biomejs.dev/blog/` works as expected.
