### PR TITLE
feat(css_formatter): support meaningful boundaries for range formatting

### DIFF
--- a/crates/biome_css_formatter/tests/specs/css/range/between_rules.css
+++ b/crates/biome_css_formatter/tests/specs/css/range/between_rules.css
@@ -1,0 +1,15 @@
+
+div {    color  : blue ;
+
+    <<<ROME_RANGE_START>>>
+    background-color  : 
+    green;
+}
+
+.foo   html
+{
+    color  : green ;
+    <<<ROME_RANGE_END>>>
+
+    background-color   : blue;
+}

--- a/crates/biome_css_formatter/tests/specs/css/range/between_rules.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/range/between_rules.css.snap
@@ -1,0 +1,56 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/range/between_rules.css
+---
+
+# Input
+
+```css
+
+div {    color  : blue ;
+
+    
+    background-color  : 
+    green;
+}
+
+.foo   html
+{
+    color  : green ;
+    
+
+    background-color   : blue;
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+
+div {
+	color: blue;
+
+	background-color: green;
+}
+
+.foo html {
+	color: green;
+
+	background-color: blue;
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/range/keyframes.css
+++ b/crates/biome_css_formatter/tests/specs/css/range/keyframes.css
@@ -1,0 +1,10 @@
+@keyframes   animation-name   {
+    10%   <<<ROME_RANGE_START>>>,  20%   {
+        opacity:   0
+           ;
+        <<<ROME_RANGE_END>>>
+    }
+
+    100%    {
+        opacity  : 1 }
+}

--- a/crates/biome_css_formatter/tests/specs/css/range/keyframes.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/range/keyframes.css.snap
@@ -1,0 +1,47 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/range/keyframes.css
+---
+
+# Input
+
+```css
+@keyframes   animation-name   {
+    10%   ,  20%   {
+        opacity:   0
+           ;
+        
+    }
+
+    100%    {
+        opacity  : 1 }
+}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+@keyframes animation-name {
+	10%,
+	20% {
+		opacity: 0;
+	}
+
+	100% {
+		opacity: 1;
+	}
+}```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/range/mid_value.css
+++ b/crates/biome_css_formatter/tests/specs/css/range/mid_value.css
@@ -1,0 +1,3 @@
+div {
+    border  :   1px <<<ROME_RANGE_START>>>  solid  green   <<<ROME_RANGE_END>>>;
+}

--- a/crates/biome_css_formatter/tests/specs/css/range/mid_value.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/range/mid_value.css.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/range/mid_value.css
+---
+
+# Input
+
+```css
+div {
+    border  :   1px   solid  green   ;
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+div {
+    border: 1px solid green   ;
+}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/range/selector_list.css
+++ b/crates/biome_css_formatter/tests/specs/css/range/selector_list.css
@@ -1,0 +1,1 @@
+.foo  , <<<ROME_RANGE_START>>> .bar:FIRST-CHILD <<<ROME_RANGE_END>>>, DIV {color: blue}

--- a/crates/biome_css_formatter/tests/specs/css/range/selector_list.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/range/selector_list.css.snap
@@ -1,0 +1,33 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/range/selector_list.css
+---
+
+# Input
+
+```css
+.foo  ,  .bar:FIRST-CHILD , DIV {color: blue}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+.foo,
+.bar:first-child,
+div {
+	color: blue;
+}```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/range/single_declaration.css
+++ b/crates/biome_css_formatter/tests/specs/css/range/single_declaration.css
@@ -1,0 +1,6 @@
+div{color  :  blue  
+    
+    ;
+    <<<ROME_RANGE_START>>>    border   :  1px   solid;<<<ROME_RANGE_END>>>
+}
+div{color:green;}

--- a/crates/biome_css_formatter/tests/specs/css/range/single_declaration.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/range/single_declaration.css.snap
@@ -1,0 +1,40 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/range/single_declaration.css
+---
+
+# Input
+
+```css
+div{color  :  blue  
+    
+    ;
+        border   :  1px   solid;
+}
+div{color:green;}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+div {
+	color: blue;
+	border: 1px solid;
+}
+div{color:green;}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/range/single_rule.css
+++ b/crates/biome_css_formatter/tests/specs/css/range/single_rule.css
@@ -1,0 +1,4 @@
+div{color:blue;}
+<<<ROME_RANGE_START>>>div{color:green;}<<<ROME_RANGE_END>>>
+
+div{color:red;}

--- a/crates/biome_css_formatter/tests/specs/css/range/single_rule.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/range/single_rule.css.snap
@@ -1,0 +1,39 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/range/single_rule.css
+---
+
+# Input
+
+```css
+div{color:blue;}
+div{color:green;}
+
+div{color:red;}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+div{color:blue;}
+div {
+	color: green;
+}
+
+div{color:red;}
+```
+
+

--- a/crates/biome_css_formatter/tests/specs/css/range/single_value.css
+++ b/crates/biome_css_formatter/tests/specs/css/range/single_value.css
@@ -1,0 +1,5 @@
+div {
+    COLOR: GREEN;
+
+    Border : 1px <<<ROME_RANGE_START>>>GrEeN<<<ROME_RANGE_END>>>   solid   ;
+}

--- a/crates/biome_css_formatter/tests/specs/css/range/single_value.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/range/single_value.css.snap
@@ -1,0 +1,37 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/range/single_value.css
+---
+
+# Input
+
+```css
+div {
+    COLOR: GREEN;
+
+    Border : 1px GrEeN   solid   ;
+}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+-----
+
+```css
+div {
+    COLOR: GREEN;
+
+    Border : 1px green   solid   ;
+}```
+
+


### PR DESCRIPTION
## Summary

#1285. This PR adds some better heuristics for handling `format_range` for CSS. In general, the logic expands the range until it hits the boundary of:
- a declaration
- a rule
- an individual value
- a complete component value list
- a selector list
- or any block-like structure

## Test Plan

This also adds a number of tests to check that those range boundaries are being respected.