### PR TITLE
docs(website): add Formatter Option Philosophy page

### DIFF
--- a/website/astro.config.ts
+++ b/website/astro.config.ts
@@ -161,7 +161,10 @@ export default defineConfig({
 					items: [
 						{ label: "Analyzer", link: "/analyzer" },
 						{ label: "Formatter", link: "/formatter" },
-						{ label: "Formatter Option Philosophy", link: "/formatter/option-philosophy" },
+						{
+							label: "Formatter Option Philosophy",
+							link: "/formatter/option-philosophy",
+						},
 						{ label: "Linter", link: "/linter" },
 						{ label: "Lint rules", link: "/linter/rules" },
 					],

--- a/website/astro.config.ts
+++ b/website/astro.config.ts
@@ -161,6 +161,7 @@ export default defineConfig({
 					items: [
 						{ label: "Analyzer", link: "/analyzer" },
 						{ label: "Formatter", link: "/formatter" },
+						{ label: "Formatter Option Philosophy", link: "/formatter/option-philosophy" },
 						{ label: "Linter", link: "/linter" },
 						{ label: "Lint rules", link: "/linter/rules" },
 					],

--- a/website/src/content/docs/formatter/option-philosophy.md
+++ b/website/src/content/docs/formatter/option-philosophy.md
@@ -1,0 +1,38 @@
+---
+title: Formatter Option Philosophy
+description: Configuring an opinionated formatter.
+---
+
+>💡 Biome follows the same [Option Philosophy as Prettier](https://prettier.io/docs/en/option-philosophy). The existing set of options for formatting is considered stable, and new options are not likely to be considered.
+>
+>This document explains some history about how and why Biome got to where it is today, and an outlook for the future.
+
+Biome is an *opinionated formatter*. In an ideal world, that means Biome assumes there is only one correct way for things to be formatted and will enforce that style at all times. No matter the project, no matter the setup, code formatted by Biome will always look the same. From another perspective, Biome is its own *automatic style guide*, not a tool for implementing other style guides.
+
+Having such a strong opinion on formatting may seem heavy-handed, but the benefits quickly become clear after adoption. All of the discussions about where spaces should go, whether a line should be broken out, whether a line should be indented, and so many more simply *vanish*. [Trivial, bike-shedding discussions](https://en.wikipedia.org/wiki/Law_of_triviality) no longer distract from focusing on what really matters. Code reviews become free of re-formatting requests and cyclical debates. All it takes is trust that Biome does its best to format code cleanly, legibly, and consistently.
+
+Beyond the benefits within individual teams and organizations, adoption of consistent formatters across the whole web ecosystem benefits everyone, making it easier to retain familiarity when moving between projects and helping newcomers learn and recognize patterns more intuitively without distractions.
+
+In the web ecosystem today, Prettier is by far the most popular code formatter, and it is also strongly opinionated, with a [strict philosophy on adding options](https://prettier.io/docs/en/option-philosophy). Biome aims to be [largely compatible with Prettier](https://biomejs.dev/blog/biome-wins-prettier-challenge), and as such has adopted many of the opinions that Prettier implements, and configuration is no exception to that.
+
+Biome is proud to have reached such a high compatibility with Prettier and make the migration path for users as painless as possible, but this also comes with similar caveats.
+
+## Existing Options
+
+Biome started out with a strict subset of configuration options, targeting the most common and contentious style guidelines in the JavaScript ecosystem: indent styles (tabs vs spaces), indent widths (2 spaces to equal a tab, or 4?), and enforced semicolons. Adding options for these points was considered sufficient enough to address most people’s needs, and there was no strong consideration for adding any others.
+
+Leaning on the [Prettier Option Philosophy](https://prettier.io/docs/en/option-philosophy), Biome had the chance to start fresh and avoid the pitfalls that Prettier had fallen into with its other existing options, like `--bracket-same-line` and `--arrow-parens`:
+
+> …[these] are not the type of options we’re happy to have. They cause a lot of bike-shedding in teams, and we’re sorry for that. Difficult to remove now, these options exist as a historical artifact and should not motivate adding more options (“If *those* options exist, why can’t this one?”).
+
+However, when the [Prettier Challenge was announced](https://twitter.com/Vjeux/status/1722733472522142022), Biome decided to accept the challenge, which required implementing all of the configuration options that Prettier had to achieve full compatibility.
+
+Biome still shares the same philosophy as Prettier about these options and considers them a legacy feature for compatibility rather than a baseline feature set. Their existence is not an indication that more options will be added, nor should they be used as a rationale to support the existence of other options in the future.
+
+## New Options
+
+Much like Prettier, Biome believes the current set of options is stable, sufficient, and not open for additions or other changes. Requests for additional configuration options are not likely to be considered and may be closed without discussion.
+
+That said, even as Biome has established itself as a capable and robust formatting tool, it is also still relatively new, meaning there is plenty of opportunity to pave the way for new advancements and ideas that may not seem feasible otherwise.
+
+The formatting style of Biome is also considered relatively stable, continuing to match Prettier as much as possible, with [few intentional deviations](https://github.com/biomejs/biome/issues/739). Changes to the style of Biome may be considered and implemented, but these are also unlikely to become configurable options and would instead be applied universally for all future versions of Biome.

--- a/website/src/content/docs/formatter/option-philosophy.md
+++ b/website/src/content/docs/formatter/option-philosophy.md
@@ -7,15 +7,15 @@ description: Configuring an opinionated formatter.
 >
 >This document explains some history about how and why Biome got to where it is today, and an outlook for the future.
 
-Biome is an *opinionated formatter*. In an ideal world, that means Biome assumes there is only one correct way for things to be formatted and will enforce that style at all times. No matter the project, no matter the setup, code formatted by Biome will always look the same. From another perspective, Biome is its own *automatic style guide*, not a tool for implementing other style guides.
+Biome is an *opinionated formatter*. In an ideal world, that means Biome assumes there is only one correct way to format things and will enforce that style at all times. No matter the project, no matter the setup, code formatted by Biome will always look the same. From another perspective, Biome is its own *automatic style guide*, not a tool for implementing other style guides.
 
-Having such a strong opinion on formatting may seem heavy-handed, but the benefits quickly become clear after adoption. All of the discussions about where spaces should go, whether a line should be broken out, whether a line should be indented, and so many more simply *vanish*. [Trivial, bike-shedding discussions](https://en.wikipedia.org/wiki/Law_of_triviality) no longer distract from focusing on what really matters. Code reviews become free of re-formatting requests and cyclical debates. All it takes is trust that Biome does its best to format code cleanly, legibly, and consistently.
+Having such a strong opinion on formatting may seem heavy-handed, but the benefits quickly become clear after adoption. All of the discussions about where spaces should go, whether a line should be broken out, whether a line should be indented, and so many more simply *vanish*. [Trivial, bike-shedding discussions](https://en.wikipedia.org/wiki/Law_of_triviality) no longer distract from focusing on what matters. Code reviews become free of re-formatting requests and cyclical debates. All it takes is trust that Biome does its best to format code cleanly, legibly, and consistently.
 
-Beyond the benefits within individual teams and organizations, adoption of consistent formatters across the whole web ecosystem benefits everyone, making it easier to retain familiarity when moving between projects and helping newcomers learn and recognize patterns more intuitively without distractions.
+Beyond the benefits within individual teams and organizations, the adoption of consistent formatters across the whole web ecosystem benefits everyone, making it easier to retain familiarity when moving between projects and helping newcomers learn and recognize patterns more intuitively without distractions.
 
-In the web ecosystem today, Prettier is by far the most popular code formatter, and it is also strongly opinionated, with a [strict philosophy on adding options](https://prettier.io/docs/en/option-philosophy). Biome aims to be [largely compatible with Prettier](https://biomejs.dev/blog/biome-wins-prettier-challenge), and as such has adopted many of the opinions that Prettier implements, and configuration is no exception to that.
+In the web ecosystem today, Prettier is by far the most popular code formatter, and it is also strongly opinionated, with a [strict philosophy on adding options](https://prettier.io/docs/en/option-philosophy). Biome aims to be [largely compatible with Prettier](https://biomejs.dev/blog/biome-wins-prettier-challenge), and as such, has adopted many of the opinions that Prettier implements, and configuration is no exception to that.
 
-Biome is proud to have reached such a high compatibility with Prettier and make the migration path for users as painless as possible, but this also comes with similar caveats.
+Biome is proud to have reached such high compatibility with Prettier and make the migration path for users as painless as possible, but this also comes with similar caveats.
 
 ## Existing Options
 
@@ -27,7 +27,7 @@ Leaning on the [Prettier Option Philosophy](https://prettier.io/docs/en/option-p
 
 However, when the [Prettier Challenge was announced](https://twitter.com/Vjeux/status/1722733472522142022), Biome decided to accept the challenge, which required implementing all of the configuration options that Prettier had to achieve full compatibility.
 
-Biome still shares the same philosophy as Prettier about these options and considers them a legacy feature for compatibility rather than a baseline feature set. Their existence is not an indication that more options will be added, nor should they be used as a rationale to support the existence of other options in the future.
+Biome still shares Prettier's philosophy about these options and considers them a legacy feature for compatibility rather than a baseline feature set. Their existence does not indicate that more options will be added, nor should they be used as a rationale to support the existence of other options in the future.
 
 ## New Options
 
@@ -35,4 +35,4 @@ Much like Prettier, Biome believes the current set of options is stable, suffici
 
 That said, even as Biome has established itself as a capable and robust formatting tool, it is also still relatively new, meaning there is plenty of opportunity to pave the way for new advancements and ideas that may not seem feasible otherwise.
 
-The formatting style of Biome is also considered relatively stable, continuing to match Prettier as much as possible, with [few intentional deviations](https://github.com/biomejs/biome/issues/739). Changes to the style of Biome may be considered and implemented, but these are also unlikely to become configurable options and would instead be applied universally for all future versions of Biome.
+The formatting style of Biome is also considered relatively stable, continuing to match Prettier as much as possible, with [few intentional deviations](https://github.com/biomejs/biome/issues/739). Changes to the style of Biome may be considered and implemented. Still, these are also unlikely to become configurable options and would instead be applied universally for all future versions of Biome.


### PR DESCRIPTION
## Summary

As Biome grows in popularity, and particularly as people look at potentially migrating from Prettier now that we've won the challenge and promote that compatibility, we're going to get a lot of the same requests for adding options to the formatter.

Even before the challenge, Biome intended to be a strongly-opinionated formatter, much like Prettier, and had the chance to start fresh with a blank set of options and no historical baggage. After the challenge, we've had to implement all of the options that Prettier already has, but we don't want to keep adding more. This page on the website acts as something we can point to when requests come up, explaining that the ideal world for Biome is _no_ options, and the existing ones only exist for compatibility.

It also leaves the door open for radical advancements in the future and even changes to the core style of Biome itself, should they ever come up, but makes it clear that requests for new options most likely will not be considered.

## Test Plan

Just opened the page on the site locally and it worked as expected.