### PR TITLE
Fix missing word in use-exhaustive-dependencies.md

### DIFF
--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
@@ -155,7 +155,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    /// Given the previous example, your hooks be used like this:
+    /// Given the previous example, your hooks can be used like this:
     ///
     /// ```js
     /// function Foo() {

--- a/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
+++ b/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
@@ -234,7 +234,7 @@ Allows to specify custom hooks - from libraries or internal projects - that can 
 }
 ```
 
-Given the previous example, your hooks be used like this:
+Given the previous example, your hooks can be used like this:
 
 ```jsx
 function Foo() {


### PR DESCRIPTION
- Add the missing word 'can' in paragraph
- Ensure the sentence now reads correctly
