### PR TITLE
fix(lint/useValidAriaProps): fix to not report `aria-atomic` as invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Fix [#728](https://github.com/biomejs/biome/issues/728). [useSingleVarDeclarator](https://biomejs.dev/linter/rules/use-single-var-declarator) no longer outputs invalid code. Contributed by @Conaclos
 
+- Fix [#1167](https://github.com/biomejs/biome/issues/1167). [useValidAriaProps] no longer reports `aria-atomic` as invalid. Contributed by @unvalley
+
 ### Parser
 
 - Fix [#1077](https://github.com/biomejs/biome/issues/1077), fix issues when parsing conditional expression where parenthesized identifier was being parsed as arrow expression. Contributed by @kalleep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   }
   ```
 
-- Fix [#651](https://github.com/biomejs/biome/issues/651), [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) no longer reports out of scope dependecies. Contributed by @kalleep
+- Fix [#651](https://github.com/biomejs/biome/issues/651), [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) no longer reports out of scope dependencies. Contributed by @kalleep
 
   The following code is no longer reported:
   ```ts

--- a/crates/biome_aria/src/properties.rs
+++ b/crates/biome_aria/src/properties.rs
@@ -391,6 +391,7 @@ impl AriaProperties {
             "aria-valuemin" => &AriaValuemin as &dyn AriaPropertyDefinition,
             "aria-valuenow" => &AriaValuenow as &dyn AriaPropertyDefinition,
             "aria-valuetext" => &AriaValuetext as &dyn AriaPropertyDefinition,
+            "aria-atomic" => &AriaAtomic as &dyn AriaPropertyDefinition,
             _ => return None,
         })
     }

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAriaProps/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAriaProps/valid.jsx
@@ -5,3 +5,4 @@ var a = <div abcARIAdef="true"></div>;
 var a = <div fooaria-foobar="true"></div>;
 var a = <div fooaria-hidden="true"></div>;
 var a = <input type="text" aria-errormessage="foobar" />;
+var a = <div type="text" aria-atomic="true" />;

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAriaProps/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAriaProps/valid.jsx.snap
@@ -11,6 +11,7 @@ var a = <div abcARIAdef="true"></div>;
 var a = <div fooaria-foobar="true"></div>;
 var a = <div fooaria-hidden="true"></div>;
 var a = <input type="text" aria-errormessage="foobar" />;
+var a = <div type="text" aria-atomic="true" />;
 
 ```
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -81,7 +81,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   }
   ```
 
-- Fix [#651](https://github.com/biomejs/biome/issues/651), [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) no longer reports out of scope dependecies. Contributed by @kalleep
+- Fix [#651](https://github.com/biomejs/biome/issues/651), [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) no longer reports out of scope dependencies. Contributed by @kalleep
 
   The following code is no longer reported:
   ```ts
@@ -95,6 +95,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   ```
 
 - Fix [#728](https://github.com/biomejs/biome/issues/728). [useSingleVarDeclarator](https://biomejs.dev/linter/rules/use-single-var-declarator) no longer outputs invalid code. Contributed by @Conaclos
+
+- Fix [#1167](https://github.com/biomejs/biome/issues/1167). [useValidAriaProps] no longer reports `aria-atomic` as invalid. Contributed by @unvalley
 
 ### Parser
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #1167 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a snapshot to accept `aria-atomic` as valid case.
<!-- What demonstrates that your implementation is correct? -->
