### PR TITLE
[ doc ] added formatter.bracketSameLine and formatter.bracketSpacing …

### DIFF
--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -453,7 +453,7 @@ How many characters can be written on a single line.
 
 ### `formatter.bracketSameLine`
 
-Choose wether the ending `>` of a multi-line HTML ( or HTML-like ) element should be on the last attribute line or not
+Choose whether the ending `>` of a multi-line HTML ( or HTML-like ) element should be on the last attribute line or not
 
 > Default: false
 

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -453,13 +453,13 @@ How many characters can be written on a single line.
 
 ### `formatter.bracketSameLine`
 
-Choose whether the ending `>` of a multi-line HTML ( or HTML-like ) element should be on the last attribute line or not
+Choose whether the ending `>` of a multi-line JSX element should be on the last attribute line or not
 
 > Default: false
 
 ### `formatter.bracketSpacing`
 
-Choose wether spaces should be added between brackets and inner values
+Choose whether spaces should be added between brackets and inner values
 
 > Default: true
 
@@ -643,13 +643,13 @@ How many characters can be written on a single line in JavaScript (and its super
 
 ### `javascript.formatter.bracketSameLine`
 
-Choose wether the ending `>` of a multi-line HTML ( or HTML-like ) element should be on the last attribute line or not
+Choose whether the ending `>` of a multi-line JSX element should be on the last attribute line or not
 
 > Default: false
 
 ### `javascript.formatter.bracketSpacing`
 
-Choose wether spaces should be added between brackets and inner values
+Choose whether spaces should be added between brackets and inner values
 
 > Default: true
 

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -451,6 +451,18 @@ How many characters can be written on a single line.
 
 > Default: `80`
 
+### `formatter.bracketSameLine`
+
+Choose wether the ending `>` of a multi-line HTML ( or HTML-like ) element should be on the last attribute line or not
+
+> Default: false
+
+### `formatter.bracketSpacing`
+
+Choose wether spaces should be added between brackets and inner values
+
+> Default: true
+
 ## `organizeImports`
 
 ### `organizeImports.enabled`
@@ -628,6 +640,18 @@ The type of line ending for JavaScript (and its super languages) files.
 How many characters can be written on a single line in JavaScript (and its super languages) files.
 
 > Default: `80`
+
+### `javascript.formatter.bracketSameLine`
+
+Choose wether the ending `>` of a multi-line HTML ( or HTML-like ) element should be on the last attribute line or not
+
+> Default: false
+
+### `javascript.formatter.bracketSpacing`
+
+Choose wether spaces should be added between brackets and inner values
+
+> Default: true
 
 
 ### `javascript.globals`


### PR DESCRIPTION
## Summary

As earlier discussed with @ematipico  in #1138 I added the `formatter.bracketSameLine` and `formatter.bracketSpacing`  as well as the `javascript.formatter.bracketSameLine` and `javascript.formatter.bracketSpacing` options to the documentation, since they were missing.