### PR TITLE
chore: broken links in `credits.mdx`

### DIFF
--- a/website/src/content/docs/internals/credits.mdx
+++ b/website/src/content/docs/internals/credits.mdx
@@ -27,7 +27,7 @@ They have been transformed in some way, sometimes substantially rewritten.
   - **Original**: [`rslint/rslint_errors`](https://github.com/rslint/rslint/tree/master/crates/rslint_errors)
   - **License**: MIT
 
-- [`crates/biome_console/src/codespan`](https://github.com/biomejs/biome/tree/main/crates/biome_console/src/codespan)
+- [`crates/biome_console/src/codespan`](https://github.com/biomejs/biome/tree/main/crates/biome_console)
   - **Original**: [`brendanzab/codespan`](https://github.com/brendanzab/codespan)
   - **License**: Apache License, Version 2.0
 
@@ -55,6 +55,6 @@ They have been transformed in some way, sometimes substantially rewritten.
   - **Original**: [`rust-analyzer/text-size`](https://github.com/rust-analyzer/text-size)
   - **License**: Apache License, Version 2.0 or MIT
 
-- [`crates/biome_service/src/ignore/pattern`](https://github.com/biomejs/biome/tree/main/crates/biome_service/src/ignore/pattern)
+- [`crates/biome_service/src/ignore/pattern`](https://github.com/biomejs/biome/tree/main/crates/biome_service/src)
     - **Original**: [`rust-lang/glob`](https://github.com/rust-lang/glob/blob/master/src/lib.rs)
     - **License**: Apache License, Version 2.0 or MIT


### PR DESCRIPTION
## Summary

There are 2 broken links located in the `credits.mdx`.
- Codespan for `biome_console`
- ignore for `biome_service`

I updated both to still link to the `src` of both packages, but maybe they should be removed if the other packages aren't used anymore
