### PR TITLE
feat(cli): document daemon logs directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
   ```
 
 - Introduced a new command called `biome explain`, which has the capability to display documentation for lint rules. Contributed by @kalleep
+- You can use the command `biome explain` to print the documentation of lint rules. Contributed by @kalleep
+  ```shell
+  biome explain noDebugger
+  biome explain useAltText
+  ```
+- You can use the command `biome explain` to print the directory where daemon logs are stored. Contributed by @ematipico
+  ```shell
+  biome explain daemon-logs
+  ```
 
 #### Bug fixes
 

--- a/crates/biome_cli/src/commands/daemon.rs
+++ b/crates/biome_cli/src/commands/daemon.rs
@@ -95,12 +95,6 @@ pub(crate) fn print_socket() -> Result<(), CliDiagnostic> {
     Ok(())
 }
 
-pub(crate) fn print_cache_dir() -> Result<(), CliDiagnostic> {
-    let cache_dir = biome_fs::ensure_cache_dir().as_path().display().to_string();
-    println!("{cache_dir}");
-    Ok(())
-}
-
 pub(crate) fn lsp_proxy(config_path: Option<PathBuf>) -> Result<(), CliDiagnostic> {
     let rt = Runtime::new()?;
     rt.block_on(start_lsp_proxy(&rt, config_path))?;
@@ -159,7 +153,7 @@ const fn log_file_name_prefix() -> &'static str {
 }
 
 pub(crate) fn read_most_recent_log_file() -> io::Result<Option<String>> {
-    let logs_dir = rome_log_dir();
+    let logs_dir = biome_log_dir();
 
     let most_recent = fs::read_dir(logs_dir)?
         .flatten()
@@ -189,7 +183,7 @@ pub(crate) fn read_most_recent_log_file() -> io::Result<Option<String>> {
 /// `biome-logs/server.log.yyyy-MM-dd-HH` files inside the system temporary
 /// directory)
 fn setup_tracing_subscriber() {
-    let file_appender = tracing_appender::rolling::hourly(rome_log_dir(), log_file_name_prefix());
+    let file_appender = tracing_appender::rolling::hourly(biome_log_dir(), log_file_name_prefix());
 
     registry()
         .with(
@@ -205,7 +199,7 @@ fn setup_tracing_subscriber() {
         .init();
 }
 
-pub(super) fn rome_log_dir() -> PathBuf {
+pub fn biome_log_dir() -> PathBuf {
     match env::var_os("BIOME_LOG_DIR") {
         Some(directory) => PathBuf::from(directory),
         None => biome_fs::ensure_cache_dir().join("biome-logs"),

--- a/crates/biome_cli/src/commands/explain.rs
+++ b/crates/biome_cli/src/commands/explain.rs
@@ -2,6 +2,7 @@ use biome_analyze::RuleMetadata;
 use biome_console::{markup, ConsoleExt};
 use biome_service::documentation::Doc;
 
+use crate::commands::daemon::biome_log_dir;
 use crate::{CliDiagnostic, CliSession};
 
 fn print_rule(session: CliSession, metadata: &RuleMetadata) {
@@ -38,6 +39,14 @@ pub(crate) fn explain(session: CliSession, doc: Doc) -> Result<(), CliDiagnostic
     match doc {
         Doc::Rule(metadata) => {
             print_rule(session, &metadata);
+            Ok(())
+        }
+        Doc::DaemonLogs => {
+            let cache_dir = biome_log_dir().display().to_string();
+            session.app.console.error(markup! {
+                <Info>"The daemon logs are available in the directory: \n"</Info>
+            });
+            session.app.console.log(markup! {{cache_dir}});
             Ok(())
         }
         Doc::Unknown(arg) => Err(CliDiagnostic::unexpected_argument(arg, "explain")),

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -255,6 +255,16 @@ pub enum BiomeCommand {
     ),
 
     /// A command to retrieve the documentation of various aspects of the CLI.
+    ///
+    /// ## Examples
+    ///
+    /// ```shell
+    /// biome explain noDebugger
+    /// ```
+    ///
+    /// ```shell
+    /// biome explain daemon-logs
+    /// ```
     #[bpaf(command)]
     Explain {
         /// Single name to display documentation for.
@@ -272,8 +282,6 @@ pub enum BiomeCommand {
     },
     #[bpaf(command("__print_socket"), hide)]
     PrintSocket,
-    #[bpaf(command("__print_cache_dir"), hide)]
-    PrintCacheDir,
 }
 
 impl BiomeCommand {
@@ -292,8 +300,7 @@ impl BiomeCommand {
             | BiomeCommand::Init
             | BiomeCommand::Explain { .. }
             | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket
-            | BiomeCommand::PrintCacheDir => None,
+            | BiomeCommand::PrintSocket => None,
         }
     }
 
