### PR TITLE
fix(js_parser): Illegal duplicate default export declarations

### DIFF
--- a/crates/biome_js_parser/src/state.rs
+++ b/crates/biome_js_parser/src/state.rs
@@ -33,14 +33,6 @@ pub(crate) enum ExportDefaultItemKind {
     Declaration,
 }
 impl ExportDefaultItemKind {
-    pub(crate) fn is_overload(&self) -> bool {
-        matches!(self, ExportDefaultItemKind::FunctionOverload)
-    }
-
-    pub(crate) fn is_function_declaration(&self) -> bool {
-        matches!(self, ExportDefaultItemKind::FunctionDeclaration)
-    }
-
     pub(crate) fn is_interface(&self) -> bool {
         matches!(self, ExportDefaultItemKind::Interface)
     }

--- a/crates/biome_js_parser/src/syntax/module.rs
+++ b/crates/biome_js_parser/src/syntax/module.rs
@@ -1308,8 +1308,7 @@ fn parse_export_default_clause(p: &mut JsParser) -> ParsedSyntax {
         if let Some(existing_default_item) =
             p.state().default_item.as_ref().filter(|_| p.is_module())
         {
-            if existing_default_item.kind.is_overload()
-                && (default_item_kind.is_overload() || default_item_kind.is_function_declaration())
+            if existing_default_item.kind.is_mergeable(&default_item_kind)
             {
                 // It's ok to have multiple overload declarations and an implementation.
                 // This check won't catch if there are multiple implementations for the same overload
@@ -1358,7 +1357,7 @@ fn parse_class_export_default_declaration_clause(
 
     (
         Present(m.complete(p, JS_EXPORT_DEFAULT_DECLARATION_CLAUSE)),
-        ExportDefaultItemKind::Declaration,
+        ExportDefaultItemKind::ClassDeclaration,
     )
 }
 

--- a/crates/biome_js_parser/src/syntax/module.rs
+++ b/crates/biome_js_parser/src/syntax/module.rs
@@ -1308,8 +1308,7 @@ fn parse_export_default_clause(p: &mut JsParser) -> ParsedSyntax {
         if let Some(existing_default_item) =
             p.state().default_item.as_ref().filter(|_| p.is_module())
         {
-            if existing_default_item.kind.is_mergeable(&default_item_kind)
-            {
+            if existing_default_item.kind.is_mergeable(&default_item_kind) {
                 // It's ok to have multiple overload declarations and an implementation.
                 // This check won't catch if there are multiple implementations for the same overload
                 // or if the overloads define different functions.

--- a/crates/biome_js_parser/test_data/inline/ok/decorator_export_default_class_and_interface.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/decorator_export_default_class_and_interface.rast
@@ -1,0 +1,123 @@
+JsModule {
+    bom_token: missing (optional),
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExport {
+            decorators: JsDecoratorList [],
+            export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")],
+                declaration: TsInterfaceDeclaration {
+                    interface_token: INTERFACE_KW@15..25 "interface" [] [Whitespace(" ")],
+                    id: TsIdentifierBinding {
+                        name_token: IDENT@25..29 "Foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    extends_clause: missing (optional),
+                    l_curly_token: L_CURLY@29..31 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [],
+                    r_curly_token: R_CURLY@31..32 "}" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+        JsExport {
+            decorators: JsDecoratorList [],
+            export_token: EXPORT_KW@32..40 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@40..48 "default" [] [Whitespace(" ")],
+                declaration: JsClassExportDefaultDeclaration {
+                    decorators: JsDecoratorList [],
+                    abstract_token: missing (optional),
+                    class_token: CLASS_KW@48..54 "class" [] [Whitespace(" ")],
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@54..58 "Foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    extends_clause: missing (optional),
+                    implements_clause: missing (optional),
+                    l_curly_token: L_CURLY@58..60 "{" [] [Whitespace(" ")],
+                    members: JsClassMemberList [],
+                    r_curly_token: R_CURLY@60..61 "}" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+        JsExport {
+            decorators: JsDecoratorList [],
+            export_token: EXPORT_KW@61..69 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@69..77 "default" [] [Whitespace(" ")],
+                declaration: TsInterfaceDeclaration {
+                    interface_token: INTERFACE_KW@77..87 "interface" [] [Whitespace(" ")],
+                    id: TsIdentifierBinding {
+                        name_token: IDENT@87..91 "Foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    extends_clause: missing (optional),
+                    l_curly_token: L_CURLY@91..93 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [],
+                    r_curly_token: R_CURLY@93..94 "}" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@94..94 "" [] [],
+}
+
+0: JS_MODULE@0..94
+  0: (empty)
+  1: (empty)
+  2: JS_DIRECTIVE_LIST@0..0
+  3: JS_MODULE_ITEM_LIST@0..94
+    0: JS_EXPORT@0..32
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..32
+        0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
+        1: TS_INTERFACE_DECLARATION@15..32
+          0: INTERFACE_KW@15..25 "interface" [] [Whitespace(" ")]
+          1: TS_IDENTIFIER_BINDING@25..29
+            0: IDENT@25..29 "Foo" [] [Whitespace(" ")]
+          2: (empty)
+          3: (empty)
+          4: L_CURLY@29..31 "{" [] [Whitespace(" ")]
+          5: TS_TYPE_MEMBER_LIST@31..31
+          6: R_CURLY@31..32 "}" [] []
+        2: (empty)
+    1: JS_EXPORT@32..61
+      0: JS_DECORATOR_LIST@32..32
+      1: EXPORT_KW@32..40 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@40..61
+        0: DEFAULT_KW@40..48 "default" [] [Whitespace(" ")]
+        1: JS_CLASS_EXPORT_DEFAULT_DECLARATION@48..61
+          0: JS_DECORATOR_LIST@48..48
+          1: (empty)
+          2: CLASS_KW@48..54 "class" [] [Whitespace(" ")]
+          3: JS_IDENTIFIER_BINDING@54..58
+            0: IDENT@54..58 "Foo" [] [Whitespace(" ")]
+          4: (empty)
+          5: (empty)
+          6: (empty)
+          7: L_CURLY@58..60 "{" [] [Whitespace(" ")]
+          8: JS_CLASS_MEMBER_LIST@60..60
+          9: R_CURLY@60..61 "}" [] []
+        2: (empty)
+    2: JS_EXPORT@61..94
+      0: JS_DECORATOR_LIST@61..61
+      1: EXPORT_KW@61..69 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@69..94
+        0: DEFAULT_KW@69..77 "default" [] [Whitespace(" ")]
+        1: TS_INTERFACE_DECLARATION@77..94
+          0: INTERFACE_KW@77..87 "interface" [] [Whitespace(" ")]
+          1: TS_IDENTIFIER_BINDING@87..91
+            0: IDENT@87..91 "Foo" [] [Whitespace(" ")]
+          2: (empty)
+          3: (empty)
+          4: L_CURLY@91..93 "{" [] [Whitespace(" ")]
+          5: TS_TYPE_MEMBER_LIST@93..93
+          6: R_CURLY@93..94 "}" [] []
+        2: (empty)
+  4: EOF@94..94 "" [] []

--- a/crates/biome_js_parser/test_data/inline/ok/decorator_export_default_class_and_interface.ts
+++ b/crates/biome_js_parser/test_data/inline/ok/decorator_export_default_class_and_interface.ts
@@ -1,0 +1,3 @@
+export default interface Foo { }
+export default class Foo { }
+export default interface Foo { }

--- a/crates/biome_js_parser/test_data/inline/ok/decorator_export_default_function_and_function_overload.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/decorator_export_default_function_and_function_overload.rast
@@ -1,0 +1,124 @@
+JsModule {
+    bom_token: missing (optional),
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExport {
+            decorators: JsDecoratorList [],
+            export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")],
+                declaration: TsDeclareFunctionExportDefaultDeclaration {
+                    async_token: missing (optional),
+                    function_token: FUNCTION_KW@15..24 "function" [] [Whitespace(" ")],
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@24..27 "Foo" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@27..28 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@28..29 ")" [] [],
+                    },
+                    return_type_annotation: TsReturnTypeAnnotation {
+                        colon_token: COLON@29..31 ":" [] [Whitespace(" ")],
+                        ty: TsVoidType {
+                            void_token: VOID_KW@31..35 "void" [] [],
+                        },
+                    },
+                    semicolon_token: SEMICOLON@35..36 ";" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+        JsExport {
+            decorators: JsDecoratorList [],
+            export_token: EXPORT_KW@36..44 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@44..52 "default" [] [Whitespace(" ")],
+                declaration: JsFunctionExportDefaultDeclaration {
+                    async_token: missing (optional),
+                    function_token: FUNCTION_KW@52..61 "function" [] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@61..64 "Foo" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@64..65 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@65..66 ")" [] [],
+                    },
+                    return_type_annotation: TsReturnTypeAnnotation {
+                        colon_token: COLON@66..68 ":" [] [Whitespace(" ")],
+                        ty: TsAnyType {
+                            any_token: ANY_KW@68..72 "any" [] [Whitespace(" ")],
+                        },
+                    },
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@72..74 "{" [] [Whitespace(" ")],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@74..75 "}" [] [],
+                    },
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@75..75 "" [] [],
+}
+
+0: JS_MODULE@0..75
+  0: (empty)
+  1: (empty)
+  2: JS_DIRECTIVE_LIST@0..0
+  3: JS_MODULE_ITEM_LIST@0..75
+    0: JS_EXPORT@0..36
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..36
+        0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
+        1: TS_DECLARE_FUNCTION_EXPORT_DEFAULT_DECLARATION@15..36
+          0: (empty)
+          1: FUNCTION_KW@15..24 "function" [] [Whitespace(" ")]
+          2: JS_IDENTIFIER_BINDING@24..27
+            0: IDENT@24..27 "Foo" [] []
+          3: (empty)
+          4: JS_PARAMETERS@27..29
+            0: L_PAREN@27..28 "(" [] []
+            1: JS_PARAMETER_LIST@28..28
+            2: R_PAREN@28..29 ")" [] []
+          5: TS_RETURN_TYPE_ANNOTATION@29..35
+            0: COLON@29..31 ":" [] [Whitespace(" ")]
+            1: TS_VOID_TYPE@31..35
+              0: VOID_KW@31..35 "void" [] []
+          6: SEMICOLON@35..36 ";" [] []
+        2: (empty)
+    1: JS_EXPORT@36..75
+      0: JS_DECORATOR_LIST@36..36
+      1: EXPORT_KW@36..44 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@44..75
+        0: DEFAULT_KW@44..52 "default" [] [Whitespace(" ")]
+        1: JS_FUNCTION_EXPORT_DEFAULT_DECLARATION@52..75
+          0: (empty)
+          1: FUNCTION_KW@52..61 "function" [] [Whitespace(" ")]
+          2: (empty)
+          3: JS_IDENTIFIER_BINDING@61..64
+            0: IDENT@61..64 "Foo" [] []
+          4: (empty)
+          5: JS_PARAMETERS@64..66
+            0: L_PAREN@64..65 "(" [] []
+            1: JS_PARAMETER_LIST@65..65
+            2: R_PAREN@65..66 ")" [] []
+          6: TS_RETURN_TYPE_ANNOTATION@66..72
+            0: COLON@66..68 ":" [] [Whitespace(" ")]
+            1: TS_ANY_TYPE@68..72
+              0: ANY_KW@68..72 "any" [] [Whitespace(" ")]
+          7: JS_FUNCTION_BODY@72..75
+            0: L_CURLY@72..74 "{" [] [Whitespace(" ")]
+            1: JS_DIRECTIVE_LIST@74..74
+            2: JS_STATEMENT_LIST@74..74
+            3: R_CURLY@74..75 "}" [] []
+        2: (empty)
+  4: EOF@75..75 "" [] []

--- a/crates/biome_js_parser/test_data/inline/ok/decorator_export_default_function_and_function_overload.ts
+++ b/crates/biome_js_parser/test_data/inline/ok/decorator_export_default_function_and_function_overload.ts
@@ -1,0 +1,2 @@
+export default function Foo(): void;
+export default function Foo(): any { }

--- a/crates/biome_js_parser/test_data/inline/ok/decorator_export_default_function_and_interface.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/decorator_export_default_function_and_interface.rast
@@ -1,0 +1,135 @@
+JsModule {
+    bom_token: missing (optional),
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExport {
+            decorators: JsDecoratorList [],
+            export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")],
+                declaration: TsInterfaceDeclaration {
+                    interface_token: INTERFACE_KW@15..25 "interface" [] [Whitespace(" ")],
+                    id: TsIdentifierBinding {
+                        name_token: IDENT@25..29 "Foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    extends_clause: missing (optional),
+                    l_curly_token: L_CURLY@29..31 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [],
+                    r_curly_token: R_CURLY@31..32 "}" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+        JsExport {
+            decorators: JsDecoratorList [],
+            export_token: EXPORT_KW@32..40 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@40..48 "default" [] [Whitespace(" ")],
+                declaration: JsFunctionExportDefaultDeclaration {
+                    async_token: missing (optional),
+                    function_token: FUNCTION_KW@48..57 "function" [] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@57..61 "Foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@61..62 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@62..64 ")" [] [Whitespace(" ")],
+                    },
+                    return_type_annotation: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@64..66 "{" [] [Whitespace(" ")],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@66..67 "}" [] [],
+                    },
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+        JsExport {
+            decorators: JsDecoratorList [],
+            export_token: EXPORT_KW@67..75 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@75..83 "default" [] [Whitespace(" ")],
+                declaration: TsInterfaceDeclaration {
+                    interface_token: INTERFACE_KW@83..93 "interface" [] [Whitespace(" ")],
+                    id: TsIdentifierBinding {
+                        name_token: IDENT@93..97 "Foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    extends_clause: missing (optional),
+                    l_curly_token: L_CURLY@97..99 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [],
+                    r_curly_token: R_CURLY@99..100 "}" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@100..100 "" [] [],
+}
+
+0: JS_MODULE@0..100
+  0: (empty)
+  1: (empty)
+  2: JS_DIRECTIVE_LIST@0..0
+  3: JS_MODULE_ITEM_LIST@0..100
+    0: JS_EXPORT@0..32
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..32
+        0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
+        1: TS_INTERFACE_DECLARATION@15..32
+          0: INTERFACE_KW@15..25 "interface" [] [Whitespace(" ")]
+          1: TS_IDENTIFIER_BINDING@25..29
+            0: IDENT@25..29 "Foo" [] [Whitespace(" ")]
+          2: (empty)
+          3: (empty)
+          4: L_CURLY@29..31 "{" [] [Whitespace(" ")]
+          5: TS_TYPE_MEMBER_LIST@31..31
+          6: R_CURLY@31..32 "}" [] []
+        2: (empty)
+    1: JS_EXPORT@32..67
+      0: JS_DECORATOR_LIST@32..32
+      1: EXPORT_KW@32..40 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@40..67
+        0: DEFAULT_KW@40..48 "default" [] [Whitespace(" ")]
+        1: JS_FUNCTION_EXPORT_DEFAULT_DECLARATION@48..67
+          0: (empty)
+          1: FUNCTION_KW@48..57 "function" [] [Whitespace(" ")]
+          2: (empty)
+          3: JS_IDENTIFIER_BINDING@57..61
+            0: IDENT@57..61 "Foo" [] [Whitespace(" ")]
+          4: (empty)
+          5: JS_PARAMETERS@61..64
+            0: L_PAREN@61..62 "(" [] []
+            1: JS_PARAMETER_LIST@62..62
+            2: R_PAREN@62..64 ")" [] [Whitespace(" ")]
+          6: (empty)
+          7: JS_FUNCTION_BODY@64..67
+            0: L_CURLY@64..66 "{" [] [Whitespace(" ")]
+            1: JS_DIRECTIVE_LIST@66..66
+            2: JS_STATEMENT_LIST@66..66
+            3: R_CURLY@66..67 "}" [] []
+        2: (empty)
+    2: JS_EXPORT@67..100
+      0: JS_DECORATOR_LIST@67..67
+      1: EXPORT_KW@67..75 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@75..100
+        0: DEFAULT_KW@75..83 "default" [] [Whitespace(" ")]
+        1: TS_INTERFACE_DECLARATION@83..100
+          0: INTERFACE_KW@83..93 "interface" [] [Whitespace(" ")]
+          1: TS_IDENTIFIER_BINDING@93..97
+            0: IDENT@93..97 "Foo" [] [Whitespace(" ")]
+          2: (empty)
+          3: (empty)
+          4: L_CURLY@97..99 "{" [] [Whitespace(" ")]
+          5: TS_TYPE_MEMBER_LIST@99..99
+          6: R_CURLY@99..100 "}" [] []
+        2: (empty)
+  4: EOF@100..100 "" [] []

--- a/crates/biome_js_parser/test_data/inline/ok/decorator_export_default_function_and_interface.ts
+++ b/crates/biome_js_parser/test_data/inline/ok/decorator_export_default_function_and_interface.ts
@@ -1,0 +1,3 @@
+export default interface Foo { }
+export default function Foo () { }
+export default interface Foo { }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

fix #1037 

```
    const fn can_merge(a: &ExportDefaultItemKind, b: &ExportDefaultItemKind) -> bool {
        match (a, b) {
            // export default function a():void;
            // export default function a(){
            // }
            (
                ExportDefaultItemKind::FunctionOverload,
                ExportDefaultItemKind::FunctionDeclaration,
            ) => true,
            // export default function a(){};
            // export default interface A{};
            (ExportDefaultItemKind::FunctionDeclaration, ExportDefaultItemKind::Interface) => true,
            // export default interface A{};
            // export default class A{};
            (ExportDefaultItemKind::Interface, ExportDefaultItemKind::ClassDeclaration) => true,
            (_, _) => false,
        }
    }
```
add can merge function

merge interface and class...
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
update snapshot