### PR TITLE
feat(css_formatter): support for var functions

### DIFF
--- a/crates/biome_css_formatter/src/css/auxiliary/custom_property.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/custom_property.rs
@@ -1,10 +1,13 @@
 use crate::prelude::*;
-use biome_css_syntax::CssCustomProperty;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssCustomProperty, CssCustomPropertyFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssCustomProperty;
 impl FormatNodeRule<CssCustomProperty> for FormatCssCustomProperty {
     fn fmt_fields(&self, node: &CssCustomProperty, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssCustomPropertyFields { value } = node.as_fields();
+
+        write!(f, [value.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/simple_function.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/simple_function.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use biome_css_syntax::{CssSimpleFunction, CssSimpleFunctionFields};
-use biome_formatter::write;
+use biome_formatter::{format_args, write};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssSimpleFunction;
@@ -17,9 +17,11 @@ impl FormatNodeRule<CssSimpleFunction> for FormatCssSimpleFunction {
             f,
             [
                 name.format(),
-                l_paren_token.format(),
-                group(&soft_block_indent(&items.format())),
-                r_paren_token.format()
+                group(&format_args![
+                    l_paren_token.format(),
+                    soft_block_indent(&items.format()),
+                    r_paren_token.format()
+                ])
             ]
         )
     }

--- a/crates/biome_css_formatter/src/css/auxiliary/var_function.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/var_function.rs
@@ -1,10 +1,34 @@
 use crate::prelude::*;
-use biome_css_syntax::CssVarFunction;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssVarFunction, CssVarFunctionFields};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssVarFunction;
 impl FormatNodeRule<CssVarFunction> for FormatCssVarFunction {
     fn fmt_fields(&self, node: &CssVarFunction, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssVarFunctionFields {
+            var_token,
+            l_paren_token,
+            property,
+            value,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                var_token.format(),
+                group(&format_args![
+                    l_paren_token.format(),
+                    property.format(),
+                    // `value` takes care of formatting both the comma and the
+                    // default value. Since it's an `Option`, it can just
+                    // always be formatted inline and will have no effect if
+                    // it is `None` instead.
+                    value.format(),
+                    r_paren_token.format()
+                ])
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/var_function_value.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/var_function_value.rs
@@ -1,10 +1,20 @@
 use crate::prelude::*;
-use biome_css_syntax::CssVarFunctionValue;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssVarFunctionValue, CssVarFunctionValueFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssVarFunctionValue;
 impl FormatNodeRule<CssVarFunctionValue> for FormatCssVarFunctionValue {
     fn fmt_fields(&self, node: &CssVarFunctionValue, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssVarFunctionValueFields { comma_token, value } = node.as_fields();
+
+        write!(
+            f,
+            [
+                comma_token.format(),
+                soft_line_break_or_space(),
+                value.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/tests/quick_test.rs
+++ b/crates/biome_css_formatter/tests/quick_test.rs
@@ -8,7 +8,7 @@ mod language {
     include!("language.rs");
 }
 
-// #[ignore]
+#[ignore]
 #[test]
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {

--- a/crates/biome_css_formatter/tests/specs/css/variables.css
+++ b/crates/biome_css_formatter/tests/specs/css/variables.css
@@ -1,0 +1,42 @@
+.foo {
+    --prop: 10px;
+    prop1: var(--prop);
+    prop2: var(--my-var, --my-background, pink);
+    prop3: calc(var(--prop) * 1px);
+}
+
+.bar {
+    --prop   : 15px;
+
+    prop2: var(    --prop);
+
+    prop3: var(
+
+    --prop
+    );
+
+    prop4: var(
+        --prop   , pink
+    );
+
+    prop5: 
+        var  (  --one-var-thats-super-long-on-its-own , --super-long-just-enough-to-make-it-break-over-lines
+        
+        );
+}
+
+
+.multiple {
+    prop: var(--prop1)    var(prop2);
+    prop: 
+    var(--prop1)   
+    var(prop2);
+
+    prop: hsl(
+        var(--hue, 
+        0) 
+        var(
+            --sat, 100
+            
+            ) var(--light  ,  1));
+}

--- a/crates/biome_css_formatter/tests/specs/css/variables.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/variables.css.snap
@@ -1,0 +1,116 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/variables.css
+---
+
+# Input
+
+```css
+.foo {
+    --prop: 10px;
+    prop1: var(--prop);
+    prop2: var(--my-var, --my-background, pink);
+    prop3: calc(var(--prop) * 1px);
+}
+
+.bar {
+    --prop   : 15px;
+
+    prop2: var(    --prop);
+
+    prop3: var(
+
+    --prop
+    );
+
+    prop4: var(
+        --prop   , pink
+    );
+
+    prop5: 
+        var  (  --one-var-thats-super-long-on-its-own , --super-long-just-enough-to-make-it-break-over-lines
+        
+        );
+}
+
+
+.multiple {
+    prop: var(--prop1)    var(prop2);
+    prop: 
+    var(--prop1)   
+    var(prop2);
+
+    prop: hsl(
+        var(--hue, 
+        0) 
+        var(
+            --sat, 100
+            
+            ) var(--light  ,  1));
+}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+.foo {
+    --prop: 10px;
+    prop1: var(--prop);
+    prop2: var(--my-var, --my-background, pink);
+    prop3: calc(var(--prop) * 1px);
+}
+
+.bar {
+    --prop   : 15px;
+
+    prop2: var(    --prop);
+
+    prop3: var(
+
+    --prop
+    );
+
+    prop4: var(
+        --prop   , pink
+    );
+
+    prop5: 
+        var  (  --one-var-thats-super-long-on-its-own , --super-long-just-enough-to-make-it-break-over-lines
+        
+        );
+}
+
+.multiple {
+    prop: var(--prop1)    var(prop2);
+    prop: 
+    var(--prop1)   
+    var(prop2);
+
+    prop: hsl(
+        var(--hue, 
+        0) 
+        var(
+            --sat, 100
+            
+            ) var(--light  ,  1));
+}
+```
+
+# Lines exceeding max width of 80 characters
+```
+   23:         var  (  --one-var-thats-super-long-on-its-own , --super-long-just-enough-to-make-it-break-over-lines
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/variables.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/variables.css.snap
@@ -73,44 +73,26 @@ Line width: 80
 }
 
 .bar {
-    --prop   : 15px;
+	--prop: 15px;
 
-    prop2: var(    --prop);
+	prop2: var(--prop);
 
-    prop3: var(
+	prop3: var(--prop);
 
-    --prop
-    );
+	prop4: var(--prop, pink);
 
-    prop4: var(
-        --prop   , pink
-    );
-
-    prop5: 
-        var  (  --one-var-thats-super-long-on-its-own , --super-long-just-enough-to-make-it-break-over-lines
-        
-        );
+	prop5: var(
+			--one-var-thats-super-long-on-its-own,
+			--super-long-just-enough-to-make-it-break-over-lines
+		);
 }
 
 .multiple {
-    prop: var(--prop1)    var(prop2);
-    prop: 
-    var(--prop1)   
-    var(prop2);
+	prop: var(--prop1) var(prop2);
+	prop: var(--prop1) var(prop2);
 
-    prop: hsl(
-        var(--hue, 
-        0) 
-        var(
-            --sat, 100
-            
-            ) var(--light  ,  1));
+	prop: hsl(var(--hue, 0) var(--sat, 100) var(--light, 1));
 }
-```
-
-# Lines exceeding max width of 80 characters
-```
-   23:         var  (  --one-var-thats-super-long-on-its-own , --super-long-just-enough-to-make-it-break-over-lines
 ```
 
 


### PR DESCRIPTION
## Summary

#1285. This implements support for formatting custom properties with the `var` function.

The parser doesn't actually interpret these yet, but the nodes exist, and the formatting is relatively straightforward, so i'm just adding the support in now. Once the parser starts emitting these nodes, the formatting should just work!

## Test Plan

Added a snapshot test and accepted it even though the formatting is incorrect. 