### PR TITLE
fix(lint/noEmptyInterface): ignore interfaces extending types in global declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Bug fixes
 
-- Fix [#959](https://github.com/biomejs/biome/issues/959). [noEmptyInterface](https://biomejs.dev/linter/rules/no-empty-interface) no longer reports interface that extends a type and is in an external module. COntributed by @Conaclos
+- Fix [#959](https://github.com/biomejs/biome/issues/959). [noEmptyInterface](https://biomejs.dev/linter/rules/no-empty-interface) no longer reports interface that extends a type and is in an external module or a global declaration. Contributed by @Conaclos
 
   Empty interface that extends a type are sometimes used to extend an existing interface.
   This is generally used to extend an interface of an external module.

--- a/crates/biome_js_analyze/src/control_flow/visitor.rs
+++ b/crates/biome_js_analyze/src/control_flow/visitor.rs
@@ -4,8 +4,7 @@ use biome_analyze::{merge_node_visitors, Visitor, VisitorContext};
 use biome_js_syntax::{
     AnyJsFunction, JsConstructorClassMember, JsGetterClassMember, JsGetterObjectMember, JsLanguage,
     JsMethodClassMember, JsMethodObjectMember, JsModule, JsScript, JsSetterClassMember,
-    JsSetterObjectMember, JsStaticInitializationBlockClassMember, TsExternalModuleDeclaration,
-    TsModuleDeclaration,
+    JsSetterObjectMember, JsStaticInitializationBlockClassMember, TsModuleDeclaration,
 };
 use biome_rowan::{declare_node_union, AstNode, SyntaxError, SyntaxResult};
 
@@ -171,7 +170,6 @@ declare_node_union! {
         | JsSetterClassMember
         | JsStaticInitializationBlockClassMember
         | TsModuleDeclaration
-        | TsExternalModuleDeclaration
 }
 
 impl biome_analyze::NodeVisitor<ControlFlowVisitor> for FunctionVisitor {

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.d.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.d.ts
@@ -1,0 +1,3 @@
+declare global {
+    export interface App extends Services {}
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.d.ts.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.d.ts
+---
+# Input
+```js
+declare global {
+    export interface App extends Services {}
+}
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.ts
@@ -9,4 +9,8 @@ interface Baz extends Foo, Bar {}
 // See https://github.com/biomejs/biome/issues/959
 declare module "external" {
   export interface App extends Services {}
+
+  global {
+    export interface App extends Services {}
+  }
 }

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.ts.snap
@@ -15,8 +15,11 @@ interface Baz extends Foo, Bar {}
 // See https://github.com/biomejs/biome/issues/959
 declare module "external" {
   export interface App extends Services {}
-}
 
+  global {
+    export interface App extends Services {}
+  }
+}
 ```
 
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -80,7 +80,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Bug fixes
 
-- Fix [#959](https://github.com/biomejs/biome/issues/959). [noEmptyInterface](https://biomejs.dev/linter/rules/no-empty-interface) no longer reports interface that extends a type and is in an external module. COntributed by @Conaclos
+- Fix [#959](https://github.com/biomejs/biome/issues/959). [noEmptyInterface](https://biomejs.dev/linter/rules/no-empty-interface) no longer reports interface that extends a type and is in an external module or a global declaration. Contributed by @Conaclos
 
   Empty interface that extends a type are sometimes used to extend an existing interface.
   This is generally used to extend an interface of an external module.


### PR DESCRIPTION
## Summary

Fix the issue [reported in a comment](https://github.com/biomejs/biome/issues/1157#issuecomment-1859292783). This is a follow-up of #1059.

## Test Plan

New tests added.