### PR TITLE
refactor(lint/noUselessElse): keep else clause comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,36 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   }
   ```
 
+- Fix [#1191](https://github.com/biomejs/biome/issues/1191). [noUselessElse](https://biomejs.dev/linter/rules/no-useless-else) now preserve comments of the `else` clause. Contributed by @Conaclos
+
+  For example, the rule suggested the following fix:
+
+  ```diff
+    function f(x) {
+      if (x <0) {
+        return 0;
+      }
+  -   // Comment
+  -   else {
+        return x;
+  -   }
+    }
+  ```
+
+  Now the rule suggests a fix that preserves the comment of the `else` clause:
+
+  ```diff
+    function f(x) {
+      if (x <0) {
+        return 0;
+      }
+      // Comment
+  -   else {
+        return x;
+  -   }
+    }
+  ```
+
 - Fix [#728](https://github.com/biomejs/biome/issues/728). [useSingleVarDeclarator](https://biomejs.dev/linter/rules/use-single-var-declarator) no longer outputs invalid code. Contributed by @Conaclos
 
 - Fix [#1167](https://github.com/biomejs/biome/issues/1167). [useValidAriaProps] no longer reports `aria-atomic` as invalid. Contributed by @unvalley

--- a/crates/biome_js_analyze/tests/specs/style/noUselessElse/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/style/noUselessElse/invalid.js
@@ -92,3 +92,13 @@ function f (x) { // 0
     } // g
     // 2
 } // 3
+
+function f (x) {
+    if (x > 0 && x < 5) {
+        return 0;
+    }
+    // Some explanations
+    else {
+        return x;
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/style/noUselessElse/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noUselessElse/invalid.js.snap
@@ -99,13 +99,23 @@ function f (x) { // 0
     // 2
 } // 3
 
+function f (x) {
+    if (x > 0 && x < 5) {
+        return 0;
+    }
+    // Some explanations
+    else {
+        return x;
+    }
+}
+
 ```
 
 # Diagnostics
 ```
 invalid.js:4:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This else clause can be omitted.
+  ! This else clause can be omitted because previous branches break early.
   
     2 │     if (x < 0) {
     3 │         throw new RangeError();
@@ -117,29 +127,16 @@ invalid.js:4:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━━
     7 │ }
     8 │ 
   
-  i This if statement uses an early breaking statement.
-  
-    1 │ function f (x) {
-  > 2 │     if (x < 0) {
-      │     ^^^^^^^^^^^^
-  > 3 │         throw new RangeError();
-  > 4 │     } else {
-  > 5 │         return x;
-  > 6 │     }
-      │     ^
-    7 │ }
-    8 │ 
-  
   i Unsafe fix: Omit the else clause.
   
-     2  2 │       if (x < 0) {
-     3  3 │           throw new RangeError();
-     4    │ - ····}·else·{
-        4 │ + ····}
-     5  5 │           return x;
-     6    │ - ····}
-     7  6 │   }
-     8  7 │   
+      2   2 │       if (x < 0) {
+      3   3 │           throw new RangeError();
+      4     │ - ····}·else·{
+          4 │ + ····}
+      5   5 │           return x;
+      6     │ - ····}
+      7   6 │   }
+      8   7 │   
   
 
 ```
@@ -147,7 +144,7 @@ invalid.js:4:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━━
 ```
 invalid.js:13:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This else clause can be omitted.
+  ! This else clause can be omitted because previous branches break early.
   
     11 │     if (x < 0) {
     12 │         throw new RangeError();
@@ -159,30 +156,16 @@ invalid.js:13:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━�
     16 │     h();
     17 │ }
   
-  i This if statement uses an early breaking statement.
-  
-     9 │ function f (x) {
-    10 │     f();
-  > 11 │     if (x < 0) {
-       │     ^^^^^^^^^^^^
-  > 12 │         throw new RangeError();
-  > 13 │     } else {
-  > 14 │         g();
-  > 15 │     }
-       │     ^
-    16 │     h();
-    17 │ }
-  
   i Unsafe fix: Omit the else clause.
   
-    11 11 │       if (x < 0) {
-    12 12 │           throw new RangeError();
-    13    │ - ····}·else·{
-       13 │ + ····}
-    14 14 │           g();
-    15    │ - ····}
-    16 15 │       h();
-    17 16 │   }
+     11  11 │       if (x < 0) {
+     12  12 │           throw new RangeError();
+     13     │ - ····}·else·{
+         13 │ + ····}
+     14  14 │           g();
+     15     │ - ····}
+     16  15 │       h();
+     17  16 │   }
   
 
 ```
@@ -190,23 +173,12 @@ invalid.js:13:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:22:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This else clause can be omitted.
+  ! This else clause can be omitted because previous branches break early.
   
     20 │     if (x < 0) {
     21 │         throw new RangeError();
   > 22 │     } else return x;
        │       ^^^^^^^^^^^^^^
