### PR TITLE
docs(website): add missing indentwidth for js in config reference

### DIFF
--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -608,6 +608,12 @@ How big the indentation should be for JavaScript (and its super languages) files
 
 > Default: `2`
 
+### `javascript.formatter.indentWidth`
+
+How big the indentation should be for JavaScript (and its super languages) files.
+
+> Default: `2`
+
 ### `javascript.formatter.lineEnding`
 
 The type of line ending for JavaScript (and its super languages) files.


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

You get a warning when using `javascript.formatter.indentSize` because it's been replaced by `indentwidth`.
The config reference for the global formatter settings has [indentSize](https://biomejs.dev/reference/configuration/#formatterindentsize) and [indentWidth](https://biomejs.dev/reference/configuration/#formatterindentwidth) but `indentWidth` is currently missing from the javascript section (see [here](https://biomejs.dev/reference/configuration/#javascriptformatterindentsize)).

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
see: #1072 
## Test Plan

<!-- What demonstrates that your implementation is correct? -->
- [ ] running the dev server and checking if the option is there
