### PR TITLE
fix(js_formatter): fix handling ts references from array types in argument grouping

### DIFF
--- a/crates/biome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/biome_js_formatter/src/js/expressions/call_arguments.rs
@@ -902,14 +902,16 @@ fn is_simple_ts_type(ty: &AnyTsType) -> bool {
     //     Foo<number, string> => Foo<number, string>
     let extracted_generic_type = match &extracted_array_type {
         Some(AnyTsType::TsReferenceType(generic)) => {
-            generic.type_arguments().and_then(|type_arguments| {
+            if let Some(type_arguments) = generic.type_arguments() {
                 let argument_list = type_arguments.ts_type_argument_list();
                 if argument_list.len() == 1 {
                     argument_list.first().and_then(|first| first.ok())
                 } else {
                     extracted_array_type
                 }
-            })
+            } else {
+                extracted_array_type
+            }
         }
         _ => extracted_array_type,
     };
@@ -924,9 +926,9 @@ fn is_simple_ts_type(ty: &AnyTsType) -> bool {
         | AnyTsType::TsBooleanType(_)
         | AnyTsType::TsNeverType(_)
         | AnyTsType::TsNullLiteralType(_)
+        | AnyTsType::TsNonPrimitiveType(_)
         | AnyTsType::TsNumberLiteralType(_)
         | AnyTsType::TsNumberType(_)
-        | AnyTsType::TsObjectType(_)
         | AnyTsType::TsStringLiteralType(_)
         | AnyTsType::TsStringType(_)
         | AnyTsType::TsSymbolType(_)

--- a/crates/biome_js_formatter/tests/specs/ts/simple_arguments.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/simple_arguments.ts
@@ -1,0 +1,47 @@
+// Tests around grouping layouts and simple arguments
+
+// Cases where the second argument is too complex to group.
+foo(() => {
+    foo
+  },
+  [] as string[][][],
+);
+foo(() => {
+    foo
+  },
+  {} as Foo<Bar, Baz>,
+);
+foo(() => {
+    foo
+  },
+  bar as {},
+);
+
+
+// Cases where the second argument is simple enough to group.
+foo(() => {
+    foo
+  },
+  [] as never[]
+);
+foo(() => {
+    foo
+  },
+  bar as boolean
+);
+foo(() => {
+    foo
+  },
+  [] as object[][]
+);
+
+foo(() => {
+    foo
+  },
+  [] as Foo<number>[][]
+);
+foo(() => {
+    foo
+  },
+  bar as MyCustomType[],
+);

--- a/crates/biome_js_formatter/tests/specs/ts/simple_arguments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/simple_arguments.ts.snap
@@ -1,0 +1,123 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: ts/simple_arguments.ts
+---
+
+# Input
+
+```ts
+// Tests around grouping layouts and simple arguments
+
+// Cases where the second argument is too complex to group.
+foo(() => {
+    foo
+  },
+  [] as string[][][],
+);
+foo(() => {
+    foo
+  },
+  {} as Foo<Bar, Baz>,
+);
+foo(() => {
+    foo
+  },
+  bar as {},
+);
+
+
+// Cases where the second argument is simple enough to group.
+foo(() => {
+    foo
+  },
+  [] as never[]
+);
+foo(() => {
+    foo
+  },
+  bar as boolean
+);
+foo(() => {
+    foo
+  },
+  [] as object[][]
+);
+
+foo(() => {
+    foo
+  },
+  [] as Foo<number>[][]
+);
+foo(() => {
+    foo
+  },
+  bar as MyCustomType[],
+);
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+-----
+
+```ts
+// Tests around grouping layouts and simple arguments
+
+// Cases where the second argument is too complex to group.
+foo(
+	() => {
+		foo;
+	},
+	[] as string[][][],
+);
+foo(
+	() => {
+		foo;
+	},
+	{} as Foo<Bar, Baz>,
+);
+foo(
+	() => {
+		foo;
+	},
+	bar as {},
+);
+
+// Cases where the second argument is simple enough to group.
+foo(() => {
+	foo;
+}, [] as never[]);
+foo(() => {
+	foo;
+}, bar as boolean);
+foo(() => {
+	foo;
+}, [] as object[][]);
+
+foo(() => {
+	foo;
+}, [] as Foo<number>[][]);
+foo(() => {
+	foo;
+}, bar as MyCustomType[]);
+```
+
+


### PR DESCRIPTION
Fixes #1208 

## Summary

`is_simple_ts_type` was recently changed to support extracting types from nested arrays and generics, but in the case that an extracted array type was _not_ a generic _and_ was not a primitive type, it was falling back to the _original_ type that was passed in. That meant it would fail the simplicity check that happened afterward and cause functions to expand pre-emptively.

```
// This should collapse, because `MyCustomType` is simple, and only within one array type
foo(() => {
    foo
  },
  bar as MyCustomType[],
);
```

I also fixed a mistyped match against `TsObjectLiteralType`, which was meant to represent the `object` keyword, but that's actually `TsNonPrimitiveLiteralType`.

## Test Plan

Added a whole set of tests around simple arguments for TS expressions to cover both of these changes, as well as all of the nesting extraction from a previous PR.