### PR TITLE
docs(website): translate versioning to portuguese

### DIFF
--- a/website/src/content/docs/pt-br/internals/versioning.mdx
+++ b/website/src/content/docs/pt-br/internals/versioning.mdx
@@ -1,49 +1,49 @@
 ---
-title: Versioning
-description: How we version Biome.
+title: Versionamento
+description: Como nós versionamos o Biome.
 ---
 
-Fixes to lint rules, formatting layouts, etc. might prevent your scripts from passing. Due to the nature of these changes,
-it's **highly recommended** to save the _exact_ version in your `package.json`, instead of using range operators.
+Correções em regras de lint, layouts de formatação, etc. podem prevenir que seus scripts passem. Dado a natureza dessas alterações,
+é **altamente recomendável** salvar a versão _exata_ em seu `package.json`, ao invés de usar operadores de intervalo de versões.
 
-This methodology will make sure that your script won't fail unexpectedly.
+Essa metodologia irá garantir que seus scripts não irão falhar inesperadamente.
 
-## Semantic Versioning
+## Versionamento Semântico
 
-Biome follows [semantic versioning](https://semver.org/). Due to the nature of Biome as a toolchain, it can be unclear what changes are considered major, minor, or patch. That's why Biome uses the following versioning guide:
+O Biome segue o [versionamento semântico](https://semver.org/lang/pt-BR/). Dado a natureza do Biome como um conjunto de ferramentas, pode ser incerto quais mudanças são consideradas maior, menor, ou de correção. Isso é o porquê do Biome usar o seguinte guia de versionamento:
 
-### Patch Release
+### Lançamento de Correção
 
-* Fixing a lint rule that raises lint errors for valid code (false positives)
-* Fixing incorrect code suggestions
-* Fixing the formatting of a syntax that results in invalid code or changes the semantics of the program.
-* Improvements to the documentation
-* Internal changes that don't change Biome's functionality:
-  * Refactors
-  * Performance improvements
-  * Increase or change in test coverage
-* Improving the wording of diagnostics or fixing the rendering of diagnostics.
-* Re-releases after a failed release
-* Changing the formatting of established syntax.
+* Corrigindo uma regra de lint que gera erros de lint para código válido (falsos positivos)
+* Corrigindo sugestão de código incorreta
+* Corrigindo a formatação de uma sintaxe que resulta em um código inválido ou altera a semântica do programa.
+* Melhorias na documentação
+* Mudanças internas que não afetam a funcionalidade do Biome:
+  * Refatorações
+  * Melhorias de performance
+  * Aumento ou alteração na cobertura de testes
+* Melhorando a redação de diagnósticos ou corrigindo a renderização de diagnósticos
+* Relançamentos após um lançamento falho
+* Alterando a formatação de sintaxe estabelecida
 
-### Minor Release
+### Lançamento Menor
 
-* Adding a new rule or promoting an existing lint rule to a stable group that is not recommended by default.
-* Adding linting and formatting support for a recently introduced language feature, even if that results in more reported linting errors.
-* Removal of recommended rules
-* Deprecation of existing rules
-* Adding new configuration optional configuration options that do not change the formatting or report more lint errors.
-* Adding a new recommended lint rule or promoting an existing lint rule from the nursery group to a recommended lint rule in a stable group.
-* Removal of a non-*nursery* rule or demoting a rule to the *nursery* group.
+* Adicionando uma nova regra ou promovendo uma regra de lint existente para um grupo estável que não é recomendando por padrão.
+* Adicionando suporte a linting e a formatação para uma funcionalidade de linguagem recentemente introduzida, mesmo que isso resulte em mais erros de linting reportados
+* Remoção de regras recomendadas
+* Descontinuação de regras existentes
+* Adicionando novas opções de configuração opcionais que não alteram a formatação ou reportem mais erros de lint
+* Adicionando uma nova regra de lint recomendada ou promovendo uma regra de lint existente do grupo experimental para uma regra de lint recomendada em um grupo estável
+* Remoção de uma regra não-*experimental* ou rebaixando uma regra para o grupo *experimental*
 
-### Major Release
-* Changes to the configuration that result in different formatting or more reported lint errors (adding/removing options, changing the default value)
-* Changes to Biome's public API
-* Promotion of new features or tools that require some spotlight
+### Lançamento maior
 
-## Visual Studio Code Extension
+* Mudanças para a configuração que resulta em uma diferente formatação ou mais reportes de erros de lint (adicionando/removendo opções, alterando valor padrão)
+* Mudanças para a API pública do Biome
+* Promoção de novas funcionalidades ou ferramentas que precisam de algum destaque
 
-Visual Studio Code [doesn't support pre-release tags](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions) for extensions. That's why Biome uses the following version schema to distinguish stable and previews:
-* Stable releases use even version numbers: 10, 12, 14, 16, ...
-* Previews use odd version numbers: 11, 13, 15, 17, ...
+### Extensão do Visual Studio Code
 
+O Visual Studio Code [não suporta tags de pré-lançamento](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions) para extensões. Isso é o porquê o Biome usa o seguinte esquema para distinguir versões estáveis e prévias:
+* Versões estáveis usam números de versão pares: 10, 12, 14, 16, ...
+* Versões prévias usam números de versão ímpares: 11, 13, 15, 17, ...


### PR DESCRIPTION
## Summary

Partial work of https://github.com/biomejs/biome/issues/1065 which translates the following files:
- `internals/versioning`

## Test Plan

Check if there is no missing translation in the translated files.
Check if the translations are correct and if they adhere to the grammatical rules of Portuguese.
