### PR TITLE
refactor(lintdoc): add support for autolink and references

### DIFF
--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -430,16 +430,19 @@ fn parse_documentation(
             }
 
             Event::Start(Tag::Link(kind, _, _)) => match kind {
-                LinkType::Inline => {
-                    write!(content, "[")?;
+                LinkType::Autolink => {
+                    write!(content, "<")?;
                 }
-                LinkType::Shortcut => {
+                LinkType::Inline | LinkType::Reference | LinkType::Shortcut => {
                     write!(content, "[")?;
                 }
                 _ => {
                     panic!("unimplemented link type")
                 }
             },
+            Event::End(Tag::Link(LinkType::Autolink, url, _)) => {
+                write!(content, "{url}>")?;
+            }
             Event::End(Tag::Link(_, url, title)) => {
                 write!(content, "]({url}")?;
                 if !title.is_empty() {


### PR DESCRIPTION
## Summary

This PR adds supports for autolink `<https://example.com>` and references `[foo][bar]` in rule documentation.

## Test Plan

Manually tested.
