### PR TITLE
feat(css_formatter): support for pseudo selectors

### DIFF
--- a/crates/biome_css_formatter/src/css/auxiliary/nth_offset.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/nth_offset.rs
@@ -1,10 +1,13 @@
 use crate::prelude::*;
-use biome_css_syntax::CssNthOffset;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssNthOffset, CssNthOffsetFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssNthOffset;
 impl FormatNodeRule<CssNthOffset> for FormatCssNthOffset {
     fn fmt_fields(&self, node: &CssNthOffset, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssNthOffsetFields { sign, value } = node.as_fields();
+
+        write!(f, [sign.format(), space(), value.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/rule.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/rule.rs
@@ -7,6 +7,15 @@ impl FormatNodeRule<CssRule> for FormatCssRule {
     fn fmt_fields(&self, node: &CssRule, f: &mut CssFormatter) -> FormatResult<()> {
         let CssRuleFields { prelude, block } = node.as_fields();
 
-        write!(f, [group(&prelude.format()), space(), &block?.format()])
+        write!(
+            f,
+            [
+                // The selector list gets expanded so that every selector
+                // appears on its own line, no matter how long they are.
+                group(&prelude.format()).should_expand(true),
+                space(),
+                &block?.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/lists/compound_selector_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/compound_selector_list.rs
@@ -5,6 +5,22 @@ pub(crate) struct FormatCssCompoundSelectorList;
 impl FormatRule<CssCompoundSelectorList> for FormatCssCompoundSelectorList {
     type Context = CssFormatContext;
     fn fmt(&self, node: &CssCompoundSelectorList, f: &mut CssFormatter) -> FormatResult<()> {
-        f.join().entries(node.iter().formatted()).finish()
+        let mut joiner = f.join_nodes_with_soft_line();
+
+        for (rule, formatted) in node.elements().zip(node.format_separated(",")) {
+            // Each selector gets `indent` added in case it breaks over multiple
+            // lines. The break is added here rather than in each selector both
+            // for simplicity and to avoid recursively adding indents when
+            // selectors are nested within other rules. The group is then added
+            // around the indent to ensure that it tries using a flat layout
+            // first and only expands when the single selector can't fit the line.
+            //
+            // For example, a selector like `div span a` is structured like
+            // `[div, [span, [a]]]`, so `a` would end up double-indented if it
+            // was handled by the selector rather than here.
+            joiner.entry(rule.node()?.syntax(), &group(&indent(&formatted)));
+        }
+
+        joiner.finish()
     }
 }

--- a/crates/biome_css_formatter/src/css/lists/pseudo_value_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/pseudo_value_list.rs
@@ -1,10 +1,17 @@
 use crate::prelude::*;
 use biome_css_syntax::CssPseudoValueList;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoValueList;
 impl FormatRule<CssPseudoValueList> for FormatCssPseudoValueList {
     type Context = CssFormatContext;
     fn fmt(&self, node: &CssPseudoValueList, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let mut joiner = f.join_nodes_with_soft_line();
+
+        for (rule, formatted) in node.elements().zip(node.format_separated(",")) {
+            joiner.entry(rule.node()?.syntax(), &formatted);
+        }
+
+        joiner.finish()
     }
 }

--- a/crates/biome_css_formatter/src/css/lists/relative_selector_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/relative_selector_list.rs
@@ -1,10 +1,27 @@
 use crate::prelude::*;
 use biome_css_syntax::CssRelativeSelectorList;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssRelativeSelectorList;
 impl FormatRule<CssRelativeSelectorList> for FormatCssRelativeSelectorList {
     type Context = CssFormatContext;
     fn fmt(&self, node: &CssRelativeSelectorList, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let mut joiner = f.join_nodes_with_soft_line();
+
+        for (rule, formatted) in node.elements().zip(node.format_separated(",")) {
+            // Each selector gets `indent` added in case it breaks over multiple
+            // lines. The break is added here rather than in each selector both
+            // for simplicity and to avoid recursively adding indents when
+            // selectors are nested within other rules. The group is then added
+            // around the indent to ensure that it tries using a flat layout
+            // first and only expands when the single selector can't fit the line.
+            //
+            // For example, a selector like `div span a` is structured like
+            // `[div, [span, [a]]]`, so `a` would end up double-indented if it
+            // was handled by the selector rather than here.
+            joiner.entry(rule.node()?.syntax(), &group(&indent(&formatted)));
+        }
+
+        joiner.finish()
     }
 }

--- a/crates/biome_css_formatter/src/css/lists/selector_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/selector_list.rs
@@ -1,11 +1,12 @@
 use crate::prelude::*;
 use biome_css_syntax::CssSelectorList;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssSelectorList;
 impl FormatRule<CssSelectorList> for FormatCssSelectorList {
     type Context = CssFormatContext;
     fn fmt(&self, node: &CssSelectorList, f: &mut CssFormatter) -> FormatResult<()> {
-        let mut joiner = f.join_nodes_with_hardline();
+        let mut joiner = f.join_nodes_with_soft_line();
 
         for (rule, formatted) in node.elements().zip(node.format_separated(",")) {
             // Each selector gets `indent` added in case it breaks over multiple

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_compound_selector_list.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_compound_selector_list.rs
@@ -1,6 +1,9 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassFunctionCompoundSelectorList;
-use biome_rowan::AstNode;
+use biome_css_syntax::{
+    CssPseudoClassFunctionCompoundSelectorList, CssPseudoClassFunctionCompoundSelectorListFields,
+};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassFunctionCompoundSelectorList;
 impl FormatNodeRule<CssPseudoClassFunctionCompoundSelectorList>
@@ -11,6 +14,23 @@ impl FormatNodeRule<CssPseudoClassFunctionCompoundSelectorList>
         node: &CssPseudoClassFunctionCompoundSelectorList,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassFunctionCompoundSelectorListFields {
+            name,
+            l_paren_token,
+            compound_selector_list,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                name.format(),
+                group(&format_args![
+                    l_paren_token.format(),
+                    soft_block_indent(&compound_selector_list.format()),
+                    r_paren_token.format()
+                ])
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_identifier.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_identifier.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassFunctionIdentifier;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoClassFunctionIdentifier, CssPseudoClassFunctionIdentifierFields};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassFunctionIdentifier;
 impl FormatNodeRule<CssPseudoClassFunctionIdentifier> for FormatCssPseudoClassFunctionIdentifier {
@@ -9,6 +10,23 @@ impl FormatNodeRule<CssPseudoClassFunctionIdentifier> for FormatCssPseudoClassFu
         node: &CssPseudoClassFunctionIdentifier,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassFunctionIdentifierFields {
+            name_token,
+            l_paren_token,
+            ident,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                name_token.format(),
+                group(&format_args![
+                    l_paren_token.format(),
+                    soft_block_indent(&ident.format()),
+                    r_paren_token.format()
+                ])
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_nth.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_nth.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassFunctionNth;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoClassFunctionNth, CssPseudoClassFunctionNthFields};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassFunctionNth;
 impl FormatNodeRule<CssPseudoClassFunctionNth> for FormatCssPseudoClassFunctionNth {
@@ -9,6 +10,23 @@ impl FormatNodeRule<CssPseudoClassFunctionNth> for FormatCssPseudoClassFunctionN
         node: &CssPseudoClassFunctionNth,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassFunctionNthFields {
+            name,
+            l_paren_token,
+            selector,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                name.format(),
+                group(&format_args![
+                    l_paren_token.format(),
+                    soft_block_indent(&selector.format()),
+                    r_paren_token.format()
+                ])
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_relative_selector_list.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_relative_selector_list.rs
@@ -1,6 +1,9 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassFunctionRelativeSelectorList;
-use biome_rowan::AstNode;
+use biome_css_syntax::{
+    CssPseudoClassFunctionRelativeSelectorList, CssPseudoClassFunctionRelativeSelectorListFields,
+};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassFunctionRelativeSelectorList;
 impl FormatNodeRule<CssPseudoClassFunctionRelativeSelectorList>
@@ -11,6 +14,23 @@ impl FormatNodeRule<CssPseudoClassFunctionRelativeSelectorList>
         node: &CssPseudoClassFunctionRelativeSelectorList,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassFunctionRelativeSelectorListFields {
+            name_token,
+            l_paren_token,
+            relative_selector_list,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                name_token.format(),
+                group(&format_args![
+                    l_paren_token.format(),
+                    soft_block_indent(&relative_selector_list.format()),
+                    r_paren_token.format()
+                ])
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_selector_list.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_selector_list.rs
@@ -1,6 +1,9 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassFunctionSelectorList;
-use biome_rowan::AstNode;
+use biome_css_syntax::{
+    CssPseudoClassFunctionSelectorList, CssPseudoClassFunctionSelectorListFields,
+};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassFunctionSelectorList;
 impl FormatNodeRule<CssPseudoClassFunctionSelectorList>
@@ -11,6 +14,23 @@ impl FormatNodeRule<CssPseudoClassFunctionSelectorList>
         node: &CssPseudoClassFunctionSelectorList,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassFunctionSelectorListFields {
+            name,
+            l_paren_token,
+            selector_list,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                name.format(),
+                group(&format_args![
+                    l_paren_token.format(),
+                    soft_block_indent(&selector_list.format()),
+                    r_paren_token.format()
+                ])
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_value_list.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_value_list.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassFunctionValueList;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoClassFunctionValueList, CssPseudoClassFunctionValueListFields};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassFunctionValueList;
 impl FormatNodeRule<CssPseudoClassFunctionValueList> for FormatCssPseudoClassFunctionValueList {
@@ -9,6 +10,23 @@ impl FormatNodeRule<CssPseudoClassFunctionValueList> for FormatCssPseudoClassFun
         node: &CssPseudoClassFunctionValueList,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassFunctionValueListFields {
+            name_token,
+            l_paren_token,
+            value_list,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                name_token.format(),
+                group(&format_args![
+                    l_paren_token.format(),
+                    soft_block_indent(&value_list.format()),
+                    r_paren_token.format()
+                ])
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_identifier.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_identifier.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassIdentifier;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoClassIdentifier, CssPseudoClassIdentifierFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassIdentifier;
 impl FormatNodeRule<CssPseudoClassIdentifier> for FormatCssPseudoClassIdentifier {
@@ -9,6 +10,8 @@ impl FormatNodeRule<CssPseudoClassIdentifier> for FormatCssPseudoClassIdentifier
         node: &CssPseudoClassIdentifier,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassIdentifierFields { name } = node.as_fields();
+
+        write!(f, [name.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_nth.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_nth.rs
@@ -1,10 +1,24 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassNth;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoClassNth, CssPseudoClassNthFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassNth;
 impl FormatNodeRule<CssPseudoClassNth> for FormatCssPseudoClassNth {
     fn fmt_fields(&self, node: &CssPseudoClassNth, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassNthFields {
+            sign,
+            value,
+            symbol_token,
+            offset,
+        } = node.as_fields();
+
+        write!(f, [sign.format(), value.format(), symbol_token.format(),])?;
+
+        if offset.is_some() {
+            write!(f, [soft_line_break_or_space(), offset.format()])?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_nth_identifier.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_nth_identifier.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassNthIdentifier;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoClassNthIdentifier, CssPseudoClassNthIdentifierFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassNthIdentifier;
 impl FormatNodeRule<CssPseudoClassNthIdentifier> for FormatCssPseudoClassNthIdentifier {
@@ -9,6 +10,8 @@ impl FormatNodeRule<CssPseudoClassNthIdentifier> for FormatCssPseudoClassNthIden
         node: &CssPseudoClassNthIdentifier,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassNthIdentifierFields { value } = node.as_fields();
+
+        write!(f, [value.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_nth_number.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_nth_number.rs
@@ -1,10 +1,13 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassNthNumber;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoClassNthNumber, CssPseudoClassNthNumberFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassNthNumber;
 impl FormatNodeRule<CssPseudoClassNthNumber> for FormatCssPseudoClassNthNumber {
     fn fmt_fields(&self, node: &CssPseudoClassNthNumber, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassNthNumberFields { sign, value } = node.as_fields();
+
+        write!(f, [sign.format(), value.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_element_function_identifier.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_element_function_identifier.rs
@@ -1,6 +1,9 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoElementFunctionIdentifier;
-use biome_rowan::AstNode;
+use biome_css_syntax::{
+    CssPseudoElementFunctionIdentifier, CssPseudoElementFunctionIdentifierFields,
+};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoElementFunctionIdentifier;
 impl FormatNodeRule<CssPseudoElementFunctionIdentifier>
@@ -11,6 +14,23 @@ impl FormatNodeRule<CssPseudoElementFunctionIdentifier>
         node: &CssPseudoElementFunctionIdentifier,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoElementFunctionIdentifierFields {
+            name,
+            l_paren_token,
+            ident,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                name.format(),
+                group(&format_args![
+                    l_paren_token.format(),
+                    soft_block_indent(&ident.format()),
+                    r_paren_token.format()
+                ])
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_element_identifier.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_element_identifier.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoElementIdentifier;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoElementIdentifier, CssPseudoElementIdentifierFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoElementIdentifier;
 impl FormatNodeRule<CssPseudoElementIdentifier> for FormatCssPseudoElementIdentifier {
@@ -9,6 +10,8 @@ impl FormatNodeRule<CssPseudoElementIdentifier> for FormatCssPseudoElementIdenti
         node: &CssPseudoElementIdentifier,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoElementIdentifierFields { name } = node.as_fields();
+
+        write!(f, [name.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/selectors/complex_selector.rs
+++ b/crates/biome_css_formatter/src/css/selectors/complex_selector.rs
@@ -18,12 +18,21 @@ impl FormatNodeRule<CssComplexSelector> for FormatCssComplexSelector {
         // to allow the complete selector to break onto multiple lines if needed.
         let formatted_combinator = format_with(|f| {
             if matches!(combinator.kind(), CssSyntaxKind::CSS_SPACE_LITERAL) {
-                write!(f, [soft_line_break_or_space(), format_removed(&combinator)])
+                write!(f, [format_removed(&combinator)])
             } else {
                 write!(f, [combinator.format()])
             }
         });
 
-        write!(f, [left.format(), formatted_combinator, right.format()])
+        write!(
+            f,
+            [
+                left.format(),
+                soft_line_break_or_space(),
+                formatted_combinator,
+                space(),
+                right.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/selectors/pseudo_class_function_compound_selector.rs
+++ b/crates/biome_css_formatter/src/css/selectors/pseudo_class_function_compound_selector.rs
@@ -1,6 +1,9 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassFunctionCompoundSelector;
-use biome_rowan::AstNode;
+use biome_css_syntax::{
+    CssPseudoClassFunctionCompoundSelector, CssPseudoClassFunctionCompoundSelectorFields,
+};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassFunctionCompoundSelector;
 impl FormatNodeRule<CssPseudoClassFunctionCompoundSelector>
@@ -11,6 +14,23 @@ impl FormatNodeRule<CssPseudoClassFunctionCompoundSelector>
         node: &CssPseudoClassFunctionCompoundSelector,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassFunctionCompoundSelectorFields {
+            name,
+            l_paren_token,
+            selector,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                name.format(),
+                group(&format_args![
+                    l_paren_token.format(),
+                    soft_block_indent(&selector.format()),
+                    r_paren_token.format()
+                ])
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/selectors/pseudo_class_function_selector.rs
+++ b/crates/biome_css_formatter/src/css/selectors/pseudo_class_function_selector.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassFunctionSelector;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoClassFunctionSelector, CssPseudoClassFunctionSelectorFields};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassFunctionSelector;
 impl FormatNodeRule<CssPseudoClassFunctionSelector> for FormatCssPseudoClassFunctionSelector {
@@ -9,6 +10,23 @@ impl FormatNodeRule<CssPseudoClassFunctionSelector> for FormatCssPseudoClassFunc
         node: &CssPseudoClassFunctionSelector,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassFunctionSelectorFields {
+            name,
+            l_paren_token,
+            selector,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                name.format(),
+                group(&format_args![
+                    l_paren_token.format(),
+                    soft_block_indent(&selector.format()),
+                    r_paren_token.format()
+                ])
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/selectors/pseudo_class_nth_selector.rs
+++ b/crates/biome_css_formatter/src/css/selectors/pseudo_class_nth_selector.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassNthSelector;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoClassNthSelector, CssPseudoClassNthSelectorFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassNthSelector;
 impl FormatNodeRule<CssPseudoClassNthSelector> for FormatCssPseudoClassNthSelector {
@@ -9,6 +10,14 @@ impl FormatNodeRule<CssPseudoClassNthSelector> for FormatCssPseudoClassNthSelect
         node: &CssPseudoClassNthSelector,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassNthSelectorFields { nth, of_selector } = node.as_fields();
+
+        write!(f, [nth.format()])?;
+
+        if of_selector.is_some() {
+            write!(f, [space(), of_selector.format()])?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/biome_css_formatter/src/css/selectors/pseudo_class_of_nth_selector.rs
+++ b/crates/biome_css_formatter/src/css/selectors/pseudo_class_of_nth_selector.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassOfNthSelector;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoClassOfNthSelector, CssPseudoClassOfNthSelectorFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassOfNthSelector;
 impl FormatNodeRule<CssPseudoClassOfNthSelector> for FormatCssPseudoClassOfNthSelector {
@@ -9,6 +10,11 @@ impl FormatNodeRule<CssPseudoClassOfNthSelector> for FormatCssPseudoClassOfNthSe
         node: &CssPseudoClassOfNthSelector,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassOfNthSelectorFields {
+            of_token,
+            selector_list,
+        } = node.as_fields();
+
+        write!(f, [of_token.format(), space(), selector_list.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/selectors/pseudo_class_selector.rs
+++ b/crates/biome_css_formatter/src/css/selectors/pseudo_class_selector.rs
@@ -1,10 +1,13 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoClassSelector;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoClassSelector, CssPseudoClassSelectorFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoClassSelector;
 impl FormatNodeRule<CssPseudoClassSelector> for FormatCssPseudoClassSelector {
     fn fmt_fields(&self, node: &CssPseudoClassSelector, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoClassSelectorFields { colon_token, class } = node.as_fields();
+
+        write!(f, [colon_token.format(), class.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/selectors/pseudo_element_function_selector.rs
+++ b/crates/biome_css_formatter/src/css/selectors/pseudo_element_function_selector.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoElementFunctionSelector;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoElementFunctionSelector, CssPseudoElementFunctionSelectorFields};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoElementFunctionSelector;
 impl FormatNodeRule<CssPseudoElementFunctionSelector> for FormatCssPseudoElementFunctionSelector {
@@ -9,6 +10,23 @@ impl FormatNodeRule<CssPseudoElementFunctionSelector> for FormatCssPseudoElement
         node: &CssPseudoElementFunctionSelector,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoElementFunctionSelectorFields {
+            name,
+            l_paren_token,
+            selector,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                name.format(),
+                group(&format_args![
+                    l_paren_token.format(),
+                    soft_block_indent(&selector.format()),
+                    r_paren_token.format()
+                ])
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/selectors/pseudo_element_selector.rs
+++ b/crates/biome_css_formatter/src/css/selectors/pseudo_element_selector.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssPseudoElementSelector;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssPseudoElementSelector, CssPseudoElementSelectorFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssPseudoElementSelector;
 impl FormatNodeRule<CssPseudoElementSelector> for FormatCssPseudoElementSelector {
@@ -9,6 +10,11 @@ impl FormatNodeRule<CssPseudoElementSelector> for FormatCssPseudoElementSelector
         node: &CssPseudoElementSelector,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssPseudoElementSelectorFields {
+            double_colon_token,
+            element,
+        } = node.as_fields();
+
+        write!(f, [double_colon_token.format(), element.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/selectors/relative_selector.rs
+++ b/crates/biome_css_formatter/src/css/selectors/relative_selector.rs
@@ -1,10 +1,16 @@
 use crate::prelude::*;
-use biome_css_syntax::CssRelativeSelector;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssRelativeSelector, CssRelativeSelectorFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssRelativeSelector;
 impl FormatNodeRule<CssRelativeSelector> for FormatCssRelativeSelector {
     fn fmt_fields(&self, node: &CssRelativeSelector, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssRelativeSelectorFields {
+            combinator,
+            selector,
+        } = node.as_fields();
+
+        write!(f, [combinator.format(), space(), selector.format()])
     }
 }

--- a/crates/biome_css_formatter/tests/quick_test.rs
+++ b/crates/biome_css_formatter/tests/quick_test.rs
@@ -8,7 +8,7 @@ mod language {
     include!("language.rs");
 }
 
-// #[ignore]
+#[ignore]
 #[test]
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
@@ -21,7 +21,7 @@ fn quick_test() {
     println!("{:#?}", parse.syntax());
 
     let options = CssFormatOptions::default()
-        .with_line_width(LineWidth::try_from(40).unwrap())
+        .with_line_width(LineWidth::try_from(80).unwrap())
         .with_indent_style(IndentStyle::Space);
     let doc = format_node(options.clone(), &parse.syntax()).unwrap();
     let result = doc.print().unwrap();

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/is.css
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/is.css
@@ -1,0 +1,28 @@
+:is(ol, ul, menu:unsupported) :is(ol, ul) {
+    color: green;
+}
+
+:is(ol, ul) :is(ol, ul) ol {
+    list-style-type: lower-greek;
+    color: chocolate;
+}
+
+:is(ol, ul, menu, dir) :is(ol, ul, menu, dir) :is(ul, menu, dir) {
+  list-style-type: square;
+}
+
+h1 {
+  font-size: 30px;
+}
+
+:is(section, article, aside, nav) h1 {
+  font-size: 25px;
+}
+
+:is(section, article, aside, nav) :is(section, article, aside, nav) h1 {
+  font-size: 20px;
+}
+
+some-element:is(::before, ::after) {
+  display: block;
+}

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/is.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/is.css.snap
@@ -1,0 +1,84 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/pseudo/is.css
+---
+
+# Input
+
+```css
+:is(ol, ul, menu:unsupported) :is(ol, ul) {
+    color: green;
+}
+
+:is(ol, ul) :is(ol, ul) ol {
+    list-style-type: lower-greek;
+    color: chocolate;
+}
+
+:is(ol, ul, menu, dir) :is(ol, ul, menu, dir) :is(ul, menu, dir) {
+  list-style-type: square;
+}
+
+h1 {
+  font-size: 30px;
+}
+
+:is(section, article, aside, nav) h1 {
+  font-size: 25px;
+}
+
+:is(section, article, aside, nav) :is(section, article, aside, nav) h1 {
+  font-size: 20px;
+}
+
+some-element:is(::before, ::after) {
+  display: block;
+}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+:is(ol, ul, menu:unsupported) :is(ol, ul) {
+	color: green;
+}
+
+:is(ol, ul) :is(ol, ul) ol {
+	list-style-type: lower-greek;
+	color: chocolate;
+}
+
+:is(ol, ul, menu, dir) :is(ol, ul, menu, dir) :is(ul, menu, dir) {
+	list-style-type: square;
+}
+
+h1 {
+	font-size: 30px;
+}
+
+:is(section, article, aside, nav) h1 {
+	font-size: 25px;
+}
+
+:is(section, article, aside, nav) :is(section, article, aside, nav) h1 {
+	font-size: 20px;
+}
+
+some-element:is(::before, ::after) {
+	display: block;
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/not.css
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/not.css
@@ -1,0 +1,12 @@
+div:not(
+    :last-child
+    ) {
+}
+
+:not(
+    div 
+    
+    +
+     #id:hover
+     
+     ) {}

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/not.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/not.css.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/pseudo/not.css
+---
+
+# Input
+
+```css
+div:not(
+    :last-child
+    ) {
+}
+
+:not(
+    div 
+    
+    +
+     #id:hover
+     
+     ) {}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+div:not(:last-child) {
+}
+
+:not(div + #id:hover) {
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_compound_selector.css
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_compound_selector.css
@@ -1,0 +1,12 @@
+:host(span:focus) {}
+
+:host(
+    span:focus
+    
+    ) {}
+
+    :host(
+
+        span#id.class:focus
+        
+        ) {}

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_compound_selector.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_compound_selector.css.snap
@@ -1,0 +1,48 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/pseudo/pseudo_class_function_compound_selector.css
+---
+
+# Input
+
+```css
+:host(span:focus) {}
+
+:host(
+    span:focus
+    
+    ) {}
+
+    :host(
+
+        span#id.class:focus
+        
+        ) {}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+:host(span:focus) {
+}
+
+:host(span:focus) {
+}
+
+:host(span#id.class:focus) {
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_compound_selector_list.css
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_compound_selector_list.css
@@ -1,0 +1,8 @@
+:-webkit-any(i,p,:link,span:focus) {}
+:-webkit-any(
+    i,  p  
+    
+    , :link  ,
+
+span:focus
+) {}

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_compound_selector_list.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_compound_selector_list.css.snap
@@ -1,0 +1,46 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/pseudo/pseudo_class_function_compound_selector_list.css
+---
+
+# Input
+
+```css
+:-webkit-any(i,p,:link,span:focus) {}
+:-webkit-any(
+    i,  p  
+    
+    , :link  ,
+
+span:focus
+) {}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+:-webkit-any(i, p, :link, span:focus) {
+}
+:-webkit-any(
+		i,
+		p,
+		:link,
+
+		span:focus
+	) {
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_nth.css
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_nth.css
@@ -1,0 +1,34 @@
+:nth-child(2n+1) {}
+:nth-child(2n + 1) {}
+:nth-child(-2n   - 3) {}
+:nth-child(+2n   - 3) {}
+:nth-child(2n
+ +
+ 
+   1) {}
+:nth-child(
+    2n+ 1) {}
+:nth-child(
+    2n) {}
+
+:nth-child(
+odd) {}
+:nth-child(
+    even) {}
+:nth-child(
+    102) {}
+:nth-child(
+    -102) {}
+
+
+:nth-child(2n+1 of li, .test) {}
+:nth-child(
+    
+    2n+1 of 
+    li,
+    
+    .test) {}
+
+:nth-child(2n+1
+     of
+     li, .test) {}

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_nth.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_nth.css.snap
@@ -1,0 +1,98 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/pseudo/pseudo_class_function_nth.css
+---
+
+# Input
+
+```css
+:nth-child(2n+1) {}
+:nth-child(2n + 1) {}
+:nth-child(-2n   - 3) {}
+:nth-child(+2n   - 3) {}
+:nth-child(2n
+ +
+ 
+   1) {}
+:nth-child(
+    2n+ 1) {}
+:nth-child(
+    2n) {}
+
+:nth-child(
+odd) {}
+:nth-child(
+    even) {}
+:nth-child(
+    102) {}
+:nth-child(
+    -102) {}
+
+
+:nth-child(2n+1 of li, .test) {}
+:nth-child(
+    
+    2n+1 of 
+    li,
+    
+    .test) {}
+
+:nth-child(2n+1
+     of
+     li, .test) {}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+:nth-child(2n + 1) {
+}
+:nth-child(2n + 1) {
+}
+:nth-child(-2n - 3) {
+}
+:nth-child(+2n - 3) {
+}
+:nth-child(2n + 1) {
+}
+:nth-child(2n + 1) {
+}
+:nth-child(2n) {
+}
+
+:nth-child(odd) {
+}
+:nth-child(even) {
+}
+:nth-child(102) {
+}
+:nth-child(-102) {
+}
+
+:nth-child(2n + 1 of li, .test) {
+}
+:nth-child(
+		2n
+		+ 1 of li,
+
+		.test
+	) {
+}
+
+:nth-child(2n + 1 of li, .test) {
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_relative_selector_list.css
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_relative_selector_list.css
@@ -1,0 +1,13 @@
+:has(> img, +dt) {}
+:has(
+    
+> img, 
+        +dt
+        ) {}
+
+:has(> img) {}
+:has(
+    > img, +   dt, >p, ~ 
+
+div 
+> p) {}

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_relative_selector_list.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_relative_selector_list.css.snap
@@ -1,0 +1,50 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/pseudo/pseudo_class_function_relative_selector_list.css
+---
+
+# Input
+
+```css
+:has(> img, +dt) {}
+:has(
+    
+> img, 
+        +dt
+        ) {}
+
+:has(> img) {}
+:has(
+    > img, +   dt, >p, ~ 
+
+div 
+> p) {}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+:has(> img, + dt) {
+}
+:has(> img, + dt) {
+}
+
+:has(> img) {
+}
+:has(> img, + dt, > p, ~ div > p) {
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_selector.css
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_selector.css
@@ -1,0 +1,19 @@
+:global(.class div) {}
+
+:global() {}
+
+:global(.class) {}
+:global(div   p   a) {}
+:global(
+    
+.class1.class2   ) {}
+
+:local(.class div) {}
+
+:local() {}
+
+:local(.class) {}
+:local(div   p   a) {}
+:local(
+    
+.class1.class2   ) {}

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_selector.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_selector.css.snap
@@ -1,0 +1,72 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/pseudo/pseudo_class_function_selector.css
+---
+
+# Input
+
+```css
+:global(.class div) {}
+
+:global() {}
+
+:global(.class) {}
+:global(div   p   a) {}
+:global(
+    
+.class1.class2   ) {}
+
+:local(.class div) {}
+
+:local() {}
+
+:local(.class) {}
+:local(div   p   a) {}
+:local(
+    
+.class1.class2   ) {}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+:global(.class div) {
+}
+
+:global() {
+}
+
+:global(.class) {
+}
+:global(div p a) {
+}
+:global(.class1.class2) {
+}
+
+:local(.class div) {
+}
+
+:local() {
+}
+
+:local(.class) {
+}
+:local(div p a) {
+}
+:local(.class1.class2) {
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_value_list.css
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_value_list.css
@@ -1,0 +1,13 @@
+:lang(de, fr) {}
+:lang(
+    de,
+    
+    fr
+    ) {}
+
+:lang(
+    de
+    ) {}
+:lang(
+    de, fr, en, es, hi, pt
+) {}

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_value_list.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_function_value_list.css.snap
@@ -1,0 +1,54 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/pseudo/pseudo_class_function_value_list.css
+---
+
+# Input
+
+```css
+:lang(de, fr) {}
+:lang(
+    de,
+    
+    fr
+    ) {}
+
+:lang(
+    de
+    ) {}
+:lang(
+    de, fr, en, es, hi, pt
+) {}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+:lang(de, fr) {
+}
+:lang(
+		de,
+
+		fr
+	) {
+}
+
+:lang(de) {
+}
+:lang(de, fr, en, es, hi, pt) {
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_identifier.css
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_identifier.css
@@ -1,0 +1,4 @@
+:first-of-type {}
+div  :first-of-type {}
+div:first-of-type {}
+div:first-of-type div {}

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_identifier.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_class_identifier.css.snap
@@ -1,0 +1,40 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/pseudo/pseudo_class_identifier.css
+---
+
+# Input
+
+```css
+:first-of-type {}
+div  :first-of-type {}
+div:first-of-type {}
+div:first-of-type div {}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+:first-of-type {
+}
+div :first-of-type {
+}
+div:first-of-type {
+}
+div:first-of-type div {
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_element_selector.css
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_element_selector.css
@@ -1,0 +1,17 @@
+a::after {}
+
+::before {}
+
+video::cue(  b 
+
+) {}
+h1 
+video::cue(  b 
+
+) area {}
+
+video::cue-region(#scroll 
+> .div
+) {}
+
+::part(  active ) {}

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_element_selector.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_element_selector.css.snap
@@ -1,0 +1,62 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/pseudo/pseudo_element_selector.css
+---
+
+# Input
+
+```css
+a::after {}
+
+::before {}
+
+video::cue(  b 
+
+) {}
+h1 
+video::cue(  b 
+
+) area {}
+
+video::cue-region(#scroll 
+> .div
+) {}
+
+::part(  active ) {}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+a::after {
+}
+
+::before {
+}
+
+video::cue(b) {
+}
+h1 video::cue(b) area {
+}
+
+video::cue-region(#scroll > .div) {
+}
+
+::part(active) {
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/where.css
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/where.css
@@ -1,0 +1,22 @@
+:where(
+  
+
+#p0:checked ~ #play:checked ~ #c1:checked, 
+
+#p1:checked ~ #play:checked ~ #c2:checked,   #p2:checked  ~     #play:checked ~   #cO:checked) ~ #result >
+#c { display: block; }
+
+:where(ol
+, ul  ,  menu:unsupported
+) :where(ol, ul) {
+    color: green;
+}
+
+:where(ol, ul)  :where( ol ,  ul ) ol {
+    list-style-type: lower-greek;
+    color: chocolate;
+}
+
+:where(  section.where-styling,   aside.where-styling   , footer.where-styling) a {
+  color: orange;
+}

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/where.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/where.css.snap
@@ -1,0 +1,73 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/pseudo/where.css
+---
+
+# Input
+
+```css
+:where(
+  
+
+#p0:checked ~ #play:checked ~ #c1:checked, 
+
+#p1:checked ~ #play:checked ~ #c2:checked,   #p2:checked  ~     #play:checked ~   #cO:checked) ~ #result >
+#c { display: block; }
+
+:where(ol
+, ul  ,  menu:unsupported
+) :where(ol, ul) {
+    color: green;
+}
+
+:where(ol, ul)  :where( ol ,  ul ) ol {
+    list-style-type: lower-greek;
+    color: chocolate;
+}
+
+:where(  section.where-styling,   aside.where-styling   , footer.where-styling) a {
+  color: orange;
+}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+:where(
+		#p0:checked ~ #play:checked ~ #c1:checked,
+
+		#p1:checked ~ #play:checked ~ #c2:checked,
+		#p2:checked ~ #play:checked ~ #cO:checked
+	)
+	~ #result
+	> #c {
+	display: block;
+}
+
+:where(ol, ul, menu:unsupported) :where(ol, ul) {
+	color: green;
+}
+
+:where(ol, ul) :where(ol, ul) ol {
+	list-style-type: lower-greek;
+	color: chocolate;
+}
+
+:where(section.where-styling, aside.where-styling, footer.where-styling) a {
+	color: orange;
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/selectors/complex_selector.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/selectors/complex_selector.css.snap
@@ -35,25 +35,25 @@ Line width: 80
 -----
 
 ```css
-.parent>.child {
+.parent > .child {
 }
-.parent>.child {
+.parent > .child {
 }
-.parent>.child {
-}
-
-.parent+.child {
-}
-.parent+.child {
-}
-.parent+.child {
+.parent > .child {
 }
 
-.parent~.child {
+.parent + .child {
 }
-.parent~.child {
+.parent + .child {
 }
-.parent~.child {
+.parent + .child {
+}
+
+.parent ~ .child {
+}
+.parent ~ .child {
+}
+.parent ~ .child {
 }
 ```
 


### PR DESCRIPTION
## Summary

#1285. This implements formatting support for (seemingly) all of the pseudo selector styles that the parser currently supports.

I'd like to deduplicate some of the work, specifically around how a lot of nodes implement the same parenthesize-and-indent pattern:

```
group(&format_args![
  l_paren_token.format(),
  soft_block_indent(the_value.format()),
  r_paren_token.format()
])
```

The consistency definitely feels like it should be managed in one place, but the difficulty is that some of the nodes use `CssIdentifier` while others have a specific `SyntaxToken` instead, so merging them isn't super straightforward. I might just make the block content re-usable? It's also a one time cost to write it all out, so maybe trying to unify them isn't super worth it.

## Test Plan

Added a bunch of different spec tests to cover the various permutations of pseudo selectors.

Of note: the selector lists currently use `join_with_*`, which tries to respect newlines in the input source, but for CSS formatting we don't actually want to do that in most cases (all cases except rule list and declaration list). I'm going to leave that as something to tackle later, but it will be needed for Prettier compatibility in the future.