### PR TITLE
chore: add `qt` alias for running quicktests

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ alias f := format
 alias t := test
 alias r := ready
 alias l := lint
+alias qt := test-quick
 
 
 # Installs the tools needed to develop
@@ -100,6 +101,10 @@ test-lintrule name:
 test-transformation name:
   just _touch crates/biome_js_transform/tests/spec_tests.rs
   cargo test -p biome_js_transform -- {{snakecase(name)}}
+
+# Run the quick_test for the given package.
+test-quick package:
+  cargo test -p {{package}} --test quick_test -- quick_test --nocapture
 
 
 # Alias for `cargo lint`, it runs clippy on the whole codebase


### PR DESCRIPTION
## Summary

For whatever reason in my VSCode setup, for quick_tests specifically, I can't just hit the "Run Tests" button in the editor and have it run. It targets the wrong thing.

This adds an alias in the Justfile to run the quick test for a single package to avoid having to write it all out on the command line:

```
cargo test -p {package} --test quick_test -- quick_test --nocapture
```
vs
```
just qt {package}
```

## Test Plan

Running `just qt ..` runs the appropriate test for all packages.