@@ -312,8 +319,7 @@ impl BiomeCommand {
             | BiomeCommand::Explain { .. }
             | BiomeCommand::LspProxy(_)
             | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket
-            | BiomeCommand::PrintCacheDir => false,
+            | BiomeCommand::PrintSocket => false,
         }
     }
 
@@ -336,8 +342,7 @@ impl BiomeCommand {
             | BiomeCommand::Explain { .. }
             | BiomeCommand::LspProxy(_)
             | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket
-            | BiomeCommand::PrintCacheDir => false,
+            | BiomeCommand::PrintSocket => false,
         }
     }
 
@@ -356,8 +361,7 @@ impl BiomeCommand {
             | BiomeCommand::Init
             | BiomeCommand::Explain { .. }
             | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket
-            | BiomeCommand::PrintCacheDir => LoggingLevel::default(),
+            | BiomeCommand::PrintSocket => LoggingLevel::default(),
         }
     }
     pub fn log_kind(&self) -> LoggingKind {
@@ -375,8 +379,7 @@ impl BiomeCommand {
             | BiomeCommand::Init
             | BiomeCommand::Explain { .. }
             | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket
-            | BiomeCommand::PrintCacheDir => LoggingKind::default(),
+            | BiomeCommand::PrintSocket => LoggingKind::default(),
         }
     }
 }

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -38,6 +38,9 @@ pub use reports::{
 };
 pub use service::{open_transport, SocketTransport};
 
+#[cfg(debug_assertions)]
+pub use crate::commands::daemon::biome_log_dir;
+
 pub(crate) const VERSION: &str = match option_env!("BIOME_VERSION") {
     Some(version) => version,
     None => env!("CARGO_PKG_VERSION"),
@@ -192,7 +195,6 @@ impl<'app> CliSession<'app> {
                 config_path,
             } => commands::daemon::run_server(stop_on_disconnect, config_path),
             BiomeCommand::PrintSocket => commands::daemon::print_socket(),
-            BiomeCommand::PrintCacheDir => commands::daemon::print_cache_dir(),
         };
 
         if has_metrics {

--- a/crates/biome_cli/tests/commands/explain.rs
+++ b/crates/biome_cli/tests/commands/explain.rs
@@ -71,3 +71,25 @@ fn explain_not_found() {
         result,
     ));
 }
+
+#[test]
+fn explain_logs() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("explain"), "daemon-logs"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "explain_logs",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snap_test.rs
+++ b/crates/biome_cli/tests/snap_test.rs
@@ -157,6 +157,7 @@ fn redact_snapshot(input: &str) -> Option<Cow<'_, str>> {
     }
 
     output = replace_temp_dir(output);
+    output = replace_biome_dir(output);
 
     // Ref: https://docs.github.com/actions/learn-github-actions/variables#default-environment-variables
     let is_github = std::env::var("GITHUB_ACTIONS")
