### PR TITLE
Fixed sponsor link in Japanese version

### DIFF
--- a/website/src/content/docs/ja/index.mdx
+++ b/website/src/content/docs/ja/index.mdx
@@ -48,7 +48,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 ## スポンサー
 
 <div class="sponsors">
-    <a class="sponsors-row" href="https://shiguredohttp://localhost:4321/ja/.jp/" rel="nofollow">
+    <a class="sponsors-row" href="https://shiguredo.jp/" rel="nofollow">
       <img title="Shiguredō" src="https://camo.githubusercontent.com/58b1dd652b0e2bfb67b97b59c2785bd5694dc0e9e8f6ce2a4182eacc35ed1fec/68747470733a2f2f73686967757265646f2e6a702f6f6666696369616c5f73686967757265646f5f6c6f676f2e737667" data-canonical-src="https://shiguredo.jp/official_shiguredo_logo.svg"  />
     </a>
 </div>


### PR DESCRIPTION
## Summary

I have fixed a broken href in the Japanese version of the documentation.
It seems to be broken since #945.

## Test Plan

The href is same as below.

https://github.com/biomejs/biome/blob/60956c87972a208d130e2a14ce818d382b366169/website/src/content/docs/index.mdx#L56