### PR TITLE
fix(project): keep parent configuration when computing overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ is enabled to process only the files that were changed. Contributed by @simonxab
 - Fix [#805](https://github.com/biomejs/biome/issues/805), by correctly parsing these kind of patterns. Contributed by @ematipico
 - Fix [#1117](https://github.com/biomejs/biome/issues/1117) by correctly respecting the matching. Contributed by @ematipico
 - Fix [#1247](https://github.com/biomejs/biome/issues/1247), Biome now prints a **warning** diagnostic if it encounters files that can't handle. Contributed by @ematipico
+- Fix [#691](https://github.com/biomejs/biome/issues/691) and [#1190](https://github.com/biomejs/biome/issues/1190), by correctly apply the configuration when computing the overrides. Contributed by @ematipico
 
 ### Configuration
 

--- a/crates/biome_cli/tests/cases/overrides_formatter.rs
+++ b/crates/biome_cli/tests/cases/overrides_formatter.rs
@@ -358,3 +358,107 @@ fn does_include_file_with_different_languages_and_files() {
         result,
     ));
 }
+
+#[test]
+fn does_not_change_formatting_settings() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let file_path = Path::new("biome.json");
+    fs.insert(
+        file_path.into(),
+        r#"{
+        "formatter": { "lineWidth": 20, "indentStyle": "space" },
+  "overrides": [
+    { "include": ["test.js"], "linter": { "enabled": false } }
+  ]
+}
+
+"#
+        .as_bytes(),
+    );
+
+    let test = Path::new("test.js");
+    fs.insert(test.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
+
+    let test2 = Path::new("test2.js");
+    fs.insert(test2.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                ("--write"),
+                test.as_os_str().to_str().unwrap(),
+                test2.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, test, FORMATTED_LINE_WITH_SPACES);
+    assert_file_contents(&fs, test2, FORMATTED_LINE_WITH_SPACES);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "does_not_change_formatting_settings",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn does_not_change_formatting_language_settings() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let file_path = Path::new("biome.json");
+    fs.insert(
+        file_path.into(),
+        r#"{
+        "javascript": { "formatter": { "quoteStyle": "single" } },
+  "overrides": [
+    { "include": ["test.js"], "linter": { "enabled": false } }
+  ]
+}
+
+"#
+        .as_bytes(),
+    );
+
+    let test = Path::new("test.js");
+    fs.insert(test.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
+
+    let test2 = Path::new("test2.js");
+    fs.insert(test2.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                ("--write"),
+                test.as_os_str().to_str().unwrap(),
+                test2.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, test, FORMATTED_WITH_SINGLE_QUOTES);
+    assert_file_contents(&fs, test2, FORMATTED_WITH_SINGLE_QUOTES);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "does_not_change_formatting_language_settings",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/cases/overrides_linter.rs
+++ b/crates/biome_cli/tests/cases/overrides_linter.rs
@@ -327,3 +327,61 @@ fn does_override_the_rules() {
         result,
     ));
 }
