### PR TITLE
fix(js_formatter): match default clause block handling with case clauses

### DIFF
--- a/crates/biome_js_formatter/src/js/auxiliary/case_clause.rs
+++ b/crates/biome_js_formatter/src/js/auxiliary/case_clause.rs
@@ -28,8 +28,8 @@ impl FormatNodeRule<JsCaseClause> for FormatJsCaseClause {
         )?;
 
         // Whether the first statement in the clause is a BlockStatement, and
-        // there are no other non-empty statements. Empties may show up
-        // depending on whether the input code includes certain newlines.
+        // there are no other non-empty statements. Empties may show up when
+        // parsing depending on if the input code includes certain newlines.
         let is_single_block_statement = matches!(
             consequent.iter().next(),
             Some(AnyJsStatement::JsBlockStatement(_))

--- a/crates/biome_js_formatter/src/js/auxiliary/default_clause.rs
+++ b/crates/biome_js_formatter/src/js/auxiliary/default_clause.rs
@@ -15,10 +15,19 @@ impl FormatNodeRule<JsDefaultClause> for FormatJsDefaultClause {
             consequent,
         } = node.as_fields();
 
-        let first_child_is_block_stmt = matches!(
+        // Whether the first statement in the clause is a BlockStatement, and
+        // there are no other non-empty statements. Empties may show up when
+        // parsing depending on if the input code includes certain newlines.
+        //
+        // See the comments in `case_clause.rs` for a detailed example.
+        let is_single_block_statement = matches!(
             consequent.iter().next(),
             Some(AnyJsStatement::JsBlockStatement(_))
-        );
+        ) && consequent
+            .iter()
+            .filter(|statement| !matches!(statement, AnyJsStatement::JsEmptyStatement(_)))
+            .count()
+            == 1;
 
         write!(f, [default_token.format(), colon_token.format()])?;
 
@@ -30,7 +39,7 @@ impl FormatNodeRule<JsDefaultClause> for FormatJsDefaultClause {
             return Ok(());
         }
 
-        if first_child_is_block_stmt {
+        if is_single_block_statement {
             write!(f, [space(), consequent.format()])
         } else {
             // no line break needed after because it is added by the indent in the switch statement

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js
@@ -33,3 +33,20 @@ switch (key) {
 	}
 	break;
 }
+
+
+switch (key) {
+	default: {
+		const a = 1;
+		break;
+	}
+}
+
+switch (key) {
+	// The block is not the only statement in the case body,
+	// so it doesn't hug the same line as the case here.
+	default: {
+		const a = 1;
+	}
+	break;
+}

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js.snap
@@ -41,6 +41,23 @@ switch (key) {
 	}
 	break;
 }
+
+
+switch (key) {
+	default: {
+		const a = 1;
+		break;
+	}
+}
+
+switch (key) {
+	// The block is not the only statement in the case body,
+	// so it doesn't hug the same line as the case here.
+	default: {
+		const a = 1;
+	}
+	break;
+}
 ```
 
 
@@ -96,6 +113,23 @@ switch (key) {
 	// The block is not the only statement in the case body,
 	// so it doesn't hug the same line as the case here.
 	case separateBlockBody:
+		{
+			const a = 1;
+		}
+		break;
+}
+
+switch (key) {
+	default: {
+		const a = 1;
+		break;
+	}
+}
+
+switch (key) {
+	// The block is not the only statement in the case body,
+	// so it doesn't hug the same line as the case here.
+	default:
 		{
 			const a = 1;
 		}


### PR DESCRIPTION
## Summary

In #1035 I fixed some issues with `case` clauses with multi-statement bodies, but those didn't carry over to `default` clauses because they are handled separately. This copies the updated logic so that they match.

## Test Plan

Added some cases to the existing spec test for `switch` to cover default clauses as well.