### PR TITLE
fix(js_formatter): refactor indention for arrow chains

### DIFF
--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/curried_indents.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/curried_indents.js
@@ -1,0 +1,44 @@
+
+// Parameters that break over multiple lines should match indention
+// with the opening parenthesis.
+// The second signature and onward are indented a second level.
+a.b(
+  (a) =>
+    (b) =>
+    (
+      c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+      d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+    ) =>
+    (e) =>
+      0,
+  );
+
+// In assignments, the first signature is indented, and all subsequent
+// signatures indent to the same level, not a second level in.
+// Block body statements also indent an additional level from the last
+// signature.
+x = (bifornCringerMoshedPerplexSawder) => ((askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) => (f00) => {
+  averredBathersBoxroomBuggyNurl();
+} // BOOM
+)
+
+// Chained assignments with arrow functions indent an additional level from the
+// last assignment, then all subsequent signatures are at the same level
+const bifornCringer1 =
+  askTrovenaBeenaDepends =
+  glimseGlyphs =
+    (argumentOne, argumentTwo) => (restOfTheArguments12345678) => {
+      return "baz";
+    };
+
+const bifornCringer2 =
+    askTrovenaBeenaDepends =
+    glimseGlyphs =
+      (argumentOne, argumentTwo) => (restOfTheArguments12345678) => (yetAnotherArgumentPastLineWidth) => {
+        return "baz";
+      };
+
+// Same-line bodies that end up expanding only indent a single time.
+import('./someComponent').then(({default: TheComponent}) => (props) => (
+  <TheComponent {...someInjectedProps} />
+));

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/curried_indents.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/curried_indents.js.snap
@@ -1,0 +1,194 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/arrow/curried_indents.js
+---
+
+# Input
+
+```js
+
+// Parameters that break over multiple lines should match indention
+// with the opening parenthesis.
+// The second signature and onward are indented a second level.
+a.b(
+  (a) =>
+    (b) =>
+    (
+      c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+      d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+    ) =>
+    (e) =>
+      0,
+  );
+
+// In assignments, the first signature is indented, and all subsequent
+// signatures indent to the same level, not a second level in.
+// Block body statements also indent an additional level from the last
+// signature.
+x = (bifornCringerMoshedPerplexSawder) => ((askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) => (f00) => {
+  averredBathersBoxroomBuggyNurl();
+} // BOOM
+)
+
+// Chained assignments with arrow functions indent an additional level from the
+// last assignment, then all subsequent signatures are at the same level
+const bifornCringer1 =
+  askTrovenaBeenaDepends =
+  glimseGlyphs =
+    (argumentOne, argumentTwo) => (restOfTheArguments12345678) => {
+      return "baz";
+    };
+
+const bifornCringer2 =
+    askTrovenaBeenaDepends =
+    glimseGlyphs =
+      (argumentOne, argumentTwo) => (restOfTheArguments12345678) => (yetAnotherArgumentPastLineWidth) => {
+        return "baz";
+      };
+
+// Same-line bodies that end up expanding only indent a single time.
+import('./someComponent').then(({default: TheComponent}) => (props) => (
+  <TheComponent {...someInjectedProps} />
+));
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+-----
+
+```js
+// Parameters that break over multiple lines should match indention
+// with the opening parenthesis.
+// The second signature and onward are indented a second level.
+a.b(
+	(a) =>
+		(b) =>
+		(
+			c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+			d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+		) =>
+		(e) =>
+			0,
+);
+
+// In assignments, the first signature is indented, and all subsequent
+// signatures indent to the same level, not a second level in.
+// Block body statements also indent an additional level from the last
+// signature.
+x =
+	(bifornCringerMoshedPerplexSawder) =>
+	(askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) =>
+	(f00) => {
+		averredBathersBoxroomBuggyNurl();
+	}; // BOOM
+
+// Chained assignments with arrow functions indent an additional level from the
+// last assignment, then all subsequent signatures are at the same level
+const bifornCringer1 =
+	(askTrovenaBeenaDepends =
+	glimseGlyphs =
+		(argumentOne, argumentTwo) => (restOfTheArguments12345678) => {
+			return "baz";
+		});
+
+const bifornCringer2 =
+	(askTrovenaBeenaDepends =
+	glimseGlyphs =
+		(argumentOne, argumentTwo) =>
+		(restOfTheArguments12345678) =>
+		(yetAnotherArgumentPastLineWidth) => {
+			return "baz";
+		});
+
+// Same-line bodies that end up expanding only indent a single time.
+import("./someComponent").then(({ default: TheComponent }) => (props) => (
+	<TheComponent {...someInjectedProps} />
+));
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: As needed
+Bracket spacing: true
+Bracket same line: false
+-----
+
+```js
+// Parameters that break over multiple lines should match indention
+// with the opening parenthesis.
+// The second signature and onward are indented a second level.
+a.b(
+	a =>
+		b =>
+		(
+			c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+			d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+		) =>
+		e =>
+			0,
+);
+
+// In assignments, the first signature is indented, and all subsequent
+// signatures indent to the same level, not a second level in.
+// Block body statements also indent an additional level from the last
+// signature.
+x =
+	bifornCringerMoshedPerplexSawder =>
+	(askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) =>
+	f00 => {
+		averredBathersBoxroomBuggyNurl();
+	}; // BOOM
+
+// Chained assignments with arrow functions indent an additional level from the
+// last assignment, then all subsequent signatures are at the same level
+const bifornCringer1 =
+	(askTrovenaBeenaDepends =
+	glimseGlyphs =
+		(argumentOne, argumentTwo) => restOfTheArguments12345678 => {
+			return "baz";
+		});
+
+const bifornCringer2 =
+	(askTrovenaBeenaDepends =
+	glimseGlyphs =
+		(argumentOne, argumentTwo) =>
+		restOfTheArguments12345678 =>
+		yetAnotherArgumentPastLineWidth => {
+			return "baz";
+		});
+
+// Same-line bodies that end up expanding only indent a single time.
+import("./someComponent").then(({ default: TheComponent }) => props => (
+	<TheComponent {...someInjectedProps} />
+));
+```
+
+


