### PR TITLE
chore: add formatter changelog entries since 1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,25 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Formatter
 
+#### Bug fixes
+
 - Fix [#1169](https://github.com/biomejs/biome/issues/1169). Account for escaped strings when computing layout for assignments. Contributed by @kalleep
+- Fix [#851](https://github.com/biomejs/biome/issues/851). Allow regular function expressions to group and break as call arguments, just like arrow function expressions. [#1003](https://github.com/biomejs/biome/issues/1003) Contributed by @faultyserver
+- Fix [#914](https://github.com/biomejs/biome/issues/914). Only parenthesize type-casted function expressions as default exports. [#1023](https://github.com/biomejs/biome/issues/1023) Contributed by @faultyserver
+- Fix [#1112](https://github.com/biomejs/biome/issues/1112). Break block bodies in case clauses onto their own lines and preserve trailing fallthrough comments. [#1035](https://github.com/biomejs/biome/pull/1035) Contributed by @faultyserver
+- Fix `RemoveSoftLinesBuffer` behavior to also removed conditional expanded content, ensuring no accidental, unused line breaks are included [#1032](https://github.com/biomejs/biome/pull/1032) Contributed by @faultyserver
+- Fix [#1024](https://github.com/biomejs/biome/issues/1024). Allow JSX expressions to nestle in arrow chains [#1033](https://github.com/biomejs/biome/pull/1033) Contributed by @faultyserver
+- Fix incorrect breaking on the left side of assignments by always using fluid assignment. [#1021](https://github.com/biomejs/biome/pull/1021) Contributed by @faultyserver
+- Fix breaking strategy for nested object patterns in function parameters [#1054](https://github.com/biomejs/biome/pull/1054) Contributed by @faultyserver
+- Fix over-indention of arrow chain expressions by simplifying the way each chain is grouped [#1036](https://github.com/biomejs/biome/pull/1036), [#1136](https://github.com/biomejs/biome/pull/1136), and [#1162](https://github.com/biomejs/biome/pull/1162) Contributed by @faultyserver. 
+- Fix "simple" checks for calls and member expressions to correctly handle array accesses, complex arguments to single-argument function calls, and multiple-argument function calls. [#1057](https://github.com/biomejs/biome/pull/1057) Contributed by @faultyserver
+- Fix text wrapping and empty line handling for JSX Text elements to match Prettier's behavior. [#1075](https://github.com/biomejs/biome/pull/1075) Contributed by @faultyserver
+- Fix leading comments in concisely-printed arrays to prevent unwanted line breaks. [#1135](https://github.com/biomejs/biome/pull/1135) Contributed by @faultyserver
+- Fix `best_fitting` and interned elements preventing expansion propagation from sibling elements. [#1141](https://github.com/biomejs/biome/pull/1141) Contributed by @faultyserver
+- Fix heuristic for grouping function parameters when type parameters with constraints are present. [#1153](https://github.com/biomejs/biome/pull/1153).  Contributed by @faultyserver.
+- Fix binary-ish and type annotation handling for grouping call arguments in function expressions and call signatures. [#1152](https://github.com/biomejs/biome/pull/1152) and [#1160](https://github.com/biomejs/biome/pull/1160) Contributed by @faultyserver
+- Fix handling of nestled JSDoc comments to preserve behavior for overloads. [#1195](https://github.com/biomejs/biome/pull/1195) Contributed by @faultyserver 
+- Fix [#1208](https://github.com/biomejs/biome/issues/1208). Fix extraction of inner types when checking for simple type annotations in call arguments. [#1195](https://github.com/biomejs/biome/pull/1195) Contributed by @faultyserver
 
 ### JavaScript APIs
 


### PR DESCRIPTION
## Summary

Adding all the changelog entries for the formatter fixes made since 1.4.0...didn't realize it was quite so many nor that it had been so long lol

## Test Plan