### PR TITLE
fix(lint/noEmptyInterface): allow empty interfaces in external module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ Read our [guidelines to categorize a change](https://biomejs.dev/internals/versi
 New entries must be placed in a section entitled `Unreleased`.
 Read our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
+## Unreleased
+
+### Analyzer
+
+### CLI
+
+### Configuration
+
+### Editors
+
+### Formatter
+
+### JavaScript APIs
+
+### Linter
+
+#### New features
+
+#### Enhancements
+
+#### Bug fixes
+
+- Fix [#959](https://github.com/biomejs/biome/issues/959). [noEmptyInterface](https://biomejs.dev/linter/rules/no-empty-interface) no longer reports interface that extends a type and is in an external module. COntributed by @Conaclos
+
+  Empty interface that extends a type are sometimes used to extend an existing interface.
+  This is generally used to extend an interface of an external module.
+
+  ```ts
+  interface Extension {
+    metadata: unknown;
+  }
+
+  declare module "@external/module" {
+    export interface ExistingInterface extends Extension {}
+  }
+  ```
+
+### Parser
+
+
 ## 1.4.1 (2023-11-30)
 
 ### Editors

--- a/crates/biome_js_analyze/src/control_flow/visitor.rs
+++ b/crates/biome_js_analyze/src/control_flow/visitor.rs
@@ -4,7 +4,8 @@ use biome_analyze::{merge_node_visitors, Visitor, VisitorContext};
 use biome_js_syntax::{
     AnyJsFunction, JsConstructorClassMember, JsGetterClassMember, JsGetterObjectMember, JsLanguage,
     JsMethodClassMember, JsMethodObjectMember, JsModule, JsScript, JsSetterClassMember,
-    JsSetterObjectMember, JsStaticInitializationBlockClassMember,
+    JsSetterObjectMember, JsStaticInitializationBlockClassMember, TsExternalModuleDeclaration,
+    TsModuleDeclaration,
 };
 use biome_rowan::{declare_node_union, AstNode, SyntaxError, SyntaxResult};
 
@@ -169,6 +170,8 @@ declare_node_union! {
         | JsGetterClassMember
         | JsSetterClassMember
         | JsStaticInitializationBlockClassMember
+        | TsModuleDeclaration
+        | TsExternalModuleDeclaration
 }
 
 impl biome_analyze::NodeVisitor<ControlFlowVisitor> for FunctionVisitor {

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
@@ -872,12 +872,19 @@ impl Named {
     }
 
     fn from_variable_declarator(var: &JsVariableDeclarator) -> Option<Named> {
-        let is_top_level_level = matches!(
-            var.syntax()
-                .ancestors()
-                .find_map(AnyJsControlFlowRoot::cast),
-            Some(AnyJsControlFlowRoot::JsModule(_) | AnyJsControlFlowRoot::JsScript(_))
-        );
+        let is_top_level_level = var
+            .syntax()
+            .ancestors()
+            .find(|x| AnyJsControlFlowRoot::can_cast(x.kind()))
+            .is_some_and(|x| {
+                matches!(
+                    x.kind(),
+                    JsSyntaxKind::JS_MODULE
+                        | JsSyntaxKind::JS_SCRIPT
+                        | JsSyntaxKind::TS_MODULE_DECLARATION
+                        | JsSyntaxKind::TS_EXTERNAL_MODULE_DECLARATION
+                )
+            });
         let var_declaration = var
             .syntax()
             .ancestors()

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/invalid.ts
@@ -11,3 +11,7 @@ interface Foo<T> extends Bar<T> {}
 declare module FooBar {
   export interface Bar extends Baz {}
 }
+
+namespace Ns {
+  export interface Bar extends Baz {}
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/invalid.ts.snap
@@ -18,6 +18,10 @@ declare module FooBar {
   export interface Bar extends Baz {}
 }
 
+namespace Ns {
+  export interface Bar extends Baz {}
+}
+
 ```
 
 # Diagnostics
@@ -156,6 +160,29 @@ invalid.ts:12:10 lint/suspicious/noEmptyInterface  FIXABLE  ━━━━━━�
        12 │ + ··export·type·Bar·=·Baz
     13 13 │   }
     14 14 │   
+  
+
+```
+
+```
+invalid.ts:16:10 lint/suspicious/noEmptyInterface  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! An interface declaring no members is equivalent to its supertype.
+  
+    15 │ namespace Ns {
+  > 16 │   export interface Bar extends Baz {}
+       │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    17 │ }
+    18 │ 
+  
+  i Safe fix: Convert empty interface to type alias.
+  
+    14 14 │   
+    15 15 │   namespace Ns {
+    16    │ - ··export·interface·Bar·extends·Baz·{}
+       16 │ + ··export·type·Bar·=·Baz
+    17 17 │   }
+    18 18 │   
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.ts
@@ -5,3 +5,8 @@ interface A extends B {
 // valid because extending multiple interfaces
 // can be used instead of a union type
 interface Baz extends Foo, Bar {}
+
+// See https://github.com/biomejs/biome/issues/959
+declare module "external" {
+  export interface App extends Services {}
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
-assertion_line: 73
 expression: valid.ts
 ---
 # Input
@@ -12,6 +11,11 @@ interface A extends B {
 // valid because extending multiple interfaces
 // can be used instead of a union type
 interface Baz extends Foo, Bar {}
+
+// See https://github.com/biomejs/biome/issues/959
+declare module "external" {
+  export interface App extends Services {}
+}
 
 ```
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -14,6 +14,46 @@ Read our [guidelines to categorize a change](https://biomejs.dev/internals/versi
 New entries must be placed in a section entitled `Unreleased`.
 Read our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
+## Unreleased
+
+### Analyzer
+
+### CLI
+
+### Configuration
+
+### Editors
+
+### Formatter
+
+### JavaScript APIs
+
+### Linter
+
+#### New features
+
+#### Enhancements
+
+#### Bug fixes
+
+- Fix [#959](https://github.com/biomejs/biome/issues/959). [noEmptyInterface](https://biomejs.dev/linter/rules/no-empty-interface) no longer reports interface that extends a type and is in an external module. COntributed by @Conaclos
+
+  Empty interface that extends a type are sometimes used to extend an existing interface.
+  This is generally used to extend an interface of an external module.
+
+  ```ts
+  interface Extension {
+    metadata: unknown;
+  }
+
+  declare module "@external/module" {
+    export interface ExistingInterface extends Extension {}
+  }
+  ```
+
+### Parser
+
+
 ## 1.4.1 (2023-11-30)
 
 ### Editors

--- a/website/src/content/docs/linter/rules/no-empty-interface.md
+++ b/website/src/content/docs/linter/rules/no-empty-interface.md
@@ -10,8 +10,8 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Disallow the declaration of empty interfaces.
 
->An empty interface in TypeScript does very little: any non-nullable value is assignable to `{}`. Using an empty interface is often a sign of programmer error, such as misunderstanding the concept of `{}` or forgetting to fill in fields.
-
+An empty interface in TypeScript does very little: any non-nullable value is assignable to `{}`.
+Using an empty interface is often a sign of programmer error, such as misunderstanding the concept of `{}` or forgetting to fill in fields.
 
 Source: https://typescript-eslint.io/rules/no-empty-interface
 
@@ -40,25 +40,22 @@ interface A {}
 </code></pre>
 
 ```ts
-// A === B
 interface A extends B {}
 ```
 
-<pre class="language-text"><code class="language-text">suspicious/noEmptyInterface.js:2:1 <a href="https://biomejs.dev/linter/rules/no-empty-interface">lint/suspicious/noEmptyInterface</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━
+<pre class="language-text"><code class="language-text">suspicious/noEmptyInterface.js:1:1 <a href="https://biomejs.dev/linter/rules/no-empty-interface">lint/suspicious/noEmptyInterface</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">An interface declaring no members is equivalent to its supertype.</span>
   
-    <strong>1 │ </strong>// A === B
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>interface A extends B {}
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>interface A extends B {}
    <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>3 │ </strong>
+    <strong>2 │ </strong>
   
 <strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Safe fix</span><span style="color: lightgreen;">: </span><span style="color: lightgreen;">Convert empty interface to type alias.</span>
   
-    <strong>1</strong> <strong>1</strong><strong> │ </strong>  // A === B
-    <strong>2</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>i</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>r</strong></span><span style="color: Tomato;"><strong>f</strong></span><span style="color: Tomato;"><strong>a</strong></span><span style="color: Tomato;"><strong>c</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">A</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>x</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>d</strong></span><span style="color: Tomato;"><strong>s</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">B</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>{</strong></span><span style="color: Tomato;"><strong>}</strong></span>
-      <strong>2</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;"><strong>t</strong></span><span style="color: MediumSeaGreen;"><strong>y</strong></span><span style="color: MediumSeaGreen;"><strong>p</strong></span><span style="color: MediumSeaGreen;"><strong>e</strong></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">A</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><strong>=</strong></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">B</span>
-    <strong>3</strong> <strong>3</strong><strong> │ </strong>  
+    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>i</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>r</strong></span><span style="color: Tomato;"><strong>f</strong></span><span style="color: Tomato;"><strong>a</strong></span><span style="color: Tomato;"><strong>c</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">A</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>x</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>d</strong></span><span style="color: Tomato;"><strong>s</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">B</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>{</strong></span><span style="color: Tomato;"><strong>}</strong></span>
+      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;"><strong>t</strong></span><span style="color: MediumSeaGreen;"><strong>y</strong></span><span style="color: MediumSeaGreen;"><strong>p</strong></span><span style="color: MediumSeaGreen;"><strong>e</strong></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">A</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><strong>=</strong></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">B</span>
+    <strong>2</strong> <strong>2</strong><strong> │ </strong>  
   
 </code></pre>
 
@@ -69,8 +66,13 @@ interface A {
   prop: string;
 }
 
-// The interface can be used as an union type.
+// Allow empty interfaces that extend at least two types.
 interface A extends B, C {}
+
+declare module "@external/module" {
+  // Allow empty interfaces that extend at least one type in external module.
+  interface Existing extends A {}
+}
 ```
 
 ## Related links


### PR DESCRIPTION
## Summary

Fix #959.

## Test Plan

I added a test.
