### PR TITLE
refactor(lint/useExponentiationOperator): preserve more comments in code fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,7 +147,24 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
   }
   ```
 
-- The code action (fix) of [noMultipleSpacesInRegularExpressionLiterals](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals/) is now marked as safe.
+- Preserve more comments in the fix of [useExponentiationOperator](https://biomejs.dev/linter/rules/use-exponentiation-operator). Contributed by @Conaclos
+
+  The rule now preserves comments that follow the (optional) trailing comma.
+
+  For example, the rule now suggests the following code fix:
+
+  ```diff
+  - Math.pow(
+  -    a, // a
+  -    2, // 2
+  -  );
+  +
+  +    a ** // a
+  +    2 // 2
+  +
+  ```
+
+- The code action (fix) of [noMultipleSpacesInRegularExpressionLiterals](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals/) is now marked as safe. Contributed by @Conaclos
 
 #### Bug fixes
 

--- a/crates/biome_js_analyze/tests/specs/style/useExponentiationOperator/invalidWithComments.js
+++ b/crates/biome_js_analyze/tests/specs/style/useExponentiationOperator/invalidWithComments.js
@@ -5,3 +5,13 @@ Math.pow(a, b)// comment
 Math.pow(/**/a/**/, /**/b/**/)
 
 Math/**/.pow/**/(a, b)
+
+
+Math // 0
+    .pow( // 1
+        // 2
+        a, // 3
+        // 4
+        b, // 5
+    // 6
+    ) // 5

--- a/crates/biome_js_analyze/tests/specs/style/useExponentiationOperator/invalidWithComments.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useExponentiationOperator/invalidWithComments.js.snap
@@ -12,6 +12,16 @@ Math.pow(/**/a/**/, /**/b/**/)
 
 Math/**/.pow/**/(a, b)
 
+
+Math // 0
+    .pow( // 1
+        // 2
+        a, // 3
+        // 4
+        b, // 5
+    // 6
+    ) // 5
+
 ```
 
 # Diagnostics
@@ -27,10 +37,10 @@ invalidWithComments.js:1:14 lint/style/useExponentiationOperator  FIXABLE  ━�
   
   i Unsafe fix: Use the '**' operator instead of 'Math.pow'.
   
-    1   │ - /*·comment·*/Math.pow(a,·b)
-      1 │ + /*·comment·*/a·**·b
-    2 2 │   Math.pow(a, b)/* comment */;
-    3 3 │   Math.pow(a, b)// comment
+     1    │ - /*·comment·*/Math.pow(a,·b)
+        1 │ + /*·comment·*/a·**·b
+     2  2 │   Math.pow(a, b)/* comment */;
+     3  3 │   Math.pow(a, b)// comment
   
 
 ```
@@ -48,11 +58,11 @@ invalidWithComments.js:2:1 lint/style/useExponentiationOperator  FIXABLE  ━━
   
   i Unsafe fix: Use the '**' operator instead of 'Math.pow'.
   
-    1 1 │   /* comment */Math.pow(a, b)
-    2   │ - Math.pow(a,·b)/*·comment·*/;
-      2 │ + a·**·b/*·comment·*/;
-    3 3 │   Math.pow(a, b)// comment
-    4 4 │   
+     1  1 │   /* comment */Math.pow(a, b)
+     2    │ - Math.pow(a,·b)/*·comment·*/;
+        2 │ + a·**·b/*·comment·*/;
+     3  3 │   Math.pow(a, b)// comment
+     4  4 │   
   
 
 ```
@@ -71,12 +81,12 @@ invalidWithComments.js:3:1 lint/style/useExponentiationOperator  FIXABLE  ━━
   
   i Unsafe fix: Use the '**' operator instead of 'Math.pow'.
   
