### PR TITLE
fix(js_formatter): don't hug blocks in case clauses with multiple statements

### DIFF
--- a/crates/biome_js_formatter/src/js/auxiliary/case_clause.rs
+++ b/crates/biome_js_formatter/src/js/auxiliary/case_clause.rs
@@ -27,17 +27,55 @@ impl FormatNodeRule<JsCaseClause> for FormatJsCaseClause {
             ]
         )?;
 
-        let is_first_child_block_stmt = matches!(
+        // Whether the first statement in the clause is a BlockStatement, and
+        // there are no other non-empty statements. Empties may show up
+        // depending on whether the input code includes certain newlines.
+        let is_single_block_statement = matches!(
             consequent.iter().next(),
             Some(AnyJsStatement::JsBlockStatement(_))
-        );
+        ) && consequent
+            .iter()
+            .filter(|statement| !matches!(statement, AnyJsStatement::JsEmptyStatement(_)))
+            .count()
+            == 1;
 
+        // When the case block is empty, the case becomes a fallthrough, so it
+        // is collapsed directly on top of the next case (just a single
+        // hardline).
+        // When the block is a single statement _and_ it's a block statement,
+        // then the opening brace of the block can hug the same line as the
+        // case. But, if there's more than one statement, then the block
+        // _cannot_ hug. This distinction helps clarify that the case continues
+        // past the end of the block statement, despite the braces making it
+        // seem like it might end.
+        // Lastly, the default case is just to break and indent the body.
+        //
+        // switch (key) {
+        //   case fallthrough:
+        //   case normalBody:
+        //     someWork();
+        //     break;
+        //
+        //   case blockBody: {
+        //     const a = 1;
+        //     break;
+        //   }
+        //
+        //   case separateBlockBody:
+        //     {
+        //       breakIsNotInsideTheBlock();
+        //     }
+        //     break;
+        //
+        //   default:
+        //     break;
+        // }
         if consequent.is_empty() {
-            // Skip inserting an indent block is the consequent is empty to print
+            // Skip inserting an indent block if the consequent is empty to print
             // the trailing comments for the case clause inline if there is no
             // block to push them into
             write!(f, [hard_line_break()])
-        } else if is_first_child_block_stmt {
+        } else if is_single_block_statement {
             write![f, [space(), consequent.format()]]
         } else {
             // no line break needed after because it is added by the indent in the switch statement

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js
@@ -17,3 +17,17 @@ switch (key) {
 switch ("test") {
   case "test": {}
 }
+
+switch (key) {
+	case blockBody: {
+		const a = 1;
+		break;
+	}
+
+	// The block is not the only statement in the case body,
+	// so it doesn't hug the same line as the case here.
+	case separateBlockBody: {
+		const a = 1;
+	}
+	break;
+}

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js.snap
@@ -26,6 +26,19 @@ switch ("test") {
   case "test": {}
 }
 
+switch (key) {
+	case blockBody: {
+		const a = 1;
+		break;
+	}
+
+	// The block is not the only statement in the case body,
+	// so it doesn't hug the same line as the case here.
+	case separateBlockBody: {
+		const a = 1;
+	}
+	break;
+}
 ```
 
 
@@ -68,6 +81,21 @@ switch (key) {
 switch ("test") {
 	case "test": {
 	}
+}
+
+switch (key) {
+	case blockBody: {
+		const a = 1;
+		break;
+	}
+
+	// The block is not the only statement in the case body,
+	// so it doesn't hug the same line as the case here.
+	case separateBlockBody:
+		{
+			const a = 1;
+		}
+		break;
 }
 ```
 


### PR DESCRIPTION
## Summary

I noticed this while checking diagnostics from trying to migrate our monorepo. Switch case clauses with a block body let the opening brace of the clause hug the same line as the `case` itself, like:

```typescript
switch(true) {
  case true: {
    const a = 1;
  }
}
```

But when the same case clause contains additional statements _after_ the block, Prettier doesn't allow them to hug:


```typescript
switch(true) {
  case true: {
    const a = 1;
  }
  break;
}

// Prettier
switch (true) {
  case true:
    {
      const a = 1;
    }
    break;
}


// Biome 
switch (true) {
  case true: {
    const a = 1;
  }
  break;
}

```

This PR makes Biome match Prettier's behavior here: if there's more than a single non-empty block statement in the case clause, the braces won't be allowed to hug.

I think this is actually good behavior, even if it's somewhat ugly, because it shows more clearly that statements after the block (i.e., the `break;` above), are still part of the case clause, even though the braces might suggest the clause has ended.

## Test Plan

Added a new test case to cover this.
