### PR TITLE
refactor(config): reduce size by 53%

### DIFF
--- a/crates/biome_service/src/configuration/linter/mod.rs
+++ b/crates/biome_service/src/configuration/linter/mod.rs
@@ -1,7 +1,7 @@
 #[rustfmt::skip]
 mod rules;
 
-pub use crate::configuration::linter::rules::{rules, Rules};
+pub use crate::configuration::linter::rules::Rules;
 use crate::configuration::merge::MergeWith;
 use crate::configuration::overrides::OverrideLinterConfiguration;
 use crate::settings::{to_matcher, LinterSettings};
@@ -28,7 +28,7 @@ pub struct LinterConfiguration {
 
     /// List of rules
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(external, optional, hide)]
+    #[bpaf(pure(Rules::default()), optional, hide)]
     pub rules: Option<Rules>,
 
     /// A list of Unix shell style patterns. The formatter will ignore files/folders that will
@@ -104,12 +104,12 @@ impl TryFrom<OverrideLinterConfiguration> for LinterSettings {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq, Bpaf)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, untagged)]
 pub enum RuleConfiguration {
     Plain(RulePlainConfiguration),
-    WithOptions(RuleWithOptions),
+    WithOptions(Box<RuleWithOptions>),
 }
 
 impl FromStr for RuleConfiguration {
@@ -170,7 +170,7 @@ impl From<&RulePlainConfiguration> for Severity {
     }
 }
 
-#[derive(Default, Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Bpaf)]
+#[derive(Default, Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub enum RulePlainConfiguration {
@@ -193,13 +193,12 @@ impl FromStr for RulePlainConfiguration {
     }
 }
 
-#[derive(Default, Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Bpaf)]
+#[derive(Default, Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RuleWithOptions {
     pub level: RulePlainConfiguration,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(pure(PossibleOptions::default()), hide, optional)]
     pub options: Option<PossibleOptions>,
 }
 

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -3,46 +3,35 @@
 use crate::{MergeWith, RuleConfiguration};
 use biome_analyze::RuleFilter;
 use biome_diagnostics::{Category, Severity};