-    23 │ }
-    24 │ 
-  
-  i This if statement uses an early breaking statement.
-  
-    19 │ function f (x) {
-  > 20 │     if (x < 0) {
-       │     ^^^^^^^^^^^^
-  > 21 │         throw new RangeError();
-  > 22 │     } else return x;
-       │     ^^^^^^^^^^^^^^^^
     23 │ }
     24 │ 
   
@@ -220,7 +192,7 @@ invalid.js:22:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:28:5 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This else clause can be omitted.
+  ! This else clause can be omitted because previous branches break early.
   
     26 │     if (x < 0)
     27 │         throw new RangeError();
@@ -231,33 +203,17 @@ invalid.js:28:5 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━�
     30 │ }
     31 │ 
   
-  i This if statement uses an early breaking statement.
-  
-    25 │ function f (x) {
-  > 26 │     if (x < 0)
-       │     ^^^^^^^^^^
-  > 27 │         throw new RangeError();
-  > 28 │     else
-  > 29 │         return x;
-       │         ^^^^^^^^^
-    30 │ }
-    31 │ 
-  
   i Unsafe fix: Omit the else clause.
   
-    26 26 │       if (x < 0)
-    27 27 │           throw new RangeError();
-    28    │ - ····else
-    29 28 │           return x;
-    30 29 │   }
-  
+    28 │ ····else
+       │     ----
 
 ```
 
 ```
 invalid.js:35:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This else clause can be omitted.
+  ! This else clause can be omitted because previous branches break early.
   
     33 │     if (x < 0) {
     34 │         throw new RangeError();
@@ -265,19 +221,6 @@ invalid.js:35:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━�
        │       ^^^^^^^^^^^^^^^^^^^
   > 36 │         return 1;
   > 37 │     } else {
-  > 38 │         return x;
-  > 39 │     }
-       │     ^
-    40 │ }
-    41 │ 
-  
-  i This if statement uses an early breaking statement.
-  
-    32 │ function f (x) {
-  > 33 │     if (x < 0) {
-       │     ^^^^^^^^^^^^
-  > 34 │         throw new RangeError();
-        ...
   > 38 │         return x;
   > 39 │     }
        │     ^
@@ -294,26 +237,12 @@ invalid.js:35:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:37:7 lint/style/noUselessElse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This else clause can be omitted.
+  ! This else clause can be omitted because previous branches break early.
   
     35 │     } else if (x === 0) {
     36 │         return 1;
   > 37 │     } else {
        │       ^^^^^^
-  > 38 │         return x;
-  > 39 │     }
-       │     ^
-    40 │ }
-    41 │ 
-  
-  i This if statement uses an early breaking statement.
-  
-    33 │     if (x < 0) {
-    34 │         throw new RangeError();
-  > 35 │     } else if (x === 0) {
-       │            ^^^^^^^^^^^^^^
-  > 36 │         return 1;
-  > 37 │     } else {
   > 38 │         return x;
   > 39 │     }
        │     ^
@@ -326,7 +255,7 @@ invalid.js:37:7 lint/style/noUselessElse ━━━━━━━━━━━━━
 ```
 invalid.js:46:11 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This else clause can be omitted.
+  ! This else clause can be omitted because previous branches break early.
   
     44 │         if (x < 0) {
     45 │             break;
@@ -338,30 +267,16 @@ invalid.js:46:11 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━�
     49 │     }
     50 │     return x;
   
-  i This if statement uses an early breaking statement.
-  
-    42 │ function f (x) {
-    43 │     while (true) {
-  > 44 │         if (x < 0) {
-       │         ^^^^^^^^^^^^
-  > 45 │             break;
-  > 46 │         } else {
-  > 47 │             x -= g(x)
-  > 48 │         }
-       │         ^
-    49 │     }
-    50 │     return x;
-  
   i Unsafe fix: Omit the else clause.
   
-    44 44 │           if (x < 0) {
-    45 45 │               break;
-    46    │ - ········}·else·{
-       46 │ + ········}
-    47 47 │               x -= g(x)
-    48    │ - ········}
-    49 48 │       }
-    50 49 │       return x;
+     44  44 │           if (x < 0) {
+     45  45 │               break;
+     46     │ - ········}·else·{
+         46 │ + ········}
+     47  47 │               x -= g(x)
+     48     │ - ········}
+     49  48 │       }
+     50  49 │       return x;
   
 
 ```
@@ -369,7 +284,7 @@ invalid.js:46:11 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:57:11 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This else clause can be omitted.
+  ! This else clause can be omitted because previous branches break early.
   
     55 │         if (x < 0) {
     56 │             break;
@@ -381,30 +296,16 @@ invalid.js:57:11 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━�
     60 │     }
     61 │     return x;
   
