### PR TITLE
fix(json_formatter): handle comments in empty arrays/objects

### DIFF
--- a/crates/biome_json_formatter/src/json/value/array_value.rs
+++ b/crates/biome_json_formatter/src/json/value/array_value.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
-use biome_formatter::write;
-use biome_json_syntax::JsonArrayValue;
-use biome_json_syntax::JsonArrayValueFields;
+use biome_formatter::{format_args, write};
+use biome_json_syntax::{JsonArrayValue, JsonArrayValueFields};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsonArrayValue;
@@ -13,13 +12,25 @@ impl FormatNodeRule<JsonArrayValue> for FormatJsonArrayValue {
             r_brack_token,
         } = node.as_fields();
 
+        let should_expand = f.comments().has_dangling_comments(node.syntax());
+
         write!(
             f,
             [
                 l_brack_token.format(),
-                group(&soft_block_indent(&elements.format())),
+                group(&soft_block_indent(&format_args![
+                    elements.format(),
+                    format_dangling_comments(node.syntax())
+                ]))
+                .should_expand(should_expand),
+                line_suffix_boundary(),
                 r_brack_token.format()
             ]
         )
+    }
+
+    fn fmt_dangling_comments(&self, _: &JsonArrayValue, _: &mut JsonFormatter) -> FormatResult<()> {
+        // Handled as part of `fmt_fields`
+        Ok(())
     }
 }

--- a/crates/biome_json_formatter/tests/specs/json/comments/empty_with_comments.json
+++ b/crates/biome_json_formatter/tests/specs/json/comments/empty_with_comments.json
@@ -1,0 +1,16 @@
+{
+    "object-block": { /* here's a block comment */},
+    "object-line": { // here's a line comment
+    },
+    "object-ownline": {
+        /* here's a block comment */
+        // and a line comment
+    },
+    "array-block": [ /* here's a block comment */],
+    "array-line": [ // here's a line comment
+    ],
+    "array-ownline": [
+        /* here's a block comment */
+        // and a line comment
+    ]
+}

--- a/crates/biome_json_formatter/tests/specs/json/comments/empty_with_comments.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/comments/empty_with_comments.json.snap
@@ -1,0 +1,66 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: json/comments/empty_with_comments.json
+---
+
+# Input
+
+```json
+{
+    "object-block": { /* here's a block comment */},
+    "object-line": { // here's a line comment
+    },
+    "object-ownline": {
+        /* here's a block comment */
+        // and a line comment
+    },
+    "array-block": [ /* here's a block comment */],
+    "array-line": [ // here's a line comment
+    ],
+    "array-ownline": [
+        /* here's a block comment */
+        // and a line comment
+    ]
+}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```json
+{
+	"object-block": {
+		/* here's a block comment */
+	},
+	"object-line": {
+		// here's a line comment
+	},
+	"object-ownline": {
+		/* here's a block comment */
+		// and a line comment
+	},
+	"array-block": [
+		/* here's a block comment */
+	],
+	"array-line": [
+		// here's a line comment
+	],
+	"array-ownline": [
+		/* here's a block comment */
+		// and a line comment
+	]
+}
+```
+
+


### PR DESCRIPTION
## Summary

Fixes #1322. Comments within empty object and array values are now placed as dangling comments, which those nodes then handle formatting for directly to place them within the braces for the value. For example:

```jsonc
{
    "object-block": { /* here's a block comment */},
    "object-line": { // here's a line comment
    },
    "object-ownline": {
        /* here's a block comment */
        // and a line comment
    }
}

// Now becomes

{
	"object-block": {
		/* here's a block comment */
	},
	"object-line": {
		// here's a line comment
	},
	"object-ownline": {
		/* here's a block comment */
		// and a line comment
	}
}
```

## Test Plan

Added a snapshot test to cover various permutations of comments in empties.