### PR DESCRIPTION
## Summary

[Playground Link with all the affected cases](https://biomejs.dev/playground/?indentStyle=space&code=CgAvAC8AIABQAGEAcgBhAG0AZQB0AGUAcgBzACAAdABoAGEAdAAgAGIAcgBlAGEAawAgAG8AdgBlAHIAIABtAHUAbAB0AGkAcABsAGUAIABsAGkAbgBlAHMAIABzAGgAbwB1AGwAZAAgAG0AYQB0AGMAaAAgAGkAbgBkAGUAbgB0AGkAbwBuAAoALwAvACAAdwBpAHQAaAAgAHQAaABlACAAbwBwAGUAbgBpAG4AZwAgAHAAYQByAGUAbgB0AGgAZQBzAGkAcwAuAAoALwAvACAAVABoAGUAIABzAGUAYwBvAG4AZAAgAHMAaQBnAG4AYQB0AHUAcgBlACAAYQBuAGQAIABvAG4AdwBhAHIAZAAgAGEAcgBlACAAaQBuAGQAZQBuAHQAZQBkACAAYQAgAHMAZQBjAG8AbgBkACAAbABlAHYAZQBsAC4ACgBhAC4AYgAoAAoAIAAgACgAYQApACAAPQA%2BAAoAIAAgACAAIAAoAGIAKQAgAD0APgAKACAAIAAgACAAKAAKACAAIAAgACAAIAAgAGMAIAA9ACAAIgBhAGIAYwBkAGUAZgBnAGgAaQBqAGsAbABtAG4AbwBwAHEAcgBzAHQAdQB2AHcAeAB5AHoAYQBiAGMAZABlAGYAZwBoAGkAagBrAGwAbQBuAG8AcABxAHIAcwB0AHUAdgB3AHgAeQB6AGEAYgBjAGQAZQBmACIALAAKACAAIAAgACAAIAAgAGQAIAA9ACAAIgBhAGIAYwBkAGUAZgBnAGgAaQBqAGsAbABtAG4AbwBwAHEAcgBzAHQAdQB2AHcAeAB5AHoAYQBiAGMAZABlAGYAZwBoAGkAagBrAGwAbQBuAG8AcABxAHIAcwB0AHUAdgB3AHgAeQB6AGEAYgBjAGQAZQBmACIALAAKACAAIAAgACAAKQAgAD0APgAKACAAIAAgACAAKABlACkAIAA9AD4ACgAgACAAIAAgACAAIAAwACwACgAgACAAKQA7AAoACgAvAC8AIABJAG4AIABhAHMAcwBpAGcAbgBtAGUAbgB0AHMALAAgAHQAaABlACAAZgBpAHIAcwB0ACAAcwBpAGcAbgBhAHQAdQByAGUAIABpAHMAIABpAG4AZABlAG4AdABlAGQALAAgAGEAbgBkACAAYQBsAGwAIABzAHUAYgBzAGUAcQB1AGUAbgB0AAoALwAvACAAcwBpAGcAbgBhAHQAdQByAGUAcwAgAGkAbgBkAGUAbgB0ACAAdABvACAAdABoAGUAIABzAGEAbQBlACAAbABlAHYAZQBsACwAIABuAG8AdAAgAGEAIABzAGUAYwBvAG4AZAAgAGwAZQB2AGUAbAAgAGkAbgAuAAoALwAvACAAQgBsAG8AYwBrACAAYgBvAGQAeQAgAHMAdABhAHQAZQBtAGUAbgB0AHMAIABhAGwAcwBvACAAaQBuAGQAZQBuAHQAIABhAG4AIABhAGQAZABpAHQAaQBvAG4AYQBsACAAbABlAHYAZQBsACAAZgByAG8AbQAgAHQAaABlACAAbABhAHMAdAAKAC8ALwAgAHMAaQBnAG4AYQB0AHUAcgBlAC4ACgB4ACAAPQAgACgAYgBpAGYAbwByAG4AQwByAGkAbgBnAGUAcgBNAG8AcwBoAGUAZABQAGUAcgBwAGwAZQB4AFMAYQB3AGQAZQByACkAIAA9AD4AIAAoACgAYQBzAGsAVAByAG8AdgBlAG4AYQBCAGUAZQBuAGEARABlAHAAZQBuAGQAcwBSAG8AdwBhAG4AcwAsACAAZwBsAGkAbQBzAGUARwBsAHkAcABoAHMASABhAHoAYQByAGQATgBvAG8AcABzAFQAaQBlAFQAaQBlACkAIAA9AD4AIAAoAGYAMAAwACkAIAA9AD4AIAB7AAoAIAAgAGEAdgBlAHIAcgBlAGQAQgBhAHQAaABlAHIAcwBCAG8AeAByAG8AbwBtAEIAdQBnAGcAeQBOAHUAcgBsACgAKQA7AAoAfQAgAC8ALwAgAEIATwBPAE0ACgApAAoACgAvAC8AIABDAGgAYQBpAG4AZQBkACAAYQBzAHMAaQBnAG4AbQBlAG4AdABzACAAdwBpAHQAaAAgAGEAcgByAG8AdwAgAGYAdQBuAGMAdABpAG8AbgBzACAAaQBuAGQAZQBuAHQAIABhAG4AIABhAGQAZABpAHQAaQBvAG4AYQBsACAAbABlAHYAZQBsACAAZgByAG8AbQAgAHQAaABlAAoALwAvACAAbABhAHMAdAAgAGEAcwBzAGkAZwBuAG0AZQBuAHQALAAgAHQAaABlAG4AIABhAGwAbAAgAHMAdQBiAHMAZQBxAHUAZQBuAHQAIABzAGkAZwBuAGEAdAB1AHIAZQBzACAAYQByAGUAIABhAHQAIAB0AGgAZQAgAHMAYQBtAGUAIABsAGUAdgBlAGwACgBjAG8AbgBzAHQAIABiAGkAZgBvAHIAbgBDAHIAaQBuAGcAZQByADEAIAA9AAoAIAAgAGEAcwBrAFQAcgBvAHYAZQBuAGEAQgBlAGUAbgBhAEQAZQBwAGUAbgBkAHMAIAA9AAoAIAAgAGcAbABpAG0AcwBlAEcAbAB5AHAAaABzACAAPQAKACAAIAAgACAAKABhAHIAZwB1AG0AZQBuAHQATwBuAGUALAAgAGEAcgBnAHUAbQBlAG4AdABUAHcAbwApACAAPQA%2BACAAKAByAGUAcwB0AE8AZgBUAGgAZQBBAHIAZwB1AG0AZQBuAHQAcwAxADIAMwA0ADUANgA3ADgAKQAgAD0APgAgAHsACgAgACAAIAAgACAAIAByAGUAdAB1AHIAbgAgACIAYgBhAHoAIgA7AAoAIAAgACAAIAB9ADsACgAKAGMAbwBuAHMAdAAgAGIAaQBmAG8AcgBuAEMAcgBpAG4AZwBlAHIAMgAgAD0ACgAgACAAIAAgAGEAcwBrAFQAcgBvAHYAZQBuAGEAQgBlAGUAbgBhAEQAZQBwAGUAbgBkAHMAIAA9AAoAIAAgACAAIABnAGwAaQBtAHMAZQBHAGwAeQBwAGgAcwAgAD0ACgAgACAAIAAgACAAIAAoAGEAcgBnAHUAbQBlAG4AdABPAG4AZQAsACAAYQByAGcAdQBtAGUAbgB0AFQAdwBvACkAIAA9AD4AIAAoAHIAZQBzAHQATwBmAFQAaABlAEEAcgBnAHUAbQBlAG4AdABzADEAMgAzADQANQA2ADcAOAApACAAPQA%2BACAAKAB5AGUAdABBAG4AbwB0AGgAZQByAEEAcgBnAHUAbQBlAG4AdABQAGEAcwB0AEwAaQBuAGUAVwBpAGQAdABoACkAIAA9AD4AIAB7AAoAIAAgACAAIAAgACAAIAAgAHIAZQB0AHUAcgBuACAAIgBiAGEAegAiADsACgAgACAAIAAgACAAIAB9ADsACgAKAC8ALwAgAFMAYQBtAGUALQBsAGkAbgBlACAAYgBvAGQAaQBlAHMAIAB0AGgAYQB0ACAAZQBuAGQAIAB1AHAAIABlAHgAcABhAG4AZABpAG4AZwAgAG8AbgBsAHkAIABpAG4AZABlAG4AdAAgAGEAIABzAGkAbgBnAGwAZQAgAHQAaQBtAGUALgAKAGkAbQBwAG8AcgB0ACgAJwAuAC8AcwBvAG0AZQBDAG8AbQBwAG8AbgBlAG4AdAAnACkALgB0AGgAZQBuACgAKAB7AGQAZQBmAGEAdQBsAHQAOgAgAFQAaABlAEMAbwBtAHAAbwBuAGUAbgB0AH0AKQAgAD0APgAgACgAcAByAG8AcABzACkAIAA9AD4AIAAoAAoAIAAgADwAVABoAGUAQwBvAG0AcABvAG4AZQBuAHQAIAB7AC4ALgAuAHMAbwBtAGUASQBuAGoAZQBjAHQAZQBkAFAAcgBvAHAAcwB9ACAALwA%2BAAoAKQApADsA).

This PR reorganizes where indents are placed in `ArrowChain` to better match Prettier, and to avoid the need to use `dedent`. The primary issue this was made to resolve was parameter lists appearing overly-dedented when the parameters broke over multiple lines:

```typescript
foo(
  (b) =>
    (
    c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
    d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
  ) =>
    (e) =>
      0,
);
```

Here, the `b` signature is appropriately indented, and the following signature is appropriately indented one additional level, but the parameters within that second signature are _dedented_ outward, causing them to not line up with the `e` signature that follows. The correct print for this statement is:

```typescript
a.b(
  (b) =>
    (
      c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
      d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
    ) =>
    (e) =>
      0,
);
```

The reason this happened was because of a `dedent` getting added around the parameters for each signature. That was originally added in #804 as an appropriate fix to parameters that were being overly _indented_ two levels when breaking. But the root cause of the issue was further up the chain. Why were the parameters being indented twice at all?

It has to do with the difference between how Biome and Prettier print out arrow chains. Prettier prints them _recursively_, nesting each signature as the body of the previous expression, up until the tail of the chain, which is at the top-level. All signatures other than the first in a chain are also indented a second level in, and so in the body for the first signature, Prettier adds another `indent`, and then the rest of the chain continues recursively. A simplified IR for this could be:

```lisp
indent([
  group("(", indent(firstSignatureParams), ")"),
  " =>",
  indent([
    line,
    group("(", indent(secondSignatureParams), ")"),
    " =>",
    line,
    group("(", indent(thirdSignatureParams), ")")
  ]),
  " =>", tailBody
])
```

The `indent` around each `signatureParams` then ensures they are indented one level further in if the parameter list breaks (see the first corrected example at the top). And this works exactly as expected.

Biome, however, prints the signature chain as a flat list, which is more efficient to process, but has different semantics. Instead of being able to rely on the first signature adding the indent and all of the subsequent ones using it implicitly, each signature has to manage its own indent level. A simplified IR here could be:

```lisp
indent([
  group("#1", [
    indent([
      group([
        dedent([ "(", indent(first_signature_params), ")" ]),
        " =>",
        dedent([ "(", indent(second_signature_params), ")" ]),
        " =>",
        dedent([ "(", indent(third_signature_params), ")" ])
      ])
    ])
  ]),
  " =>", tail_body
])
```

This example is stripped down from a direct export from Biome before these changes. Importantly, notice that there _are_ two `indent`s around the entire signature chain. _Somehow_ the first signature was appropriately _not_ indenting a second time, but all of the following ones were. I'm not at all sure how, and I think that's part of why this was not functioning as expected. Unfortunately I do not have the capacity to figure that out now, but it isn't an issue anymore anyway since these changes refactor it entirely.

Anyway, this IR also shows that along with the two outer indents, each signature is also wrapped with both a `dedent` _and_ another `indent`, effectively cancelling each other out. But something internally obviously doesn't fully cancel, since we encountered the original issue here as shown in the first example: the parameter list ends up overly dedented when it breaks over multiple lines. I'm also not entirely sure why here, but this combination of `indent` and `dedent` was clearly causing some of it.

_So_, this PR refactors all of the indention handling for arrow chains to more closely match Prettier. After the refactor, a simplified IR from Biome looks like this:

```lisp
indent([
  group("#1", [
    group("(", indent(first_signature_params), ")"),
    " =>",
    indent(group("(", indent(second_signature_params), ")")),
    " =>",
    indent(group("(", indent(third_signature_params), ")")),
  ]),
  " =>", tail_body
]),
```

This matches much closer to Prettier's representation, removes the need for `dedent` at all, and also removes the mysteriously-correct behavior with behavior that follows very clearly from the IR. The entire chain is indented by the outer indent, then the signatures are written as a flat list. The first signature writes itself directly, with the parameters gaining an indent for if they break. All of the subsequent signatures then _also_ indent themselves an additional level, as expected in the printed output.

Another nice consequence of this refactor is that some of the conditional logic that was correcting the previous odd behaviors is no longer necessary, like checking if the expression is within a call expression or not. That behavior now comes naturally from the existing IR, matching Prettier as well.

Note also that there are other permutations of arrow chains that are handled slightly differently, hence the reason that the `=>` tokens are not part of the indent. Those cases are commented inline in the code.

## Test Plan

There were somehow no tests that covered this! Like nothing about indention of expanded parameters in arrow chains. Not from Prettier and not in our own specs.....wild. So I added a new spec test with all of the permutations of this pattern I've seen, and the snapshot appears as expected, matching the output of Prettier.
