### PR TITLE
feat(parse/noTypeOnlyImportAttributes): report type-only imports/exports with attributes

### DIFF
--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -105,6 +105,7 @@ define_categories! {
     "lint/nursery/noEmptyBlockStatements": "https://biomejs.dev/linter/rules/no-empty-block-statements",
     "lint/nursery/noImplicitAnyLet": "https://biomejs.dev/lint/rules/no-implicit-any-let",
     "lint/nursery/noMisleadingCharacterClass": "https://biomejs.dev/linter/rules/no-misleading-character-class",
+    "lint/nursery/noTypeOnlyImportAttributes": "https://biomejs.dev/linter/rules/no-type-only-import-attributes",
     "lint/nursery/noUnusedImports": "https://biomejs.dev/linter/rules/no-unused-imports",
     "lint/nursery/noUnusedPrivateClassMembers": "https://biomejs.dev/linter/rules/no-unused-private-class-members",
     "lint/nursery/noUselessLoneBlockStatements": "https://biomejs.dev/linter/rules/no-useless-lone-block-statements",

--- a/crates/biome_js_analyze/src/syntax.rs
+++ b/crates/biome_js_analyze/src/syntax.rs
@@ -1,4 +1,5 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 pub(crate) mod correctness;
-::biome_analyze::declare_category! { pub (crate) Syntax { kind : Syntax , groups : [self :: correctness :: Correctness ,] } }
+pub(crate) mod nursery;
+::biome_analyze::declare_category! { pub (crate) Syntax { kind : Syntax , groups : [self :: correctness :: Correctness , self :: nursery :: Nursery ,] } }

--- a/crates/biome_js_analyze/src/syntax/nursery.rs
+++ b/crates/biome_js_analyze/src/syntax/nursery.rs
@@ -1,0 +1,14 @@
+//! Generated file, do not edit by hand, see `xtask/codegen`
+
+use biome_analyze::declare_group;
+
+pub(crate) mod no_type_only_import_attributes;
+
+declare_group! {
+    pub (crate) Nursery {
+        name : "nursery" ,
+        rules : [
+            self :: no_type_only_import_attributes :: NoTypeOnlyImportAttributes ,
+        ]
+     }
+}

--- a/crates/biome_js_analyze/src/syntax/nursery/no_type_only_import_attributes.rs
+++ b/crates/biome_js_analyze/src/syntax/nursery/no_type_only_import_attributes.rs
@@ -1,0 +1,130 @@
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_console::markup;
+use biome_js_syntax::{
+    AnyJsExportClause, AnyJsImportClause, AnyJsModuleItem, JsNamedImportSpecifiers, JsSyntaxToken,
+};
+use biome_rowan::{AstNode, AstSeparatedList, TextRange};
+
+declare_rule! {
+    /// Disallow type-only imports and exports with import attributes.
+    ///
+    /// ## Examples
+    ///
+    /// ```js
+    /// import type { A } from "./a.json" with { type: "json" };
+    /// ```
+    pub(crate) NoTypeOnlyImportAttributes {
+        version: "1.5.0",
+        name: "noTypeOnlyImportAttributes",
+    }
+}
+
+impl Rule for NoTypeOnlyImportAttributes {
+    type Query = Ast<AnyJsModuleItem>;
+    type State = RuleState;
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let module_item = ctx.query();
+        match module_item {
+            AnyJsModuleItem::AnyJsStatement(_) => None,
+            AnyJsModuleItem::JsExport(export) => match export.export_clause().ok()? {
+                AnyJsExportClause::AnyJsDeclarationClause(_)
+                | AnyJsExportClause::JsExportDefaultDeclarationClause(_)
+                | AnyJsExportClause::JsExportDefaultExpressionClause(_)
+                | AnyJsExportClause::JsExportNamedClause(_)
+                | AnyJsExportClause::TsExportAsNamespaceClause(_)
+                | AnyJsExportClause::TsExportAssignmentClause(_)
+                | AnyJsExportClause::TsExportDeclareClause(_) => None,
+                AnyJsExportClause::JsExportFromClause(clause) => Some(RuleState {
+                    assertion_range: clause.assertion()?.range(),
+                    type_token_range: clause.type_token()?.text_trimmed_range(),
+                }),
+                AnyJsExportClause::JsExportNamedFromClause(clause) => {
+                    let assertion_range = clause.assertion()?.range();
+                    let type_token = clause.type_token().or_else(|| {
+                        clause
+                            .specifiers()
+                            .iter()
+                            .filter_map(|specifier| specifier.ok())
+                            .find_map(|specifier| specifier.type_token())
+                    })?;
+                    Some(RuleState {
+                        assertion_range,
+                        type_token_range: type_token.text_trimmed_range(),
+                    })
+                }
+            },
+            AnyJsModuleItem::JsImport(import) => match import.import_clause().ok()? {
+                AnyJsImportClause::JsImportBareClause(_) => None,
+                AnyJsImportClause::JsImportCombinedClause(clause) => {
+                    let assertion_range = clause.assertion()?.range();
+                    let type_token = find_first_type_token(
+                        clause.specifier().ok()?.as_js_named_import_specifiers()?,
+                    )?;
+                    Some(RuleState {
+                        assertion_range,
+                        type_token_range: type_token.text_trimmed_range(),
+                    })
+                }
+                AnyJsImportClause::JsImportDefaultClause(clause) => Some(RuleState {
+                    assertion_range: clause.assertion()?.range(),
+                    type_token_range: clause.type_token()?.text_trimmed_range(),
+                }),
+                AnyJsImportClause::JsImportNamedClause(clause) => {
+                    let assertion_range = clause.assertion()?.range();
+                    let type_token = clause
+                        .type_token()
+                        .or_else(|| find_first_type_token(&clause.named_specifiers().ok()?))?;
+                    Some(RuleState {
+                        assertion_range,
+                        type_token_range: type_token.text_trimmed_range(),
+                    })
+                }
+                AnyJsImportClause::JsImportNamespaceClause(clause) => Some(RuleState {
+                    assertion_range: clause.assertion()?.range(),
+                    type_token_range: clause.type_token()?.text_trimmed_range(),
+                }),
+            },
+        }
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        let node = ctx.query();
+        let import_or_export = if matches!(node, AnyJsModuleItem::JsImport(_)) {
+            "import"
+        } else {
+            "export"
+        };
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                state.assertion_range,
+                markup! {
+                    "Import attributes cannot be used with a type-only "{import_or_export}"."
+                },
+            )
+            .detail(
+                state.type_token_range,
+                markup! { "The type-only "{import_or_export}" is defined here." },
+            ),
+        )
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RuleState {
+    /// Range of the first found type token
+    type_token_range: TextRange,
+    /// Range of import attributes
+    assertion_range: TextRange,
+}
+
+fn find_first_type_token(named_specifiers: &JsNamedImportSpecifiers) -> Option<JsSyntaxToken> {
+    named_specifiers
+        .specifiers()
+        .iter()
+        .filter_map(|specifier| specifier.ok())
+        .find_map(|specifier| specifier.type_token())
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noTypeOnlyImportAttributes/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noTypeOnlyImportAttributes/invalid.ts
@@ -1,0 +1,9 @@
+import type A from "" with { type: "json" };
+import type * as B from "" with { type: "json" };
+import type { C } from "" with { type: "json" };
+import { type D } from "" with { type: "json" };
+import { E, type F } from "" with { type: "json" };
+
+export type { A } from "" with { type: "json" };
+export type * as B from "" with { type: "json" };
+export { E, type F } from "" with { type: "json" };

--- a/crates/biome_js_analyze/tests/specs/nursery/noTypeOnlyImportAttributes/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noTypeOnlyImportAttributes/invalid.ts.snap
@@ -1,0 +1,197 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+---
+# Input
+```js
+import type A from "" with { type: "json" };
+import type * as B from "" with { type: "json" };
+import type { C } from "" with { type: "json" };
+import { type D } from "" with { type: "json" };
+import { E, type F } from "" with { type: "json" };
+
+export type { A } from "" with { type: "json" };
+export type * as B from "" with { type: "json" };
+export { E, type F } from "" with { type: "json" };
+```
+
+# Diagnostics
+```
+invalid.ts:1:23 lint/nursery/noTypeOnlyImportAttributes ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Import attributes cannot be used with a type-only import.
+  
+  > 1 │ import type A from "" with { type: "json" };
+      │                       ^^^^^^^^^^^^^^^^^^^^^
+    2 │ import type * as B from "" with { type: "json" };
+    3 │ import type { C } from "" with { type: "json" };
+  
+  i The type-only import is defined here.
+  
+  > 1 │ import type A from "" with { type: "json" };
+      │        ^^^^
+    2 │ import type * as B from "" with { type: "json" };
+    3 │ import type { C } from "" with { type: "json" };
+  
+
+```
+
+```
+invalid.ts:2:28 lint/nursery/noTypeOnlyImportAttributes ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Import attributes cannot be used with a type-only import.
+  
+    1 │ import type A from "" with { type: "json" };
+  > 2 │ import type * as B from "" with { type: "json" };
+      │                            ^^^^^^^^^^^^^^^^^^^^^
+    3 │ import type { C } from "" with { type: "json" };
+    4 │ import { type D } from "" with { type: "json" };
+  
+  i The type-only import is defined here.
+  
+    1 │ import type A from "" with { type: "json" };
+  > 2 │ import type * as B from "" with { type: "json" };
+      │        ^^^^
+    3 │ import type { C } from "" with { type: "json" };
+    4 │ import { type D } from "" with { type: "json" };
+  
+
+```
+
+```
+invalid.ts:3:27 lint/nursery/noTypeOnlyImportAttributes ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Import attributes cannot be used with a type-only import.
+  
+    1 │ import type A from "" with { type: "json" };
+    2 │ import type * as B from "" with { type: "json" };
+  > 3 │ import type { C } from "" with { type: "json" };
+      │                           ^^^^^^^^^^^^^^^^^^^^^
+    4 │ import { type D } from "" with { type: "json" };
+    5 │ import { E, type F } from "" with { type: "json" };
+  
+  i The type-only import is defined here.
+  
+    1 │ import type A from "" with { type: "json" };
+    2 │ import type * as B from "" with { type: "json" };
+  > 3 │ import type { C } from "" with { type: "json" };
+      │        ^^^^
+    4 │ import { type D } from "" with { type: "json" };
+    5 │ import { E, type F } from "" with { type: "json" };
+  
+
+```
+
+```
+invalid.ts:4:27 lint/nursery/noTypeOnlyImportAttributes ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Import attributes cannot be used with a type-only import.
+  
+    2 │ import type * as B from "" with { type: "json" };
+    3 │ import type { C } from "" with { type: "json" };
+  > 4 │ import { type D } from "" with { type: "json" };
+      │                           ^^^^^^^^^^^^^^^^^^^^^
+    5 │ import { E, type F } from "" with { type: "json" };
+    6 │ 
+  
+  i The type-only import is defined here.
+  
+    2 │ import type * as B from "" with { type: "json" };
+    3 │ import type { C } from "" with { type: "json" };
+  > 4 │ import { type D } from "" with { type: "json" };
+      │          ^^^^
+    5 │ import { E, type F } from "" with { type: "json" };
+    6 │ 
+  
+
+```
+
+```
+invalid.ts:5:30 lint/nursery/noTypeOnlyImportAttributes ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Import attributes cannot be used with a type-only import.
+  
+    3 │ import type { C } from "" with { type: "json" };
+    4 │ import { type D } from "" with { type: "json" };
+  > 5 │ import { E, type F } from "" with { type: "json" };
+      │                              ^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+    7 │ export type { A } from "" with { type: "json" };
+  
+  i The type-only import is defined here.
+  
+    3 │ import type { C } from "" with { type: "json" };
+    4 │ import { type D } from "" with { type: "json" };
+  > 5 │ import { E, type F } from "" with { type: "json" };
+      │             ^^^^
+    6 │ 
+    7 │ export type { A } from "" with { type: "json" };
+  
+
+```
+
+```
+invalid.ts:7:27 lint/nursery/noTypeOnlyImportAttributes ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Import attributes cannot be used with a type-only export.
+  
+    5 │ import { E, type F } from "" with { type: "json" };
+    6 │ 
+  > 7 │ export type { A } from "" with { type: "json" };
+      │                           ^^^^^^^^^^^^^^^^^^^^^
+    8 │ export type * as B from "" with { type: "json" };
+    9 │ export { E, type F } from "" with { type: "json" };
+  
+  i The type-only export is defined here.
+  
+    5 │ import { E, type F } from "" with { type: "json" };
+    6 │ 
+  > 7 │ export type { A } from "" with { type: "json" };
+      │        ^^^^
+    8 │ export type * as B from "" with { type: "json" };
+    9 │ export { E, type F } from "" with { type: "json" };
+  
+
+```
+
+```
+invalid.ts:8:28 lint/nursery/noTypeOnlyImportAttributes ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Import attributes cannot be used with a type-only export.
+  
+    7 │ export type { A } from "" with { type: "json" };
+  > 8 │ export type * as B from "" with { type: "json" };
+      │                            ^^^^^^^^^^^^^^^^^^^^^
+    9 │ export { E, type F } from "" with { type: "json" };
+  
+  i The type-only export is defined here.
+  
+    7 │ export type { A } from "" with { type: "json" };
+  > 8 │ export type * as B from "" with { type: "json" };
+      │        ^^^^
+    9 │ export { E, type F } from "" with { type: "json" };
+  
+
+```
+
+```
+invalid.ts:9:30 lint/nursery/noTypeOnlyImportAttributes ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Import attributes cannot be used with a type-only export.
+  
+    7 │ export type { A } from "" with { type: "json" };
+    8 │ export type * as B from "" with { type: "json" };
+  > 9 │ export { E, type F } from "" with { type: "json" };
+      │                              ^^^^^^^^^^^^^^^^^^^^^
+  
+  i The type-only export is defined here.
+  
+    7 │ export type { A } from "" with { type: "json" };
+    8 │ export type * as B from "" with { type: "json" };
+  > 9 │ export { E, type F } from "" with { type: "json" };
+      │             ^^^^
+  
+
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/noTypeOnlyImportAttributes/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noTypeOnlyImportAttributes/valid.js
@@ -1,0 +1,9 @@
+import A from "" with { type: "json" };
+import * as B from "" with { type: "json" };
+import { C } from "" with { type: "json" };
+import D, * as E from "" with { type: "json" };
+import F, { G } from "" with { type: "json" };
+
+export { A } from "" with { type: "json" };
+export * as B from "" with { type: "json" };
+export { E, F } from "" with { type: "json" };

--- a/crates/biome_js_analyze/tests/specs/nursery/noTypeOnlyImportAttributes/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noTypeOnlyImportAttributes/valid.js.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```js
+import A from "" with { type: "json" };
+import * as B from "" with { type: "json" };
+import { C } from "" with { type: "json" };
+import D, * as E from "" with { type: "json" };
+import F, { G } from "" with { type: "json" };
+
+export { A } from "" with { type: "json" };
+export * as B from "" with { type: "json" };
+export { E, F } from "" with { type: "json" };
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/noTypeOnlyImportAttributes/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noTypeOnlyImportAttributes/valid.ts
@@ -1,0 +1,8 @@
+import type A from "";
+import type * as B from "";
+import type { C } from "";
+import { type D } from "";
+
+export type { A } from "";
+export type * as B from "";
+export { E, type F } from "";

--- a/crates/biome_js_analyze/tests/specs/nursery/noTypeOnlyImportAttributes/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noTypeOnlyImportAttributes/valid.ts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```js
+import type A from "";
+import type * as B from "";
+import type { C } from "";
+import { type D } from "";
+
+export type { A } from "";
+export type * as B from "";
+export { E, type F } from "";
+```
+
+

--- a/crates/biome_js_syntax/src/import_ext.rs
+++ b/crates/biome_js_syntax/src/import_ext.rs
@@ -1,6 +1,6 @@
 use crate::{
     inner_string_text, AnyJsBinding, AnyJsImportClause, AnyJsNamedImportSpecifier, JsImport,
-    JsModuleSource, JsSyntaxToken,
+    JsImportAssertion, JsModuleSource, JsSyntaxToken,
 };
 use biome_rowan::{AstNode, SyntaxResult, TokenText};
 
@@ -63,6 +63,29 @@ impl AnyJsImportClause {
             Self::JsImportNamedClause(clause) => clause.source(),
             Self::JsImportNamespaceClause(clause) => clause.source(),
             Self::JsImportCombinedClause(clause) => clause.source(),
+        }
+    }
+
+    /// Assertion of this import clause.
+    ///
+    /// ```
+    /// use biome_js_factory::make;
+    /// use biome_js_syntax::T;
+    ///
+    /// let source = make::js_module_source(make::js_string_literal("react"));
+    /// let binding = make::js_identifier_binding(make::ident("React"));
+    /// let specifier = make::js_default_import_specifier(binding.into());
+    /// let clause = make::js_import_default_clause(specifier, make::token(T![from]), source).build();
+    ///
+    /// assert_eq!(clause.source().unwrap().inner_string_text().unwrap().text(), "react");
+    /// ```
+    pub fn assertion(&self) -> Option<JsImportAssertion> {
+        match self {
+            Self::JsImportBareClause(clause) => clause.assertion(),
+            Self::JsImportDefaultClause(clause) => clause.assertion(),
+            Self::JsImportNamedClause(clause) => clause.assertion(),
+            Self::JsImportNamespaceClause(clause) => clause.assertion(),
+            Self::JsImportCombinedClause(clause) => clause.assertion(),
         }
     }
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1525,6 +1525,7 @@ export type Category =
 	| "lint/nursery/noEmptyBlockStatements"
 	| "lint/nursery/noImplicitAnyLet"
 	| "lint/nursery/noMisleadingCharacterClass"
+	| "lint/nursery/noTypeOnlyImportAttributes"
 	| "lint/nursery/noUnusedImports"
 	| "lint/nursery/noUnusedPrivateClassMembers"
 	| "lint/nursery/noUselessLoneBlockStatements"


### PR DESCRIPTION
## Summary

Implement a syntax rule that ensures that type-only imports and exports are not combined with import attributes.

## Possible alternative

Instead of implementing a syntax rule, we could check this directly in the parser.

## Test Plan

Tests added.