-  i This if statement uses an early breaking statement.
-  
-    53 │ function f (x) {
-    54 │     while (true) {
-  > 55 │         if (x < 0) {
-       │         ^^^^^^^^^^^^
-  > 56 │             break;
-  > 57 │         } else {
-  > 58 │             x -= g(x)
-  > 59 │         }
-       │         ^
-    60 │     }
-    61 │     return x;
-  
   i Unsafe fix: Omit the else clause.
   
-    55 55 │           if (x < 0) {
-    56 56 │               break;
-    57    │ - ········}·else·{
-       57 │ + ········}
-    58 58 │               x -= g(x)
-    59    │ - ········}
-    60 59 │       }
-    61 60 │       return x;
+     55  55 │           if (x < 0) {
+     56  56 │               break;
+     57     │ - ········}·else·{
+         57 │ + ········}
+     58  58 │               x -= g(x)
+     59     │ - ········}
+     60  59 │       }
+     61  60 │       return x;
   
 
 ```
@@ -412,7 +313,7 @@ invalid.js:57:11 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:73:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This else clause can be omitted.
+  ! This else clause can be omitted because previous branches break early.
   
     71 │                 return x;
     72 │         }
@@ -424,29 +325,16 @@ invalid.js:73:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━�
     76 │ }
     77 │ 
   
-  i This if statement uses an early breaking statement.
-  
-    64 │ function f (x) {
-  > 65 │     if (x > 0 && x < 5) {
-       │     ^^^^^^^^^^^^^^^^^^^^^
-  > 66 │         switch (x) {
-        ...
-  > 74 │         return x;
-  > 75 │     }
-       │     ^
-    76 │ }
-    77 │ 
-  
   i Unsafe fix: Omit the else clause.
   
-    71 71 │                   return x;
-    72 72 │           }
-    73    │ - ····}·else·{
-       73 │ + ····}
-    74 74 │           return x;
-    75    │ - ····}
-    76 75 │   }
-    77 76 │   
+     71  71 │                   return x;
+     72  72 │           }
+     73     │ - ····}·else·{
+         73 │ + ····}
+     74  74 │           return x;
+     75     │ - ····}
+     76  75 │   }
+     77  76 │   
   
 
 ```
@@ -454,7 +342,7 @@ invalid.js:73:7 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:88:13 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This else clause can be omitted.
+  ! This else clause can be omitted because previous branches break early.
   
     86 │                 return x;
     87 │         }
@@ -468,32 +356,47 @@ invalid.js:88:13 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━�
     93 │     // 2
     94 │ } // 3
   
-  i This if statement uses an early breaking statement.
+  i Unsafe fix: Omit the else clause.
   
-    78 │ function f (x) { // 0
-    79 │     // 1
-  > 80 │     if (x > 0 && x < 5) {
-       │     ^^^^^^^^^^^^^^^^^^^^^
-  > 81 │         switch (x) {
-        ...
-  > 91 │         // f
-  > 92 │     } // g
-       │     ^
-    93 │     // 2
-    94 │ } // 3
+     86  86 │                   return x;
+     87  87 │           }
+     88     │ - ····}·/*a*/·else·/*b*/·{·//·c
+         88 │ + ····}/*b*/·
+     89  89 │           // d
+     90  90 │           return x; // e
+     91     │ - ········//·f
+     92     │ - ····}·//·g
+     93  91 │       // 2
+     94  92 │   } // 3
+  
+
+```
+
+```
+invalid.js:101:5 lint/style/noUselessElse  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This else clause can be omitted because previous branches break early.
+  
+     99 │     }
+    100 │     // Some explanations
+  > 101 │     else {
+        │     ^^^^^^
+  > 102 │         return x;
+  > 103 │     }
+        │     ^
+    104 │ }
+    105 │ 
   
   i Unsafe fix: Omit the else clause.
   
-    86 86 │                   return x;
-    87 87 │           }
-    88    │ - ····}·/*a*/·else·/*b*/·{·//·c
-       88 │ + ····}
-    89 89 │           // d
-    90 90 │           return x; // e
-    91    │ - ········//·f
-    92    │ - ····}·//·g
-    93 91 │       // 2
-    94 92 │   } // 3
+     99  99 │       }
+    100 100 │       // Some explanations
+    101     │ - ····else·{
+        101 │ + ····
+    102 102 │           return x;
+    103     │ - ····}
+    104 103 │   }
+    105 104 │   
   
 
 ```

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -96,6 +96,36 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   }
   ```
 
