### PR TITLE
ci(release_cli): remove homebrew bump

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -236,22 +236,3 @@ jobs:
             biome-*
           fail_on_unmatched_files: true
           generate_release_notes: true
-
-  homebrew:
-    name: Bump Homebrew formula
-    if: needs.build.outputs.prerelease != 'true'
-    runs-on: ubuntu-latest
-    needs: build
-    environment: package_manager
-    continue-on-error: true
-    steps:
-      - name: Bump Homebrew formula
-        run: >
-          brew bump-formula-pr 
-            --no-audit 
-            --no-browse 
-            --version "${{ needs.build.outputs.version }}" 
-            --fork-org ${{ github.repository_owner }}  
-            biome
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_BUMP_PR_TOKEN }}


### PR DESCRIPTION
## Summary

This PR removes the job that autobumps the homebrew formula.

Homebrew now automatically bumps the biome formula via their `autobump` [workflow](https://github.com/Homebrew/homebrew-core/blob/c70d765179895fb101f57645fa2b7aa075f4931a/.github/workflows/autobump.yml#L161), so we no longer have to handle it ourselves.