@@ -239,6 +240,46 @@ fn replace_temp_dir(input: Cow<str>) -> Cow<str> {
 
         result.push_str(before);
         result.push_str("<TEMP_DIR>");
+
+        let after = after.split_at(temp_dir.len()).1;
+        let header_line = after.lines().next().unwrap();
+
+        match header_line.split_once('\u{2501}') {
+            Some((between_temp_and_line, _)) => {
+                // Diagnostic header line, normalize the horizontal line
+                result.push_str(between_temp_and_line);
+                result.push_str(&"\u{2501}".repeat(20));
+                rest = after.split_at(header_line.len()).1;
+            }
+            None => {
+                // Not a header line, only replace tempdir
+                rest = after;
+            }
+        }
+    }
+
+    if result.is_empty() {
+        input
+    } else {
+        result.push_str(rest);
+        Cow::Owned(result)
+    }
+}
+
+/// Replace the path to the temporary directory with "<TEMP_DIR>"
+/// And normalizes the count of `-` at the end of the diagnostic
+fn replace_biome_dir(input: Cow<str>) -> Cow<str> {
+    let mut result = String::new();
+    let mut rest = input.as_ref();
+
+    let temp_dir = biome_fs::ensure_cache_dir().display().to_string();
+    let temp_dir = temp_dir.trim_end_matches(MAIN_SEPARATOR);
+
+    while let Some(index) = rest.find(temp_dir) {
+        let (before, after) = rest.split_at(index);
+
+        result.push_str(before);
+        result.push_str("<BIOME_DIR>");
 
         let after = after.split_at(temp_dir.len()).1;
         let header_line = after.lines().next().unwrap();

--- a/crates/biome_cli/tests/snapshots/main_commands_explain/explain_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_explain/explain_help.snap
@@ -6,6 +6,9 @@ expression: content
 
 ```block
 A command to retrieve the documentation of various aspects of the CLI.
+## Examples
+```shell biome explain noDebugger ```
+```shell biome explain daemon-logs ```
 
 Usage: explain NAME
 

--- a/crates/biome_cli/tests/snapshots/main_commands_explain/explain_logs.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_explain/explain_logs.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+# Emitted Messages
+
+```block
+The logs directory is available at: 
+
+```
+
+```block
+<BIOME_DIR>/biome-logs
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_explain/explain_logs.snap.new
+++ b/crates/biome_cli/tests/snapshots/main_commands_explain/explain_logs.snap.new
@@ -1,0 +1,17 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 429
+expression: content
+---
+# Emitted Messages
+
+```block
+The daemon logs are available in the directory: 
+
+```
+
+```block
+<BIOME_DIR>/biome-logs
+```
+
+

--- a/crates/biome_service/src/documentation/mod.rs
+++ b/crates/biome_service/src/documentation/mod.rs
@@ -7,6 +7,7 @@ use std::{collections::BTreeMap, str::FromStr};
 #[derive(Debug, Clone)]
 pub enum Doc {
     Rule(RuleMetadata),
+    DaemonLogs,
     Unknown(String),
 }
 
@@ -14,11 +15,16 @@ impl FromStr for Doc {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Some(metadata) = LintRulesVisitor::new().get_metadata(s) {
-            return Ok(Doc::Rule(metadata));
-        };
+        match s {
+            "daemon-logs" => Ok(Doc::DaemonLogs),
+            _ => {
+                if let Some(metadata) = LintRulesVisitor::new().get_metadata(s) {
+                    return Ok(Doc::Rule(metadata));
+                };
 
-        Ok(Doc::Unknown(s.to_string()))
+                Ok(Doc::Unknown(s.to_string()))
+            }
+        }
     }
 }
 

--- a/website/src/content/docs/guides/integrate-in-editor.mdx
+++ b/website/src/content/docs/guides/integrate-in-editor.mdx
@@ -127,7 +127,7 @@ For other operative systems, you can find the folder in the system's temporary d
 
 To obtain the precise path, execute the following command:
 ```shell
-biome __print_cache_dir
+biome explain daemon-logs
 ```
 
 The log files are rotated on an hourly basis.

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -37,6 +37,15 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
   ```
 
 - Introduced a new command called `biome explain`, which has the capability to display documentation for lint rules. Contributed by @kalleep
+- You can use the command `biome explain` to print the documentation of lint rules. Contributed by @kalleep
+  ```shell
+  biome explain noDebugger
+  biome explain useAltText
+  ```
+- You can use the command `biome explain` to print the directory where daemon logs are stored. Contributed by @ematipico
+  ```shell
+  biome explain daemon-logs
+  ```
 
 #### Bug fixes
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR removes `__print-cache-dir`.

Instead, I added `daemon-logs` to the `biome explain` command.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new snapshot test

<!-- What demonstrates that your implementation is correct? -->
