### PR TITLE
chore: use new logo in readme

### DIFF
--- a/crates/biome_css_formatter/README.md
+++ b/crates/biome_css_formatter/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/biome-logo-slogan.svg"/>
+	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg"/>
 </p>
 
 <div align="center">

--- a/crates/biome_css_parser/README.md
+++ b/crates/biome_css_parser/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/biome-logo-slogan.svg"/>
+	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg"/>
 </p>
 
 <div align="center">

--- a/crates/biome_formatter/README.md
+++ b/crates/biome_formatter/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/biome-logo-slogan.svg"/>
+	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg"/>
 </p>
 
 <div align="center">

--- a/crates/biome_js_formatter/README.md
+++ b/crates/biome_js_formatter/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/biome-logo-slogan.svg"/>
+	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg"/>
 </p>
 
 <div align="center">

--- a/crates/biome_js_parser/README.md
+++ b/crates/biome_js_parser/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/biome-logo-slogan.svg"/>
+	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg"/>
 </p>
 
 <div align="center">

--- a/crates/biome_json_formatter/README.md
+++ b/crates/biome_json_formatter/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/biome-logo-slogan.svg"/>
+	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg"/>
 </p>
 
 <div align="center">

--- a/crates/biome_json_parser/README.md
+++ b/crates/biome_json_parser/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/biome-logo-slogan.svg"/>
+	<img alt="Biome - Toolchain of the web" width="400" src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg"/>
 </p>
 
 <div align="center">

--- a/packages/@biomejs/biome/README.md
+++ b/packages/@biomejs/biome/README.md
@@ -1,7 +1,9 @@
 <p align="center">
-    <img alt="Biome - Toolchain of the web"
-         src="https://raw.githubusercontent.com/biomejs/resources/main/biome-logo-slogan.svg"
-         width="400">
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-dark-transparent.svg">
+        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg">
+        <img alt="Shows the banner of Biome, with its logo and the phrase 'Biome - Toolchain of the web'." src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg" width="700">
+    </picture>
 </p>
 
 <div align="center">


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR updates the various `README.md` to use the new logo.

The one that we use for npm/github, uses the new way for dark/light theme. We fallback to the light theme because npmjs.org doesn't support dark/light themes (sadly).

The `README.md` of Rust crates use the light theme transparent. crates.io doesn't support dark/light themes.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Check if that's what we want :) 

<!-- What demonstrates that your implementation is correct? -->
