### PR TITLE
fix(css_formatter): syntax errors after parser refactoring

### DIFF
--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_compound_selector_list.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_compound_selector_list.rs
@@ -17,7 +17,7 @@ impl FormatNodeRule<CssPseudoClassFunctionCompoundSelectorList>
         let CssPseudoClassFunctionCompoundSelectorListFields {
             name,
             l_paren_token,
-            compound_selector_list,
+            compound_selectors,
             r_paren_token,
         } = node.as_fields();
 
@@ -27,7 +27,7 @@ impl FormatNodeRule<CssPseudoClassFunctionCompoundSelectorList>
                 name.format(),
                 group(&format_args![
                     l_paren_token.format(),
-                    soft_block_indent(&compound_selector_list.format()),
+                    soft_block_indent(&compound_selectors.format()),
                     r_paren_token.format()
                 ])
             ]

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_relative_selector_list.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_relative_selector_list.rs
@@ -17,7 +17,7 @@ impl FormatNodeRule<CssPseudoClassFunctionRelativeSelectorList>
         let CssPseudoClassFunctionRelativeSelectorListFields {
             name_token,
             l_paren_token,
-            relative_selector_list,
+            relative_selectors,
             r_paren_token,
         } = node.as_fields();
 
@@ -27,7 +27,7 @@ impl FormatNodeRule<CssPseudoClassFunctionRelativeSelectorList>
                 name_token.format(),
                 group(&format_args![
                     l_paren_token.format(),
-                    soft_block_indent(&relative_selector_list.format()),
+                    soft_block_indent(&relative_selectors.format()),
                     r_paren_token.format()
                 ])
             ]

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_selector_list.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_selector_list.rs
@@ -17,7 +17,7 @@ impl FormatNodeRule<CssPseudoClassFunctionSelectorList>
         let CssPseudoClassFunctionSelectorListFields {
             name,
             l_paren_token,
-            selector_list,
+            selectors,
             r_paren_token,
         } = node.as_fields();
 
@@ -27,7 +27,7 @@ impl FormatNodeRule<CssPseudoClassFunctionSelectorList>
                 name.format(),
                 group(&format_args![
                     l_paren_token.format(),
-                    soft_block_indent(&selector_list.format()),
+                    soft_block_indent(&selectors.format()),
                     r_paren_token.format()
                 ])
             ]

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_value_list.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_class_function_value_list.rs
@@ -13,7 +13,7 @@ impl FormatNodeRule<CssPseudoClassFunctionValueList> for FormatCssPseudoClassFun
         let CssPseudoClassFunctionValueListFields {
             name_token,
             l_paren_token,
-            value_list,
+            values,
             r_paren_token,
         } = node.as_fields();
 
@@ -23,7 +23,7 @@ impl FormatNodeRule<CssPseudoClassFunctionValueList> for FormatCssPseudoClassFun
                 name_token.format(),
                 group(&format_args![
                     l_paren_token.format(),
-                    soft_block_indent(&value_list.format()),
+                    soft_block_indent(&values.format()),
                     r_paren_token.format()
                 ])
             ]

--- a/crates/biome_css_formatter/src/css/selectors/pseudo_class_of_nth_selector.rs
+++ b/crates/biome_css_formatter/src/css/selectors/pseudo_class_of_nth_selector.rs
@@ -12,9 +12,9 @@ impl FormatNodeRule<CssPseudoClassOfNthSelector> for FormatCssPseudoClassOfNthSe
     ) -> FormatResult<()> {
         let CssPseudoClassOfNthSelectorFields {
             of_token,
-            selector_list,
+            selectors,
         } = node.as_fields();
 
-        write!(f, [of_token.format(), space(), selector_list.format()])
+        write!(f, [of_token.format(), space(), selectors.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/statements/media_at_rule.rs
+++ b/crates/biome_css_formatter/src/css/statements/media_at_rule.rs
@@ -8,7 +8,7 @@ impl FormatNodeRule<CssMediaAtRule> for FormatCssMediaAtRule {
     fn fmt_fields(&self, node: &CssMediaAtRule, f: &mut CssFormatter) -> FormatResult<()> {
         let CssMediaAtRuleFields {
             media_token,
-            query_list,
+            queries,
             block,
         } = node.as_fields();
 
@@ -36,7 +36,7 @@ impl FormatNodeRule<CssMediaAtRule> for FormatCssMediaAtRule {
                 // 	     all and (min-device-pixel-ratio: 1.5)
                 //   {
                 //   }
-                group(&indent(&query_list.format())),
+                group(&indent(&queries.format())),
                 space(),
                 block.format()
             ]


### PR DESCRIPTION
## Summary

In the big chain of merges for the formatter, a few of them had drifted behind the current syntax of the parser, leading to errors on compilation. This fixes all of the things that were renamed.

## Test Plan

Compilation succeeds and all of the tests are passing again.