### PR TITLE
Parse recovery trait

### DIFF
--- a/crates/biome_css_parser/src/syntax/at_rule/charset.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/charset.rs
@@ -3,7 +3,7 @@ use crate::syntax::parse_error::expected_string;
 use crate::syntax::parse_string;
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, TextRange, T};
-use biome_parser::parse_recovery::ParseRecovery;
+use biome_parser::parse_recovery::ParseRecoveryTokenSet;
 use biome_parser::parsed_syntax::ParsedSyntax::Present;
 use biome_parser::prelude::ParsedSyntax::Absent;
 use biome_parser::prelude::*;
@@ -24,9 +24,10 @@ pub(crate) fn parse_charset_at_rule(p: &mut CssParser) -> ParsedSyntax {
 
     p.bump(T![charset]);
 
-    let kind = match parse_string(p).or_recover(
+    let kind = match parse_string(p).or_recover_with_token_set(
         p,
-        &ParseRecovery::new(CSS_BOGUS, CHARTSET_RECOVERY_SET).enable_recovery_on_line_break(),
+        &ParseRecoveryTokenSet::new(CSS_BOGUS, CHARTSET_RECOVERY_SET)
+            .enable_recovery_on_line_break(),
         expected_string,
     ) {
         Ok(encoding) if !encoding.kind(p).is_bogus() => {
@@ -52,7 +53,7 @@ fn eat_or_recover_close_token(p: &mut CssParser, encoding: CompletedMarker) -> b
     if p.eat(T![;]) {
         true
     } else {
-        if let Ok(m) = ParseRecovery::new(CSS_BOGUS, CHARTSET_RECOVERY_SET)
+        if let Ok(m) = ParseRecoveryTokenSet::new(CSS_BOGUS, CHARTSET_RECOVERY_SET)
             .enable_recovery_on_line_break()
             .recover(p)
         {

--- a/crates/biome_css_parser/src/syntax/at_rule/color_profile.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/color_profile.rs
@@ -5,7 +5,7 @@ use crate::syntax::parse_custom_identifier;
 use crate::syntax::parse_error::expected_non_css_wide_keyword_identifier;
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
-use biome_parser::parse_recovery::ParseRecovery;
+use biome_parser::parse_recovery::ParseRecoveryTokenSet;
 use biome_parser::parsed_syntax::ParsedSyntax::Present;
 use biome_parser::prelude::ParsedSyntax::Absent;
 use biome_parser::prelude::*;
@@ -27,9 +27,9 @@ pub(crate) fn parse_color_profile_at_rule(p: &mut CssParser) -> ParsedSyntax {
 
     // TODO: This should actually be `<dashed-ident> | device-cmyk`.
     let kind = if parse_custom_identifier(p, CssLexContext::Regular)
-        .or_recover(
+        .or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS, COLOR_PROFILE_RECOVERY_SET)
+            &ParseRecoveryTokenSet::new(CSS_BOGUS, COLOR_PROFILE_RECOVERY_SET)
                 .enable_recovery_on_line_break(),
             expected_non_css_wide_keyword_identifier,
         )

--- a/crates/biome_css_parser/src/syntax/at_rule/counter_style.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/counter_style.rs
@@ -5,7 +5,7 @@ use crate::syntax::parse_custom_identifier;
 use crate::syntax::parse_error::expected_non_css_wide_keyword_identifier;
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
-use biome_parser::parse_recovery::ParseRecovery;
+use biome_parser::parse_recovery::ParseRecoveryTokenSet;
 use biome_parser::parsed_syntax::ParsedSyntax::Present;
 use biome_parser::prelude::ParsedSyntax::Absent;
 use biome_parser::prelude::*;
@@ -26,9 +26,9 @@ pub(crate) fn parse_counter_style_at_rule(p: &mut CssParser) -> ParsedSyntax {
     p.bump(T![counter_style]);
 
     let kind = if parse_custom_identifier(p, CssLexContext::Regular)
-        .or_recover(
+        .or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS, COUNTER_STYLE_RECOVERY_SET)
+            &ParseRecoveryTokenSet::new(CSS_BOGUS, COUNTER_STYLE_RECOVERY_SET)
                 .enable_recovery_on_line_break(),
             expected_non_css_wide_keyword_identifier,
         )

--- a/crates/biome_css_parser/src/syntax/at_rule/font_palette_values.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/font_palette_values.rs
@@ -6,7 +6,7 @@ use biome_css_syntax::{
     T,
 };
 use biome_parser::{
-    parse_recovery::ParseRecovery,
+    parse_recovery::ParseRecoveryTokenSet,
     parsed_syntax::ParsedSyntax::{self, Present},
     prelude::ParsedSyntax::Absent,
     token_set, Parser, TokenSet,
@@ -28,9 +28,9 @@ pub(crate) fn parse_font_palette_values_at_rule(p: &mut CssParser) -> ParsedSynt
     p.bump(T![font_palette_values]);
 
     let kind = if parse_dashed_identifier(p)
-        .or_recover(
+        .or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS, FONT_PALETTE_VALUES_RECOVERY_SET)
+            &ParseRecoveryTokenSet::new(CSS_BOGUS, FONT_PALETTE_VALUES_RECOVERY_SET)
                 .enable_recovery_on_line_break(),
             expected_dashed_identifier,
         )

--- a/crates/biome_css_parser/src/syntax/at_rule/keyframes.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/keyframes.rs
@@ -10,7 +10,7 @@ use crate::syntax::{is_at_identifier, parse_custom_identifier, parse_string, BOD
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::parse_lists::{ParseNodeList, ParseSeparatedList};
-use biome_parser::parse_recovery::{ParseRecovery, RecoveryResult};
+use biome_parser::parse_recovery::{ParseRecovery, ParseRecoveryTokenSet, RecoveryResult};
 use biome_parser::parsed_syntax::ParsedSyntax::Present;
 use biome_parser::prelude::ParsedSyntax::Absent;
 use biome_parser::prelude::*;
@@ -37,9 +37,9 @@ pub(crate) fn parse_keyframes_at_rule(p: &mut CssParser) -> ParsedSyntax {
     };
 
     let kind = if name
-        .or_recover(
+        .or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS, KEYFRAMES_NAME_RECOVERY_SET)
+            &ParseRecoveryTokenSet::new(CSS_BOGUS, KEYFRAMES_NAME_RECOVERY_SET)
                 .enable_recovery_on_line_break(),
             expected_non_css_wide_keyword_identifier,
         )
@@ -51,9 +51,10 @@ pub(crate) fn parse_keyframes_at_rule(p: &mut CssParser) -> ParsedSyntax {
     };
 
     if parse_keyframes_block(p)
-        .or_recover(
+        .or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS_BLOCK, BODY_RECOVERY_SET).enable_recovery_on_line_break(),
+            &ParseRecoveryTokenSet::new(CSS_BOGUS_BLOCK, BODY_RECOVERY_SET)
+                .enable_recovery_on_line_break(),
             expected_block,
         )
         .is_err()
@@ -73,7 +74,7 @@ fn parse_keyframes_block(p: &mut CssParser) -> ParsedSyntax {
 
     let m = p.start();
     p.expect(T!['{']);
-    CssKeyframesItemList.parse_list(p);
+    KeyframesItemList.parse_list(p);
     p.expect(T!['}']);
 
     Present(m.complete(p, CSS_KEYFRAMES_BLOCK))
@@ -82,9 +83,9 @@ fn parse_keyframes_block(p: &mut CssParser) -> ParsedSyntax {
 const KEYFRAMES_ITEM_LIST_RECOVERY_SET: TokenSet<CssSyntaxKind> =
     KEYFRAMES_ITEM_SELECTOR_SET.union(token_set!(T!['}']));
 
-struct CssKeyframesItemList;
+struct KeyframesItemList;
 
-impl ParseNodeList for CssKeyframesItemList {
+impl ParseNodeList for KeyframesItemList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
     const LIST_KIND: Self::Kind = CSS_KEYFRAMES_ITEM_LIST;
@@ -102,9 +103,9 @@ impl ParseNodeList for CssKeyframesItemList {
         p: &mut Self::Parser<'_>,
         parsed_element: ParsedSyntax,
     ) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS_KEYFRAMES_ITEM, KEYFRAMES_ITEM_LIST_RECOVERY_SET),
+            &ParseRecoveryTokenSet::new(CSS_BOGUS_KEYFRAMES_ITEM, KEYFRAMES_ITEM_LIST_RECOVERY_SET),
             expected_keyframes_item,
         )
     }
@@ -117,12 +118,13 @@ fn parse_keyframes_item(p: &mut CssParser) -> ParsedSyntax {
     }
 
     let m = p.start();
-    CssKeyframesSelectorList.parse_list(p);
+    KeyframesSelectorList.parse_list(p);
 
     if parse_declaration_list_block(p)
-        .or_recover(
+        .or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS_BLOCK, BODY_RECOVERY_SET).enable_recovery_on_line_break(),
+            &ParseRecoveryTokenSet::new(CSS_BOGUS_BLOCK, BODY_RECOVERY_SET)
+                .enable_recovery_on_line_break(),
             expected_block,
         )
         .is_err()
@@ -133,24 +135,27 @@ fn parse_keyframes_item(p: &mut CssParser) -> ParsedSyntax {
     Present(m.complete(p, CSS_KEYFRAMES_ITEM))
 }
 
-const KEYFRAMES_ITEM_SELECTOR_LIST_RECOVERY_SET: TokenSet<CssSyntaxKind> =
-    KEYFRAMES_ITEM_SELECTOR_SET.union(token_set!(T!['{']));
+struct KeyframesSelectorListParseRecovery;
 
-struct CssKeyframesSelectorList;
+impl ParseRecovery for KeyframesSelectorListParseRecovery {
+    type Kind = CssSyntaxKind;
+    type Parser<'source> = CssParser<'source>;
+    const RECOVERED_KIND: Self::Kind = CSS_BOGUS_SELECTOR;
 
-impl ParseSeparatedList for CssKeyframesSelectorList {
+    fn is_at_recovered(&self, p: &mut Self::Parser<'_>) -> bool {
+        p.at(T!['{']) || is_at_keyframes_item_selector(p)
+    }
+}
+
+struct KeyframesSelectorList;
+
+impl ParseSeparatedList for KeyframesSelectorList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
     const LIST_KIND: Self::Kind = CSS_KEYFRAMES_SELECTOR_LIST;
 
     fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
-        //TODO better error recovery? we need to extend ParseRecovery to support nth_at token
-        if p.at(CSS_NUMBER_LITERAL) && !p.nth_at(1, T![%]) {
-            p.bump(CSS_NUMBER_LITERAL);
-            Absent
-        } else {
-            parse_keyframes_item_selector(p)
-        }
+        parse_keyframes_item_selector(p)
     }
 
     fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
@@ -164,10 +169,7 @@ impl ParseSeparatedList for CssKeyframesSelectorList {
     ) -> RecoveryResult {
         parsed_element.or_recover(
             p,
-            &ParseRecovery::new(
-                CSS_BOGUS_SELECTOR,
-                KEYFRAMES_ITEM_SELECTOR_LIST_RECOVERY_SET,
-            ),
+            &KeyframesSelectorListParseRecovery,
             expected_keyframes_item_selector,
         )
     }

--- a/crates/biome_css_parser/src/syntax/at_rule/layer.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/layer.rs
@@ -6,7 +6,7 @@ use crate::syntax::{is_at_identifier, parse_regular_identifier};
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::parse_lists::ParseSeparatedList;
-use biome_parser::parse_recovery::{ParseRecovery, RecoveryResult};
+use biome_parser::parse_recovery::{ParseRecoveryTokenSet, RecoveryResult};
 use biome_parser::parsed_syntax::ParsedSyntax::Present;
 use biome_parser::prelude::ParsedSyntax::Absent;
 use biome_parser::prelude::*;
@@ -35,7 +35,7 @@ pub(crate) fn parse_layer_at_rule(p: &mut CssParser) -> ParsedSyntax {
 pub(crate) fn parse_any_layer(p: &mut CssParser) -> CompletedMarker {
     let m = p.start();
 
-    CssLayerReferenceList.parse_list(p);
+    LayerReferenceList.parse_list(p);
 
     if p.at(T!['{']) {
         let kind = if parse_or_recover_rule_list_block(p).is_ok() {
@@ -60,15 +60,15 @@ const LAYER_REFERENCE_LIST_END_SET: TokenSet<CssSyntaxKind> = token_set!(T!['{']
 const LAYER_REFERENCE_LIST_RECOVERY_SET: TokenSet<CssSyntaxKind> =
     LAYER_REFERENCE_LIST_END_SET.union(token_set!(T![,]));
 
-struct CssLayerReferenceList;
+struct LayerReferenceList;
 
-impl ParseSeparatedList for CssLayerReferenceList {
+impl ParseSeparatedList for LayerReferenceList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
     const LIST_KIND: Self::Kind = CSS_LAYER_REFERENCE_LIST;
 
     fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
-        Present(CssLayerNameList.parse_list(p))
+        Present(LayerNameList.parse_list(p))
     }
 
     fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
@@ -80,9 +80,9 @@ impl ParseSeparatedList for CssLayerReferenceList {
         p: &mut Self::Parser<'_>,
         parsed_element: ParsedSyntax,
     ) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS, LAYER_REFERENCE_LIST_RECOVERY_SET)
+            &ParseRecoveryTokenSet::new(CSS_BOGUS, LAYER_REFERENCE_LIST_RECOVERY_SET)
                 .enable_recovery_on_line_break(),
             expected_identifier,
         )
@@ -97,9 +97,9 @@ const LAYER_NAME_LIST_END_SET: TokenSet<CssSyntaxKind> = token_set!(T![,], T!['{
 const LAYER_NAME_LIST_RECOVERY_SET: TokenSet<CssSyntaxKind> =
     LAYER_NAME_LIST_END_SET.union(token_set!(T![.]));
 
-struct CssLayerNameList;
+struct LayerNameList;
 
-impl ParseSeparatedList for CssLayerNameList {
+impl ParseSeparatedList for LayerNameList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
     const LIST_KIND: Self::Kind = CSS_LAYER_NAME_LIST;
@@ -127,9 +127,9 @@ impl ParseSeparatedList for CssLayerNameList {
         p: &mut Self::Parser<'_>,
         parsed_element: ParsedSyntax,
     ) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS, LAYER_NAME_LIST_RECOVERY_SET),
+            &ParseRecoveryTokenSet::new(CSS_BOGUS, LAYER_NAME_LIST_RECOVERY_SET),
             expected_identifier,
         )
     }

--- a/crates/biome_css_parser/src/syntax/at_rule/media.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/media.rs
@@ -6,7 +6,7 @@ use crate::syntax::{is_at_identifier, is_nth_at_identifier, parse_regular_identi
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::parse_lists::ParseSeparatedList;
-use biome_parser::parse_recovery::{ParseRecovery, RecoveryResult};
+use biome_parser::parse_recovery::{ParseRecoveryTokenSet, RecoveryResult};
 use biome_parser::parsed_syntax::ParsedSyntax::Present;
 use biome_parser::prelude::ParsedSyntax::Absent;
 use biome_parser::prelude::*;
@@ -26,7 +26,7 @@ pub(crate) fn parse_media_at_rule(p: &mut CssParser) -> ParsedSyntax {
 
     p.bump(T![media]);
 
-    CssMediaQueryList.parse_list(p);
+    MediaQueryList.parse_list(p);
 
     if parse_or_recover_rule_list_block(p).is_err() {
         return Present(m.complete(p, CSS_BOGUS_AT_RULE));
@@ -36,9 +36,9 @@ pub(crate) fn parse_media_at_rule(p: &mut CssParser) -> ParsedSyntax {
 }
 
 #[derive(Default)]
-pub(crate) struct CssMediaQueryList;
+pub(crate) struct MediaQueryList;
 
-impl ParseSeparatedList for CssMediaQueryList {
+impl ParseSeparatedList for MediaQueryList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
     const LIST_KIND: Self::Kind = CSS_MEDIA_QUERY_LIST;
@@ -56,9 +56,9 @@ impl ParseSeparatedList for CssMediaQueryList {
         p: &mut Self::Parser<'_>,
         parsed_element: ParsedSyntax,
     ) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS_MEDIA_QUERY, token_set!(T![,], T!['{'])),
+            &ParseRecoveryTokenSet::new(CSS_BOGUS_MEDIA_QUERY, token_set!(T![,], T!['{'])),
             expected_media_query,
         )
     }

--- a/crates/biome_css_parser/src/syntax/at_rule/mod.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/mod.rs
@@ -39,13 +39,13 @@ use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 use biome_parser::prelude::*;
 
 #[inline]
-pub(crate) fn at_at_rule(p: &mut CssParser) -> bool {
+pub(crate) fn is_at_at_rule(p: &mut CssParser) -> bool {
     p.at(T![@])
 }
 
 #[inline]
 pub(crate) fn parse_at_rule(p: &mut CssParser) -> ParsedSyntax {
-    if !at_at_rule(p) {
+    if !is_at_at_rule(p) {
         return Absent;
     }
 

--- a/crates/biome_css_parser/src/syntax/at_rule/page.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/page.rs
@@ -3,7 +3,7 @@ use crate::parser::CssParser;
 use crate::syntax::at_rule::parse_error::{
     expected_any_page_at_rule_item, expected_page_selector, expected_page_selector_pseudo,
 };
-use crate::syntax::at_rule::{at_at_rule, parse_at_rule};
+use crate::syntax::at_rule::{is_at_at_rule, parse_at_rule};
 use crate::syntax::blocks::parse_or_recover_declaration_or_rule_list_block;
 use crate::syntax::parse_error::expected_block;
 use crate::syntax::{
@@ -196,7 +196,7 @@ impl ParseNodeList for PageAtRuleItemList {
     fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
         if at_margin_rule(p) {
             parse_margin_at_rule(p)
-        } else if at_at_rule(p) {
+        } else if is_at_at_rule(p) {
             parse_at_rule(p)
         } else {
             parse_declaration_with_semicolon(p)

--- a/crates/biome_css_parser/src/syntax/at_rule/page.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/page.rs
@@ -13,7 +13,7 @@ use crate::syntax::{
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::parse_lists::{ParseNodeList, ParseSeparatedList};
-use biome_parser::parse_recovery::{ParseRecovery, RecoveryResult};
+use biome_parser::parse_recovery::{ParseRecoveryTokenSet, RecoveryResult};
 use biome_parser::parsed_syntax::ParsedSyntax::Present;
 use biome_parser::prelude::ParsedSyntax::Absent;
 use biome_parser::prelude::*;
@@ -33,12 +33,13 @@ pub(crate) fn parse_page_at_rule(p: &mut CssParser) -> ParsedSyntax {
 
     p.bump(T![page]);
 
-    CssPageSelectorList.parse_list(p);
+    PageSelectorList.parse_list(p);
 
     if parse_page_block(p)
-        .or_recover(
+        .or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS_BLOCK, BODY_RECOVERY_SET).enable_recovery_on_line_break(),
+            &ParseRecoveryTokenSet::new(CSS_BOGUS_BLOCK, BODY_RECOVERY_SET)
+                .enable_recovery_on_line_break(),
             expected_block,
         )
         .is_err()
@@ -52,9 +53,9 @@ pub(crate) fn parse_page_at_rule(p: &mut CssParser) -> ParsedSyntax {
 const PAGE_SELECTOR_SET: TokenSet<CssSyntaxKind> = token_set!(T![ident], T![:]);
 const PAGE_SELECTOR_LIST_RECOVERY_SET: TokenSet<CssSyntaxKind> =
     PAGE_SELECTOR_SET.union(token_set!(T!['{']));
-struct CssPageSelectorList;
+struct PageSelectorList;
 
-impl ParseSeparatedList for CssPageSelectorList {
+impl ParseSeparatedList for PageSelectorList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
     const LIST_KIND: Self::Kind = CSS_PAGE_SELECTOR_LIST;
@@ -72,9 +73,9 @@ impl ParseSeparatedList for CssPageSelectorList {
         p: &mut Self::Parser<'_>,
         parsed_element: ParsedSyntax,
     ) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS_SELECTOR, PAGE_SELECTOR_LIST_RECOVERY_SET),
+            &ParseRecoveryTokenSet::new(CSS_BOGUS_SELECTOR, PAGE_SELECTOR_LIST_RECOVERY_SET),
             expected_page_selector,
         )
     }
@@ -103,7 +104,7 @@ pub(crate) fn parse_page_selector(p: &mut CssParser) -> ParsedSyntax {
     // sensitive, we use a `<custom-ident>` instead to preserve the casing, but
     // need to allow the CSS-wide keywords that would otherwise be disallowed.
     parse_custom_identifier_with_keywords(p, CssLexContext::Regular, true).ok();
-    CssPageSelectorPseudoList.parse_list(p);
+    PageSelectorPseudoList.parse_list(p);
 
     Present(m.complete(p, CSS_PAGE_SELECTOR))
 }
@@ -112,9 +113,9 @@ const PAGE_SELECTOR_PSEUDO_LIST_END_SET: TokenSet<CssSyntaxKind> = token_set!(T!
 const PAGE_SELECTOR_PSEUDO_LIST_RECOVERY_SET: TokenSet<CssSyntaxKind> =
     PAGE_SELECTOR_PSEUDO_LIST_END_SET.union(token_set!(T![:]));
 
-struct CssPageSelectorPseudoList;
+struct PageSelectorPseudoList;
 
-impl ParseNodeList for CssPageSelectorPseudoList {
+impl ParseNodeList for PageSelectorPseudoList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
     const LIST_KIND: Self::Kind = CSS_PAGE_SELECTOR_PSEUDO_LIST;
@@ -132,9 +133,9 @@ impl ParseNodeList for CssPageSelectorPseudoList {
         p: &mut Self::Parser<'_>,
         parsed_element: ParsedSyntax,
     ) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(
+            &ParseRecoveryTokenSet::new(
                 CSS_BOGUS_PSEUDO_CLASS,
                 PAGE_SELECTOR_PSEUDO_LIST_RECOVERY_SET,
             ),
@@ -178,7 +179,7 @@ pub(crate) fn parse_page_block(p: &mut CssParser) -> ParsedSyntax {
     let m = p.start();
 
     p.expect(T!['{']);
-    CssPageAtRuleItemList.parse_list(p);
+    PageAtRuleItemList.parse_list(p);
     p.expect(T!['}']);
 
     Present(m.complete(p, CSS_PAGE_AT_RULE_BLOCK))
@@ -186,8 +187,8 @@ pub(crate) fn parse_page_block(p: &mut CssParser) -> ParsedSyntax {
 
 const CSS_PAGE_AT_RULE_ITEM_LIST_RECOVERY_SET: TokenSet<CssSyntaxKind> =
     token_set!(T![@], T![ident]);
-struct CssPageAtRuleItemList;
-impl ParseNodeList for CssPageAtRuleItemList {
+struct PageAtRuleItemList;
+impl ParseNodeList for PageAtRuleItemList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
     const LIST_KIND: Self::Kind = CSS_PAGE_AT_RULE_ITEM_LIST;
@@ -211,9 +212,9 @@ impl ParseNodeList for CssPageAtRuleItemList {
         p: &mut Self::Parser<'_>,
         parsed_element: ParsedSyntax,
     ) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS, CSS_PAGE_AT_RULE_ITEM_LIST_RECOVERY_SET),
+            &ParseRecoveryTokenSet::new(CSS_BOGUS, CSS_PAGE_AT_RULE_ITEM_LIST_RECOVERY_SET),
             expected_any_page_at_rule_item,
         )
     }

--- a/crates/biome_css_parser/src/syntax/at_rule/scope.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/scope.rs
@@ -1,11 +1,11 @@
 use crate::parser::CssParser;
 use crate::syntax::at_rule::parse_error::expected_any_scope_range;
 use crate::syntax::blocks::parse_or_recover_rule_list_block;
-use crate::syntax::selector::CssSelectorList;
+use crate::syntax::selector::SelectorList;
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::parse_lists::ParseSeparatedList;
-use biome_parser::parse_recovery::{ParseRecovery, RecoveryResult};
+use biome_parser::parse_recovery::{ParseRecoveryTokenSet, RecoveryResult};
 use biome_parser::parsed_syntax::ParsedSyntax::Present;
 use biome_parser::prelude::ParsedSyntax::Absent;
 use biome_parser::prelude::*;
@@ -102,9 +102,10 @@ const SCOPE_EDGE_RECOVERY_SET: TokenSet<CssSyntaxKind> =
     SCOPE_RANGE_RECOVERY_SET.union(token_set![T!['{']]);
 #[inline]
 pub(crate) fn parse_or_recover_scope_edge(p: &mut CssParser) -> RecoveryResult {
-    parse_scope_edge(p).or_recover(
+    parse_scope_edge(p).or_recover_with_token_set(
         p,
-        &ParseRecovery::new(CSS_BOGUS, SCOPE_EDGE_RECOVERY_SET).enable_recovery_on_line_break(),
+        &ParseRecoveryTokenSet::new(CSS_BOGUS, SCOPE_EDGE_RECOVERY_SET)
+            .enable_recovery_on_line_break(),
         expected_any_scope_range,
     )
 }
@@ -122,7 +123,7 @@ pub(crate) fn parse_scope_edge(p: &mut CssParser) -> ParsedSyntax {
     let m = p.start();
 
     p.bump(T!['(']);
-    CssSelectorList::default()
+    SelectorList::default()
         .with_end_kind_ts(SCOPE_EDGE_SELECTOR_LIST_END_SET)
         .parse_list(p);
     p.expect(T![')']);

--- a/crates/biome_css_parser/src/syntax/blocks.rs
+++ b/crates/biome_css_parser/src/syntax/blocks.rs
@@ -1,5 +1,5 @@
 use crate::parser::CssParser;
-use crate::syntax::at_rule::{at_at_rule, parse_at_rule};
+use crate::syntax::at_rule::{is_at_at_rule, parse_at_rule};
 use crate::syntax::parse_error::{expected_any_declaration_or_at_rule, expected_block};
 use crate::syntax::{
     parse_declaration_with_semicolon, DeclarationList, RuleList, BODY_RECOVERY_SET,
@@ -96,7 +96,7 @@ impl ParseNodeList for DeclarationOrAtRuleList {
     const LIST_KIND: Self::Kind = CSS_DECLARATION_OR_AT_RULE_LIST;
 
     fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
-        if at_at_rule(p) {
+        if is_at_at_rule(p) {
             parse_at_rule(p)
         } else {
             parse_declaration_with_semicolon(p)

--- a/crates/biome_css_parser/src/syntax/blocks.rs
+++ b/crates/biome_css_parser/src/syntax/blocks.rs
@@ -2,21 +2,22 @@ use crate::parser::CssParser;
 use crate::syntax::at_rule::{at_at_rule, parse_at_rule};
 use crate::syntax::parse_error::{expected_any_declaration_or_at_rule, expected_block};
 use crate::syntax::{
-    parse_declaration_with_semicolon, CssDeclarationList, CssRuleList, BODY_RECOVERY_SET,
+    parse_declaration_with_semicolon, DeclarationList, RuleList, BODY_RECOVERY_SET,
 };
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::parse_lists::{ParseNodeList, ParseSeparatedList};
-use biome_parser::parse_recovery::{ParseRecovery, RecoveryResult};
+use biome_parser::parse_recovery::{ParseRecoveryTokenSet, RecoveryResult};
 use biome_parser::parsed_syntax::ParsedSyntax;
 use biome_parser::parsed_syntax::ParsedSyntax::{Absent, Present};
 use biome_parser::{token_set, Parser, TokenSet};
 
 #[inline]
 pub(crate) fn parse_or_recover_declaration_list_block(p: &mut CssParser) -> RecoveryResult {
-    parse_declaration_list_block(p).or_recover(
+    parse_declaration_list_block(p).or_recover_with_token_set(
         p,
-        &ParseRecovery::new(CSS_BOGUS_BLOCK, BODY_RECOVERY_SET).enable_recovery_on_line_break(),
+        &ParseRecoveryTokenSet::new(CSS_BOGUS_BLOCK, BODY_RECOVERY_SET)
+            .enable_recovery_on_line_break(),
         expected_block,
     )
 }
@@ -30,7 +31,7 @@ pub(crate) fn parse_declaration_list_block(p: &mut CssParser) -> ParsedSyntax {
     let m = p.start();
 
     p.expect(T!['{']);
-    CssDeclarationList.parse_list(p);
+    DeclarationList.parse_list(p);
     p.expect(T!['}']);
 
     Present(m.complete(p, CSS_DECLARATION_LIST_BLOCK))
@@ -38,9 +39,10 @@ pub(crate) fn parse_declaration_list_block(p: &mut CssParser) -> ParsedSyntax {
 
 #[inline]
 pub(crate) fn parse_or_recover_rule_list_block(p: &mut CssParser) -> RecoveryResult {
-    parse_rule_list_block(p).or_recover(
+    parse_rule_list_block(p).or_recover_with_token_set(
         p,
-        &ParseRecovery::new(CSS_BOGUS_BLOCK, BODY_RECOVERY_SET).enable_recovery_on_line_break(),
+        &ParseRecoveryTokenSet::new(CSS_BOGUS_BLOCK, BODY_RECOVERY_SET)
+            .enable_recovery_on_line_break(),
         expected_block,
     )
 }
@@ -54,7 +56,7 @@ pub(crate) fn parse_rule_list_block(p: &mut CssParser) -> ParsedSyntax {
     let m = p.start();
 
     p.expect(T!['{']);
-    CssRuleList::new(T!['}']).parse_list(p);
+    RuleList::new(T!['}']).parse_list(p);
     p.expect(T!['}']);
 
     Present(m.complete(p, CSS_RULE_LIST_BLOCK))
@@ -62,9 +64,10 @@ pub(crate) fn parse_rule_list_block(p: &mut CssParser) -> ParsedSyntax {
 
 #[inline]
 pub(crate) fn parse_or_recover_declaration_or_rule_list_block(p: &mut CssParser) -> RecoveryResult {
-    parse_declaration_or_rule_list_block(p).or_recover(
+    parse_declaration_or_rule_list_block(p).or_recover_with_token_set(
         p,
-        &ParseRecovery::new(CSS_BOGUS_BLOCK, BODY_RECOVERY_SET).enable_recovery_on_line_break(),
+        &ParseRecoveryTokenSet::new(CSS_BOGUS_BLOCK, BODY_RECOVERY_SET)
+            .enable_recovery_on_line_break(),
         expected_block,
     )
 }
@@ -78,7 +81,7 @@ pub(crate) fn parse_declaration_or_rule_list_block(p: &mut CssParser) -> ParsedS
     let m = p.start();
 
     p.expect(T!['{']);
-    CssDeclarationOrAtRuleList.parse_list(p);
+    DeclarationOrAtRuleList.parse_list(p);
     p.expect(T!['}']);
 
     Present(m.complete(p, CSS_DECLARATION_OR_AT_RULE_BLOCK))
@@ -86,8 +89,8 @@ pub(crate) fn parse_declaration_or_rule_list_block(p: &mut CssParser) -> ParsedS
 
 const CSS_DECLARATION_OR_AT_RULE_LIST_RECOVERY_SET: TokenSet<CssSyntaxKind> =
     token_set!(T![@], T![ident]);
-struct CssDeclarationOrAtRuleList;
-impl ParseNodeList for CssDeclarationOrAtRuleList {
+struct DeclarationOrAtRuleList;
+impl ParseNodeList for DeclarationOrAtRuleList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
     const LIST_KIND: Self::Kind = CSS_DECLARATION_OR_AT_RULE_LIST;
@@ -109,9 +112,9 @@ impl ParseNodeList for CssDeclarationOrAtRuleList {
         p: &mut Self::Parser<'_>,
         parsed_element: ParsedSyntax,
     ) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS, CSS_DECLARATION_OR_AT_RULE_LIST_RECOVERY_SET),
+            &ParseRecoveryTokenSet::new(CSS_BOGUS, CSS_DECLARATION_OR_AT_RULE_LIST_RECOVERY_SET),
             expected_any_declaration_or_at_rule,
         )
     }

--- a/crates/biome_css_parser/src/syntax/mod.rs
+++ b/crates/biome_css_parser/src/syntax/mod.rs
@@ -6,7 +6,7 @@ mod selector;
 
 use crate::lexer::CssLexContext;
 use crate::parser::CssParser;
-use crate::syntax::at_rule::{at_at_rule, parse_at_rule};
+use crate::syntax::at_rule::{is_at_at_rule, parse_at_rule};
 use crate::syntax::blocks::parse_or_recover_declaration_list_block;
 use crate::syntax::css_dimension::{is_at_any_dimension, parse_any_dimension};
 use crate::syntax::parse_error::expected_any_rule;
@@ -68,7 +68,7 @@ impl ParseRecovery for RuleListParseRecovery {
     const RECOVERED_KIND: Self::Kind = CSS_BOGUS_RULE;
 
     fn is_at_recovered(&self, p: &mut Self::Parser<'_>) -> bool {
-        at_at_rule(p) || is_at_rule(p)
+        is_at_at_rule(p) || is_at_rule(p)
     }
 }
 
@@ -78,7 +78,7 @@ impl ParseNodeList for RuleList {
     const LIST_KIND: Self::Kind = CSS_RULE_LIST;
 
     fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
-        if at_at_rule(p) {
+        if is_at_at_rule(p) {
             parse_at_rule(p)
         } else if is_at_rule(p) {
             parse_rule(p)

--- a/crates/biome_css_parser/src/syntax/mod.rs
+++ b/crates/biome_css_parser/src/syntax/mod.rs
@@ -12,12 +12,12 @@ use crate::syntax::css_dimension::{is_at_any_dimension, parse_any_dimension};
 use crate::syntax::parse_error::expected_any_rule;
 use crate::syntax::parse_error::expected_expression;
 use crate::syntax::parse_error::expected_identifier;
-use crate::syntax::selector::SelectorList;
 use crate::syntax::selector::is_at_selector;
+use crate::syntax::selector::SelectorList;
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::parse_lists::{ParseNodeList, ParseSeparatedList};
-use biome_parser::parse_recovery::{ParseRecoveryTokenSet, ParseRecovery, RecoveryResult};
+use biome_parser::parse_recovery::{ParseRecovery, ParseRecoveryTokenSet, RecoveryResult};
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 use biome_parser::{token_set, Parser, TokenSet};
@@ -96,11 +96,7 @@ impl ParseNodeList for RuleList {
         p: &mut Self::Parser<'_>,
         parsed_element: ParsedSyntax,
     ) -> RecoveryResult {
-        parsed_element.or_recover(
-            p,
-            &RuleListParseRecovery,
-            expected_any_rule,
-        )
+        parsed_element.or_recover(p, &RuleListParseRecovery, expected_any_rule)
     }
 }
 

--- a/crates/biome_css_parser/src/syntax/selector/attribute.rs
+++ b/crates/biome_css_parser/src/syntax/selector/attribute.rs
@@ -7,7 +7,7 @@ use crate::syntax::{is_at_identifier, parse_regular_identifier, parse_string};
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::diagnostic::expected_token;
-use biome_parser::parse_recovery::ParseRecovery;
+use biome_parser::parse_recovery::ParseRecoveryTokenSet;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 use biome_parser::{token_set, Parser, TokenSet};
@@ -31,7 +31,7 @@ pub(crate) fn parse_attribute_selector(p: &mut CssParser) -> ParsedSyntax {
 
     let context = selector_lex_context(p);
     if !p.eat_with_context(T![']'], context)
-        && ParseRecovery::new(CSS_BOGUS, ATTRIBUTE_SELECTOR_RECOVERY_SET)
+        && ParseRecoveryTokenSet::new(CSS_BOGUS, ATTRIBUTE_SELECTOR_RECOVERY_SET)
             .recover(p)
             .is_err()
     {

--- a/crates/biome_css_parser/src/syntax/selector/mod.rs
+++ b/crates/biome_css_parser/src/syntax/selector/mod.rs
@@ -18,7 +18,7 @@ use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, TextRange, T};
 use biome_parser::diagnostic::ToDiagnostic;
 use biome_parser::parse_lists::{ParseNodeList, ParseSeparatedList};
-use biome_parser::parse_recovery::{ParseRecovery, RecoveryError, RecoveryResult};
+use biome_parser::parse_recovery::{ParseRecoveryTokenSet, RecoveryError, RecoveryResult};
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 use biome_parser::{token_set, CompletedMarker, Parser, ParserProgress, TokenSet};
@@ -37,21 +37,21 @@ fn selector_lex_context(p: &mut CssParser) -> CssLexContext {
     }
 }
 
-pub(crate) struct CssSelectorList {
+pub(crate) struct SelectorList {
     end_kind_ts: TokenSet<CssSyntaxKind>,
     is_recovery_disabled: bool,
 }
 
-impl Default for CssSelectorList {
+impl Default for SelectorList {
     fn default() -> Self {
-        CssSelectorList {
+        SelectorList {
             end_kind_ts: token_set!(T!['{']),
             is_recovery_disabled: false,
         }
     }
 }
 
-impl CssSelectorList {
+impl SelectorList {
     pub(crate) fn with_end_kind_ts(mut self, end_kind_ts: TokenSet<CssSyntaxKind>) -> Self {
         self.end_kind_ts = end_kind_ts;
         self
@@ -68,7 +68,7 @@ impl CssSelectorList {
     }
 }
 
-impl ParseSeparatedList for CssSelectorList {
+impl ParseSeparatedList for SelectorList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
     const LIST_KIND: Self::Kind = CSS_SELECTOR_LIST;
@@ -90,9 +90,9 @@ impl ParseSeparatedList for CssSelectorList {
             p.error(expected_selector(p, p.cur_range()));
             Err(RecoveryError::RecoveryDisabled)
         } else {
-            parsed_element.or_recover(
+            parsed_element.or_recover_with_token_set(
                 p,
-                &ParseRecovery::new(CSS_BOGUS_SELECTOR, SELECTOR_RECOVERY_SET)
+                &ParseRecoveryTokenSet::new(CSS_BOGUS_SELECTOR, SELECTOR_RECOVERY_SET)
                     .enable_recovery_on_line_break(),
                 expected_selector,
             )
@@ -148,7 +148,7 @@ fn parse_complex_selector(p: &mut CssParser, mut left: CompletedMarker) -> Parse
 
 #[inline]
 fn is_at_compound_selector(p: &mut CssParser) -> bool {
-    p.at(T![&]) || is_at_simple_selector(p) || p.at_ts(CssSubSelectorList::START_SET)
+    p.at(T![&]) || is_at_simple_selector(p) || p.at_ts(SubSelectorList::START_SET)
 }
 #[inline]
 fn parse_compound_selector(p: &mut CssParser) -> ParsedSyntax {
@@ -160,7 +160,7 @@ fn parse_compound_selector(p: &mut CssParser) -> ParsedSyntax {
 
     p.eat(T![&]);
     parse_simple_selector(p).ok();
-    CssSubSelectorList.parse_list(p);
+    SubSelectorList.parse_list(p);
 
     Present(m.complete(p, CSS_COMPOUND_SELECTOR))
 }
@@ -229,12 +229,12 @@ fn parse_namespace_prefix(p: &mut CssParser) -> ParsedSyntax {
     Present(m.complete(p, kind))
 }
 
-pub(crate) struct CssSubSelectorList;
-impl CssSubSelectorList {
+pub(crate) struct SubSelectorList;
+impl SubSelectorList {
     pub(crate) const START_SET: TokenSet<CssSyntaxKind> =
         token_set![T![#], T![.], T![:], T![::], T!['[']];
 }
-impl ParseNodeList for CssSubSelectorList {
+impl ParseNodeList for SubSelectorList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
 
@@ -249,9 +249,9 @@ impl ParseNodeList for CssSubSelectorList {
     }
 
     fn recover(&mut self, p: &mut CssParser, parsed_element: ParsedSyntax) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(CSS_BOGUS_SUB_SELECTOR, Self::START_SET),
+            &ParseRecoveryTokenSet::new(CSS_BOGUS_SUB_SELECTOR, Self::START_SET),
             expected_any_sub_selector,
         )
     }
@@ -358,7 +358,7 @@ where
     if p.eat_with_context(T![')'], context) {
         true
     } else {
-        if let Ok(m) = ParseRecovery::new(CSS_BOGUS, SELECTOR_FUNCTION_RECOVERY_SET)
+        if let Ok(m) = ParseRecoveryTokenSet::new(CSS_BOGUS, SELECTOR_FUNCTION_RECOVERY_SET)
             .enable_recovery_on_line_break()
             .recover(p)
         {
@@ -384,7 +384,7 @@ where
 {
     let start = p.cur_range().start();
 
-    let range = ParseRecovery::new(CSS_BOGUS, SELECTOR_FUNCTION_RECOVERY_SET)
+    let range = ParseRecoveryTokenSet::new(CSS_BOGUS, SELECTOR_FUNCTION_RECOVERY_SET)
         .enable_recovery_on_line_break()
         .recover(p)
         .map(|m| m.range(p))

--- a/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_compound_selector_list.rs
+++ b/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_compound_selector_list.rs
@@ -35,7 +35,7 @@ pub(crate) fn parse_pseudo_class_function_compound_selector_list(
     p.bump_ts(PSEUDO_CLASS_FUNCTION_COMPOUND_SELECTOR_LIST_SET);
     p.bump(T!['(']);
 
-    let list = CssCompoundSelectorList.parse_list(p);
+    let list = CompoundSelectorList.parse_list(p);
     let list_range = list.range(p);
 
     if list_range.is_empty() {
@@ -54,9 +54,9 @@ pub(crate) fn parse_pseudo_class_function_compound_selector_list(
     Present(m.complete(p, kind))
 }
 
-struct CssCompoundSelectorList;
+struct CompoundSelectorList;
 
-impl ParseSeparatedList for CssCompoundSelectorList {
+impl ParseSeparatedList for CompoundSelectorList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
 

--- a/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_nth.rs
+++ b/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_nth.rs
@@ -2,8 +2,7 @@ use crate::lexer::CssLexContext;
 use crate::parser::CssParser;
 use crate::syntax::parse_error::{expected_any_pseudo_class_nth, expected_number};
 use crate::syntax::selector::{
-    eat_or_recover_selector_function_close_token, recover_selector_function_parameter,
-    CssSelectorList,
+    eat_or_recover_selector_function_close_token, recover_selector_function_parameter, SelectorList,
 };
 use crate::syntax::{parse_number, parse_regular_number};
 use biome_css_syntax::CssSyntaxKind::*;
@@ -145,9 +144,7 @@ fn parse_pseudo_class_of_nth_selector(p: &mut CssParser) -> ParsedSyntax {
 
     p.bump(OF_KW);
 
-    CssSelectorList::default()
-        .with_end_kind(T![')'])
-        .parse_list(p);
+    SelectorList::default().with_end_kind(T![')']).parse_list(p);
 
     Present(m.complete(p, CSS_PSEUDO_CLASS_OF_NTH_SELECTOR))
 }

--- a/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_relative_selector_list.rs
+++ b/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_relative_selector_list.rs
@@ -36,7 +36,7 @@ pub(crate) fn parse_pseudo_class_function_relative_selector_list(
     p.bump_ts(PSEUDO_CLASS_FUNCTION_RELATIVE_SELECTOR_LIST_SET);
     p.bump(T!['(']);
 
-    let list = CssRelativeSelectorList.parse_list(p);
+    let list = RelativeSelectorList.parse_list(p);
     let list_range = list.range(p);
 
     if list_range.is_empty() && p.at(T![')']) {
@@ -55,9 +55,9 @@ pub(crate) fn parse_pseudo_class_function_relative_selector_list(
     Present(m.complete(p, kind))
 }
 
-struct CssRelativeSelectorList;
+struct RelativeSelectorList;
 
-impl ParseSeparatedList for CssRelativeSelectorList {
+impl ParseSeparatedList for RelativeSelectorList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
 

--- a/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_selector_list.rs
+++ b/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_selector_list.rs
@@ -1,6 +1,6 @@
 use crate::parser::CssParser;
 use crate::syntax::parse_error::expected_selector;
-use crate::syntax::selector::{eat_or_recover_selector_function_close_token, CssSelectorList};
+use crate::syntax::selector::{eat_or_recover_selector_function_close_token, SelectorList};
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::parse_lists::ParseSeparatedList;
@@ -27,7 +27,7 @@ pub(crate) fn parse_pseudo_class_function_selector_list(p: &mut CssParser) -> Pa
     p.bump_ts(PSEUDO_CLASS_FUNCTION_SELECTOR_LIST_SET);
     p.bump(T!['(']);
 
-    let list = CssSelectorList::default()
+    let list = SelectorList::default()
         .with_end_kind(T![')'])
         // we don't need to recover here, because we have a better diagnostic message in a close token
         .disable_recovery()

--- a/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_value_list.rs
+++ b/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_value_list.rs
@@ -28,7 +28,7 @@ pub(crate) fn parse_pseudo_class_function_value_list(p: &mut CssParser) -> Parse
     p.bump_ts(PSEUDO_CLASS_FUNCTION_VALUE_LIST_SET);
     p.bump(T!['(']);
 
-    let list = CssPseudoValueList.parse_list(p);
+    let list = PseudoValueList.parse_list(p);
     let list_range = list.range(p);
 
     if list_range.is_empty() {
@@ -47,9 +47,9 @@ pub(crate) fn parse_pseudo_class_function_value_list(p: &mut CssParser) -> Parse
     Present(m.complete(p, kind))
 }
 
-struct CssPseudoValueList;
+struct PseudoValueList;
 
-impl ParseSeparatedList for CssPseudoValueList {
+impl ParseSeparatedList for PseudoValueList {
     type Kind = CssSyntaxKind;
     type Parser<'source> = CssParser<'source>;
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_keyframes.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_keyframes.css.snap
@@ -279,74 +279,64 @@ CssRoot {
         },
         CssAtRule {
             at_token: AT@223..226 "@" [Newline("\n"), Newline("\n")] [],
-            rule: CssBogusAtRule {
-                items: [
-                    KEYFRAMES_KW@226..236 "keyframes" [] [Whitespace(" ")],
-                    CssCustomIdentifier {
-                        value_token: IDENT@236..244 "slidein" [] [Whitespace(" ")],
-                    },
-                    CssBogus {
-                        items: [
-                            L_CURLY@244..245 "{" [] [],
-                            CssBogus {
-                                items: [
-                                    CssBogus {
-                                        items: [
-                                            CssBogus {
-                                                items: [
-                                                    CSS_NUMBER_LITERAL@245..250 "100" [Newline("\n"), Whitespace("\t")] [],
-                                                    CssBogusSelector {
-                                                        items: [
-                                                            VH_KW@250..253 "vh" [] [Whitespace(" ")],
-                                                        ],
-                                                    },
-                                                ],
-                                            },
-                                            CssDeclarationListBlock {
-                                                l_curly_token: L_CURLY@253..254 "{" [] [],
-                                                declarations: CssDeclarationList [
-                                                    CssDeclaration {
-                                                        name: CssIdentifier {
-                                                            value_token: IDENT@254..266 "transform" [Newline("\n"), Whitespace("\t\t")] [],
-                                                        },
-                                                        colon_token: COLON@266..268 ":" [] [Whitespace(" ")],
-                                                        value: CssComponentValueList [
-                                                            CssSimpleFunction {
-                                                                name: CssIdentifier {
-                                                                    value_token: IDENT@268..278 "translateX" [] [],
-                                                                },
-                                                                l_paren_token: L_PAREN@278..279 "(" [] [],
-                                                                items: CssParameterList [
-                                                                    CssParameter {
-                                                                        any_css_expression: CssListOfComponentValuesExpression {
-                                                                            css_component_value_list: CssComponentValueList [
-                                                                                CssPercentage {
-                                                                                    value: CssNumber {
-                                                                                        value_token: CSS_NUMBER_LITERAL@279..280 "0" [] [],
-                                                                                    },
-                                                                                    reminder_token: PERCENT@280..281 "%" [] [],
-                                                                                },
-                                                                            ],
-                                                                        },
+            rule: CssKeyframesAtRule {
+                keyframes_token: KEYFRAMES_KW@226..236 "keyframes" [] [Whitespace(" ")],
+                name: CssCustomIdentifier {
+                    value_token: IDENT@236..244 "slidein" [] [Whitespace(" ")],
+                },
+                block: CssKeyframesBlock {
+                    l_curly_token: L_CURLY@244..245 "{" [] [],
+                    items: CssKeyframesItemList [
+                        CssKeyframesItem {
+                            selectors: CssKeyframesSelectorList [
+                                CssBogusSelector {
+                                    items: [
+                                        CSS_NUMBER_LITERAL@245..250 "100" [Newline("\n"), Whitespace("\t")] [],
+                                        VH_KW@250..253 "vh" [] [Whitespace(" ")],
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationListBlock {
+                                l_curly_token: L_CURLY@253..254 "{" [] [],
+                                declarations: CssDeclarationList [
+                                    CssDeclaration {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@254..266 "transform" [Newline("\n"), Whitespace("\t\t")] [],
+                                        },
+                                        colon_token: COLON@266..268 ":" [] [Whitespace(" ")],
+                                        value: CssComponentValueList [
+                                            CssSimpleFunction {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@268..278 "translateX" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@278..279 "(" [] [],
+                                                items: CssParameterList [
+                                                    CssParameter {
+                                                        any_css_expression: CssListOfComponentValuesExpression {
+                                                            css_component_value_list: CssComponentValueList [
+                                                                CssPercentage {
+                                                                    value: CssNumber {
+                                                                        value_token: CSS_NUMBER_LITERAL@279..280 "0" [] [],
                                                                     },
-                                                                ],
-                                                                r_paren_token: R_PAREN@281..282 ")" [] [],
-                                                            },
-                                                        ],
-                                                        important: missing (optional),
+                                                                    reminder_token: PERCENT@280..281 "%" [] [],
+                                                                },
+                                                            ],
+                                                        },
                                                     },
-                                                    SEMICOLON@282..283 ";" [] [],
                                                 ],
-                                                r_curly_token: R_CURLY@283..286 "}" [Newline("\n"), Whitespace("\t")] [],
+                                                r_paren_token: R_PAREN@281..282 ")" [] [],
                                             },
                                         ],
+                                        important: missing (optional),
                                     },
+                                    SEMICOLON@282..283 ";" [] [],
                                 ],
+                                r_curly_token: R_CURLY@283..286 "}" [Newline("\n"), Whitespace("\t")] [],
                             },
-                            R_CURLY@286..288 "}" [Newline("\n")] [],
-                        ],
-                    },
-                ],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@286..288 "}" [Newline("\n")] [],
+                },
             },
         },
         CssAtRule {
@@ -915,18 +905,18 @@ CssRoot {
           2: R_CURLY@221..223 "}" [Newline("\n")] []
     2: CSS_AT_RULE@223..288
       0: AT@223..226 "@" [Newline("\n"), Newline("\n")] []
-      1: CSS_BOGUS_AT_RULE@226..288
+      1: CSS_KEYFRAMES_AT_RULE@226..288
         0: KEYFRAMES_KW@226..236 "keyframes" [] [Whitespace(" ")]
         1: CSS_CUSTOM_IDENTIFIER@236..244
           0: IDENT@236..244 "slidein" [] [Whitespace(" ")]
-        2: CSS_BOGUS@244..288
+        2: CSS_KEYFRAMES_BLOCK@244..288
           0: L_CURLY@244..245 "{" [] []
-          1: CSS_BOGUS@245..286
-            0: CSS_BOGUS@245..286
-              0: CSS_BOGUS@245..253
-                0: CSS_NUMBER_LITERAL@245..250 "100" [Newline("\n"), Whitespace("\t")] []
-                1: CSS_BOGUS_SELECTOR@250..253
-                  0: VH_KW@250..253 "vh" [] [Whitespace(" ")]
+          1: CSS_KEYFRAMES_ITEM_LIST@245..286
+            0: CSS_KEYFRAMES_ITEM@245..286
+              0: CSS_KEYFRAMES_SELECTOR_LIST@245..253
+                0: CSS_BOGUS_SELECTOR@245..253
+                  0: CSS_NUMBER_LITERAL@245..250 "100" [Newline("\n"), Whitespace("\t")] []
+                  1: VH_KW@250..253 "vh" [] [Whitespace(" ")]
               1: CSS_DECLARATION_LIST_BLOCK@253..286
                 0: L_CURLY@253..254 "{" [] []
                 1: CSS_DECLARATION_LIST@254..283
@@ -1309,13 +1299,13 @@ at_rule_keyframes.css:18:10 parse ━━━━━━━━━━━━━━━�
   
   i Remove {
   
-at_rule_keyframes.css:24:5 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+at_rule_keyframes.css:24:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
   
     23 │ @keyframes slidein {
   > 24 │ 	100vh {
-       │ 	   ^^
+       │ 	^^^^^
     25 │ 		transform: translateX(0%);
     26 │ 	}
   

--- a/crates/biome_js_parser/src/lib.rs
+++ b/crates/biome_js_parser/src/lib.rs
@@ -138,7 +138,7 @@ pub use crate::{
 use biome_js_factory::JsSyntaxFactory;
 use biome_js_syntax::{JsLanguage, JsSyntaxKind, LanguageVariant};
 use biome_parser::tree_sink::LosslessTreeSink;
-pub(crate) use parser::{JsParser, ParseRecovery};
+pub(crate) use parser::{JsParser, ParseRecoveryTokenSet};
 pub(crate) use state::{ParserState, StrictMode};
 use std::fmt::Debug;
 

--- a/crates/biome_js_parser/src/parser.rs
+++ b/crates/biome_js_parser/src/parser.rs
@@ -8,7 +8,9 @@ pub(crate) mod rewrite_parser;
 pub(crate) mod single_token_parse_recovery;
 
 use crate::lexer::JsReLexContext;
-pub(crate) use crate::parser::parse_recovery::{ParseRecovery, RecoveryError, RecoveryResult};
+pub(crate) use crate::parser::parse_recovery::{
+    ParseRecoveryTokenSet, RecoveryError, RecoveryResult,
+};
 use crate::prelude::*;
 use crate::state::{ChangeParserState, ParserStateGuard};
 use crate::*;

--- a/crates/biome_js_parser/src/syntax/class.rs
+++ b/crates/biome_js_parser/src/syntax/class.rs
@@ -40,7 +40,7 @@ use biome_js_syntax::JsSyntaxKind::*;
 use biome_js_syntax::TextSize;
 use biome_js_syntax::{JsSyntaxKind, T};
 use biome_parser::parse_lists::ParseNodeList;
-use biome_parser::parse_recovery::ParseRecovery;
+use biome_parser::parse_recovery::ParseRecoveryTokenSet;
 use biome_parser::ParserProgress;
 use biome_rowan::{SyntaxKind, TextRange};
 use bitflags::bitflags;
@@ -479,9 +479,9 @@ impl ParseNodeList for ClassMembersList {
         //     let a=;
         //   };
         // };
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(
+            &ParseRecoveryTokenSet::new(
                 JS_BOGUS_MEMBER,
                 token_set![
                     T![;],

--- a/crates/biome_js_parser/src/syntax/function.rs
+++ b/crates/biome_js_parser/src/syntax/function.rs
@@ -23,7 +23,7 @@ use crate::syntax::typescript::{
 
 use crate::JsSyntaxFeature::TypeScript;
 use crate::ParsedSyntax::{Absent, Present};
-use crate::{JsParser, JsSyntaxFeature, ParseRecovery};
+use crate::{JsParser, JsSyntaxFeature, ParseRecoveryTokenSet};
 use biome_js_syntax::JsSyntaxKind::*;
 use biome_js_syntax::{JsSyntaxKind, TextRange, T};
 use biome_parser::ParserProgress;
@@ -1384,9 +1384,9 @@ pub(super) fn parse_parameters_list(
 
             // test_err js formal_params_invalid
             // function (a++, c) {}
-            let recovered_result = parameter.or_recover(
+            let recovered_result = parameter.or_recover_with_token_set(
                 p,
-                &ParseRecovery::new(
+                &ParseRecoveryTokenSet::new(
                     JS_BOGUS_PARAMETER,
                     token_set![
                         T![ident],

--- a/crates/biome_js_parser/src/syntax/jsx/mod.rs
+++ b/crates/biome_js_parser/src/syntax/jsx/mod.rs
@@ -17,7 +17,7 @@ use crate::syntax::jsx::jsx_parse_errors::{
 };
 use crate::syntax::typescript::TypeContext;
 use crate::JsSyntaxFeature::TypeScript;
-use crate::{parser::RecoveryResult, JsParser, ParseRecovery, ParsedSyntax};
+use crate::{parser::RecoveryResult, JsParser, ParseRecoveryTokenSet, ParsedSyntax};
 use crate::{Absent, Present};
 
 use super::typescript::parse_ts_type_arguments;
@@ -338,9 +338,9 @@ impl ParseNodeList for JsxChildrenList {
     }
 
     fn recover(&mut self, p: &mut JsParser, parsed_element: ParsedSyntax) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(
+            &ParseRecoveryTokenSet::new(
                 JsSyntaxKind::JS_BOGUS,
                 token_set![T![<], T![>], T!['{'], T!['}']],
             ),
@@ -504,9 +504,9 @@ impl ParseNodeList for JsxAttributeList {
     }
 
     fn recover(&mut self, p: &mut JsParser, parsed_element: ParsedSyntax) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(
+            &ParseRecoveryTokenSet::new(
                 JsSyntaxKind::JS_BOGUS,
                 token_set![T![/], T![>], T![<], T!['{'], T!['}'], T![...], T![ident]],
             ),

--- a/crates/biome_js_parser/src/syntax/module.rs
+++ b/crates/biome_js_parser/src/syntax/module.rs
@@ -29,7 +29,7 @@ use crate::syntax::typescript::{
     parse_ts_interface_declaration,
 };
 use crate::JsSyntaxFeature::TypeScript;
-use crate::{Absent, JsParser, ParseRecovery, ParsedSyntax, Present};
+use crate::{Absent, JsParser, ParseRecoveryTokenSet, ParsedSyntax, Present};
 use biome_js_syntax::JsSyntaxKind::*;
 use biome_js_syntax::{JsSyntaxKind, TextRange, T};
 use biome_parser::diagnostic::{expected_any, expected_node};
@@ -99,9 +99,9 @@ pub(crate) fn parse_module_item_list(
 
         let module_item = parse_module_item(p);
 
-        let recovered = module_item.or_recover(
+        let recovered = module_item.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(JS_BOGUS_STATEMENT, recovery_set),
+            &ParseRecoveryTokenSet::new(JS_BOGUS_STATEMENT, recovery_set),
             expected_statement,
         );
 
@@ -435,9 +435,9 @@ impl ParseSeparatedList for NamedImportSpecifierList {
     }
 
     fn recover(&mut self, p: &mut JsParser, parsed_element: ParsedSyntax) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(
+            &ParseRecoveryTokenSet::new(
                 JS_BOGUS_NAMED_IMPORT_SPECIFIER,
                 STMT_RECOVERY_SET.union(token_set![T![,], T!['}'], T![;]]),
             )
@@ -609,9 +609,9 @@ impl ParseSeparatedList for ImportAssertionList {
     }
 
     fn recover(&mut self, p: &mut JsParser, parsed_element: ParsedSyntax) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(
+            &ParseRecoveryTokenSet::new(
                 JS_BOGUS_IMPORT_ASSERTION_ENTRY,
                 STMT_RECOVERY_SET.union(token_set![T![,], T!['}']]),
             )
@@ -841,9 +841,9 @@ impl ParseSeparatedList for ExportNamedSpecifierList {
     }
 
     fn recover(&mut self, p: &mut JsParser, parsed_element: ParsedSyntax) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(
+            &ParseRecoveryTokenSet::new(
                 JS_BOGUS,
                 STMT_RECOVERY_SET.union(token_set![T![,], T!['}'], T![;]]),
             )
@@ -1132,9 +1132,9 @@ impl ParseSeparatedList for ExportNamedFromSpecifierList {
     }
 
     fn recover(&mut self, p: &mut JsParser, parsed_element: ParsedSyntax) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(
+            &ParseRecoveryTokenSet::new(
                 JS_BOGUS,
                 STMT_RECOVERY_SET.union(token_set![T![,], T!['}'], T![;]]),
             )

--- a/crates/biome_js_parser/src/syntax/object.rs
+++ b/crates/biome_js_parser/src/syntax/object.rs
@@ -22,7 +22,7 @@ use crate::syntax::typescript::{
     TypeContext,
 };
 use crate::JsSyntaxFeature::TypeScript;
-use crate::{JsParser, ParseRecovery};
+use crate::{JsParser, ParseRecoveryTokenSet};
 use biome_js_syntax::JsSyntaxKind::*;
 use biome_js_syntax::{JsSyntaxKind, T};
 use biome_parser::parse_lists::ParseSeparatedList;
@@ -53,9 +53,9 @@ impl ParseSeparatedList for ObjectMembersList {
     }
 
     fn recover(&mut self, p: &mut JsParser, parsed_element: ParsedSyntax) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(JS_BOGUS_MEMBER, token_set![T![,], T!['}'], T![;], T![:]])
+            &ParseRecoveryTokenSet::new(JS_BOGUS_MEMBER, token_set![T![,], T!['}'], T![;], T![:]])
                 .enable_recovery_on_line_break(),
             js_parse_error::expected_object_member,
         )

--- a/crates/biome_js_parser/src/syntax/stmt.rs
+++ b/crates/biome_js_parser/src/syntax/stmt.rs
@@ -29,7 +29,7 @@ use crate::syntax::typescript::ts_parse_error::{expected_ts_type, ts_only_syntax
 use crate::span::Span;
 use crate::JsSyntaxFeature::{StrictMode, TypeScript};
 use crate::ParsedSyntax::{Absent, Present};
-use crate::{parser, JsParser, JsSyntaxFeature, ParseRecovery};
+use crate::{parser, JsParser, JsSyntaxFeature, ParseRecoveryTokenSet};
 use biome_js_syntax::{JsSyntaxKind::*, *};
 use biome_parser::diagnostic::expected_token;
 use biome_parser::parse_lists::{ParseNodeList, ParseSeparatedList};
@@ -903,9 +903,9 @@ pub(crate) fn parse_statements(p: &mut JsParser, stop_on_r_curly: bool, statemen
         }
 
         if parse_statement(p, StatementContext::StatementList)
-            .or_recover(
+            .or_recover_with_token_set(
                 p,
-                &ParseRecovery::new(JS_BOGUS_STATEMENT, recovery_set),
+                &ParseRecoveryTokenSet::new(JS_BOGUS_STATEMENT, recovery_set),
                 expected_statement,
             )
             .is_err()
@@ -1270,9 +1270,9 @@ impl ParseSeparatedList for VariableDeclaratorList {
     }
 
     fn recover(&mut self, p: &mut JsParser, parsed_element: ParsedSyntax) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(JS_BOGUS, STMT_RECOVERY_SET.union(token_set!(T![,])))
+            &ParseRecoveryTokenSet::new(JS_BOGUS, STMT_RECOVERY_SET.union(token_set!(T![,])))
                 .enable_recovery_on_line_break(),
             expected_binding,
         )
@@ -1804,9 +1804,9 @@ impl ParseNodeList for SwitchCaseStatementList {
         p: &mut JsParser,
         parsed_element: ParsedSyntax,
     ) -> parser::RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(JS_BOGUS_STATEMENT, STMT_RECOVERY_SET),
+            &ParseRecoveryTokenSet::new(JS_BOGUS_STATEMENT, STMT_RECOVERY_SET),
             js_parse_error::expected_case,
         )
     }
@@ -1898,9 +1898,9 @@ impl ParseNodeList for SwitchCasesList {
             let m = p.start();
             let statements = p.start();
 
-            let recovered_element = parsed_element.or_recover(
+            let recovered_element = parsed_element.or_recover_with_token_set(
                 p,
-                &ParseRecovery::new(
+                &ParseRecoveryTokenSet::new(
                     JS_BOGUS_STATEMENT,
                     token_set![T![default], T![case], T!['}']],
                 )

--- a/crates/biome_js_parser/src/syntax/typescript/statement.rs
+++ b/crates/biome_js_parser/src/syntax/typescript/statement.rs
@@ -17,7 +17,7 @@ use crate::syntax::typescript::{
     expect_ts_type_list, parse_ts_identifier_binding, parse_ts_implements_clause, parse_ts_name,
     parse_ts_type, parse_ts_type_parameters, TypeContext, TypeMembers,
 };
-use crate::{syntax, Absent, JsParser, ParseRecovery, ParsedSyntax, Present};
+use crate::{syntax, Absent, JsParser, ParseRecoveryTokenSet, ParsedSyntax, Present};
 use biome_js_syntax::{JsSyntaxKind::*, *};
 use biome_parser::diagnostic::expected_token;
 use biome_parser::parse_lists::{ParseNodeList, ParseSeparatedList};
@@ -87,9 +87,9 @@ impl ParseSeparatedList for TsEnumMembersList {
     }
 
     fn recover(&mut self, p: &mut JsParser, parsed_element: ParsedSyntax) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(
+            &ParseRecoveryTokenSet::new(
                 JS_BOGUS_MEMBER,
                 STMT_RECOVERY_SET.union(token_set![JsSyntaxKind::IDENT, T![,], T!['}']]),
             )

--- a/crates/biome_js_parser/src/syntax/typescript/types.rs
+++ b/crates/biome_js_parser/src/syntax/typescript/types.rs
@@ -33,7 +33,7 @@ use crate::lexer::{JsLexContext, JsReLexContext};
 use crate::span::Span;
 use crate::syntax::class::parse_decorators;
 use crate::JsSyntaxFeature::TypeScript;
-use crate::{Absent, JsParser, ParseRecovery, ParsedSyntax, Present};
+use crate::{Absent, JsParser, ParseRecoveryTokenSet, ParsedSyntax, Present};
 use biome_js_syntax::JsSyntaxKind::TS_TYPE_ANNOTATION;
 use biome_js_syntax::T;
 use biome_js_syntax::{JsSyntaxKind::*, *};
@@ -230,9 +230,9 @@ impl ParseSeparatedList for TsTypeParameterList {
     }
 
     fn recover(&mut self, p: &mut JsParser, parsed_element: ParsedSyntax) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(
+            &ParseRecoveryTokenSet::new(
                 TS_BOGUS_TYPE,
                 token_set![T![>], T![,], T![ident], T![yield], T![await]],
             )
@@ -1185,9 +1185,9 @@ impl ParseNodeList for TypeMembers {
     }
 
     fn recover(&mut self, p: &mut JsParser, member: ParsedSyntax) -> RecoveryResult {
-        member.or_recover(
+        member.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(JS_BOGUS, token_set![T!['}'], T![,], T![;]])
+            &ParseRecoveryTokenSet::new(JS_BOGUS, token_set![T!['}'], T![,], T![;]])
                 .enable_recovery_on_line_break(),
             expected_property_or_signature,
         )
@@ -1463,9 +1463,9 @@ impl ParseSeparatedList for TsTupleTypeElementList {
     }
 
     fn recover(&mut self, p: &mut JsParser, parsed_element: ParsedSyntax) -> RecoveryResult {
-        parsed_element.or_recover(
+        parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecovery::new(
+            &ParseRecoveryTokenSet::new(
                 TS_BOGUS_TYPE,
                 token_set![
                     T![']'],
@@ -2109,9 +2109,9 @@ impl ParseSeparatedList for TypeArgumentsList {
             // The parser shouldn't perform error recovery in that case and simply bail out of parsing
             RecoveryResult::Err(RecoveryError::AlreadyRecovered)
         } else {
-            parsed_element.or_recover(
+            parsed_element.or_recover_with_token_set(
                 p,
-                &ParseRecovery::new(
+                &ParseRecoveryTokenSet::new(
                     TS_BOGUS_TYPE,
                     token_set![T![>], T![,], T![ident], T![yield], T![await]],
                 )

--- a/crates/biome_json_parser/src/syntax.rs
+++ b/crates/biome_json_parser/src/syntax.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use biome_json_syntax::JsonSyntaxKind;
 use biome_json_syntax::JsonSyntaxKind::*;
 use biome_parser::diagnostic::{expected_any, expected_node};
-use biome_parser::parse_recovery::ParseRecovery;
+use biome_parser::parse_recovery::ParseRecoveryTokenSet;
 use biome_parser::parsed_syntax::ParsedSyntax::Absent;
 use biome_parser::prelude::ParsedSyntax::Present;
 use biome_parser::ParserProgress;
@@ -29,7 +29,7 @@ pub(crate) fn parse_root(p: &mut JsonParser) {
         Present(value) => Present(value),
         Absent => {
             p.error(expected_value(p, p.cur_range()));
-            match ParseRecovery::new(JSON_BOGUS_VALUE, VALUE_START).recover(p) {
+            match ParseRecoveryTokenSet::new(JSON_BOGUS_VALUE, VALUE_START).recover(p) {
                 Ok(value) => Present(value),
                 Err(_) => Absent,
             }
@@ -189,7 +189,7 @@ fn parse_sequence(p: &mut JsonParser, root_kind: SequenceKind) -> ParsedSyntax {
                     let range = if p.at(T![,]) {
                         p.cur_range()
                     } else {
-                        match ParseRecovery::new(JSON_BOGUS_VALUE, current.recovery_set())
+                        match ParseRecoveryTokenSet::new(JSON_BOGUS_VALUE, current.recovery_set())
                             .enable_recovery_on_line_break()
                             .recover(p)
                         {
@@ -317,7 +317,7 @@ fn parse_rest(p: &mut JsonParser, value: ParsedSyntax) {
     while !p.at(EOF) {
         let range = match parse_value(p) {
             Present(value) => value.range(p),
-            Absent => ParseRecovery::new(JSON_BOGUS_VALUE, VALUE_START)
+            Absent => ParseRecoveryTokenSet::new(JSON_BOGUS_VALUE, VALUE_START)
                 .recover(p)
                 .expect("Expect recovery to succeed because parser isn't at EOF nor at a value.")
                 .range(p),

--- a/crates/biome_parser/src/lib.rs
+++ b/crates/biome_parser/src/lib.rs
@@ -145,7 +145,7 @@
 //!     ) -> parser::RecoveryResult {
 //!         parsed_element.or_recover(
 //!             p,
-//!             &ParseRecovery::new(JS_BOGUS_STATEMENT, STMT_RECOVERY_SET),
+//!             &ParseRecoveryTokenSet::new(JS_BOGUS_STATEMENT, STMT_RECOVERY_SET),
 //!             js_parse_error::expected_case,
 //!         )
 //!     }
@@ -157,7 +157,7 @@
 //! ```rust, ignore
 //! parsed_element.or_recover(
 //!     p,
-//!     &ParseRecovery::new(JS_BOGUS_STATEMENT, STMT_RECOVERY_SET),
+//!     &ParseRecoveryTokenSet::new(JS_BOGUS_STATEMENT, STMT_RECOVERY_SET),
 //!     js_parse_error::expected_case,
 //! )
 //! ```


### PR DESCRIPTION
## Summary

Introducing the `ParseRecovery` trait. It has the same syntax as `ParseSeparatedList` or `ParseNodeList`.
This trait allows the use of a parser inside the recovery function. For example, we can use at_something functions or look beyond just the current token.

```
pub trait ParseRecovery {
    type Kind: SyntaxKind;
    type Parser<'source>: Parser<Kind = Self::Kind>;

    /// The kind of the recovered node
    const RECOVERED_KIND: Self::Kind;

    /// Checks if the parser is in a recovered state.
    fn is_at_recovered(&self, p: &mut Self::Parser<'_>) -> bool;
}
```

I've tried to implement `ParseRecovery` trait for `ParseRecoveryTokenSet`, however it requires too many changes. If you have any ideas for to do it feel free to help.

## Test Plan

`cargo test`