-use bpaf::Bpaf;
 use indexmap::IndexSet;
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq, Bpaf)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Rules {
     #[doc = r" It enables the lint rules recommended by Biome. `true` by default."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub recommended: Option<bool>,
     #[doc = r" It enables ALL rules. The rules that belong to `nursery` won't be enabled."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub all: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(external, hide, optional)]
     pub a11y: Option<A11y>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(external, hide, optional)]
     pub complexity: Option<Complexity>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(external, hide, optional)]
     pub correctness: Option<Correctness>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(external, hide, optional)]
     pub nursery: Option<Nursery>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(external, hide, optional)]
     pub performance: Option<Performance>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(external, hide, optional)]
     pub security: Option<Security>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(external, hide, optional)]
     pub style: Option<Style>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(external, hide, optional)]
     pub suspicious: Option<Suspicious>,
 }
 impl Default for Rules {
@@ -416,174 +405,99 @@ impl Rules {
         disabled_rules
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct A11y {
     #[doc = r" It enables the recommended rules for this group"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub recommended: Option<bool>,
     #[doc = r" It enables ALL rules for this group."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub all: Option<bool>,
     #[doc = "Enforce that the accessKey attribute is not used on any HTML element."]
-    #[bpaf(long("no-access-key"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_access_key: Option<RuleConfiguration>,
     #[doc = "Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes."]
-    #[bpaf(
-        long("no-aria-unsupported-elements"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_aria_unsupported_elements: Option<RuleConfiguration>,
     #[doc = "Enforce that autoFocus prop is not used on elements."]
-    #[bpaf(long("no-autofocus"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_autofocus: Option<RuleConfiguration>,
     #[doc = "Disallow target=\"_blank\" attribute without rel=\"noreferrer\""]
-    #[bpaf(long("no-blank-target"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_blank_target: Option<RuleConfiguration>,
     #[doc = "Enforces that no distracting elements are used."]
-    #[bpaf(
-        long("no-distracting-elements"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_distracting_elements: Option<RuleConfiguration>,
     #[doc = "The scope prop should be used only on <th> elements."]
-    #[bpaf(long("no-header-scope"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_header_scope: Option<RuleConfiguration>,
     #[doc = "Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements."]
-    #[bpaf(
-        long("no-interactive-element-to-noninteractive-role"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_interactive_element_to_noninteractive_role: Option<RuleConfiguration>,
     #[doc = "Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements."]
-    #[bpaf(
-        long("no-noninteractive-element-to-interactive-role"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_noninteractive_element_to_interactive_role: Option<RuleConfiguration>,
     #[doc = "Enforce that tabIndex is not assigned to non-interactive HTML elements."]
-    #[bpaf(
-        long("no-noninteractive-tabindex"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_noninteractive_tabindex: Option<RuleConfiguration>,
     #[doc = "Prevent the usage of positive integers on tabIndex property"]
-    #[bpaf(long("no-positive-tabindex"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_positive_tabindex: Option<RuleConfiguration>,
     #[doc = "Enforce img alt prop does not contain the word \"image\", \"picture\", or \"photo\"."]
-    #[bpaf(long("no-redundant-alt"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_redundant_alt: Option<RuleConfiguration>,
     #[doc = "Enforce explicit role property is not the same as implicit/default role property on an element."]
-    #[bpaf(long("no-redundant-roles"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_redundant_roles: Option<RuleConfiguration>,
     #[doc = "Enforces the usage of the title element for the svg element."]
-    #[bpaf(long("no-svg-without-title"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_svg_without_title: Option<RuleConfiguration>,
     #[doc = "Enforce that all elements that require alternative text have meaningful information to relay back to the end user."]
-    #[bpaf(long("use-alt-text"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_alt_text: Option<RuleConfiguration>,
     #[doc = "Enforce that anchors have content and that the content is accessible to screen readers."]
-    #[bpaf(long("use-anchor-content"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_anchor_content: Option<RuleConfiguration>,
     #[doc = "Enforce that tabIndex is assigned to non-interactive HTML elements with aria-activedescendant."]
-    #[bpaf(
-        long("use-aria-activedescendant-with-tabindex"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_aria_activedescendant_with_tabindex: Option<RuleConfiguration>,
     #[doc = "Enforce that elements with ARIA roles must have all required ARIA attributes for that role."]
-    #[bpaf(
-        long("use-aria-props-for-role"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_aria_props_for_role: Option<RuleConfiguration>,
     #[doc = "Enforces the usage of the attribute type for the element button"]
-    #[bpaf(long("use-button-type"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_button_type: Option<RuleConfiguration>,
     #[doc = "Enforce that heading elements (h1, h2, etc.) have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the aria-hidden prop."]
-    #[bpaf(long("use-heading-content"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_heading_content: Option<RuleConfiguration>,
     #[doc = "Enforce that html element has lang attribute."]
-    #[bpaf(long("use-html-lang"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_html_lang: Option<RuleConfiguration>,
     #[doc = "Enforces the usage of the attribute title for the element iframe."]
-    #[bpaf(long("use-iframe-title"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_iframe_title: Option<RuleConfiguration>,
     #[doc = "Enforce onClick is accompanied by at least one of the following: onKeyUp, onKeyDown, onKeyPress."]
-    #[bpaf(
-        long("use-key-with-click-events"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_key_with_click_events: Option<RuleConfiguration>,
     #[doc = "Enforce onMouseOver / onMouseOut are accompanied by onFocus / onBlur."]
-    #[bpaf(
-        long("use-key-with-mouse-events"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_key_with_mouse_events: Option<RuleConfiguration>,
     #[doc = "Enforces that audio and video elements must have a track for captions."]
-    #[bpaf(long("use-media-caption"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_media_caption: Option<RuleConfiguration>,
     #[doc = "Enforce that all anchors are valid, and they are navigable elements."]
-    #[bpaf(long("use-valid-anchor"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_valid_anchor: Option<RuleConfiguration>,
     #[doc = "Ensures that ARIA properties aria-* are all valid."]
-    #[bpaf(long("use-valid-aria-props"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_valid_aria_props: Option<RuleConfiguration>,
     #[doc = "Enforce that ARIA state and property values are valid."]
-    #[bpaf(long("use-valid-aria-values"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_valid_aria_values: Option<RuleConfiguration>,
     #[doc = "Ensure that the attribute passed to the lang attribute is a correct ISO language and/or country."]
-    #[bpaf(long("use-valid-lang"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_valid_lang: Option<RuleConfiguration>,
 }
@@ -1187,153 +1101,87 @@ impl A11y {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Complexity {
     #[doc = r" It enables the recommended rules for this group"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub recommended: Option<bool>,
     #[doc = r" It enables ALL rules for this group."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub all: Option<bool>,
     #[doc = "Disallow primitive type aliases and misleading types."]
-    #[bpaf(long("no-banned-types"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_banned_types: Option<RuleConfiguration>,
     #[doc = "Disallow functions that exceed a given Cognitive Complexity score."]
-    #[bpaf(
-        long("no-excessive-cognitive-complexity"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_excessive_cognitive_complexity: Option<RuleConfiguration>,
     #[doc = "Disallow unnecessary boolean casts"]
-    #[bpaf(long("no-extra-boolean-cast"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_extra_boolean_cast: Option<RuleConfiguration>,
     #[doc = "Prefer for...of statement instead of Array.forEach."]
-    #[bpaf(long("no-for-each"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_for_each: Option<RuleConfiguration>,
     #[doc = "Disallow unclear usage of consecutive space characters in regular expression literals"]
-    #[bpaf(
-        long("no-multiple-spaces-in-regular-expression-literals"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_multiple_spaces_in_regular_expression_literals: Option<RuleConfiguration>,
     #[doc = "This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace."]
-    #[bpaf(long("no-static-only-class"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_static_only_class: Option<RuleConfiguration>,
     #[doc = "Disallow this and super in static contexts."]
-    #[bpaf(long("no-this-in-static"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_this_in_static: Option<RuleConfiguration>,
     #[doc = "Disallow unnecessary catch clauses."]
-    #[bpaf(long("no-useless-catch"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_catch: Option<RuleConfiguration>,
     #[doc = "Disallow unnecessary constructors."]
-    #[bpaf(
-        long("no-useless-constructor"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_constructor: Option<RuleConfiguration>,
     #[doc = "Disallow empty exports that don't change anything in a module file."]
-    #[bpaf(
-        long("no-useless-empty-export"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_empty_export: Option<RuleConfiguration>,
     #[doc = "Disallow unnecessary fragments"]
-    #[bpaf(long("no-useless-fragments"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_fragments: Option<RuleConfiguration>,
     #[doc = "Disallow unnecessary labels."]
-    #[bpaf(long("no-useless-label"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_label: Option<RuleConfiguration>,
     #[doc = "Disallow renaming import, export, and destructured assignments to the same name."]
-    #[bpaf(long("no-useless-rename"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_rename: Option<RuleConfiguration>,
     #[doc = "Disallow useless case in switch statements."]
-    #[bpaf(
-        long("no-useless-switch-case"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_switch_case: Option<RuleConfiguration>,
     #[doc = "Disallow useless this aliasing."]
-    #[bpaf(long("no-useless-this-alias"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_this_alias: Option<RuleConfiguration>,
     #[doc = "Disallow using any or unknown as type constraint."]
-    #[bpaf(
-        long("no-useless-type-constraint"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_type_constraint: Option<RuleConfiguration>,
     #[doc = "Disallow the use of void operators, which is not a familiar operator."]
-    #[bpaf(long("no-void"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_void: Option<RuleConfiguration>,
     #[doc = "Disallow with statements in non-strict contexts."]
-    #[bpaf(long("no-with"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_with: Option<RuleConfiguration>,
     #[doc = "Use arrow functions over function expressions."]
-    #[bpaf(long("use-arrow-function"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_arrow_function: Option<RuleConfiguration>,
     #[doc = "Promotes the use of .flatMap() when map().flat() are used together."]
-    #[bpaf(long("use-flat-map"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_flat_map: Option<RuleConfiguration>,
     #[doc = "Enforce the usage of a literal access to properties over computed property access."]
-    #[bpaf(long("use-literal-keys"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_literal_keys: Option<RuleConfiguration>,
     #[doc = "Enforce using concise optional chain instead of chained logical expressions."]
-    #[bpaf(long("use-optional-chain"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_optional_chain: Option<RuleConfiguration>,
     #[doc = "Disallow number literal object member names which are not base10 or uses underscore as separator"]
-    #[bpaf(
-        long("use-simple-number-keys"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_simple_number_keys: Option<RuleConfiguration>,
     #[doc = "Discard redundant terms from logical expressions."]
-    #[bpaf(
-        long("use-simplified-logic-expression"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_simplified_logic_expression: Option<RuleConfiguration>,
 }
@@ -1855,219 +1703,114 @@ impl Complexity {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Correctness {
     #[doc = r" It enables the recommended rules for this group"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub recommended: Option<bool>,
     #[doc = r" It enables ALL rules for this group."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub all: Option<bool>,
     #[doc = "Prevent passing of children as props."]
-    #[bpaf(long("no-children-prop"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_children_prop: Option<RuleConfiguration>,
     #[doc = "Prevents from having const variables being re-assigned."]
-    #[bpaf(long("no-const-assign"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_const_assign: Option<RuleConfiguration>,
     #[doc = "Disallow constant expressions in conditions"]
-    #[bpaf(long("no-constant-condition"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_constant_condition: Option<RuleConfiguration>,
     #[doc = "Disallow returning a value from a constructor."]
-    #[bpaf(long("no-constructor-return"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_constructor_return: Option<RuleConfiguration>,
     #[doc = "Disallow empty character classes in regular expression literals."]
-    #[bpaf(
-        long("no-empty-character-class-in-regex"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_empty_character_class_in_regex: Option<RuleConfiguration>,
     #[doc = "Disallows empty destructuring patterns."]
-    #[bpaf(long("no-empty-pattern"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_empty_pattern: Option<RuleConfiguration>,
     #[doc = "Disallow calling global object properties as functions"]
-    #[bpaf(
-        long("no-global-object-calls"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_global_object_calls: Option<RuleConfiguration>,
     #[doc = "Disallow function and var declarations that are accessible outside their block."]
-    #[bpaf(long("no-inner-declarations"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_inner_declarations: Option<RuleConfiguration>,
     #[doc = "Prevents the incorrect use of super() inside classes. It also checks whether a call super() is missing from classes that extends other constructors."]
-    #[bpaf(
-        long("no-invalid-constructor-super"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_invalid_constructor_super: Option<RuleConfiguration>,
     #[doc = "Disallow new operators with global non-constructor functions."]
-    #[bpaf(
-        long("no-invalid-new-builtin"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_invalid_new_builtin: Option<RuleConfiguration>,
     #[doc = "Disallow new operators with the Symbol object."]
-    #[bpaf(long("no-new-symbol"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_new_symbol: Option<RuleConfiguration>,
     #[doc = "Disallow \\8 and \\9 escape sequences in string literals."]
-    #[bpaf(
-        long("no-nonoctal-decimal-escape"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_nonoctal_decimal_escape: Option<RuleConfiguration>,
     #[doc = "Disallow literal numbers that lose precision"]
-    #[bpaf(long("no-precision-loss"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_precision_loss: Option<RuleConfiguration>,
     #[doc = "Prevent the usage of the return value of React.render."]
-    #[bpaf(
-        long("no-render-return-value"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_render_return_value: Option<RuleConfiguration>,
     #[doc = "Disallow assignments where both sides are exactly the same."]
-    #[bpaf(long("no-self-assign"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_self_assign: Option<RuleConfiguration>,
     #[doc = "Disallow returning a value from a setter"]
-    #[bpaf(long("no-setter-return"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_setter_return: Option<RuleConfiguration>,
     #[doc = "Disallow comparison of expressions modifying the string case with non-compliant value."]
-    #[bpaf(
-        long("no-string-case-mismatch"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_string_case_mismatch: Option<RuleConfiguration>,
     #[doc = "Disallow lexical declarations in switch clauses."]
-    #[bpaf(
-        long("no-switch-declarations"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_switch_declarations: Option<RuleConfiguration>,
     #[doc = "Prevents the usage of variables that haven't been declared inside the document."]
-    #[bpaf(
-        long("no-undeclared-variables"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_undeclared_variables: Option<RuleConfiguration>,
     #[doc = "Avoid using unnecessary continue."]
-    #[bpaf(
-        long("no-unnecessary-continue"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_unnecessary_continue: Option<RuleConfiguration>,
     #[doc = "Disallow unreachable code"]
-    #[bpaf(long("no-unreachable"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_unreachable: Option<RuleConfiguration>,
     #[doc = "Ensures the super() constructor is called exactly once on every code  path in a class constructor before this is accessed if the class has a superclass"]
-    #[bpaf(long("no-unreachable-super"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_unreachable_super: Option<RuleConfiguration>,
     #[doc = "Disallow control flow statements in finally blocks."]
-    #[bpaf(long("no-unsafe-finally"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_unsafe_finally: Option<RuleConfiguration>,
     #[doc = "Disallow the use of optional chaining in contexts where the undefined value is not allowed."]
-    #[bpaf(
-        long("no-unsafe-optional-chaining"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_unsafe_optional_chaining: Option<RuleConfiguration>,
     #[doc = "Disallow unused labels."]
-    #[bpaf(long("no-unused-labels"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_unused_labels: Option<RuleConfiguration>,
     #[doc = "Disallow unused variables."]
-    #[bpaf(long("no-unused-variables"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_unused_variables: Option<RuleConfiguration>,
     #[doc = "This rules prevents void elements (AKA self-closing elements) from having children."]
-    #[bpaf(
-        long("no-void-elements-with-children"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_void_elements_with_children: Option<RuleConfiguration>,
     #[doc = "Disallow returning a value from a function with the return type 'void'"]
-    #[bpaf(long("no-void-type-return"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_void_type_return: Option<RuleConfiguration>,
     #[doc = "Enforce all dependencies are correctly specified in a React hook."]
-    #[bpaf(
-        long("use-exhaustive-dependencies"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_exhaustive_dependencies: Option<RuleConfiguration>,
     #[doc = "Enforce that all React hooks are being called from the Top Level component functions."]
-    #[bpaf(long("use-hook-at-top-level"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_hook_at_top_level: Option<RuleConfiguration>,
     #[doc = "Require calls to isNaN() when checking for NaN."]
-    #[bpaf(long("use-is-nan"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_is_nan: Option<RuleConfiguration>,
     #[doc = "Enforce \"for\" loop update clause moving the counter in the right direction."]
-    #[bpaf(
-        long("use-valid-for-direction"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_valid_for_direction: Option<RuleConfiguration>,
     #[doc = "Require generator functions to contain yield."]
-    #[bpaf(long("use-yield"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_yield: Option<RuleConfiguration>,
 }
@@ -2738,156 +2481,78 @@ impl Correctness {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Nursery {
     #[doc = r" It enables the recommended rules for this group"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub recommended: Option<bool>,
     #[doc = r" It enables ALL rules for this group."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub all: Option<bool>,
     #[doc = "Enforce that aria-hidden=\"true\" is not set on focusable elements."]
-    #[bpaf(
-        long("no-aria-hidden-on-focusable"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_aria_hidden_on_focusable: Option<RuleConfiguration>,
     #[doc = "Disallow default exports."]
-    #[bpaf(long("no-default-export"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_default_export: Option<RuleConfiguration>,
     #[doc = "Disallow two keys with the same name inside a JSON object."]
-    #[bpaf(
-        long("no-duplicate-json-keys"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_duplicate_json_keys: Option<RuleConfiguration>,
     #[doc = "Disallow empty block statements and static blocks."]
-    #[bpaf(
-        long("no-empty-block-statements"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_empty_block_statements: Option<RuleConfiguration>,
     #[doc = "Disallow use of implicit any type on variable declarations."]
-    #[bpaf(long("no-implicit-any-let"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_implicit_any_let: Option<RuleConfiguration>,
     #[doc = "Disallow the use of variables and function parameters before their declaration"]
-    #[bpaf(
-        long("no-invalid-use-before-declaration"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_invalid_use_before_declaration: Option<RuleConfiguration>,
     #[doc = "Disallow characters made with multiple code points in character class syntax."]
-    #[bpaf(
-        long("no-misleading-character-class"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_misleading_character_class: Option<RuleConfiguration>,
     #[doc = "Forbid the use of Node.js builtin modules. Can be useful for client-side web projects that do not have access to those modules."]
-    #[bpaf(long("no-nodejs-modules"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_nodejs_modules: Option<RuleConfiguration>,
     #[doc = "Disallow unused imports."]
-    #[bpaf(long("no-unused-imports"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_unused_imports: Option<RuleConfiguration>,
     #[doc = "Disallow unused private class members"]
-    #[bpaf(
-        long("no-unused-private-class-members"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_unused_private_class_members: Option<RuleConfiguration>,
     #[doc = "Disallow unnecessary nested block statements."]
-    #[bpaf(
-        long("no-useless-lone-block-statements"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_lone_block_statements: Option<RuleConfiguration>,
     #[doc = "Disallow ternary operators when simpler alternatives exist."]
-    #[bpaf(long("no-useless-ternary"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_ternary: Option<RuleConfiguration>,
     #[doc = "Ensure async functions utilize await."]
-    #[bpaf(long("use-await"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_await: Option<RuleConfiguration>,
     #[doc = "Promotes the use of export type for types."]
-    #[bpaf(long("use-export-type"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_export_type: Option<RuleConfiguration>,
     #[doc = "This rule recommends a for-of loop when in a for loop, the index used to extract an item from the iterated array."]
-    #[bpaf(long("use-for-of"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_for_of: Option<RuleConfiguration>,
     #[doc = "Enforce the use of import type when an import only has specifiers with type qualifier."]
-    #[bpaf(
-        long("use-grouped-type-import"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_grouped_type_import: Option<RuleConfiguration>,
     #[doc = "Disallows package private imports."]
-    #[bpaf(
-        long("use-import-restrictions"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_import_restrictions: Option<RuleConfiguration>,
     #[doc = "Enforces using the node: protocol for Node.js builtin modules."]
-    #[bpaf(
-        long("use-node-import-protocol"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_node_import_protocol: Option<RuleConfiguration>,
     #[doc = "Enforce the use of the regular expression literals instead of the RegExp constructor if possible."]
-    #[bpaf(long("use-regex-literals"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_regex_literals: Option<RuleConfiguration>,
     #[doc = "Enforce using function types instead of object type with call signatures."]
-    #[bpaf(
-        long("use-shorthand-function-type"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_shorthand_function_type: Option<RuleConfiguration>,
     #[doc = "Elements with ARIA roles must use a valid, non-abstract ARIA role."]
-    #[bpaf(long("use-valid-aria-role"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_valid_aria_role: Option<RuleConfiguration>,
 }
@@ -3324,30 +2989,21 @@ impl Nursery {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Performance {
     #[doc = r" It enables the recommended rules for this group"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub recommended: Option<bool>,
     #[doc = r" It enables ALL rules for this group."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub all: Option<bool>,
     #[doc = "Disallow the use of spread (...) syntax on accumulators."]
-    #[bpaf(
-        long("no-accumulating-spread"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_accumulating_spread: Option<RuleConfiguration>,
     #[doc = "Disallow the use of the delete operator."]
-    #[bpaf(long("no-delete"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_delete: Option<RuleConfiguration>,
 }
@@ -3462,35 +3118,21 @@ impl Performance {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Security {
     #[doc = r" It enables the recommended rules for this group"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub recommended: Option<bool>,
     #[doc = r" It enables ALL rules for this group."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub all: Option<bool>,
     #[doc = "Prevent the usage of dangerous JSX props"]
-    #[bpaf(
-        long("no-dangerously-set-inner-html"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_dangerously_set_inner_html: Option<RuleConfiguration>,
     #[doc = "Report when a DOM element or a component uses both children and dangerouslySetInnerHTML prop."]
-    #[bpaf(
-        long("no-dangerously-set-inner-html-with-children"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_dangerously_set_inner_html_with_children: Option<RuleConfiguration>,
 }
@@ -3616,195 +3258,111 @@ impl Security {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Style {
     #[doc = r" It enables the recommended rules for this group"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub recommended: Option<bool>,
     #[doc = r" It enables ALL rules for this group."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub all: Option<bool>,
     #[doc = "Disallow the use of arguments"]
-    #[bpaf(long("no-arguments"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_arguments: Option<RuleConfiguration>,
     #[doc = "Disallow comma operator."]
-    #[bpaf(long("no-comma-operator"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_comma_operator: Option<RuleConfiguration>,
     #[doc = "Disallow implicit true values on JSX boolean attributes"]
-    #[bpaf(long("no-implicit-boolean"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_implicit_boolean: Option<RuleConfiguration>,
     #[doc = "Disallow type annotations for variables, parameters, and class properties initialized with a literal expression."]
-    #[bpaf(long("no-inferrable-types"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_inferrable_types: Option<RuleConfiguration>,
     #[doc = "Disallow the use of TypeScript's namespaces."]
-    #[bpaf(long("no-namespace"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_namespace: Option<RuleConfiguration>,
     #[doc = "Disallow negation in the condition of an if statement if it has an else clause."]
-    #[bpaf(long("no-negation-else"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_negation_else: Option<RuleConfiguration>,
     #[doc = "Disallow non-null assertions using the ! postfix operator."]
-    #[bpaf(long("no-non-null-assertion"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_non_null_assertion: Option<RuleConfiguration>,
     #[doc = "Disallow reassigning function parameters."]
-    #[bpaf(long("no-parameter-assign"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_parameter_assign: Option<RuleConfiguration>,
     #[doc = "Disallow the use of parameter properties in class constructors."]
-    #[bpaf(
-        long("no-parameter-properties"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_parameter_properties: Option<RuleConfiguration>,
     #[doc = "This rule allows you to specify global variable names that you don’t want to use in your application."]
-    #[bpaf(long("no-restricted-globals"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_restricted_globals: Option<RuleConfiguration>,
     #[doc = "Disallow the use of constants which its value is the upper-case version of its name."]
-    #[bpaf(long("no-shouty-constants"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_shouty_constants: Option<RuleConfiguration>,
     #[doc = "Disallow template literals if interpolation and special-character handling are not needed"]
-    #[bpaf(
-        long("no-unused-template-literal"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_unused_template_literal: Option<RuleConfiguration>,
     #[doc = "Disallow else block when the if block breaks early."]
-    #[bpaf(long("no-useless-else"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_else: Option<RuleConfiguration>,
     #[doc = "Disallow the use of var"]
-    #[bpaf(long("no-var"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_var: Option<RuleConfiguration>,
     #[doc = "Enforce the use of as const over literal type and type annotation."]
-    #[bpaf(
-        long("use-as-const-assertion"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_as_const_assertion: Option<RuleConfiguration>,
     #[doc = "Requires following curly brace conventions."]
-    #[bpaf(long("use-block-statements"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_block_statements: Option<RuleConfiguration>,
     #[doc = "Enforce using else if instead of nested if in else clauses."]
-    #[bpaf(long("use-collapsed-else-if"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_collapsed_else_if: Option<RuleConfiguration>,
     #[doc = "Require const declarations for variables that are never reassigned after declared."]
-    #[bpaf(long("use-const"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_const: Option<RuleConfiguration>,
     #[doc = "Enforce default function parameters and optional function parameters to be last."]
-    #[bpaf(
-        long("use-default-parameter-last"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_default_parameter_last: Option<RuleConfiguration>,
     #[doc = "Require that each enum member value be explicitly initialized."]
-    #[bpaf(long("use-enum-initializers"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_enum_initializers: Option<RuleConfiguration>,
     #[doc = "Disallow the use of Math.pow in favor of the ** operator."]
-    #[bpaf(
-        long("use-exponentiation-operator"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_exponentiation_operator: Option<RuleConfiguration>,
     #[doc = "This rule enforces the use of <>...</> over <Fragment>...</Fragment>."]
-    #[bpaf(long("use-fragment-syntax"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_fragment_syntax: Option<RuleConfiguration>,
     #[doc = "Require all enum members to be literal values."]
-    #[bpaf(
-        long("use-literal-enum-members"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_literal_enum_members: Option<RuleConfiguration>,
     #[doc = "Enforce naming conventions for everything across a codebase."]
-    #[bpaf(long("use-naming-convention"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_naming_convention: Option<RuleConfiguration>,
     #[doc = "Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals"]
-    #[bpaf(long("use-numeric-literals"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_numeric_literals: Option<RuleConfiguration>,
     #[doc = "Prevent extra closing tags for components without children"]
-    #[bpaf(
-        long("use-self-closing-elements"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_self_closing_elements: Option<RuleConfiguration>,
     #[doc = "When expressing array types, this rule promotes the usage of T[] shorthand instead of Array<T>."]
-    #[bpaf(
-        long("use-shorthand-array-type"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_shorthand_array_type: Option<RuleConfiguration>,
     #[doc = "Require assignment operator shorthand where possible."]
-    #[bpaf(long("use-shorthand-assign"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_shorthand_assign: Option<RuleConfiguration>,
     #[doc = "Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block."]
-    #[bpaf(
-        long("use-single-case-statement"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_single_case_statement: Option<RuleConfiguration>,
     #[doc = "Disallow multiple variable declarations in the same variable statement"]
-    #[bpaf(
-        long("use-single-var-declarator"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_single_var_declarator: Option<RuleConfiguration>,
     #[doc = "Prefer template literals over string concatenation."]
-    #[bpaf(long("use-template"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_template: Option<RuleConfiguration>,
     #[doc = "Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed."]
-    #[bpaf(long("use-while"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_while: Option<RuleConfiguration>,
 }
@@ -4439,278 +3997,147 @@ impl Style {
         }
     }
 }
-#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone, Bpaf)]
+#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Suspicious {
     #[doc = r" It enables the recommended rules for this group"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub recommended: Option<bool>,
     #[doc = r" It enables ALL rules for this group."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(hide)]
     pub all: Option<bool>,
     #[doc = "Usually, the definition in the standard library is more precise than what people come up with or the used constant exceeds the maximum precision of the number type."]
-    #[bpaf(
-        long("no-approximative-numeric-constant"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_approximative_numeric_constant: Option<RuleConfiguration>,
     #[doc = "Discourage the usage of Array index in keys."]
-    #[bpaf(long("no-array-index-key"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_array_index_key: Option<RuleConfiguration>,
     #[doc = "Disallow assignments in expressions."]
-    #[bpaf(
-        long("no-assign-in-expressions"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_assign_in_expressions: Option<RuleConfiguration>,
     #[doc = "Disallows using an async function as a Promise executor."]
-    #[bpaf(
-        long("no-async-promise-executor"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_async_promise_executor: Option<RuleConfiguration>,
     #[doc = "Disallow reassigning exceptions in catch clauses."]
-    #[bpaf(long("no-catch-assign"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_catch_assign: Option<RuleConfiguration>,
     #[doc = "Disallow reassigning class members."]
-    #[bpaf(long("no-class-assign"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_class_assign: Option<RuleConfiguration>,
     #[doc = "Prevent comments from being inserted as text nodes"]
-    #[bpaf(long("no-comment-text"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_comment_text: Option<RuleConfiguration>,
     #[doc = "Disallow comparing against -0"]
-    #[bpaf(long("no-compare-neg-zero"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_compare_neg_zero: Option<RuleConfiguration>,
     #[doc = "Disallow labeled statements that are not loops."]
-    #[bpaf(long("no-confusing-labels"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_confusing_labels: Option<RuleConfiguration>,
     #[doc = "Disallow void type outside of generic or return types."]
-    #[bpaf(
-        long("no-confusing-void-type"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_confusing_void_type: Option<RuleConfiguration>,
     #[doc = "Disallow the use of console.log"]
-    #[bpaf(long("no-console-log"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_console_log: Option<RuleConfiguration>,
     #[doc = "Disallow TypeScript const enum"]
-    #[bpaf(long("no-const-enum"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_const_enum: Option<RuleConfiguration>,
     #[doc = "Prevents from having control characters and some escape sequences that match control characters in regular expressions."]
-    #[bpaf(
-        long("no-control-characters-in-regex"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_control_characters_in_regex: Option<RuleConfiguration>,
     #[doc = "Disallow the use of debugger"]
-    #[bpaf(long("no-debugger"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_debugger: Option<RuleConfiguration>,
     #[doc = "Require the use of === and !=="]
-    #[bpaf(long("no-double-equals"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_double_equals: Option<RuleConfiguration>,
     #[doc = "Disallow duplicate case labels."]
-    #[bpaf(long("no-duplicate-case"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_duplicate_case: Option<RuleConfiguration>,
     #[doc = "Disallow duplicate class members."]
-    #[bpaf(
-        long("no-duplicate-class-members"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_duplicate_class_members: Option<RuleConfiguration>,
     #[doc = "Prevents JSX properties to be assigned multiple times."]
-    #[bpaf(
-        long("no-duplicate-jsx-props"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_duplicate_jsx_props: Option<RuleConfiguration>,
     #[doc = "Prevents object literals having more than one property declaration for the same name."]
-    #[bpaf(
-        long("no-duplicate-object-keys"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_duplicate_object_keys: Option<RuleConfiguration>,
     #[doc = "Disallow duplicate function parameter name."]
-    #[bpaf(
-        long("no-duplicate-parameters"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_duplicate_parameters: Option<RuleConfiguration>,
     #[doc = "Disallow the declaration of empty interfaces."]
-    #[bpaf(long("no-empty-interface"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_empty_interface: Option<RuleConfiguration>,
     #[doc = "Disallow the any type usage."]
-    #[bpaf(long("no-explicit-any"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_explicit_any: Option<RuleConfiguration>,
     #[doc = "Prevents the wrong usage of the non-null assertion operator (!) in TypeScript files."]
-    #[bpaf(
-        long("no-extra-non-null-assertion"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_extra_non_null_assertion: Option<RuleConfiguration>,
     #[doc = "Disallow fallthrough of switch clauses."]
-    #[bpaf(
-        long("no-fallthrough-switch-clause"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_fallthrough_switch_clause: Option<RuleConfiguration>,
     #[doc = "Disallow reassigning function declarations."]
-    #[bpaf(long("no-function-assign"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_function_assign: Option<RuleConfiguration>,
     #[doc = "Use Number.isFinite instead of global isFinite."]
-    #[bpaf(long("no-global-is-finite"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_global_is_finite: Option<RuleConfiguration>,
     #[doc = "Use Number.isNaN instead of global isNaN."]
-    #[bpaf(long("no-global-is-nan"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_global_is_nan: Option<RuleConfiguration>,
     #[doc = "Disallow assigning to imported bindings"]
-    #[bpaf(long("no-import-assign"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_import_assign: Option<RuleConfiguration>,
     #[doc = "Disallow labels that share a name with a variable"]
-    #[bpaf(long("no-label-var"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_label_var: Option<RuleConfiguration>,
     #[doc = "Enforce proper usage of new and constructor."]
-    #[bpaf(
-        long("no-misleading-instantiator"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_misleading_instantiator: Option<RuleConfiguration>,
     #[doc = "Disallow shorthand assign when variable appears on both sides."]
-    #[bpaf(
-        long("no-misrefactored-shorthand-assign"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_misrefactored_shorthand_assign: Option<RuleConfiguration>,
     #[doc = "Disallow direct use of Object.prototype builtins."]
-    #[bpaf(long("no-prototype-builtins"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_prototype_builtins: Option<RuleConfiguration>,
     #[doc = "Disallow variable, function, class, and type redeclarations in the same scope."]
-    #[bpaf(long("no-redeclare"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_redeclare: Option<RuleConfiguration>,
     #[doc = "Prevents from having redundant \"use strict\"."]
-    #[bpaf(
-        long("no-redundant-use-strict"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_redundant_use_strict: Option<RuleConfiguration>,
     #[doc = "Disallow comparisons where both sides are exactly the same."]
-    #[bpaf(long("no-self-compare"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_self_compare: Option<RuleConfiguration>,
     #[doc = "Disallow identifiers from shadowing restricted names."]
-    #[bpaf(
-        long("no-shadow-restricted-names"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_shadow_restricted_names: Option<RuleConfiguration>,
     #[doc = "Disallow sparse arrays"]
-    #[bpaf(long("no-sparse-array"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_sparse_array: Option<RuleConfiguration>,
     #[doc = "Disallow unsafe declaration merging between interfaces and classes."]
-    #[bpaf(
-        long("no-unsafe-declaration-merging"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_unsafe_declaration_merging: Option<RuleConfiguration>,
     #[doc = "Disallow using unsafe negation."]
-    #[bpaf(long("no-unsafe-negation"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_unsafe_negation: Option<RuleConfiguration>,
     #[doc = "Enforce default clauses in switch statements to be last"]
-    #[bpaf(
-        long("use-default-switch-clause-last"),
-        argument("on|off|warn"),
-        optional,
-        hide
-    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_default_switch_clause_last: Option<RuleConfiguration>,
     #[doc = "Enforce get methods to always return a value."]
-    #[bpaf(long("use-getter-return"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_getter_return: Option<RuleConfiguration>,
     #[doc = "Use Array.isArray() instead of instanceof Array."]
-    #[bpaf(long("use-is-array"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_is_array: Option<RuleConfiguration>,
     #[doc = "Require using the namespace keyword over the module keyword to declare TypeScript namespaces."]
-    #[bpaf(long("use-namespace-keyword"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_namespace_keyword: Option<RuleConfiguration>,
     #[doc = "This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions"]
-    #[bpaf(long("use-valid-typeof"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_valid_typeof: Option<RuleConfiguration>,
 }

--- a/crates/biome_service/src/configuration/overrides.rs
+++ b/crates/biome_service/src/configuration/overrides.rs
@@ -1,5 +1,4 @@
 use crate::configuration::formatter::{deserialize_line_width, serialize_line_width};
-use crate::configuration::linter::rules;
 use crate::configuration::{
     css_configuration, javascript_configuration, json_configuration, CssConfiguration,
     JavascriptConfiguration, JsonConfiguration, PlainIndentStyle,
@@ -280,7 +279,7 @@ pub struct OverrideLinterConfiguration {
 
     /// List of rules
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(external, optional, hide)]
+    #[bpaf(pure(Rules::default()), optional, hide)]
     pub rules: Option<Rules>,
 }
 

--- a/crates/biome_service/src/configuration/parse/json/linter.rs
+++ b/crates/biome_service/src/configuration/parse/json/linter.rs
@@ -114,7 +114,7 @@ impl DeserializationVisitor for RuleConfigurationVisitor {
                 )),
             }
         }
-        Some(RuleConfiguration::WithOptions(result))
+        Some(RuleConfiguration::WithOptions(Box::new(result)))
     }
 }
 


### PR DESCRIPTION
## Summary

Part of #1263.

This PR reduces by 53% (from 8440 bytes to 3976 bytes) the memory usage of `biome.json`.

Most of the memory usage comes from the `RuleConfiguration` type (40 bytes) that is present for every rule. `RuleConfiguration` is an enum with two variants, thus it takes the size of its biggest variant: `RuleWithOptions`. Most of the rules have no options, so this is just a waste of memory. This PR replace `RuleWithOptions` with `Box<RuleWithOptions>`. This allows reducing `RuleConfiguration` from 40 bytes to 16 bytes. It is not an ideal fix because `Box` incurs a heap allocation. However, this only happen when configuring a rule with options (we only have a few one at the moment).

Alternatively, we could add lifetime annotations on every config struct/enums and use a reference instead of a `Box`.

Another solution could be of exposing the option type of every rule (most of them the type is the unit type `()`) and using it in a generic `RuleConfiguration` type:

```rs
pub enum RuleConfiguration<T> {
    Plain(RulePlainConfiguration),
    WithOptions(T),
}
```

Note: I had to remove Bpaf for rules' configuration because it doesn't support `Box`.

## Test Plan

CI and local test with the CLI.
