### PR TITLE
docs(formatter): Explain divergence for typescript vs babel from Prettier

### DIFF
--- a/website/src/content/docs/formatter/differences-with-prettier.md
+++ b/website/src/content/docs/formatter/differences-with-prettier.md
@@ -267,7 +267,7 @@ Input
 (1)++;
 ```
 
-```js title="example.js" del{1} add={2}
+```js title="example.js" del={1} add={2}
 1++;
 (1)++;
 ```
@@ -285,7 +285,7 @@ class C {
 Diff
 
 
-```ts title="example.js" del{2} add={3}
+```ts title="example.js" del={2} add={3}
 class C {
   abstract f(): number;
   abstract f() : number;
@@ -316,7 +316,7 @@ function someFunctionName(
 Diff
 
 
-```ts title="example.js" del{5} ins={6,7,8,9}
+```ts title="example.js" del={5} ins={6,7,8,9}
 function someFunctionName(
   someLongBreakingParameterName,
   anotherLongParameterName,


### PR DESCRIPTION
## Summary

Adding docs about how Biome's output might not match Prettier when it was parsed with `typescript` rather than `babel-ts`. This accounted for almost a dozen diffs when run on our monorepo, and the bugs have been reported to Prettier as inconsistencies.

Biome matches the output of `babel-ts` and `babel`, which feels like the correct target for consistent output across JS and TS combined.

## Test Plan

N/A
