### PR TITLE
fix(cli): fix traversal of relative paths as inputs

### DIFF
--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -264,7 +264,7 @@ fn traverse_inputs(
                 .map(PathBuf::from)
                 .map(|path| {
                     if let Some(working_directory) = fs.working_directory() {
-                        if path.starts_with(".") || path.starts_with("./") {
+                        if path.to_str() == Some(".") || path.to_str() == Some("./") {
                             working_directory.join(path)
                         } else {
                             path

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -265,9 +265,9 @@ fn traverse_inputs(
                 .map(|path| {
                     if let Some(working_directory) = fs.working_directory() {
                         if path.starts_with(".") || path.starts_with("./") {
-                            working_directory
-                        } else {
                             working_directory.join(path)
+                        } else {
+                            path
                         }
                     } else {
                         path


### PR DESCRIPTION
## Summary

I was getting `stack overflow` errors when trying to run a command like

```
cargo run --bin biome format ./crates/biome_js_formatter/tests/specs/js/module/comments.js
```

from a clean main branch. After a bit of bisecting and debugging with lots of print statements, I found that I was using a relative path (starting with `.`), and the path resolution done to set up the traversal was inadvertently turning that full path into _just_ the working directory. In other words, given a path like `./path/to/file`, it was trying to resolve that to an absolute path like `/home/user/path/to/file`, but would actually just return `/home/user`...

That in itself wasn't actually the problem, but isn't correct, either. So, this PR fixes that issue and properly returns the complete absolute path with the working directory and the path joined together, or just the path if it's not relative.

With that in place, the above command now works and doesn't error out, but the actual cause of the issue was (i think) from circular symlinks or something else with symlink resolution. Now, if I run `biome format .` at the root of this repository, i get the same stack overflow error.

I'd like to merge this fix in for the short term to sidestep the issue for the majority of cases, but the actual solution will need more investigation and a proper fix separately.

## Test Plan

I was able to run the above command without errors.
