### PR TITLE
feat(css_formatter): automatically downcase all keywords and regular identifiers

### DIFF
--- a/crates/biome_css_formatter/src/css/auxiliary/attribute_matcher_value.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/attribute_matcher_value.rs
@@ -24,12 +24,16 @@ impl FormatNodeRule<CssAttributeMatcherValue> for FormatCssAttributeMatcherValue
                 write!(f, [string.format()])
             }
             AnyCssAttributeMatcherValue::CssIdentifier(ident) => {
-                let value = ident.value_token()?;
-
                 if f.comments().is_suppressed(ident.syntax()) {
                     return write!(f, [ident.format()]);
                 }
 
+                // Unlike almost all other usages of regular identifiers,
+                // attribute values are case-sensitive, so the identifier here
+                // does not get converted to lowercase. Once it's quoted, it
+                // will be parsed as a CssString on the next pass, at which
+                // point casing is preserved no matter what.
+                let value = ident.value_token()?;
                 let quoted = std::format!("\"{}\"", value.text_trimmed());
 
                 write!(

--- a/crates/biome_css_formatter/src/css/auxiliary/identifier.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/identifier.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::{prelude::*, utils::string_utils::FormatTokenAsLowercase};
 use biome_css_syntax::{CssIdentifier, CssIdentifierFields};
 use biome_formatter::write;
 
@@ -9,6 +9,16 @@ impl FormatNodeRule<CssIdentifier> for FormatCssIdentifier {
     fn fmt_fields(&self, node: &CssIdentifier, f: &mut CssFormatter) -> FormatResult<()> {
         let CssIdentifierFields { value_token } = node.as_fields();
 
-        write!(f, [value_token.format()])
+        // Identifiers in CSS are used all over the place. Type selectors,
+        // declaration names, value definitions, and plenty more. For the most
+        // part, these identifiers are case-insensitive, meaning they can
+        // safely be re-written in any casing, and for formatting we want them
+        // to always be in lowercase.
+        //
+        // Other kinds of identifiers (custom identifiers and dashed
+        // identifiers) are defined to be case-sensitive, which is why they
+        // have their own types to be parsed and formatted separately, ensuring
+        // that only identifiers which _can_ be re-written this way are.
+        write!(f, [FormatTokenAsLowercase::from(value_token?)])
     }
 }

--- a/crates/biome_css_formatter/tests/specs/css/atrule/container.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/container.css.snap
@@ -142,9 +142,9 @@ Line width: 80
 @container (inline-size >= calc(200px)) {
 }
 
-@container (WIDTH <= 150px) {
+@container (width <= 150px) {
 }
-@container (150px <= WIDTH) {
+@container (150px <= width) {
 }
 ```
 

--- a/crates/biome_css_formatter/tests/specs/css/atrule/layer.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/layer.css.snap
@@ -168,7 +168,7 @@ Line width: 80
 }
 
 @layer framework {
-	@media ONLY screen AND (color) {
+	@media only screen and (color) {
 		article {
 			padding: 1rem 3rem;
 		}

--- a/crates/biome_css_formatter/tests/specs/css/atrule/page.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/page.css.snap
@@ -182,9 +182,9 @@ Line width: 80
 	margin: 20px;
 }
 
-@page :FIRST {
+@page :first {
 }
-@page :LEFT {
+@page :left {
 }
 ```
 

--- a/crates/biome_css_formatter/tests/specs/css/atrule/scope.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/scope.css.snap
@@ -125,7 +125,7 @@ Line width: 80
 	}
 }
 
-@scope TO (.content > *) {
+@scope to (.content > *) {
 	img {
 		border-radius: 50%;
 	}

--- a/crates/biome_css_formatter/tests/specs/css/atrule/supports.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/supports.css.snap
@@ -223,7 +223,7 @@ Line width: 80
 }
 @supports not (display: flex) {
 }
-@SUPPORTS not (display: flex) {
+@supports not (display: flex) {
 }
 @supports (box-shadow: 0 0 2px black inset) or
 	(-moz-box-shadow: 0 0 2px black inset) or
@@ -245,15 +245,15 @@ Line width: 80
 }
 @supports (display: flex !important) {
 }
-@supports NOT (display: flex) {
+@supports not (display: flex) {
 }
-@supports ((transition-property: color) OR (animation-name: foo)) AND
+@supports ((transition-property: color) or (animation-name: foo)) and
 	(transform: rotate(10deg)) {
 }
-@supports (transition-property: color) OR
-	((animation-name: foo) AND (transform: rotate(10deg))) {
+@supports (transition-property: color) or
+	((animation-name: foo) and (transform: rotate(10deg))) {
 }
-@supports (NOT (display: flex)) {
+@supports (not (display: flex)) {
 }
 
 @supports selector(col || td) {

--- a/crates/biome_css_formatter/tests/specs/css/casing.css
+++ b/crates/biome_css_formatter/tests/specs/css/casing.css
@@ -1,0 +1,29 @@
+/*
+ * All values in CSS are case-insensitive except for Custom and Dashed
+ * identifiers. Everything else can and will be re-written in lowercase.
+ */
+
+DIV { COLOR: BLUE; }
+
+DIV.classNames#AND_Ids.ArePreserved {}
+
+[attr=IdentifierValuesPreserveWhenStringified] {}
+
+@MEDiA NoT SCReEN AND (  CoLOR  ), PRINT AND (COLOR) { }
+
+DIV {
+    --Preserved-Casing: BLUE;
+    ColOR: VAR(--Preserved-Casing);
+}
+
+@font-PALETTE-values --AnyCASInG-works {  }
+
+/*
+ * The only exception (at least that I've found so far in the spec), is @page
+ * using a _regular_ identifier for the page name, but where that identifier is
+ * considered case-sensitive. Biome uses a CssCustomIdentifier here instead to
+ * automatically preserve casing rather than creating a special exception.
+ */
+@PAGE ThisIsPreserved:FIRST {
+
+}

--- a/crates/biome_css_formatter/tests/specs/css/casing.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/casing.css.snap
@@ -1,0 +1,91 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/casing.css
+---
+
+# Input
+
+```css
+/*
+ * All values in CSS are case-insensitive except for Custom and Dashed
+ * identifiers. Everything else can and will be re-written in lowercase.
+ */
+
+DIV { COLOR: BLUE; }
+
+DIV.classNames#AND_Ids.ArePreserved {}
+
+[attr=IdentifierValuesPreserveWhenStringified] {}
+
+@MEDiA NoT SCReEN AND (  CoLOR  ), PRINT AND (COLOR) { }
+
+DIV {
+    --Preserved-Casing: BLUE;
+    ColOR: VAR(--Preserved-Casing);
+}
+
+@font-PALETTE-values --AnyCASInG-works {  }
+
+/*
+ * The only exception (at least that I've found so far in the spec), is @page
+ * using a _regular_ identifier for the page name, but where that identifier is
+ * considered case-sensitive. Biome uses a CssCustomIdentifier here instead to
+ * automatically preserve casing rather than creating a special exception.
+ */
+@PAGE ThisIsPreserved:FIRST {
+
+}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+/*
+ * All values in CSS are case-insensitive except for Custom and Dashed
+ * identifiers. Everything else can and will be re-written in lowercase.
+ */
+
+div {
+	color: blue;
+}
+
+div.classNames#AND_Ids.ArePreserved {
+}
+
+[attr="IdentifierValuesPreserveWhenStringified"] {
+}
+
+@media not screen and (color), print and (color) {
+}
+
+div {
+	--preserved-casing: blue;
+	color: var(--Preserved-Casing);
+}
+
+@font-palette-values --AnyCASInG-works {
+}
+
+/*
+ * The only exception (at least that I've found so far in the spec), is @page
+ * using a _regular_ identifier for the page name, but where that identifier is
+ * considered case-sensitive. Biome uses a CssCustomIdentifier here instead to
+ * automatically preserve casing rather than creating a special exception.
+ */
+@page ThisIsPreserved:first {
+}
+```
+
+

--- a/crates/biome_json_formatter/src/lib.rs
+++ b/crates/biome_json_formatter/src/lib.rs
@@ -258,7 +258,7 @@ impl FormatLanguage for JsonFormatLanguage {
     }
 }
 
-/// Format implementation specific to JavaScript tokens.
+/// Format implementation specific to JSON tokens.
 pub(crate) type FormatJsonSyntaxToken = FormatToken<JsonFormatContext>;
 
 impl AsFormat<JsonFormatContext> for JsonSyntaxToken {


### PR DESCRIPTION
## Summary

Dependent on #1353. This PR starts automatically writing all keywords and regular identifiers in lowercase. By definition in the spec, this should be a safe transformation, but only because we now distinguish between regular and custom/dashed identifiers (the latter are case _sensitive_). The one apparent exception that I've found, `@page` rule names, is also parsed using a `CssCustomIdentifier`, ensuring that it preserves casing, even though the spec uses a regular `<ident>` and just states "this one's case sensitive".

This behavior is _similar_ to what Prettier does, but actually a lot more consistent. Prettier does _not_ downcase type selectors, attribute selectors, value definitions, and other things, even though they are explicitly defined as case-insensitive. Biome's behavior after this PR will be an intentional deviation from Prettier, and once we get to Prettier compatibility testing, I'll be sure to add a note about it there. For example:

```css
/* input */
DIV.aClassName[Class=Something] {
  COLOR: White;
}

/* Prettier */
DIV.aClassName[Class="Something"] {
    color: White;
}

/* Biome */
div.aClassName[class="Something"] {
  color: white;
}
```

Biome's result ensures a much more consistent output while still preserving all of the actually-sensitive values: the class name and attribute _matcher value_ in this example.

## Test Plan

Added a new test specifically for testing the different casing situations, and all of the other spec tests have updated with the downcasing now.