### PR TITLE
fix(lsp): correctly infer file source from un-named files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,7 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
 #### Bug fixes
 
 - Fix [#933](https://github.com/biomejs/biome/issues/933). Some files are properly ignored in the LSP too. E.g. `package.json`, `tsconfig.json`, etc.
+- Fix [#1394](https://github.com/biomejs/biome/issues/1394), by inferring the language extension from the internal saved files. Now newly created files JavaScript correctly show diagnostics.
 
 ### Formatter
 

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -193,7 +193,7 @@ fn debug_formatter_ir(
     Ok(root_element.to_string())
 }
 
-#[tracing::instrument(level = "debug", skip(parse))]
+#[tracing::instrument(level = "debug", skip(parse, settings))]
 fn format(
     rome_path: &RomePath,
     parse: AnyParse,
@@ -261,90 +261,94 @@ fn format_on_type(
     Ok(printed)
 }
 fn lint(params: LintParams) -> LintResults {
-    tracing::debug_span!("lint").in_scope(move || {
-        let root: JsonRoot = params.parse.tree();
-        let mut diagnostics = params.parse.into_diagnostics();
+    tracing::debug_span!("Linting JSON file", path =? params.path, language =? params.language)
+        .in_scope(move || {
+            let root: JsonRoot = params.parse.tree();
+            let mut diagnostics = params.parse.into_diagnostics();
 
-        // if we're parsing the `biome.json` file, we deserialize it, so we can emit diagnostics for
-        // malformed configuration
-        if params.path.ends_with(ROME_JSON) || params.path.ends_with(BIOME_JSON) {
-            let deserialized = deserialize_from_json_ast::<Configuration>(&root);
+            // if we're parsing the `biome.json` file, we deserialize it, so we can emit diagnostics for
+            // malformed configuration
+            if params.path.ends_with(ROME_JSON) || params.path.ends_with(BIOME_JSON) {
+                let deserialized = deserialize_from_json_ast::<Configuration>(&root);
+                diagnostics.extend(
+                    deserialized
+                        .into_diagnostics()
+                        .into_iter()
+                        .map(biome_diagnostics::serde::Diagnostic::new)
+                        .collect::<Vec<_>>(),
+                );
+            }
+
+            let mut diagnostic_count = diagnostics.len() as u64;
+            let mut errors = diagnostics
+                .iter()
+                .filter(|diag| diag.severity() <= Severity::Error)
+                .count();
+
+            let skipped_diagnostics = diagnostic_count - diagnostics.len() as u64;
+
+            let has_lint = params.filter.categories.contains(RuleCategories::LINT);
+            let analyzer_options =
+                compute_analyzer_options(&params.settings, PathBuf::from(params.path.as_path()));
+
+            let (_, analyze_diagnostics) =
+                analyze(&root, params.filter, &analyzer_options, |signal| {
+                    if let Some(mut diagnostic) = signal.diagnostic() {
+                        // Do not report unused suppression comment diagnostics if this is a syntax-only analyzer pass
+                        if !has_lint
+                            && diagnostic.category() == Some(category!("suppressions/unused"))
+                        {
+                            return ControlFlow::<Never>::Continue(());
+                        }
+
+                        diagnostic_count += 1;
+
+                        // We do now check if the severity of the diagnostics should be changed.
+                        // The configuration allows to change the severity of the diagnostics emitted by rules.
+                        let severity = diagnostic
+                            .category()
+                            .filter(|category| category.name().starts_with("lint/"))
+                            .map(|category| {
+                                params
+                                    .rules
+                                    .and_then(|rules| rules.get_severity_from_code(category))
+                                    .unwrap_or(Severity::Warning)
+                            })
+                            .unwrap_or_else(|| diagnostic.severity());
+
+                        if severity <= Severity::Error {
+                            errors += 1;
+                        }
+
+                        if diagnostic_count <= params.max_diagnostics {
+                            for action in signal.actions() {
+                                if !action.is_suppression() {
+                                    diagnostic = diagnostic.add_code_suggestion(action.into());
+                                }
+                            }
+
+                            let error = diagnostic.with_severity(severity);
+
+                            diagnostics.push(biome_diagnostics::serde::Diagnostic::new(error));
+                        }
+                    }
+
+                    ControlFlow::<Never>::Continue(())
+                });
+
             diagnostics.extend(
-                deserialized
-                    .into_diagnostics()
+                analyze_diagnostics
                     .into_iter()
                     .map(biome_diagnostics::serde::Diagnostic::new)
                     .collect::<Vec<_>>(),
             );
-        }
 
-        let mut diagnostic_count = diagnostics.len() as u64;
-        let mut errors = diagnostics
-            .iter()
-            .filter(|diag| diag.severity() <= Severity::Error)
-            .count();
-
-        let skipped_diagnostics = diagnostic_count - diagnostics.len() as u64;
-
-        let has_lint = params.filter.categories.contains(RuleCategories::LINT);
-        let analyzer_options =
-            compute_analyzer_options(&params.settings, PathBuf::from(params.path.as_path()));
-
-        let (_, analyze_diagnostics) = analyze(&root, params.filter, &analyzer_options, |signal| {
-            if let Some(mut diagnostic) = signal.diagnostic() {
-                // Do not report unused suppression comment diagnostics if this is a syntax-only analyzer pass
-                if !has_lint && diagnostic.category() == Some(category!("suppressions/unused")) {
-                    return ControlFlow::<Never>::Continue(());
-                }
-
-                diagnostic_count += 1;
-
-                // We do now check if the severity of the diagnostics should be changed.
-                // The configuration allows to change the severity of the diagnostics emitted by rules.
-                let severity = diagnostic
-                    .category()
-                    .filter(|category| category.name().starts_with("lint/"))
-                    .map(|category| {
-                        params
-                            .rules
-                            .and_then(|rules| rules.get_severity_from_code(category))
-                            .unwrap_or(Severity::Warning)
-                    })
-                    .unwrap_or_else(|| diagnostic.severity());
-
-                if severity <= Severity::Error {
-                    errors += 1;
-                }
-
-                if diagnostic_count <= params.max_diagnostics {
-                    for action in signal.actions() {
-                        if !action.is_suppression() {
-                            diagnostic = diagnostic.add_code_suggestion(action.into());
-                        }
-                    }
-
-                    let error = diagnostic.with_severity(severity);
-
-                    diagnostics.push(biome_diagnostics::serde::Diagnostic::new(error));
-                }
+            LintResults {
+                diagnostics,
+                errors,
+                skipped_diagnostics,
             }
-
-            ControlFlow::<Never>::Continue(())
-        });
-
-        diagnostics.extend(
-            analyze_diagnostics
-                .into_iter()
-                .map(biome_diagnostics::serde::Diagnostic::new)
-                .collect::<Vec<_>>(),
-        );
-
-        LintResults {
-            diagnostics,
-            errors,
-            skipped_diagnostics,
-        }
-    })
+        })
 }
 fn code_actions(
     _parse: AnyParse,

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -14,7 +14,7 @@ use biome_console::markup;
 use biome_diagnostics::{Diagnostic, Severity};
 use biome_formatter::Printed;
 use biome_fs::RomePath;
-use biome_js_syntax::{TextRange, TextSize};
+use biome_js_syntax::{JsFileSource, TextRange, TextSize};
 use biome_parser::AnyParse;
 use biome_rowan::NodeCache;
 pub use javascript::JsFormatterSettings;
@@ -162,6 +162,16 @@ impl Language {
     pub const fn is_css_like(&self) -> bool {
         matches!(self, Language::Css)
     }
+
+    pub fn as_js_file_source(&self) -> Option<JsFileSource> {
+        match self {
+            Language::JavaScript => Some(JsFileSource::js_module()),
+            Language::JavaScriptReact => Some(JsFileSource::jsx()),
+            Language::TypeScript => Some(JsFileSource::tsx()),
+            Language::TypeScriptReact => Some(JsFileSource::tsx()),
+            Language::Json | Language::Jsonc | Language::Css | Language::Unknown => None,
+        }
+    }
 }
 
 impl biome_console::fmt::Display for Language {
@@ -252,6 +262,7 @@ pub(crate) struct LintParams<'a> {
     pub(crate) filter: AnalysisFilter<'a>,
     pub(crate) rules: Option<&'a Rules>,
     pub(crate) settings: SettingsHandle<'a>,
+    pub(crate) language: Language,
     pub(crate) max_diagnostics: u64,
     pub(crate) path: &'a RomePath,
 }

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -29,7 +29,7 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use std::ffi::OsStr;
 use std::path::Path;
 use std::{panic::RefUnwindSafe, sync::RwLock};
-use tracing::{info_span, trace};
+use tracing::{debug, info, info_span, trace};
 
 pub(super) struct WorkspaceServer {
     /// features available throughout the application
@@ -87,6 +87,7 @@ impl WorkspaceServer {
     fn get_file_capabilities(&self, path: &RomePath) -> Capabilities {
         let language = self.get_language(path);
 
+        debug!("File capabilities: {:?} {:?}", &language, &path);
         self.features.get_capabilities(path, language)
     }
 
@@ -455,6 +456,7 @@ impl Workspace for WorkspaceServer {
     }
 
     /// Retrieves the list of diagnostics associated with a file
+    #[tracing::instrument(level = "debug", skip(self))]
     fn pull_diagnostics(
         &self,
         params: PullDiagnosticsParams,
@@ -491,6 +493,7 @@ impl Workspace for WorkspaceServer {
                     settings: self.settings(),
                     max_diagnostics: params.max_diagnostics,
                     path: &params.path,
+                    language: self.get_language(&params.path),
                 });
 
                 (
@@ -509,6 +512,7 @@ impl Workspace for WorkspaceServer {
             (parse_diagnostics, errors, 0)
         };
 
+        info!("Pulled {:?} diagnostic(s)", diagnostics.len());
         Ok(PullDiagnosticsResult {
             diagnostics: diagnostics
                 .into_iter()
@@ -524,6 +528,7 @@ impl Workspace for WorkspaceServer {
 
     /// Retrieves the list of code actions available for a given cursor
     /// position within a file
+    #[tracing::instrument(level = "debug", skip(self))]
     fn pull_actions(&self, params: PullActionsParams) -> Result<PullActionsResult, WorkspaceError> {
         let capabilities = self.get_file_capabilities(&params.path);
         let code_actions = capabilities

--- a/justfile
+++ b/justfile
@@ -19,16 +19,16 @@ upgrade-tools:
 	cargo binstall cargo-insta cargo-nextest taplo-cli wasm-pack wasm-tools cargo-workspaces --force
 
 # Generate all files across crates and tools. You rarely want to use it locally.
-codegen:
+gen:
   cargo codegen all
   cargo codegen-configuration
   cargo lintdoc
-  just codegen-bindings
-  cargo codegen-website
+  just gen-bindings
+  jest gen-web
   cargo format
 
 # Generates TypeScript types and JSON schema of the configuration
-codegen-bindings:
+gen-bindings:
   cargo codegen-schema
   cargo codegen-bindings
 
@@ -36,7 +36,7 @@ codegen-bindings:
 gen-lint:
   cargo codegen analyzer
   cargo codegen-configuration
-  just codegen-bindings
+  just gen-bindings
   cargo lintdoc
 
 # Generates code generated files for the website

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -285,6 +285,7 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
 #### Bug fixes
 
 - Fix [#933](https://github.com/biomejs/biome/issues/933). Some files are properly ignored in the LSP too. E.g. `package.json`, `tsconfig.json`, etc.
+- Fix [#1394](https://github.com/biomejs/biome/issues/1394), by inferring the language extension from the internal saved files. Now newly created files JavaScript correctly show diagnostics.
 
 ### Formatter
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/1394

Newly created files weren't correctly processed when calling the analyzer from the LSP. The reason why this wasn't working anymore is because:
- Some time ago we changed the JavaScript analyzer to accept the `JsFileSource`, which tells what kind of JavaScript file we are processing (JS, JSX, TS, etc.). The analyser changed to default to zero diagnostics in case we couldn't compute the `JsFileSource` from the file path. This broke the LSP when the LSP analyzed untitled files.
- We didn't have a test to check these cases

Untitled files are saved and updated by using the actions `textDocument/didOpen` and `textDocument/didChange`, that's where we keep track of their language.

Now when pulling diagnostics and computing `JsFileSource`, we:
- try to compute it from the file path;
- if we fail, we compute it from the language hint;
- if we fail, we return 0 diagnostics

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test

<!-- What demonstrates that your implementation is correct? -->
