### PR TITLE
feat(website): remove language select outside docs

### DIFF
--- a/website/astro.config.ts
+++ b/website/astro.config.ts
@@ -133,10 +133,10 @@ export default defineConfig({
 			},
 			sidebar: [
 				{ label: "Home", link: "/" },
-				{ label: "Blog", link: "/blog" },
+				{ label: "Blog", link: "../blog" },
 				{
 					label: "Playground",
-					link: "/playground",
+					link: "../playground",
 				},
 				{
 					label: "Guides",

--- a/website/src/layouts/StarlightSplashLayout.astro
+++ b/website/src/layouts/StarlightSplashLayout.astro
@@ -79,4 +79,8 @@ const pageProps = getPageProps(Astro.props);
   :global(:root) {
     --__toc-width: 0rem;
   }
+
+  :global(starlight-lang-select) {
+    display: none;
+  }
 </style>


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a CSS line to remove the language select to docs and changes the link configuration in the sidebar for both blog and playground to remove the language part (if it exists), so a user would never naturally reach `https://biomejs.dev/ja/blog` for example.



## Test Plan

I've tested going to both the `/ja` and `/zh-cn` versions of the docs and clicking the "Blog" and "Playground" links. None ended up sending me to a 404 page.
