### PR TITLE
feat(website): add autolink headings back

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,12 @@ importers:
       hast-util-to-html:
         specifier: ^8.0.4
         version: 8.0.4
+      hastscript:
+        specifier: ^8.0.0
+        version: 8.0.0
+      html-escaper:
+        specifier: ^3.0.3
+        version: 3.0.3
       lang-rome-formatter-ir:
         specifier: 0.0.2
         version: 0.0.2

--- a/website/astro.config.ts
+++ b/website/astro.config.ts
@@ -3,9 +3,7 @@ import { netlifyStatic } from "@astrojs/netlify";
 import react from "@astrojs/react";
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
-import rehypeAutolinkHeadings, {
-	type Options as AutolinkOptions,
-} from "rehype-autolink-headings";
+import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import { escape } from "html-escaper";
 import rehypeSlug from "rehype-slug";
 import remarkToc from "remark-toc";

--- a/website/astro.config.ts
+++ b/website/astro.config.ts
@@ -1,10 +1,10 @@
-import { h } from "hastscript";
 import { netlifyStatic } from "@astrojs/netlify";
 import react from "@astrojs/react";
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
+import { h } from "hastscript";
+import { escape as htmlEscape } from "html-escaper";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
-import { escape } from "html-escaper";
 import rehypeSlug from "rehype-slug";
 import remarkToc from "remark-toc";
 
@@ -25,7 +25,7 @@ const anchorLinkSRLabel = (text: string) =>
 	h(
 		"span",
 		{ "is:raw": true, class: "sr-only" },
-		`Section titled ${escape(text)}`,
+		`Section titled ${htmlEscape(text)}`,
 	);
 
 const autolinkConfig = {

--- a/website/package.json
+++ b/website/package.json
@@ -39,6 +39,8 @@
 		"codemirror-lang-rome-ast": "0.0.6",
 		"fast-diff": "^1.3.0",
 		"hast-util-to-html": "^8.0.4",
+		"hastscript": "^8.0.0",
+		"html-escaper": "^3.0.3",
 		"lang-rome-formatter-ir": "0.0.2",
 		"mdast-util-to-hast": "^12.3.0",
 		"mermaid": "^9.4.3",

--- a/website/src/styles/_markdown.scss
+++ b/website/src/styles/_markdown.scss
@@ -1,0 +1,72 @@
+/* Heading anchor link styles */
+.sl-markdown-content .heading-wrapper {
+	--icon-size: 0.75em;
+	--icon-spacing: 0.25em;
+	line-height: var(--sl-line-height-headings);
+}
+
+/* Set font-size on wrapper element, so line-height, margins etc. match heading size. */
+.sl-markdown-content {
+	.level-h2 {
+		font-size: var(--sl-text-h2);
+	}
+
+	.level-h3 {
+		font-size: var(--sl-text-h3);
+	}
+
+	.level-h4 {
+		font-size: var(--sl-text-h4);
+	}
+
+	.level-h5 {
+		font-size: var(--sl-text-h5);
+	}
+}
+
+.sl-markdown-content .heading-wrapper> :first-child {
+	margin-inline-end: calc(var(--icon-size) + var(--icon-spacing));
+	display: inline;
+}
+
+.sl-markdown-content .heading-wrapper svg {
+	display: inline;
+	width: var(--icon-size);
+}
+
+.sl-markdown-content .anchor-link {
+	margin-inline-start: calc(-1 * (var(--icon-size)));
+	color: var(--sl-color-gray-3);
+
+	&:hover,
+	&:focus {
+		color: var(--sl-color-text-accent);
+	}
+}
+
+@media (hover: hover) {
+	.sl-markdown-content .anchor-link {
+		opacity: 0;
+	}
+}
+
+.sl-markdown-content .heading-wrapper:hover>.anchor-link,
+.sl-markdown-content .anchor-link:focus {
+	opacity: 1;
+}
+
+/* Float anchor links to the left of headings on larger screens. */
+@media (min-width: 95em) {
+	.sl-markdown-content .heading-wrapper {
+		display: flex;
+		flex-direction: row-reverse;
+		justify-content: flex-end;
+		gap: var(--icon-spacing);
+		margin-inline-start: calc(-1 * (var(--icon-size) + var(--icon-spacing)));
+	}
+
+	.sl-markdown-content .heading-wrapper> :first-child,
+	.sl-markdown-content .anchor-link {
+		margin: 0;
+	}
+}

--- a/website/src/styles/index.scss
+++ b/website/src/styles/index.scss
@@ -5,3 +5,4 @@
 @import "_credits";
 @import "_pre";
 @import "_sponsors";
+@import "_markdown";


### PR DESCRIPTION
## Summary

This PR adds back the autolink headings that were lost in the Rome -> Biome migration. 

Credits to Astro Docs where I respectfully stole this code from 😛 

## Test Plan

When you hover over a heading, you will now see a new icon that will link to the current heading. This works both in desktop and mobile since the icon will be moved to the most appropriate place according to the viewport.

Notes:
- I added two new small dev dependencies to accomplish this: `hastscript` & `html-escaper`.
- This will also apply to blog post entries, where we don't have a table of contents, so that's an extra nicety.
- I've removed some (supposedly) unused code from the `astro.config.mjs` file - If necessary I can add it back.

Example:

Mobile viewport
![image](https://github.com/biomejs/biome/assets/61414485/389deb2b-e7a4-42c0-a849-2df14e8510e5)

Medium-sized viewport (+ hover style example)
![image](https://github.com/biomejs/biome/assets/61414485/325bd7d3-b533-40c5-8549-77bfecaec4e2)

Large viewport
![image](https://github.com/biomejs/biome/assets/61414485/c6dea0d5-0b6f-4dbb-a7dd-62ac093b67a2)
