### PR TITLE
fix(editors/intellij): remove build range

### DIFF
--- a/editors/intellij/gradle.properties
+++ b/editors/intellij/gradle.properties
@@ -3,12 +3,9 @@
 pluginGroup = com.github.biomejs.intellijbiome
 pluginName = Biome
 pluginRepositoryUrl = https://github.com/biomejs/biome
-# SemVer format -> https://semver.org
-pluginVersion = 0.0.6
 
-# Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 232
-pluginUntilBuild = 232.*
+# SemVer format -> https://semver.org
+pluginVersion = 0.0.7
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU

--- a/editors/intellij/gradle.properties
+++ b/editors/intellij/gradle.properties
@@ -6,9 +6,12 @@ pluginRepositoryUrl = https://github.com/biomejs/biome
 # SemVer format -> https://semver.org
 pluginVersion = 0.0.7
 
+# Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
+pluginSinceBuild = 232
+
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU
-platformVersion = 232-EAP-SNAPSHOT
+platformVersion = 233-EAP-SNAPSHOT
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/editors/intellij/gradle.properties
+++ b/editors/intellij/gradle.properties
@@ -3,7 +3,6 @@
 pluginGroup = com.github.biomejs.intellijbiome
 pluginName = Biome
 pluginRepositoryUrl = https://github.com/biomejs/biome
-
 # SemVer format -> https://semver.org
 pluginVersion = 0.0.7
 


### PR DESCRIPTION
## Summary

Fixes #1091

This PR removes the fixed build range that limit new Jetbrains IDE versions to be compatible with the plugin.

## Test Plan

- Test the plugin on WebStorm 2023.3, Intellij 2023.3  and PyCharm 2023.3 using ./gradlew runIde