### PR TITLE
refcator(linter): don't require rule config to implement Bpaf's Parser trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,6 @@ dependencies = [
  "biome_rowan",
  "biome_test_utils",
  "biome_text_edit",
- "bpaf",
  "countme",
  "insta",
  "lazy_static",

--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -474,19 +474,17 @@ let options = ctx.options();
 ```
 
 The compiler should warn you that `MyRuleOptions` does not implement some required types.
-We currently require implementing _serde_'s traits `Deserialize`/`Serialize` and _Bpaf_'s parser trait.
+We currently require implementing _serde_'s traits `Deserialize`/`Serialize`.
 You can simply use a derive macros:
 
 ```rust,ignore
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Bpaf)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct MyRuleOptions {
-    #[bpaf(hide)]
     #[serde(default, skip_serializing_if = "is_default")]
     main_behavior: Behavior,
 
-    #[bpaf(hide)]
     #[serde(default, skip_serializing_if = "is_default")]
     extra_behaviors: Vec<Behavior>,
 }

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -24,7 +24,6 @@ biome_js_unicode_table = { workspace = true }
 biome_json_factory     = { workspace = true }
 biome_json_syntax      = { workspace = true }
 biome_rowan            = { workspace = true }
-bpaf.workspace         = true
 lazy_static            = { workspace = true }
 log                    = "0.4.20"
 natord                 = "1.0.9"

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_excessive_cognitive_complexity.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_excessive_cognitive_complexity.rs
@@ -12,9 +12,8 @@ use biome_js_syntax::{
     JsLogicalExpression, JsLogicalOperator,
 };
 use biome_rowan::{AstNode, Language, SyntaxNode, TextRange, WalkEvent};
-use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
-use std::{num::NonZeroU8, str::FromStr};
+use std::num::NonZeroU8;
 
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
@@ -372,7 +371,7 @@ pub struct ComplexityScore {
 }
 
 /// Options for the rule `noExcessiveCognitiveComplexity`.
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Bpaf)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ComplexityOptions {
@@ -385,15 +384,6 @@ impl Default for ComplexityOptions {
         Self {
             max_allowed_complexity: NonZeroU8::new(15).unwrap(),
         }
-    }
-}
-
-// Required by [Bpaf].
-impl FromStr for ComplexityOptions {
-    type Err = ();
-
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::default())
     }
 }
 

