### PR TITLE
feat(lint/noInvalidUseBeforeDeclaration): add rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,15 @@ is enabled to process only the files that were changed. Contributed by @simonxab
 
 - Add [useNodeImportProtocol](https://biomejs.dev/linter/rules/use-node-import-protocol) that forces the use of the `node:` protocol when importing Node.js modules. Contributed by @2-NOW
 
+- Add [noInvalidUseBeforeDeclaration](https://biomejs.dev/linter/rules/no-invalid-use-before-declaration) that reports variables and function parameters used before their declaration. Contributed by @Conaclos
+
+  ```js
+  function f() {
+    console.log(c); // Use of `c` before its declaration.
+    const c = 0;
+  }
+  ```
+
 #### Enhancements
 
 #### Bug fixes

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -104,6 +104,7 @@ define_categories! {
     "lint/nursery/noDuplicateJsonKeys": "https://biomejs.dev/linter/rules/no-duplicate-json-keys",
     "lint/nursery/noEmptyBlockStatements": "https://biomejs.dev/linter/rules/no-empty-block-statements",
     "lint/nursery/noImplicitAnyLet": "https://biomejs.dev/lint/rules/no-implicit-any-let",
+    "lint/nursery/noInvalidUseBeforeDeclaration": "https://biomejs.dev/linter/rules/no-invalid-use-before-declaration",
     "lint/nursery/noMisleadingCharacterClass": "https://biomejs.dev/linter/rules/no-misleading-character-class",
     "lint/nursery/noNodejsModules": "https://biomejs.dev/linter/rules/no-nodejs-modules",
     "lint/nursery/noTypeOnlyImportAttributes": "https://biomejs.dev/linter/rules/no-type-only-import-attributes",

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery.rs
@@ -2,6 +2,7 @@
 
 use biome_analyze::declare_group;
 
+pub(crate) mod no_invalid_use_before_declaration;
 pub(crate) mod no_misleading_character_class;
 pub(crate) mod no_nodejs_modules;
 pub(crate) mod no_unused_imports;
@@ -12,6 +13,7 @@ declare_group! {
     pub (crate) Nursery {
         name : "nursery" ,
         rules : [
+            self :: no_invalid_use_before_declaration :: NoInvalidUseBeforeDeclaration ,
             self :: no_misleading_character_class :: NoMisleadingCharacterClass ,
             self :: no_nodejs_modules :: NoNodejsModules ,
             self :: no_unused_imports :: NoUnusedImports ,

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_invalid_use_before_declaration.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_invalid_use_before_declaration.rs
@@ -1,0 +1,214 @@
+use crate::{control_flow::AnyJsControlFlowRoot, semantic_services::SemanticServices};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_console::markup;
+use biome_js_syntax::{
+    binding_ext::{AnyJsBindingDeclaration, AnyJsIdentifierBinding},
+    AnyJsExportNamedSpecifier,
+};
+use biome_rowan::{AstNode, SyntaxNodeOptionExt, TextRange};
+
+declare_rule! {
+    /// Disallow the use of variables and function parameters before their declaration
+    ///
+    /// JavaScript doesn't allow the use of block-scoped variables (`let`, `const`) and function parameters before their declaration.
+    /// A `ReferenceError` will be thrown with any attempt to access the variable or the parameter before its declaration.
+    ///
+    /// The rule also reports the use of variables declared with `var` before their declarations.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// function f() {
+    ///     console.log(x);
+    ///     const x;
+    /// }
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// function f() {
+    ///     console.log(x);
+    ///     var x = 0;
+    /// }
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// function f(a = b, b = 0) {}
+    /// ```
+    ///
+    /// ## Valid
+    ///
+    /// ```js
+    /// f();
+    /// function f() {}
+    ///
+    /// new C();
+    /// class C {}
+    /// ```
+    ///
+    /// ```js
+    /// // An export can reference a variable before its declaration.
+    /// export { CONSTANT };
+    /// const CONSTANT = 0;
+    /// ```
+    ///
+    /// ```js
+    /// function f() { return CONSTANT; }
+    /// const CONSTANT = 0;
+    /// ```
+    pub(crate) NoInvalidUseBeforeDeclaration {
+        version: "next",
+        name: "noInvalidUseBeforeDeclaration",
+        recommended: false,
+    }
+}
+
+impl Rule for NoInvalidUseBeforeDeclaration {
+    type Query = SemanticServices;
+    type State = InvalidUseBeforeDeclaration;
+    type Signals = Vec<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let model = ctx.model();
+        let mut result = vec![];
+        for binding in model.all_bindings() {
+            let AnyJsIdentifierBinding::JsIdentifierBinding(id) = binding.tree() else {
+                continue;
+            };
+            let Some(declaration) = id.declaration() else {
+                continue;
+            };
+            let Ok(declaration_kind) = DeclarationKind::try_from(&declaration) else {
+                continue;
+            };
+            let declaration_control_flow_root = if matches!(
+                declaration,
+                AnyJsBindingDeclaration::JsVariableDeclarator(_)
+            ) {
+                declaration
+                    .syntax()
+                    .ancestors()
+                    .skip(1)
+                    .find(|ancestor| AnyJsControlFlowRoot::can_cast(ancestor.kind()))
+            } else {
+                None
+            };
+            let declaration_end = declaration.range().end();
+            for reference in binding.all_references() {
+                let reference_range = reference.range();
+                if reference_range.start() < declaration_end
+                    // References that are exports, such as `export { a }` are always valid,
+                    // even when they appear before the declaration.
+                    // For example:
+                    //
+                    // ```js
+                    // export { X };
+                    // const X = 0;
+                    // ```
+                    && reference
+                        .syntax()
+                        .parent()
+                        .kind()
+                        .filter(|parent_kind| AnyJsExportNamedSpecifier::can_cast(*parent_kind))
+                        .is_none()
+                    // Don't report variables used in another control flow root (function, classes, ...)
+                    // For example:
+                    //
+                    // ```js
+                    // function f() { X; }
+                    // const X = 0;
+                    // ```
+                    && (declaration_control_flow_root.is_none() ||
+                    declaration_control_flow_root == reference.syntax().ancestors().skip(1).find(|ancestor| AnyJsControlFlowRoot::can_cast(ancestor.kind()))
+                    )
+                {
+                    result.push(InvalidUseBeforeDeclaration {
+                        declaration_kind,
+                        reference_range: *reference_range,
+                        binding_range: id.range(),
+                    });
+                }
+            }
+        }
+        result
+    }
+
+    fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        let InvalidUseBeforeDeclaration {
+            declaration_kind,
+            reference_range,
+            binding_range: declaration_range,
+        } = state;
+        let declaration_kind_text = match declaration_kind {
+            DeclarationKind::Parameter => "parameter",
+            DeclarationKind::Variable => "variable",
+        };
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                reference_range,
+                markup! { "This "{declaration_kind_text}" is used before its declaration." },
+            )
+            .detail(
+                declaration_range,
+                markup! { "The "{declaration_kind_text}" is declared here:" },
+            ),
+        )
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct InvalidUseBeforeDeclaration {
+    declaration_kind: DeclarationKind,
+    reference_range: TextRange,
+    binding_range: TextRange,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum DeclarationKind {
+    Parameter,
+    Variable,
+}
+
+impl TryFrom<&AnyJsBindingDeclaration> for DeclarationKind {
+    type Error = ();
+
+    fn try_from(value: &AnyJsBindingDeclaration) -> Result<Self, Self::Error> {
+        match value {
+            // Variable declaration
+            AnyJsBindingDeclaration::JsVariableDeclarator(_) => Ok(DeclarationKind::Variable),
+            // Parameters
+            AnyJsBindingDeclaration::JsFormalParameter(_)
+            | AnyJsBindingDeclaration::JsRestParameter(_)
+            | AnyJsBindingDeclaration::TsPropertyParameter(_) => Ok(DeclarationKind::Parameter),
+            // Other declarations allow use before definition
+            AnyJsBindingDeclaration::JsArrowFunctionExpression(_)
+            | AnyJsBindingDeclaration::JsBogusParameter(_)
+            | AnyJsBindingDeclaration::TsIndexSignatureParameter(_)
+            | AnyJsBindingDeclaration::TsInferType(_)
+            | AnyJsBindingDeclaration::TsMappedType(_)
+            | AnyJsBindingDeclaration::TsTypeParameter(_)
+            | AnyJsBindingDeclaration::JsFunctionDeclaration(_)
+            | AnyJsBindingDeclaration::JsFunctionExpression(_)
+            | AnyJsBindingDeclaration::TsDeclareFunctionDeclaration(_)
+            | AnyJsBindingDeclaration::JsClassDeclaration(_)
+            | AnyJsBindingDeclaration::JsClassExpression(_)
+            | AnyJsBindingDeclaration::TsInterfaceDeclaration(_)
+            | AnyJsBindingDeclaration::TsTypeAliasDeclaration(_)
+            | AnyJsBindingDeclaration::TsEnumDeclaration(_)
+            | AnyJsBindingDeclaration::TsModuleDeclaration(_)
+            | AnyJsBindingDeclaration::JsShorthandNamedImportSpecifier(_)
+            | AnyJsBindingDeclaration::JsNamedImportSpecifier(_)
+            | AnyJsBindingDeclaration::JsBogusNamedImportSpecifier(_)
+            | AnyJsBindingDeclaration::JsDefaultImportSpecifier(_)
+            | AnyJsBindingDeclaration::JsNamespaceImportSpecifier(_)
+            | AnyJsBindingDeclaration::TsImportEqualsDeclaration(_)
+            | AnyJsBindingDeclaration::JsClassExportDefaultDeclaration(_)
+            | AnyJsBindingDeclaration::JsFunctionExportDefaultDeclaration(_)
+            | AnyJsBindingDeclaration::TsDeclareFunctionExportDefaultDeclaration(_)
+            | AnyJsBindingDeclaration::JsCatchDeclaration(_) => Err(()),
+        }
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/invalid.js
@@ -1,0 +1,18 @@
+a;
+const a = 0;
+
+const b = b;
+
+c;
+let c;
+
+let d = d;
+
+e;
+var e;
+
+var f = f;
+
+function f(a = b, b = 0) {}
+
+function g(a = a) {}

--- a/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/invalid.js.snap
@@ -1,0 +1,196 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.js
+---
+# Input
+```js
+a;
+const a = 0;
+
+const b = b;
+
+c;
+let c;
+
+let d = d;
+
+e;
+var e;
+
+var f = f;
+
+function f(a = b, b = 0) {}
+
+function g(a = a) {}
+
+```
+
+# Diagnostics
+```
+invalid.js:1:1 lint/nursery/noInvalidUseBeforeDeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable is used before its declaration.
+  
+  > 1 │ a;
+      │ ^
+    2 │ const a = 0;
+    3 │ 
+  
+  i The variable is declared here:
+  
+    1 │ a;
+  > 2 │ const a = 0;
+      │       ^
+    3 │ 
+    4 │ const b = b;
+  
+
+```
+
+```
+invalid.js:4:11 lint/nursery/noInvalidUseBeforeDeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable is used before its declaration.
+  
+    2 │ const a = 0;
+    3 │ 
+  > 4 │ const b = b;
+      │           ^
+    5 │ 
+    6 │ c;
+  
+  i The variable is declared here:
+  
+    2 │ const a = 0;
+    3 │ 
+  > 4 │ const b = b;
+      │       ^
+    5 │ 
+    6 │ c;
+  
+
+```
+
+```
+invalid.js:4:13 lint/nursery/noInvalidUseBeforeDeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable is used before its declaration.
+  
+    2 │ const a = 0;
+    3 │ 
+  > 4 │ const b = b;
+      │             
+  > 5 │ 
+  > 6 │ c;
+      │ ^
+    7 │ let c;
+    8 │ 
+  
+  i The variable is declared here:
+  
+    6 │ c;
+  > 7 │ let c;
+      │     ^
+    8 │ 
+    9 │ let d = d;
+  
+
+```
+
+```
+invalid.js:9:9 lint/nursery/noInvalidUseBeforeDeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable is used before its declaration.
+  
+     7 │ let c;
+     8 │ 
+   > 9 │ let d = d;
+       │         ^
+    10 │ 
+    11 │ e;
+  
+  i The variable is declared here:
+  
+     7 │ let c;
+     8 │ 
+   > 9 │ let d = d;
+       │     ^
+    10 │ 
+    11 │ e;
+  
+
+```
+
+```
+invalid.js:9:11 lint/nursery/noInvalidUseBeforeDeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable is used before its declaration.
+  
+     7 │ let c;
+     8 │ 
+   > 9 │ let d = d;
+       │           
+  > 10 │ 
+  > 11 │ e;
+       │ ^
+    12 │ var e;
+    13 │ 
+  
+  i The variable is declared here:
+  
+    11 │ e;
+  > 12 │ var e;
+       │     ^
+    13 │ 
+    14 │ var f = f;
+  
+
+```
+
+```
+invalid.js:16:16 lint/nursery/noInvalidUseBeforeDeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This parameter is used before its declaration.
+  
+    14 │ var f = f;
+    15 │ 
+  > 16 │ function f(a = b, b = 0) {}
+       │                ^
+    17 │ 
+    18 │ function g(a = a) {}
+  
+  i The parameter is declared here:
+  
+    14 │ var f = f;
+    15 │ 
+  > 16 │ function f(a = b, b = 0) {}
+       │                   ^
+    17 │ 
+    18 │ function g(a = a) {}
+  
+
+```
+
+```
+invalid.js:18:16 lint/nursery/noInvalidUseBeforeDeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This parameter is used before its declaration.
+  
+    16 │ function f(a = b, b = 0) {}
+    17 │ 
+  > 18 │ function g(a = a) {}
+       │                ^
+    19 │ 
+  
+  i The parameter is declared here:
+  
+    16 │ function f(a = b, b = 0) {}
+    17 │ 
+  > 18 │ function g(a = a) {}
+       │            ^
+    19 │ 
+  
+
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/invalid.ts
@@ -1,0 +1,3 @@
+class C {
+    constructor(readonly a = b, readonly b = 0) {}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/invalid.ts.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+---
+# Input
+```js
+class C {
+    constructor(readonly a = b, readonly b = 0) {}
+}
+
+```
+
+# Diagnostics
+```
+invalid.ts:2:30 lint/nursery/noInvalidUseBeforeDeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This parameter is used before its declaration.
+  
+    1 │ class C {
+  > 2 │     constructor(readonly a = b, readonly b = 0) {}
+      │                              ^
+    3 │ }
+    4 │ 
+  
+  i The parameter is declared here:
+  
+    1 │ class C {
+  > 2 │     constructor(readonly a = b, readonly b = 0) {}
+      │                                          ^
+    3 │ }
+    4 │ 
+  
+
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.js
@@ -1,0 +1,12 @@
+
+g();
+function g() { f(); }
+function f() {}
+
+new C(); class C {}
+
+export { X }; const X = 1;
+
+let a; console.log(a);
+
+function h() { X; }; const X = 0;

--- a/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.js.snap
@@ -1,0 +1,22 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```js
+
+g();
+function g() { f(); }
+function f() {}
+
+new C(); class C {}
+
+export { X }; const X = 1;
+
+let a; console.log(a);
+
+function h() { X; }; const X = 0;
+
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.ts
@@ -1,0 +1,14 @@
+
+let i: I;
+interface I {}
+
+let t: T;
+type T = T[] | null;
+
+let e: E;
+enum E {}
+
+let n = N.X;
+namespace N {
+    export const X = 0;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.ts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```js
+
+let i: I;
+interface I {}
+
+let t: T;
+type T = T[] | null;
+
+let e: E;
+enum E {}
+
+let n = N.X;
+namespace N {
+    export const X = 0;
+}
+
+```
+
+

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -2786,6 +2786,15 @@ pub struct Nursery {
     #[bpaf(long("no-implicit-any-let"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_implicit_any_let: Option<RuleConfiguration>,
+    #[doc = "Disallow the use of variables and function parameters before their declaration"]
+    #[bpaf(
+        long("no-invalid-use-before-declaration"),
+        argument("on|off|warn"),
+        optional,
+        hide
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_invalid_use_before_declaration: Option<RuleConfiguration>,
     #[doc = "Disallow characters made with multiple code points in character class syntax."]
     #[bpaf(
         long("no-misleading-character-class"),
@@ -2899,6 +2908,9 @@ impl MergeWith<Nursery> for Nursery {
         if let Some(no_implicit_any_let) = other.no_implicit_any_let {
             self.no_implicit_any_let = Some(no_implicit_any_let);
         }
+        if let Some(no_invalid_use_before_declaration) = other.no_invalid_use_before_declaration {
+            self.no_invalid_use_before_declaration = Some(no_invalid_use_before_declaration);
+        }
         if let Some(no_misleading_character_class) = other.no_misleading_character_class {
             self.no_misleading_character_class = Some(no_misleading_character_class);
         }
@@ -2956,12 +2968,13 @@ impl MergeWith<Nursery> for Nursery {
 }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
-    pub(crate) const GROUP_RULES: [&'static str; 20] = [
+    pub(crate) const GROUP_RULES: [&'static str; 21] = [
         "noAriaHiddenOnFocusable",
         "noDefaultExport",
         "noDuplicateJsonKeys",
         "noEmptyBlockStatements",
         "noImplicitAnyLet",
+        "noInvalidUseBeforeDeclaration",
         "noMisleadingCharacterClass",
         "noNodejsModules",
         "noUnusedImports",
@@ -2992,13 +3005,13 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
     ];
-    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 20] = [
+    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 21] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
@@ -3019,6 +3032,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended(&self) -> bool {
@@ -3060,79 +3074,84 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
             }
         }
-        if let Some(rule) = self.no_misleading_character_class.as_ref() {
+        if let Some(rule) = self.no_invalid_use_before_declaration.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
             }
         }
-        if let Some(rule) = self.no_nodejs_modules.as_ref() {
+        if let Some(rule) = self.no_misleading_character_class.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
             }
         }
-        if let Some(rule) = self.no_unused_imports.as_ref() {
+        if let Some(rule) = self.no_nodejs_modules.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
             }
         }
-        if let Some(rule) = self.no_unused_private_class_members.as_ref() {
+        if let Some(rule) = self.no_unused_imports.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
             }
         }
-        if let Some(rule) = self.no_useless_lone_block_statements.as_ref() {
+        if let Some(rule) = self.no_unused_private_class_members.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
             }
         }
-        if let Some(rule) = self.no_useless_ternary.as_ref() {
+        if let Some(rule) = self.no_useless_lone_block_statements.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.use_await.as_ref() {
+        if let Some(rule) = self.no_useless_ternary.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.use_export_type.as_ref() {
+        if let Some(rule) = self.use_await.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.use_for_of.as_ref() {
+        if let Some(rule) = self.use_export_type.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_for_of.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.use_node_import_protocol.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.use_regex_literals.as_ref() {
+        if let Some(rule) = self.use_node_import_protocol.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.use_shorthand_function_type.as_ref() {
+        if let Some(rule) = self.use_regex_literals.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+        if let Some(rule) = self.use_shorthand_function_type.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
+            }
+        }
+        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
         index_set
@@ -3164,79 +3183,84 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
             }
         }
-        if let Some(rule) = self.no_misleading_character_class.as_ref() {
+        if let Some(rule) = self.no_invalid_use_before_declaration.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
             }
         }
-        if let Some(rule) = self.no_nodejs_modules.as_ref() {
+        if let Some(rule) = self.no_misleading_character_class.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
             }
         }
-        if let Some(rule) = self.no_unused_imports.as_ref() {
+        if let Some(rule) = self.no_nodejs_modules.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
             }
         }
-        if let Some(rule) = self.no_unused_private_class_members.as_ref() {
+        if let Some(rule) = self.no_unused_imports.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
             }
         }
-        if let Some(rule) = self.no_useless_lone_block_statements.as_ref() {
+        if let Some(rule) = self.no_unused_private_class_members.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
             }
         }
-        if let Some(rule) = self.no_useless_ternary.as_ref() {
+        if let Some(rule) = self.no_useless_lone_block_statements.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.use_await.as_ref() {
+        if let Some(rule) = self.no_useless_ternary.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.use_export_type.as_ref() {
+        if let Some(rule) = self.use_await.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.use_for_of.as_ref() {
+        if let Some(rule) = self.use_export_type.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_for_of.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.use_node_import_protocol.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.use_regex_literals.as_ref() {
+        if let Some(rule) = self.use_node_import_protocol.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.use_shorthand_function_type.as_ref() {
+        if let Some(rule) = self.use_regex_literals.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+        if let Some(rule) = self.use_shorthand_function_type.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
+            }
+        }
+        if let Some(rule) = self.use_valid_aria_role.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
         index_set
@@ -3252,7 +3276,7 @@ impl Nursery {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 8] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 20] {
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 21] {
         Self::ALL_RULES_AS_FILTERS
     }
     #[doc = r" Select preset rules"]
@@ -3280,6 +3304,7 @@ impl Nursery {
             "noDuplicateJsonKeys" => self.no_duplicate_json_keys.as_ref(),
             "noEmptyBlockStatements" => self.no_empty_block_statements.as_ref(),
             "noImplicitAnyLet" => self.no_implicit_any_let.as_ref(),
+            "noInvalidUseBeforeDeclaration" => self.no_invalid_use_before_declaration.as_ref(),
             "noMisleadingCharacterClass" => self.no_misleading_character_class.as_ref(),
             "noNodejsModules" => self.no_nodejs_modules.as_ref(),
             "noUnusedImports" => self.no_unused_imports.as_ref(),

--- a/crates/biome_service/src/configuration/parse/json/rules.rs
+++ b/crates/biome_service/src/configuration/parse/json/rules.rs
@@ -937,6 +937,13 @@ impl Deserializable for Nursery {
                                 diagnostics,
                             );
                         }
+                        "noInvalidUseBeforeDeclaration" => {
+                            result.no_invalid_use_before_declaration = Deserializable::deserialize(
+                                &value,
+                                "noInvalidUseBeforeDeclaration",
+                                diagnostics,
+                            );
+                        }
                         "noMisleadingCharacterClass" => {
                             result.no_misleading_character_class = Deserializable::deserialize(
                                 &value,
@@ -1039,6 +1046,7 @@ impl Deserializable for Nursery {
                                     "noDuplicateJsonKeys",
                                     "noEmptyBlockStatements",
                                     "noImplicitAnyLet",
+                                    "noInvalidUseBeforeDeclaration",
                                     "noMisleadingCharacterClass",
                                     "noNodejsModules",
                                     "noUnusedImports",

--- a/crates/biome_service/tests/invalid/hooks_incorrect_options.json.snap
+++ b/crates/biome_service/tests/invalid/hooks_incorrect_options.json.snap
@@ -22,6 +22,7 @@ hooks_incorrect_options.json:6:5 deserialize ━━━━━━━━━━━�
   - noDuplicateJsonKeys
   - noEmptyBlockStatements
   - noImplicitAnyLet
+  - noInvalidUseBeforeDeclaration
   - noMisleadingCharacterClass
   - noNodejsModules
   - noUnusedImports

--- a/crates/biome_service/tests/invalid/hooks_missing_name.json.snap
+++ b/crates/biome_service/tests/invalid/hooks_missing_name.json.snap
@@ -22,6 +22,7 @@ hooks_missing_name.json:6:5 deserialize ━━━━━━━━━━━━━�
   - noDuplicateJsonKeys
   - noEmptyBlockStatements
   - noImplicitAnyLet
+  - noInvalidUseBeforeDeclaration
   - noMisleadingCharacterClass
   - noNodejsModules
   - noUnusedImports

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -860,6 +860,10 @@ export interface Nursery {
 	 */
 	noImplicitAnyLet?: RuleConfiguration;
 	/**
+	 * Disallow the use of variables and function parameters before their declaration
+	 */
+	noInvalidUseBeforeDeclaration?: RuleConfiguration;
+	/**
 	 * Disallow characters made with multiple code points in character class syntax.
 	 */
 	noMisleadingCharacterClass?: RuleConfiguration;
@@ -1593,6 +1597,7 @@ export type Category =
 	| "lint/nursery/noDuplicateJsonKeys"
 	| "lint/nursery/noEmptyBlockStatements"
 	| "lint/nursery/noImplicitAnyLet"
+	| "lint/nursery/noInvalidUseBeforeDeclaration"
 	| "lint/nursery/noMisleadingCharacterClass"
 	| "lint/nursery/noNodejsModules"
 	| "lint/nursery/noTypeOnlyImportAttributes"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1220,6 +1220,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noInvalidUseBeforeDeclaration": {
+					"description": "Disallow the use of variables and function parameters before their declaration",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noMisleadingCharacterClass": {
 					"description": "Disallow characters made with multiple code points in character class syntax.",
 					"anyOf": [

--- a/website/src/components/generated/NumberOfRules.astro
+++ b/website/src/components/generated/NumberOfRules.astro
@@ -1,2 +1,2 @@
 <!-- this file is auto generated, use `cargo lintdoc` to update it -->
- <p>Biome's linter has a total of <strong><a href='/linter/rules'>185 rules</a></strong><p>
+ <p>Biome's linter has a total of <strong><a href='/linter/rules'>186 rules</a></strong><p>

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -89,6 +89,15 @@ is enabled to process only the files that were changed. Contributed by @simonxab
 
 - Add [useNodeImportProtocol](https://biomejs.dev/linter/rules/use-node-import-protocol) that forces the use of the `node:` protocol when importing Node.js modules. Contributed by @2-NOW
 
+- Add [noInvalidUseBeforeDeclaration](https://biomejs.dev/linter/rules/no-invalid-use-before-declaration) that reports variables and function parameters used before their declaration. Contributed by @Conaclos
+
+  ```js
+  function f() {
+    console.log(c); // Use of `c` before its declaration.
+    const c = 0;
+  }
+  ```
+
 #### Enhancements
 
 #### Bug fixes

--- a/website/src/content/docs/linter/rules/index.mdx
+++ b/website/src/content/docs/linter/rules/index.mdx
@@ -232,6 +232,7 @@ Rules that belong to this group <strong>are not subject to semantic version</str
 | [noDuplicateJsonKeys](/linter/rules/no-duplicate-json-keys) | Disallow two keys with the same name inside a JSON object. |  |
 | [noEmptyBlockStatements](/linter/rules/no-empty-block-statements) | Disallow empty block statements and static blocks. |  |
 | [noImplicitAnyLet](/linter/rules/no-implicit-any-let) | Disallow use of implicit <code>any</code> type on variable declarations. |  |
+| [noInvalidUseBeforeDeclaration](/linter/rules/no-invalid-use-before-declaration) | Disallow the use of variables and function parameters before their declaration |  |
 | [noMisleadingCharacterClass](/linter/rules/no-misleading-character-class) | Disallow characters made with multiple code points in character class syntax. | <span aria-label="The rule has a safe fix" role="img" title="The rule has a safe fix">🔧 </span> |
 | [noNodejsModules](/linter/rules/no-nodejs-modules) | Forbid the use of Node.js builtin modules. Can be useful for client-side web projects that
 do not have access to those modules. |  |

--- a/website/src/content/docs/linter/rules/no-invalid-use-before-declaration.md
+++ b/website/src/content/docs/linter/rules/no-invalid-use-before-declaration.md
@@ -1,0 +1,116 @@
+---
+title: noInvalidUseBeforeDeclaration (since vnext)
+---
+
+**Diagnostic Category: `lint/nursery/noInvalidUseBeforeDeclaration`**
+
+:::caution
+This rule is part of the [nursery](/linter/rules/#nursery) group.
+:::
+
+Disallow the use of variables and function parameters before their declaration
+
+JavaScript doesn't allow the use of block-scoped variables (`let`, `const`) and function parameters before their declaration.
+A `ReferenceError` will be thrown with any attempt to access the variable or the parameter before its declaration.
+
+The rule also reports the use of variables declared with `var` before their declarations.
+
+## Examples
+
+### Invalid
+
+```jsx
+function f() {
+    console.log(x);
+    const x;
+}
+```
+
+<pre class="language-text"><code class="language-text">nursery/noInvalidUseBeforeDeclaration.js:3:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Const declarations must have an initialized value</span>
+  
+    <strong>1 │ </strong>function f() {
+    <strong>2 │ </strong>    console.log(x);
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>    const x;
+   <strong>   │ </strong>          <strong><span style="color: Tomato;">^</span></strong>
+    <strong>4 │ </strong>}
+    <strong>5 │ </strong>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">this variable needs to be initialized</span>
+  
+</code></pre>
+
+```jsx
+function f() {
+    console.log(x);
+    var x = 0;
+}
+```
+
+<pre class="language-text"><code class="language-text">nursery/noInvalidUseBeforeDeclaration.js:2:17 <a href="https://biomejs.dev/linter/rules/no-invalid-use-before-declaration">lint/nursery/noInvalidUseBeforeDeclaration</a> ━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">This variable is used before its declaration.</span>
+  
+    <strong>1 │ </strong>function f() {
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>    console.log(x);
+   <strong>   │ </strong>                <strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>    var x = 0;
+    <strong>4 │ </strong>}
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">The variable is declared here:</span>
+  
+    <strong>1 │ </strong>function f() {
+    <strong>2 │ </strong>    console.log(x);
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>    var x = 0;
+   <strong>   │ </strong>        <strong><span style="color: Tomato;">^</span></strong>
+    <strong>4 │ </strong>}
+    <strong>5 │ </strong>
+  
+</code></pre>
+
+```jsx
+function f(a = b, b = 0) {}
+```
+
+<pre class="language-text"><code class="language-text">nursery/noInvalidUseBeforeDeclaration.js:1:16 <a href="https://biomejs.dev/linter/rules/no-invalid-use-before-declaration">lint/nursery/noInvalidUseBeforeDeclaration</a> ━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">This parameter is used before its declaration.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>function f(a = b, b = 0) {}
+   <strong>   │ </strong>               <strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">The parameter is declared here:</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>function f(a = b, b = 0) {}
+   <strong>   │ </strong>                  <strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+</code></pre>
+
+## Valid
+
+```jsx
+f();
+function f() {}
+
+new C();
+class C {}
+```
+
+```jsx
+// An export can reference a variable before its declaration.
+export { CONSTANT };
+const CONSTANT = 0;
+```
+
+```jsx
+function f() { return CONSTANT; }
+const CONSTANT = 0;
+```
+
+## Related links
+
+- [Disable a rule](/linter/#disable-a-lint-rule)
+- [Rule options](/linter/#rule-options)


### PR DESCRIPTION
## Summary

Rule requested in [a comment](https://github.com/biomejs/biome/discussions/3#discussioncomment-7900845).

In JavaScript, referencing a block-scoped variable or a function parameter before its declaration is an error.
The rule reports some of these errors. It cannot report cases where a function that uses a variable is called before the declaration of the variable.
For example:

```js
f();
const CONSTANT = 0;
functionf () { console.log(CONSTANT); }
```

Note that we correctly allow using a variable before its declaration if it is used in an `export` or in a distinct control flow root. For instance:

```js
export { CONSTANT };
const CONSTANT = 0;
```

```js
functionf () { console.log(CONSTANT); }
const CONSTANT = 0;
```

Although it is not invalid in JavaScript, we also report use before declaration of hoisted-variable such as:

```js
function f() {
  console.log(x);
  var x = 0;
}
```

This is likely an error, because `x` is undefined.

## Test Plan

I added test for both variables and function parameters.
