### PR TITLE
fix(css_parser): CSS Parser: unify `_list` nodes

### DIFF
--- a/crates/biome_css_factory/src/generated/node_factory.rs
+++ b/crates/biome_css_factory/src/generated/node_factory.rs
@@ -450,14 +450,14 @@ pub fn css_declaration_important(
 }
 pub fn css_declaration_list_block(
     l_curly_token: SyntaxToken,
-    declaration_list: CssDeclarationList,
+    declarations: CssDeclarationList,
     r_curly_token: SyntaxToken,
 ) -> CssDeclarationListBlock {
     CssDeclarationListBlock::unwrap_cast(SyntaxNode::new_detached(
         CssSyntaxKind::CSS_DECLARATION_LIST_BLOCK,
         [
             Some(SyntaxElement::Token(l_curly_token)),
-            Some(SyntaxElement::Node(declaration_list.into_syntax())),
+            Some(SyntaxElement::Node(declarations.into_syntax())),
             Some(SyntaxElement::Token(r_curly_token)),
         ],
     ))
@@ -587,14 +587,14 @@ pub fn css_media_and_type_query(
 }
 pub fn css_media_at_rule(
     media_token: SyntaxToken,
-    query_list: CssMediaQueryList,
+    queries: CssMediaQueryList,
     block: AnyCssRuleListBlock,
 ) -> CssMediaAtRule {
     CssMediaAtRule::unwrap_cast(SyntaxNode::new_detached(
         CssSyntaxKind::CSS_MEDIA_AT_RULE,
         [
             Some(SyntaxElement::Token(media_token)),
-            Some(SyntaxElement::Node(query_list.into_syntax())),
+            Some(SyntaxElement::Node(queries.into_syntax())),
             Some(SyntaxElement::Node(block.into_syntax())),
         ],
     ))
@@ -782,7 +782,7 @@ pub fn css_pseudo_class_function_compound_selector(
 pub fn css_pseudo_class_function_compound_selector_list(
     name_token: SyntaxToken,
     l_paren_token: SyntaxToken,
-    compound_selector_list: CssCompoundSelectorList,
+    compound_selectors: CssCompoundSelectorList,
     r_paren_token: SyntaxToken,
 ) -> CssPseudoClassFunctionCompoundSelectorList {
     CssPseudoClassFunctionCompoundSelectorList::unwrap_cast(SyntaxNode::new_detached(
@@ -790,7 +790,7 @@ pub fn css_pseudo_class_function_compound_selector_list(
         [
             Some(SyntaxElement::Token(name_token)),
             Some(SyntaxElement::Token(l_paren_token)),
-            Some(SyntaxElement::Node(compound_selector_list.into_syntax())),
+            Some(SyntaxElement::Node(compound_selectors.into_syntax())),
             Some(SyntaxElement::Token(r_paren_token)),
         ],
     ))
@@ -830,7 +830,7 @@ pub fn css_pseudo_class_function_nth(
 pub fn css_pseudo_class_function_relative_selector_list(
     name_token: SyntaxToken,
     l_paren_token: SyntaxToken,
-    relative_selector_list: CssRelativeSelectorList,
+    relative_selectors: CssRelativeSelectorList,
     r_paren_token: SyntaxToken,
 ) -> CssPseudoClassFunctionRelativeSelectorList {
     CssPseudoClassFunctionRelativeSelectorList::unwrap_cast(SyntaxNode::new_detached(
@@ -838,7 +838,7 @@ pub fn css_pseudo_class_function_relative_selector_list(
         [
             Some(SyntaxElement::Token(name_token)),
             Some(SyntaxElement::Token(l_paren_token)),
-            Some(SyntaxElement::Node(relative_selector_list.into_syntax())),
+            Some(SyntaxElement::Node(relative_selectors.into_syntax())),
             Some(SyntaxElement::Token(r_paren_token)),
         ],
     ))
@@ -862,7 +862,7 @@ pub fn css_pseudo_class_function_selector(
 pub fn css_pseudo_class_function_selector_list(
     name_token: SyntaxToken,
     l_paren_token: SyntaxToken,
-    selector_list: CssSelectorList,
+    selectors: CssSelectorList,
     r_paren_token: SyntaxToken,
 ) -> CssPseudoClassFunctionSelectorList {
     CssPseudoClassFunctionSelectorList::unwrap_cast(SyntaxNode::new_detached(
@@ -870,7 +870,7 @@ pub fn css_pseudo_class_function_selector_list(
         [
             Some(SyntaxElement::Token(name_token)),
             Some(SyntaxElement::Token(l_paren_token)),
-            Some(SyntaxElement::Node(selector_list.into_syntax())),
+            Some(SyntaxElement::Node(selectors.into_syntax())),
             Some(SyntaxElement::Token(r_paren_token)),
         ],
     ))
@@ -878,7 +878,7 @@ pub fn css_pseudo_class_function_selector_list(
 pub fn css_pseudo_class_function_value_list(
     name_token: SyntaxToken,
     l_paren_token: SyntaxToken,
-    value_list: CssPseudoValueList,
+    values: CssPseudoValueList,
     r_paren_token: SyntaxToken,
 ) -> CssPseudoClassFunctionValueList {
     CssPseudoClassFunctionValueList::unwrap_cast(SyntaxNode::new_detached(
@@ -886,7 +886,7 @@ pub fn css_pseudo_class_function_value_list(
         [
             Some(SyntaxElement::Token(name_token)),
             Some(SyntaxElement::Token(l_paren_token)),
-            Some(SyntaxElement::Node(value_list.into_syntax())),
+            Some(SyntaxElement::Node(values.into_syntax())),
             Some(SyntaxElement::Token(r_paren_token)),
         ],
     ))
@@ -999,13 +999,13 @@ impl CssPseudoClassNthSelectorBuilder {
 }
 pub fn css_pseudo_class_of_nth_selector(
     of_token: SyntaxToken,
-    selector_list: CssSelectorList,
+    selectors: CssSelectorList,
 ) -> CssPseudoClassOfNthSelector {
     CssPseudoClassOfNthSelector::unwrap_cast(SyntaxNode::new_detached(
         CssSyntaxKind::CSS_PSEUDO_CLASS_OF_NTH_SELECTOR,
         [
             Some(SyntaxElement::Token(of_token)),
-            Some(SyntaxElement::Node(selector_list.into_syntax())),
+            Some(SyntaxElement::Node(selectors.into_syntax())),
         ],
     ))
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/declaration_list_block.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/declaration_list_block.rs
@@ -7,13 +7,13 @@ impl FormatNodeRule<CssDeclarationListBlock> for FormatCssDeclarationListBlock {
     fn fmt_fields(&self, node: &CssDeclarationListBlock, f: &mut CssFormatter) -> FormatResult<()> {
         let CssDeclarationListBlockFields {
             l_curly_token,
-            declaration_list,
+            declarations,
             r_curly_token,
         } = node.as_fields();
 
         // When the list is empty, we still print a hard line to put the
         // closing curly on the next line.
-        if declaration_list.is_empty() {
+        if declarations.is_empty() {
             write!(
                 f,
                 [
@@ -27,7 +27,7 @@ impl FormatNodeRule<CssDeclarationListBlock> for FormatCssDeclarationListBlock {
                 f,
                 [
                     l_curly_token.format(),
-                    block_indent(&declaration_list.format()),
+                    block_indent(&declarations.format()),
                     r_curly_token.format()
                 ]
             )

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_color_profile_error.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_color_profile_error.css.snap
@@ -148,91 +148,91 @@ CssRoot {
 at_rule_color_profile_error.css:1:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '112321'.
-
+  
   > 1 │ @color-profile 112321 {  }
       │                ^^^^^^
     2 │ @color-profile 'string' {  }
     3 │ @color-profile  {  }
-
+  
   i Expected an identifier here.
-
+  
   > 1 │ @color-profile 112321 {  }
       │                ^^^^^^
     2 │ @color-profile 'string' {  }
     3 │ @color-profile  {  }
-
+  
 at_rule_color_profile_error.css:2:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found ''string''.
-
+  
     1 │ @color-profile 112321 {  }
   > 2 │ @color-profile 'string' {  }
       │                ^^^^^^^^
     3 │ @color-profile  {  }
     4 │ @color-profile DEVICE-CMYK
-
+  
   i Expected an identifier here.
-
+  
     1 │ @color-profile 112321 {  }
   > 2 │ @color-profile 'string' {  }
       │                ^^^^^^^^
     3 │ @color-profile  {  }
     4 │ @color-profile DEVICE-CMYK
-
+  
 at_rule_color_profile_error.css:3:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-
+  
     1 │ @color-profile 112321 {  }
     2 │ @color-profile 'string' {  }
   > 3 │ @color-profile  {  }
       │                 ^
     4 │ @color-profile DEVICE-CMYK
     5 │ @color-profile
-
+  
   i Expected an identifier here.
-
+  
     1 │ @color-profile 112321 {  }
     2 │ @color-profile 'string' {  }
   > 3 │ @color-profile  {  }
       │                 ^
     4 │ @color-profile DEVICE-CMYK
     5 │ @color-profile
-
+  
 at_rule_color_profile_error.css:5:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found '@'.
-
+  
     3 │ @color-profile  {  }
     4 │ @color-profile DEVICE-CMYK
   > 5 │ @color-profile
       │ ^
-    6 │
-
+    6 │ 
+  
   i Expected a body here.
-
+  
     3 │ @color-profile  {  }
     4 │ @color-profile DEVICE-CMYK
   > 5 │ @color-profile
       │ ^
-    6 │
-
+    6 │ 
+  
 at_rule_color_profile_error.css:6:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found the end of the file.
-
+  
     4 │ @color-profile DEVICE-CMYK
     5 │ @color-profile
-  > 6 │
-      │
-
+  > 6 │ 
+      │ 
+  
   i Expected an identifier here.
-
+  
     4 │ @color-profile DEVICE-CMYK
     5 │ @color-profile
-  > 6 │
-      │
-
+  > 6 │ 
+      │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_color_profile_error.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_color_profile_error.css.snap
@@ -33,7 +33,7 @@ CssRoot {
                     },
                     CssDeclarationListBlock {
                         l_curly_token: L_CURLY@22..25 "{" [] [Whitespace("  ")],
-                        declaration_list: CssDeclarationList [],
+                        declarations: CssDeclarationList [],
                         r_curly_token: R_CURLY@25..26 "}" [] [],
                     },
                 ],
@@ -51,7 +51,7 @@ CssRoot {
                     },
                     CssDeclarationListBlock {
                         l_curly_token: L_CURLY@51..54 "{" [] [Whitespace("  ")],
-                        declaration_list: CssDeclarationList [],
+                        declarations: CssDeclarationList [],
                         r_curly_token: R_CURLY@54..55 "}" [] [],
                     },
                 ],
@@ -64,7 +64,7 @@ CssRoot {
                     COLOR_PROFILE_KW@57..72 "color-profile" [] [Whitespace("  ")],
                     CssDeclarationListBlock {
                         l_curly_token: L_CURLY@72..75 "{" [] [Whitespace("  ")],
-                        declaration_list: CssDeclarationList [],
+                        declarations: CssDeclarationList [],
                         r_curly_token: R_CURLY@75..76 "}" [] [],
                     },
                 ],
@@ -148,91 +148,91 @@ CssRoot {
 at_rule_color_profile_error.css:1:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '112321'.
-  
+
   > 1 │ @color-profile 112321 {  }
       │                ^^^^^^
     2 │ @color-profile 'string' {  }
     3 │ @color-profile  {  }
-  
+
   i Expected an identifier here.
-  
+
   > 1 │ @color-profile 112321 {  }
       │                ^^^^^^
     2 │ @color-profile 'string' {  }
     3 │ @color-profile  {  }
-  
+
 at_rule_color_profile_error.css:2:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found ''string''.
-  
+
     1 │ @color-profile 112321 {  }
   > 2 │ @color-profile 'string' {  }
       │                ^^^^^^^^
     3 │ @color-profile  {  }
     4 │ @color-profile DEVICE-CMYK
-  
+
   i Expected an identifier here.
-  
+
     1 │ @color-profile 112321 {  }
   > 2 │ @color-profile 'string' {  }
       │                ^^^^^^^^
     3 │ @color-profile  {  }
     4 │ @color-profile DEVICE-CMYK
-  
+
 at_rule_color_profile_error.css:3:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-  
+
     1 │ @color-profile 112321 {  }
     2 │ @color-profile 'string' {  }
   > 3 │ @color-profile  {  }
       │                 ^
     4 │ @color-profile DEVICE-CMYK
     5 │ @color-profile
-  
+
   i Expected an identifier here.
-  
+
     1 │ @color-profile 112321 {  }
     2 │ @color-profile 'string' {  }
   > 3 │ @color-profile  {  }
       │                 ^
     4 │ @color-profile DEVICE-CMYK
     5 │ @color-profile
-  
+
 at_rule_color_profile_error.css:5:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found '@'.
-  
+
     3 │ @color-profile  {  }
     4 │ @color-profile DEVICE-CMYK
   > 5 │ @color-profile
       │ ^
-    6 │ 
-  
+    6 │
+
   i Expected a body here.
-  
+
     3 │ @color-profile  {  }
     4 │ @color-profile DEVICE-CMYK
   > 5 │ @color-profile
       │ ^
-    6 │ 
-  
+    6 │
+
 at_rule_color_profile_error.css:6:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found the end of the file.
-  
+
     4 │ @color-profile DEVICE-CMYK
     5 │ @color-profile
-  > 6 │ 
-      │ 
-  
+  > 6 │
+      │
+
   i Expected an identifier here.
-  
+
     4 │ @color-profile DEVICE-CMYK
     5 │ @color-profile
-  > 6 │ 
-      │ 
-  
+  > 6 │
+      │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_counter_style_error.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_counter_style_error.css.snap
@@ -28,7 +28,7 @@ CssRoot {
                     COUNTER_STYLE_KW@1..16 "counter-style" [] [Whitespace("  ")],
                     CssDeclarationListBlock {
                         l_curly_token: L_CURLY@16..19 "{" [] [Whitespace("  ")],
-                        declaration_list: CssDeclarationList [],
+                        declarations: CssDeclarationList [],
                         r_curly_token: R_CURLY@19..20 "}" [] [],
                     },
                 ],
@@ -46,7 +46,7 @@ CssRoot {
                     },
                     CssDeclarationListBlock {
                         l_curly_token: L_CURLY@41..44 "{" [] [Whitespace("  ")],
-                        declaration_list: CssDeclarationList [],
+                        declarations: CssDeclarationList [],
                         r_curly_token: R_CURLY@44..45 "}" [] [],
                     },
                 ],
@@ -64,7 +64,7 @@ CssRoot {
                     },
                     CssDeclarationListBlock {
                         l_curly_token: L_CURLY@70..73 "{" [] [Whitespace("  ")],
-                        declaration_list: CssDeclarationList [],
+                        declarations: CssDeclarationList [],
                         r_curly_token: R_CURLY@73..74 "}" [] [],
                     },
                 ],
@@ -153,91 +153,91 @@ CssRoot {
 at_rule_counter_style_error.css:1:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-  
+
   > 1 │ @counter-style  {  }
       │                 ^
     2 │ @counter-style 6788 {  }
     3 │ @counter-style 'string' {  }
-  
+
   i Expected an identifier here.
-  
+
   > 1 │ @counter-style  {  }
       │                 ^
     2 │ @counter-style 6788 {  }
     3 │ @counter-style 'string' {  }
-  
+
 at_rule_counter_style_error.css:2:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '6788'.
-  
+
     1 │ @counter-style  {  }
   > 2 │ @counter-style 6788 {  }
       │                ^^^^
     3 │ @counter-style 'string' {  }
     4 │ @counter-style ident
-  
+
   i Expected an identifier here.
-  
+
     1 │ @counter-style  {  }
   > 2 │ @counter-style 6788 {  }
       │                ^^^^
     3 │ @counter-style 'string' {  }
     4 │ @counter-style ident
-  
+
 at_rule_counter_style_error.css:3:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found ''string''.
-  
+
     1 │ @counter-style  {  }
     2 │ @counter-style 6788 {  }
   > 3 │ @counter-style 'string' {  }
       │                ^^^^^^^^
     4 │ @counter-style ident
     5 │ @counter-style ident
-  
+
   i Expected an identifier here.
-  
+
     1 │ @counter-style  {  }
     2 │ @counter-style 6788 {  }
   > 3 │ @counter-style 'string' {  }
       │                ^^^^^^^^
     4 │ @counter-style ident
     5 │ @counter-style ident
-  
+
 at_rule_counter_style_error.css:5:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found '@'.
-  
+
     3 │ @counter-style 'string' {  }
     4 │ @counter-style ident
   > 5 │ @counter-style ident
       │ ^
-    6 │ 
-  
+    6 │
+
   i Expected a body here.
-  
+
     3 │ @counter-style 'string' {  }
     4 │ @counter-style ident
   > 5 │ @counter-style ident
       │ ^
-    6 │ 
-  
+    6 │
+
 at_rule_counter_style_error.css:6:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found the end of the file.
-  
+
     4 │ @counter-style ident
     5 │ @counter-style ident
-  > 6 │ 
-      │ 
-  
+  > 6 │
+      │
+
   i Expected a body here.
-  
+
     4 │ @counter-style ident
     5 │ @counter-style ident
-  > 6 │ 
-      │ 
-  
+  > 6 │
+      │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_counter_style_error.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_counter_style_error.css.snap
@@ -153,91 +153,91 @@ CssRoot {
 at_rule_counter_style_error.css:1:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-
+  
   > 1 │ @counter-style  {  }
       │                 ^
     2 │ @counter-style 6788 {  }
     3 │ @counter-style 'string' {  }
-
+  
   i Expected an identifier here.
-
+  
   > 1 │ @counter-style  {  }
       │                 ^
     2 │ @counter-style 6788 {  }
     3 │ @counter-style 'string' {  }
-
+  
 at_rule_counter_style_error.css:2:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '6788'.
-
+  
     1 │ @counter-style  {  }
   > 2 │ @counter-style 6788 {  }
       │                ^^^^
     3 │ @counter-style 'string' {  }
     4 │ @counter-style ident
-
+  
   i Expected an identifier here.
-
+  
     1 │ @counter-style  {  }
   > 2 │ @counter-style 6788 {  }
       │                ^^^^
     3 │ @counter-style 'string' {  }
     4 │ @counter-style ident
-
+  
 at_rule_counter_style_error.css:3:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found ''string''.
-
+  
     1 │ @counter-style  {  }
     2 │ @counter-style 6788 {  }
   > 3 │ @counter-style 'string' {  }
       │                ^^^^^^^^
     4 │ @counter-style ident
     5 │ @counter-style ident
-
+  
   i Expected an identifier here.
-
+  
     1 │ @counter-style  {  }
     2 │ @counter-style 6788 {  }
   > 3 │ @counter-style 'string' {  }
       │                ^^^^^^^^
     4 │ @counter-style ident
     5 │ @counter-style ident
-
+  
 at_rule_counter_style_error.css:5:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found '@'.
-
+  
     3 │ @counter-style 'string' {  }
     4 │ @counter-style ident
   > 5 │ @counter-style ident
       │ ^
-    6 │
-
+    6 │ 
+  
   i Expected a body here.
-
+  
     3 │ @counter-style 'string' {  }
     4 │ @counter-style ident
   > 5 │ @counter-style ident
       │ ^
-    6 │
-
+    6 │ 
+  
 at_rule_counter_style_error.css:6:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found the end of the file.
-
+  
     4 │ @counter-style ident
     5 │ @counter-style ident
-  > 6 │
-      │
-
+  > 6 │ 
+      │ 
+  
   i Expected a body here.
-
+  
     4 │ @counter-style ident
     5 │ @counter-style ident
-  > 6 │
-      │
-
+  > 6 │ 
+      │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_font_face_error.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_font_face_error.css.snap
@@ -41,7 +41,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@15..16 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@16..17 "}" [] [],
             },
         },
@@ -146,73 +146,73 @@ CssRoot {
 at_rule_font_face_error.css:1:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found 'foo'.
-  
+
   > 1 │ @font-face foo {}
       │            ^^^
     2 │ @font-face foo;
     3 │ @font-face ;
-  
+
   i Expected a body here.
-  
+
   > 1 │ @font-face foo {}
       │            ^^^
     2 │ @font-face foo;
     3 │ @font-face ;
-  
+
 at_rule_font_face_error.css:2:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found 'foo'.
-  
+
     1 │ @font-face foo {}
   > 2 │ @font-face foo;
       │            ^^^
     3 │ @font-face ;
-  
+
   i Expected a body here.
-  
+
     1 │ @font-face foo {}
   > 2 │ @font-face foo;
       │            ^^^
     3 │ @font-face ;
-  
+
 at_rule_font_face_error.css:2:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `;`
-  
+
     1 │ @font-face foo {}
   > 2 │ @font-face foo;
       │               ^
     3 │ @font-face ;
-  
+
   i Remove ;
-  
+
 at_rule_font_face_error.css:3:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `@`
-  
+
     1 │ @font-face foo {}
     2 │ @font-face foo;
   > 3 │ @font-face ;
       │ ^
-  
+
   i Remove @
-  
+
 at_rule_font_face_error.css:3:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found ';'.
-  
+
     1 │ @font-face foo {}
     2 │ @font-face foo;
   > 3 │ @font-face ;
       │            ^
-  
+
   i Expected a body here.
-  
+
     1 │ @font-face foo {}
     2 │ @font-face foo;
   > 3 │ @font-face ;
       │            ^
-  
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_font_face_error.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_font_face_error.css.snap
@@ -146,73 +146,73 @@ CssRoot {
 at_rule_font_face_error.css:1:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found 'foo'.
-
+  
   > 1 │ @font-face foo {}
       │            ^^^
     2 │ @font-face foo;
     3 │ @font-face ;
-
+  
   i Expected a body here.
-
+  
   > 1 │ @font-face foo {}
       │            ^^^
     2 │ @font-face foo;
     3 │ @font-face ;
-
+  
 at_rule_font_face_error.css:2:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found 'foo'.
-
+  
     1 │ @font-face foo {}
   > 2 │ @font-face foo;
       │            ^^^
     3 │ @font-face ;
-
+  
   i Expected a body here.
-
+  
     1 │ @font-face foo {}
   > 2 │ @font-face foo;
       │            ^^^
     3 │ @font-face ;
-
+  
 at_rule_font_face_error.css:2:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `;`
-
+  
     1 │ @font-face foo {}
   > 2 │ @font-face foo;
       │               ^
     3 │ @font-face ;
-
+  
   i Remove ;
-
+  
 at_rule_font_face_error.css:3:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `@`
-
+  
     1 │ @font-face foo {}
     2 │ @font-face foo;
   > 3 │ @font-face ;
       │ ^
-
+  
   i Remove @
-
+  
 at_rule_font_face_error.css:3:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found ';'.
-
+  
     1 │ @font-face foo {}
     2 │ @font-face foo;
   > 3 │ @font-face ;
       │            ^
-
+  
   i Expected a body here.
-
+  
     1 │ @font-face foo {}
     2 │ @font-face foo;
   > 3 │ @font-face ;
       │            ^
-
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_font_palette_values_error.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_font_palette_values_error.css.snap
@@ -155,109 +155,109 @@ CssRoot {
 at_rule_font_palette_values_error.css:1:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-
+  
   > 1 │ @font-palette-values  {  }
       │                       ^
     2 │ @font-palette-values 6788 {  }
     3 │ @font-palette-values 'string' {  }
-
+  
   i Expected an identifier here.
-
+  
   > 1 │ @font-palette-values  {  }
       │                       ^
     2 │ @font-palette-values 6788 {  }
     3 │ @font-palette-values 'string' {  }
-
+  
 at_rule_font_palette_values_error.css:2:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '6788'.
-
+  
     1 │ @font-palette-values  {  }
   > 2 │ @font-palette-values 6788 {  }
       │                      ^^^^
     3 │ @font-palette-values 'string' {  }
     4 │ @font-palette-values ident
-
+  
   i Expected an identifier here.
-
+  
     1 │ @font-palette-values  {  }
   > 2 │ @font-palette-values 6788 {  }
       │                      ^^^^
     3 │ @font-palette-values 'string' {  }
     4 │ @font-palette-values ident
-
+  
 at_rule_font_palette_values_error.css:3:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found ''string''.
-
+  
     1 │ @font-palette-values  {  }
     2 │ @font-palette-values 6788 {  }
   > 3 │ @font-palette-values 'string' {  }
       │                      ^^^^^^^^
     4 │ @font-palette-values ident
     5 │ @font-palette-values ;
-
+  
   i Expected an identifier here.
-
+  
     1 │ @font-palette-values  {  }
     2 │ @font-palette-values 6788 {  }
   > 3 │ @font-palette-values 'string' {  }
       │                      ^^^^^^^^
     4 │ @font-palette-values ident
     5 │ @font-palette-values ;
-
+  
 at_rule_font_palette_values_error.css:5:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found '@'.
-
+  
     3 │ @font-palette-values 'string' {  }
     4 │ @font-palette-values ident
   > 5 │ @font-palette-values ;
       │ ^
-    6 │
-
+    6 │ 
+  
   i Expected a body here.
-
+  
     3 │ @font-palette-values 'string' {  }
     4 │ @font-palette-values ident
   > 5 │ @font-palette-values ;
       │ ^
-    6 │
-
+    6 │ 
+  
 at_rule_font_palette_values_error.css:5:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found ';'.
-
+  
     3 │ @font-palette-values 'string' {  }
     4 │ @font-palette-values ident
   > 5 │ @font-palette-values ;
       │                      ^
-    6 │
-
+    6 │ 
+  
   i Expected an identifier here.
-
+  
     3 │ @font-palette-values 'string' {  }
     4 │ @font-palette-values ident
   > 5 │ @font-palette-values ;
       │                      ^
-    6 │
-
+    6 │ 
+  
 at_rule_font_palette_values_error.css:6:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found the end of the file.
-
+  
     4 │ @font-palette-values ident
     5 │ @font-palette-values ;
-  > 6 │
-      │
-
+  > 6 │ 
+      │ 
+  
   i Expected a body here.
-
+  
     4 │ @font-palette-values ident
     5 │ @font-palette-values ;
-  > 6 │
-      │
-
+  > 6 │ 
+      │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_font_palette_values_error.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_font_palette_values_error.css.snap
@@ -28,7 +28,7 @@ CssRoot {
                     FONT_PALETTE_VALUES_KW@1..22 "font-palette-values" [] [Whitespace("  ")],
                     CssDeclarationListBlock {
                         l_curly_token: L_CURLY@22..25 "{" [] [Whitespace("  ")],
-                        declaration_list: CssDeclarationList [],
+                        declarations: CssDeclarationList [],
                         r_curly_token: R_CURLY@25..26 "}" [] [],
                     },
                 ],
@@ -46,7 +46,7 @@ CssRoot {
                     },
                     CssDeclarationListBlock {
                         l_curly_token: L_CURLY@53..56 "{" [] [Whitespace("  ")],
-                        declaration_list: CssDeclarationList [],
+                        declarations: CssDeclarationList [],
                         r_curly_token: R_CURLY@56..57 "}" [] [],
                     },
                 ],
@@ -64,7 +64,7 @@ CssRoot {
                     },
                     CssDeclarationListBlock {
                         l_curly_token: L_CURLY@88..91 "{" [] [Whitespace("  ")],
-                        declaration_list: CssDeclarationList [],
+                        declarations: CssDeclarationList [],
                         r_curly_token: R_CURLY@91..92 "}" [] [],
                     },
                 ],
@@ -155,109 +155,109 @@ CssRoot {
 at_rule_font_palette_values_error.css:1:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-  
+
   > 1 │ @font-palette-values  {  }
       │                       ^
     2 │ @font-palette-values 6788 {  }
     3 │ @font-palette-values 'string' {  }
-  
+
   i Expected an identifier here.
-  
+
   > 1 │ @font-palette-values  {  }
       │                       ^
     2 │ @font-palette-values 6788 {  }
     3 │ @font-palette-values 'string' {  }
-  
+
 at_rule_font_palette_values_error.css:2:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '6788'.
-  
+
     1 │ @font-palette-values  {  }
   > 2 │ @font-palette-values 6788 {  }
       │                      ^^^^
     3 │ @font-palette-values 'string' {  }
     4 │ @font-palette-values ident
-  
+
   i Expected an identifier here.
-  
+
     1 │ @font-palette-values  {  }
   > 2 │ @font-palette-values 6788 {  }
       │                      ^^^^
     3 │ @font-palette-values 'string' {  }
     4 │ @font-palette-values ident
-  
+
 at_rule_font_palette_values_error.css:3:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found ''string''.
-  
+
     1 │ @font-palette-values  {  }
     2 │ @font-palette-values 6788 {  }
   > 3 │ @font-palette-values 'string' {  }
       │                      ^^^^^^^^
     4 │ @font-palette-values ident
     5 │ @font-palette-values ;
-  
+
   i Expected an identifier here.
-  
+
     1 │ @font-palette-values  {  }
     2 │ @font-palette-values 6788 {  }
   > 3 │ @font-palette-values 'string' {  }
       │                      ^^^^^^^^
     4 │ @font-palette-values ident
     5 │ @font-palette-values ;
-  
+
 at_rule_font_palette_values_error.css:5:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found '@'.
-  
+
     3 │ @font-palette-values 'string' {  }
     4 │ @font-palette-values ident
   > 5 │ @font-palette-values ;
       │ ^
-    6 │ 
-  
+    6 │
+
   i Expected a body here.
-  
+
     3 │ @font-palette-values 'string' {  }
     4 │ @font-palette-values ident
   > 5 │ @font-palette-values ;
       │ ^
-    6 │ 
-  
+    6 │
+
 at_rule_font_palette_values_error.css:5:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found ';'.
-  
+
     3 │ @font-palette-values 'string' {  }
     4 │ @font-palette-values ident
   > 5 │ @font-palette-values ;
       │                      ^
-    6 │ 
-  
+    6 │
+
   i Expected an identifier here.
-  
+
     3 │ @font-palette-values 'string' {  }
     4 │ @font-palette-values ident
   > 5 │ @font-palette-values ;
       │                      ^
-    6 │ 
-  
+    6 │
+
 at_rule_font_palette_values_error.css:6:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a body but instead found the end of the file.
-  
+
     4 │ @font-palette-values ident
     5 │ @font-palette-values ;
-  > 6 │ 
-      │ 
-  
+  > 6 │
+      │
+
   i Expected a body here.
-  
+
     4 │ @font-palette-values ident
     5 │ @font-palette-values ;
-  > 6 │ 
-      │ 
-  
+  > 6 │
+      │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_keyframes.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_keyframes.css.snap
@@ -1100,24 +1100,24 @@ CssRoot {
 at_rule_keyframes.css:1:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-
+  
   > 1 │ @keyframes {
       │            ^
     2 │ 	from {
     3 │ 		transform: translateX(0%);
-
+  
   i Expected an identifier here.
-
+  
   > 1 │ @keyframes {
       │            ^
     2 │ 	from {
     3 │ 		transform: translateX(0%);
-
+  
 at_rule_keyframes.css:12:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a keyframes item but instead found '{
     		transform: translateX('.
-
+  
     11 │ @keyframes slidein {
   > 12 │ 	{
        │ 	^
@@ -1125,9 +1125,9 @@ at_rule_keyframes.css:12:2 parse ━━━━━━━━━━━━━━━�
        │ 		^^^^^^^^^^^^^^^^^^^^^^
     14 │ 	}
     15 │ }
-
+  
   i Expected a keyframes item here.
-
+  
     11 │ @keyframes slidein {
   > 12 │ 	{
        │ 	^
@@ -1135,201 +1135,201 @@ at_rule_keyframes.css:12:2 parse ━━━━━━━━━━━━━━━�
        │ 		^^^^^^^^^^^^^^^^^^^^^^
     14 │ 	}
     15 │ }
-
+  
 at_rule_keyframes.css:13:27 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `)`
-
+  
     11 │ @keyframes slidein {
     12 │ 	{
   > 13 │ 		transform: translateX(0%);
        │ 		                        ^
     14 │ 	}
     15 │ }
-
+  
   i Remove )
-
+  
 at_rule_keyframes.css:18:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `:` but instead found `to`
-
+  
     17 │ @keyframes slidein {
   > 18 │ 	from to {
        │ 	     ^^
     19 │ 		transform: translateX(100%);
     20 │ 	}
-
+  
   i Remove to
-
+  
 at_rule_keyframes.css:18:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `;` but instead found `{`
-
+  
     17 │ @keyframes slidein {
   > 18 │ 	from to {
        │ 	        ^
     19 │ 		transform: translateX(100%);
     20 │ 	}
-
+  
   i Remove {
-
+  
 at_rule_keyframes.css:24:5 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
-
+  
     23 │ @keyframes slidein {
   > 24 │ 	100vh {
        │ 	   ^^
     25 │ 		transform: translateX(0%);
     26 │ 	}
-
+  
   i Expected one of:
-
+  
   - from
   - to
   - number
-
+  
 at_rule_keyframes.css:34:5 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `:` but instead found `{`
-
+  
   > 34 │ 	to {
        │ 	   ^
     35 │ 		transform: translateX(100%);
     36 │ 	}
-
+  
   i Remove {
-
+  
 at_rule_keyframes.css:41:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `transform`
-
+  
     39 │ @keyframes slidein {
     40 │ 	from
   > 41 │ 		transform: translateX(0%);
        │ 		^^^^^^^^^
     42 │ 	}
-    43 │
-
+    43 │ 
+  
   i Remove transform
-
+  
 at_rule_keyframes.css:41:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `0`
-
+  
     39 │ @keyframes slidein {
     40 │ 	from
   > 41 │ 		transform: translateX(0%);
        │ 		                      ^
     42 │ 	}
-    43 │
-
+    43 │ 
+  
   i Remove 0
-
+  
 at_rule_keyframes.css:41:27 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `)`
-
+  
     39 │ @keyframes slidein {
     40 │ 	from
   > 41 │ 		transform: translateX(0%);
        │ 		                        ^
     42 │ 	}
-    43 │
-
+    43 │ 
+  
   i Remove )
-
+  
 at_rule_keyframes.css:44:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `to`
-
+  
     42 │ 	}
-    43 │
+    43 │ 
   > 44 │ 	to {
        │ 	^^
     45 │ 		transform: translateX(100%);
     46 │ 	}
-
+  
   i Remove to
-
+  
 at_rule_keyframes.css:55:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `transform`
-
+  
     54 │ 	to
   > 55 │ 		transform: translateX(100%);
        │ 		^^^^^^^^^
     56 │ 	}
     57 │ }
-
+  
   i Remove transform
-
+  
 at_rule_keyframes.css:55:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `100`
-
+  
     54 │ 	to
   > 55 │ 		transform: translateX(100%);
        │ 		                      ^^^
     56 │ 	}
     57 │ }
-
+  
   i Remove 100
-
+  
 at_rule_keyframes.css:55:29 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `)`
-
+  
     54 │ 	to
   > 55 │ 		transform: translateX(100%);
        │ 		                          ^
     56 │ 	}
     57 │ }
-
+  
   i Remove )
-
+  
 at_rule_keyframes.css:60:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `:` but instead found `{`
-
+  
     59 │ @keyframes slidein {
   > 60 │ 	from {
        │ 	     ^
     61 │ 		transform: translateX(0%);
     62 │ 	}
-
+  
   i Remove {
-
+  
 at_rule_keyframes.css:69:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a keyframes item but instead found '@keyframes slidein'.
-
+  
     67 │ }
-    68 │
+    68 │ 
   > 69 │ @keyframes slidein
        │ ^^^^^^^^^^^^^^^^^^
-    70 │
-
+    70 │ 
+  
   i Expected a keyframes item here.
-
+  
     67 │ }
-    68 │
+    68 │ 
   > 69 │ @keyframes slidein
        │ ^^^^^^^^^^^^^^^^^^
-    70 │
-
+    70 │ 
+  
 at_rule_keyframes.css:72:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `}` but instead the file ends
-
-  > 72 │
-       │
-
+  
+  > 72 │ 
+       │ 
+  
   i the file ends here
-
-  > 72 │
-       │
-
+  
+  > 72 │ 
+       │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_keyframes.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_keyframes.css.snap
@@ -103,7 +103,7 @@ CssRoot {
                                 ],
                                 block: CssDeclarationListBlock {
                                     l_curly_token: L_CURLY@19..20 "{" [] [],
-                                    declaration_list: CssDeclarationList [
+                                    declarations: CssDeclarationList [
                                         CssDeclaration {
                                             name: CssIdentifier {
                                                 value_token: IDENT@20..32 "transform" [Newline("\n"), Whitespace("\t\t")] [],
@@ -147,7 +147,7 @@ CssRoot {
                                 ],
                                 block: CssDeclarationListBlock {
                                     l_curly_token: L_CURLY@58..59 "{" [] [],
-                                    declaration_list: CssDeclarationList [
+                                    declarations: CssDeclarationList [
                                         CssDeclaration {
                                             name: CssIdentifier {
                                                 value_token: IDENT@59..71 "transform" [Newline("\n"), Whitespace("\t\t")] [],
@@ -299,7 +299,7 @@ CssRoot {
                                             },
                                             CssDeclarationListBlock {
                                                 l_curly_token: L_CURLY@253..254 "{" [] [],
-                                                declaration_list: CssDeclarationList [
+                                                declarations: CssDeclarationList [
                                                     CssDeclaration {
                                                         name: CssIdentifier {
                                                             value_token: IDENT@254..266 "transform" [Newline("\n"), Whitespace("\t\t")] [],
@@ -476,7 +476,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@457..458 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@458..470 "transform" [Newline("\n"), Whitespace("\t\t")] [],
@@ -535,7 +535,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@523..524 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@524..536 "transform" [Newline("\n"), Whitespace("\t\t")] [],
@@ -647,7 +647,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@665..666 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@666..678 "transform" [Newline("\n"), Whitespace("\t\t")] [],
@@ -1100,24 +1100,24 @@ CssRoot {
 at_rule_keyframes.css:1:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-  
+
   > 1 │ @keyframes {
       │            ^
     2 │ 	from {
     3 │ 		transform: translateX(0%);
-  
+
   i Expected an identifier here.
-  
+
   > 1 │ @keyframes {
       │            ^
     2 │ 	from {
     3 │ 		transform: translateX(0%);
-  
+
 at_rule_keyframes.css:12:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a keyframes item but instead found '{
     		transform: translateX('.
-  
+
     11 │ @keyframes slidein {
   > 12 │ 	{
        │ 	^
@@ -1125,9 +1125,9 @@ at_rule_keyframes.css:12:2 parse ━━━━━━━━━━━━━━━�
        │ 		^^^^^^^^^^^^^^^^^^^^^^
     14 │ 	}
     15 │ }
-  
+
   i Expected a keyframes item here.
-  
+
     11 │ @keyframes slidein {
   > 12 │ 	{
        │ 	^
@@ -1135,201 +1135,201 @@ at_rule_keyframes.css:12:2 parse ━━━━━━━━━━━━━━━�
        │ 		^^^^^^^^^^^^^^^^^^^^^^
     14 │ 	}
     15 │ }
-  
+
 at_rule_keyframes.css:13:27 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `)`
-  
+
     11 │ @keyframes slidein {
     12 │ 	{
   > 13 │ 		transform: translateX(0%);
        │ 		                        ^
     14 │ 	}
     15 │ }
-  
+
   i Remove )
-  
+
 at_rule_keyframes.css:18:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `:` but instead found `to`
-  
+
     17 │ @keyframes slidein {
   > 18 │ 	from to {
        │ 	     ^^
     19 │ 		transform: translateX(100%);
     20 │ 	}
-  
+
   i Remove to
-  
+
 at_rule_keyframes.css:18:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `;` but instead found `{`
-  
+
     17 │ @keyframes slidein {
   > 18 │ 	from to {
        │ 	        ^
     19 │ 		transform: translateX(100%);
     20 │ 	}
-  
+
   i Remove {
-  
+
 at_rule_keyframes.css:24:5 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
-  
+
     23 │ @keyframes slidein {
   > 24 │ 	100vh {
        │ 	   ^^
     25 │ 		transform: translateX(0%);
     26 │ 	}
-  
+
   i Expected one of:
-  
+
   - from
   - to
   - number
-  
+
 at_rule_keyframes.css:34:5 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `:` but instead found `{`
-  
+
   > 34 │ 	to {
        │ 	   ^
     35 │ 		transform: translateX(100%);
     36 │ 	}
-  
+
   i Remove {
-  
+
 at_rule_keyframes.css:41:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `transform`
-  
+
     39 │ @keyframes slidein {
     40 │ 	from
   > 41 │ 		transform: translateX(0%);
        │ 		^^^^^^^^^
     42 │ 	}
-    43 │ 
-  
+    43 │
+
   i Remove transform
-  
+
 at_rule_keyframes.css:41:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `0`
-  
+
     39 │ @keyframes slidein {
     40 │ 	from
   > 41 │ 		transform: translateX(0%);
        │ 		                      ^
     42 │ 	}
-    43 │ 
-  
+    43 │
+
   i Remove 0
-  
+
 at_rule_keyframes.css:41:27 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `)`
-  
+
     39 │ @keyframes slidein {
     40 │ 	from
   > 41 │ 		transform: translateX(0%);
        │ 		                        ^
     42 │ 	}
-    43 │ 
-  
+    43 │
+
   i Remove )
-  
+
 at_rule_keyframes.css:44:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `to`
-  
+
     42 │ 	}
-    43 │ 
+    43 │
   > 44 │ 	to {
        │ 	^^
     45 │ 		transform: translateX(100%);
     46 │ 	}
-  
+
   i Remove to
-  
+
 at_rule_keyframes.css:55:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `transform`
-  
+
     54 │ 	to
   > 55 │ 		transform: translateX(100%);
        │ 		^^^^^^^^^
     56 │ 	}
     57 │ }
-  
+
   i Remove transform
-  
+
 at_rule_keyframes.css:55:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `100`
-  
+
     54 │ 	to
   > 55 │ 		transform: translateX(100%);
        │ 		                      ^^^
     56 │ 	}
     57 │ }
-  
+
   i Remove 100
-  
+
 at_rule_keyframes.css:55:29 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `)`
-  
+
     54 │ 	to
   > 55 │ 		transform: translateX(100%);
        │ 		                          ^
     56 │ 	}
     57 │ }
-  
+
   i Remove )
-  
+
 at_rule_keyframes.css:60:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `:` but instead found `{`
-  
+
     59 │ @keyframes slidein {
   > 60 │ 	from {
        │ 	     ^
     61 │ 		transform: translateX(0%);
     62 │ 	}
-  
+
   i Remove {
-  
+
 at_rule_keyframes.css:69:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a keyframes item but instead found '@keyframes slidein'.
-  
+
     67 │ }
-    68 │ 
+    68 │
   > 69 │ @keyframes slidein
        │ ^^^^^^^^^^^^^^^^^^
-    70 │ 
-  
+    70 │
+
   i Expected a keyframes item here.
-  
+
     67 │ }
-    68 │ 
+    68 │
   > 69 │ @keyframes slidein
        │ ^^^^^^^^^^^^^^^^^^
-    70 │ 
-  
+    70 │
+
 at_rule_keyframes.css:72:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `}` but instead the file ends
-  
-  > 72 │ 
-       │ 
-  
+
+  > 72 │
+       │
+
   i the file ends here
-  
-  > 72 │ 
-       │ 
-  
+
+  > 72 │
+       │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/css_unfinished_block.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/css_unfinished_block.css.snap
@@ -73,17 +73,17 @@ CssRoot {
 css_unfinished_block.css:2:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `}` but instead the file ends
-
+  
     1 │ .action {
-  > 2 │
-      │
-
+  > 2 │ 
+      │ 
+  
   i the file ends here
-
+  
     1 │ .action {
-  > 2 │
-      │
-
+  > 2 │ 
+      │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/css_unfinished_block.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/css_unfinished_block.css.snap
@@ -34,7 +34,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@8..9 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: missing (required),
             },
         },
@@ -73,17 +73,17 @@ CssRoot {
 css_unfinished_block.css:2:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `}` but instead the file ends
-  
+
     1 │ .action {
-  > 2 │ 
-      │ 
-  
+  > 2 │
+      │
+
   i the file ends here
-  
+
     1 │ .action {
-  > 2 │ 
-      │ 
-  
+  > 2 │
+      │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/attribute_selector.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/attribute_selector.css.snap
@@ -252,52 +252,52 @@ CssRoot {
 attribute_selector.css:3:14 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a s, a S, an i, or a I but instead found 'P'.
-
+  
     1 │ [ .class {}
-    2 │
+    2 │ 
   > 3 │ [title="foo" P] {}
       │              ^
-    4 │
+    4 │ 
     5 │ [title="foo" s {}
-
+  
   i Expected a s, a S, an i, or a I here.
-
+  
     1 │ [ .class {}
-    2 │
+    2 │ 
   > 3 │ [title="foo" P] {}
       │              ^
-    4 │
+    4 │ 
     5 │ [title="foo" s {}
-
+  
 attribute_selector.css:5:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `]` but instead found `{`
-
+  
     3 │ [title="foo" P] {}
-    4 │
+    4 │ 
   > 5 │ [title="foo" s {}
       │                ^
     6 │ [title="foo" s
-    7 │
-
+    7 │ 
+  
   i Remove {
-
+  
 attribute_selector.css:7:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `]` but instead the file ends
-
+  
     5 │ [title="foo" s {}
     6 │ [title="foo" s
-  > 7 │
-      │
-
+  > 7 │ 
+      │ 
+  
   i the file ends here
-
+  
     5 │ [title="foo" s {}
     6 │ [title="foo" s
-  > 7 │
-      │
-
+  > 7 │ 
+      │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/attribute_selector.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/attribute_selector.css.snap
@@ -44,7 +44,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@9..10 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@10..11 "}" [] [],
             },
         },
@@ -82,7 +82,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@29..30 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@30..31 "}" [] [],
             },
         },
@@ -116,7 +116,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@48..49 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@49..50 "}" [] [],
             },
         },
@@ -252,52 +252,52 @@ CssRoot {
 attribute_selector.css:3:14 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a s, a S, an i, or a I but instead found 'P'.
-  
+
     1 │ [ .class {}
-    2 │ 
+    2 │
   > 3 │ [title="foo" P] {}
       │              ^
-    4 │ 
+    4 │
     5 │ [title="foo" s {}
-  
+
   i Expected a s, a S, an i, or a I here.
-  
+
     1 │ [ .class {}
-    2 │ 
+    2 │
   > 3 │ [title="foo" P] {}
       │              ^
-    4 │ 
+    4 │
     5 │ [title="foo" s {}
-  
+
 attribute_selector.css:5:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `]` but instead found `{`
-  
+
     3 │ [title="foo" P] {}
-    4 │ 
+    4 │
   > 5 │ [title="foo" s {}
       │                ^
     6 │ [title="foo" s
-    7 │ 
-  
+    7 │
+
   i Remove {
-  
+
 attribute_selector.css:7:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `]` but instead the file ends
-  
+
     5 │ [title="foo" s {}
     6 │ [title="foo" s
-  > 7 │ 
-      │ 
-  
+  > 7 │
+      │
+
   i the file ends here
-  
+
     5 │ [title="foo" s {}
     6 │ [title="foo" s
-  > 7 │ 
-      │ 
-  
+  > 7 │
+      │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/class_selector_err.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/class_selector_err.css.snap
@@ -38,7 +38,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@9..10 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@10..11 "}" [] [],
             },
         },
@@ -80,17 +80,17 @@ CssRoot {
 class_selector_err.css:1:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '.'.
-  
+
   > 1 │ . .class {}
       │   ^
-    2 │ 
-  
+    2 │
+
   i Expected an identifier here.
-  
+
   > 1 │ . .class {}
       │   ^
-    2 │ 
-  
+    2 │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/class_selector_err.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/class_selector_err.css.snap
@@ -80,17 +80,17 @@ CssRoot {
 class_selector_err.css:1:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '.'.
-
+  
   > 1 │ . .class {}
       │   ^
-    2 │
-
+    2 │ 
+  
   i Expected an identifier here.
-
+  
   > 1 │ . .class {}
       │   ^
-    2 │
-
+    2 │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/id_selector_err.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/id_selector_err.css.snap
@@ -38,7 +38,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@9..10 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@10..11 "}" [] [],
             },
         },
@@ -80,17 +80,17 @@ CssRoot {
 id_selector_err.css:1:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '.'.
-  
+
   > 1 │ # .class {}
       │   ^
-    2 │ 
-  
+    2 │
+
   i Expected an identifier here.
-  
+
   > 1 │ # .class {}
       │   ^
-    2 │ 
-  
+    2 │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/id_selector_err.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/id_selector_err.css.snap
@@ -80,17 +80,17 @@ CssRoot {
 id_selector_err.css:1:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '.'.
-
+  
   > 1 │ # .class {}
       │   ^
-    2 │
-
+    2 │ 
+  
   i Expected an identifier here.
-
+  
   > 1 │ # .class {}
       │   ^
-    2 │
-
+    2 │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/invalid_selector.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/invalid_selector.css.snap
@@ -84,30 +84,30 @@ CssRoot {
 invalid_selector.css:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '!'.
-
+  
   > 1 │ !.selector {
       │ ^
-    2 │
+    2 │ 
     3 │ }
-
+  
   i Expected a selector here.
-
+  
   > 1 │ !.selector {
       │ ^
-    2 │
+    2 │ 
     3 │ }
-
+  
 invalid_selector.css:1:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `.`
-
+  
   > 1 │ !.selector {
       │  ^
-    2 │
+    2 │ 
     3 │ }
-
+  
   i Remove .
-
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/invalid_selector.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/invalid_selector.css.snap
@@ -42,7 +42,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@11..12 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@12..15 "}" [Newline("\n"), Newline("\n")] [],
             },
         },
@@ -84,30 +84,30 @@ CssRoot {
 invalid_selector.css:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '!'.
-  
+
   > 1 │ !.selector {
       │ ^
-    2 │ 
+    2 │
     3 │ }
-  
+
   i Expected a selector here.
-  
+
   > 1 │ !.selector {
       │ ^
-    2 │ 
+    2 │
     3 │ }
-  
+
 invalid_selector.css:1:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `.`
-  
+
   > 1 │ !.selector {
       │  ^
-    2 │ 
+    2 │
     3 │ }
-  
+
   i Remove .
-  
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/missing_identifier.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/missing_identifier.css.snap
@@ -43,7 +43,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@6..7 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@7..8 "}" [] [],
             },
         },
@@ -89,31 +89,31 @@ CssRoot {
 missing_identifier.css:1:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found ','.
-  
+
   > 1 │ . , # {}
       │   ^
-    2 │ 
-  
+    2 │
+
   i Expected an identifier here.
-  
+
   > 1 │ . , # {}
       │   ^
-    2 │ 
-  
+    2 │
+
 missing_identifier.css:1:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-  
+
   > 1 │ . , # {}
       │       ^
-    2 │ 
-  
+    2 │
+
   i Expected an identifier here.
-  
+
   > 1 │ . , # {}
       │       ^
-    2 │ 
-  
+    2 │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/missing_identifier.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/missing_identifier.css.snap
@@ -89,31 +89,31 @@ CssRoot {
 missing_identifier.css:1:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found ','.
-
+  
   > 1 │ . , # {}
       │   ^
-    2 │
-
+    2 │ 
+  
   i Expected an identifier here.
-
+  
   > 1 │ . , # {}
       │   ^
-    2 │
-
+    2 │ 
+  
 missing_identifier.css:1:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-
+  
   > 1 │ . , # {}
       │       ^
-    2 │
-
+    2 │ 
+  
   i Expected an identifier here.
-
+  
   > 1 │ . , # {}
       │       ^
-    2 │
-
+    2 │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_compound_selector.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_compound_selector.css.snap
@@ -44,7 +44,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@7..8 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@8..9 "}" [] [],
             },
         },
@@ -69,7 +69,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@18..19 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@19..20 "}" [] [],
             },
         },
@@ -113,7 +113,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@41..42 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@42..43 "}" [] [],
             },
         },
@@ -156,7 +156,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@63..64 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@64..65 "}" [] [],
             },
         },
@@ -200,7 +200,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@85..86 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@86..87 "}" [] [],
             },
         },
@@ -243,7 +243,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@106..107 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@107..108 "}" [] [],
             },
         },
@@ -279,7 +279,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@120..121 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@121..122 "}" [] [],
             },
         },
@@ -520,172 +520,172 @@ CssRoot {
 pseudo_class_function_compound_selector.css:1:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '{'.
-  
+
   > 1 │ :host( {}
       │        ^
     2 │ :host() {}
     3 │ :host(.div, .class) {}
-  
+
   i Expected a compound selector here.
-  
+
   > 1 │ :host( {}
       │        ^
     2 │ :host() {}
     3 │ :host(.div, .class) {}
-  
+
 pseudo_class_function_compound_selector.css:2:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found ')'.
-  
+
     1 │ :host( {}
   > 2 │ :host() {}
       │       ^
     3 │ :host(.div, .class) {}
     4 │ :host(.div, .class {}
-  
+
   i Expected a compound selector here.
-  
+
     1 │ :host( {}
   > 2 │ :host() {}
       │       ^
     3 │ :host(.div, .class) {}
     4 │ :host(.div, .class {}
-  
+
 pseudo_class_function_compound_selector.css:3:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div, .class'.
-  
+
     1 │ :host( {}
     2 │ :host() {}
   > 3 │ :host(.div, .class) {}
       │       ^^^^^^^^^^^^
     4 │ :host(.div, .class {}
     5 │ :host(.div .class) {}
-  
+
   i Expected a compound selector here.
-  
+
     1 │ :host( {}
     2 │ :host() {}
   > 3 │ :host(.div, .class) {}
       │       ^^^^^^^^^^^^
     4 │ :host(.div, .class {}
     5 │ :host(.div .class) {}
-  
+
 pseudo_class_function_compound_selector.css:4:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div, .class'.
-  
+
     2 │ :host() {}
     3 │ :host(.div, .class) {}
   > 4 │ :host(.div, .class {}
       │       ^^^^^^^^^^^^
     5 │ :host(.div .class) {}
     6 │ :host(.div .class {}
-  
+
   i Expected a compound selector here.
-  
+
     2 │ :host() {}
     3 │ :host(.div, .class) {}
   > 4 │ :host(.div, .class {}
       │       ^^^^^^^^^^^^
     5 │ :host(.div .class) {}
     6 │ :host(.div .class {}
-  
+
 pseudo_class_function_compound_selector.css:4:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     2 │ :host() {}
     3 │ :host(.div, .class) {}
   > 4 │ :host(.div, .class {}
       │                    ^
     5 │ :host(.div .class) {}
     6 │ :host(.div .class {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_compound_selector.css:5:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div .class'.
-  
+
     3 │ :host(.div, .class) {}
     4 │ :host(.div, .class {}
   > 5 │ :host(.div .class) {}
       │       ^^^^^^^^^^^
     6 │ :host(.div .class {}
     7 │ :host(.div {}
-  
+
   i Expected a compound selector here.
-  
+
     3 │ :host(.div, .class) {}
     4 │ :host(.div, .class {}
   > 5 │ :host(.div .class) {}
       │       ^^^^^^^^^^^
     6 │ :host(.div .class {}
     7 │ :host(.div {}
-  
+
 pseudo_class_function_compound_selector.css:6:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div .class'.
-  
+
     4 │ :host(.div, .class {}
     5 │ :host(.div .class) {}
   > 6 │ :host(.div .class {}
       │       ^^^^^^^^^^^
     7 │ :host(.div {}
     8 │ :host(.div
-  
+
   i Expected a compound selector here.
-  
+
     4 │ :host(.div, .class {}
     5 │ :host(.div .class) {}
   > 6 │ :host(.div .class {}
       │       ^^^^^^^^^^^
     7 │ :host(.div {}
     8 │ :host(.div
-  
+
 pseudo_class_function_compound_selector.css:6:19 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     4 │ :host(.div, .class {}
     5 │ :host(.div .class) {}
   > 6 │ :host(.div .class {}
       │                   ^
     7 │ :host(.div {}
     8 │ :host(.div
-  
+
   i Remove {
-  
+
 pseudo_class_function_compound_selector.css:7:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     5 │ :host(.div .class) {}
     6 │ :host(.div .class {}
   > 7 │ :host(.div {}
       │            ^
     8 │ :host(.div
-    9 │ 
-  
+    9 │
+
   i Remove {
-  
+
 pseudo_class_function_compound_selector.css:9:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-  
+
     7 │ :host(.div {}
     8 │ :host(.div
-  > 9 │ 
-      │ 
-  
+  > 9 │
+      │
+
   i the file ends here
-  
+
     7 │ :host(.div {}
     8 │ :host(.div
-  > 9 │ 
-      │ 
-  
+  > 9 │
+      │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_compound_selector.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_compound_selector.css.snap
@@ -520,172 +520,172 @@ CssRoot {
 pseudo_class_function_compound_selector.css:1:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '{'.
-
+  
   > 1 │ :host( {}
       │        ^
     2 │ :host() {}
     3 │ :host(.div, .class) {}
-
+  
   i Expected a compound selector here.
-
+  
   > 1 │ :host( {}
       │        ^
     2 │ :host() {}
     3 │ :host(.div, .class) {}
-
+  
 pseudo_class_function_compound_selector.css:2:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found ')'.
-
+  
     1 │ :host( {}
   > 2 │ :host() {}
       │       ^
     3 │ :host(.div, .class) {}
     4 │ :host(.div, .class {}
-
+  
   i Expected a compound selector here.
-
+  
     1 │ :host( {}
   > 2 │ :host() {}
       │       ^
     3 │ :host(.div, .class) {}
     4 │ :host(.div, .class {}
-
+  
 pseudo_class_function_compound_selector.css:3:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div, .class'.
-
+  
     1 │ :host( {}
     2 │ :host() {}
   > 3 │ :host(.div, .class) {}
       │       ^^^^^^^^^^^^
     4 │ :host(.div, .class {}
     5 │ :host(.div .class) {}
-
+  
   i Expected a compound selector here.
-
+  
     1 │ :host( {}
     2 │ :host() {}
   > 3 │ :host(.div, .class) {}
       │       ^^^^^^^^^^^^
     4 │ :host(.div, .class {}
     5 │ :host(.div .class) {}
-
+  
 pseudo_class_function_compound_selector.css:4:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div, .class'.
-
+  
     2 │ :host() {}
     3 │ :host(.div, .class) {}
   > 4 │ :host(.div, .class {}
       │       ^^^^^^^^^^^^
     5 │ :host(.div .class) {}
     6 │ :host(.div .class {}
-
+  
   i Expected a compound selector here.
-
+  
     2 │ :host() {}
     3 │ :host(.div, .class) {}
   > 4 │ :host(.div, .class {}
       │       ^^^^^^^^^^^^
     5 │ :host(.div .class) {}
     6 │ :host(.div .class {}
-
+  
 pseudo_class_function_compound_selector.css:4:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     2 │ :host() {}
     3 │ :host(.div, .class) {}
   > 4 │ :host(.div, .class {}
       │                    ^
     5 │ :host(.div .class) {}
     6 │ :host(.div .class {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_compound_selector.css:5:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div .class'.
-
+  
     3 │ :host(.div, .class) {}
     4 │ :host(.div, .class {}
   > 5 │ :host(.div .class) {}
       │       ^^^^^^^^^^^
     6 │ :host(.div .class {}
     7 │ :host(.div {}
-
+  
   i Expected a compound selector here.
-
+  
     3 │ :host(.div, .class) {}
     4 │ :host(.div, .class {}
   > 5 │ :host(.div .class) {}
       │       ^^^^^^^^^^^
     6 │ :host(.div .class {}
     7 │ :host(.div {}
-
+  
 pseudo_class_function_compound_selector.css:6:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div .class'.
-
+  
     4 │ :host(.div, .class {}
     5 │ :host(.div .class) {}
   > 6 │ :host(.div .class {}
       │       ^^^^^^^^^^^
     7 │ :host(.div {}
     8 │ :host(.div
-
+  
   i Expected a compound selector here.
-
+  
     4 │ :host(.div, .class {}
     5 │ :host(.div .class) {}
   > 6 │ :host(.div .class {}
       │       ^^^^^^^^^^^
     7 │ :host(.div {}
     8 │ :host(.div
-
+  
 pseudo_class_function_compound_selector.css:6:19 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     4 │ :host(.div, .class {}
     5 │ :host(.div .class) {}
   > 6 │ :host(.div .class {}
       │                   ^
     7 │ :host(.div {}
     8 │ :host(.div
-
+  
   i Remove {
-
+  
 pseudo_class_function_compound_selector.css:7:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     5 │ :host(.div .class) {}
     6 │ :host(.div .class {}
   > 7 │ :host(.div {}
       │            ^
     8 │ :host(.div
-    9 │
-
+    9 │ 
+  
   i Remove {
-
+  
 pseudo_class_function_compound_selector.css:9:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-
+  
     7 │ :host(.div {}
     8 │ :host(.div
-  > 9 │
-      │
-
+  > 9 │ 
+      │ 
+  
   i the file ends here
-
+  
     7 │ :host(.div {}
     8 │ :host(.div
-  > 9 │
-      │
-
+  > 9 │ 
+      │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_compound_selector_list.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_compound_selector_list.css.snap
@@ -46,7 +46,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@7..8 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@8..9 "}" [] [],
             },
         },
@@ -72,7 +72,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@18..19 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@19..20 "}" [] [],
             },
         },
@@ -104,7 +104,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@37..38 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@38..39 "}" [] [],
             },
         },
@@ -135,7 +135,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@55..56 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@56..57 "}" [] [],
             },
         },
@@ -181,7 +181,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@77..78 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@78..79 "}" [] [],
             },
         },
@@ -228,7 +228,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@100..101 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@101..102 "}" [] [],
             },
         },
@@ -273,7 +273,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@121..122 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@122..123 "}" [] [],
             },
         },
@@ -311,7 +311,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@135..136 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@136..137 "}" [] [],
             },
         },
@@ -574,231 +574,231 @@ CssRoot {
 pseudo_class_function_compound_selector_list.css:1:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '{'.
-  
+
   > 1 │ :past( {}
       │        ^
     2 │ :past() {}
     3 │ :past(^invalid) {}
-  
+
   i Expected a compound selector here.
-  
+
   > 1 │ :past( {}
       │        ^
     2 │ :past() {}
     3 │ :past(^invalid) {}
-  
+
 pseudo_class_function_compound_selector_list.css:2:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found ''.
-  
+
     1 │ :past( {}
   > 2 │ :past() {}
-      │       
+      │
     3 │ :past(^invalid) {}
     4 │ :past(^invalid {}
-  
+
   i Expected a compound selector here.
-  
+
     1 │ :past( {}
   > 2 │ :past() {}
-      │       
+      │
     3 │ :past(^invalid) {}
     4 │ :past(^invalid {}
-  
+
 pseudo_class_function_compound_selector_list.css:3:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '^'.
-  
+
     1 │ :past( {}
     2 │ :past() {}
   > 3 │ :past(^invalid) {}
       │       ^
     4 │ :past(^invalid {}
     5 │ :past(.div .class) {}
-  
+
   i Expected a compound selector here.
-  
+
     1 │ :past( {}
     2 │ :past() {}
   > 3 │ :past(^invalid) {}
       │       ^
     4 │ :past(^invalid {}
     5 │ :past(.div .class) {}
-  
+
 pseudo_class_function_compound_selector_list.css:4:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '^'.
-  
+
     2 │ :past() {}
     3 │ :past(^invalid) {}
   > 4 │ :past(^invalid {}
       │       ^
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
-  
+
   i Expected a compound selector here.
-  
+
     2 │ :past() {}
     3 │ :past(^invalid) {}
   > 4 │ :past(^invalid {}
       │       ^
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
-  
+
 pseudo_class_function_compound_selector_list.css:4:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     2 │ :past() {}
     3 │ :past(^invalid) {}
   > 4 │ :past(^invalid {}
       │                ^
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_compound_selector_list.css:5:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found ` `
-  
+
     3 │ :past(^invalid) {}
     4 │ :past(^invalid {}
   > 5 │ :past(.div .class) {}
       │           ^
     6 │ :past(.div .class,) {}
     7 │ :past(.div .class {}
-  
-  i Remove  
-  
+
+  i Remove
+
 pseudo_class_function_compound_selector_list.css:5:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div .class'.
-  
+
     3 │ :past(^invalid) {}
     4 │ :past(^invalid {}
   > 5 │ :past(.div .class) {}
       │       ^^^^^^^^^^^
     6 │ :past(.div .class,) {}
     7 │ :past(.div .class {}
-  
+
   i Expected a compound selector here.
-  
+
     3 │ :past(^invalid) {}
     4 │ :past(^invalid {}
   > 5 │ :past(.div .class) {}
       │       ^^^^^^^^^^^
     6 │ :past(.div .class,) {}
     7 │ :past(.div .class {}
-  
+
 pseudo_class_function_compound_selector_list.css:6:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found ` `
-  
+
     4 │ :past(^invalid {}
     5 │ :past(.div .class) {}
   > 6 │ :past(.div .class,) {}
       │           ^
     7 │ :past(.div .class {}
     8 │ :past(.div {}
-  
-  i Remove  
-  
+
+  i Remove
+
 pseudo_class_function_compound_selector_list.css:6:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div .class,'.
-  
+
     4 │ :past(^invalid {}
     5 │ :past(.div .class) {}
   > 6 │ :past(.div .class,) {}
       │       ^^^^^^^^^^^^
     7 │ :past(.div .class {}
     8 │ :past(.div {}
-  
+
   i Expected a compound selector here.
-  
+
     4 │ :past(^invalid {}
     5 │ :past(.div .class) {}
   > 6 │ :past(.div .class,) {}
       │       ^^^^^^^^^^^^
     7 │ :past(.div .class {}
     8 │ :past(.div {}
-  
+
 pseudo_class_function_compound_selector_list.css:7:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found ` `
-  
+
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
   > 7 │ :past(.div .class {}
       │           ^
     8 │ :past(.div {}
     9 │ :past(.div
-  
-  i Remove  
-  
+
+  i Remove
+
 pseudo_class_function_compound_selector_list.css:7:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div .class'.
-  
+
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
   > 7 │ :past(.div .class {}
       │       ^^^^^^^^^^^
     8 │ :past(.div {}
     9 │ :past(.div
-  
+
   i Expected a compound selector here.
-  
+
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
   > 7 │ :past(.div .class {}
       │       ^^^^^^^^^^^
     8 │ :past(.div {}
     9 │ :past(.div
-  
+
 pseudo_class_function_compound_selector_list.css:7:19 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
   > 7 │ :past(.div .class {}
       │                   ^
     8 │ :past(.div {}
     9 │ :past(.div
-  
+
   i Remove {
-  
+
 pseudo_class_function_compound_selector_list.css:8:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-  
+
      6 │ :past(.div .class,) {}
      7 │ :past(.div .class {}
    > 8 │ :past(.div {}
        │            ^
      9 │ :past(.div
-    10 │ 
-  
+    10 │
+
   i Remove {
-  
+
 pseudo_class_function_compound_selector_list.css:10:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-  
+
      8 │ :past(.div {}
      9 │ :past(.div
-  > 10 │ 
-       │ 
-  
+  > 10 │
+       │
+
   i the file ends here
-  
+
      8 │ :past(.div {}
      9 │ :past(.div
-  > 10 │ 
-       │ 
-  
+  > 10 │
+       │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_compound_selector_list.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_compound_selector_list.css.snap
@@ -574,231 +574,231 @@ CssRoot {
 pseudo_class_function_compound_selector_list.css:1:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '{'.
-
+  
   > 1 │ :past( {}
       │        ^
     2 │ :past() {}
     3 │ :past(^invalid) {}
-
+  
   i Expected a compound selector here.
-
+  
   > 1 │ :past( {}
       │        ^
     2 │ :past() {}
     3 │ :past(^invalid) {}
-
+  
 pseudo_class_function_compound_selector_list.css:2:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found ''.
-
+  
     1 │ :past( {}
   > 2 │ :past() {}
-      │
+      │       
     3 │ :past(^invalid) {}
     4 │ :past(^invalid {}
-
+  
   i Expected a compound selector here.
-
+  
     1 │ :past( {}
   > 2 │ :past() {}
-      │
+      │       
     3 │ :past(^invalid) {}
     4 │ :past(^invalid {}
-
+  
 pseudo_class_function_compound_selector_list.css:3:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '^'.
-
+  
     1 │ :past( {}
     2 │ :past() {}
   > 3 │ :past(^invalid) {}
       │       ^
     4 │ :past(^invalid {}
     5 │ :past(.div .class) {}
-
+  
   i Expected a compound selector here.
-
+  
     1 │ :past( {}
     2 │ :past() {}
   > 3 │ :past(^invalid) {}
       │       ^
     4 │ :past(^invalid {}
     5 │ :past(.div .class) {}
-
+  
 pseudo_class_function_compound_selector_list.css:4:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '^'.
-
+  
     2 │ :past() {}
     3 │ :past(^invalid) {}
   > 4 │ :past(^invalid {}
       │       ^
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
-
+  
   i Expected a compound selector here.
-
+  
     2 │ :past() {}
     3 │ :past(^invalid) {}
   > 4 │ :past(^invalid {}
       │       ^
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
-
+  
 pseudo_class_function_compound_selector_list.css:4:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     2 │ :past() {}
     3 │ :past(^invalid) {}
   > 4 │ :past(^invalid {}
       │                ^
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_compound_selector_list.css:5:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found ` `
-
+  
     3 │ :past(^invalid) {}
     4 │ :past(^invalid {}
   > 5 │ :past(.div .class) {}
       │           ^
     6 │ :past(.div .class,) {}
     7 │ :past(.div .class {}
-
-  i Remove
-
+  
+  i Remove  
+  
 pseudo_class_function_compound_selector_list.css:5:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div .class'.
-
+  
     3 │ :past(^invalid) {}
     4 │ :past(^invalid {}
   > 5 │ :past(.div .class) {}
       │       ^^^^^^^^^^^
     6 │ :past(.div .class,) {}
     7 │ :past(.div .class {}
-
+  
   i Expected a compound selector here.
-
+  
     3 │ :past(^invalid) {}
     4 │ :past(^invalid {}
   > 5 │ :past(.div .class) {}
       │       ^^^^^^^^^^^
     6 │ :past(.div .class,) {}
     7 │ :past(.div .class {}
-
+  
 pseudo_class_function_compound_selector_list.css:6:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found ` `
-
+  
     4 │ :past(^invalid {}
     5 │ :past(.div .class) {}
   > 6 │ :past(.div .class,) {}
       │           ^
     7 │ :past(.div .class {}
     8 │ :past(.div {}
-
-  i Remove
-
+  
+  i Remove  
+  
 pseudo_class_function_compound_selector_list.css:6:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div .class,'.
-
+  
     4 │ :past(^invalid {}
     5 │ :past(.div .class) {}
   > 6 │ :past(.div .class,) {}
       │       ^^^^^^^^^^^^
     7 │ :past(.div .class {}
     8 │ :past(.div {}
-
+  
   i Expected a compound selector here.
-
+  
     4 │ :past(^invalid {}
     5 │ :past(.div .class) {}
   > 6 │ :past(.div .class,) {}
       │       ^^^^^^^^^^^^
     7 │ :past(.div .class {}
     8 │ :past(.div {}
-
+  
 pseudo_class_function_compound_selector_list.css:7:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found ` `
-
+  
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
   > 7 │ :past(.div .class {}
       │           ^
     8 │ :past(.div {}
     9 │ :past(.div
-
-  i Remove
-
+  
+  i Remove  
+  
 pseudo_class_function_compound_selector_list.css:7:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a compound selector but instead found '.div .class'.
-
+  
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
   > 7 │ :past(.div .class {}
       │       ^^^^^^^^^^^
     8 │ :past(.div {}
     9 │ :past(.div
-
+  
   i Expected a compound selector here.
-
+  
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
   > 7 │ :past(.div .class {}
       │       ^^^^^^^^^^^
     8 │ :past(.div {}
     9 │ :past(.div
-
+  
 pseudo_class_function_compound_selector_list.css:7:19 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     5 │ :past(.div .class) {}
     6 │ :past(.div .class,) {}
   > 7 │ :past(.div .class {}
       │                   ^
     8 │ :past(.div {}
     9 │ :past(.div
-
+  
   i Remove {
-
+  
 pseudo_class_function_compound_selector_list.css:8:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-
+  
      6 │ :past(.div .class,) {}
      7 │ :past(.div .class {}
    > 8 │ :past(.div {}
        │            ^
      9 │ :past(.div
-    10 │
-
+    10 │ 
+  
   i Remove {
-
+  
 pseudo_class_function_compound_selector_list.css:10:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-
+  
      8 │ :past(.div {}
      9 │ :past(.div
-  > 10 │
-       │
-
+  > 10 │ 
+       │ 
+  
   i the file ends here
-
+  
      8 │ :past(.div {}
      9 │ :past(.div
-  > 10 │
-       │
-
+  > 10 │ 
+       │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_identifier.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_identifier.css.snap
@@ -47,7 +47,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@6..7 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@7..8 "}" [] [],
             },
         },
@@ -72,7 +72,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@16..17 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@17..18 "}" [] [],
             },
         },
@@ -99,7 +99,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@28..29 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@29..30 "}" [] [],
             },
         },
@@ -128,7 +128,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@44..45 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@45..46 "}" [] [],
             },
         },
@@ -159,7 +159,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@62..63 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@63..64 "}" [] [],
             },
         },
@@ -189,7 +189,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@79..80 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@80..81 "}" [] [],
             },
         },
@@ -222,7 +222,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@98..99 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@99..100 "}" [] [],
             },
         },
@@ -256,7 +256,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@118..119 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@119..120 "}" [] [],
             },
         },
@@ -287,7 +287,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@141..142 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@142..143 "}" [] [],
             },
         },
@@ -319,7 +319,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@165..166 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@166..167 "}" [] [],
             },
         },
@@ -567,276 +567,276 @@ CssRoot {
 pseudo_class_function_identifier.css:1:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found '{'.
-  
+
   > 1 │ :dir( {}
       │       ^
     2 │ :dir() {}
     3 │ :dir(ltr {}
-  
+
   i Expected a ltr, or a rtl here.
-  
+
   > 1 │ :dir( {}
       │       ^
     2 │ :dir() {}
     3 │ :dir(ltr {}
-  
+
 pseudo_class_function_identifier.css:2:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found ')'.
-  
+
     1 │ :dir( {}
   > 2 │ :dir() {}
       │      ^
     3 │ :dir(ltr {}
     4 │ :dir(invalid {}
-  
+
   i Expected a ltr, or a rtl here.
-  
+
     1 │ :dir( {}
   > 2 │ :dir() {}
       │      ^
     3 │ :dir(ltr {}
     4 │ :dir(invalid {}
-  
+
 pseudo_class_function_identifier.css:3:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     1 │ :dir( {}
     2 │ :dir() {}
   > 3 │ :dir(ltr {}
       │          ^
     4 │ :dir(invalid {}
     5 │ :dir(.invalid) {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_identifier.css:4:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found 'invalid'.
-  
+
     2 │ :dir() {}
     3 │ :dir(ltr {}
   > 4 │ :dir(invalid {}
       │      ^^^^^^^
     5 │ :dir(.invalid) {}
     6 │ :dir(.invalid {}
-  
+
   i Expected a ltr, or a rtl here.
-  
+
     2 │ :dir() {}
     3 │ :dir(ltr {}
   > 4 │ :dir(invalid {}
       │      ^^^^^^^
     5 │ :dir(.invalid) {}
     6 │ :dir(.invalid {}
-  
+
 pseudo_class_function_identifier.css:4:14 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     2 │ :dir() {}
     3 │ :dir(ltr {}
   > 4 │ :dir(invalid {}
       │              ^
     5 │ :dir(.invalid) {}
     6 │ :dir(.invalid {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_identifier.css:5:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found '.invalid'.
-  
+
     3 │ :dir(ltr {}
     4 │ :dir(invalid {}
   > 5 │ :dir(.invalid) {}
       │      ^^^^^^^^
     6 │ :dir(.invalid {}
     7 │ :dir(ltr .class {}
-  
+
   i Expected a ltr, or a rtl here.
-  
+
     3 │ :dir(ltr {}
     4 │ :dir(invalid {}
   > 5 │ :dir(.invalid) {}
       │      ^^^^^^^^
     6 │ :dir(.invalid {}
     7 │ :dir(ltr .class {}
-  
+
 pseudo_class_function_identifier.css:6:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found '.invalid'.
-  
+
     4 │ :dir(invalid {}
     5 │ :dir(.invalid) {}
   > 6 │ :dir(.invalid {}
       │      ^^^^^^^^
     7 │ :dir(ltr .class {}
     8 │ :dir(ltr .class) {}
-  
+
   i Expected a ltr, or a rtl here.
-  
+
     4 │ :dir(invalid {}
     5 │ :dir(.invalid) {}
   > 6 │ :dir(.invalid {}
       │      ^^^^^^^^
     7 │ :dir(ltr .class {}
     8 │ :dir(ltr .class) {}
-  
+
 pseudo_class_function_identifier.css:6:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     4 │ :dir(invalid {}
     5 │ :dir(.invalid) {}
   > 6 │ :dir(.invalid {}
       │               ^
     7 │ :dir(ltr .class {}
     8 │ :dir(ltr .class) {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_identifier.css:7:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found 'ltr .class'.
-  
+
     5 │ :dir(.invalid) {}
     6 │ :dir(.invalid {}
   > 7 │ :dir(ltr .class {}
       │      ^^^^^^^^^^
     8 │ :dir(ltr .class) {}
     9 │ :dir(invalid .class {}
-  
+
   i Expected a ltr, or a rtl here.
-  
+
     5 │ :dir(.invalid) {}
     6 │ :dir(.invalid {}
   > 7 │ :dir(ltr .class {}
       │      ^^^^^^^^^^
     8 │ :dir(ltr .class) {}
     9 │ :dir(invalid .class {}
-  
+
 pseudo_class_function_identifier.css:7:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     5 │ :dir(.invalid) {}
     6 │ :dir(.invalid {}
   > 7 │ :dir(ltr .class {}
       │                 ^
     8 │ :dir(ltr .class) {}
     9 │ :dir(invalid .class {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_identifier.css:8:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found 'ltr .class'.
-  
+
      6 │ :dir(.invalid {}
      7 │ :dir(ltr .class {}
    > 8 │ :dir(ltr .class) {}
        │      ^^^^^^^^^^
      9 │ :dir(invalid .class {}
     10 │ :dir(invalid .class) {}
-  
+
   i Expected a ltr, or a rtl here.
-  
+
      6 │ :dir(.invalid {}
      7 │ :dir(ltr .class {}
    > 8 │ :dir(ltr .class) {}
        │      ^^^^^^^^^^
      9 │ :dir(invalid .class {}
     10 │ :dir(invalid .class) {}
-  
+
 pseudo_class_function_identifier.css:9:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found 'invalid .class'.
-  
+
      7 │ :dir(ltr .class {}
      8 │ :dir(ltr .class) {}
    > 9 │ :dir(invalid .class {}
        │      ^^^^^^^^^^^^^^
     10 │ :dir(invalid .class) {}
     11 │ :dir(.invalid
-  
+
   i Expected a ltr, or a rtl here.
-  
+
      7 │ :dir(ltr .class {}
      8 │ :dir(ltr .class) {}
    > 9 │ :dir(invalid .class {}
        │      ^^^^^^^^^^^^^^
     10 │ :dir(invalid .class) {}
     11 │ :dir(.invalid
-  
+
 pseudo_class_function_identifier.css:9:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
      7 │ :dir(ltr .class {}
      8 │ :dir(ltr .class) {}
    > 9 │ :dir(invalid .class {}
        │                     ^
     10 │ :dir(invalid .class) {}
     11 │ :dir(.invalid
-  
+
   i Remove {
-  
+
 pseudo_class_function_identifier.css:10:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found 'invalid .class'.
-  
+
      8 │ :dir(ltr .class) {}
      9 │ :dir(invalid .class {}
   > 10 │ :dir(invalid .class) {}
        │      ^^^^^^^^^^^^^^
     11 │ :dir(.invalid
-    12 │ 
-  
+    12 │
+
   i Expected a ltr, or a rtl here.
-  
+
      8 │ :dir(ltr .class) {}
      9 │ :dir(invalid .class {}
   > 10 │ :dir(invalid .class) {}
        │      ^^^^^^^^^^^^^^
     11 │ :dir(.invalid
-    12 │ 
-  
+    12 │
+
 pseudo_class_function_identifier.css:11:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found '.invalid'.
-  
+
      9 │ :dir(invalid .class {}
     10 │ :dir(invalid .class) {}
   > 11 │ :dir(.invalid
        │      ^^^^^^^^
-    12 │ 
-  
+    12 │
+
   i Expected a ltr, or a rtl here.
-  
+
      9 │ :dir(invalid .class {}
     10 │ :dir(invalid .class) {}
   > 11 │ :dir(.invalid
        │      ^^^^^^^^
-    12 │ 
-  
+    12 │
+
 pseudo_class_function_identifier.css:12:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-  
+
     10 │ :dir(invalid .class) {}
     11 │ :dir(.invalid
-  > 12 │ 
-       │ 
-  
+  > 12 │
+       │
+
   i the file ends here
-  
+
     10 │ :dir(invalid .class) {}
     11 │ :dir(.invalid
-  > 12 │ 
-       │ 
-  
+  > 12 │
+       │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_identifier.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_identifier.css.snap
@@ -567,276 +567,276 @@ CssRoot {
 pseudo_class_function_identifier.css:1:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found '{'.
-
+  
   > 1 │ :dir( {}
       │       ^
     2 │ :dir() {}
     3 │ :dir(ltr {}
-
+  
   i Expected a ltr, or a rtl here.
-
+  
   > 1 │ :dir( {}
       │       ^
     2 │ :dir() {}
     3 │ :dir(ltr {}
-
+  
 pseudo_class_function_identifier.css:2:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found ')'.
-
+  
     1 │ :dir( {}
   > 2 │ :dir() {}
       │      ^
     3 │ :dir(ltr {}
     4 │ :dir(invalid {}
-
+  
   i Expected a ltr, or a rtl here.
-
+  
     1 │ :dir( {}
   > 2 │ :dir() {}
       │      ^
     3 │ :dir(ltr {}
     4 │ :dir(invalid {}
-
+  
 pseudo_class_function_identifier.css:3:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     1 │ :dir( {}
     2 │ :dir() {}
   > 3 │ :dir(ltr {}
       │          ^
     4 │ :dir(invalid {}
     5 │ :dir(.invalid) {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_identifier.css:4:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found 'invalid'.
-
+  
     2 │ :dir() {}
     3 │ :dir(ltr {}
   > 4 │ :dir(invalid {}
       │      ^^^^^^^
     5 │ :dir(.invalid) {}
     6 │ :dir(.invalid {}
-
+  
   i Expected a ltr, or a rtl here.
-
+  
     2 │ :dir() {}
     3 │ :dir(ltr {}
   > 4 │ :dir(invalid {}
       │      ^^^^^^^
     5 │ :dir(.invalid) {}
     6 │ :dir(.invalid {}
-
+  
 pseudo_class_function_identifier.css:4:14 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     2 │ :dir() {}
     3 │ :dir(ltr {}
   > 4 │ :dir(invalid {}
       │              ^
     5 │ :dir(.invalid) {}
     6 │ :dir(.invalid {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_identifier.css:5:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found '.invalid'.
-
+  
     3 │ :dir(ltr {}
     4 │ :dir(invalid {}
   > 5 │ :dir(.invalid) {}
       │      ^^^^^^^^
     6 │ :dir(.invalid {}
     7 │ :dir(ltr .class {}
-
+  
   i Expected a ltr, or a rtl here.
-
+  
     3 │ :dir(ltr {}
     4 │ :dir(invalid {}
   > 5 │ :dir(.invalid) {}
       │      ^^^^^^^^
     6 │ :dir(.invalid {}
     7 │ :dir(ltr .class {}
-
+  
 pseudo_class_function_identifier.css:6:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found '.invalid'.
-
+  
     4 │ :dir(invalid {}
     5 │ :dir(.invalid) {}
   > 6 │ :dir(.invalid {}
       │      ^^^^^^^^
     7 │ :dir(ltr .class {}
     8 │ :dir(ltr .class) {}
-
+  
   i Expected a ltr, or a rtl here.
-
+  
     4 │ :dir(invalid {}
     5 │ :dir(.invalid) {}
   > 6 │ :dir(.invalid {}
       │      ^^^^^^^^
     7 │ :dir(ltr .class {}
     8 │ :dir(ltr .class) {}
-
+  
 pseudo_class_function_identifier.css:6:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     4 │ :dir(invalid {}
     5 │ :dir(.invalid) {}
   > 6 │ :dir(.invalid {}
       │               ^
     7 │ :dir(ltr .class {}
     8 │ :dir(ltr .class) {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_identifier.css:7:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found 'ltr .class'.
-
+  
     5 │ :dir(.invalid) {}
     6 │ :dir(.invalid {}
   > 7 │ :dir(ltr .class {}
       │      ^^^^^^^^^^
     8 │ :dir(ltr .class) {}
     9 │ :dir(invalid .class {}
-
+  
   i Expected a ltr, or a rtl here.
-
+  
     5 │ :dir(.invalid) {}
     6 │ :dir(.invalid {}
   > 7 │ :dir(ltr .class {}
       │      ^^^^^^^^^^
     8 │ :dir(ltr .class) {}
     9 │ :dir(invalid .class {}
-
+  
 pseudo_class_function_identifier.css:7:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     5 │ :dir(.invalid) {}
     6 │ :dir(.invalid {}
   > 7 │ :dir(ltr .class {}
       │                 ^
     8 │ :dir(ltr .class) {}
     9 │ :dir(invalid .class {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_identifier.css:8:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found 'ltr .class'.
-
+  
      6 │ :dir(.invalid {}
      7 │ :dir(ltr .class {}
    > 8 │ :dir(ltr .class) {}
        │      ^^^^^^^^^^
      9 │ :dir(invalid .class {}
     10 │ :dir(invalid .class) {}
-
+  
   i Expected a ltr, or a rtl here.
-
+  
      6 │ :dir(.invalid {}
      7 │ :dir(ltr .class {}
    > 8 │ :dir(ltr .class) {}
        │      ^^^^^^^^^^
      9 │ :dir(invalid .class {}
     10 │ :dir(invalid .class) {}
-
+  
 pseudo_class_function_identifier.css:9:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found 'invalid .class'.
-
+  
      7 │ :dir(ltr .class {}
      8 │ :dir(ltr .class) {}
    > 9 │ :dir(invalid .class {}
        │      ^^^^^^^^^^^^^^
     10 │ :dir(invalid .class) {}
     11 │ :dir(.invalid
-
+  
   i Expected a ltr, or a rtl here.
-
+  
      7 │ :dir(ltr .class {}
      8 │ :dir(ltr .class) {}
    > 9 │ :dir(invalid .class {}
        │      ^^^^^^^^^^^^^^
     10 │ :dir(invalid .class) {}
     11 │ :dir(.invalid
-
+  
 pseudo_class_function_identifier.css:9:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
      7 │ :dir(ltr .class {}
      8 │ :dir(ltr .class) {}
    > 9 │ :dir(invalid .class {}
        │                     ^
     10 │ :dir(invalid .class) {}
     11 │ :dir(.invalid
-
+  
   i Remove {
-
+  
 pseudo_class_function_identifier.css:10:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found 'invalid .class'.
-
+  
      8 │ :dir(ltr .class) {}
      9 │ :dir(invalid .class {}
   > 10 │ :dir(invalid .class) {}
        │      ^^^^^^^^^^^^^^
     11 │ :dir(.invalid
-    12 │
-
+    12 │ 
+  
   i Expected a ltr, or a rtl here.
-
+  
      8 │ :dir(ltr .class) {}
      9 │ :dir(invalid .class {}
   > 10 │ :dir(invalid .class) {}
        │      ^^^^^^^^^^^^^^
     11 │ :dir(.invalid
-    12 │
-
+    12 │ 
+  
 pseudo_class_function_identifier.css:11:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a ltr, or a rtl but instead found '.invalid'.
-
+  
      9 │ :dir(invalid .class {}
     10 │ :dir(invalid .class) {}
   > 11 │ :dir(.invalid
        │      ^^^^^^^^
-    12 │
-
+    12 │ 
+  
   i Expected a ltr, or a rtl here.
-
+  
      9 │ :dir(invalid .class {}
     10 │ :dir(invalid .class) {}
   > 11 │ :dir(.invalid
        │      ^^^^^^^^
-    12 │
-
+    12 │ 
+  
 pseudo_class_function_identifier.css:12:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-
+  
     10 │ :dir(invalid .class) {}
     11 │ :dir(.invalid
-  > 12 │
-       │
-
+  > 12 │ 
+       │ 
+  
   i the file ends here
-
+  
     10 │ :dir(invalid .class) {}
     11 │ :dir(.invalid
-  > 12 │
-       │
-
+  > 12 │ 
+       │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_nth.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_nth.css.snap
@@ -58,7 +58,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@20..21 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@21..22 "}" [] [],
             },
         },
@@ -99,7 +99,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@40..41 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@41..42 "}" [] [],
             },
         },
@@ -146,7 +146,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@66..67 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@67..68 "}" [] [],
             },
         },
@@ -192,7 +192,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@91..92 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@92..93 "}" [] [],
             },
         },
@@ -231,7 +231,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@114..115 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@115..116 "}" [] [],
             },
         },
@@ -273,7 +273,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@143..144 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@144..145 "}" [] [],
             },
         },
@@ -313,7 +313,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@165..166 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@166..167 "}" [] [],
             },
         },
@@ -357,7 +357,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@189..190 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@190..191 "}" [] [],
             },
         },
@@ -400,7 +400,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@212..213 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@213..214 "}" [] [],
             },
         },
@@ -437,7 +437,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@237..238 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@238..239 "}" [] [],
             },
         },
@@ -473,7 +473,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@261..262 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@262..263 "}" [] [],
             },
         },
@@ -494,7 +494,7 @@ CssRoot {
                                     },
                                     of_selector: CssPseudoClassOfNthSelector {
                                         of_token: OF_KW@280..283 "of" [] [Whitespace(" ")],
-                                        selector_list: CssSelectorList [
+                                        selectors: CssSelectorList [
                                             CssBogusSelector {
                                                 items: [
                                                     CARET@283..284 "^" [] [],
@@ -524,7 +524,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@290..291 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@291..292 "}" [] [],
             },
         },
@@ -546,7 +546,7 @@ CssRoot {
                                         },
                                         of_selector: CssPseudoClassOfNthSelector {
                                             of_token: OF_KW@309..312 "of" [] [Whitespace(" ")],
-                                            selector_list: CssSelectorList [
+                                            selectors: CssSelectorList [
                                                 CssBogusSelector {
                                                     items: [
                                                         CARET@312..313 "^" [] [],
@@ -576,7 +576,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@318..319 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@319..320 "}" [] [],
             },
         },
@@ -615,7 +615,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@345..346 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@346..347 "}" [] [],
             },
         },
@@ -653,7 +653,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@371..372 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@372..373 "}" [] [],
             },
         },
@@ -1134,417 +1134,417 @@ CssRoot {
 pseudo_class_function_nth.css:1:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found 'invalid'.
-  
+
   > 1 │ :nth-child(invalid) {}
       │            ^^^^^^^
     2 │ :nth-child(2not) {}
     3 │ :nth-child(2n+1 + 100) {}
-  
+
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-  
+
   > 1 │ :nth-child(invalid) {}
       │            ^^^^^^^
     2 │ :nth-child(2not) {}
     3 │ :nth-child(2n+1 + 100) {}
-  
+
 pseudo_class_function_nth.css:2:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found '2not'.
-  
+
     1 │ :nth-child(invalid) {}
   > 2 │ :nth-child(2not) {}
       │            ^^^^
     3 │ :nth-child(2n+1 + 100) {}
     4 │ :nth-child(2n+1 + 100 {}
-  
+
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-  
+
     1 │ :nth-child(invalid) {}
   > 2 │ :nth-child(2not) {}
       │            ^^^^
     3 │ :nth-child(2n+1 + 100) {}
     4 │ :nth-child(2n+1 + 100 {}
-  
+
 pseudo_class_function_nth.css:3:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found '2n+1 + 100'.
-  
+
     1 │ :nth-child(invalid) {}
     2 │ :nth-child(2not) {}
   > 3 │ :nth-child(2n+1 + 100) {}
       │            ^^^^^^^^^^
     4 │ :nth-child(2n+1 + 100 {}
     5 │ :nth-child(2n + +1) {}
-  
+
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-  
+
     1 │ :nth-child(invalid) {}
     2 │ :nth-child(2not) {}
   > 3 │ :nth-child(2n+1 + 100) {}
       │            ^^^^^^^^^^
     4 │ :nth-child(2n+1 + 100 {}
     5 │ :nth-child(2n + +1) {}
-  
+
 pseudo_class_function_nth.css:4:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found '2n+1 + 100'.
-  
+
     2 │ :nth-child(2not) {}
     3 │ :nth-child(2n+1 + 100) {}
   > 4 │ :nth-child(2n+1 + 100 {}
       │            ^^^^^^^^^^
     5 │ :nth-child(2n + +1) {}
     6 │ :nth-child(2n invalid +1) {}
-  
+
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-  
+
     2 │ :nth-child(2not) {}
     3 │ :nth-child(2n+1 + 100) {}
   > 4 │ :nth-child(2n+1 + 100 {}
       │            ^^^^^^^^^^
     5 │ :nth-child(2n + +1) {}
     6 │ :nth-child(2n invalid +1) {}
-  
+
 pseudo_class_function_nth.css:4:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     2 │ :nth-child(2not) {}
     3 │ :nth-child(2n+1 + 100) {}
   > 4 │ :nth-child(2n+1 + 100 {}
       │                       ^
     5 │ :nth-child(2n + +1) {}
     6 │ :nth-child(2n invalid +1) {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_nth.css:6:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found '2n invalid +1'.
-  
+
     4 │ :nth-child(2n+1 + 100 {}
     5 │ :nth-child(2n + +1) {}
   > 6 │ :nth-child(2n invalid +1) {}
       │            ^^^^^^^^^^^^^
     7 │ :nth-child(2n + +1 {}
     8 │ :nth-child(2n + not) {}
-  
+
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-  
+
     4 │ :nth-child(2n+1 + 100 {}
     5 │ :nth-child(2n + +1) {}
   > 6 │ :nth-child(2n invalid +1) {}
       │            ^^^^^^^^^^^^^
     7 │ :nth-child(2n + +1 {}
     8 │ :nth-child(2n + not) {}
-  
+
 pseudo_class_function_nth.css:7:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     5 │ :nth-child(2n + +1) {}
     6 │ :nth-child(2n invalid +1) {}
   > 7 │ :nth-child(2n + +1 {}
       │                    ^
     8 │ :nth-child(2n + not) {}
     9 │ :nth-child(2n + not {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_nth.css:8:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a number but instead found 'not'.
-  
+
      6 │ :nth-child(2n invalid +1) {}
      7 │ :nth-child(2n + +1 {}
    > 8 │ :nth-child(2n + not) {}
        │                 ^^^
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
-  
+
   i Expected a number here.
-  
+
      6 │ :nth-child(2n invalid +1) {}
      7 │ :nth-child(2n + +1 {}
    > 8 │ :nth-child(2n + not) {}
        │                 ^^^
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
-  
+
 pseudo_class_function_nth.css:8:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found '2n + not'.
-  
+
      6 │ :nth-child(2n invalid +1) {}
      7 │ :nth-child(2n + +1 {}
    > 8 │ :nth-child(2n + not) {}
        │            ^^^^^^^^
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
-  
+
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-  
+
      6 │ :nth-child(2n invalid +1) {}
      7 │ :nth-child(2n + +1 {}
    > 8 │ :nth-child(2n + not) {}
        │            ^^^^^^^^
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
-  
+
 pseudo_class_function_nth.css:9:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a number but instead found 'not'.
-  
+
      7 │ :nth-child(2n + +1 {}
      8 │ :nth-child(2n + not) {}
    > 9 │ :nth-child(2n + not {}
        │                 ^^^
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
-  
+
   i Expected a number here.
-  
+
      7 │ :nth-child(2n + +1 {}
      8 │ :nth-child(2n + not) {}
    > 9 │ :nth-child(2n + not {}
        │                 ^^^
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
-  
+
 pseudo_class_function_nth.css:9:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found '2n + not'.
-  
+
      7 │ :nth-child(2n + +1 {}
      8 │ :nth-child(2n + not) {}
    > 9 │ :nth-child(2n + not {}
        │            ^^^^^^^^
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
-  
+
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-  
+
      7 │ :nth-child(2n + +1 {}
      8 │ :nth-child(2n + not) {}
    > 9 │ :nth-child(2n + not {}
        │            ^^^^^^^^
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
-  
+
 pseudo_class_function_nth.css:9:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
      7 │ :nth-child(2n + +1 {}
      8 │ :nth-child(2n + not) {}
    > 9 │ :nth-child(2n + not {}
        │                     ^
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_nth.css:10:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found 'even .div'.
-  
+
      8 │ :nth-child(2n + not) {}
      9 │ :nth-child(2n + not {}
   > 10 │ :nth-child(even .div) {}
        │            ^^^^^^^^^
     11 │ :nth-child(even .div {}
     12 │ :nth-child(even of ^.div) {}
-  
+
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-  
+
      8 │ :nth-child(2n + not) {}
      9 │ :nth-child(2n + not {}
   > 10 │ :nth-child(even .div) {}
        │            ^^^^^^^^^
     11 │ :nth-child(even .div {}
     12 │ :nth-child(even of ^.div) {}
-  
+
 pseudo_class_function_nth.css:11:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found 'even .div'.
-  
+
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
   > 11 │ :nth-child(even .div {}
        │            ^^^^^^^^^
     12 │ :nth-child(even of ^.div) {}
     13 │ :nth-child(even of ^.div {}
-  
+
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-  
+
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
   > 11 │ :nth-child(even .div {}
        │            ^^^^^^^^^
     12 │ :nth-child(even of ^.div) {}
     13 │ :nth-child(even of ^.div {}
-  
+
 pseudo_class_function_nth.css:11:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
   > 11 │ :nth-child(even .div {}
        │                      ^
     12 │ :nth-child(even of ^.div) {}
     13 │ :nth-child(even of ^.div {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_nth.css:12:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '^'.
-  
+
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
   > 12 │ :nth-child(even of ^.div) {}
        │                    ^
     13 │ :nth-child(even of ^.div {}
     14 │ :nth-child(even ^.div,) {}
-  
+
   i Expected a selector here.
-  
+
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
   > 12 │ :nth-child(even of ^.div) {}
        │                    ^
     13 │ :nth-child(even of ^.div {}
     14 │ :nth-child(even ^.div,) {}
-  
+
 pseudo_class_function_nth.css:12:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `.`
-  
+
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
   > 12 │ :nth-child(even of ^.div) {}
        │                     ^
     13 │ :nth-child(even of ^.div {}
     14 │ :nth-child(even ^.div,) {}
-  
+
   i Remove .
-  
+
 pseudo_class_function_nth.css:13:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '^'.
-  
+
     11 │ :nth-child(even .div {}
     12 │ :nth-child(even of ^.div) {}
   > 13 │ :nth-child(even of ^.div {}
        │                    ^
     14 │ :nth-child(even ^.div,) {}
     15 │ :nth-child(even ^.div, {}
-  
+
   i Expected a selector here.
-  
+
     11 │ :nth-child(even .div {}
     12 │ :nth-child(even of ^.div) {}
   > 13 │ :nth-child(even of ^.div {}
        │                    ^
     14 │ :nth-child(even ^.div,) {}
     15 │ :nth-child(even ^.div, {}
-  
+
 pseudo_class_function_nth.css:13:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `.`
-  
+
     11 │ :nth-child(even .div {}
     12 │ :nth-child(even of ^.div) {}
   > 13 │ :nth-child(even of ^.div {}
        │                     ^
     14 │ :nth-child(even ^.div,) {}
     15 │ :nth-child(even ^.div, {}
-  
+
   i Remove .
-  
+
 pseudo_class_function_nth.css:13:26 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-  
+
     11 │ :nth-child(even .div {}
     12 │ :nth-child(even of ^.div) {}
   > 13 │ :nth-child(even of ^.div {}
        │                          ^
     14 │ :nth-child(even ^.div,) {}
     15 │ :nth-child(even ^.div, {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_nth.css:14:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found 'even ^.div,'.
-  
+
     12 │ :nth-child(even of ^.div) {}
     13 │ :nth-child(even of ^.div {}
   > 14 │ :nth-child(even ^.div,) {}
        │            ^^^^^^^^^^^
     15 │ :nth-child(even ^.div, {}
     16 │ :nth-child(2n + 1
-  
+
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-  
+
     12 │ :nth-child(even of ^.div) {}
     13 │ :nth-child(even of ^.div {}
   > 14 │ :nth-child(even ^.div,) {}
        │            ^^^^^^^^^^^
     15 │ :nth-child(even ^.div, {}
     16 │ :nth-child(2n + 1
-  
+
 pseudo_class_function_nth.css:15:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found 'even ^.div,'.
-  
+
     13 │ :nth-child(even of ^.div {}
     14 │ :nth-child(even ^.div,) {}
   > 15 │ :nth-child(even ^.div, {}
        │            ^^^^^^^^^^^
     16 │ :nth-child(2n + 1
-    17 │ 
-  
+    17 │
+
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-  
+
     13 │ :nth-child(even of ^.div {}
     14 │ :nth-child(even ^.div,) {}
   > 15 │ :nth-child(even ^.div, {}
        │            ^^^^^^^^^^^
     16 │ :nth-child(2n + 1
-    17 │ 
-  
+    17 │
+
 pseudo_class_function_nth.css:15:24 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     13 │ :nth-child(even of ^.div {}
     14 │ :nth-child(even ^.div,) {}
   > 15 │ :nth-child(even ^.div, {}
        │                        ^
     16 │ :nth-child(2n + 1
-    17 │ 
-  
+    17 │
+
   i Remove {
-  
+
 pseudo_class_function_nth.css:17:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-  
+
     15 │ :nth-child(even ^.div, {}
     16 │ :nth-child(2n + 1
-  > 17 │ 
-       │ 
-  
+  > 17 │
+       │
+
   i the file ends here
-  
+
     15 │ :nth-child(even ^.div, {}
     16 │ :nth-child(2n + 1
-  > 17 │ 
-       │ 
-  
+  > 17 │
+       │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_nth.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_nth.css.snap
@@ -1134,417 +1134,417 @@ CssRoot {
 pseudo_class_function_nth.css:1:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found 'invalid'.
-
+  
   > 1 │ :nth-child(invalid) {}
       │            ^^^^^^^
     2 │ :nth-child(2not) {}
     3 │ :nth-child(2n+1 + 100) {}
-
+  
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-
+  
   > 1 │ :nth-child(invalid) {}
       │            ^^^^^^^
     2 │ :nth-child(2not) {}
     3 │ :nth-child(2n+1 + 100) {}
-
+  
 pseudo_class_function_nth.css:2:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found '2not'.
-
+  
     1 │ :nth-child(invalid) {}
   > 2 │ :nth-child(2not) {}
       │            ^^^^
     3 │ :nth-child(2n+1 + 100) {}
     4 │ :nth-child(2n+1 + 100 {}
-
+  
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-
+  
     1 │ :nth-child(invalid) {}
   > 2 │ :nth-child(2not) {}
       │            ^^^^
     3 │ :nth-child(2n+1 + 100) {}
     4 │ :nth-child(2n+1 + 100 {}
-
+  
 pseudo_class_function_nth.css:3:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found '2n+1 + 100'.
-
+  
     1 │ :nth-child(invalid) {}
     2 │ :nth-child(2not) {}
   > 3 │ :nth-child(2n+1 + 100) {}
       │            ^^^^^^^^^^
     4 │ :nth-child(2n+1 + 100 {}
     5 │ :nth-child(2n + +1) {}
-
+  
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-
+  
     1 │ :nth-child(invalid) {}
     2 │ :nth-child(2not) {}
   > 3 │ :nth-child(2n+1 + 100) {}
       │            ^^^^^^^^^^
     4 │ :nth-child(2n+1 + 100 {}
     5 │ :nth-child(2n + +1) {}
-
+  
 pseudo_class_function_nth.css:4:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found '2n+1 + 100'.
-
+  
     2 │ :nth-child(2not) {}
     3 │ :nth-child(2n+1 + 100) {}
   > 4 │ :nth-child(2n+1 + 100 {}
       │            ^^^^^^^^^^
     5 │ :nth-child(2n + +1) {}
     6 │ :nth-child(2n invalid +1) {}
-
+  
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-
+  
     2 │ :nth-child(2not) {}
     3 │ :nth-child(2n+1 + 100) {}
   > 4 │ :nth-child(2n+1 + 100 {}
       │            ^^^^^^^^^^
     5 │ :nth-child(2n + +1) {}
     6 │ :nth-child(2n invalid +1) {}
-
+  
 pseudo_class_function_nth.css:4:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     2 │ :nth-child(2not) {}
     3 │ :nth-child(2n+1 + 100) {}
   > 4 │ :nth-child(2n+1 + 100 {}
       │                       ^
     5 │ :nth-child(2n + +1) {}
     6 │ :nth-child(2n invalid +1) {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_nth.css:6:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found '2n invalid +1'.
-
+  
     4 │ :nth-child(2n+1 + 100 {}
     5 │ :nth-child(2n + +1) {}
   > 6 │ :nth-child(2n invalid +1) {}
       │            ^^^^^^^^^^^^^
     7 │ :nth-child(2n + +1 {}
     8 │ :nth-child(2n + not) {}
-
+  
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-
+  
     4 │ :nth-child(2n+1 + 100 {}
     5 │ :nth-child(2n + +1) {}
   > 6 │ :nth-child(2n invalid +1) {}
       │            ^^^^^^^^^^^^^
     7 │ :nth-child(2n + +1 {}
     8 │ :nth-child(2n + not) {}
-
+  
 pseudo_class_function_nth.css:7:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     5 │ :nth-child(2n + +1) {}
     6 │ :nth-child(2n invalid +1) {}
   > 7 │ :nth-child(2n + +1 {}
       │                    ^
     8 │ :nth-child(2n + not) {}
     9 │ :nth-child(2n + not {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_nth.css:8:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a number but instead found 'not'.
-
+  
      6 │ :nth-child(2n invalid +1) {}
      7 │ :nth-child(2n + +1 {}
    > 8 │ :nth-child(2n + not) {}
        │                 ^^^
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
-
+  
   i Expected a number here.
-
+  
      6 │ :nth-child(2n invalid +1) {}
      7 │ :nth-child(2n + +1 {}
    > 8 │ :nth-child(2n + not) {}
        │                 ^^^
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
-
+  
 pseudo_class_function_nth.css:8:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found '2n + not'.
-
+  
      6 │ :nth-child(2n invalid +1) {}
      7 │ :nth-child(2n + +1 {}
    > 8 │ :nth-child(2n + not) {}
        │            ^^^^^^^^
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
-
+  
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-
+  
      6 │ :nth-child(2n invalid +1) {}
      7 │ :nth-child(2n + +1 {}
    > 8 │ :nth-child(2n + not) {}
        │            ^^^^^^^^
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
-
+  
 pseudo_class_function_nth.css:9:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a number but instead found 'not'.
-
+  
      7 │ :nth-child(2n + +1 {}
      8 │ :nth-child(2n + not) {}
    > 9 │ :nth-child(2n + not {}
        │                 ^^^
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
-
+  
   i Expected a number here.
-
+  
      7 │ :nth-child(2n + +1 {}
      8 │ :nth-child(2n + not) {}
    > 9 │ :nth-child(2n + not {}
        │                 ^^^
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
-
+  
 pseudo_class_function_nth.css:9:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found '2n + not'.
-
+  
      7 │ :nth-child(2n + +1 {}
      8 │ :nth-child(2n + not) {}
    > 9 │ :nth-child(2n + not {}
        │            ^^^^^^^^
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
-
+  
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-
+  
      7 │ :nth-child(2n + +1 {}
      8 │ :nth-child(2n + not) {}
    > 9 │ :nth-child(2n + not {}
        │            ^^^^^^^^
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
-
+  
 pseudo_class_function_nth.css:9:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
      7 │ :nth-child(2n + +1 {}
      8 │ :nth-child(2n + not) {}
    > 9 │ :nth-child(2n + not {}
        │                     ^
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_nth.css:10:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found 'even .div'.
-
+  
      8 │ :nth-child(2n + not) {}
      9 │ :nth-child(2n + not {}
   > 10 │ :nth-child(even .div) {}
        │            ^^^^^^^^^
     11 │ :nth-child(even .div {}
     12 │ :nth-child(even of ^.div) {}
-
+  
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-
+  
      8 │ :nth-child(2n + not) {}
      9 │ :nth-child(2n + not {}
   > 10 │ :nth-child(even .div) {}
        │            ^^^^^^^^^
     11 │ :nth-child(even .div {}
     12 │ :nth-child(even of ^.div) {}
-
+  
 pseudo_class_function_nth.css:11:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found 'even .div'.
-
+  
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
   > 11 │ :nth-child(even .div {}
        │            ^^^^^^^^^
     12 │ :nth-child(even of ^.div) {}
     13 │ :nth-child(even of ^.div {}
-
+  
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-
+  
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
   > 11 │ :nth-child(even .div {}
        │            ^^^^^^^^^
     12 │ :nth-child(even of ^.div) {}
     13 │ :nth-child(even of ^.div {}
-
+  
 pseudo_class_function_nth.css:11:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
      9 │ :nth-child(2n + not {}
     10 │ :nth-child(even .div) {}
   > 11 │ :nth-child(even .div {}
        │                      ^
     12 │ :nth-child(even of ^.div) {}
     13 │ :nth-child(even of ^.div {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_nth.css:12:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '^'.
-
+  
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
   > 12 │ :nth-child(even of ^.div) {}
        │                    ^
     13 │ :nth-child(even of ^.div {}
     14 │ :nth-child(even ^.div,) {}
-
+  
   i Expected a selector here.
-
+  
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
   > 12 │ :nth-child(even of ^.div) {}
        │                    ^
     13 │ :nth-child(even of ^.div {}
     14 │ :nth-child(even ^.div,) {}
-
+  
 pseudo_class_function_nth.css:12:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `.`
-
+  
     10 │ :nth-child(even .div) {}
     11 │ :nth-child(even .div {}
   > 12 │ :nth-child(even of ^.div) {}
        │                     ^
     13 │ :nth-child(even of ^.div {}
     14 │ :nth-child(even ^.div,) {}
-
+  
   i Remove .
-
+  
 pseudo_class_function_nth.css:13:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '^'.
-
+  
     11 │ :nth-child(even .div {}
     12 │ :nth-child(even of ^.div) {}
   > 13 │ :nth-child(even of ^.div {}
        │                    ^
     14 │ :nth-child(even ^.div,) {}
     15 │ :nth-child(even ^.div, {}
-
+  
   i Expected a selector here.
-
+  
     11 │ :nth-child(even .div {}
     12 │ :nth-child(even of ^.div) {}
   > 13 │ :nth-child(even of ^.div {}
        │                    ^
     14 │ :nth-child(even ^.div,) {}
     15 │ :nth-child(even ^.div, {}
-
+  
 pseudo_class_function_nth.css:13:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `.`
-
+  
     11 │ :nth-child(even .div {}
     12 │ :nth-child(even of ^.div) {}
   > 13 │ :nth-child(even of ^.div {}
        │                     ^
     14 │ :nth-child(even ^.div,) {}
     15 │ :nth-child(even ^.div, {}
-
+  
   i Remove .
-
+  
 pseudo_class_function_nth.css:13:26 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-
+  
     11 │ :nth-child(even .div {}
     12 │ :nth-child(even of ^.div) {}
   > 13 │ :nth-child(even of ^.div {}
        │                          ^
     14 │ :nth-child(even ^.div,) {}
     15 │ :nth-child(even ^.div, {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_nth.css:14:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found 'even ^.div,'.
-
+  
     12 │ :nth-child(even of ^.div) {}
     13 │ :nth-child(even of ^.div {}
   > 14 │ :nth-child(even ^.div,) {}
        │            ^^^^^^^^^^^
     15 │ :nth-child(even ^.div, {}
     16 │ :nth-child(2n + 1
-
+  
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-
+  
     12 │ :nth-child(even of ^.div) {}
     13 │ :nth-child(even of ^.div {}
   > 14 │ :nth-child(even ^.div,) {}
        │            ^^^^^^^^^^^
     15 │ :nth-child(even ^.div, {}
     16 │ :nth-child(2n + 1
-
+  
 pseudo_class_function_nth.css:15:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an even, an odd, a n, a <An+B>, or a number but instead found 'even ^.div,'.
-
+  
     13 │ :nth-child(even of ^.div {}
     14 │ :nth-child(even ^.div,) {}
   > 15 │ :nth-child(even ^.div, {}
        │            ^^^^^^^^^^^
     16 │ :nth-child(2n + 1
-    17 │
-
+    17 │ 
+  
   i Expected an even, an odd, a n, a <An+B>, or a number here.
-
+  
     13 │ :nth-child(even of ^.div {}
     14 │ :nth-child(even ^.div,) {}
   > 15 │ :nth-child(even ^.div, {}
        │            ^^^^^^^^^^^
     16 │ :nth-child(2n + 1
-    17 │
-
+    17 │ 
+  
 pseudo_class_function_nth.css:15:24 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     13 │ :nth-child(even of ^.div {}
     14 │ :nth-child(even ^.div,) {}
   > 15 │ :nth-child(even ^.div, {}
        │                        ^
     16 │ :nth-child(2n + 1
-    17 │
-
+    17 │ 
+  
   i Remove {
-
+  
 pseudo_class_function_nth.css:17:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-
+  
     15 │ :nth-child(even ^.div, {}
     16 │ :nth-child(2n + 1
-  > 17 │
-       │
-
+  > 17 │ 
+       │ 
+  
   i the file ends here
-
+  
     15 │ :nth-child(even ^.div, {}
     16 │ :nth-child(2n + 1
-  > 17 │
-       │
-
+  > 17 │ 
+       │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_relative_selector_list.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_relative_selector_list.css.snap
@@ -614,192 +614,192 @@ CssRoot {
 pseudo_class_function_relative_selector_list.css:1:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found '{'.
-
+  
   > 1 │ :has( {}
       │       ^
     2 │ :has() {}
     3 │ :has(^invalid) {}
-
+  
   i Expected a relative selector here.
-
+  
   > 1 │ :has( {}
       │       ^
     2 │ :has() {}
     3 │ :has(^invalid) {}
-
+  
 pseudo_class_function_relative_selector_list.css:2:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found ''.
-
+  
     1 │ :has( {}
   > 2 │ :has() {}
-      │
+      │      
     3 │ :has(^invalid) {}
     4 │ :has(^invalid {}
-
+  
   i Expected a relative selector here.
-
+  
     1 │ :has( {}
   > 2 │ :has() {}
-      │
+      │      
     3 │ :has(^invalid) {}
     4 │ :has(^invalid {}
-
+  
 pseudo_class_function_relative_selector_list.css:3:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found '^'.
-
+  
     1 │ :has( {}
     2 │ :has() {}
   > 3 │ :has(^invalid) {}
       │      ^
     4 │ :has(^invalid {}
     5 │ :has(^invalid .class) {}
-
+  
   i Expected a relative selector here.
-
+  
     1 │ :has( {}
     2 │ :has() {}
   > 3 │ :has(^invalid) {}
       │      ^
     4 │ :has(^invalid {}
     5 │ :has(^invalid .class) {}
-
+  
 pseudo_class_function_relative_selector_list.css:4:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found '^'.
-
+  
     2 │ :has() {}
     3 │ :has(^invalid) {}
   > 4 │ :has(^invalid {}
       │      ^
     5 │ :has(^invalid .class) {}
     6 │ :has(.div .class,^invalid) {}
-
+  
   i Expected a relative selector here.
-
+  
     2 │ :has() {}
     3 │ :has(^invalid) {}
   > 4 │ :has(^invalid {}
       │      ^
     5 │ :has(^invalid .class) {}
     6 │ :has(.div .class,^invalid) {}
-
+  
 pseudo_class_function_relative_selector_list.css:4:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     2 │ :has() {}
     3 │ :has(^invalid) {}
   > 4 │ :has(^invalid {}
       │               ^
     5 │ :has(^invalid .class) {}
     6 │ :has(.div .class,^invalid) {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_relative_selector_list.css:5:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found '^'.
-
+  
     3 │ :has(^invalid) {}
     4 │ :has(^invalid {}
   > 5 │ :has(^invalid .class) {}
       │      ^
     6 │ :has(.div .class,^invalid) {}
     7 │ :has(.div .class {}
-
+  
   i Expected a relative selector here.
-
+  
     3 │ :has(^invalid) {}
     4 │ :has(^invalid {}
   > 5 │ :has(^invalid .class) {}
       │      ^
     6 │ :has(.div .class,^invalid) {}
     7 │ :has(.div .class {}
-
+  
 pseudo_class_function_relative_selector_list.css:6:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found '^'.
-
+  
     4 │ :has(^invalid {}
     5 │ :has(^invalid .class) {}
   > 6 │ :has(.div .class,^invalid) {}
       │                  ^
     7 │ :has(.div .class {}
     8 │ :has(.div {}
-
+  
   i Expected a relative selector here.
-
+  
     4 │ :has(^invalid {}
     5 │ :has(^invalid .class) {}
   > 6 │ :has(.div .class,^invalid) {}
       │                  ^
     7 │ :has(.div .class {}
     8 │ :has(.div {}
-
+  
 pseudo_class_function_relative_selector_list.css:6:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found '.div .class,^invalid'.
-
+  
     4 │ :has(^invalid {}
     5 │ :has(^invalid .class) {}
   > 6 │ :has(.div .class,^invalid) {}
       │      ^^^^^^^^^^^^^^^^^^^^
     7 │ :has(.div .class {}
     8 │ :has(.div {}
-
+  
   i Expected a relative selector here.
-
+  
     4 │ :has(^invalid {}
     5 │ :has(^invalid .class) {}
   > 6 │ :has(.div .class,^invalid) {}
       │      ^^^^^^^^^^^^^^^^^^^^
     7 │ :has(.div .class {}
     8 │ :has(.div {}
-
+  
 pseudo_class_function_relative_selector_list.css:7:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-
+  
     5 │ :has(^invalid .class) {}
     6 │ :has(.div .class,^invalid) {}
   > 7 │ :has(.div .class {}
       │                  ^
     8 │ :has(.div {}
     9 │ :has(.div
-
+  
   i Remove {
-
+  
 pseudo_class_function_relative_selector_list.css:8:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-
+  
      6 │ :has(.div .class,^invalid) {}
      7 │ :has(.div .class {}
    > 8 │ :has(.div {}
        │           ^
      9 │ :has(.div
-    10 │
-
+    10 │ 
+  
   i Remove {
-
+  
 pseudo_class_function_relative_selector_list.css:10:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-
+  
      8 │ :has(.div {}
      9 │ :has(.div
-  > 10 │
-       │
-
+  > 10 │ 
+       │ 
+  
   i the file ends here
-
+  
      8 │ :has(.div {}
      9 │ :has(.div
-  > 10 │
-       │
-
+  > 10 │ 
+       │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_relative_selector_list.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_relative_selector_list.css.snap
@@ -46,7 +46,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@6..7 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@7..8 "}" [] [],
             },
         },
@@ -72,7 +72,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@16..17 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@17..18 "}" [] [],
             },
         },
@@ -104,7 +104,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@34..35 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@35..36 "}" [] [],
             },
         },
@@ -135,7 +135,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@51..52 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@52..53 "}" [] [],
             },
         },
@@ -169,7 +169,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@76..77 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@77..78 "}" [] [],
             },
         },
@@ -234,7 +234,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@106..107 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@107..108 "}" [] [],
             },
         },
@@ -290,7 +290,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@126..127 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@127..128 "}" [] [],
             },
         },
@@ -331,7 +331,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@139..140 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@140..141 "}" [] [],
             },
         },
@@ -614,192 +614,192 @@ CssRoot {
 pseudo_class_function_relative_selector_list.css:1:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found '{'.
-  
+
   > 1 │ :has( {}
       │       ^
     2 │ :has() {}
     3 │ :has(^invalid) {}
-  
+
   i Expected a relative selector here.
-  
+
   > 1 │ :has( {}
       │       ^
     2 │ :has() {}
     3 │ :has(^invalid) {}
-  
+
 pseudo_class_function_relative_selector_list.css:2:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found ''.
-  
+
     1 │ :has( {}
   > 2 │ :has() {}
-      │      
+      │
     3 │ :has(^invalid) {}
     4 │ :has(^invalid {}
-  
+
   i Expected a relative selector here.
-  
+
     1 │ :has( {}
   > 2 │ :has() {}
-      │      
+      │
     3 │ :has(^invalid) {}
     4 │ :has(^invalid {}
-  
+
 pseudo_class_function_relative_selector_list.css:3:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found '^'.
-  
+
     1 │ :has( {}
     2 │ :has() {}
   > 3 │ :has(^invalid) {}
       │      ^
     4 │ :has(^invalid {}
     5 │ :has(^invalid .class) {}
-  
+
   i Expected a relative selector here.
-  
+
     1 │ :has( {}
     2 │ :has() {}
   > 3 │ :has(^invalid) {}
       │      ^
     4 │ :has(^invalid {}
     5 │ :has(^invalid .class) {}
-  
+
 pseudo_class_function_relative_selector_list.css:4:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found '^'.
-  
+
     2 │ :has() {}
     3 │ :has(^invalid) {}
   > 4 │ :has(^invalid {}
       │      ^
     5 │ :has(^invalid .class) {}
     6 │ :has(.div .class,^invalid) {}
-  
+
   i Expected a relative selector here.
-  
+
     2 │ :has() {}
     3 │ :has(^invalid) {}
   > 4 │ :has(^invalid {}
       │      ^
     5 │ :has(^invalid .class) {}
     6 │ :has(.div .class,^invalid) {}
-  
+
 pseudo_class_function_relative_selector_list.css:4:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     2 │ :has() {}
     3 │ :has(^invalid) {}
   > 4 │ :has(^invalid {}
       │               ^
     5 │ :has(^invalid .class) {}
     6 │ :has(.div .class,^invalid) {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_relative_selector_list.css:5:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found '^'.
-  
+
     3 │ :has(^invalid) {}
     4 │ :has(^invalid {}
   > 5 │ :has(^invalid .class) {}
       │      ^
     6 │ :has(.div .class,^invalid) {}
     7 │ :has(.div .class {}
-  
+
   i Expected a relative selector here.
-  
+
     3 │ :has(^invalid) {}
     4 │ :has(^invalid {}
   > 5 │ :has(^invalid .class) {}
       │      ^
     6 │ :has(.div .class,^invalid) {}
     7 │ :has(.div .class {}
-  
+
 pseudo_class_function_relative_selector_list.css:6:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found '^'.
-  
+
     4 │ :has(^invalid {}
     5 │ :has(^invalid .class) {}
   > 6 │ :has(.div .class,^invalid) {}
       │                  ^
     7 │ :has(.div .class {}
     8 │ :has(.div {}
-  
+
   i Expected a relative selector here.
-  
+
     4 │ :has(^invalid {}
     5 │ :has(^invalid .class) {}
   > 6 │ :has(.div .class,^invalid) {}
       │                  ^
     7 │ :has(.div .class {}
     8 │ :has(.div {}
-  
+
 pseudo_class_function_relative_selector_list.css:6:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a relative selector but instead found '.div .class,^invalid'.
-  
+
     4 │ :has(^invalid {}
     5 │ :has(^invalid .class) {}
   > 6 │ :has(.div .class,^invalid) {}
       │      ^^^^^^^^^^^^^^^^^^^^
     7 │ :has(.div .class {}
     8 │ :has(.div {}
-  
+
   i Expected a relative selector here.
-  
+
     4 │ :has(^invalid {}
     5 │ :has(^invalid .class) {}
   > 6 │ :has(.div .class,^invalid) {}
       │      ^^^^^^^^^^^^^^^^^^^^
     7 │ :has(.div .class {}
     8 │ :has(.div {}
-  
+
 pseudo_class_function_relative_selector_list.css:7:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-  
+
     5 │ :has(^invalid .class) {}
     6 │ :has(.div .class,^invalid) {}
   > 7 │ :has(.div .class {}
       │                  ^
     8 │ :has(.div {}
     9 │ :has(.div
-  
+
   i Remove {
-  
+
 pseudo_class_function_relative_selector_list.css:8:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-  
+
      6 │ :has(.div .class,^invalid) {}
      7 │ :has(.div .class {}
    > 8 │ :has(.div {}
        │           ^
      9 │ :has(.div
-    10 │ 
-  
+    10 │
+
   i Remove {
-  
+
 pseudo_class_function_relative_selector_list.css:10:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-  
+
      8 │ :has(.div {}
      9 │ :has(.div
-  > 10 │ 
-       │ 
-  
+  > 10 │
+       │
+
   i the file ends here
-  
+
      8 │ :has(.div {}
      9 │ :has(.div
-  > 10 │ 
-       │ 
-  
+  > 10 │
+       │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector.css.snap
@@ -426,119 +426,119 @@ CssRoot {
 pseudo_class_function_selector.css:1:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '{'.
-
+  
   > 1 │ :global( {}
       │          ^
     2 │ :global() {}
     3 │ :global(.div, .class) {}
-
+  
   i Expected a selector here.
-
+  
   > 1 │ :global( {}
       │          ^
     2 │ :global() {}
     3 │ :global(.div, .class) {}
-
+  
 pseudo_class_function_selector.css:2:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found ')'.
-
+  
     1 │ :global( {}
   > 2 │ :global() {}
       │         ^
     3 │ :global(.div, .class) {}
     4 │ :global(.div, .class {}
-
+  
   i Expected a selector here.
-
+  
     1 │ :global( {}
   > 2 │ :global() {}
       │         ^
     3 │ :global(.div, .class) {}
     4 │ :global(.div, .class {}
-
+  
 pseudo_class_function_selector.css:3:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '.div, .class'.
-
+  
     1 │ :global( {}
     2 │ :global() {}
   > 3 │ :global(.div, .class) {}
       │         ^^^^^^^^^^^^
     4 │ :global(.div, .class {}
     5 │ :global(.div .class {}
-
+  
   i Expected a selector here.
-
+  
     1 │ :global( {}
     2 │ :global() {}
   > 3 │ :global(.div, .class) {}
       │         ^^^^^^^^^^^^
     4 │ :global(.div, .class {}
     5 │ :global(.div .class {}
-
+  
 pseudo_class_function_selector.css:4:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '.div, .class'.
-
+  
     2 │ :global() {}
     3 │ :global(.div, .class) {}
   > 4 │ :global(.div, .class {}
       │         ^^^^^^^^^^^^
     5 │ :global(.div .class {}
     6 │ :global(.div .class
-
+  
   i Expected a selector here.
-
+  
     2 │ :global() {}
     3 │ :global(.div, .class) {}
   > 4 │ :global(.div, .class {}
       │         ^^^^^^^^^^^^
     5 │ :global(.div .class {}
     6 │ :global(.div .class
-
+  
 pseudo_class_function_selector.css:4:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     2 │ :global() {}
     3 │ :global(.div, .class) {}
   > 4 │ :global(.div, .class {}
       │                      ^
     5 │ :global(.div .class {}
     6 │ :global(.div .class
-
+  
   i Remove {
-
+  
 pseudo_class_function_selector.css:5:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     3 │ :global(.div, .class) {}
     4 │ :global(.div, .class {}
   > 5 │ :global(.div .class {}
       │                     ^
     6 │ :global(.div .class
-    7 │
-
+    7 │ 
+  
   i Remove {
-
+  
 pseudo_class_function_selector.css:7:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-
+  
     5 │ :global(.div .class {}
     6 │ :global(.div .class
-  > 7 │
-      │
-
+  > 7 │ 
+      │ 
+  
   i the file ends here
-
+  
     5 │ :global(.div .class {}
     6 │ :global(.div .class
-  > 7 │
-      │
-
+  > 7 │ 
+      │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector.css.snap
@@ -42,7 +42,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@9..10 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@10..11 "}" [] [],
             },
         },
@@ -67,7 +67,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@22..23 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@23..24 "}" [] [],
             },
         },
@@ -111,7 +111,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@47..48 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@48..49 "}" [] [],
             },
         },
@@ -154,7 +154,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@71..72 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@72..73 "}" [] [],
             },
         },
@@ -205,7 +205,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@94..95 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@95..96 "}" [] [],
             },
         },
@@ -426,119 +426,119 @@ CssRoot {
 pseudo_class_function_selector.css:1:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '{'.
-  
+
   > 1 │ :global( {}
       │          ^
     2 │ :global() {}
     3 │ :global(.div, .class) {}
-  
+
   i Expected a selector here.
-  
+
   > 1 │ :global( {}
       │          ^
     2 │ :global() {}
     3 │ :global(.div, .class) {}
-  
+
 pseudo_class_function_selector.css:2:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found ')'.
-  
+
     1 │ :global( {}
   > 2 │ :global() {}
       │         ^
     3 │ :global(.div, .class) {}
     4 │ :global(.div, .class {}
-  
+
   i Expected a selector here.
-  
+
     1 │ :global( {}
   > 2 │ :global() {}
       │         ^
     3 │ :global(.div, .class) {}
     4 │ :global(.div, .class {}
-  
+
 pseudo_class_function_selector.css:3:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '.div, .class'.
-  
+
     1 │ :global( {}
     2 │ :global() {}
   > 3 │ :global(.div, .class) {}
       │         ^^^^^^^^^^^^
     4 │ :global(.div, .class {}
     5 │ :global(.div .class {}
-  
+
   i Expected a selector here.
-  
+
     1 │ :global( {}
     2 │ :global() {}
   > 3 │ :global(.div, .class) {}
       │         ^^^^^^^^^^^^
     4 │ :global(.div, .class {}
     5 │ :global(.div .class {}
-  
+
 pseudo_class_function_selector.css:4:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '.div, .class'.
-  
+
     2 │ :global() {}
     3 │ :global(.div, .class) {}
   > 4 │ :global(.div, .class {}
       │         ^^^^^^^^^^^^
     5 │ :global(.div .class {}
     6 │ :global(.div .class
-  
+
   i Expected a selector here.
-  
+
     2 │ :global() {}
     3 │ :global(.div, .class) {}
   > 4 │ :global(.div, .class {}
       │         ^^^^^^^^^^^^
     5 │ :global(.div .class {}
     6 │ :global(.div .class
-  
+
 pseudo_class_function_selector.css:4:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     2 │ :global() {}
     3 │ :global(.div, .class) {}
   > 4 │ :global(.div, .class {}
       │                      ^
     5 │ :global(.div .class {}
     6 │ :global(.div .class
-  
+
   i Remove {
-  
+
 pseudo_class_function_selector.css:5:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     3 │ :global(.div, .class) {}
     4 │ :global(.div, .class {}
   > 5 │ :global(.div .class {}
       │                     ^
     6 │ :global(.div .class
-    7 │ 
-  
+    7 │
+
   i Remove {
-  
+
 pseudo_class_function_selector.css:7:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-  
+
     5 │ :global(.div .class {}
     6 │ :global(.div .class
-  > 7 │ 
-      │ 
-  
+  > 7 │
+      │
+
   i the file ends here
-  
+
     5 │ :global(.div .class {}
     6 │ :global(.div .class
-  > 7 │ 
-      │ 
-  
+  > 7 │
+      │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector_list.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector_list.css.snap
@@ -46,7 +46,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@8..9 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@9..10 "}" [] [],
             },
         },
@@ -72,7 +72,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@20..21 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@21..22 "}" [] [],
             },
         },
@@ -104,7 +104,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@40..41 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@41..42 "}" [] [],
             },
         },
@@ -135,7 +135,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@59..60 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@60..61 "}" [] [],
             },
         },
@@ -169,7 +169,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@86..87 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@87..88 "}" [] [],
             },
         },
@@ -231,7 +231,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@118..119 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@119..120 "}" [] [],
             },
         },
@@ -284,7 +284,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@140..141 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@141..142 "}" [] [],
             },
         },
@@ -322,7 +322,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@155..156 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@156..157 "}" [] [],
             },
         },
@@ -594,192 +594,192 @@ CssRoot {
 pseudo_class_function_selector_list.css:1:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '{'.
-  
+
   > 1 │ :where( {}
       │         ^
     2 │ :where() {}
     3 │ :where(^invalid) {}
-  
+
   i Expected a selector here.
-  
+
   > 1 │ :where( {}
       │         ^
     2 │ :where() {}
     3 │ :where(^invalid) {}
-  
+
 pseudo_class_function_selector_list.css:2:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found ''.
-  
+
     1 │ :where( {}
   > 2 │ :where() {}
-      │        
+      │
     3 │ :where(^invalid) {}
     4 │ :where(^invalid {}
-  
+
   i Expected a selector here.
-  
+
     1 │ :where( {}
   > 2 │ :where() {}
-      │        
+      │
     3 │ :where(^invalid) {}
     4 │ :where(^invalid {}
-  
+
 pseudo_class_function_selector_list.css:3:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '^'.
-  
+
     1 │ :where( {}
     2 │ :where() {}
   > 3 │ :where(^invalid) {}
       │        ^
     4 │ :where(^invalid {}
     5 │ :where(^invalid .class) {}
-  
+
   i Expected a selector here.
-  
+
     1 │ :where( {}
     2 │ :where() {}
   > 3 │ :where(^invalid) {}
       │        ^
     4 │ :where(^invalid {}
     5 │ :where(^invalid .class) {}
-  
+
 pseudo_class_function_selector_list.css:4:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '^'.
-  
+
     2 │ :where() {}
     3 │ :where(^invalid) {}
   > 4 │ :where(^invalid {}
       │        ^
     5 │ :where(^invalid .class) {}
     6 │ :where(.div .class,^invalid) {}
-  
+
   i Expected a selector here.
-  
+
     2 │ :where() {}
     3 │ :where(^invalid) {}
   > 4 │ :where(^invalid {}
       │        ^
     5 │ :where(^invalid .class) {}
     6 │ :where(.div .class,^invalid) {}
-  
+
 pseudo_class_function_selector_list.css:4:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     2 │ :where() {}
     3 │ :where(^invalid) {}
   > 4 │ :where(^invalid {}
       │                 ^
     5 │ :where(^invalid .class) {}
     6 │ :where(.div .class,^invalid) {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_selector_list.css:5:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '^'.
-  
+
     3 │ :where(^invalid) {}
     4 │ :where(^invalid {}
   > 5 │ :where(^invalid .class) {}
       │        ^
     6 │ :where(.div .class,^invalid) {}
     7 │ :where(.div .class {}
-  
+
   i Expected a selector here.
-  
+
     3 │ :where(^invalid) {}
     4 │ :where(^invalid {}
   > 5 │ :where(^invalid .class) {}
       │        ^
     6 │ :where(.div .class,^invalid) {}
     7 │ :where(.div .class {}
-  
+
 pseudo_class_function_selector_list.css:6:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '^'.
-  
+
     4 │ :where(^invalid {}
     5 │ :where(^invalid .class) {}
   > 6 │ :where(.div .class,^invalid) {}
       │                    ^
     7 │ :where(.div .class {}
     8 │ :where(.div {}
-  
+
   i Expected a selector here.
-  
+
     4 │ :where(^invalid {}
     5 │ :where(^invalid .class) {}
   > 6 │ :where(.div .class,^invalid) {}
       │                    ^
     7 │ :where(.div .class {}
     8 │ :where(.div {}
-  
+
 pseudo_class_function_selector_list.css:6:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '.div .class,^invalid'.
-  
+
     4 │ :where(^invalid {}
     5 │ :where(^invalid .class) {}
   > 6 │ :where(.div .class,^invalid) {}
       │        ^^^^^^^^^^^^^^^^^^^^
     7 │ :where(.div .class {}
     8 │ :where(.div {}
-  
+
   i Expected a selector here.
-  
+
     4 │ :where(^invalid {}
     5 │ :where(^invalid .class) {}
   > 6 │ :where(.div .class,^invalid) {}
       │        ^^^^^^^^^^^^^^^^^^^^
     7 │ :where(.div .class {}
     8 │ :where(.div {}
-  
+
 pseudo_class_function_selector_list.css:7:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-  
+
     5 │ :where(^invalid .class) {}
     6 │ :where(.div .class,^invalid) {}
   > 7 │ :where(.div .class {}
       │                    ^
     8 │ :where(.div {}
     9 │ :where(.div
-  
+
   i Remove {
-  
+
 pseudo_class_function_selector_list.css:8:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-  
+
      6 │ :where(.div .class,^invalid) {}
      7 │ :where(.div .class {}
    > 8 │ :where(.div {}
        │             ^
      9 │ :where(.div
-    10 │ 
-  
+    10 │
+
   i Remove {
-  
+
 pseudo_class_function_selector_list.css:10:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-  
+
      8 │ :where(.div {}
      9 │ :where(.div
-  > 10 │ 
-       │ 
-  
+  > 10 │
+       │
+
   i the file ends here
-  
+
      8 │ :where(.div {}
      9 │ :where(.div
-  > 10 │ 
-       │ 
-  
+  > 10 │
+       │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector_list.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector_list.css.snap
@@ -594,192 +594,192 @@ CssRoot {
 pseudo_class_function_selector_list.css:1:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '{'.
-
+  
   > 1 │ :where( {}
       │         ^
     2 │ :where() {}
     3 │ :where(^invalid) {}
-
+  
   i Expected a selector here.
-
+  
   > 1 │ :where( {}
       │         ^
     2 │ :where() {}
     3 │ :where(^invalid) {}
-
+  
 pseudo_class_function_selector_list.css:2:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found ''.
-
+  
     1 │ :where( {}
   > 2 │ :where() {}
-      │
+      │        
     3 │ :where(^invalid) {}
     4 │ :where(^invalid {}
-
+  
   i Expected a selector here.
-
+  
     1 │ :where( {}
   > 2 │ :where() {}
-      │
+      │        
     3 │ :where(^invalid) {}
     4 │ :where(^invalid {}
-
+  
 pseudo_class_function_selector_list.css:3:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '^'.
-
+  
     1 │ :where( {}
     2 │ :where() {}
   > 3 │ :where(^invalid) {}
       │        ^
     4 │ :where(^invalid {}
     5 │ :where(^invalid .class) {}
-
+  
   i Expected a selector here.
-
+  
     1 │ :where( {}
     2 │ :where() {}
   > 3 │ :where(^invalid) {}
       │        ^
     4 │ :where(^invalid {}
     5 │ :where(^invalid .class) {}
-
+  
 pseudo_class_function_selector_list.css:4:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '^'.
-
+  
     2 │ :where() {}
     3 │ :where(^invalid) {}
   > 4 │ :where(^invalid {}
       │        ^
     5 │ :where(^invalid .class) {}
     6 │ :where(.div .class,^invalid) {}
-
+  
   i Expected a selector here.
-
+  
     2 │ :where() {}
     3 │ :where(^invalid) {}
   > 4 │ :where(^invalid {}
       │        ^
     5 │ :where(^invalid .class) {}
     6 │ :where(.div .class,^invalid) {}
-
+  
 pseudo_class_function_selector_list.css:4:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     2 │ :where() {}
     3 │ :where(^invalid) {}
   > 4 │ :where(^invalid {}
       │                 ^
     5 │ :where(^invalid .class) {}
     6 │ :where(.div .class,^invalid) {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_selector_list.css:5:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '^'.
-
+  
     3 │ :where(^invalid) {}
     4 │ :where(^invalid {}
   > 5 │ :where(^invalid .class) {}
       │        ^
     6 │ :where(.div .class,^invalid) {}
     7 │ :where(.div .class {}
-
+  
   i Expected a selector here.
-
+  
     3 │ :where(^invalid) {}
     4 │ :where(^invalid {}
   > 5 │ :where(^invalid .class) {}
       │        ^
     6 │ :where(.div .class,^invalid) {}
     7 │ :where(.div .class {}
-
+  
 pseudo_class_function_selector_list.css:6:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '^'.
-
+  
     4 │ :where(^invalid {}
     5 │ :where(^invalid .class) {}
   > 6 │ :where(.div .class,^invalid) {}
       │                    ^
     7 │ :where(.div .class {}
     8 │ :where(.div {}
-
+  
   i Expected a selector here.
-
+  
     4 │ :where(^invalid {}
     5 │ :where(^invalid .class) {}
   > 6 │ :where(.div .class,^invalid) {}
       │                    ^
     7 │ :where(.div .class {}
     8 │ :where(.div {}
-
+  
 pseudo_class_function_selector_list.css:6:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '.div .class,^invalid'.
-
+  
     4 │ :where(^invalid {}
     5 │ :where(^invalid .class) {}
   > 6 │ :where(.div .class,^invalid) {}
       │        ^^^^^^^^^^^^^^^^^^^^
     7 │ :where(.div .class {}
     8 │ :where(.div {}
-
+  
   i Expected a selector here.
-
+  
     4 │ :where(^invalid {}
     5 │ :where(^invalid .class) {}
   > 6 │ :where(.div .class,^invalid) {}
       │        ^^^^^^^^^^^^^^^^^^^^
     7 │ :where(.div .class {}
     8 │ :where(.div {}
-
+  
 pseudo_class_function_selector_list.css:7:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-
+  
     5 │ :where(^invalid .class) {}
     6 │ :where(.div .class,^invalid) {}
   > 7 │ :where(.div .class {}
       │                    ^
     8 │ :where(.div {}
     9 │ :where(.div
-
+  
   i Remove {
-
+  
 pseudo_class_function_selector_list.css:8:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-
+  
      6 │ :where(.div .class,^invalid) {}
      7 │ :where(.div .class {}
    > 8 │ :where(.div {}
        │             ^
      9 │ :where(.div
-    10 │
-
+    10 │ 
+  
   i Remove {
-
+  
 pseudo_class_function_selector_list.css:10:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-
+  
      8 │ :where(.div {}
      9 │ :where(.div
-  > 10 │
-       │
-
+  > 10 │ 
+       │ 
+  
   i the file ends here
-
+  
      8 │ :where(.div {}
      9 │ :where(.div
-  > 10 │
-       │
-
+  > 10 │ 
+       │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_value_list.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_value_list.css.snap
@@ -44,7 +44,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@7..8 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@8..9 "}" [] [],
             },
         },
@@ -70,7 +70,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@18..19 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@19..20 "}" [] [],
             },
         },
@@ -105,7 +105,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@41..42 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@42..43 "}" [] [],
             },
         },
@@ -139,7 +139,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@63..64 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@64..65 "}" [] [],
             },
         },
@@ -154,7 +154,7 @@ CssRoot {
                             class: CssPseudoClassFunctionValueList {
                                 name_token: LANG_KW@67..71 "lang" [] [],
                                 l_paren_token: L_PAREN@71..72 "(" [] [],
-                                value_list: CssPseudoValueList [
+                                values: CssPseudoValueList [
                                     CssIdentifier {
                                         value_token: IDENT@72..75 "de" [] [Whitespace(" ")],
                                     },
@@ -171,7 +171,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@79..80 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@80..81 "}" [] [],
             },
         },
@@ -204,7 +204,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@94..95 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@95..96 "}" [] [],
             },
         },
@@ -397,145 +397,145 @@ CssRoot {
 pseudo_class_function_value_list.css:1:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-  
+
   > 1 │ :lang( {}
       │        ^
     2 │ :lang() {}
     3 │ :lang(.div, .class) {}
-  
+
   i Expected an identifier here.
-  
+
   > 1 │ :lang( {}
       │        ^
     2 │ :lang() {}
     3 │ :lang(.div, .class) {}
-  
+
 pseudo_class_function_value_list.css:2:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found ''.
-  
+
     1 │ :lang( {}
   > 2 │ :lang() {}
-      │       
+      │
     3 │ :lang(.div, .class) {}
     4 │ :lang(.div, .class {}
-  
+
   i Expected an identifier here.
-  
+
     1 │ :lang( {}
   > 2 │ :lang() {}
-      │       
+      │
     3 │ :lang(.div, .class) {}
     4 │ :lang(.div, .class {}
-  
+
 pseudo_class_function_value_list.css:3:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '.'.
-  
+
     1 │ :lang( {}
     2 │ :lang() {}
   > 3 │ :lang(.div, .class) {}
       │       ^
     4 │ :lang(.div, .class {}
     5 │ :lang(de fr) {}
-  
+
   i Expected an identifier here.
-  
+
     1 │ :lang( {}
     2 │ :lang() {}
   > 3 │ :lang(.div, .class) {}
       │       ^
     4 │ :lang(.div, .class {}
     5 │ :lang(de fr) {}
-  
+
 pseudo_class_function_value_list.css:4:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '.'.
-  
+
     2 │ :lang() {}
     3 │ :lang(.div, .class) {}
   > 4 │ :lang(.div, .class {}
       │       ^
     5 │ :lang(de fr) {}
     6 │ :lang(de fr {}
-  
+
   i Expected an identifier here.
-  
+
     2 │ :lang() {}
     3 │ :lang(.div, .class) {}
   > 4 │ :lang(.div, .class {}
       │       ^
     5 │ :lang(de fr) {}
     6 │ :lang(de fr {}
-  
+
 pseudo_class_function_value_list.css:4:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     2 │ :lang() {}
     3 │ :lang(.div, .class) {}
   > 4 │ :lang(.div, .class {}
       │                    ^
     5 │ :lang(de fr) {}
     6 │ :lang(de fr {}
-  
+
   i Remove {
-  
+
 pseudo_class_function_value_list.css:5:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `fr`
-  
+
     3 │ :lang(.div, .class) {}
     4 │ :lang(.div, .class {}
   > 5 │ :lang(de fr) {}
       │          ^^
     6 │ :lang(de fr {}
     7 │ :lang(de, fr
-  
+
   i Remove fr
-  
+
 pseudo_class_function_value_list.css:6:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `fr`
-  
+
     4 │ :lang(.div, .class {}
     5 │ :lang(de fr) {}
   > 6 │ :lang(de fr {}
       │          ^^
     7 │ :lang(de, fr
-    8 │ 
-  
+    8 │
+
   i Remove fr
-  
+
 pseudo_class_function_value_list.css:6:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-  
+
     4 │ :lang(.div, .class {}
     5 │ :lang(de fr) {}
   > 6 │ :lang(de fr {}
       │             ^
     7 │ :lang(de, fr
-    8 │ 
-  
+    8 │
+
   i Remove {
-  
+
 pseudo_class_function_value_list.css:8:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-  
+
     6 │ :lang(de fr {}
     7 │ :lang(de, fr
-  > 8 │ 
-      │ 
-  
+  > 8 │
+      │
+
   i the file ends here
-  
+
     6 │ :lang(de fr {}
     7 │ :lang(de, fr
-  > 8 │ 
-      │ 
-  
+  > 8 │
+      │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_value_list.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_value_list.css.snap
@@ -397,145 +397,145 @@ CssRoot {
 pseudo_class_function_value_list.css:1:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-
+  
   > 1 │ :lang( {}
       │        ^
     2 │ :lang() {}
     3 │ :lang(.div, .class) {}
-
+  
   i Expected an identifier here.
-
+  
   > 1 │ :lang( {}
       │        ^
     2 │ :lang() {}
     3 │ :lang(.div, .class) {}
-
+  
 pseudo_class_function_value_list.css:2:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found ''.
-
+  
     1 │ :lang( {}
   > 2 │ :lang() {}
-      │
+      │       
     3 │ :lang(.div, .class) {}
     4 │ :lang(.div, .class {}
-
+  
   i Expected an identifier here.
-
+  
     1 │ :lang( {}
   > 2 │ :lang() {}
-      │
+      │       
     3 │ :lang(.div, .class) {}
     4 │ :lang(.div, .class {}
-
+  
 pseudo_class_function_value_list.css:3:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '.'.
-
+  
     1 │ :lang( {}
     2 │ :lang() {}
   > 3 │ :lang(.div, .class) {}
       │       ^
     4 │ :lang(.div, .class {}
     5 │ :lang(de fr) {}
-
+  
   i Expected an identifier here.
-
+  
     1 │ :lang( {}
     2 │ :lang() {}
   > 3 │ :lang(.div, .class) {}
       │       ^
     4 │ :lang(.div, .class {}
     5 │ :lang(de fr) {}
-
+  
 pseudo_class_function_value_list.css:4:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '.'.
-
+  
     2 │ :lang() {}
     3 │ :lang(.div, .class) {}
   > 4 │ :lang(.div, .class {}
       │       ^
     5 │ :lang(de fr) {}
     6 │ :lang(de fr {}
-
+  
   i Expected an identifier here.
-
+  
     2 │ :lang() {}
     3 │ :lang(.div, .class) {}
   > 4 │ :lang(.div, .class {}
       │       ^
     5 │ :lang(de fr) {}
     6 │ :lang(de fr {}
-
+  
 pseudo_class_function_value_list.css:4:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     2 │ :lang() {}
     3 │ :lang(.div, .class) {}
   > 4 │ :lang(.div, .class {}
       │                    ^
     5 │ :lang(de fr) {}
     6 │ :lang(de fr {}
-
+  
   i Remove {
-
+  
 pseudo_class_function_value_list.css:5:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `fr`
-
+  
     3 │ :lang(.div, .class) {}
     4 │ :lang(.div, .class {}
   > 5 │ :lang(de fr) {}
       │          ^^
     6 │ :lang(de fr {}
     7 │ :lang(de, fr
-
+  
   i Remove fr
-
+  
 pseudo_class_function_value_list.css:6:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `fr`
-
+  
     4 │ :lang(.div, .class {}
     5 │ :lang(de fr) {}
   > 6 │ :lang(de fr {}
       │          ^^
     7 │ :lang(de, fr
-    8 │
-
+    8 │ 
+  
   i Remove fr
-
+  
 pseudo_class_function_value_list.css:6:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `,` but instead found `{`
-
+  
     4 │ :lang(.div, .class {}
     5 │ :lang(de fr) {}
   > 6 │ :lang(de fr {}
       │             ^
     7 │ :lang(de, fr
-    8 │
-
+    8 │ 
+  
   i Remove {
-
+  
 pseudo_class_function_value_list.css:8:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
-
+  
     6 │ :lang(de fr {}
     7 │ :lang(de, fr
-  > 8 │
-      │
-
+  > 8 │ 
+      │ 
+  
   i the file ends here
-
+  
     6 │ :lang(de fr {}
     7 │ :lang(de, fr
-  > 8 │
-      │
-
+  > 8 │ 
+      │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_identifier.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_identifier.css.snap
@@ -36,7 +36,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@2..3 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@3..4 "}" [] [],
             },
         },
@@ -62,7 +62,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@13..14 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@14..15 "}" [] [],
             },
         },
@@ -88,7 +88,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@24..25 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@25..26 "}" [] [],
             },
         },
@@ -182,14 +182,14 @@ CssRoot {
 pseudo_class_identifier.css:1:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
-  
+
   > 1 │ : {}
       │   ^
     2 │ : .class{}
     3 │ .class: {}
-  
+
   i Expected one of:
-  
+
   - hover
   - focus
   - active
@@ -235,19 +235,19 @@ pseudo_class_identifier.css:1:3 parse ━━━━━━━━━━━━━━
   - current
   - past
   - future
-  
+
 pseudo_class_identifier.css:2:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
-  
+
     1 │ : {}
   > 2 │ : .class{}
       │   ^
     3 │ .class: {}
     4 │ :
-  
+
   i Expected one of:
-  
+
   - hover
   - focus
   - active
@@ -293,20 +293,20 @@ pseudo_class_identifier.css:2:3 parse ━━━━━━━━━━━━━━
   - current
   - past
   - future
-  
+
 pseudo_class_identifier.css:3:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
-  
+
     1 │ : {}
     2 │ : .class{}
   > 3 │ .class: {}
       │         ^
     4 │ :
-    5 │ 
-  
+    5 │
+
   i Expected one of:
-  
+
   - hover
   - focus
   - active
@@ -352,18 +352,18 @@ pseudo_class_identifier.css:3:9 parse ━━━━━━━━━━━━━━
   - current
   - past
   - future
-  
+
 pseudo_class_identifier.css:5:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
-  
+
     3 │ .class: {}
     4 │ :
-  > 5 │ 
-      │ 
-  
+  > 5 │
+      │
+
   i Expected one of:
-  
+
   - hover
   - focus
   - active
@@ -409,7 +409,7 @@ pseudo_class_identifier.css:5:1 parse ━━━━━━━━━━━━━━
   - current
   - past
   - future
-  
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_identifier.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_identifier.css.snap
@@ -182,14 +182,14 @@ CssRoot {
 pseudo_class_identifier.css:1:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
-
+  
   > 1 │ : {}
       │   ^
     2 │ : .class{}
     3 │ .class: {}
-
+  
   i Expected one of:
-
+  
   - hover
   - focus
   - active
@@ -235,19 +235,19 @@ pseudo_class_identifier.css:1:3 parse ━━━━━━━━━━━━━━
   - current
   - past
   - future
-
+  
 pseudo_class_identifier.css:2:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
-
+  
     1 │ : {}
   > 2 │ : .class{}
       │   ^
     3 │ .class: {}
     4 │ :
-
+  
   i Expected one of:
-
+  
   - hover
   - focus
   - active
@@ -293,20 +293,20 @@ pseudo_class_identifier.css:2:3 parse ━━━━━━━━━━━━━━
   - current
   - past
   - future
-
+  
 pseudo_class_identifier.css:3:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
-
+  
     1 │ : {}
     2 │ : .class{}
   > 3 │ .class: {}
       │         ^
     4 │ :
-    5 │
-
+    5 │ 
+  
   i Expected one of:
-
+  
   - hover
   - focus
   - active
@@ -352,18 +352,18 @@ pseudo_class_identifier.css:3:9 parse ━━━━━━━━━━━━━━
   - current
   - past
   - future
-
+  
 pseudo_class_identifier.css:5:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
-
+  
     3 │ .class: {}
     4 │ :
-  > 5 │
-      │
-
+  > 5 │ 
+      │ 
+  
   i Expected one of:
-
+  
   - hover
   - focus
   - active
@@ -409,7 +409,7 @@ pseudo_class_identifier.css:5:1 parse ━━━━━━━━━━━━━━
   - current
   - past
   - future
-
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_element.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_element.css.snap
@@ -285,14 +285,14 @@ CssRoot {
 pseudo_element.css:1:4 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
-
+  
   > 1 │ :: {}
       │    ^
-    2 │
+    2 │ 
     3 │ ::mark( {}
-
+  
   i Expected one of:
-
+  
   - after
   - backdrop
   - before
@@ -308,91 +308,91 @@ pseudo_element.css:1:4 parse ━━━━━━━━━━━━━━━━━
   - slotted
   - spelling-error
   - target-text
-
+  
 pseudo_element.css:3:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '{'.
-
+  
     1 │ :: {}
-    2 │
+    2 │ 
   > 3 │ ::mark( {}
       │         ^
-    4 │
+    4 │ 
     5 │ ::mark( div {}
-
+  
   i Expected a selector here.
-
+  
     1 │ :: {}
-    2 │
+    2 │ 
   > 3 │ ::mark( {}
       │         ^
-    4 │
+    4 │ 
     5 │ ::mark( div {}
-
+  
 pseudo_element.css:5:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     3 │ ::mark( {}
-    4 │
+    4 │ 
   > 5 │ ::mark( div {}
       │             ^
-    6 │
+    6 │ 
     7 │ ::mark( + div {}
-
+  
   i Remove {
-
+  
 pseudo_element.css:7:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '+ div'.
-
+  
     5 │ ::mark( div {}
-    6 │
+    6 │ 
   > 7 │ ::mark( + div {}
       │         ^^^^^
-    8 │
+    8 │ 
     9 │ ::highlight(div + div) {}
-
+  
   i Expected a selector here.
-
+  
     5 │ ::mark( div {}
-    6 │
+    6 │ 
   > 7 │ ::mark( + div {}
       │         ^^^^^
-    8 │
+    8 │ 
     9 │ ::highlight(div + div) {}
-
+  
 pseudo_element.css:7:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     5 │ ::mark( div {}
-    6 │
+    6 │ 
   > 7 │ ::mark( + div {}
       │               ^
-    8 │
+    8 │ 
     9 │ ::highlight(div + div) {}
-
+  
   i Remove {
-
+  
 pseudo_element.css:9:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found 'div + div'.
-
+  
      7 │ ::mark( + div {}
-     8 │
+     8 │ 
    > 9 │ ::highlight(div + div) {}
        │             ^^^^^^^^^
-    10 │
-
+    10 │ 
+  
   i Expected an identifier here.
-
+  
      7 │ ::mark( + div {}
-     8 │
+     8 │ 
    > 9 │ ::highlight(div + div) {}
        │             ^^^^^^^^^
-    10 │
-
+    10 │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_element.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_element.css.snap
@@ -40,7 +40,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@3..4 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@4..5 "}" [] [],
             },
         },
@@ -66,7 +66,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@15..16 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@16..17 "}" [] [],
             },
         },
@@ -102,7 +102,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@31..32 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@32..33 "}" [] [],
             },
         },
@@ -134,7 +134,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@49..50 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@50..51 "}" [] [],
             },
         },
@@ -168,7 +168,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@76..77 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@77..78 "}" [] [],
             },
         },
@@ -285,14 +285,14 @@ CssRoot {
 pseudo_element.css:1:4 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
-  
+
   > 1 │ :: {}
       │    ^
-    2 │ 
+    2 │
     3 │ ::mark( {}
-  
+
   i Expected one of:
-  
+
   - after
   - backdrop
   - before
@@ -308,91 +308,91 @@ pseudo_element.css:1:4 parse ━━━━━━━━━━━━━━━━━
   - slotted
   - spelling-error
   - target-text
-  
+
 pseudo_element.css:3:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '{'.
-  
+
     1 │ :: {}
-    2 │ 
+    2 │
   > 3 │ ::mark( {}
       │         ^
-    4 │ 
+    4 │
     5 │ ::mark( div {}
-  
+
   i Expected a selector here.
-  
+
     1 │ :: {}
-    2 │ 
+    2 │
   > 3 │ ::mark( {}
       │         ^
-    4 │ 
+    4 │
     5 │ ::mark( div {}
-  
+
 pseudo_element.css:5:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     3 │ ::mark( {}
-    4 │ 
+    4 │
   > 5 │ ::mark( div {}
       │             ^
-    6 │ 
+    6 │
     7 │ ::mark( + div {}
-  
+
   i Remove {
-  
+
 pseudo_element.css:7:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '+ div'.
-  
+
     5 │ ::mark( div {}
-    6 │ 
+    6 │
   > 7 │ ::mark( + div {}
       │         ^^^^^
-    8 │ 
+    8 │
     9 │ ::highlight(div + div) {}
-  
+
   i Expected a selector here.
-  
+
     5 │ ::mark( div {}
-    6 │ 
+    6 │
   > 7 │ ::mark( + div {}
       │         ^^^^^
-    8 │ 
+    8 │
     9 │ ::highlight(div + div) {}
-  
+
 pseudo_element.css:7:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     5 │ ::mark( div {}
-    6 │ 
+    6 │
   > 7 │ ::mark( + div {}
       │               ^
-    8 │ 
+    8 │
     9 │ ::highlight(div + div) {}
-  
+
   i Remove {
-  
+
 pseudo_element.css:9:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found 'div + div'.
-  
+
      7 │ ::mark( + div {}
-     8 │ 
+     8 │
    > 9 │ ::highlight(div + div) {}
        │             ^^^^^^^^^
-    10 │ 
-  
+    10 │
+
   i Expected an identifier here.
-  
+
      7 │ ::mark( + div {}
-     8 │ 
+     8 │
    > 9 │ ::highlight(div + div) {}
        │             ^^^^^^^^^
-    10 │ 
-  
+    10 │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_element_function_identifier.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_element_function_identifier.css.snap
@@ -49,7 +49,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@23..24 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@24..25 "}" [] [],
             },
         },
@@ -73,7 +73,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@39..40 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@40..41 "}" [] [],
             },
         },
@@ -166,53 +166,53 @@ CssRoot {
 pseudo_element_function_identifier.css:1:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found 'div + div'.
-  
+
   > 1 │ ::highlight(div + div) {}
       │             ^^^^^^^^^
     2 │ ::highlight( {}
     3 │ ::highlight(
-  
+
   i Expected an identifier here.
-  
+
   > 1 │ ::highlight(div + div) {}
       │             ^^^^^^^^^
     2 │ ::highlight( {}
     3 │ ::highlight(
-  
+
 pseudo_element_function_identifier.css:2:14 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-  
+
     1 │ ::highlight(div + div) {}
   > 2 │ ::highlight( {}
       │              ^
     3 │ ::highlight(
-    4 │ 
-  
+    4 │
+
   i Expected an identifier here.
-  
+
     1 │ ::highlight(div + div) {}
   > 2 │ ::highlight( {}
       │              ^
     3 │ ::highlight(
-    4 │ 
-  
+    4 │
+
 pseudo_element_function_identifier.css:4:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found the end of the file.
-  
+
     2 │ ::highlight( {}
     3 │ ::highlight(
-  > 4 │ 
-      │ 
-  
+  > 4 │
+      │
+
   i Expected an identifier here.
-  
+
     2 │ ::highlight( {}
     3 │ ::highlight(
-  > 4 │ 
-      │ 
-  
+  > 4 │
+      │
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_element_function_identifier.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_element_function_identifier.css.snap
@@ -166,53 +166,53 @@ CssRoot {
 pseudo_element_function_identifier.css:1:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found 'div + div'.
-
+  
   > 1 │ ::highlight(div + div) {}
       │             ^^^^^^^^^
     2 │ ::highlight( {}
     3 │ ::highlight(
-
+  
   i Expected an identifier here.
-
+  
   > 1 │ ::highlight(div + div) {}
       │             ^^^^^^^^^
     2 │ ::highlight( {}
     3 │ ::highlight(
-
+  
 pseudo_element_function_identifier.css:2:14 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found '{'.
-
+  
     1 │ ::highlight(div + div) {}
   > 2 │ ::highlight( {}
       │              ^
     3 │ ::highlight(
-    4 │
-
+    4 │ 
+  
   i Expected an identifier here.
-
+  
     1 │ ::highlight(div + div) {}
   > 2 │ ::highlight( {}
       │              ^
     3 │ ::highlight(
-    4 │
-
+    4 │ 
+  
 pseudo_element_function_identifier.css:4:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an identifier but instead found the end of the file.
-
+  
     2 │ ::highlight( {}
     3 │ ::highlight(
-  > 4 │
-      │
-
+  > 4 │ 
+      │ 
+  
   i Expected an identifier here.
-
+  
     2 │ ::highlight( {}
     3 │ ::highlight(
-  > 4 │
-      │
-
+  > 4 │ 
+      │ 
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_element_function_selector.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_element_function_selector.css.snap
@@ -363,102 +363,102 @@ CssRoot {
 pseudo_element_function_selector.css:1:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '{'.
-
+  
   > 1 │ ::cure( {}
       │         ^
     2 │ ::cure() {}
     3 │ ::cure(.div, .class) {}
-
+  
   i Expected a selector here.
-
+  
   > 1 │ ::cure( {}
       │         ^
     2 │ ::cure() {}
     3 │ ::cure(.div, .class) {}
-
+  
 pseudo_element_function_selector.css:2:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found ')'.
-
+  
     1 │ ::cure( {}
   > 2 │ ::cure() {}
       │        ^
     3 │ ::cure(.div, .class) {}
     4 │ ::cure(.div, .class {}
-
+  
   i Expected a selector here.
-
+  
     1 │ ::cure( {}
   > 2 │ ::cure() {}
       │        ^
     3 │ ::cure(.div, .class) {}
     4 │ ::cure(.div, .class {}
-
+  
 pseudo_element_function_selector.css:3:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '.div, .class'.
-
+  
     1 │ ::cure( {}
     2 │ ::cure() {}
   > 3 │ ::cure(.div, .class) {}
       │        ^^^^^^^^^^^^
     4 │ ::cure(.div, .class {}
     5 │ ::cure(.div .class {}
-
+  
   i Expected a selector here.
-
+  
     1 │ ::cure( {}
     2 │ ::cure() {}
   > 3 │ ::cure(.div, .class) {}
       │        ^^^^^^^^^^^^
     4 │ ::cure(.div, .class {}
     5 │ ::cure(.div .class {}
-
+  
 pseudo_element_function_selector.css:4:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '.div, .class'.
-
+  
     2 │ ::cure() {}
     3 │ ::cure(.div, .class) {}
   > 4 │ ::cure(.div, .class {}
       │        ^^^^^^^^^^^^
     5 │ ::cure(.div .class {}
-    6 │
-
+    6 │ 
+  
   i Expected a selector here.
-
+  
     2 │ ::cure() {}
     3 │ ::cure(.div, .class) {}
   > 4 │ ::cure(.div, .class {}
       │        ^^^^^^^^^^^^
     5 │ ::cure(.div .class {}
-    6 │
-
+    6 │ 
+  
 pseudo_element_function_selector.css:4:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     2 │ ::cure() {}
     3 │ ::cure(.div, .class) {}
   > 4 │ ::cure(.div, .class {}
       │                     ^
     5 │ ::cure(.div .class {}
-    6 │
-
+    6 │ 
+  
   i Remove {
-
+  
 pseudo_element_function_selector.css:5:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-
+  
     3 │ ::cure(.div, .class) {}
     4 │ ::cure(.div, .class {}
   > 5 │ ::cure(.div .class {}
       │                    ^
-    6 │
-
+    6 │ 
+  
   i Remove {
-
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_element_function_selector.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_element_function_selector.css.snap
@@ -43,7 +43,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@8..9 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@9..10 "}" [] [],
             },
         },
@@ -70,7 +70,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@20..21 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@21..22 "}" [] [],
             },
         },
@@ -116,7 +116,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@44..45 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@45..46 "}" [] [],
             },
         },
@@ -161,7 +161,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@67..68 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@68..69 "}" [] [],
             },
         },
@@ -214,7 +214,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@89..90 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@90..91 "}" [] [],
             },
         },
@@ -363,102 +363,102 @@ CssRoot {
 pseudo_element_function_selector.css:1:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '{'.
-  
+
   > 1 │ ::cure( {}
       │         ^
     2 │ ::cure() {}
     3 │ ::cure(.div, .class) {}
-  
+
   i Expected a selector here.
-  
+
   > 1 │ ::cure( {}
       │         ^
     2 │ ::cure() {}
     3 │ ::cure(.div, .class) {}
-  
+
 pseudo_element_function_selector.css:2:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found ')'.
-  
+
     1 │ ::cure( {}
   > 2 │ ::cure() {}
       │        ^
     3 │ ::cure(.div, .class) {}
     4 │ ::cure(.div, .class {}
-  
+
   i Expected a selector here.
-  
+
     1 │ ::cure( {}
   > 2 │ ::cure() {}
       │        ^
     3 │ ::cure(.div, .class) {}
     4 │ ::cure(.div, .class {}
-  
+
 pseudo_element_function_selector.css:3:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '.div, .class'.
-  
+
     1 │ ::cure( {}
     2 │ ::cure() {}
   > 3 │ ::cure(.div, .class) {}
       │        ^^^^^^^^^^^^
     4 │ ::cure(.div, .class {}
     5 │ ::cure(.div .class {}
-  
+
   i Expected a selector here.
-  
+
     1 │ ::cure( {}
     2 │ ::cure() {}
   > 3 │ ::cure(.div, .class) {}
       │        ^^^^^^^^^^^^
     4 │ ::cure(.div, .class {}
     5 │ ::cure(.div .class {}
-  
+
 pseudo_element_function_selector.css:4:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '.div, .class'.
-  
+
     2 │ ::cure() {}
     3 │ ::cure(.div, .class) {}
   > 4 │ ::cure(.div, .class {}
       │        ^^^^^^^^^^^^
     5 │ ::cure(.div .class {}
-    6 │ 
-  
+    6 │
+
   i Expected a selector here.
-  
+
     2 │ ::cure() {}
     3 │ ::cure(.div, .class) {}
   > 4 │ ::cure(.div, .class {}
       │        ^^^^^^^^^^^^
     5 │ ::cure(.div .class {}
-    6 │ 
-  
+    6 │
+
 pseudo_element_function_selector.css:4:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     2 │ ::cure() {}
     3 │ ::cure(.div, .class) {}
   > 4 │ ::cure(.div, .class {}
       │                     ^
     5 │ ::cure(.div .class {}
-    6 │ 
-  
+    6 │
+
   i Remove {
-  
+
 pseudo_element_function_selector.css:5:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
-  
+
     3 │ ::cure(.div, .class) {}
     4 │ ::cure(.div, .class {}
   > 5 │ ::cure(.div .class {}
       │                    ^
-    6 │ 
-  
+    6 │
+
   i Remove {
-  
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/traling_comma.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/traling_comma.css.snap
@@ -38,7 +38,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@11..12 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@12..15 "}" [Newline("\n"), Newline("\n")] [],
             },
         },
@@ -79,19 +79,19 @@ CssRoot {
 traling_comma.css:1:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '{'.
-  
+
   > 1 │ .selector, {
       │            ^
-    2 │ 
+    2 │
     3 │ }
-  
+
   i Expected a selector here.
-  
+
   > 1 │ .selector, {
       │            ^
-    2 │ 
+    2 │
     3 │ }
-  
+
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/traling_comma.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/traling_comma.css.snap
@@ -79,19 +79,19 @@ CssRoot {
 traling_comma.css:1:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a selector but instead found '{'.
-
+  
   > 1 │ .selector, {
       │            ^
-    2 │
+    2 │ 
     3 │ }
-
+  
   i Expected a selector here.
-
+  
   > 1 │ .selector, {
       │            ^
-    2 │
+    2 │ 
     3 │ }
-
+  
 ```
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_color_profile.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_color_profile.css.snap
@@ -30,7 +30,7 @@ CssRoot {
                 },
                 block: CssDeclarationListBlock {
                     l_curly_token: L_CURLY@25..28 "{" [] [Whitespace("  ")],
-                    declaration_list: CssDeclarationList [],
+                    declarations: CssDeclarationList [],
                     r_curly_token: R_CURLY@28..29 "}" [] [],
                 },
             },
@@ -44,7 +44,7 @@ CssRoot {
                 },
                 block: CssDeclarationListBlock {
                     l_curly_token: L_CURLY@58..61 "{" [] [Whitespace("  ")],
-                    declaration_list: CssDeclarationList [],
+                    declarations: CssDeclarationList [],
                     r_curly_token: R_CURLY@61..62 "}" [] [],
                 },
             },
@@ -58,7 +58,7 @@ CssRoot {
                 },
                 block: CssDeclarationListBlock {
                     l_curly_token: L_CURLY@91..94 "{" [] [Whitespace("  ")],
-                    declaration_list: CssDeclarationList [],
+                    declarations: CssDeclarationList [],
                     r_curly_token: R_CURLY@94..95 "}" [] [],
                 },
             },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_container_complex.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_container_complex.css.snap
@@ -1047,7 +1047,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@1044..1045 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@1045..1064 "background-color" [Newline("\n"), Whitespace("\t\t")] [],
@@ -1080,7 +1080,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@1083..1084 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@1084..1103 "background-color" [Newline("\n"), Whitespace("\t\t")] [],

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_counter_style.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_counter_style.css.snap
@@ -26,7 +26,7 @@ CssRoot {
                 },
                 block: CssDeclarationListBlock {
                     l_curly_token: L_CURLY@22..25 "{" [] [Whitespace("  ")],
-                    declaration_list: CssDeclarationList [],
+                    declarations: CssDeclarationList [],
                     r_curly_token: R_CURLY@25..26 "}" [] [],
                 },
             },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_font_face.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_font_face.css.snap
@@ -22,7 +22,7 @@ CssRoot {
                 font_face_token: FONT_FACE_KW@1..11 "font-face" [] [Whitespace(" ")],
                 block: CssDeclarationListBlock {
                     l_curly_token: L_CURLY@11..12 "{" [] [],
-                    declaration_list: CssDeclarationList [],
+                    declarations: CssDeclarationList [],
                     r_curly_token: R_CURLY@12..13 "}" [] [],
                 },
             },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_font_palette_values.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_font_palette_values.css.snap
@@ -26,7 +26,7 @@ CssRoot {
                 },
                 block: CssDeclarationListBlock {
                     l_curly_token: L_CURLY@27..30 "{" [] [Whitespace("  ")],
-                    declaration_list: CssDeclarationList [],
+                    declarations: CssDeclarationList [],
                     r_curly_token: R_CURLY@30..31 "}" [] [],
                 },
             },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_keyframe.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_keyframe.css.snap
@@ -130,7 +130,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@123..124 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@124..136 "transform" [Newline("\n"), Whitespace("\t\t")] [],
@@ -174,7 +174,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@162..163 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@163..175 "transform" [Newline("\n"), Whitespace("\t\t")] [],
@@ -238,7 +238,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@233..235 "{" [] [Whitespace(" ")],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@235..238 "top" [] [],
@@ -282,7 +282,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@259..261 "{" [] [Whitespace(" ")],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@261..264 "top" [] [],
@@ -327,7 +327,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@284..286 "{" [] [Whitespace(" ")],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@286..290 "left" [] [],
@@ -363,7 +363,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@306..308 "{" [] [Whitespace(" ")],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@308..311 "top" [] [],
@@ -467,7 +467,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@443..444 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@444..458 "margin-left" [Newline("\n"), Whitespace("\t\t")] [],
@@ -503,7 +503,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@474..475 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@475..489 "margin-left" [Newline("\n"), Whitespace("\t\t")] [],
@@ -552,7 +552,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@521..522 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@522..532 "opacity" [Newline("\n"), Whitespace("\t\t")] [],
@@ -578,7 +578,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@547..548 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@548..562 "margin-left" [Newline("\n"), Whitespace("\t\t")] [],
@@ -624,7 +624,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@613..614 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@614..626 "transform" [Newline("\n"), Whitespace("\t\t")] [],
@@ -668,7 +668,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@652..653 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@653..665 "transform" [Newline("\n"), Whitespace("\t\t")] [],

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_media.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_media.css.snap
@@ -138,7 +138,7 @@ CssRoot {
             at_token: AT@0..1 "@" [] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1..8 "\\media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaTypeQuery {
                         modifier: missing (optional),
                         ty: CssMediaType {
@@ -159,7 +159,7 @@ CssRoot {
             at_token: AT@17..19 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@19..26 "\\media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaTypeQuery {
                         modifier: missing (optional),
                         ty: CssMediaType {
@@ -180,7 +180,7 @@ CssRoot {
             at_token: AT@36..39 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@39..45 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaTypeQuery {
                         modifier: missing (optional),
                         ty: CssMediaType {
@@ -201,7 +201,7 @@ CssRoot {
             at_token: AT@51..53 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@53..59 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaTypeQuery {
                         modifier: missing (optional),
                         ty: CssMediaType {
@@ -222,7 +222,7 @@ CssRoot {
             at_token: AT@68..70 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@70..76 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaTypeQuery {
                         modifier: missing (optional),
                         ty: CssMediaType {
@@ -243,7 +243,7 @@ CssRoot {
             at_token: AT@84..86 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@86..92 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: missing (optional),
@@ -276,7 +276,7 @@ CssRoot {
             at_token: AT@113..115 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@115..121 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: missing (optional),
@@ -330,7 +330,7 @@ CssRoot {
             at_token: AT@166..168 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@168..177 "media" [] [Whitespace("    ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: missing (optional),
@@ -384,7 +384,7 @@ CssRoot {
             at_token: AT@252..254 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@254..260 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: missing (optional),
@@ -426,7 +426,7 @@ CssRoot {
             at_token: AT@298..300 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@300..309 "media" [] [Whitespace("    ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaTypeQuery {
                         modifier: missing (optional),
                         ty: CssMediaType {
@@ -447,7 +447,7 @@ CssRoot {
             at_token: AT@318..320 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@320..326 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: missing (optional),
@@ -480,7 +480,7 @@ CssRoot {
             at_token: AT@347..349 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@349..357 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: missing (optional),
@@ -513,7 +513,7 @@ CssRoot {
             at_token: AT@391..394 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@394..400 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: NOT_KW@400..404 "not" [] [Whitespace(" ")],
@@ -546,7 +546,7 @@ CssRoot {
             at_token: AT@427..429 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@429..435 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: NOT_KW@435..439 "not" [] [Whitespace(" ")],
@@ -600,7 +600,7 @@ CssRoot {
             at_token: AT@479..481 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@481..487 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaNotCondition {
                             not_token: NOT_KW@487..491 "not" [] [Whitespace(" ")],
@@ -637,7 +637,7 @@ CssRoot {
             at_token: AT@521..523 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@523..529 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaNotCondition {
                             not_token: NOT_KW@529..533 "not" [] [Whitespace(" ")],
@@ -674,7 +674,7 @@ CssRoot {
             at_token: AT@565..567 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@567..573 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaTypeQuery {
                         modifier: NOT_KW@573..577 "not" [] [Whitespace(" ")],
                         ty: CssMediaType {
@@ -695,7 +695,7 @@ CssRoot {
             at_token: AT@583..585 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@585..594 "media" [] [Whitespace("    ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaTypeQuery {
                         modifier: NOT_KW@594..600 "not" [] [Whitespace("   ")],
                         ty: CssMediaType {
@@ -716,7 +716,7 @@ CssRoot {
             at_token: AT@608..611 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@611..617 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: ONLY_KW@617..622 "only" [] [Whitespace(" ")],
@@ -749,7 +749,7 @@ CssRoot {
             at_token: AT@643..645 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@645..653 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: ONLY_KW@653..660 "only" [] [Whitespace("   ")],
@@ -782,7 +782,7 @@ CssRoot {
             at_token: AT@693..696 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@696..702 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@702..703 "(" [] [],
@@ -815,7 +815,7 @@ CssRoot {
             at_token: AT@722..724 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@724..729 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@729..730 "(" [] [],
@@ -848,7 +848,7 @@ CssRoot {
             at_token: AT@748..750 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@750..758 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@758..762 "(" [] [Whitespace("   ")],
@@ -881,7 +881,7 @@ CssRoot {
             at_token: AT@791..793 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@793..799 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@799..800 "(" [] [],
@@ -915,7 +915,7 @@ CssRoot {
             at_token: AT@829..831 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@831..840 "media" [] [Whitespace("    ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@840..844 "(" [] [Whitespace("   ")],
@@ -949,7 +949,7 @@ CssRoot {
             at_token: AT@890..892 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@892..898 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaFeatureInParens {
@@ -994,7 +994,7 @@ CssRoot {
             at_token: AT@929..931 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@931..937 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@937..938 "(" [] [],
@@ -1018,7 +1018,7 @@ CssRoot {
             at_token: AT@952..955 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@955..961 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaFeatureInParens {
@@ -1072,7 +1072,7 @@ CssRoot {
             at_token: AT@1003..1005 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1005..1013 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaFeatureInParens {
@@ -1126,7 +1126,7 @@ CssRoot {
             at_token: AT@1080..1082 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1082..1088 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaFeatureInParens {
@@ -1201,7 +1201,7 @@ CssRoot {
             at_token: AT@1158..1160 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1160..1165 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaFeatureInParens {
@@ -1255,7 +1255,7 @@ CssRoot {
             at_token: AT@1204..1206 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1206..1211 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaFeatureInParens {
@@ -1309,7 +1309,7 @@ CssRoot {
             at_token: AT@1249..1252 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1252..1258 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaOrCondition {
                             left: CssMediaFeatureInParens {
@@ -1353,7 +1353,7 @@ CssRoot {
             at_token: AT@1292..1294 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1294..1302 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaOrCondition {
                             left: CssMediaFeatureInParens {
@@ -1397,7 +1397,7 @@ CssRoot {
             at_token: AT@1366..1368 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1368..1373 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaOrCondition {
                             left: CssMediaFeatureInParens {
@@ -1441,7 +1441,7 @@ CssRoot {
             at_token: AT@1405..1408 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1408..1414 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1414..1415 "(" [] [],
@@ -1476,7 +1476,7 @@ CssRoot {
             at_token: AT@1433..1435 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1435..1441 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1441..1442 "(" [] [],
@@ -1511,7 +1511,7 @@ CssRoot {
             at_token: AT@1461..1463 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1463..1469 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1469..1470 "(" [] [],
@@ -1546,7 +1546,7 @@ CssRoot {
             at_token: AT@1488..1490 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1490..1496 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1496..1497 "(" [] [],
@@ -1581,7 +1581,7 @@ CssRoot {
             at_token: AT@1516..1518 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1518..1524 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1524..1525 "(" [] [],
@@ -1616,7 +1616,7 @@ CssRoot {
             at_token: AT@1543..1545 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1545..1553 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1553..1557 "(" [] [Whitespace("   ")],
@@ -1651,7 +1651,7 @@ CssRoot {
             at_token: AT@1584..1586 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1586..1594 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1594..1598 "(" [] [Whitespace("   ")],
@@ -1686,7 +1686,7 @@ CssRoot {
             at_token: AT@1626..1628 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1628..1636 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1636..1640 "(" [] [Whitespace("   ")],
@@ -1721,7 +1721,7 @@ CssRoot {
             at_token: AT@1667..1669 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1669..1677 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1677..1681 "(" [] [Whitespace("   ")],
@@ -1756,7 +1756,7 @@ CssRoot {
             at_token: AT@1709..1711 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1711..1719 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1719..1723 "(" [] [Whitespace("   ")],
@@ -1791,7 +1791,7 @@ CssRoot {
             at_token: AT@1750..1752 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1752..1757 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1757..1758 "(" [] [],
@@ -1826,7 +1826,7 @@ CssRoot {
             at_token: AT@1773..1775 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1775..1780 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1780..1781 "(" [] [],
@@ -1861,7 +1861,7 @@ CssRoot {
             at_token: AT@1798..1801 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1801..1807 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1807..1808 "(" [] [],
@@ -1896,7 +1896,7 @@ CssRoot {
             at_token: AT@1826..1828 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1828..1834 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1834..1835 "(" [] [],
@@ -1931,7 +1931,7 @@ CssRoot {
             at_token: AT@1854..1856 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1856..1862 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1862..1863 "(" [] [],
@@ -1966,7 +1966,7 @@ CssRoot {
             at_token: AT@1881..1883 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1883..1889 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1889..1890 "(" [] [],
@@ -2001,7 +2001,7 @@ CssRoot {
             at_token: AT@1909..1911 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1911..1917 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1917..1918 "(" [] [],
@@ -2036,7 +2036,7 @@ CssRoot {
             at_token: AT@1936..1938 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1938..1946 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1946..1950 "(" [] [Whitespace("   ")],
@@ -2071,7 +2071,7 @@ CssRoot {
             at_token: AT@1977..1979 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1979..1987 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@1987..1991 "(" [] [Whitespace("   ")],
@@ -2106,7 +2106,7 @@ CssRoot {
             at_token: AT@2019..2021 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2021..2029 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2029..2033 "(" [] [Whitespace("   ")],
@@ -2141,7 +2141,7 @@ CssRoot {
             at_token: AT@2060..2062 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2062..2070 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2070..2074 "(" [] [Whitespace("   ")],
@@ -2176,7 +2176,7 @@ CssRoot {
             at_token: AT@2102..2104 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2104..2112 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2112..2116 "(" [] [Whitespace("   ")],
@@ -2211,7 +2211,7 @@ CssRoot {
             at_token: AT@2143..2145 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2145..2150 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2150..2151 "(" [] [],
@@ -2246,7 +2246,7 @@ CssRoot {
             at_token: AT@2167..2169 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2169..2174 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2174..2175 "(" [] [],
@@ -2281,7 +2281,7 @@ CssRoot {
             at_token: AT@2192..2195 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2195..2201 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2201..2202 "(" [] [],
@@ -2327,7 +2327,7 @@ CssRoot {
             at_token: AT@2227..2229 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2229..2235 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2235..2236 "(" [] [],
@@ -2373,7 +2373,7 @@ CssRoot {
             at_token: AT@2262..2264 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2264..2270 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2270..2271 "(" [] [],
@@ -2419,7 +2419,7 @@ CssRoot {
             at_token: AT@2297..2299 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2299..2305 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2305..2306 "(" [] [],
@@ -2465,7 +2465,7 @@ CssRoot {
             at_token: AT@2333..2335 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2335..2340 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2340..2341 "(" [] [],
@@ -2511,7 +2511,7 @@ CssRoot {
             at_token: AT@2361..2363 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2363..2368 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2368..2369 "(" [] [],
@@ -2557,7 +2557,7 @@ CssRoot {
             at_token: AT@2391..2393 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2393..2401 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2401..2405 "(" [] [Whitespace("   ")],
@@ -2603,7 +2603,7 @@ CssRoot {
             at_token: AT@2443..2445 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2445..2453 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2453..2457 "(" [] [Whitespace("   ")],
@@ -2649,7 +2649,7 @@ CssRoot {
             at_token: AT@2496..2498 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2498..2506 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2506..2510 "(" [] [Whitespace("   ")],
@@ -2695,7 +2695,7 @@ CssRoot {
             at_token: AT@2549..2551 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2551..2559 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2559..2563 "(" [] [Whitespace("   ")],
@@ -2741,7 +2741,7 @@ CssRoot {
             at_token: AT@2603..2605 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2605..2610 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2610..2611 "(" [] [],
@@ -2787,7 +2787,7 @@ CssRoot {
             at_token: AT@2631..2633 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2633..2638 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2638..2639 "(" [] [],
@@ -2833,7 +2833,7 @@ CssRoot {
             at_token: AT@2661..2664 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2664..2670 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2670..2671 "(" [] [],
@@ -2879,7 +2879,7 @@ CssRoot {
             at_token: AT@2696..2698 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2698..2704 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2704..2705 "(" [] [],
@@ -2925,7 +2925,7 @@ CssRoot {
             at_token: AT@2731..2733 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2733..2739 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2739..2740 "(" [] [],
@@ -2971,7 +2971,7 @@ CssRoot {
             at_token: AT@2766..2768 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2768..2774 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2774..2775 "(" [] [],
@@ -3017,7 +3017,7 @@ CssRoot {
             at_token: AT@2802..2804 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2804..2809 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2809..2810 "(" [] [],
@@ -3063,7 +3063,7 @@ CssRoot {
             at_token: AT@2830..2832 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2832..2837 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2837..2838 "(" [] [],
@@ -3109,7 +3109,7 @@ CssRoot {
             at_token: AT@2861..2863 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2863..2871 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2871..2875 "(" [] [Whitespace("   ")],
@@ -3155,7 +3155,7 @@ CssRoot {
             at_token: AT@2913..2915 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2915..2923 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2923..2927 "(" [] [Whitespace("   ")],
@@ -3201,7 +3201,7 @@ CssRoot {
             at_token: AT@2966..2968 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@2968..2976 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@2976..2980 "(" [] [Whitespace("   ")],
@@ -3247,7 +3247,7 @@ CssRoot {
             at_token: AT@3019..3021 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3021..3029 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@3029..3033 "(" [] [Whitespace("   ")],
@@ -3293,7 +3293,7 @@ CssRoot {
             at_token: AT@3073..3075 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3075..3080 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@3080..3081 "(" [] [],
@@ -3339,7 +3339,7 @@ CssRoot {
             at_token: AT@3101..3103 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3103..3108 "media" [] [],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@3108..3109 "(" [] [],
@@ -3385,7 +3385,7 @@ CssRoot {
             at_token: AT@3131..3134 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3134..3140 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaFeatureInParens {
@@ -3430,7 +3430,7 @@ CssRoot {
             at_token: AT@3177..3180 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3180..3186 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaOrCondition {
                             left: CssMediaConditionInParens {
@@ -3473,7 +3473,7 @@ CssRoot {
             at_token: AT@3213..3215 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3215..3223 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaOrCondition {
                             left: CssMediaConditionInParens {
@@ -3516,7 +3516,7 @@ CssRoot {
             at_token: AT@3277..3279 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3279..3285 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaConditionInParens {
@@ -3579,7 +3579,7 @@ CssRoot {
             at_token: AT@3329..3331 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3331..3337 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaConditionInParens {
@@ -3650,7 +3650,7 @@ CssRoot {
             at_token: AT@3385..3387 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3387..3393 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaConditionInParens {
@@ -3729,7 +3729,7 @@ CssRoot {
             at_token: AT@3445..3447 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3447..3455 "media" [] [Whitespace("   ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaConditionInParens {
@@ -3808,7 +3808,7 @@ CssRoot {
             at_token: AT@3569..3572 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3572..3578 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaOrCondition {
                             left: CssMediaConditionInParens {
@@ -3887,7 +3887,7 @@ CssRoot {
             at_token: AT@3646..3648 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3648..3654 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaFeatureInParens {
@@ -3966,7 +3966,7 @@ CssRoot {
             at_token: AT@3722..3725 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3725..3734 "media" [] [Whitespace("    ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaTypeQuery {
                         modifier: NOT_KW@3734..3740 "NOT" [] [Whitespace("   ")],
                         ty: CssMediaType {
@@ -3987,7 +3987,7 @@ CssRoot {
             at_token: AT@3748..3750 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3750..3756 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: ONLY_KW@3756..3761 "ONLY" [] [Whitespace(" ")],
@@ -4020,7 +4020,7 @@ CssRoot {
             at_token: AT@3782..3784 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3784..3790 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaOrCondition {
                             left: CssMediaConditionInParens {
@@ -4099,7 +4099,7 @@ CssRoot {
             at_token: AT@3858..3860 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3860..3866 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaFeatureInParens {
@@ -4178,7 +4178,7 @@ CssRoot {
             at_token: AT@3934..3937 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3937..3943 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaTypeQuery {
                         modifier: missing (optional),
                         ty: CssMediaType {
@@ -4199,7 +4199,7 @@ CssRoot {
             at_token: AT@3949..3952 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3952..3958 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaTypeQuery {
                         modifier: missing (optional),
                         ty: CssMediaType {
@@ -4220,7 +4220,7 @@ CssRoot {
             at_token: AT@3967..3971 "@" [Newline("\n"), Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@3971..3977 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaOrCondition {
                             left: CssMediaConditionInParens {

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_media_complex.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_media_complex.css.snap
@@ -42,7 +42,7 @@ CssRoot {
             at_token: AT@0..1 "@" [] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@1..7 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [],
+                queries: CssMediaQueryList [],
                 block: CssRuleListBlock {
                     l_curly_token: L_CURLY@7..8 "{" [] [],
                     rules: CssRuleList [],
@@ -54,7 +54,7 @@ CssRoot {
             at_token: AT@9..12 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@12..18 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: NOT_KW@18..22 "not" [] [Whitespace(" ")],
@@ -90,7 +90,7 @@ CssRoot {
             at_token: AT@47..50 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@50..56 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: NOT_KW@56..60 "not" [] [Whitespace(" ")],
@@ -135,7 +135,7 @@ CssRoot {
             at_token: AT@93..96 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@96..102 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: NOT_KW@102..106 "not" [] [Whitespace(" ")],
@@ -180,7 +180,7 @@ CssRoot {
             at_token: AT@139..142 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@142..148 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaFeatureInParens {
@@ -270,7 +270,7 @@ CssRoot {
             at_token: AT@220..222 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@222..228 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaOrCondition {
                             left: CssMediaFeatureInParens {
@@ -379,7 +379,7 @@ CssRoot {
             at_token: AT@316..318 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@318..324 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaAndCondition {
                             left: CssMediaFeatureInParens {
@@ -473,7 +473,7 @@ CssRoot {
             at_token: AT@401..403 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@403..409 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaOrCondition {
                             left: CssMediaFeatureInParens {
@@ -558,7 +558,7 @@ CssRoot {
             at_token: AT@473..475 "@" [Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@475..481 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaConditionQuery {
                         condition: CssMediaFeatureInParens {
                             l_paren_token: L_PAREN@481..482 "(" [] [],
@@ -628,7 +628,7 @@ CssRoot {
             at_token: AT@534..537 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 media_token: MEDIA_KW@537..543 "media" [] [Whitespace(" ")],
-                query_list: CssMediaQueryList [
+                queries: CssMediaQueryList [
                     CssMediaAndTypeQuery {
                         left: CssMediaTypeQuery {
                             modifier: NOT_KW@543..547 "not" [] [Whitespace(" ")],
@@ -673,7 +673,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@581..582 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@582..603 "background-color" [Newline("\n"), Whitespace("\t\t\t\t")] [],
@@ -706,7 +706,7 @@ CssRoot {
                             ],
                             block: CssDeclarationListBlock {
                                 l_curly_token: L_CURLY@624..625 "{" [] [],
-                                declaration_list: CssDeclarationList [
+                                declarations: CssDeclarationList [
                                     CssDeclaration {
                                         name: CssIdentifier {
                                             value_token: IDENT@625..646 "background-color" [Newline("\n"), Whitespace("\t\t\t\t")] [],

--- a/crates/biome_css_parser/tests/css_test_suite/ok/class_selector.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/class_selector.css.snap
@@ -34,7 +34,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@8..9 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@9..10 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/declaration_list.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/declaration_list.css.snap
@@ -71,7 +71,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@2..3 "{" [] [],
-                declaration_list: CssDeclarationList [
+                declarations: CssDeclarationList [
                     CssDeclaration {
                         name: CssIdentifier {
                             value_token: IDENT@3..13 "prop1" [Newline("\n"), Whitespace("    ")] [],
@@ -117,7 +117,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@45..46 "{" [] [],
-                declaration_list: CssDeclarationList [
+                declarations: CssDeclarationList [
                     CssDeclaration {
                         name: CssIdentifier {
                             value_token: IDENT@46..56 "prop1" [Newline("\n"), Whitespace("    ")] [],
@@ -155,7 +155,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@68..69 "{" [] [],
-                declaration_list: CssDeclarationList [
+                declarations: CssDeclarationList [
                     CssDeclaration {
                         name: CssIdentifier {
                             value_token: IDENT@69..79 "prop1" [Newline("\n"), Whitespace("    ")] [],
@@ -195,7 +195,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@91..92 "{" [] [],
-                declaration_list: CssDeclarationList [
+                declarations: CssDeclarationList [
                     CssDeclaration {
                         name: CssIdentifier {
                             value_token: IDENT@92..102 "prop1" [Newline("\n"), Whitespace("    ")] [],
@@ -243,7 +243,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@115..116 "{" [] [],
-                declaration_list: CssDeclarationList [
+                declarations: CssDeclarationList [
                     CssDeclaration {
                         name: CssIdentifier {
                             value_token: IDENT@116..126 "prop1" [Newline("\n"), Whitespace("    ")] [],
@@ -299,7 +299,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@141..142 "{" [] [],
-                declaration_list: CssDeclarationList [
+                declarations: CssDeclarationList [
                     CssDeclaration {
                         name: CssIdentifier {
                             value_token: IDENT@142..152 "prop1" [Newline("\n"), Whitespace("    ")] [],
@@ -358,7 +358,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@169..170 "{" [] [],
-                declaration_list: CssDeclarationList [
+                declarations: CssDeclarationList [
                     CssDeclaration {
                         name: CssIdentifier {
                             value_token: IDENT@170..180 "prop1" [Newline("\n"), Whitespace("    ")] [],
@@ -397,7 +397,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@192..193 "{" [] [],
-                declaration_list: CssDeclarationList [
+                declarations: CssDeclarationList [
                     CssDeclaration {
                         name: CssIdentifier {
                             value_token: IDENT@193..203 "prop1" [Newline("\n"), Whitespace("    ")] [],
@@ -432,7 +432,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@222..223 "{" [] [],
-                declaration_list: CssDeclarationList [
+                declarations: CssDeclarationList [
                     CssDeclaration {
                         name: CssIdentifier {
                             value_token: IDENT@223..229 "flex" [Newline("\n"), Whitespace("\t")] [],
@@ -474,7 +474,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@259..260 "{" [] [],
-                declaration_list: CssDeclarationList [
+                declarations: CssDeclarationList [
                     CssDeclaration {
                         name: CssIdentifier {
                             value_token: IDENT@260..287 "border-bottom-left-radius" [Newline("\n"), Whitespace("\t")] [],

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/attribute.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/attribute.css.snap
@@ -86,7 +86,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@8..9 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@9..10 "}" [] [],
             },
         },
@@ -120,7 +120,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@23..24 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@24..25 "}" [] [],
             },
         },
@@ -154,7 +154,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@40..41 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@41..42 "}" [] [],
             },
         },
@@ -188,7 +188,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@61..62 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@62..63 "}" [] [],
             },
         },
@@ -222,7 +222,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@90..91 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@91..92 "}" [] [],
             },
         },
@@ -256,7 +256,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@109..110 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@110..111 "}" [] [],
             },
         },
@@ -290,7 +290,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@125..126 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@126..127 "}" [] [],
             },
         },
@@ -324,7 +324,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@140..141 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@141..142 "}" [] [],
             },
         },
@@ -358,7 +358,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@158..159 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@159..160 "}" [] [],
             },
         },
@@ -392,7 +392,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@179..180 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@180..181 "}" [] [],
             },
         },
@@ -426,7 +426,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@206..207 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@207..208 "}" [] [],
             },
         },
@@ -460,7 +460,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@233..234 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@234..235 "}" [] [],
             },
         },
@@ -494,7 +494,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@253..254 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@254..255 "}" [] [],
             },
         },
@@ -528,7 +528,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@273..274 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@274..275 "}" [] [],
             },
         },
@@ -554,7 +554,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@282..283 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@283..284 "}" [] [],
             },
         },
@@ -580,7 +580,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@293..294 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@294..295 "}" [] [],
             },
         },
@@ -606,7 +606,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@308..309 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@309..310 "}" [] [],
             },
         },
@@ -645,7 +645,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@331..332 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@332..333 "}" [] [],
             },
         },
@@ -684,7 +684,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@362..363 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@363..364 "}" [] [],
             },
         },
@@ -718,7 +718,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@391..392 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@392..393 "}" [] [],
             },
         },
@@ -752,7 +752,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@426..427 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@427..428 "}" [] [],
             },
         },
@@ -786,7 +786,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@467..468 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@468..469 "}" [] [],
             },
         },
@@ -812,7 +812,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@483..484 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@484..485 "}" [] [],
             },
         },
@@ -846,7 +846,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@503..504 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@504..505 "}" [] [],
             },
         },
@@ -884,7 +884,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@524..525 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@525..526 "}" [] [],
             },
         },
@@ -916,7 +916,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@539..540 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@540..541 "}" [] [],
             },
         },
@@ -948,7 +948,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@557..558 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@558..559 "}" [] [],
             },
         },
@@ -982,7 +982,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@574..575 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@575..576 "}" [] [],
             },
         },
@@ -1027,7 +1027,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@612..613 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@613..614 "}" [] [],
             },
         },
@@ -1072,7 +1072,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@653..654 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@654..655 "}" [] [],
             },
         },
@@ -1111,7 +1111,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@673..674 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@674..675 "}" [] [],
             },
         },
@@ -1150,7 +1150,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@693..694 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@694..695 "}" [] [],
             },
         },
@@ -1176,7 +1176,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@708..709 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@709..710 "}" [] [],
             },
         },
@@ -1202,7 +1202,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@725..726 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@726..727 "}" [] [],
             },
         },
@@ -1228,7 +1228,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@745..746 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@746..747 "}" [] [],
             },
         },
@@ -1262,7 +1262,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@757..758 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@758..759 "}" [] [],
             },
         },
@@ -1296,7 +1296,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@769..770 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@770..771 "}" [] [],
             },
         },
@@ -1330,7 +1330,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@781..782 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@782..783 "}" [] [],
             },
         },
@@ -1364,7 +1364,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@811..812 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@812..813 "}" [] [],
             },
         },
@@ -1398,7 +1398,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@824..826 "{" [] [Whitespace(" ")],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@826..827 "}" [] [],
             },
         },
@@ -1437,7 +1437,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@845..846 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@846..847 "}" [] [],
             },
         },
@@ -1478,7 +1478,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@867..868 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@868..869 "}" [] [],
             },
         },
@@ -1519,7 +1519,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@884..885 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@885..886 "}" [] [],
             },
         },
@@ -1550,7 +1550,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@895..896 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@896..897 "}" [] [],
             },
         },
@@ -1581,7 +1581,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@912..913 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@913..914 "}" [] [],
             },
         },
@@ -1610,7 +1610,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@922..923 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@923..924 "}" [] [],
             },
         },
@@ -1639,7 +1639,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@934..935 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@935..936 "}" [] [],
             },
         },
@@ -1668,7 +1668,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@950..951 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@951..952 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/class.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/class.css.snap
@@ -62,7 +62,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@29..30 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@30..33 "}" [Newline("\n"), Newline("\n")] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/complex.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/complex.css.snap
@@ -85,7 +85,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@12..13 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@13..14 "}" [] [],
             },
         },
@@ -134,7 +134,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@35..36 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@36..39 "}" [Newline("\n"), Newline("\n")] [],
             },
         },
@@ -170,7 +170,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@53..54 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@54..55 "}" [] [],
             },
         },
@@ -219,7 +219,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@76..77 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@77..80 "}" [Newline("\n"), Newline("\n")] [],
             },
         },
@@ -255,7 +255,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@94..95 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@95..96 "}" [] [],
             },
         },
@@ -304,7 +304,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@117..118 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@118..121 "}" [Newline("\n"), Newline("\n")] [],
             },
         },
@@ -340,7 +340,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@136..137 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@137..138 "}" [] [],
             },
         },
@@ -389,7 +389,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@161..162 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@162..165 "}" [Newline("\n"), Newline("\n")] [],
             },
         },
@@ -473,7 +473,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@208..209 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@209..212 "}" [Newline("\n"), Newline("\n")] [],
             },
         },
@@ -509,7 +509,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@224..225 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@225..226 "}" [] [],
             },
         },
@@ -558,7 +558,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@245..246 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@246..249 "}" [Newline("\n"), Newline("\n")] [],
             },
         },
@@ -648,7 +648,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@294..295 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@295..298 "}" [Newline("\n"), Newline("\n")] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/id.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/id.css.snap
@@ -62,7 +62,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@29..30 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@30..33 "}" [Newline("\n"), Newline("\n")] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_an_plus_b.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_an_plus_b.css.snap
@@ -159,7 +159,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@17..18 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@18..19 "}" [] [],
             },
         },
@@ -198,7 +198,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@38..39 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@39..40 "}" [] [],
             },
         },
@@ -237,7 +237,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@60..61 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@61..62 "}" [] [],
             },
         },
@@ -276,7 +276,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@81..82 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@82..83 "}" [] [],
             },
         },
@@ -315,7 +315,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@101..102 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@102..103 "}" [] [],
             },
         },
@@ -354,7 +354,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@122..123 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@123..124 "}" [] [],
             },
         },
@@ -393,7 +393,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@143..144 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@144..145 "}" [] [],
             },
         },
@@ -432,7 +432,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@165..166 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@166..167 "}" [] [],
             },
         },
@@ -471,7 +471,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@186..187 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@187..188 "}" [] [],
             },
         },
@@ -510,7 +510,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@208..209 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@209..210 "}" [] [],
             },
         },
@@ -549,7 +549,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@231..232 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@232..233 "}" [] [],
             },
         },
@@ -588,7 +588,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@253..254 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@254..255 "}" [] [],
             },
         },
@@ -627,7 +627,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@274..275 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@275..276 "}" [] [],
             },
         },
@@ -666,7 +666,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@296..297 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@297..298 "}" [] [],
             },
         },
@@ -705,7 +705,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@319..320 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@320..321 "}" [] [],
             },
         },
@@ -744,7 +744,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@340..341 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@341..342 "}" [] [],
             },
         },
@@ -783,7 +783,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@362..363 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@363..364 "}" [] [],
             },
         },
@@ -822,7 +822,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@385..386 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@386..387 "}" [] [],
             },
         },
@@ -861,7 +861,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@407..408 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@408..409 "}" [] [],
             },
         },
@@ -900,7 +900,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@428..429 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@429..430 "}" [] [],
             },
         },
@@ -939,7 +939,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@450..451 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@451..452 "}" [] [],
             },
         },
@@ -978,7 +978,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@472..473 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@473..474 "}" [] [],
             },
         },
@@ -1017,7 +1017,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@495..496 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@496..497 "}" [] [],
             },
         },
@@ -1054,7 +1054,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@514..515 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@515..516 "}" [] [],
             },
         },
@@ -1091,7 +1091,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@534..535 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@535..536 "}" [] [],
             },
         },
@@ -1128,7 +1128,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@555..556 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@556..557 "}" [] [],
             },
         },
@@ -1165,7 +1165,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@575..576 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@576..577 "}" [] [],
             },
         },
@@ -1202,7 +1202,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@594..595 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@595..596 "}" [] [],
             },
         },
@@ -1239,7 +1239,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@614..615 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@615..616 "}" [] [],
             },
         },
@@ -1276,7 +1276,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@634..635 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@635..636 "}" [] [],
             },
         },
@@ -1313,7 +1313,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@655..656 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@656..657 "}" [] [],
             },
         },
@@ -1350,7 +1350,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@675..676 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@676..677 "}" [] [],
             },
         },
@@ -1387,7 +1387,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@696..697 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@697..698 "}" [] [],
             },
         },
@@ -1424,7 +1424,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@718..719 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@719..720 "}" [] [],
             },
         },
@@ -1461,7 +1461,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@739..740 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@740..741 "}" [] [],
             },
         },
@@ -1498,7 +1498,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@759..760 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@760..761 "}" [] [],
             },
         },
@@ -1535,7 +1535,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@780..781 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@781..782 "}" [] [],
             },
         },
@@ -1572,7 +1572,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@801..802 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@802..803 "}" [] [],
             },
         },
@@ -1609,7 +1609,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@823..824 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@824..825 "}" [] [],
             },
         },
@@ -1646,7 +1646,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@843..844 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@844..845 "}" [] [],
             },
         },
@@ -1683,7 +1683,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@864..865 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@865..866 "}" [] [],
             },
         },
@@ -1720,7 +1720,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@886..887 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@887..888 "}" [] [],
             },
         },
@@ -1757,7 +1757,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@907..908 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@908..909 "}" [] [],
             },
         },
@@ -1794,7 +1794,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@927..928 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@928..929 "}" [] [],
             },
         },
@@ -1831,7 +1831,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@948..949 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@949..950 "}" [] [],
             },
         },
@@ -1868,7 +1868,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@969..970 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@970..971 "}" [] [],
             },
         },
@@ -1905,7 +1905,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@991..992 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@992..993 "}" [] [],
             },
         },
@@ -1937,7 +1937,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1008..1009 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1009..1010 "}" [] [],
             },
         },
@@ -1969,7 +1969,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1026..1027 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1027..1028 "}" [] [],
             },
         },
@@ -2001,7 +2001,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1044..1045 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1045..1046 "}" [] [],
             },
         },
@@ -2035,7 +2035,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1062..1063 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1063..1064 "}" [] [],
             },
         },
@@ -2069,7 +2069,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1081..1082 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1082..1083 "}" [] [],
             },
         },
@@ -2103,7 +2103,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1100..1101 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1101..1102 "}" [] [],
             },
         },
@@ -2135,7 +2135,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1117..1118 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1118..1119 "}" [] [],
             },
         },
@@ -2167,7 +2167,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1135..1136 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1136..1137 "}" [] [],
             },
         },
@@ -2199,7 +2199,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1153..1154 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1154..1155 "}" [] [],
             },
         },
@@ -2233,7 +2233,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1171..1172 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1172..1173 "}" [] [],
             },
         },
@@ -2267,7 +2267,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1190..1191 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1191..1192 "}" [] [],
             },
         },
@@ -2301,7 +2301,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1209..1210 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1210..1211 "}" [] [],
             },
         },
@@ -2333,7 +2333,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1226..1227 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1227..1228 "}" [] [],
             },
         },
@@ -2365,7 +2365,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1244..1245 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1245..1246 "}" [] [],
             },
         },
@@ -2397,7 +2397,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1262..1263 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1263..1264 "}" [] [],
             },
         },
@@ -2436,7 +2436,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1294..1295 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1295..1296 "}" [] [],
             },
         },
@@ -2475,7 +2475,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1315..1316 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1316..1317 "}" [] [],
             },
         },
@@ -2514,7 +2514,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1335..1336 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1336..1337 "}" [] [],
             },
         },
@@ -2543,7 +2543,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1355..1356 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1356..1357 "}" [] [],
             },
         },
@@ -2572,7 +2572,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1374..1375 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1375..1376 "}" [] [],
             },
         },
@@ -2601,7 +2601,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1393..1394 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1394..1395 "}" [] [],
             },
         },
@@ -2630,7 +2630,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1413..1414 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1414..1415 "}" [] [],
             },
         },
@@ -2659,7 +2659,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1433..1434 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1434..1435 "}" [] [],
             },
         },
@@ -2688,7 +2688,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1453..1454 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1454..1455 "}" [] [],
             },
         },
@@ -2727,7 +2727,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1506..1507 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1507..1508 "}" [] [],
             },
         },
@@ -2766,7 +2766,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1564..1565 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1565..1566 "}" [] [],
             },
         },
@@ -2805,7 +2805,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1593..1594 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1594..1595 "}" [] [],
             },
         },
@@ -2844,7 +2844,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1627..1628 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1628..1629 "}" [] [],
             },
         },
@@ -2883,7 +2883,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1649..1650 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1650..1651 "}" [] [],
             },
         },
@@ -2922,7 +2922,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1674..1675 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1675..1676 "}" [] [],
             },
         },
@@ -2961,7 +2961,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1696..1697 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1697..1698 "}" [] [],
             },
         },
@@ -3000,7 +3000,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1723..1724 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1724..1725 "}" [] [],
             },
         },
@@ -3029,7 +3029,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1741..1742 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1742..1743 "}" [] [],
             },
         },
@@ -3068,7 +3068,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1759..1760 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1760..1761 "}" [] [],
             },
         },
@@ -3097,7 +3097,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1781..1782 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1782..1783 "}" [] [],
             },
         },
@@ -3136,7 +3136,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1804..1805 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1805..1806 "}" [] [],
             },
         },
@@ -3173,7 +3173,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1823..1824 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1824..1825 "}" [] [],
             },
         },
@@ -3210,7 +3210,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1841..1842 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1842..1843 "}" [] [],
             },
         },
@@ -3247,7 +3247,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1859..1860 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1860..1861 "}" [] [],
             },
         },
@@ -3284,7 +3284,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1876..1877 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1877..1878 "}" [] [],
             },
         },
@@ -3321,7 +3321,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1894..1895 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1895..1896 "}" [] [],
             },
         },
@@ -3358,7 +3358,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1912..1913 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1913..1914 "}" [] [],
             },
         },
@@ -3395,7 +3395,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1929..1930 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1930..1931 "}" [] [],
             },
         },
@@ -3432,7 +3432,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1947..1948 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1948..1949 "}" [] [],
             },
         },
@@ -3469,7 +3469,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1965..1966 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1966..1967 "}" [] [],
             },
         },
@@ -3500,7 +3500,7 @@ CssRoot {
                                     },
                                     of_selector: CssPseudoClassOfNthSelector {
                                         of_token: OF_KW@1985..1988 "of" [] [Whitespace(" ")],
-                                        selector_list: CssSelectorList [
+                                        selectors: CssSelectorList [
                                             CssCompoundSelector {
                                                 nesting_selector_token: missing (optional),
                                                 simple_selector: CssTypeSelector {
@@ -3522,7 +3522,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@1992..1993 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@1993..1994 "}" [] [],
             },
         },
@@ -3553,7 +3553,7 @@ CssRoot {
                                     },
                                     of_selector: CssPseudoClassOfNthSelector {
                                         of_token: OF_KW@2014..2017 "of" [] [Whitespace(" ")],
-                                        selector_list: CssSelectorList [
+                                        selectors: CssSelectorList [
                                             CssCompoundSelector {
                                                 nesting_selector_token: missing (optional),
                                                 simple_selector: CssTypeSelector {
@@ -3575,7 +3575,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@2024..2025 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@2025..2026 "}" [] [],
             },
         },
@@ -3606,7 +3606,7 @@ CssRoot {
                                     },
                                     of_selector: CssPseudoClassOfNthSelector {
                                         of_token: OF_KW@2043..2046 "of" [] [Whitespace(" ")],
-                                        selector_list: CssSelectorList [
+                                        selectors: CssSelectorList [
                                             CssCompoundSelector {
                                                 nesting_selector_token: missing (optional),
                                                 simple_selector: CssTypeSelector {
@@ -3641,7 +3641,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@2056..2057 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@2057..2058 "}" [] [],
             },
         },
@@ -3672,7 +3672,7 @@ CssRoot {
                                     },
                                     of_selector: CssPseudoClassOfNthSelector {
                                         of_token: OF_KW@2075..2078 "of" [] [Whitespace(" ")],
-                                        selector_list: CssSelectorList [
+                                        selectors: CssSelectorList [
                                             CssCompoundSelector {
                                                 nesting_selector_token: missing (optional),
                                                 simple_selector: CssTypeSelector {
@@ -3707,7 +3707,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@2089..2090 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@2090..2091 "}" [] [],
             },
         },
@@ -3736,7 +3736,7 @@ CssRoot {
                                     },
                                     of_selector: CssPseudoClassOfNthSelector {
                                         of_token: OF_KW@2108..2111 "of" [] [Whitespace(" ")],
-                                        selector_list: CssSelectorList [
+                                        selectors: CssSelectorList [
                                             CssCompoundSelector {
                                                 nesting_selector_token: missing (optional),
                                                 simple_selector: CssTypeSelector {
@@ -3765,7 +3765,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@2125..2126 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@2126..2127 "}" [] [],
             },
         },
@@ -3791,7 +3791,7 @@ CssRoot {
                                     },
                                     of_selector: CssPseudoClassOfNthSelector {
                                         of_token: OF_KW@2146..2149 "of" [] [Whitespace(" ")],
-                                        selector_list: CssSelectorList [
+                                        selectors: CssSelectorList [
                                             CssCompoundSelector {
                                                 nesting_selector_token: missing (optional),
                                                 simple_selector: missing (optional),
@@ -3801,7 +3801,7 @@ CssRoot {
                                                         class: CssPseudoClassFunctionSelectorList {
                                                             name: NOT_KW@2150..2153 "not" [] [],
                                                             l_paren_token: L_PAREN@2153..2154 "(" [] [],
-                                                            selector_list: CssSelectorList [
+                                                            selectors: CssSelectorList [
                                                                 CssCompoundSelector {
                                                                     nesting_selector_token: missing (optional),
                                                                     simple_selector: missing (optional),
@@ -3836,7 +3836,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@2165..2166 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@2166..2167 "}" [] [],
             },
         },
@@ -3890,7 +3890,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@2192..2193 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@2193..2194 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_any.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_any.css.snap
@@ -45,7 +45,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: ANY_KW@1..12 "-webkit-any" [] [],
                                 l_paren_token: L_PAREN@12..13 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -65,7 +65,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@23..24 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@24..25 "}" [] [],
             },
         },
@@ -80,7 +80,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: ANY_KW@27..35 "-moz-any" [] [],
                                 l_paren_token: L_PAREN@35..36 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -100,7 +100,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@46..47 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@47..48 "}" [] [],
             },
         },
@@ -116,7 +116,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionCompoundSelectorList {
                                     name: ANY_KW@50..61 "-webkit-any" [] [],
                                     l_paren_token: L_PAREN@61..62 "(" [] [],
-                                    compound_selector_list: CssCompoundSelectorList [
+                                    compound_selectors: CssCompoundSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -179,7 +179,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@92..93 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@93..94 "}" [] [],
             },
         },
@@ -195,7 +195,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionCompoundSelectorList {
                                     name: ANY_KW@96..104 "-moz-any" [] [],
                                     l_paren_token: L_PAREN@104..105 "(" [] [],
-                                    compound_selector_list: CssCompoundSelectorList [
+                                    compound_selectors: CssCompoundSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -258,7 +258,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@135..136 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@136..137 "}" [] [],
             },
         },
@@ -273,7 +273,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: ANY_KW@139..150 "-webkit-any" [] [],
                                 l_paren_token: L_PAREN@150..151 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -306,7 +306,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@165..166 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@166..167 "}" [] [],
             },
         },
@@ -321,7 +321,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: ANY_KW@169..177 "-moz-any" [] [],
                                 l_paren_token: L_PAREN@177..178 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -354,7 +354,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@192..193 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@193..194 "}" [] [],
             },
         },
@@ -369,7 +369,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: ANY_KW@196..207 "-webkit-any" [] [],
                                 l_paren_token: L_PAREN@207..208 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -415,7 +415,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@230..231 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@231..232 "}" [] [],
             },
         },
@@ -430,7 +430,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: ANY_KW@234..242 "-moz-any" [] [],
                                 l_paren_token: L_PAREN@242..243 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -476,7 +476,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@265..266 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@266..267 "}" [] [],
             },
         },
@@ -491,7 +491,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: ANY_KW@269..280 "-webkit-any" [] [],
                                 l_paren_token: L_PAREN@280..281 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -518,7 +518,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: ANY_KW@287..298 "-webkit-any" [] [],
                                 l_paren_token: L_PAREN@298..300 "(" [] [Whitespace(" ")],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -558,7 +558,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: ANY_KW@313..324 "-webkit-any" [] [],
                                 l_paren_token: L_PAREN@324..325 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -600,7 +600,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: ANY_KW@339..350 "-webkit-any" [] [],
                                 l_paren_token: L_PAREN@350..351 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -666,7 +666,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@373..374 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@374..375 "}" [] [],
             },
         },
@@ -695,7 +695,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionCompoundSelectorList {
                                     name: ANY_KW@395..406 "-webkit-any" [] [],
                                     l_paren_token: L_PAREN@406..407 "(" [] [],
-                                    compound_selector_list: CssCompoundSelectorList [
+                                    compound_selectors: CssCompoundSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: missing (optional),
@@ -727,7 +727,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: ANY_KW@422..433 "-webkit-any" [] [],
                                 l_paren_token: L_PAREN@433..434 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -780,7 +780,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionCompoundSelectorList {
                                     name: ANY_KW@464..475 "-webkit-any" [] [],
                                     l_paren_token: L_PAREN@475..476 "(" [] [],
-                                    compound_selector_list: CssCompoundSelectorList [
+                                    compound_selectors: CssCompoundSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: missing (optional),
@@ -832,7 +832,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: ANY_KW@495..506 "-webkit-any" [] [],
                                 l_paren_token: L_PAREN@506..507 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -867,7 +867,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@523..524 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@524..525 "}" [] [],
             },
         },
@@ -883,7 +883,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionCompoundSelectorList {
                                     name: ANY_KW@527..535 "-moz-any" [] [],
                                     l_paren_token: L_PAREN@535..536 "(" [] [],
-                                    compound_selector_list: CssCompoundSelectorList [
+                                    compound_selectors: CssCompoundSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -917,7 +917,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@551..552 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@552..553 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_basic.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_basic.css.snap
@@ -54,7 +54,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@6..7 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@7..8 "}" [] [],
             },
         },
@@ -77,7 +77,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@19..20 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@20..21 "}" [] [],
             },
         },
@@ -105,7 +105,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@35..36 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@36..37 "}" [] [],
             },
         },
@@ -124,7 +124,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@50..51 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@51..52 "}" [] [],
             },
         },
@@ -152,7 +152,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@66..67 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@67..68 "}" [] [],
             },
         },
@@ -171,7 +171,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@75..76 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@76..77 "}" [] [],
             },
         },
@@ -187,7 +187,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: MATCHES_KW@79..86 "matches" [] [],
                                     l_paren_token: L_PAREN@86..87 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -252,7 +252,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@120..121 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@121..122 "}" [] [],
             },
         },
@@ -272,7 +272,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@129..132 "not" [] [],
                                 l_paren_token: L_PAREN@132..133 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -307,7 +307,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@150..151 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@151..152 "}" [] [],
             },
         },
@@ -333,7 +333,7 @@ CssRoot {
                             class: CssPseudoClassFunctionRelativeSelectorList {
                                 name_token: HAS_KW@165..168 "has" [] [],
                                 l_paren_token: L_PAREN@168..169 "(" [] [],
-                                relative_selector_list: CssRelativeSelectorList [
+                                relative_selectors: CssRelativeSelectorList [
                                     CssRelativeSelector {
                                         combinator: missing (optional),
                                         selector: CssCompoundSelector {
@@ -372,7 +372,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@185..188 "not" [] [],
                                 l_paren_token: L_PAREN@188..189 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -382,7 +382,7 @@ CssRoot {
                                                 class: CssPseudoClassFunctionRelativeSelectorList {
                                                     name_token: HAS_KW@190..193 "has" [] [],
                                                     l_paren_token: L_PAREN@193..194 "(" [] [],
-                                                    relative_selector_list: CssRelativeSelectorList [
+                                                    relative_selectors: CssRelativeSelectorList [
                                                         CssRelativeSelector {
                                                             combinator: missing (optional),
                                                             selector: CssCompoundSelector {
@@ -427,7 +427,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@211..212 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@212..213 "}" [] [],
             },
         },
@@ -458,7 +458,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@256..257 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@257..258 "}" [] [],
             },
         },
@@ -497,7 +497,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@307..308 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@308..309 "}" [] [],
             },
         },
@@ -542,7 +542,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@363..364 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@364..365 "}" [] [],
             },
         },
@@ -560,7 +560,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: IS_KW@368..370 "is" [] [],
                                 l_paren_token: L_PAREN@370..371 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssUniversalSelector {
@@ -578,7 +578,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@374..375 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@375..376 "}" [] [],
             },
         },
@@ -601,7 +601,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@388..389 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@389..390 "}" [] [],
             },
         },
@@ -629,7 +629,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@410..411 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@411..412 "}" [] [],
             },
         },
@@ -665,7 +665,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@429..430 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@430..431 "}" [] [],
             },
         },
@@ -710,7 +710,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@450..451 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@451..452 "}" [] [],
             },
         },
@@ -738,7 +738,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@461..462 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@462..463 "}" [] [],
             },
         },
@@ -774,7 +774,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@487..488 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@488..489 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_current.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_current.css.snap
@@ -29,7 +29,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: CURRENT_KW@1..8 "current" [] [],
                                 l_paren_token: L_PAREN@8..9 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -82,7 +82,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@24..25 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@25..26 "}" [] [],
             },
         },
@@ -98,7 +98,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionCompoundSelectorList {
                                     name: CURRENT_KW@28..35 "current" [] [],
                                     l_paren_token: L_PAREN@35..36 "(" [] [],
-                                    compound_selector_list: CssCompoundSelectorList [
+                                    compound_selectors: CssCompoundSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -165,7 +165,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@56..57 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@57..58 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_dir.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_dir.css.snap
@@ -44,7 +44,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@10..11 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@11..12 "}" [] [],
             },
         },
@@ -70,7 +70,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@29..30 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@30..31 "}" [] [],
             },
         },
@@ -96,7 +96,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@42..43 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@43..44 "}" [] [],
             },
         },
@@ -122,7 +122,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@61..62 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@62..63 "}" [] [],
             },
         },
@@ -148,7 +148,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@80..81 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@81..82 "}" [] [],
             },
         },
@@ -189,7 +189,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@98..99 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@99..100 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_future.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_future.css.snap
@@ -29,7 +29,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: FUTURE_KW@1..7 "future" [] [],
                                 l_paren_token: L_PAREN@7..8 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -82,7 +82,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@23..24 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@24..25 "}" [] [],
             },
         },
@@ -98,7 +98,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionCompoundSelectorList {
                                     name: FUTURE_KW@27..33 "future" [] [],
                                     l_paren_token: L_PAREN@33..34 "(" [] [],
-                                    compound_selector_list: CssCompoundSelectorList [
+                                    compound_selectors: CssCompoundSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -165,7 +165,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@54..55 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@55..56 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_has.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_has.css.snap
@@ -43,7 +43,7 @@ CssRoot {
                             class: CssPseudoClassFunctionRelativeSelectorList {
                                 name_token: HAS_KW@2..5 "has" [] [],
                                 l_paren_token: L_PAREN@5..6 "(" [] [],
-                                relative_selector_list: CssRelativeSelectorList [
+                                relative_selectors: CssRelativeSelectorList [
                                     CssRelativeSelector {
                                         combinator: R_ANGLE@6..8 ">" [] [Whitespace(" ")],
                                         selector: CssCompoundSelector {
@@ -66,7 +66,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@13..14 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@14..15 "}" [] [],
             },
         },
@@ -86,7 +86,7 @@ CssRoot {
                             class: CssPseudoClassFunctionRelativeSelectorList {
                                 name_token: HAS_KW@18..21 "has" [] [],
                                 l_paren_token: L_PAREN@21..25 "(" [] [Whitespace("   ")],
-                                relative_selector_list: CssRelativeSelectorList [
+                                relative_selectors: CssRelativeSelectorList [
                                     CssRelativeSelector {
                                         combinator: R_ANGLE@25..27 ">" [] [Whitespace(" ")],
                                         selector: CssCompoundSelector {
@@ -109,7 +109,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@35..36 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@36..37 "}" [] [],
             },
         },
@@ -129,7 +129,7 @@ CssRoot {
                             class: CssPseudoClassFunctionRelativeSelectorList {
                                 name_token: HAS_KW@40..43 "has" [] [],
                                 l_paren_token: L_PAREN@43..47 "(" [] [Whitespace("   ")],
-                                relative_selector_list: CssRelativeSelectorList [
+                                relative_selectors: CssRelativeSelectorList [
                                     CssRelativeSelector {
                                         combinator: R_ANGLE@47..51 ">" [] [Whitespace("   ")],
                                         selector: CssCompoundSelector {
@@ -152,7 +152,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@59..60 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@60..61 "}" [] [],
             },
         },
@@ -172,7 +172,7 @@ CssRoot {
                             class: CssPseudoClassFunctionRelativeSelectorList {
                                 name_token: HAS_KW@64..67 "has" [] [],
                                 l_paren_token: L_PAREN@67..71 "(" [] [Whitespace("   ")],
-                                relative_selector_list: CssRelativeSelectorList [
+                                relative_selectors: CssRelativeSelectorList [
                                     CssRelativeSelector {
                                         combinator: R_ANGLE@71..75 ">" [] [Whitespace("   ")],
                                         selector: CssCompoundSelector {
@@ -209,7 +209,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@97..98 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@98..99 "}" [] [],
             },
         },
@@ -229,7 +229,7 @@ CssRoot {
                             class: CssPseudoClassFunctionRelativeSelectorList {
                                 name_token: HAS_KW@102..105 "has" [] [],
                                 l_paren_token: L_PAREN@105..109 "(" [] [Whitespace("   ")],
-                                relative_selector_list: CssRelativeSelectorList [
+                                relative_selectors: CssRelativeSelectorList [
                                     CssRelativeSelector {
                                         combinator: missing (optional),
                                         selector: CssCompoundSelector {
@@ -252,7 +252,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@117..118 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@118..119 "}" [] [],
             },
         },
@@ -272,7 +272,7 @@ CssRoot {
                             class: CssPseudoClassFunctionRelativeSelectorList {
                                 name_token: HAS_KW@123..126 "has" [] [],
                                 l_paren_token: L_PAREN@126..127 "(" [] [],
-                                relative_selector_list: CssRelativeSelectorList [
+                                relative_selectors: CssRelativeSelectorList [
                                     CssRelativeSelector {
                                         combinator: PLUS@127..129 "+" [] [Whitespace(" ")],
                                         selector: CssCompoundSelector {
@@ -295,7 +295,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@133..134 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@134..135 "}" [] [],
             },
         },
@@ -315,7 +315,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@144..147 "not" [] [],
                                 l_paren_token: L_PAREN@147..148 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -325,7 +325,7 @@ CssRoot {
                                                 class: CssPseudoClassFunctionRelativeSelectorList {
                                                     name_token: HAS_KW@149..152 "has" [] [],
                                                     l_paren_token: L_PAREN@152..153 "(" [] [],
-                                                    relative_selector_list: CssRelativeSelectorList [
+                                                    relative_selectors: CssRelativeSelectorList [
                                                         CssRelativeSelector {
                                                             combinator: missing (optional),
                                                             selector: CssCompoundSelector {
@@ -424,7 +424,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@178..179 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@179..180 "}" [] [],
             },
         },
@@ -444,7 +444,7 @@ CssRoot {
                             class: CssPseudoClassFunctionRelativeSelectorList {
                                 name_token: HAS_KW@189..192 "has" [] [],
                                 l_paren_token: L_PAREN@192..193 "(" [] [],
-                                relative_selector_list: CssRelativeSelectorList [
+                                relative_selectors: CssRelativeSelectorList [
                                     CssRelativeSelector {
                                         combinator: missing (optional),
                                         selector: CssCompoundSelector {
@@ -456,7 +456,7 @@ CssRoot {
                                                     class: CssPseudoClassFunctionSelectorList {
                                                         name: NOT_KW@194..197 "not" [] [],
                                                         l_paren_token: L_PAREN@197..198 "(" [] [],
-                                                        selector_list: CssSelectorList [
+                                                        selectors: CssSelectorList [
                                                             CssCompoundSelector {
                                                                 nesting_selector_token: missing (optional),
                                                                 simple_selector: CssTypeSelector {
@@ -538,7 +538,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@223..224 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@224..225 "}" [] [],
             },
         },
@@ -558,7 +558,7 @@ CssRoot {
                             class: CssPseudoClassFunctionRelativeSelectorList {
                                 name_token: HAS_KW@230..233 "has" [] [],
                                 l_paren_token: L_PAREN@233..234 "(" [] [],
-                                relative_selector_list: CssRelativeSelectorList [
+                                relative_selectors: CssRelativeSelectorList [
                                     CssRelativeSelector {
                                         combinator: missing (optional),
                                         selector: CssCompoundSelector {
@@ -581,7 +581,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@237..238 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@238..239 "}" [] [],
             },
         },
@@ -603,7 +603,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionRelativeSelectorList {
                                     name_token: HAS_KW@254..257 "has" [] [],
                                     l_paren_token: L_PAREN@257..258 "(" [] [],
-                                    relative_selector_list: CssRelativeSelectorList [
+                                    relative_selectors: CssRelativeSelectorList [
                                         CssRelativeSelector {
                                             combinator: missing (optional),
                                             selector: CssCompoundSelector {
@@ -626,7 +626,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionRelativeSelectorList {
                                     name_token: HAS_KW@262..265 "has" [] [],
                                     l_paren_token: L_PAREN@265..266 "(" [] [],
-                                    relative_selector_list: CssRelativeSelectorList [
+                                    relative_selectors: CssRelativeSelectorList [
                                         CssRelativeSelector {
                                             combinator: missing (optional),
                                             selector: CssCompoundSelector {
@@ -663,7 +663,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@280..281 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@281..282 "}" [] [],
             },
         },
@@ -684,7 +684,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionRelativeSelectorList {
                                     name_token: HAS_KW@285..288 "has" [] [],
                                     l_paren_token: L_PAREN@288..289 "(" [] [],
-                                    relative_selector_list: CssRelativeSelectorList [
+                                    relative_selectors: CssRelativeSelectorList [
                                         CssRelativeSelector {
                                             combinator: R_ANGLE@289..291 ">" [] [Whitespace(" ")],
                                             selector: CssCompoundSelector {
@@ -721,7 +721,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@301..302 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@302..303 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_host.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_host.css.snap
@@ -52,7 +52,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@31..32 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@32..33 "}" [] [],
             },
         },
@@ -87,7 +87,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@71..72 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@72..73 "}" [] [],
             },
         },
@@ -122,7 +122,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@89..90 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@90..91 "}" [] [],
             },
         },
@@ -145,7 +145,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@98..99 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@99..100 "}" [] [],
             },
         },
@@ -195,7 +195,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@121..122 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@122..123 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_host_context.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_host_context.css.snap
@@ -48,7 +48,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@18..19 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@19..20 "}" [] [],
             },
         },
@@ -81,7 +81,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@45..46 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@46..47 "}" [] [],
             },
         },
@@ -129,7 +129,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@71..72 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@72..73 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_ident.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_ident.css.snap
@@ -43,7 +43,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@15..16 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@16..17 "}" [] [],
             },
         },
@@ -66,7 +66,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@31..32 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@32..33 "}" [] [],
             },
         },
@@ -89,7 +89,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@41..42 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@42..43 "}" [] [],
             },
         },
@@ -112,7 +112,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@52..53 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@53..54 "}" [] [],
             },
         },
@@ -135,7 +135,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@65..66 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@66..67 "}" [] [],
             },
         },
@@ -158,7 +158,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@78..79 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@79..80 "}" [] [],
             },
         },
@@ -181,7 +181,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@88..89 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@89..90 "}" [] [],
             },
         },
@@ -204,7 +204,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@98..99 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@99..100 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_is.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_is.css.snap
@@ -44,7 +44,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: IS_KW@1..3 "is" [] [],
                                     l_paren_token: L_PAREN@3..4 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -76,7 +76,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@11..12 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@12..13 "}" [] [],
             },
         },
@@ -92,7 +92,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: IS_KW@15..17 "is" [] [],
                                     l_paren_token: L_PAREN@17..18 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -135,7 +135,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@29..30 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@30..31 "}" [] [],
             },
         },
@@ -151,7 +151,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: IS_KW@33..35 "is" [] [],
                                     l_paren_token: L_PAREN@35..36 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -214,7 +214,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@66..67 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@67..68 "}" [] [],
             },
         },
@@ -234,7 +234,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: IS_KW@73..75 "is" [] [],
                                 l_paren_token: L_PAREN@75..76 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -269,7 +269,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@89..90 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@90..91 "}" [] [],
             },
         },
@@ -286,7 +286,7 @@ CssRoot {
                                     class: CssPseudoClassFunctionSelectorList {
                                         name: IS_KW@93..95 "is" [] [],
                                         l_paren_token: L_PAREN@95..96 "(" [] [],
-                                        selector_list: CssSelectorList [
+                                        selectors: CssSelectorList [
                                             CssCompoundSelector {
                                                 nesting_selector_token: missing (optional),
                                                 simple_selector: CssTypeSelector {
@@ -346,7 +346,7 @@ CssRoot {
                                     class: CssPseudoClassFunctionSelectorList {
                                         name: IS_KW@116..118 "is" [] [],
                                         l_paren_token: L_PAREN@118..119 "(" [] [],
-                                        selector_list: CssSelectorList [
+                                        selectors: CssSelectorList [
                                             CssCompoundSelector {
                                                 nesting_selector_token: missing (optional),
                                                 simple_selector: CssTypeSelector {
@@ -407,7 +407,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: IS_KW@139..141 "is" [] [],
                                     l_paren_token: L_PAREN@141..142 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -450,7 +450,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@157..158 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@158..159 "}" [] [],
             },
         },
@@ -468,7 +468,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: IS_KW@162..164 "is" [] [],
                                 l_paren_token: L_PAREN@164..165 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -507,7 +507,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@181..182 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@182..183 "}" [] [],
             },
         },
@@ -525,7 +525,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: IS_KW@186..188 "is" [] [],
                                 l_paren_token: L_PAREN@188..189 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssUniversalSelector {
@@ -570,7 +570,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@207..208 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@208..209 "}" [] [],
             },
         },
@@ -586,7 +586,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: IS_KW@211..213 "is" [] [],
                                     l_paren_token: L_PAREN@213..214 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -649,7 +649,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@240..241 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@241..242 "}" [] [],
             },
         },
@@ -664,7 +664,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: IS_KW@244..246 "is" [] [],
                                 l_paren_token: L_PAREN@246..247 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -704,7 +704,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@265..266 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@266..267 "}" [] [],
             },
         },
@@ -719,7 +719,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: IS_KW@269..271 "is" [] [],
                                 l_paren_token: L_PAREN@271..272 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -758,7 +758,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@294..295 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@295..296 "}" [] [],
             },
         },
@@ -778,7 +778,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: IS_KW@299..301 "is" [] [],
                                 l_paren_token: L_PAREN@301..302 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -788,7 +788,7 @@ CssRoot {
                                                 class: CssPseudoClassFunctionSelectorList {
                                                     name: NOT_KW@303..306 "not" [] [],
                                                     l_paren_token: L_PAREN@306..307 "(" [] [],
-                                                    selector_list: CssSelectorList [
+                                                    selectors: CssSelectorList [
                                                         CssCompoundSelector {
                                                             nesting_selector_token: missing (optional),
                                                             simple_selector: missing (optional),
@@ -818,7 +818,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@316..317 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@317..318 "}" [] [],
             },
         },
@@ -834,7 +834,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: IS_KW@320..322 "is" [] [],
                                     l_paren_token: L_PAREN@322..323 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -894,7 +894,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: IS_KW@354..356 "is" [] [],
                                     l_paren_token: L_PAREN@356..357 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -970,7 +970,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@381..382 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@382..383 "}" [] [],
             },
         },
@@ -986,7 +986,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionCompoundSelectorList {
                                     name: ANY_KW@385..396 "-webkit-any" [] [],
                                     l_paren_token: L_PAREN@396..397 "(" [] [],
-                                    compound_selector_list: CssCompoundSelectorList [
+                                    compound_selectors: CssCompoundSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -1049,7 +1049,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@427..428 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@428..429 "}" [] [],
             },
         },
@@ -1065,7 +1065,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionCompoundSelectorList {
                                     name: ANY_KW@431..439 "-moz-any" [] [],
                                     l_paren_token: L_PAREN@439..440 "(" [] [],
-                                    compound_selector_list: CssCompoundSelectorList [
+                                    compound_selectors: CssCompoundSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -1128,7 +1128,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@470..471 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@471..472 "}" [] [],
             },
         },
@@ -1144,7 +1144,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: MATCHES_KW@474..481 "matches" [] [],
                                     l_paren_token: L_PAREN@481..482 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -1207,7 +1207,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@512..513 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@513..514 "}" [] [],
             },
         },
@@ -1223,7 +1223,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: IS_KW@516..518 "is" [] [],
                                     l_paren_token: L_PAREN@518..519 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -1286,7 +1286,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@549..550 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@550..551 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_lang.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_lang.css.snap
@@ -35,7 +35,7 @@ CssRoot {
                             class: CssPseudoClassFunctionValueList {
                                 name_token: LANG_KW@1..5 "lang" [] [],
                                 l_paren_token: L_PAREN@5..6 "(" [] [],
-                                value_list: CssPseudoValueList [
+                                values: CssPseudoValueList [
                                     CssIdentifier {
                                         value_token: IDENT@6..13 "\\*-Latn" [] [],
                                     },
@@ -48,7 +48,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@15..16 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@16..17 "}" [] [],
             },
         },
@@ -63,7 +63,7 @@ CssRoot {
                             class: CssPseudoClassFunctionValueList {
                                 name_token: LANG_KW@19..23 "lang" [] [],
                                 l_paren_token: L_PAREN@23..24 "(" [] [],
-                                value_list: CssPseudoValueList [
+                                values: CssPseudoValueList [
                                     CssString {
                                         value_token: CSS_STRING_LITERAL@24..32 "\"*-Latn\"" [] [],
                                     },
@@ -76,7 +76,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@34..35 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@35..36 "}" [] [],
             },
         },
@@ -96,7 +96,7 @@ CssRoot {
                             class: CssPseudoClassFunctionValueList {
                                 name_token: LANG_KW@42..46 "lang" [] [],
                                 l_paren_token: L_PAREN@46..47 "(" [] [],
-                                value_list: CssPseudoValueList [
+                                values: CssPseudoValueList [
                                     CssIdentifier {
                                         value_token: IDENT@47..52 "fr-be" [] [],
                                     },
@@ -109,7 +109,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@54..55 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@55..56 "}" [] [],
             },
         },
@@ -129,7 +129,7 @@ CssRoot {
                             class: CssPseudoClassFunctionValueList {
                                 name_token: LANG_KW@62..66 "lang" [] [],
                                 l_paren_token: L_PAREN@66..67 "(" [] [],
-                                value_list: CssPseudoValueList [
+                                values: CssPseudoValueList [
                                     CssIdentifier {
                                         value_token: IDENT@67..69 "de" [] [],
                                     },
@@ -142,7 +142,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@71..72 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@72..73 "}" [] [],
             },
         },
@@ -162,7 +162,7 @@ CssRoot {
                             class: CssPseudoClassFunctionValueList {
                                 name_token: LANG_KW@79..83 "lang" [] [],
                                 l_paren_token: L_PAREN@83..84 "(" [] [],
-                                value_list: CssPseudoValueList [
+                                values: CssPseudoValueList [
                                     CssIdentifier {
                                         value_token: IDENT@84..86 "de" [] [],
                                     },
@@ -179,7 +179,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@92..93 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@93..94 "}" [] [],
             },
         },
@@ -195,7 +195,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionValueList {
                                     name_token: LANG_KW@96..100 "lang" [] [],
                                     l_paren_token: L_PAREN@100..101 "(" [] [],
-                                    value_list: CssPseudoValueList [
+                                    values: CssPseudoValueList [
                                         CssIdentifier {
                                             value_token: IDENT@101..106 "fr-be" [] [],
                                         },
@@ -220,7 +220,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@112..113 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@113..114 "}" [] [],
             },
         },
@@ -236,7 +236,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionValueList {
                                     name_token: LANG_KW@116..120 "lang" [] [],
                                     l_paren_token: L_PAREN@120..121 "(" [] [],
-                                    value_list: CssPseudoValueList [
+                                    values: CssPseudoValueList [
                                         CssIdentifier {
                                             value_token: IDENT@121..123 "de" [] [],
                                         },
@@ -261,7 +261,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@129..130 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@130..131 "}" [] [],
             },
         },
@@ -277,7 +277,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionValueList {
                                     name_token: LANG_KW@133..137 "lang" [] [],
                                     l_paren_token: L_PAREN@137..138 "(" [] [],
-                                    value_list: CssPseudoValueList [
+                                    values: CssPseudoValueList [
                                         CssIdentifier {
                                             value_token: IDENT@138..143 "fr-be" [] [],
                                         },
@@ -304,7 +304,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@152..153 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@153..154 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_matches.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_matches.css.snap
@@ -30,7 +30,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: MATCHES_KW@1..8 "matches" [] [],
                                     l_paren_token: L_PAREN@8..9 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -62,7 +62,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@16..17 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@17..18 "}" [] [],
             },
         },
@@ -78,7 +78,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: MATCHES_KW@20..27 "matches" [] [],
                                     l_paren_token: L_PAREN@27..28 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -121,7 +121,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@39..40 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@40..41 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_module.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_module.css.snap
@@ -63,7 +63,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@20..21 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@21..22 "}" [] [],
             },
         },
@@ -126,7 +126,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@48..49 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@49..50 "}" [] [],
             },
         },
@@ -189,7 +189,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@76..77 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@77..78 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_not.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_not.css.snap
@@ -53,7 +53,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@1..4 "not" [] [],
                                 l_paren_token: L_PAREN@4..5 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -73,7 +73,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@8..9 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@9..10 "}" [] [],
             },
         },
@@ -88,7 +88,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@12..15 "not" [] [],
                                 l_paren_token: L_PAREN@15..19 "(" [] [Whitespace("   ")],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -108,7 +108,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@25..26 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@26..27 "}" [] [],
             },
         },
@@ -123,7 +123,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@29..32 "not" [] [],
                                 l_paren_token: L_PAREN@32..33 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -143,7 +143,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@38..39 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@39..40 "}" [] [],
             },
         },
@@ -163,7 +163,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@48..51 "not" [] [],
                                 l_paren_token: L_PAREN@51..52 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -190,7 +190,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@64..65 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@65..66 "}" [] [],
             },
         },
@@ -208,7 +208,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@69..72 "not" [] [],
                                 l_paren_token: L_PAREN@72..73 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -228,7 +228,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@78..79 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@79..80 "}" [] [],
             },
         },
@@ -246,7 +246,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@83..86 "not" [] [],
                                 l_paren_token: L_PAREN@86..87 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -270,7 +270,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@94..97 "not" [] [],
                                 l_paren_token: L_PAREN@97..98 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -294,7 +294,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@108..109 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@109..110 "}" [] [],
             },
         },
@@ -315,7 +315,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@121..124 "not" [] [],
                                 l_paren_token: L_PAREN@124..125 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssUniversalSelector {
@@ -342,7 +342,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@133..134 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@134..135 "}" [] [],
             },
         },
@@ -357,7 +357,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@137..140 "not" [] [],
                                 l_paren_token: L_PAREN@140..141 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -367,7 +367,7 @@ CssRoot {
                                                 class: CssPseudoClassFunctionSelectorList {
                                                     name: NOT_KW@142..145 "not" [] [],
                                                     l_paren_token: L_PAREN@145..146 "(" [] [],
-                                                    selector_list: CssSelectorList [
+                                                    selectors: CssSelectorList [
                                                         CssCompoundSelector {
                                                             nesting_selector_token: missing (optional),
                                                             simple_selector: CssTypeSelector {
@@ -393,7 +393,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@157..158 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@158..159 "}" [] [],
             },
         },
@@ -413,7 +413,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@162..165 "not" [] [],
                                 l_paren_token: L_PAREN@165..166 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -435,7 +435,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@174..175 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@175..176 "}" [] [],
             },
         },
@@ -462,7 +462,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: NOT_KW@183..186 "not" [] [],
                                     l_paren_token: L_PAREN@186..187 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -483,7 +483,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@190..191 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@191..192 "}" [] [],
             },
         },
@@ -510,7 +510,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: NOT_KW@199..202 "not" [] [],
                                     l_paren_token: L_PAREN@202..203 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -530,7 +530,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: NOT_KW@208..211 "not" [] [],
                                     l_paren_token: L_PAREN@211..212 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -551,7 +551,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@218..219 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@219..220 "}" [] [],
             },
         },
@@ -578,7 +578,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: NOT_KW@227..230 "not" [] [],
                                     l_paren_token: L_PAREN@230..231 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -612,7 +612,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@244..245 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@245..246 "}" [] [],
             },
         },
@@ -639,7 +639,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: NOT_KW@251..254 "not" [] [],
                                     l_paren_token: L_PAREN@254..255 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -667,7 +667,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@265..266 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@266..267 "}" [] [],
             },
         },
@@ -699,7 +699,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: NOT_KW@278..281 "not" [] [],
                                     l_paren_token: L_PAREN@281..282 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: missing (optional),
@@ -723,7 +723,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: NOT_KW@298..301 "not" [] [],
                                     l_paren_token: L_PAREN@301..302 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: missing (optional),
@@ -748,7 +748,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@317..318 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@318..319 "}" [] [],
             },
         },
@@ -763,7 +763,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@321..324 "not" [] [],
                                 l_paren_token: L_PAREN@324..325 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -801,7 +801,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@341..342 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@342..343 "}" [] [],
             },
         },
@@ -819,7 +819,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@346..349 "not" [] [],
                                 l_paren_token: L_PAREN@349..350 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -843,7 +843,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@357..360 "not" [] [],
                                 l_paren_token: L_PAREN@360..361 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -867,7 +867,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@371..372 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@372..373 "}" [] [],
             },
         },
@@ -885,7 +885,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@376..379 "not" [] [],
                                 l_paren_token: L_PAREN@379..380 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -905,7 +905,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@385..386 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@386..387 "}" [] [],
             },
         },
@@ -925,7 +925,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@395..398 "not" [] [],
                                 l_paren_token: L_PAREN@398..399 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -952,7 +952,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@411..412 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@412..413 "}" [] [],
             },
         },
@@ -972,7 +972,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@416..419 "not" [] [],
                                 l_paren_token: L_PAREN@419..420 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -996,7 +996,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@428..429 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@429..430 "}" [] [],
             },
         },
@@ -1016,7 +1016,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@433..436 "not" [] [],
                                 l_paren_token: L_PAREN@436..437 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -1026,7 +1026,7 @@ CssRoot {
                                                 class: CssPseudoClassFunctionSelectorList {
                                                     name: NOT_KW@438..441 "not" [] [],
                                                     l_paren_token: L_PAREN@441..442 "(" [] [],
-                                                    selector_list: CssSelectorList [
+                                                    selectors: CssSelectorList [
                                                         CssCompoundSelector {
                                                             nesting_selector_token: missing (optional),
                                                             simple_selector: missing (optional),
@@ -1056,7 +1056,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@451..452 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@452..453 "}" [] [],
             },
         },
@@ -1076,7 +1076,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@462..465 "not" [] [],
                                 l_paren_token: L_PAREN@465..466 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -1086,7 +1086,7 @@ CssRoot {
                                                 class: CssPseudoClassFunctionSelectorList {
                                                     name: NOT_KW@467..470 "not" [] [],
                                                     l_paren_token: L_PAREN@470..471 "(" [] [],
-                                                    selector_list: CssSelectorList [
+                                                    selectors: CssSelectorList [
                                                         CssCompoundSelector {
                                                             nesting_selector_token: missing (optional),
                                                             simple_selector: CssTypeSelector {
@@ -1167,7 +1167,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@496..497 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@497..498 "}" [] [],
             },
         },
@@ -1187,7 +1187,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: NOT_KW@507..510 "not" [] [],
                                 l_paren_token: L_PAREN@510..511 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -1197,7 +1197,7 @@ CssRoot {
                                                 class: CssPseudoClassFunctionSelectorList {
                                                     name: NOT_KW@512..515 "not" [] [],
                                                     l_paren_token: L_PAREN@515..516 "(" [] [],
-                                                    selector_list: CssSelectorList [
+                                                    selectors: CssSelectorList [
                                                         CssCompoundSelector {
                                                             nesting_selector_token: missing (optional),
                                                             simple_selector: CssTypeSelector {
@@ -1278,7 +1278,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@541..542 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@542..543 "}" [] [],
             },
         },
@@ -1310,7 +1310,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: NOT_KW@550..553 "not" [] [],
                                     l_paren_token: L_PAREN@553..554 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: missing (optional),
@@ -1335,7 +1335,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@570..571 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@571..572 "}" [] [],
             },
         },
@@ -1351,7 +1351,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: NOT_KW@574..577 "not" [] [],
                                     l_paren_token: L_PAREN@577..578 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -1385,7 +1385,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@586..587 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@587..588 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_past.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_past.css.snap
@@ -29,7 +29,7 @@ CssRoot {
                             class: CssPseudoClassFunctionCompoundSelectorList {
                                 name: PAST_KW@1..5 "past" [] [],
                                 l_paren_token: L_PAREN@5..6 "(" [] [],
-                                compound_selector_list: CssCompoundSelectorList [
+                                compound_selectors: CssCompoundSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -82,7 +82,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@21..22 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@22..23 "}" [] [],
             },
         },
@@ -98,7 +98,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionCompoundSelectorList {
                                     name: PAST_KW@25..29 "past" [] [],
                                     l_paren_token: L_PAREN@29..30 "(" [] [],
-                                    compound_selector_list: CssCompoundSelectorList [
+                                    compound_selectors: CssCompoundSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -165,7 +165,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@50..51 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@51..52 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_where.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_where.css.snap
@@ -39,7 +39,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: WHERE_KW@1..6 "where" [] [],
                                     l_paren_token: L_PAREN@6..7 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -71,7 +71,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@14..15 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@15..16 "}" [] [],
             },
         },
@@ -87,7 +87,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: WHERE_KW@18..23 "where" [] [],
                                     l_paren_token: L_PAREN@23..24 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -130,7 +130,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@35..36 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@36..37 "}" [] [],
             },
         },
@@ -146,7 +146,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: WHERE_KW@39..44 "where" [] [],
                                     l_paren_token: L_PAREN@44..45 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -209,7 +209,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@75..76 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@76..77 "}" [] [],
             },
         },
@@ -229,7 +229,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: WHERE_KW@82..87 "where" [] [],
                                 l_paren_token: L_PAREN@87..88 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -264,7 +264,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@101..102 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@102..103 "}" [] [],
             },
         },
@@ -281,7 +281,7 @@ CssRoot {
                                     class: CssPseudoClassFunctionSelectorList {
                                         name: WHERE_KW@105..110 "where" [] [],
                                         l_paren_token: L_PAREN@110..111 "(" [] [],
-                                        selector_list: CssSelectorList [
+                                        selectors: CssSelectorList [
                                             CssCompoundSelector {
                                                 nesting_selector_token: missing (optional),
                                                 simple_selector: CssTypeSelector {
@@ -341,7 +341,7 @@ CssRoot {
                                     class: CssPseudoClassFunctionSelectorList {
                                         name: WHERE_KW@131..136 "where" [] [],
                                         l_paren_token: L_PAREN@136..137 "(" [] [],
-                                        selector_list: CssSelectorList [
+                                        selectors: CssSelectorList [
                                             CssCompoundSelector {
                                                 nesting_selector_token: missing (optional),
                                                 simple_selector: CssTypeSelector {
@@ -402,7 +402,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: WHERE_KW@157..162 "where" [] [],
                                     l_paren_token: L_PAREN@162..163 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -445,7 +445,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@178..179 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@179..180 "}" [] [],
             },
         },
@@ -463,7 +463,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: WHERE_KW@183..188 "where" [] [],
                                 l_paren_token: L_PAREN@188..189 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -502,7 +502,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@205..206 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@206..207 "}" [] [],
             },
         },
@@ -520,7 +520,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: WHERE_KW@210..215 "where" [] [],
                                 l_paren_token: L_PAREN@215..216 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssUniversalSelector {
@@ -565,7 +565,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@234..235 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@235..236 "}" [] [],
             },
         },
@@ -581,7 +581,7 @@ CssRoot {
                                 class: CssPseudoClassFunctionSelectorList {
                                     name: WHERE_KW@238..243 "where" [] [],
                                     l_paren_token: L_PAREN@243..244 "(" [] [],
-                                    selector_list: CssSelectorList [
+                                    selectors: CssSelectorList [
                                         CssCompoundSelector {
                                             nesting_selector_token: missing (optional),
                                             simple_selector: CssTypeSelector {
@@ -644,7 +644,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@273..274 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@274..275 "}" [] [],
             },
         },
@@ -659,7 +659,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: WHERE_KW@277..282 "where" [] [],
                                 l_paren_token: L_PAREN@282..283 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: CssTypeSelector {
@@ -699,7 +699,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@301..302 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@302..303 "}" [] [],
             },
         },
@@ -714,7 +714,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: WHERE_KW@305..310 "where" [] [],
                                 l_paren_token: L_PAREN@310..311 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -753,7 +753,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@333..334 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@334..335 "}" [] [],
             },
         },
@@ -773,7 +773,7 @@ CssRoot {
                             class: CssPseudoClassFunctionSelectorList {
                                 name: WHERE_KW@338..343 "where" [] [],
                                 l_paren_token: L_PAREN@343..344 "(" [] [],
-                                selector_list: CssSelectorList [
+                                selectors: CssSelectorList [
                                     CssCompoundSelector {
                                         nesting_selector_token: missing (optional),
                                         simple_selector: missing (optional),
@@ -783,7 +783,7 @@ CssRoot {
                                                 class: CssPseudoClassFunctionSelectorList {
                                                     name: NOT_KW@345..348 "not" [] [],
                                                     l_paren_token: L_PAREN@348..349 "(" [] [],
-                                                    selector_list: CssSelectorList [
+                                                    selectors: CssSelectorList [
                                                         CssCompoundSelector {
                                                             nesting_selector_token: missing (optional),
                                                             simple_selector: missing (optional),
@@ -813,7 +813,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@358..359 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@359..360 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/basic.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/basic.css.snap
@@ -74,7 +74,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@9..10 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@10..11 "}" [] [],
             },
         },
@@ -102,7 +102,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@30..31 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@31..32 "}" [] [],
             },
         },
@@ -130,7 +130,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@44..45 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@45..46 "}" [] [],
             },
         },
@@ -158,7 +158,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@59..60 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@60..61 "}" [] [],
             },
         },
@@ -198,7 +198,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@76..77 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@77..78 "}" [] [],
             },
         },
@@ -226,7 +226,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@98..99 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@99..100 "}" [] [],
             },
         },
@@ -283,7 +283,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@135..136 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@136..137 "}" [] [],
             },
         },
@@ -306,7 +306,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@155..156 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@156..157 "}" [] [],
             },
         },
@@ -329,7 +329,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@168..169 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@169..170 "}" [] [],
             },
         },
@@ -360,7 +360,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@205..206 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@206..207 "}" [] [],
             },
         },
@@ -383,7 +383,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@223..224 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@224..225 "}" [] [],
             },
         },
@@ -406,7 +406,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@239..240 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@240..241 "}" [] [],
             },
         },
@@ -439,7 +439,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@256..257 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@257..258 "}" [] [],
             },
         },
@@ -474,7 +474,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@275..276 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@276..277 "}" [] [],
             },
         },
@@ -497,7 +497,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@296..297 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@297..298 "}" [] [],
             },
         },
@@ -520,7 +520,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@314..315 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@315..316 "}" [] [],
             },
         },
@@ -549,7 +549,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@352..353 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@353..354 "}" [] [],
             },
         },
@@ -577,7 +577,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@366..367 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@367..368 "}" [] [],
             },
         },
@@ -630,7 +630,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@390..391 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@391..392 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/cue-region.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/cue-region.css.snap
@@ -43,7 +43,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@18..19 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@19..20 "}" [] [],
             },
         },
@@ -85,7 +85,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@48..49 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@49..50 "}" [] [],
             },
         },
@@ -127,7 +127,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@84..85 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@85..86 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/cue.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/cue.css.snap
@@ -41,7 +41,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@6..7 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@7..8 "}" [] [],
             },
         },
@@ -96,7 +96,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@32..33 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@33..34 "}" [] [],
             },
         },
@@ -151,7 +151,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@64..65 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@65..66 "}" [] [],
             },
         },
@@ -179,7 +179,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@78..79 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@79..80 "}" [] [],
             },
         },
@@ -219,7 +219,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@95..96 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@96..97 "}" [] [],
             },
         },
@@ -261,7 +261,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@116..117 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@117..118 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/escaped.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/escaped.css.snap
@@ -41,7 +41,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@13..14 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@14..15 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/highlight.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/highlight.css.snap
@@ -46,7 +46,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@20..21 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@21..23 "}" [Newline("\n")] [],
             },
         },
@@ -77,7 +77,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@45..46 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@46..48 "}" [Newline("\n")] [],
             },
         },
@@ -108,7 +108,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@70..71 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@71..73 "}" [Newline("\n")] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/part.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/part.css.snap
@@ -45,7 +45,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@36..37 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@37..38 "}" [] [],
             },
         },
@@ -76,7 +76,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@81..82 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@82..83 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/presudo_complex.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/presudo_complex.css.snap
@@ -59,7 +59,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@13..14 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@14..15 "}" [] [],
             },
         },
@@ -100,7 +100,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@31..32 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@32..33 "}" [] [],
             },
         },
@@ -153,7 +153,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@52..53 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@53..54 "}" [] [],
             },
         },
@@ -192,7 +192,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@79..80 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@80..81 "}" [] [],
             },
         },
@@ -231,7 +231,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@101..102 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@102..103 "}" [] [],
             },
         },
@@ -286,7 +286,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@128..129 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@129..130 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/slotted.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_element/slotted.css.snap
@@ -50,7 +50,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@13..14 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@14..15 "}" [] [],
             },
         },
@@ -85,7 +85,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@32..33 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@33..34 "}" [] [],
             },
         },
@@ -120,7 +120,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@57..58 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@58..59 "}" [] [],
             },
         },
@@ -155,7 +155,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@76..77 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@77..79 "}" [Newline("\n")] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/subselector.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/subselector.css.snap
@@ -61,7 +61,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@24..25 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@25..26 "}" [] [],
             },
         },
@@ -103,7 +103,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@50..51 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@51..52 "}" [] [],
             },
         },
@@ -142,7 +142,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@75..76 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@76..77 "}" [] [],
             },
         },
@@ -251,7 +251,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@150..151 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@151..152 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/type.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/type.css.snap
@@ -46,7 +46,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@7..8 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@8..9 "}" [] [],
             },
         },
@@ -72,7 +72,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@17..18 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@18..19 "}" [] [],
             },
         },
@@ -94,7 +94,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@24..25 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@25..26 "}" [] [],
             },
         },
@@ -118,7 +118,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@32..33 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@33..34 "}" [] [],
             },
         },

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/universal.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/universal.css.snap
@@ -41,7 +41,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@6..7 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@7..8 "}" [] [],
             },
         },
@@ -63,7 +63,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@13..14 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@14..15 "}" [] [],
             },
         },
@@ -87,7 +87,7 @@ CssRoot {
             ],
             block: CssDeclarationListBlock {
                 l_curly_token: L_CURLY@22..23 "{" [] [],
-                declaration_list: CssDeclarationList [],
+                declarations: CssDeclarationList [],
                 r_curly_token: R_CURLY@23..24 "}" [] [],
             },
         },

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -1190,14 +1190,14 @@ impl CssDeclarationListBlock {
     pub fn as_fields(&self) -> CssDeclarationListBlockFields {
         CssDeclarationListBlockFields {
             l_curly_token: self.l_curly_token(),
-            declaration_list: self.declaration_list(),
+            declarations: self.declarations(),
             r_curly_token: self.r_curly_token(),
         }
     }
     pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
-    pub fn declaration_list(&self) -> CssDeclarationList {
+    pub fn declarations(&self) -> CssDeclarationList {
         support::list(&self.syntax, 1usize)
     }
     pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
@@ -1216,7 +1216,7 @@ impl Serialize for CssDeclarationListBlock {
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct CssDeclarationListBlockFields {
     pub l_curly_token: SyntaxResult<SyntaxToken>,
-    pub declaration_list: CssDeclarationList,
+    pub declarations: CssDeclarationList,
     pub r_curly_token: SyntaxResult<SyntaxToken>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -1697,14 +1697,14 @@ impl CssMediaAtRule {
     pub fn as_fields(&self) -> CssMediaAtRuleFields {
         CssMediaAtRuleFields {
             media_token: self.media_token(),
-            query_list: self.query_list(),
+            queries: self.queries(),
             block: self.block(),
         }
     }
     pub fn media_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
-    pub fn query_list(&self) -> CssMediaQueryList {
+    pub fn queries(&self) -> CssMediaQueryList {
         support::list(&self.syntax, 1usize)
     }
     pub fn block(&self) -> SyntaxResult<AnyCssRuleListBlock> {
@@ -1723,7 +1723,7 @@ impl Serialize for CssMediaAtRule {
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct CssMediaAtRuleFields {
     pub media_token: SyntaxResult<SyntaxToken>,
-    pub query_list: CssMediaQueryList,
+    pub queries: CssMediaQueryList,
     pub block: SyntaxResult<AnyCssRuleListBlock>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -2357,7 +2357,7 @@ impl CssPseudoClassFunctionCompoundSelectorList {
         CssPseudoClassFunctionCompoundSelectorListFields {
             name: self.name(),
             l_paren_token: self.l_paren_token(),
-            compound_selector_list: self.compound_selector_list(),
+            compound_selectors: self.compound_selectors(),
             r_paren_token: self.r_paren_token(),
         }
     }
@@ -2367,7 +2367,7 @@ impl CssPseudoClassFunctionCompoundSelectorList {
     pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
     }
-    pub fn compound_selector_list(&self) -> CssCompoundSelectorList {
+    pub fn compound_selectors(&self) -> CssCompoundSelectorList {
         support::list(&self.syntax, 2usize)
     }
     pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
@@ -2387,7 +2387,7 @@ impl Serialize for CssPseudoClassFunctionCompoundSelectorList {
 pub struct CssPseudoClassFunctionCompoundSelectorListFields {
     pub name: SyntaxResult<SyntaxToken>,
     pub l_paren_token: SyntaxResult<SyntaxToken>,
-    pub compound_selector_list: CssCompoundSelectorList,
+    pub compound_selectors: CssCompoundSelectorList,
     pub r_paren_token: SyntaxResult<SyntaxToken>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -2510,7 +2510,7 @@ impl CssPseudoClassFunctionRelativeSelectorList {
         CssPseudoClassFunctionRelativeSelectorListFields {
             name_token: self.name_token(),
             l_paren_token: self.l_paren_token(),
-            relative_selector_list: self.relative_selector_list(),
+            relative_selectors: self.relative_selectors(),
             r_paren_token: self.r_paren_token(),
         }
     }
@@ -2520,7 +2520,7 @@ impl CssPseudoClassFunctionRelativeSelectorList {
     pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
     }
-    pub fn relative_selector_list(&self) -> CssRelativeSelectorList {
+    pub fn relative_selectors(&self) -> CssRelativeSelectorList {
         support::list(&self.syntax, 2usize)
     }
     pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
@@ -2540,7 +2540,7 @@ impl Serialize for CssPseudoClassFunctionRelativeSelectorList {
 pub struct CssPseudoClassFunctionRelativeSelectorListFields {
     pub name_token: SyntaxResult<SyntaxToken>,
     pub l_paren_token: SyntaxResult<SyntaxToken>,
-    pub relative_selector_list: CssRelativeSelectorList,
+    pub relative_selectors: CssRelativeSelectorList,
     pub r_paren_token: SyntaxResult<SyntaxToken>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -2612,7 +2612,7 @@ impl CssPseudoClassFunctionSelectorList {
         CssPseudoClassFunctionSelectorListFields {
             name: self.name(),
             l_paren_token: self.l_paren_token(),
-            selector_list: self.selector_list(),
+            selectors: self.selectors(),
             r_paren_token: self.r_paren_token(),
         }
     }
@@ -2622,7 +2622,7 @@ impl CssPseudoClassFunctionSelectorList {
     pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
     }
-    pub fn selector_list(&self) -> CssSelectorList {
+    pub fn selectors(&self) -> CssSelectorList {
         support::list(&self.syntax, 2usize)
     }
     pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
@@ -2642,7 +2642,7 @@ impl Serialize for CssPseudoClassFunctionSelectorList {
 pub struct CssPseudoClassFunctionSelectorListFields {
     pub name: SyntaxResult<SyntaxToken>,
     pub l_paren_token: SyntaxResult<SyntaxToken>,
-    pub selector_list: CssSelectorList,
+    pub selectors: CssSelectorList,
     pub r_paren_token: SyntaxResult<SyntaxToken>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -2663,7 +2663,7 @@ impl CssPseudoClassFunctionValueList {
         CssPseudoClassFunctionValueListFields {
             name_token: self.name_token(),
             l_paren_token: self.l_paren_token(),
-            value_list: self.value_list(),
+            values: self.values(),
             r_paren_token: self.r_paren_token(),
         }
     }
@@ -2673,7 +2673,7 @@ impl CssPseudoClassFunctionValueList {
     pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
     }
-    pub fn value_list(&self) -> CssPseudoValueList {
+    pub fn values(&self) -> CssPseudoValueList {
         support::list(&self.syntax, 2usize)
     }
     pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
@@ -2693,7 +2693,7 @@ impl Serialize for CssPseudoClassFunctionValueList {
 pub struct CssPseudoClassFunctionValueListFields {
     pub name_token: SyntaxResult<SyntaxToken>,
     pub l_paren_token: SyntaxResult<SyntaxToken>,
-    pub value_list: CssPseudoValueList,
+    pub values: CssPseudoValueList,
     pub r_paren_token: SyntaxResult<SyntaxToken>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -2916,13 +2916,13 @@ impl CssPseudoClassOfNthSelector {
     pub fn as_fields(&self) -> CssPseudoClassOfNthSelectorFields {
         CssPseudoClassOfNthSelectorFields {
             of_token: self.of_token(),
-            selector_list: self.selector_list(),
+            selectors: self.selectors(),
         }
     }
     pub fn of_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
-    pub fn selector_list(&self) -> CssSelectorList {
+    pub fn selectors(&self) -> CssSelectorList {
         support::list(&self.syntax, 1usize)
     }
 }
@@ -2938,7 +2938,7 @@ impl Serialize for CssPseudoClassOfNthSelector {
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct CssPseudoClassOfNthSelectorFields {
     pub of_token: SyntaxResult<SyntaxToken>,
-    pub selector_list: CssSelectorList,
+    pub selectors: CssSelectorList,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct CssPseudoClassSelector {
@@ -6256,7 +6256,7 @@ impl std::fmt::Debug for CssDeclarationListBlock {
                 "l_curly_token",
                 &support::DebugSyntaxResult(self.l_curly_token()),
             )
-            .field("declaration_list", &self.declaration_list())
+            .field("declarations", &self.declarations())
             .field(
                 "r_curly_token",
                 &support::DebugSyntaxResult(self.r_curly_token()),
@@ -6751,7 +6751,7 @@ impl std::fmt::Debug for CssMediaAtRule {
                 "media_token",
                 &support::DebugSyntaxResult(self.media_token()),
             )
-            .field("query_list", &self.query_list())
+            .field("queries", &self.queries())
             .field("block", &support::DebugSyntaxResult(self.block()))
             .finish()
     }
@@ -7409,7 +7409,7 @@ impl std::fmt::Debug for CssPseudoClassFunctionCompoundSelectorList {
                 "l_paren_token",
                 &support::DebugSyntaxResult(self.l_paren_token()),
             )
-            .field("compound_selector_list", &self.compound_selector_list())
+            .field("compound_selectors", &self.compound_selectors())
             .field(
                 "r_paren_token",
                 &support::DebugSyntaxResult(self.r_paren_token()),
@@ -7551,7 +7551,7 @@ impl std::fmt::Debug for CssPseudoClassFunctionRelativeSelectorList {
                 "l_paren_token",
                 &support::DebugSyntaxResult(self.l_paren_token()),
             )
-            .field("relative_selector_list", &self.relative_selector_list())
+            .field("relative_selectors", &self.relative_selectors())
             .field(
                 "r_paren_token",
                 &support::DebugSyntaxResult(self.r_paren_token()),
@@ -7646,7 +7646,7 @@ impl std::fmt::Debug for CssPseudoClassFunctionSelectorList {
                 "l_paren_token",
                 &support::DebugSyntaxResult(self.l_paren_token()),
             )
-            .field("selector_list", &self.selector_list())
+            .field("selectors", &self.selectors())
             .field(
                 "r_paren_token",
                 &support::DebugSyntaxResult(self.r_paren_token()),
@@ -7693,7 +7693,7 @@ impl std::fmt::Debug for CssPseudoClassFunctionValueList {
                 "l_paren_token",
                 &support::DebugSyntaxResult(self.l_paren_token()),
             )
-            .field("value_list", &self.value_list())
+            .field("values", &self.values())
             .field(
                 "r_paren_token",
                 &support::DebugSyntaxResult(self.r_paren_token()),
@@ -7937,7 +7937,7 @@ impl std::fmt::Debug for CssPseudoClassOfNthSelector {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CssPseudoClassOfNthSelector")
             .field("of_token", &support::DebugSyntaxResult(self.of_token()))
-            .field("selector_list", &self.selector_list())
+            .field("selectors", &self.selectors())
             .finish()
     }
 }

--- a/crates/biome_css_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_css_syntax/src/generated/nodes_mut.rs
@@ -482,7 +482,7 @@ impl CssDeclarationListBlock {
                 .splice_slots(0usize..=0usize, once(Some(element.into()))),
         )
     }
-    pub fn with_declaration_list(self, element: CssDeclarationList) -> Self {
+    pub fn with_declarations(self, element: CssDeclarationList) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
@@ -668,7 +668,7 @@ impl CssMediaAtRule {
                 .splice_slots(0usize..=0usize, once(Some(element.into()))),
         )
     }
-    pub fn with_query_list(self, element: CssMediaQueryList) -> Self {
+    pub fn with_queries(self, element: CssMediaQueryList) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
@@ -904,7 +904,7 @@ impl CssPseudoClassFunctionCompoundSelectorList {
                 .splice_slots(1usize..=1usize, once(Some(element.into()))),
         )
     }
-    pub fn with_compound_selector_list(self, element: CssCompoundSelectorList) -> Self {
+    pub fn with_compound_selectors(self, element: CssCompoundSelectorList) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(2usize..=2usize, once(Some(element.into_syntax().into()))),
@@ -982,7 +982,7 @@ impl CssPseudoClassFunctionRelativeSelectorList {
                 .splice_slots(1usize..=1usize, once(Some(element.into()))),
         )
     }
-    pub fn with_relative_selector_list(self, element: CssRelativeSelectorList) -> Self {
+    pub fn with_relative_selectors(self, element: CssRelativeSelectorList) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(2usize..=2usize, once(Some(element.into_syntax().into()))),
@@ -1034,7 +1034,7 @@ impl CssPseudoClassFunctionSelectorList {
                 .splice_slots(1usize..=1usize, once(Some(element.into()))),
         )
     }
-    pub fn with_selector_list(self, element: CssSelectorList) -> Self {
+    pub fn with_selectors(self, element: CssSelectorList) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(2usize..=2usize, once(Some(element.into_syntax().into()))),
@@ -1060,7 +1060,7 @@ impl CssPseudoClassFunctionValueList {
                 .splice_slots(1usize..=1usize, once(Some(element.into()))),
         )
     }
-    pub fn with_value_list(self, element: CssPseudoValueList) -> Self {
+    pub fn with_values(self, element: CssPseudoValueList) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(2usize..=2usize, once(Some(element.into_syntax().into()))),
@@ -1150,7 +1150,7 @@ impl CssPseudoClassOfNthSelector {
                 .splice_slots(0usize..=0usize, once(Some(element.into()))),
         )
     }
-    pub fn with_selector_list(self, element: CssSelectorList) -> Self {
+    pub fn with_selectors(self, element: CssSelectorList) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -226,7 +226,7 @@ CssPseudoClassFunctionSelector =
 CssPseudoClassFunctionSelectorList =
  	name: ('matches' | 'not' | 'is' | 'where')
 	'('
-	selector_list: CssSelectorList
+	selectors: CssSelectorList
 	')'
 
 // :-webkit-any(i,p,:link,span:focus) {}
@@ -234,7 +234,7 @@ CssPseudoClassFunctionSelectorList =
 CssPseudoClassFunctionCompoundSelectorList =
  	name: ('any' | 'past' | 'current' | 'future')
 	'('
-	compound_selector_list: CssCompoundSelectorList
+	compound_selectors: CssCompoundSelectorList
 	')'
 
 // :-webkit-any(i,p,:link,span:focus) {}
@@ -258,7 +258,7 @@ AnyCssCompoundSelector =
 CssPseudoClassFunctionRelativeSelectorList =
  	name: 'has'
 	'('
-	relative_selector_list: CssRelativeSelectorList
+	relative_selectors: CssRelativeSelectorList
 	')'
 
 // :has(> img, +dt) {}
@@ -280,7 +280,7 @@ CssRelativeSelector =
 CssPseudoClassFunctionValueList =
  	name: 'lang'
 	'('
-	value_list: CssPseudoValueList
+	values: CssPseudoValueList
 	')'
 
 // :lang(de, fr) {}
@@ -357,7 +357,7 @@ CssNthOffset =
 //             		 ^^^^^^^^^^^^
 CssPseudoClassOfNthSelector =
 	'of'
-	selector_list: CssSelectorList
+	selectors: CssSelectorList
 
 // a::after {}
 //  ^^^^^^^^
@@ -404,7 +404,7 @@ AnyCssDeclarationListBlock =
 
 CssDeclarationListBlock =
 	'{'
-	declaration_list: CssDeclarationList
+	declarations: CssDeclarationList
  	'}'
 
 AnyCssRuleListBlock =
@@ -726,7 +726,7 @@ CssKeyframesPercentageSelector =
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 CssMediaAtRule =
 	'media'
-	query_list: CssMediaQueryList
+	queries: CssMediaQueryList
 	block: AnyCssRuleListBlock
 
 // @media screen, (width > 500px), print {}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

I've noticed that we have different names for the list nodes in css.


## Test Plan

`cargo test`