--- a/crates/biome_js_analyze/src/aria_analyzers/nursery/use_valid_aria_role.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/nursery/use_valid_aria_role.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use crate::{aria_services::Aria, JsRuleAction};
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
@@ -11,7 +9,6 @@ use biome_deserialize::{
 use biome_diagnostics::Applicability;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::{AstNode, BatchMutationExt};
-use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 
 declare_rule! {
@@ -79,22 +76,12 @@ declare_rule! {
     }
 }
 
-#[derive(Default, Deserialize, Serialize, Eq, PartialEq, Debug, Clone, Bpaf)]
+#[derive(Default, Deserialize, Serialize, Eq, PartialEq, Debug, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ValidAriaRoleOptions {
-    #[bpaf(hide, argument::<String>("roles"), many)]
     allowed_invalid_roles: Vec<String>,
-    #[bpaf(hide)]
     ignore_non_dom: bool,
-}
-
-impl FromStr for ValidAriaRoleOptions {
-    type Err = ();
-
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        Ok(ValidAriaRoleOptions::default())
-    }
 }
 
 impl Deserializable for ValidAriaRoleOptions {

--- a/crates/biome_js_analyze/src/options.rs
+++ b/crates/biome_js_analyze/src/options.rs
@@ -1,52 +1,37 @@
 //! This module contains the rules that have options
 
-use crate::analyzers::complexity::no_excessive_cognitive_complexity::{
-    complexity_options, ComplexityOptions,
-};
-use crate::aria_analyzers::nursery::use_valid_aria_role::{
-    valid_aria_role_options, ValidAriaRoleOptions,
-};
-use crate::semantic_analyzers::correctness::use_exhaustive_dependencies::{
-    hooks_options, HooksOptions,
-};
-use crate::semantic_analyzers::style::no_restricted_globals::{
-    restricted_globals_options, RestrictedGlobalsOptions,
-};
-use crate::semantic_analyzers::style::use_naming_convention::{
-    naming_convention_options, NamingConventionOptions,
-};
+use crate::analyzers::complexity::no_excessive_cognitive_complexity::ComplexityOptions;
+use crate::aria_analyzers::nursery::use_valid_aria_role::ValidAriaRoleOptions;
+use crate::semantic_analyzers::correctness::use_exhaustive_dependencies::HooksOptions;
+use crate::semantic_analyzers::style::no_restricted_globals::RestrictedGlobalsOptions;
+use crate::semantic_analyzers::style::use_naming_convention::NamingConventionOptions;
 use biome_analyze::options::RuleOptions;
 use biome_analyze::RuleKey;
 use biome_console::markup;
 use biome_deserialize::{Deserializable, DeserializableValue, DeserializationDiagnostic};
-use bpaf::Bpaf;
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
 
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Bpaf)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, untagged)]
 pub enum PossibleOptions {
     /// Options for `noExcessiveComplexity` rule
-    Complexity(#[bpaf(external(complexity_options), hide)] ComplexityOptions),
+    Complexity(ComplexityOptions),
     /// Options for `useExhaustiveDependencies` and `useHookAtTopLevel` rule
-    Hooks(#[bpaf(external(hooks_options), hide)] HooksOptions),
+    Hooks(HooksOptions),
     /// Options for `useNamingConvention` rule
-    NamingConvention(#[bpaf(external(naming_convention_options), hide)] NamingConventionOptions),
+    NamingConvention(NamingConventionOptions),
     /// Options for `noRestrictedGlobals` rule
-    RestrictedGlobals(#[bpaf(external(restricted_globals_options), hide)] RestrictedGlobalsOptions),
+    RestrictedGlobals(RestrictedGlobalsOptions),
     /// Options for `useValidAriaRole` rule
-    ValidAriaRole(#[bpaf(external(valid_aria_role_options), hide)] ValidAriaRoleOptions),
+    ValidAriaRole(ValidAriaRoleOptions),
 }
 
-// Required by [Bpaf].
-impl FromStr for PossibleOptions {
-    type Err = ();
-
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::Complexity(ComplexityOptions::default()))
+impl Default for PossibleOptions {
+    fn default() -> Self {
+        Self::Complexity(ComplexityOptions::default())
     }
 }
 

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
@@ -13,11 +13,9 @@ use biome_js_syntax::{
 };
 use biome_js_syntax::{AnyJsExpression, JsIdentifierExpression, TsTypeofType};
 use biome_rowan::{AstNode, SyntaxNodeCast};
-use bpaf::Bpaf;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::str::FromStr;
 
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
@@ -220,21 +218,12 @@ impl Default for ReactExtensiveDependenciesOptions {
 }
 
 /// Options for the rule `useExhaustiveDependencies` and `useHookAtTopLevel`
-#[derive(Default, Deserialize, Serialize, Eq, PartialEq, Debug, Clone, Bpaf)]
+#[derive(Default, Deserialize, Serialize, Eq, PartialEq, Debug, Clone)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct HooksOptions {
-    #[bpaf(external, hide, many)]
     /// List of safe hooks
     pub hooks: Vec<Hooks>,
-}
-
-impl FromStr for HooksOptions {
-    type Err = ();
-
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        Ok(HooksOptions::default())
-    }
 }
 
 impl Deserializable for HooksOptions {
@@ -289,29 +278,18 @@ impl DeserializationVisitor for HooksOptionsVisitor {
     }
 }
 
-#[derive(Default, Deserialize, Serialize, Eq, PartialEq, Debug, Clone, Bpaf)]
+#[derive(Default, Deserialize, Serialize, Eq, PartialEq, Debug, Clone)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Hooks {
-    #[bpaf(hide)]
     /// The name of the hook
     pub name: String,
-    #[bpaf(hide)]
     /// The "position" of the closure function, starting from zero.
     ///
     /// ### Example
     pub closure_index: Option<usize>,
-    #[bpaf(hide)]
     /// The "position" of the array of dependencies, starting from zero.
     pub dependencies_index: Option<usize>,
-}
-
-impl FromStr for Hooks {
-    type Err = ();
-
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        Ok(Hooks::default())
-    }
 }
 
 impl Deserializable for Hooks {

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/no_restricted_globals.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/no_restricted_globals.rs
@@ -9,9 +9,7 @@ use biome_deserialize::{
 use biome_js_semantic::{Binding, BindingExtensions};
 use biome_js_syntax::{AnyJsIdentifierUsage, TextRange};
 use biome_rowan::AstNode;
-use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
 
 declare_rule! {
     /// This rule allows you to specify global variable names that you don’t want to use in your application.
@@ -60,24 +58,13 @@ declare_rule! {
 const RESTRICTED_GLOBALS: [&str; 2] = ["event", "error"];
 
 /// Options for the rule `noRestrictedGlobals`.
-#[derive(Default, Deserialize, Serialize, Eq, PartialEq, Debug, Clone, Bpaf)]
+#[derive(Default, Deserialize, Serialize, Eq, PartialEq, Debug, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RestrictedGlobalsOptions {
     /// A list of names that should trigger the rule
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide, argument::<String>("NUM"), many, optional)]
     denied_globals: Option<Vec<String>>,
-}
-
-// Required by [Bpaf].
-impl FromStr for RestrictedGlobalsOptions {
-    type Err = &'static str;
-
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        // WARNING: should not be used.
-        Ok(Self::default())
-    }
 }
 
 impl Deserializable for RestrictedGlobalsOptions {

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
@@ -27,7 +27,6 @@ use biome_js_unicode_table::is_js_ident;
 use biome_rowan::{
     declare_node_union, AstNode, AstNodeList, BatchMutationExt, SyntaxResult, TextRange, TokenText,
 };
-use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
@@ -457,13 +456,12 @@ pub(crate) struct State {
 }
 
 /// Rule's options.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Bpaf)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NamingConventionOptions {
     /// If `false`, then consecutive uppercase are allowed in _camel_ and _pascal_ cases.
     /// This does not affect other [Case].
-    #[bpaf(hide)]
     #[serde(
         default = "default_strict_case",
         skip_serializing_if = "is_default_strict_case"
@@ -471,7 +469,6 @@ pub struct NamingConventionOptions {
     pub strict_case: bool,
 
     /// Allowed cases for _TypeScript_ `enum` member names.
-    #[bpaf(hide)]
     #[serde(default, skip_serializing_if = "is_default")]
     pub enum_member_case: EnumMemberCase,
 }
@@ -494,16 +491,6 @@ impl Default for NamingConventionOptions {
             strict_case: default_strict_case(),
             enum_member_case: EnumMemberCase::default(),
         }
-    }
-}
-
-// Required by [Bpaf].
-impl FromStr for NamingConventionOptions {
-    type Err = &'static str;
-
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        // WARNING: should not be used.
-        Ok(Self::default())
     }
 }
 

