### PR TITLE
feat(css_formatter): media and container queries

### DIFF
--- a/crates/biome_css_formatter/src/css/auxiliary/container_and_query.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/container_and_query.rs
@@ -1,10 +1,26 @@
 use crate::prelude::*;
-use biome_css_syntax::CssContainerAndQuery;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssContainerAndQuery, CssContainerAndQueryFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssContainerAndQuery;
 impl FormatNodeRule<CssContainerAndQuery> for FormatCssContainerAndQuery {
     fn fmt_fields(&self, node: &CssContainerAndQuery, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssContainerAndQueryFields {
+            left,
+            and_token,
+            right,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                left.format(),
+                space(),
+                and_token.format(),
+                space(),
+                right.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/container_not_query.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/container_not_query.rs
@@ -1,10 +1,13 @@
 use crate::prelude::*;
-use biome_css_syntax::CssContainerNotQuery;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssContainerNotQuery, CssContainerNotQueryFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssContainerNotQuery;
 impl FormatNodeRule<CssContainerNotQuery> for FormatCssContainerNotQuery {
     fn fmt_fields(&self, node: &CssContainerNotQuery, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssContainerNotQueryFields { not_token, query } = node.as_fields();
+
+        write!(f, [not_token.format(), space(), query.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/container_or_query.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/container_or_query.rs
@@ -1,10 +1,26 @@
 use crate::prelude::*;
-use biome_css_syntax::CssContainerOrQuery;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssContainerOrQuery, CssContainerOrQueryFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssContainerOrQuery;
 impl FormatNodeRule<CssContainerOrQuery> for FormatCssContainerOrQuery {
     fn fmt_fields(&self, node: &CssContainerOrQuery, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssContainerOrQueryFields {
+            left,
+            or_token,
+            right,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                left.format(),
+                space(),
+                or_token.format(),
+                space(),
+                right.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/container_query_in_parens.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/container_query_in_parens.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssContainerQueryInParens;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssContainerQueryInParens, CssContainerQueryInParensFields};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssContainerQueryInParens;
 impl FormatNodeRule<CssContainerQueryInParens> for FormatCssContainerQueryInParens {
@@ -9,6 +10,19 @@ impl FormatNodeRule<CssContainerQueryInParens> for FormatCssContainerQueryInPare
         node: &CssContainerQueryInParens,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssContainerQueryInParensFields {
+            l_paren_token,
+            query,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [group(&format_args![
+                l_paren_token.format(),
+                soft_block_indent(&query.format()),
+                r_paren_token.format()
+            ])]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/container_size_feature_in_parens.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/container_size_feature_in_parens.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssContainerSizeFeatureInParens;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssContainerSizeFeatureInParens, CssContainerSizeFeatureInParensFields};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssContainerSizeFeatureInParens;
 impl FormatNodeRule<CssContainerSizeFeatureInParens> for FormatCssContainerSizeFeatureInParens {
@@ -9,6 +10,19 @@ impl FormatNodeRule<CssContainerSizeFeatureInParens> for FormatCssContainerSizeF
         node: &CssContainerSizeFeatureInParens,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssContainerSizeFeatureInParensFields {
+            l_paren_token,
+            feature,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [group(&format_args![
+                l_paren_token.format(),
+                soft_block_indent(&feature.format()),
+                r_paren_token.format()
+            ])]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/container_style_and_query.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/container_style_and_query.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssContainerStyleAndQuery;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssContainerStyleAndQuery, CssContainerStyleAndQueryFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssContainerStyleAndQuery;
 impl FormatNodeRule<CssContainerStyleAndQuery> for FormatCssContainerStyleAndQuery {
@@ -9,6 +10,21 @@ impl FormatNodeRule<CssContainerStyleAndQuery> for FormatCssContainerStyleAndQue
         node: &CssContainerStyleAndQuery,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssContainerStyleAndQueryFields {
+            left,
+            and_token,
+            right,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                left.format(),
+                space(),
+                and_token.format(),
+                space(),
+                right.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/container_style_in_parens.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/container_style_in_parens.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssContainerStyleInParens;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssContainerStyleInParens, CssContainerStyleInParensFields};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssContainerStyleInParens;
 impl FormatNodeRule<CssContainerStyleInParens> for FormatCssContainerStyleInParens {
@@ -9,6 +10,19 @@ impl FormatNodeRule<CssContainerStyleInParens> for FormatCssContainerStyleInPare
         node: &CssContainerStyleInParens,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssContainerStyleInParensFields {
+            l_paren_token,
+            query,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [group(&format_args![
+                l_paren_token.format(),
+                &soft_block_indent(&query.format()),
+                r_paren_token.format()
+            ])]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/container_style_not_query.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/container_style_not_query.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
-use biome_css_syntax::CssContainerStyleNotQuery;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssContainerStyleNotQuery, CssContainerStyleNotQueryFields};
+use biome_formatter::write;
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssContainerStyleNotQuery;
 impl FormatNodeRule<CssContainerStyleNotQuery> for FormatCssContainerStyleNotQuery {
@@ -9,6 +9,8 @@ impl FormatNodeRule<CssContainerStyleNotQuery> for FormatCssContainerStyleNotQue
         node: &CssContainerStyleNotQuery,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssContainerStyleNotQueryFields { not_token, query } = node.as_fields();
+
+        write!(f, [not_token.format(), space(), query.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/container_style_or_query.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/container_style_or_query.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssContainerStyleOrQuery;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssContainerStyleOrQuery, CssContainerStyleOrQueryFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssContainerStyleOrQuery;
 impl FormatNodeRule<CssContainerStyleOrQuery> for FormatCssContainerStyleOrQuery {
@@ -9,6 +10,21 @@ impl FormatNodeRule<CssContainerStyleOrQuery> for FormatCssContainerStyleOrQuery
         node: &CssContainerStyleOrQuery,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssContainerStyleOrQueryFields {
+            left,
+            or_token,
+            right,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                left.format(),
+                space(),
+                or_token.format(),
+                space(),
+                right.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/container_style_query_in_parens.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/container_style_query_in_parens.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssContainerStyleQueryInParens;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssContainerStyleQueryInParens, CssContainerStyleQueryInParensFields};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssContainerStyleQueryInParens;
 impl FormatNodeRule<CssContainerStyleQueryInParens> for FormatCssContainerStyleQueryInParens {
@@ -9,6 +10,24 @@ impl FormatNodeRule<CssContainerStyleQueryInParens> for FormatCssContainerStyleQ
         node: &CssContainerStyleQueryInParens,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssContainerStyleQueryInParensFields {
+            style_token,
+            l_paren_token,
+            query,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                style_token.format(),
+                space(),
+                group(&format_args![
+                    l_paren_token.format(),
+                    soft_block_indent(&query.format()),
+                    r_paren_token.format()
+                ])
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/media_and_condition.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/media_and_condition.rs
@@ -1,10 +1,26 @@
 use crate::prelude::*;
-use biome_css_syntax::CssMediaAndCondition;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssMediaAndCondition, CssMediaAndConditionFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaAndCondition;
 impl FormatNodeRule<CssMediaAndCondition> for FormatCssMediaAndCondition {
     fn fmt_fields(&self, node: &CssMediaAndCondition, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssMediaAndConditionFields {
+            left,
+            and_token,
+            right,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                left.format(),
+                space(),
+                and_token.format(),
+                space(),
+                right.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/media_and_type_query.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/media_and_type_query.rs
@@ -1,10 +1,26 @@
 use crate::prelude::*;
-use biome_css_syntax::CssMediaAndTypeQuery;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssMediaAndTypeQuery, CssMediaAndTypeQueryFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaAndTypeQuery;
 impl FormatNodeRule<CssMediaAndTypeQuery> for FormatCssMediaAndTypeQuery {
     fn fmt_fields(&self, node: &CssMediaAndTypeQuery, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssMediaAndTypeQueryFields {
+            left,
+            and_token,
+            right,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                left.format(),
+                space(),
+                and_token.format(),
+                space(),
+                right.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/media_condition_in_parens.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/media_condition_in_parens.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssMediaConditionInParens;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssMediaConditionInParens, CssMediaConditionInParensFields};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaConditionInParens;
 impl FormatNodeRule<CssMediaConditionInParens> for FormatCssMediaConditionInParens {
@@ -9,6 +10,19 @@ impl FormatNodeRule<CssMediaConditionInParens> for FormatCssMediaConditionInPare
         node: &CssMediaConditionInParens,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssMediaConditionInParensFields {
+            l_paren_token,
+            condition,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [group(&format_args![
+                l_paren_token.format(),
+                soft_block_indent(&condition.format()),
+                r_paren_token.format()
+            ])]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/media_condition_query.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/media_condition_query.rs
@@ -1,10 +1,13 @@
 use crate::prelude::*;
-use biome_css_syntax::CssMediaConditionQuery;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssMediaConditionQuery, CssMediaConditionQueryFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaConditionQuery;
 impl FormatNodeRule<CssMediaConditionQuery> for FormatCssMediaConditionQuery {
     fn fmt_fields(&self, node: &CssMediaConditionQuery, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssMediaConditionQueryFields { condition } = node.as_fields();
+
+        write!(f, [condition.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/media_feature_in_parens.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/media_feature_in_parens.rs
@@ -1,10 +1,24 @@
 use crate::prelude::*;
-use biome_css_syntax::CssMediaFeatureInParens;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssMediaFeatureInParens, CssMediaFeatureInParensFields};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaFeatureInParens;
 impl FormatNodeRule<CssMediaFeatureInParens> for FormatCssMediaFeatureInParens {
     fn fmt_fields(&self, node: &CssMediaFeatureInParens, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssMediaFeatureInParensFields {
+            l_paren_token,
+            feature,
+            r_paren_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [group(&format_args![
+                l_paren_token.format(),
+                soft_block_indent(&feature.format()),
+                r_paren_token.format()
+            ])]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/media_not_condition.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/media_not_condition.rs
@@ -1,10 +1,16 @@
 use crate::prelude::*;
-use biome_css_syntax::CssMediaNotCondition;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssMediaNotCondition, CssMediaNotConditionFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaNotCondition;
 impl FormatNodeRule<CssMediaNotCondition> for FormatCssMediaNotCondition {
     fn fmt_fields(&self, node: &CssMediaNotCondition, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssMediaNotConditionFields {
+            not_token,
+            condition,
+        } = node.as_fields();
+
+        write!(f, [not_token.format(), space(), condition.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/media_or_condition.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/media_or_condition.rs
@@ -1,10 +1,26 @@
 use crate::prelude::*;
-use biome_css_syntax::CssMediaOrCondition;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssMediaOrCondition, CssMediaOrConditionFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaOrCondition;
 impl FormatNodeRule<CssMediaOrCondition> for FormatCssMediaOrCondition {
     fn fmt_fields(&self, node: &CssMediaOrCondition, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssMediaOrConditionFields {
+            left,
+            or_token,
+            right,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                left.format(),
+                space(),
+                or_token.format(),
+                space(),
+                right.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/media_type.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/media_type.rs
@@ -1,10 +1,13 @@
 use crate::prelude::*;
-use biome_css_syntax::CssMediaType;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssMediaType, CssMediaTypeFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaType;
 impl FormatNodeRule<CssMediaType> for FormatCssMediaType {
     fn fmt_fields(&self, node: &CssMediaType, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssMediaTypeFields { value } = node.as_fields();
+
+        write!(f, [value.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/media_type_query.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/media_type_query.rs
@@ -1,10 +1,17 @@
 use crate::prelude::*;
-use biome_css_syntax::CssMediaTypeQuery;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssMediaTypeQuery, CssMediaTypeQueryFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaTypeQuery;
 impl FormatNodeRule<CssMediaTypeQuery> for FormatCssMediaTypeQuery {
     fn fmt_fields(&self, node: &CssMediaTypeQuery, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssMediaTypeQueryFields { modifier, ty } = node.as_fields();
+
+        if modifier.is_some() {
+            write!(f, [modifier.format(), space()])?;
+        }
+
+        write!(f, [ty.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/query_feature_boolean.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/query_feature_boolean.rs
@@ -1,10 +1,13 @@
 use crate::prelude::*;
-use biome_css_syntax::CssQueryFeatureBoolean;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssQueryFeatureBoolean, CssQueryFeatureBooleanFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssQueryFeatureBoolean;
 impl FormatNodeRule<CssQueryFeatureBoolean> for FormatCssQueryFeatureBoolean {
     fn fmt_fields(&self, node: &CssQueryFeatureBoolean, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssQueryFeatureBooleanFields { name } = node.as_fields();
+
+        write!(f, [name.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/query_feature_plain.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/query_feature_plain.rs
@@ -1,10 +1,20 @@
 use crate::prelude::*;
-use biome_css_syntax::CssQueryFeaturePlain;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssQueryFeaturePlain, CssQueryFeaturePlainFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssQueryFeaturePlain;
 impl FormatNodeRule<CssQueryFeaturePlain> for FormatCssQueryFeaturePlain {
     fn fmt_fields(&self, node: &CssQueryFeaturePlain, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssQueryFeaturePlainFields {
+            name,
+            colon_token,
+            value,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [name.format(), colon_token.format(), space(), value.format()]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/query_feature_range.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/query_feature_range.rs
@@ -1,10 +1,26 @@
 use crate::prelude::*;
-use biome_css_syntax::CssQueryFeatureRange;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssQueryFeatureRange, CssQueryFeatureRangeFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssQueryFeatureRange;
 impl FormatNodeRule<CssQueryFeatureRange> for FormatCssQueryFeatureRange {
     fn fmt_fields(&self, node: &CssQueryFeatureRange, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssQueryFeatureRangeFields {
+            left,
+            comparison,
+            right,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                left.format(),
+                space(),
+                comparison.format(),
+                space(),
+                right.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/query_feature_range_comparison.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/query_feature_range_comparison.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssQueryFeatureRangeComparison;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssQueryFeatureRangeComparison, CssQueryFeatureRangeComparisonFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssQueryFeatureRangeComparison;
 impl FormatNodeRule<CssQueryFeatureRangeComparison> for FormatCssQueryFeatureRangeComparison {
@@ -9,6 +10,8 @@ impl FormatNodeRule<CssQueryFeatureRangeComparison> for FormatCssQueryFeatureRan
         node: &CssQueryFeatureRangeComparison,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssQueryFeatureRangeComparisonFields { operator } = node.as_fields();
+
+        write!(f, [operator.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/query_feature_range_interval.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/query_feature_range_interval.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssQueryFeatureRangeInterval;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssQueryFeatureRangeInterval, CssQueryFeatureRangeIntervalFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssQueryFeatureRangeInterval;
 impl FormatNodeRule<CssQueryFeatureRangeInterval> for FormatCssQueryFeatureRangeInterval {
@@ -9,6 +10,26 @@ impl FormatNodeRule<CssQueryFeatureRangeInterval> for FormatCssQueryFeatureRange
         node: &CssQueryFeatureRangeInterval,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssQueryFeatureRangeIntervalFields {
+            left,
+            left_comparison,
+            name,
+            right_comparison,
+            right,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                left.format(),
+                space(),
+                left_comparison.format(),
+                space(),
+                name.format(),
+                space(),
+                right_comparison.format(),
+                right.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/query_feature_reverse_range.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/query_feature_reverse_range.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::CssQueryFeatureReverseRange;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssQueryFeatureReverseRange, CssQueryFeatureReverseRangeFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssQueryFeatureReverseRange;
 impl FormatNodeRule<CssQueryFeatureReverseRange> for FormatCssQueryFeatureReverseRange {
@@ -9,6 +10,21 @@ impl FormatNodeRule<CssQueryFeatureReverseRange> for FormatCssQueryFeatureRevers
         node: &CssQueryFeatureReverseRange,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssQueryFeatureReverseRangeFields {
+            left,
+            comparison,
+            right,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                left.format(),
+                space(),
+                comparison.format(),
+                space(),
+                right.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/lists/media_query_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/media_query_list.rs
@@ -1,10 +1,13 @@
 use crate::prelude::*;
 use biome_css_syntax::CssMediaQueryList;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaQueryList;
 impl FormatRule<CssMediaQueryList> for FormatCssMediaQueryList {
     type Context = CssFormatContext;
     fn fmt(&self, node: &CssMediaQueryList, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        f.fill()
+            .entries(&soft_line_break_or_space(), node.format_separated(","))
+            .finish()
     }
 }

--- a/crates/biome_css_formatter/src/css/statements/at_rule.rs
+++ b/crates/biome_css_formatter/src/css/statements/at_rule.rs
@@ -1,10 +1,13 @@
 use crate::prelude::*;
-use biome_css_syntax::CssAtRule;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssAtRule, CssAtRuleFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssAtRule;
 impl FormatNodeRule<CssAtRule> for FormatCssAtRule {
     fn fmt_fields(&self, node: &CssAtRule, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssAtRuleFields { at_token, rule } = node.as_fields();
+
+        write!(f, [at_token.format(), rule.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/statements/container_at_rule.rs
+++ b/crates/biome_css_formatter/src/css/statements/container_at_rule.rs
@@ -1,10 +1,24 @@
 use crate::prelude::*;
-use biome_css_syntax::CssContainerAtRule;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssContainerAtRule, CssContainerAtRuleFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssContainerAtRule;
 impl FormatNodeRule<CssContainerAtRule> for FormatCssContainerAtRule {
     fn fmt_fields(&self, node: &CssContainerAtRule, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssContainerAtRuleFields {
+            container_token,
+            name,
+            query,
+            block,
+        } = node.as_fields();
+
+        write!(f, [container_token.format(), space()])?;
+
+        if name.is_some() {
+            write!(f, [name.format(), space()])?;
+        }
+
+        write!(f, [query.format(), space(), block.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/statements/media_at_rule.rs
+++ b/crates/biome_css_formatter/src/css/statements/media_at_rule.rs
@@ -1,10 +1,45 @@
 use crate::prelude::*;
-use biome_css_syntax::CssMediaAtRule;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssMediaAtRule, CssMediaAtRuleFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaAtRule;
 impl FormatNodeRule<CssMediaAtRule> for FormatCssMediaAtRule {
     fn fmt_fields(&self, node: &CssMediaAtRule, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssMediaAtRuleFields {
+            media_token,
+            query_list,
+            block,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                media_token.format(),
+                space(),
+                // A regular indent here keeps the start of the query on the
+                // same line, even if it ends up breaking over multiple lines
+                // afterward, then lets the block start on the same line as
+                // well. Example:
+                //   @media all and (-webkit-min-device-pixel-ratio: 1.5),
+                // 	     all and (-o-min-device-pixel-ratio: 3 / 2),
+                // 	     all and (min--moz-device-pixel-ratio: 1.5),
+                // 	     all and (min-device-pixel-ratio: 1.5) {
+                //   }
+                // Most other instances use a `soft_block_indent`, but that
+                // would put the query on its own set of lines, which doesn't
+                // flow as neatly:
+                //   @media
+                //       all and (-webkit-min-device-pixel-ratio: 1.5),
+                // 	     all and (-o-min-device-pixel-ratio: 3 / 2),
+                // 	     all and (min--moz-device-pixel-ratio: 1.5),
+                // 	     all and (min-device-pixel-ratio: 1.5)
+                //   {
+                //   }
+                group(&indent(&query_list.format())),
+                space(),
+                block.format()
+            ]
+        )
     }
 }

--- a/crates/biome_css_formatter/tests/specs/css/atrule/container.css
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/container.css
@@ -1,0 +1,68 @@
+@container name   not (width <= 500px) {  }
+
+@container my-layout  (   inline-size  >   45em) {  }
+
+@container card (inline-size > 30em)   or  style(--responsive: true) {  }
+@container card (inline-size > 30em)   
+
+and
+  style(--responsive: true) {  }
+  
+@container card 
+(
+    inline-size
+     > 
+     30em
+     )   
+
+  and
+
+    style(
+        --responsive:
+         true) {  }
+
+@container (
+    
+inline-size 
+
+>=   0px
+) { }
+
+@container card
+
+( 
+    inline-size > 
+30em  )  and (inline-size < 
+45em
+) {  }
+
+@container (
+    100px >
+     width   >
+      150px  ) {  }
+
+@container (not  (  width   <= 150px ) ) {  }
+
+@container (  ( 
+    width 
+    <= 150px)  ) {  }
+
+@container (
+    min-width: 700px) {  }
+
+@container sidebar (min-width: 400px) {  }
+
+@container test style(
+    --responsive: true
+    ) {  }
+
+@container style(--responsive: true) {  }
+
+@container card (inline-size > 30em) {  }
+
+@container style(--responsive: true) {  }
+
+@container(inline-size>=calc(200px)) { }
+
+@container ( WIDTH <= 150px ) {  }
+@container ( 150px <= WIDTH ) {  }

--- a/crates/biome_css_formatter/tests/specs/css/atrule/container.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/container.css.snap
@@ -1,0 +1,151 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/atrule/container.css
+---
+
+# Input
+
+```css
+@container name   not (width <= 500px) {  }
+
+@container my-layout  (   inline-size  >   45em) {  }
+
+@container card (inline-size > 30em)   or  style(--responsive: true) {  }
+@container card (inline-size > 30em)   
+
+and
+  style(--responsive: true) {  }
+  
+@container card 
+(
+    inline-size
+     > 
+     30em
+     )   
+
+  and
+
+    style(
+        --responsive:
+         true) {  }
+
+@container (
+    
+inline-size 
+
+>=   0px
+) { }
+
+@container card
+
+( 
+    inline-size > 
+30em  )  and (inline-size < 
+45em
+) {  }
+
+@container (
+    100px >
+     width   >
+      150px  ) {  }
+
+@container (not  (  width   <= 150px ) ) {  }
+
+@container (  ( 
+    width 
+    <= 150px)  ) {  }
+
+@container (
+    min-width: 700px) {  }
+
+@container sidebar (min-width: 400px) {  }
+
+@container test style(
+    --responsive: true
+    ) {  }
+
+@container style(--responsive: true) {  }
+
+@container card (inline-size > 30em) {  }
+
+@container style(--responsive: true) {  }
+
+@container(inline-size>=calc(200px)) { }
+
+@container ( WIDTH <= 150px ) {  }
+@container ( 150px <= WIDTH ) {  }
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+@container name not (width <= 500px) {
+}
+
+@container my-layout (inline-size > 45em) {
+}
+
+@container card (inline-size > 30em) or style (--responsive: true) {
+}
+@container card (inline-size > 30em) and style (--responsive: true) {
+}
+
+@container card (inline-size > 30em) and style (--responsive: true) {
+}
+
+@container (inline-size >= 0px) {
+}
+
+@container card (inline-size > 30em) and (inline-size < 45em) {
+}
+
+@container (100px > width >150px) {
+}
+
+@container (not (width <= 150px)) {
+}
+
+@container ((width <= 150px)) {
+}
+
+@container (min-width: 700px) {
+}
+
+@container sidebar (min-width: 400px) {
+}
+
+@container test style (--responsive: true) {
+}
+
+@container style (--responsive: true) {
+}
+
+@container card (inline-size > 30em) {
+}
+
+@container style (--responsive: true) {
+}
+
+@container (inline-size >= calc(200px)) {
+}
+
+@container (WIDTH <= 150px) {
+}
+@container (150px <= WIDTH) {
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/atrule/media.css
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/media.css
@@ -1,0 +1,47 @@
+@media screen and (min-width: 480px) {}
+@media  screen and (min-width: 480px) {}
+@media screen and  (min-width: 480px) {}
+@media screen and (min-width: 480px) {}
+@media screen and (min-width :480px) {}
+@media screen and (min-width : 480px) {}
+@media screen and (min-width  :  480px) {}
+@media
+  screen
+  and
+  (min-width
+  :
+  480px) {}
+@media screen and ( min-width: 480px) {}
+@media screen and (min-width: 480px ) {}
+@media screen and ( min-width: 480px ) {}
+@media screen and (  min-width:  480px  ) {}
+@media not screen and (color), print and (color) { }
+@media not screen and (color) , print and (color) { }
+@media not screen and (color),print and (color) { }
+@media not screen and (color) , print and (color) { }
+@media not screen and (color)  ,  print and (color) { }
+@media not screen and ( color), print and (color) { }
+@media not screen and (color ), print and (color) { }
+@media not screen and ( color ), print and (color) { }
+@media not screen and (  color  ), print and (color) { }
+@media (--small-viewport) {}
+@media
+(
+--small-viewport
+)
+{
+}
+@media
+
+(
+
+--small-viewport
+
+)
+
+{
+
+}
+
+
+@media all and (-webkit-min-device-pixel-ratio: 1.5), all and (-o-min-device-pixel-ratio: 3/2), all and (min--moz-device-pixel-ratio: 1.5), all and (min-device-pixel-ratio: 1.5) {}

--- a/crates/biome_css_formatter/tests/specs/css/atrule/media.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/media.css.snap
@@ -1,0 +1,129 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/atrule/media.css
+---
+
+# Input
+
+```css
+@media screen and (min-width: 480px) {}
+@media  screen and (min-width: 480px) {}
+@media screen and  (min-width: 480px) {}
+@media screen and (min-width: 480px) {}
+@media screen and (min-width :480px) {}
+@media screen and (min-width : 480px) {}
+@media screen and (min-width  :  480px) {}
+@media
+  screen
+  and
+  (min-width
+  :
+  480px) {}
+@media screen and ( min-width: 480px) {}
+@media screen and (min-width: 480px ) {}
+@media screen and ( min-width: 480px ) {}
+@media screen and (  min-width:  480px  ) {}
+@media not screen and (color), print and (color) { }
+@media not screen and (color) , print and (color) { }
+@media not screen and (color),print and (color) { }
+@media not screen and (color) , print and (color) { }
+@media not screen and (color)  ,  print and (color) { }
+@media not screen and ( color), print and (color) { }
+@media not screen and (color ), print and (color) { }
+@media not screen and ( color ), print and (color) { }
+@media not screen and (  color  ), print and (color) { }
+@media (--small-viewport) {}
+@media
+(
+--small-viewport
+)
+{
+}
+@media
+
+(
+
+--small-viewport
+
+)
+
+{
+
+}
+
+
+@media all and (-webkit-min-device-pixel-ratio: 1.5), all and (-o-min-device-pixel-ratio: 3/2), all and (min--moz-device-pixel-ratio: 1.5), all and (min-device-pixel-ratio: 1.5) {}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+@media screen and (min-width: 480px) {
+}
+@media screen and (min-width: 480px) {
+}
+@media screen and (min-width: 480px) {
+}
+@media screen and (min-width: 480px) {
+}
+@media screen and (min-width: 480px) {
+}
+@media screen and (min-width: 480px) {
+}
+@media screen and (min-width: 480px) {
+}
+@media screen and (min-width: 480px) {
+}
+@media screen and (min-width: 480px) {
+}
+@media screen and (min-width: 480px) {
+}
+@media screen and (min-width: 480px) {
+}
+@media screen and (min-width: 480px) {
+}
+@media not screen and (color), print and (color) {
+}
+@media not screen and (color), print and (color) {
+}
+@media not screen and (color), print and (color) {
+}
+@media not screen and (color), print and (color) {
+}
+@media not screen and (color), print and (color) {
+}
+@media not screen and (color), print and (color) {
+}
+@media not screen and (color), print and (color) {
+}
+@media not screen and (color), print and (color) {
+}
+@media not screen and (color), print and (color) {
+}
+@media (--small-viewport) {
+}
+@media (--small-viewport) {
+}
+@media (--small-viewport) {
+}
+
+@media all and (-webkit-min-device-pixel-ratio: 1.5),
+	all and (-o-min-device-pixel-ratio: 3 / 2),
+	all and (min--moz-device-pixel-ratio: 1.5),
+	all and (min-device-pixel-ratio: 1.5) {
+}
+```
+
+


### PR DESCRIPTION
## Summary

#1285. _whew_ there are a bunch of nodes for at rules with queries. Thankfully they're all pretty straightforward and combine well.

Checking with Prettier, it looks like they don't really do any parsing of media and container queries and just print them out _almost_ verbatim. They use a `fill` and effectively treat it just like a normal selector list (each entry is comma separated, everything within the entry is another `fill` with space separators). I think this implementation gets pretty close to that, but we'll have to write some stress/fuzz tests to compare against Prettier for full compatibility, since their tests don't really cover everything in great detail.


## Test Plan

The `@media` tests from Prettier are actually pretty good! So I just copied that over as the spec test, then copied over the parser tests for `@container` and added some variations to cover whitespace and newlines in there.