-    1 1 │   /* comment */Math.pow(a, b)
-    2 2 │   Math.pow(a, b)/* comment */;
-    3   │ - Math.pow(a,·b)//·comment
-      3 │ + a·**·b//·comment
-    4 4 │   
-    5 5 │   Math.pow(/**/a/**/, /**/b/**/)
+     1  1 │   /* comment */Math.pow(a, b)
+     2  2 │   Math.pow(a, b)/* comment */;
+     3    │ - Math.pow(a,·b)//·comment
+        3 │ + a·**·b//·comment
+     4  4 │   
+     5  5 │   Math.pow(/**/a/**/, /**/b/**/)
   
 
 ```
@@ -95,12 +105,12 @@ invalidWithComments.js:5:1 lint/style/useExponentiationOperator  FIXABLE  ━━
   
   i Unsafe fix: Use the '**' operator instead of 'Math.pow'.
   
-    3 3 │   Math.pow(a, b)// comment
-    4 4 │   
-    5   │ - Math.pow(/**/a/**/,·/**/b/**/)
-      5 │ + /**/a/**/·**·/**/b/**/
-    6 6 │   
-    7 7 │   Math/**/.pow/**/(a, b)
+     3  3 │   Math.pow(a, b)// comment
+     4  4 │   
+     5    │ - Math.pow(/**/a/**/,·/**/b/**/)
+        5 │ + /**/a/**/·**·/**/b/**/
+     6  6 │   
+     7  7 │   Math/**/.pow/**/(a, b)
   
 
 ```
@@ -118,11 +128,48 @@ invalidWithComments.js:7:1 lint/style/useExponentiationOperator  FIXABLE  ━━
   
   i Unsafe fix: Use the '**' operator instead of 'Math.pow'.
   
-    5 5 │   Math.pow(/**/a/**/, /**/b/**/)
-    6 6 │   
-    7   │ - Math/**/.pow/**/(a,·b)
-      7 │ + a·**·b
-    8 8 │   
+     5  5 │   Math.pow(/**/a/**/, /**/b/**/)
+     6  6 │   
+     7    │ - Math/**/.pow/**/(a,·b)
+        7 │ + a·**·b
+     8  8 │   
+     9  9 │   
+  
+
+```
+
+```
+invalidWithComments.js:10:1 lint/style/useExponentiationOperator  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use the '**' operator instead of 'Math.pow'.
+  
+  > 10 │ Math // 0
+       │ ^^^^^^^^^
+  > 11 │     .pow( // 1
+        ...
+  > 15 │         b, // 5
+  > 16 │     // 6
+  > 17 │     ) // 5
+       │     ^
+    18 │ 
+  
+  i Unsafe fix: Use the '**' operator instead of 'Math.pow'.
+  
+     8  8 │   
+     9  9 │   
+    10    │ - Math·//·0
+    11    │ - ····.pow(·//·1
+       10 │ + ·//·1
+    12 11 │           // 2
+    13    │ - ········a,·//·3
+       12 │ + ········a·**·//·3
+    14 13 │           // 4
+    15    │ - ········b,·//·5
+       14 │ + ········b·//·5
+    16 15 │       // 6
+    17    │ - ····)·//·5
+       16 │ + ·····//·5
+    18 17 │   
   
 
 ```

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -153,7 +153,24 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
   }
   ```
 
-- The code action (fix) of [noMultipleSpacesInRegularExpressionLiterals](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals/) is now marked as safe.
+- Preserve more comments in the fix of [useExponentiationOperator](https://biomejs.dev/linter/rules/use-exponentiation-operator). Contributed by @Conaclos
+
+  The rule now preserves comments that follow the (optional) trailing comma.
+
+  For example, the rule now suggests the following code fix:
+
+  ```diff
+  - Math.pow(
+  -    a, // a
+  -    2, // 2
+  -  );
+  +
+  +    a ** // a
+  +    2 // 2
+  +
+  ```
+
+- The code action (fix) of [noMultipleSpacesInRegularExpressionLiterals](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals/) is now marked as safe. Contributed by @Conaclos
 
 #### Bug fixes
 


### PR DESCRIPTION
## Summary

Before making the code fix of `useExponentiationOperator` safe, we should improve comment preservation.
This PR improves it by transferring comment following the optional trailing comma of `Math.pow` call.

## Test Plan

New test added.