--- a/crates/biome_service/src/configuration/linter/mod.rs
+++ b/crates/biome_service/src/configuration/linter/mod.rs
@@ -8,7 +8,7 @@ use crate::settings::{to_matcher, LinterSettings};
 use crate::{Matcher, WorkspaceError};
 use biome_deserialize::StringSet;
 use biome_diagnostics::Severity;
-use biome_js_analyze::options::{possible_options, PossibleOptions};
+use biome_js_analyze::options::PossibleOptions;
 use bpaf::Bpaf;
 pub use rules::*;
 #[cfg(feature = "schema")]
@@ -199,7 +199,7 @@ impl FromStr for RulePlainConfiguration {
 pub struct RuleWithOptions {
     pub level: RulePlainConfiguration,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(external(possible_options), hide, optional)]
+    #[bpaf(pure(PossibleOptions::default()), hide, optional)]
     pub options: Option<PossibleOptions>,
 }
 


### PR DESCRIPTION
## Summary

This PR allows removing `Bpaf` dependency of `biome_js_analyze` crate.
This also allows simplifying a rule's configuration implementation since we no longer need to implement Bpaf's `Parser` trait and `FromStr` trait (required by Bpaf).

To do that, I use a pure parser for `PossibleOptions` enum.

## Future improvements

We could go beyond and use a pure parser for the entire linter configuration.

## Test Plan

CI and manually testd.