+
+#[test]
+fn does_not_change_linting_settings() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let file_path = Path::new("biome.json");
+    fs.insert(
+        file_path.into(),
+        r#"{
+        "linter": {
+                "rules": {
+                    "suspicious": {
+                        "noDebugger": "off"
+                    }
+                }
+            },
+  "overrides": [
+    { "include": ["test.js"], "formatter": { "enabled": false } }
+  ]
+}
+
+"#
+        .as_bytes(),
+    );
+
+    let test = Path::new("test.js");
+    fs.insert(test.into(), DEBUGGER_BEFORE.as_bytes());
+
+    let test2 = Path::new("test2.js");
+    fs.insert(test2.into(), DEBUGGER_BEFORE.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("lint"),
+                ("--apply-unsafe"),
+                test.as_os_str().to_str().unwrap(),
+                test2.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, test, DEBUGGER_BEFORE);
+    assert_file_contents(&fs, test2, DEBUGGER_BEFORE);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "does_not_change_linting_settings",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snap_test.rs
+++ b/crates/biome_cli/tests/snap_test.rs
@@ -401,7 +401,7 @@ pub fn assert_file_contents(fs: &MemoryFileSystem, path: &Path, expected_content
     assert_eq!(
         content,
         expected_content,
-        "file {} doesn't match the expected content",
+        "file {} doesn't match the expected content (right)",
         path.display()
     );
 }

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/does_not_change_formatting_language_settings.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/does_not_change_formatting_language_settings.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "javascript": { "formatter": { "quoteStyle": "single" } },
+  "overrides": [{ "include": ["test.js"], "linter": { "enabled": false } }]
+}
+```
+
+## `test.js`
+
+```js
+const a = ['loreum', 'ipsum'];
+
+```
+
+## `test2.js`
+
+```js
+const a = ['loreum', 'ipsum'];
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 2 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/does_not_change_formatting_settings.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/does_not_change_formatting_settings.snap
@@ -1,0 +1,40 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "formatter": { "lineWidth": 20, "indentStyle": "space" },
+  "overrides": [{ "include": ["test.js"], "linter": { "enabled": false } }]
+}
+```
+
+## `test.js`
+
+```js
+const a = [
+  "loreum",
+  "ipsum",
+];
+
+```
+
+## `test2.js`
+
+```js
+const a = [
+  "loreum",
+  "ipsum",
+];
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 2 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_not_change_linting_settings.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_not_change_linting_settings.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "suspicious": {
+        "noDebugger": "off"
+      }
+    }
+  },
+  "overrides": [{ "include": ["test.js"], "formatter": { "enabled": false } }]
+}
+```
+
+## `test.js`
+
+```js
+debugger
+```
+
+## `test2.js`
+
+```js
+debugger
+```
+
+# Emitted Messages
+
+```block
+Fixed 2 file(s) in <TIME>
+```
+
+

--- a/crates/biome_service/src/configuration/overrides.rs
+++ b/crates/biome_service/src/configuration/overrides.rs
@@ -1,5 +1,5 @@
 use crate::configuration::formatter::{deserialize_line_width, serialize_line_width};
-use crate::configuration::linter::{rules, to_linter_settings};
+use crate::configuration::linter::rules;
 use crate::configuration::{
     css_configuration, javascript_configuration, json_configuration, CssConfiguration,
     JavascriptConfiguration, JsonConfiguration, PlainIndentStyle,

--- a/crates/biome_service/src/configuration/overrides.rs
+++ b/crates/biome_service/src/configuration/overrides.rs
@@ -1,16 +1,17 @@
 use crate::configuration::formatter::{deserialize_line_width, serialize_line_width};
-use crate::configuration::linter::rules;
+use crate::configuration::linter::{rules, to_linter_settings};
 use crate::configuration::{
     css_configuration, javascript_configuration, json_configuration, CssConfiguration,
     JavascriptConfiguration, JsonConfiguration, PlainIndentStyle,
 };
 use crate::settings::{
-    to_matcher, LanguageListSettings, OverrideFormatSettings, OverrideLinterSettings,
-    OverrideOrganizeImportsSettings, OverrideSettingPattern, OverrideSettings,
+    to_matcher, FormatSettings, LanguageListSettings, LinterSettings, OrganizeImportsSettings,
+    OverrideFormatSettings, OverrideLinterSettings, OverrideOrganizeImportsSettings,
+    OverrideSettingPattern, OverrideSettings, WorkspaceSettings,
 };
 use crate::{MergeWith, Rules, WorkspaceError};
 use biome_deserialize::StringSet;
-use biome_formatter::{IndentStyle, LineEnding, LineWidth};
+use biome_formatter::{LineEnding, LineWidth};
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -335,17 +336,19 @@ pub fn to_override_settings(
     overrides: Overrides,
     vcs_base_path: Option<PathBuf>,
     gitignore_matches: &[String],
+    current_settings: &WorkspaceSettings,
 ) -> Result<OverrideSettings, WorkspaceError> {
     let mut override_settings = OverrideSettings::default();
     for mut pattern in overrides.0 {
         let formatter = pattern.formatter.take().unwrap_or_default();
-        let formatter = OverrideFormatSettings::try_from(formatter)?;
+        let formatter = to_format_settings(formatter, &current_settings.formatter);
 
         let linter = pattern.linter.take().unwrap_or_default();
-        let linter = OverrideLinterSettings::try_from(linter)?;
+        let linter = to_override_linter_settings(linter, &current_settings.linter);
 
         let organize_imports = pattern.organize_imports.take().unwrap_or_default();
-        let organize_imports = OverrideOrganizeImportsSettings::try_from(organize_imports)?;
+        let organize_imports =
+            to_organize_imports_settings(organize_imports, &current_settings.organize_imports);
 
         let mut languages = LanguageListSettings::default();
         if let Some(javascript) = pattern.javascript {
@@ -370,6 +373,7 @@ pub fn to_override_settings(
             formatter,
             linter,
             organize_imports,
+
             languages,
         };
 
@@ -379,49 +383,50 @@ pub fn to_override_settings(
     Ok(override_settings)
 }
 
-impl TryFrom<OverrideFormatterConfiguration> for OverrideFormatSettings {
-    type Error = WorkspaceError;
+pub(crate) fn to_format_settings(
+    conf: OverrideFormatterConfiguration,
+    format_settings: &FormatSettings,
+) -> OverrideFormatSettings {
+    let indent_style = conf
+        .indent_style
+        .map(Into::into)
+        .or(format_settings.indent_style);
+    let indent_width = conf
+        .indent_width
+        .map(Into::into)
+        .or(conf.indent_size.map(Into::into))
+        .or(format_settings.indent_width);
 
-    fn try_from(conf: OverrideFormatterConfiguration) -> Result<Self, Self::Error> {
-        let indent_style = match conf.indent_style {
-            Some(PlainIndentStyle::Tab) => IndentStyle::Tab,
-            Some(PlainIndentStyle::Space) => IndentStyle::Space,
-            None => IndentStyle::default(),
-        };
-        let indent_width = conf
-            .indent_width
-            .map(Into::into)
-            .or(conf.indent_size.map(Into::into))
-            .unwrap_or_default();
-
-        Ok(Self {
-            enabled: conf.enabled,
-            indent_style: Some(indent_style),
-            indent_width: Some(indent_width),
-            line_ending: conf.line_ending,
-            line_width: conf.line_width,
-            format_with_errors: conf.format_with_errors.unwrap_or_default(),
-        })
+    let line_ending = conf.line_ending.or(format_settings.line_ending);
+    let line_width = conf.line_width.or(format_settings.line_width);
+    let format_with_errors = conf
+        .format_with_errors
+        .unwrap_or(format_settings.format_with_errors);
+    OverrideFormatSettings {
+        enabled: conf.enabled.or(Some(format_settings.enabled)),
+        indent_style,
+        indent_width,
+        line_ending,
+        line_width,
+        format_with_errors,
     }
 }
 
-impl TryFrom<OverrideLinterConfiguration> for OverrideLinterSettings {
-    type Error = WorkspaceError;
-
-    fn try_from(conf: OverrideLinterConfiguration) -> Result<Self, Self::Error> {
-        Ok(Self {
-            enabled: conf.enabled,
-            rules: conf.rules,
-        })
+fn to_override_linter_settings(
+    conf: OverrideLinterConfiguration,
+    lint_settings: &LinterSettings,
+) -> OverrideLinterSettings {
+    OverrideLinterSettings {
+        enabled: conf.enabled.or(Some(lint_settings.enabled)),
+        rules: conf.rules.or(lint_settings.rules.clone()),
     }
 }
 
-impl TryFrom<OverrideOrganizeImportsConfiguration> for OverrideOrganizeImportsSettings {
-    type Error = WorkspaceError;
-
-    fn try_from(conf: OverrideOrganizeImportsConfiguration) -> Result<Self, Self::Error> {
-        Ok(Self {
-            enabled: conf.enabled,
-        })
+fn to_organize_imports_settings(
+    conf: OverrideOrganizeImportsConfiguration,
+    settings: &OrganizeImportsSettings,
+) -> OverrideOrganizeImportsSettings {
+    OverrideOrganizeImportsSettings {
+        enabled: conf.enabled.or(Some(settings.enabled)),
     }
 }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -134,7 +134,7 @@ impl WorkspaceSettings {
         // NOTE: keep this last. Computing the overrides require reading the settings computed by the parent settings.
         if let Some(overrides) = configuration.overrides {
             self.override_settings =
-                to_override_settings(overrides, vcs_path, gitignore_matches, &self)?;
+                to_override_settings(overrides, vcs_path, gitignore_matches, self)?;
         }
 
         Ok(())

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -118,10 +118,6 @@ impl WorkspaceSettings {
             )?;
         }
 
-        if let Some(overrides) = configuration.overrides {
-            self.override_settings = to_override_settings(overrides, vcs_path, gitignore_matches)?;
-        }
-
         // javascript settings
         if let Some(javascript) = configuration.javascript {
             self.languages.javascript = javascript.into();
@@ -133,6 +129,12 @@ impl WorkspaceSettings {
         // css settings
         if let Some(css) = configuration.css {
             self.languages.css = css.into();
+        }
+
+        // NOTE: keep this last. Computing the overrides require reading the settings computed by the parent settings.
+        if let Some(overrides) = configuration.overrides {
+            self.override_settings =
+                to_override_settings(overrides, vcs_path, gitignore_matches, &self)?;
         }
 
         Ok(())
@@ -551,7 +553,6 @@ impl OverrideSettings {
             if included {
                 let js_formatter = &pattern.languages.javascript.formatter;
                 let formatter = &pattern.formatter;
-
                 if let Some(indent_style) = js_formatter.indent_style.or(formatter.indent_style) {
                     options.set_indent_style(indent_style);
                 }

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -36,6 +36,7 @@ is enabled to process only the files that were changed. Contributed by @simonxab
 - Fix [#805](https://github.com/biomejs/biome/issues/805), by correctly parsing these kind of patterns. Contributed by @ematipico
 - Fix [#1117](https://github.com/biomejs/biome/issues/1117) by correctly respecting the matching. Contributed by @ematipico
 - Fix [#1247](https://github.com/biomejs/biome/issues/1247), Biome now prints a **warning** diagnostic if it encounters files that can't handle. Contributed by @ematipico
+- Fix [#691](https://github.com/biomejs/biome/issues/691) and [#1190](https://github.com/biomejs/biome/issues/1190), by correctly apply the configuration when computing the overrides. Contributed by @ematipico
 
 ### Configuration
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/691 https://github.com/biomejs/biome/issues/1190 

The issue was that when we were computing the overrides of the formatter and the linter, we were silently applying Biome's defaults.

This PR fixes the issue by using the parent configuration before applying the default.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added new test cases

<!-- What demonstrates that your implementation is correct? -->
