### PR TITLE
fix(js_formatter): Only parenthesize default-export function cast expressions

### DIFF
--- a/crates/biome_js_formatter/tests/quick_test.rs
+++ b/crates/biome_js_formatter/tests/quick_test.rs
@@ -9,31 +9,20 @@ mod language {
     include!("language.rs");
 }
 
+#[ignore]
 #[test]
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
     let src = r#"
-    
-const makeSomeFunction =
-(services = {logger:null}) =>
-  (a, b, c) =>
-    services.logger(a,b,c)
-
-const makeSomeFunction2 =
-(services = {
-  logger: null
-}) =>
-  (a, b, c) =>
-    services.logger(a, b, c)
-
+  export default foo as bar;
     "#;
-    let syntax = JsFileSource::tsx();
+    let source_type = JsFileSource::tsx();
     let tree = parse(
         src,
-        syntax,
+        source_type,
         JsParserOptions::default().with_parse_class_parameter_decorators(),
     );
-    let options = JsFormatOptions::new(syntax)
+    let options = JsFormatOptions::new(source_type)
         .with_indent_style(IndentStyle::Space)
         .with_semicolons(Semicolons::Always)
         .with_quote_style(QuoteStyle::Double)
@@ -42,7 +31,6 @@ const makeSomeFunction2 =
 
     let doc = format_node(options.clone(), &tree.syntax()).unwrap();
     let result = doc.print().unwrap();
-    let source_type = JsFileSource::js_module();
 
     println!("{}", doc.into_document());
     eprintln!("{}", result.as_code());


### PR DESCRIPTION
## Summary

Fixes #914. This is the last case of that issue (the middle one).

Default-exported cast expressions for functions require parentheses to disambiguate between a cast expression for the function and a default function _declaration_ export. As an example:

```typescript
export default function foo() {} as typeof console.log;
// is actually
export default function foo() {};
as;
typeof console.log;
// because the declaration statement ends, and then `as` is considered a new statement
```

In this case parentheses force the statement to be interpreted as a default export of a cast, rather than a declaration:

```typescript
export default (function foo() {} as typeof console.log);
```

But (seemingly) all other kinds of default export expressions are able to be written without parentheses, as Prettier prints them out that way. So this PR implements a new check for when the parent of the cast is an `export default` and only adds parentheses for function expressions then, omitting them in every other case.

All other types of parent expressions are unaffected.

## Test Plan

Added some `needs_parentheses` tests in `as_expressions.rs` to ensure these cases are hit correctly.