### PR TITLE
docs: fix incorrect file name

### DIFF
--- a/website/src/content/docs/analyzer/index.mdx
+++ b/website/src/content/docs/analyzer/index.mdx
@@ -124,7 +124,7 @@ By default, this action can be run using the <kbd title="Shift">⇧</kbd>+<kbd>A
 
 You can add the following to your editor configuration if you want the action to run automatically on save instead of calling it manually:
 
-```json title="biome.json"
+```json title="settings.json"
 {
 	"editor.codeActionsOnSave":{
 		"source.organizeImports.biome": true

--- a/website/src/content/docs/ja/analyzer/index.mdx
+++ b/website/src/content/docs/ja/analyzer/index.mdx
@@ -125,7 +125,7 @@ BiomeのVS Code拡張機能は、_Organize Imports_ コードアクションに�
 
 ファイル保存時に自動で実行したい場合は、エディタの設定に以下を追加することで実現できます。
 
-```json
+```json title="settings.json"
 {
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": true

--- a/website/src/content/docs/pt-br/analyzer/index.mdx
+++ b/website/src/content/docs/pt-br/analyzer/index.mdx
@@ -124,7 +124,7 @@ Por padrão, essa ação será executada ao usar o atalho de teclado <kbd title=
 
 Você pode adicionar o seguinte à configuração do seu editor se você deseja que a ação seja executada automaticamente ao salvar em vez de chamá-la manualmente:
 
-```json title="biome.json"
+```json title="settings.json"
 {
 	"editor.codeActionsOnSave":{
 		"source.organizeImports.biome": true

--- a/website/src/content/docs/zh-cn/analyzer/index.mdx
+++ b/website/src/content/docs/zh-cn/analyzer/index.mdx
@@ -124,7 +124,7 @@ Biome VS Code扩展通过“Organize Imports”代码操作支持导入排序。
 
 如果希望自动在保存时运行该操作而不是手动调用它，请将以下内容添加到编辑器配置中：
 
-```json title="biome.json"
+```json title="settings.json"
 {
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": true


### PR DESCRIPTION
## Summary

This PR updates the file name in the "Import sorting via VSCode extension" examples to accurately reflect the vscode settings file.
