### PR TITLE
fix(js_formatter): fix binaryish and ts type handling for grouping call arguments

### DIFF
--- a/crates/biome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/biome_js_formatter/src/js/expressions/call_arguments.rs
@@ -15,7 +15,8 @@ use biome_js_syntax::{
     AnyJsCallArgument, AnyJsExpression, AnyJsFunctionBody, AnyJsLiteralExpression, AnyJsStatement,
     AnyTsReturnType, AnyTsType, JsBinaryExpressionFields, JsCallArgumentList, JsCallArguments,
     JsCallArgumentsFields, JsCallExpression, JsExpressionStatement, JsFunctionExpression,
-    JsImportCallExpression, JsLanguage, TsAsExpressionFields, TsSatisfiesExpressionFields,
+    JsImportCallExpression, JsLanguage, JsLogicalExpressionFields, TsAsExpressionFields,
+    TsSatisfiesExpressionFields,
 };
 use biome_rowan::{AstSeparatedElement, AstSeparatedList, SyntaxResult};
 
@@ -915,6 +916,18 @@ fn is_relatively_short_argument(argument: AnyJsExpression) -> bool {
                 operator_token: _,
                 right: Ok(right),
             } = binary_expression.as_fields()
+            {
+                SimpleArgument::from(left).is_simple() && SimpleArgument::from(right).is_simple()
+            } else {
+                false
+            }
+        }
+        AnyJsExpression::JsLogicalExpression(logical_expression) => {
+            if let JsLogicalExpressionFields {
+                left: Ok(left),
+                operator_token: _,
+                right: Ok(right),
+            } = logical_expression.as_fields()
             {
                 SimpleArgument::from(left).is_simple() && SimpleArgument::from(right).is_simple()
             } else {

--- a/crates/biome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/biome_js_formatter/src/js/expressions/call_arguments.rs
@@ -902,10 +902,10 @@ fn is_simple_ts_type(ty: &AnyTsType) -> bool {
     //     Foo<number, string> => Foo<number, string>
     let extracted_generic_type = match &extracted_array_type {
         Some(AnyTsType::TsReferenceType(generic)) => {
-            generic.type_arguments().map_or(None, |type_arguments| {
+            generic.type_arguments().and_then(|type_arguments| {
                 let argument_list = type_arguments.ts_type_argument_list();
                 if argument_list.len() == 1 {
-                    argument_list.first().map_or(None, |first| first.ok())
+                    argument_list.first().and_then(|first| first.ok())
                 } else {
                     extracted_array_type
                 }

--- a/crates/biome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/biome_js_formatter/src/js/expressions/call_arguments.rs
@@ -874,11 +874,48 @@ fn should_group_last_argument(
 ///     HTMLElement     => true
 ///     string | object => false
 ///     Foo<string>     => false
-///
-/// Note that Prettier allows extracting the inner type from arrays and
-/// single-argument generic types, but for now, this implementation does not.
-fn is_simple_ts_type(ty: AnyTsType) -> bool {
-    match ty {
+/// This function also introspects into array and generic types to extract the
+/// core type, but only to a limited extent:
+///     string[]        => string
+///     string[][]      => string
+///     string[][][]    => string
+///     Foo<string>[][] => string
+///     Foo<string[]>[] => string[]
+///     Foo<string[][]> => string[][]
+fn is_simple_ts_type(ty: &AnyTsType) -> bool {
+    // Reach up to two-levels deep into array types:
+    //     string[]     => string
+    //     string[][]   => string
+    //     string[][][] => string[]
+    let extracted_array_type = match ty {
+        AnyTsType::TsArrayType(array) => match array.element_type() {
+            Ok(AnyTsType::TsArrayType(inner_array)) => inner_array.element_type().ok(),
+            Ok(element_type) => Some(element_type),
+            _ => None,
+        },
+        _ => None,
+    };
+
+    // Then, extract the first type parameter of a Generic as long as it's the
+    // only parameter:
+    //     Foo<number> => number
+    //     Foo<number, string> => Foo<number, string>
+    let extracted_generic_type = match &extracted_array_type {
+        Some(AnyTsType::TsReferenceType(generic)) => {
+            generic.type_arguments().map_or(None, |type_arguments| {
+                let argument_list = type_arguments.ts_type_argument_list();
+                if argument_list.len() == 1 {
+                    argument_list.first().map_or(None, |first| first.ok())
+                } else {
+                    extracted_array_type
+                }
+            })
+        }
+        _ => extracted_array_type,
+    };
+
+    let resolved_type = extracted_generic_type.as_ref().unwrap_or(ty);
+    match resolved_type {
         // Any keyword or literal types
         AnyTsType::TsAnyType(_)
         | AnyTsType::TsBigintLiteralType(_)
@@ -941,7 +978,7 @@ fn is_relatively_short_argument(argument: AnyJsExpression) -> bool {
                 ty: Ok(annotation),
             } = as_expression.as_fields()
             {
-                is_simple_ts_type(annotation) && SimpleArgument::from(expression).is_simple()
+                is_simple_ts_type(&annotation) && SimpleArgument::from(expression).is_simple()
             } else {
                 false
             }
@@ -953,7 +990,7 @@ fn is_relatively_short_argument(argument: AnyJsExpression) -> bool {
                 ty: Ok(annotation),
             } = as_expression.as_fields()
             {
-                is_simple_ts_type(annotation) && SimpleArgument::from(expression).is_simple()
+                is_simple_ts_type(&annotation) && SimpleArgument::from(expression).is_simple()
             } else {
                 false
             }

--- a/crates/biome_js_formatter/tests/quick_test.rs
+++ b/crates/biome_js_formatter/tests/quick_test.rs
@@ -14,11 +14,9 @@ mod language {
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
     let src = r#"
-  <div>
-    <span a b>
-      <Hi />
-    </span> ({variable})
-  </div>;
+    setTimeout(() => {
+      updateDebouncedQuery(query);
+    }, debounceTime ?? 500);
     "#;
     let source_type = JsFileSource::tsx();
     let tree = parse(

--- a/crates/biome_js_formatter/tests/specs/js/module/call/simple_arguments.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/call/simple_arguments.js
@@ -26,6 +26,16 @@ foo( () => {
 	},
 	arr[Math.floor(1 + 2)],
 );
+foo( () => {
+		foo;
+	},
+	a || b + 1,
+);
+foo( () => {
+		foo;
+	},
+	a + b ?? 1,
+);
 
 
 // Cases where the second argument is simple enough to group.
@@ -49,6 +59,9 @@ foo(() => {
   },
   a + b,
 );
+foo(() => {
+  foo;
+}, a || b);
 foo(() => {
     foo
   },

--- a/crates/biome_js_formatter/tests/specs/js/module/call/simple_arguments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/call/simple_arguments.js.snap
@@ -34,6 +34,16 @@ foo( () => {
 	},
 	arr[Math.floor(1 + 2)],
 );
+foo( () => {
+		foo;
+	},
+	a || b + 1,
+);
+foo( () => {
+		foo;
+	},
+	a + b ?? 1,
+);
 
 
 // Cases where the second argument is simple enough to group.
@@ -58,6 +68,9 @@ foo(() => {
   a + b,
 );
 foo(() => {
+  foo;
+}, a || b);
+foo(() => {
     foo
   },
   ++b,
@@ -78,7 +91,6 @@ foo(() => {
 foo(() => {
     foo;
 }, [Math.floor(1 + 2)]);
-
 ```
 
 
@@ -137,6 +149,18 @@ foo(
 	},
 	arr[Math.floor(1 + 2)],
 );
+foo(
+	() => {
+		foo;
+	},
+	a || b + 1,
+);
+foo(
+	() => {
+		foo;
+	},
+	a + b ?? 1,
+);
 
 // Cases where the second argument is simple enough to group.
 foo(() => {
@@ -151,6 +175,9 @@ foo(() => {
 foo(() => {
 	foo;
 }, a + b);
+foo(() => {
+	foo;
+}, a || b);
 foo(() => {
 	foo;
 }, ++b);


### PR DESCRIPTION
## Summary

When I added `is_relatively_short_argument` in #777, I added `JsBinaryExpression` as a match arm, but didn't realize that wouldn't encompass expressions like `a ?? b`, which are actually `JsLogicalExpression`. This PR just adds a similar arm to that function for handling logicals exactly like binaries, which matches Prettier's `isBinaryish` function used in the same place.

This PR also implements the missing half of Prettier's `isSimpleTsType`, introspecting arrays and generic types to extract the core type before checking for simplicity.

## Test Plan

Added to the spec test for simple_arguments and grouping to cover logical expressions.