### PR TITLE
docs(website): add missing indentWidth for json

### DIFF
--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -700,6 +700,12 @@ How big the indentation should be for JSON (and its super languages) files.
 
 > Default: `2`
 
+### `json.formatter.indentWidth`
+
+How big the indentation should be for JSON (and its super languages) files.
+
+> Default: `2`
+
 ### `json.formatter.lineEnding`
 
 The type of line ending for JSON (and its super languages) files.


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
The config option for `json.formatter.indentWidth` is missing.
Similar to #1073 but for json

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
closes #1084 
## Test Plan

<!-- What demonstrates that your implementation is correct? -->
