### PR TITLE
docs: update language server setup info for Helix

### DIFF
--- a/editors/helix/manual.md
+++ b/editors/helix/manual.md
@@ -14,27 +14,27 @@ biome = { command = "biome", args = ["lsp-proxy"] }
 
 [[language]]
 name = "javascript"
-language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome"]
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome" ]
 auto-format = true
 
 [[language]]
 name = "typescript"
-language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome"]
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome" ]
 auto-format = true
 
 [[language]]
 name = "tsx"
 auto-format = true
-language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome"]
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome" ]
 
 [[language]]
 name = "jsx"
 auto-format = true
-language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome"]
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome" ]
 
 [[language]]
 name = "json"
-language-servers = [ { name = "vscode-json-language-server", except-features = [ "format" ] }, "biome"]
+language-servers = [ { name = "vscode-json-language-server", except-features = [ "format" ] }, "biome" ]
 ```
 
 # Video record

--- a/editors/helix/manual.md
+++ b/editors/helix/manual.md
@@ -11,7 +11,6 @@ Helix 23.10 has [support for multiple language servers](https://github.com/helix
 ```toml
 [language-server]
 biome = { command = "biome", args = ["lsp-proxy"] }
-vscode-json-language-server = { command = "vscode-json-language-server", args = ["--stdio"], config = { provideFormatter = false, json = { validate = { enable = true } } } }
 
 [[language]]
 name = "javascript"

--- a/editors/helix/manual.md
+++ b/editors/helix/manual.md
@@ -2,52 +2,11 @@
 
 Currently, biome supports the following file extensions: `js`, `jsx`, `ts`, `tsx`, `d.ts`, `json` and `jsonc`.
 
-Biome has a an `lsp-proxy` command that acts as a server for the Language Server Protocol over stdin/stdout.
+Biome has an `lsp-proxy` command that acts as a server for the Language Server Protocol over stdin/stdout.
 
+## Helix 23.10
 
-## Helix 23.05
-
-**languages.toml**
-```toml
-[[language]]
-name = "javascript"
-scope = "source.js"
-file-types = ["js"]
-language-server = { command = "biome", args = ["lsp-proxy"] }
-formatter = { command = "biome", args = ["format", "--stdin-file-path", "test.js"]}
-auto-format = true
-
-[[language]]
-name = "jsx"
-scope = "source.jsx"
-file-types = ["jsx"]
-language-server = { command = "biome", args = ["lsp-proxy"] }
-formatter = { command = "biome", args = ["format", "--stdin-file-path", "test.jsx"]}
-auto-format = true
-
-[[language]]
-name = "typescript"
-scope = "source.ts"
-file-types = ["ts"]
-language-server = { command = "biome", args = ["lsp-proxy"] }
-formatter = { command = "biome", args = ["format", "--stdin-file-path", "test.ts"]}
-auto-format = true
-
-[[language]]
-name = "tsx"
-scope = "source.tsx"
-file-types = ["tsx"]
-language-server = { command = "biome", args = ["lsp-proxy"] }
-formatter = { command = "biome", args = ["format", "--stdin-file-path", "test.tsx"]}
-auto-format = true
-```
-
-
-## Helix Nightly
-
-The version of Helix after 23.05 will have [support for multiple language servers](https://github.com/helix-editor/helix/issues/1396) and the language server configuration has changed a bit.
-
-Now you can use biome alongside `typescript-language-server`.
+Helix 23.10 has [support for multiple language servers](https://github.com/helix-editor/helix/pull/2507). Now you can use biome alongside `typescript-language-server`.
 
 ```toml
 [language-server]
@@ -144,13 +103,11 @@ command = "biome"
 args = ["format", "--stdin-file-path", "test.json"]
 ```
 
-
 # Video record
 
 ## Code Action
 
 https://user-images.githubusercontent.com/17974631/190205045-aeb86f87-1915-4d8b-8aad-2c046443ba83.mp4
-
 
 ## Formatting
 

--- a/editors/helix/manual.md
+++ b/editors/helix/manual.md
@@ -11,96 +11,31 @@ Helix 23.10 has [support for multiple language servers](https://github.com/helix
 ```toml
 [language-server]
 biome = { command = "biome", args = ["lsp-proxy"] }
+vscode-json-language-server = { command = "vscode-json-language-server", args = ["--stdio"], config = { provideFormatter = false, json = { validate = { enable = true } } } }
 
 [[language]]
 name = "javascript"
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome"]
 auto-format = true
-comment-token = "//"
-file-types = ["js", "mjs", "cjs"]
-injection-regex = "(js|javascript)"
-language-id = "javascript"
-language-servers = ["typescript-language-server", "biome"]
-roots = []
-scope = "source.js"
-shebangs = ["node"]
-
-[language.formatter]
-command = "biome"
-args = ["format", "--stdin-file-path", "test.js"]
-
-[language.indent]
-tab-width = 2
-unit = "  "
 
 [[language]]
 name = "typescript"
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome"]
 auto-format = true
-file-types = ["ts", "mts", "cts"]
-injection-regex = "(ts|typescript)"
-language-id = "typescript"
-language-servers = ["typescript-language-server", "biome"]
-roots = []
-scope = "source.ts"
-shebangs = []
-
-[language.formatter]
-command = "biome"
-args = ["format", "--stdin-file-path", "test.ts"]
-
-[language.indent]
-tab-width = 2
-unit = "  "
 
 [[language]]
 name = "tsx"
 auto-format = true
-file-types = ["tsx"]
-injection-regex = "(tsx)"
-language-id = "typescriptreact"
-language-servers = ["typescript-language-server", "biome"]
-roots = []
-scope = "source.tsx"
-
-[language.formatter]
-command = "biome"
-args = ["format", "--stdin-file-path", "test.tsx"]
-
-[language.indent]
-tab-width = 2
-unit = "  "
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome"]
 
 [[language]]
 name = "jsx"
 auto-format = true
-comment-token = "//"
-file-types = ["jsx"]
-grammar = "javascript"
-injection-regex = "jsx"
-language-id = "javascriptreact"
-language-servers = ["typescript-language-server", "biome"]
-roots = []
-scope = "source.jsx"
-
-[language.formatter]
-command = "biome"
-args = ["format", "--stdin-file-path", "test.jsx"]
-
-[language.indent]
-tab-width = 2
-unit = "  "
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome"]
 
 [[language]]
 name = "json"
-auto-format = true
-file-types = ["json", "jsonc", "arb", "ipynb", "geojson"]
-injection-regex = "json"
-language-servers = ["biome"]
-roots = []
-scope = "source.json"
-
-[language.formatter]
-command = "biome"
-args = ["format", "--stdin-file-path", "test.json"]
+language-servers = [ { name = "vscode-json-language-server", except-features = [ "format" ] }, "biome"]
 ```
 
 # Video record


### PR DESCRIPTION
## Summary

The info on Helix was out of date, version `23.10` has been out for 5 weeks+: https://helix-editor.com/news/release-23-10-highlights/. It now has the multiple language servers feature built in. You can see it is widely adopted here: https://github.com/helix-editor/helix#installation, and anyone can download the binary https://github.com/helix-editor/helix/releases/tag/23.10, so it is readily available for all users.

Another point of concern is the redundancy of keys in the current configuration. Many of the keys are unnecessary duplicates, as they are already inherited from the default configuration found at https://github.com/helix-editor/helix/blob/master/languages.toml. Users should only need to specify overrides or add new keys in their personal configuration files. I have not altered that as perhaps there was a reason behind this decision I might not be aware of?

Thank you for providing information about setting up Helix; it's truly appreciated!
