### PR TITLE
feat(css_formatter): formatting for functions and parameters

### DIFF
--- a/crates/biome_css_formatter/src/css/auxiliary/any_function.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/any_function.rs
@@ -1,10 +1,16 @@
 use crate::prelude::*;
-use biome_css_syntax::CssAnyFunction;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssAnyFunction, CssAnyFunctionFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssAnyFunction;
 impl FormatNodeRule<CssAnyFunction> for FormatCssAnyFunction {
+    // TODO: This is really `AnyCssFunction` and will probably get moved to be that later.
     fn fmt_fields(&self, node: &CssAnyFunction, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssAnyFunctionFields {
+            css_simple_function,
+        } = node.as_fields();
+
+        write!(f, [css_simple_function.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/parameter.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/parameter.rs
@@ -1,10 +1,15 @@
 use crate::prelude::*;
-use biome_css_syntax::CssParameter;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssParameter, CssParameterFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssParameter;
 impl FormatNodeRule<CssParameter> for FormatCssParameter {
     fn fmt_fields(&self, node: &CssParameter, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssParameterFields {
+            css_component_value_list,
+        } = node.as_fields();
+
+        write!(f, [css_component_value_list.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/simple_function.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/simple_function.rs
@@ -1,10 +1,26 @@
 use crate::prelude::*;
-use biome_css_syntax::CssSimpleFunction;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssSimpleFunction, CssSimpleFunctionFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssSimpleFunction;
 impl FormatNodeRule<CssSimpleFunction> for FormatCssSimpleFunction {
     fn fmt_fields(&self, node: &CssSimpleFunction, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssSimpleFunctionFields {
+            name,
+            l_paren_token,
+            items,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                name.format(),
+                l_paren_token.format(),
+                group(&soft_block_indent(&items.format())),
+                r_paren_token.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/lists/component_value_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/component_value_list.rs
@@ -1,10 +1,63 @@
-use crate::prelude::*;
+use crate::{comments::CssComments, prelude::*};
 use biome_css_syntax::CssComponentValueList;
+use biome_formatter::{write, CstFormatContext};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssComponentValueList;
 impl FormatRule<CssComponentValueList> for FormatCssComponentValueList {
     type Context = CssFormatContext;
+
     fn fmt(&self, node: &CssComponentValueList, f: &mut CssFormatter) -> FormatResult<()> {
-        f.join().entries(node.iter().formatted()).finish()
+        let layout = get_value_list_layout(node, f.context().comments());
+
+        match layout {
+            ValueListLayout::Fill => {
+                let values = format_with(|f: &mut Formatter<'_, CssFormatContext>| {
+                    f.fill()
+                        .entries(&soft_line_break_or_space(), node.iter().formatted())
+                        .finish()
+                });
+
+                write!(f, [group(&indent(&values))])
+            }
+            // TODO: Add formatting for one-per-line once comma-separated lists are supported.
+            ValueListLayout::OnePerLine => write!(f, [format_verbatim_node(node.syntax())]),
+        }
     }
+}
+
+#[derive(Copy, Clone, Debug)]
+enum ValueListLayout {
+    /// Tries to fit as many values on a single line as possible, then wraps
+    /// and indents the next line to keep filling on that line, and so on.
+    ///
+    /// ```css
+    /// background: red blue white
+    ///     green orange rgba(0, 0, 0, 1)
+    ///     black blue;
+    /// ```
+    Fill,
+
+    /// Prints every value on a single line if the whole list exceeds the line
+    /// width, or any of its elements gets printed in *expanded* mode.
+    /// ```css
+    /// font-family:
+    ///     "Lato",
+    ///     -apple-system,
+    ///     "Helvetica Neue",
+    ///     Helvetica,
+    ///     Arial,
+    ///     sans-serif;
+    /// ```
+    #[allow(unused)]
+    OnePerLine,
+}
+
+/// Returns the layout to use when printing the provided CssComponentValueList.
+/// Until the parser supports comma-separated lists, this will always return
+/// [ValueListLayout::Fill], since all space-separated lists are intentionally
+/// printed compactly.
+fn get_value_list_layout(_list: &CssComponentValueList, _: &CssComments) -> ValueListLayout {
+    // TODO: Check for comments, check for the types of elements in the list, etc.
+    ValueListLayout::Fill
 }

--- a/crates/biome_css_formatter/src/css/lists/declaration_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/declaration_list.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, separated::FormatAstSeparatedListExtension};
+use crate::prelude::*;
 use biome_css_syntax::CssDeclarationList;
 use biome_formatter::separated::TrailingSeparator;
 #[derive(Debug, Clone, Default)]

--- a/crates/biome_css_formatter/src/css/lists/parameter_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/parameter_list.rs
@@ -1,10 +1,17 @@
 use crate::prelude::*;
 use biome_css_syntax::CssParameterList;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssParameterList;
 impl FormatRule<CssParameterList> for FormatCssParameterList {
     type Context = CssFormatContext;
     fn fmt(&self, node: &CssParameterList, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let mut joiner = f.join_nodes_with_soft_line();
+
+        for (rule, formatted) in node.elements().zip(node.format_separated(",")) {
+            joiner.entry(rule.node()?.syntax(), &formatted);
+        }
+
+        joiner.finish()
     }
 }

--- a/crates/biome_css_formatter/src/css/lists/selector_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/selector_list.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, separated::FormatAstSeparatedListExtension};
+use crate::prelude::*;
 use biome_css_syntax::CssSelectorList;
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssSelectorList;

--- a/crates/biome_css_formatter/src/prelude.rs
+++ b/crates/biome_css_formatter/src/prelude.rs
@@ -8,3 +8,5 @@ pub(crate) use crate::{
 pub(crate) use biome_formatter::prelude::*;
 #[allow(unused_imports)]
 pub(crate) use biome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};
+
+pub(crate) use crate::separated::FormatAstSeparatedListExtension;

--- a/crates/biome_css_formatter/tests/quick_test.rs
+++ b/crates/biome_css_formatter/tests/quick_test.rs
@@ -1,27 +1,28 @@
 use biome_css_formatter::context::CssFormatOptions;
 use biome_css_formatter::format_node;
 use biome_css_parser::{parse_css, CssParserOptions};
+use biome_formatter::{IndentStyle, LineWidth};
 use biome_formatter_test::check_reformat::CheckReformat;
 
 mod language {
     include!("language.rs");
 }
 
-#[ignore]
+// #[ignore]
 #[test]
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
     let src = r#"
-
-    div
-    
-    span, span p {
-        font-size: 12px;
+    div {
+        a: 4px;
     }
 "#;
     let parse = parse_css(src, CssParserOptions::default());
+    println!("{:#?}", parse.syntax());
 
-    let options = CssFormatOptions::default();
+    let options = CssFormatOptions::default()
+        .with_line_width(LineWidth::try_from(40).unwrap())
+        .with_indent_style(IndentStyle::Space);
     let doc = format_node(options.clone(), &parse.syntax()).unwrap();
     let result = doc.print().unwrap();
 

--- a/crates/biome_css_formatter/tests/specs/css/functions.css
+++ b/crates/biome_css_formatter/tests/specs/css/functions.css
@@ -1,0 +1,12 @@
+div {
+    color: rgba(255, 255, 255, 1);
+    color:   rgba   (
+        0,
+        1,
+        255,
+        1
+    );
+    color: arbitrary(really long list, of complex parameter values, each one on its own line);
+    color: more-arbitrary(just, has, lots, of, individual, parameters, breaking, over, lines);
+    color: arbitrary(one really long parameter value that itself will break over multiple lines and fill together);
+}

--- a/crates/biome_css_formatter/tests/specs/css/functions.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/functions.css.snap
@@ -1,0 +1,64 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/functions.css
+---
+
+# Input
+
+```css
+div {
+    color: rgba(255, 255, 255, 1);
+    color:   rgba   (
+        0,
+        1,
+        255,
+        1
+    );
+    color: arbitrary(really long list, of complex parameter values, each one on its own line);
+    color: more-arbitrary(just, has, lots, of, individual, parameters, breaking, over, lines);
+    color: arbitrary(one really long parameter value that itself will break over multiple lines and fill together);
+}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+div {
+	color: rgba(255, 255, 255, 1);
+	color: rgba(0, 1, 255, 1);
+	color: arbitrary(
+			really long list,
+			of complex parameter values,
+			each one on its own line
+		);
+	color: more-arbitrary(
+			just,
+			has,
+			lots,
+			of,
+			individual,
+			parameters,
+			breaking,
+			over,
+			lines
+		);
+	color: arbitrary(
+			one really long parameter value that itself will break over multiple lines
+				and fill together
+		);
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/units.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/units.css.snap
@@ -90,7 +90,7 @@ Line width: 80
 	a: 5deg;
 	a: 5grad;
 	a: 5rad;
-	a: 5s;
+	a: 5 s;
 	a: 5ms;
 	a: 5hz;
 	a: 5khz;

--- a/crates/biome_css_formatter/tests/specs/css/value_fill.css
+++ b/crates/biome_css_formatter/tests/specs/css/value_fill.css
@@ -1,0 +1,3 @@
+div {
+    background: one really long list of values that keeps going onandon and on farbeyondthe linewidth and fillingon each line like it just keeps going and going forever onward intothenight;
+  }

--- a/crates/biome_css_formatter/tests/specs/css/value_fill.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/value_fill.css.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/value_fill.css
+---
+
+# Input
+
+```css
+div {
+    background: one really long list of values that keeps going onandon and on farbeyondthe linewidth and fillingon each line like it just keeps going and going forever onward intothenight;
+  }
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+div {
+	background: one really long list of values that keeps going onandon and on
+		farbeyondthe linewidth and fillingon each line like it just keeps going and
+		going forever onward intothenight;
+}
+```
+
+


### PR DESCRIPTION
## Summary

#1285. This implements formatting for "component values" - basically everything on the right side of the `:` in a declaration. Nothing too complex for now, but it sets up the `component_value_list` to be able to support `Fill` and `OnePerLine` modes separately (just like `array_element_list` in JS), which will be needed once the parser supports comma-separated lists. Then there will also need to be more logic to decide which layout gets used as well.

## Test Plan

Added tests for value fills in general and covering the different structures that functions can have (single/multi parameters, simple/complex values).