### PR TITLE
feat(lint/useFilenamingConvention): allow PascalCase in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,14 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
   +
   ```
 
+- [useFilenamingConvention](https://biomejs.dev/linter/rules/use-filenaming-convention) accepts `PascalCase` in its configuration.
+
+  By default, the rule enforces that the filename is either in [`camelCase`], [`kebab-case`], [`snake_case`], or equal to the name of one export in the file.
+  The rule now accepts `PascalCase`.
+
+  Contributed by @Conaclos
+  Address [#1409](https://github.com/biomejs/biome/discussions/1409).
+
 - The code action (fix) of [noMultipleSpacesInRegularExpressionLiterals](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals/) is now marked as safe. Contributed by @Conaclos
 
 #### Bug fixes

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_filenaming_convention.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_filenaming_convention.rs
@@ -58,11 +58,12 @@ declare_rule! {
     /// By default, the rule enforces that the filename  is either in [`camelCase`], [`kebab-case`], [`snake_case`], or equal to the name of one export in the file.
     ///
     /// You can enforce a stricter convention by setting `filenameCases` option.
-    /// `filenameCases` accepts an array of cases among the following cases: [`camelCase`], [`kebab-case`], [`snake_case`], and `export`.
+    /// `filenameCases` accepts an array of cases among the following cases: [`camelCase`], [`kebab-case`], [`PascalCase`], [`snake_case`], and `export`.
     ///
     /// [case]: https://en.wikipedia.org/wiki/Naming_convention_(programming)#Examples_of_multiple-word_identifier_formats
     /// [`camelCase`]: https://en.wikipedia.org/wiki/Camel_case
     /// [`kebab-case`]: https://en.wikipedia.org/wiki/Letter_case#Kebab_case
+    /// [`PascalCase`]: https://en.wikipedia.org/wiki/Camel_case
     /// [`snake_case`]: https://en.wikipedia.org/wiki/Snake_case
     pub(crate) UseFilenamingConvention {
         version: "next",
@@ -234,7 +235,7 @@ const fn is_default_strict_case(strict_case: &bool) -> bool {
 }
 
 fn is_default_filename_cases(value: &FilenameCases) -> bool {
-    value.0.len() == 4
+    value.0.len() == 4 && !value.0.contains(&FilenameCase::Pascal)
 }
 
 impl Default for FilenamingConventionOptions {
@@ -367,13 +368,22 @@ pub enum FilenameCase {
     Kebab,
 
     /// PascalCase
+    #[serde(rename = "PascalCase")]
+    Pascal,
+
+    /// snake_case
     #[serde(rename = "snake_case")]
     Snake,
 }
 
 impl FilenameCase {
-    pub const ALLOWED_VARIANTS: &'static [&'static str] =
-        &["camelCase", "export", "kebab-case", "snake_case"];
+    pub const ALLOWED_VARIANTS: &'static [&'static str] = &[
+        "camelCase",
+        "export",
+        "kebab-case",
+        "PascalCase",
+        "snake_case",
+    ];
 }
 
 impl FromStr for FilenameCase {
@@ -384,6 +394,7 @@ impl FromStr for FilenameCase {
             "camelCase" => Ok(Self::Camel),
             "export" => Ok(Self::Export),
             "kebab-case" => Ok(Self::Kebab),
+            "PascalCase" => Ok(Self::Pascal),
             "snake_case" => Ok(Self::Snake),
             _ => Err("Value not supported for enum member case"),
         }
@@ -396,7 +407,6 @@ impl Deserializable for FilenameCase {
         name: &str,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<Self> {
-        const ALLOWED_VARIANTS: &[&str] = &["camelCase", "export", "kebab-case", "snake_case"];
         let value_text = Text::deserialize(value, name, diagnostics)?;
         if let Ok(value) = value_text.parse::<Self>() {
             Some(value)
@@ -404,7 +414,7 @@ impl Deserializable for FilenameCase {
             diagnostics.push(DeserializationDiagnostic::new_unknown_value(
                 value_text.text(),
                 value.range(),
-                ALLOWED_VARIANTS,
+                Self::ALLOWED_VARIANTS,
             ));
             None
         }
@@ -419,6 +429,7 @@ impl TryFrom<FilenameCase> for Case {
             FilenameCase::Camel => Ok(Self::Camel),
             FilenameCase::Export => Err("`export` is not a valid case"),
             FilenameCase::Kebab => Ok(Self::Kebab),
+            FilenameCase::Pascal => Ok(Self::Pascal),
             FilenameCase::Snake => Ok(Self::Snake),
         }
     }

--- a/crates/biome_js_analyze/tests/specs/nursery/useFilenamingConvention/ValidPascalCase.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useFilenamingConvention/ValidPascalCase.js.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ValidPascalCase.js
+---
+# Input
+```js
+
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/useFilenamingConvention/ValidPascalCase.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useFilenamingConvention/ValidPascalCase.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useFilenamingConvention": {
+					"level": "error",
+					"options": {
+						"filenameCases": ["PascalCase"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1455,7 +1455,12 @@ export type EnumMemberCase = "PascalCase" | "CONSTANT_CASE" | "camelCase";
 /**
  * Supported cases for TypeScript `enum` member names.
  */
-export type FilenameCase = "camelCase" | "export" | "kebab-case" | "snake_case";
+export type FilenameCase =
+	| "camelCase"
+	| "export"
+	| "kebab-case"
+	| "PascalCase"
+	| "snake_case";
 export interface ProjectFeaturesParams {
 	manifest_path: RomePath;
 }

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -826,6 +826,11 @@
 				{
 					"description": "PascalCase",
 					"type": "string",
+					"enum": ["PascalCase"]
+				},
+				{
+					"description": "snake_case",
+					"type": "string",
 					"enum": ["snake_case"]
 				}
 			]

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -178,6 +178,14 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
   +
   ```
 
+- [useFilenamingConvention](https://biomejs.dev/linter/rules/use-filenaming-convention) accepts `PascalCase` in its configuration.
+
+  By default, the rule enforces that the filename is either in [`camelCase`], [`kebab-case`], [`snake_case`], or equal to the name of one export in the file.
+  The rule now accepts `PascalCase`.
+
+  Contributed by @Conaclos
+  Address [#1409](https://github.com/biomejs/biome/discussions/1409).
+
 - The code action (fix) of [noMultipleSpacesInRegularExpressionLiterals](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals/) is now marked as safe. Contributed by @Conaclos
 
 #### Bug fixes

--- a/website/src/content/docs/linter/rules/use-filenaming-convention.md
+++ b/website/src/content/docs/linter/rules/use-filenaming-convention.md
@@ -51,7 +51,7 @@ Default: `true`
 By default, the rule enforces that the filename  is either in [`camelCase`](https://en.wikipedia.org/wiki/Camel_case), [`kebab-case`](https://en.wikipedia.org/wiki/Letter_case#Kebab_case), [`snake_case`](https://en.wikipedia.org/wiki/Snake_case), or equal to the name of one export in the file.
 
 You can enforce a stricter convention by setting `filenameCases` option.
-`filenameCases` accepts an array of cases among the following cases: [`camelCase`](https://en.wikipedia.org/wiki/Camel_case), [`kebab-case`](https://en.wikipedia.org/wiki/Letter_case#Kebab_case), [`snake_case`](https://en.wikipedia.org/wiki/Snake_case), and `export`.
+`filenameCases` accepts an array of cases among the following cases: [`camelCase`](https://en.wikipedia.org/wiki/Camel_case), [`kebab-case`](https://en.wikipedia.org/wiki/Letter_case#Kebab_case), [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case), [`snake_case`](https://en.wikipedia.org/wiki/Snake_case), and `export`.
 
 ## Related links
 


### PR DESCRIPTION
## Summary

Address #1409

We now allows `pascalCase` as variant for `filenameCases` configuration.
By default, this variant is not included.

## Test Plan

New test added