+- Fix [#1191](https://github.com/biomejs/biome/issues/1191). [noUselessElse](https://biomejs.dev/linter/rules/no-useless-else) now preserve comments of the `else` clause. Contributed by @Conaclos
+
+  For example, the rule suggested the following fix:
+
+  ```diff
+    function f(x) {
+      if (x <0) {
+        return 0;
+      }
+  -   // Comment
+  -   else {
+        return x;
+  -   }
+    }
+  ```
+
+  Now the rule suggests a fix that preserves the comment of the `else` clause:
+
+  ```diff
+    function f(x) {
+      if (x <0) {
+        return 0;
+      }
+      // Comment
+  -   else {
+        return x;
+  -   }
+    }
+  ```
+
 - Fix [#728](https://github.com/biomejs/biome/issues/728). [useSingleVarDeclarator](https://biomejs.dev/linter/rules/use-single-var-declarator) no longer outputs invalid code. Contributed by @Conaclos
 
 - Fix [#1167](https://github.com/biomejs/biome/issues/1167). [useValidAriaProps] no longer reports `aria-atomic` as invalid. Contributed by @unvalley

--- a/website/src/content/docs/linter/rules/no-useless-else.md
+++ b/website/src/content/docs/linter/rules/no-useless-else.md
@@ -37,25 +37,12 @@ while (x > 0) {
 
 <pre class="language-text"><code class="language-text">style/noUselessElse.js:4:7 <a href="https://biomejs.dev/linter/rules/no-useless-else">lint/style/noUselessElse</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This </span><span style="color: Tomato;"><strong>else</strong></span><span style="color: Tomato;"> clause can be omitted.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This </span><span style="color: Tomato;"><strong>else</strong></span><span style="color: Tomato;"> clause can be omitted because previous branches break early.</span>
   
     <strong>2 │ </strong>    if (f(x)) {
     <strong>3 │ </strong>        break;
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>    } else {
    <strong>   │ </strong>      <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>5 │ </strong>        x++
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>6 │ </strong>    }
-   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
-    <strong>7 │ </strong>}
-    <strong>8 │ </strong>
-  
-<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">This </span><span style="color: lightgreen;"><strong>if</strong></span><span style="color: lightgreen;"> statement uses an early breaking statement.</span>
-  
-    <strong>1 │ </strong>while (x &gt; 0) {
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>    if (f(x)) {
-   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>        break;
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>    } else {
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>5 │ </strong>        x++
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>6 │ </strong>    }
    <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
@@ -87,25 +74,12 @@ function f(x) {
 
 <pre class="language-text"><code class="language-text">style/noUselessElse.js:4:7 <a href="https://biomejs.dev/linter/rules/no-useless-else">lint/style/noUselessElse</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This </span><span style="color: Tomato;"><strong>else</strong></span><span style="color: Tomato;"> clause can be omitted.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This </span><span style="color: Tomato;"><strong>else</strong></span><span style="color: Tomato;"> clause can be omitted because previous branches break early.</span>
   
     <strong>2 │ </strong>    if (x &lt; 0) {
     <strong>3 │ </strong>        return 0;
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>    } else {
    <strong>   │ </strong>      <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>5 │ </strong>        return x;
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>6 │ </strong>    }
-   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
-    <strong>7 │ </strong>}
-    <strong>8 │ </strong>
-  
-<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">This </span><span style="color: lightgreen;"><strong>if</strong></span><span style="color: lightgreen;"> statement uses an early breaking statement.</span>
-  
-    <strong>1 │ </strong>function f(x) {
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>    if (x &lt; 0) {
-   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>        return 0;
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>    } else {
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>5 │ </strong>        return x;
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>6 │ </strong>    }
    <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
@@ -137,25 +111,12 @@ function f(x) {
 
 <pre class="language-text"><code class="language-text">style/noUselessElse.js:4:7 <a href="https://biomejs.dev/linter/rules/no-useless-else">lint/style/noUselessElse</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This </span><span style="color: Tomato;"><strong>else</strong></span><span style="color: Tomato;"> clause can be omitted.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This </span><span style="color: Tomato;"><strong>else</strong></span><span style="color: Tomato;"> clause can be omitted because previous branches break early.</span>
   
     <strong>2 │ </strong>    if (x &lt; 0) {
     <strong>3 │ </strong>        throw new RangeError();
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>    } else {
    <strong>   │ </strong>      <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>5 │ </strong>        return x;
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>6 │ </strong>    }
-   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
-    <strong>7 │ </strong>}
-    <strong>8 │ </strong>
-  
-<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">This </span><span style="color: lightgreen;"><strong>if</strong></span><span style="color: lightgreen;"> statement uses an early breaking statement.</span>
-  
-    <strong>1 │ </strong>function f(x) {
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>    if (x &lt; 0) {
-   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>        throw new RangeError();
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>    } else {
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>5 │ </strong>        return x;
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>6 │ </strong>    }
    <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>


### PR DESCRIPTION
## Summary

Fix #1191.

I removed the note from the diagnostic because this was misleading. The rule now checks that every preceding branch break early, not only the previous branch.

## Test Plan

New test added with a comment on the `else` clause.
