### PR TITLE
feat(parser,css_parser): implement checkpoint rewinding

### DIFF
--- a/crates/biome_css_parser/src/lib.rs
+++ b/crates/biome_css_parser/src/lib.rs
@@ -13,6 +13,7 @@ pub use parser::CssParserOptions;
 mod lexer;
 mod parser;
 mod prelude;
+mod state;
 mod syntax;
 mod token_source;
 

--- a/crates/biome_css_parser/src/parser.rs
+++ b/crates/biome_css_parser/src/parser.rs
@@ -51,11 +51,6 @@ impl<'source> CssParser<'source> {
         &mut self.state
     }
 
-    #[inline]
-    fn is_speculative_parsing(&self) -> bool {
-        self.state.speculative_parsing
-    }
-
     pub fn checkpoint(&self) -> CssParserCheckpoint {
         CssParserCheckpoint {
             context: self.context.checkpoint(),

--- a/crates/biome_css_parser/src/state.rs
+++ b/crates/biome_css_parser/src/state.rs
@@ -1,0 +1,22 @@
+pub(crate) struct CssParserState {
+    /// Indicates that the parser is speculatively parsing a syntax. Speculative parsing means that the
+    /// parser tries to parse a syntax as one kind and determines at the end if the assumption was right
+    /// by testing if the parser is at a specific token (or has no errors). For this approach to work,
+    /// the parser isn't allowed to skip any tokens while doing error recovery because it may then successfully
+    /// skip over all invalid tokens, so that it appears as if it was able to parse the syntax correctly.
+    ///
+    /// Speculative parsing is useful if a syntax is ambiguous and no amount of lookahead (except parsing the whole syntax)
+    /// is sufficient to determine what syntax it is. For example, the syntax `(a, b) ...`
+    /// in JavaScript is either a parenthesized expression or an arrow expression if `...` is a `=>`.
+    /// The challenge is, that it isn't possible to tell which of the two kinds it is until the parser
+    /// processed all of `(a, b)`.
+    pub(crate) speculative_parsing: bool,
+}
+
+impl CssParserState {
+    pub fn new() -> Self {
+        Self {
+            speculative_parsing: false,
+        }
+    }
+}

--- a/crates/biome_css_parser/src/syntax/mod.rs
+++ b/crates/biome_css_parser/src/syntax/mod.rs
@@ -612,7 +612,10 @@ pub(crate) fn try_parse<T, E>(
     func: impl FnOnce(&mut CssParser) -> Result<T, E>,
 ) -> Result<T, E> {
     let checkpoint = p.checkpoint();
+    let old_speculative_parsing = std::mem::replace(&mut p.state_mut().speculative_parsing, true);
+
     let res = func(p);
+    p.state_mut().speculative_parsing = old_speculative_parsing;
 
     if res.is_err() {
         p.rewind(checkpoint);

--- a/crates/biome_css_parser/src/token_source.rs
+++ b/crates/biome_css_parser/src/token_source.rs
@@ -5,7 +5,7 @@ use biome_css_syntax::{CssSyntaxKind, TextRange};
 use biome_parser::diagnostic::ParseDiagnostic;
 use biome_parser::lexer::{BufferedLexer, LexContext};
 use biome_parser::prelude::{BumpWithContext, NthToken, TokenSource};
-use biome_parser::token_source::Trivia;
+use biome_parser::token_source::{TokenSourceCheckpoint, Trivia};
 use biome_rowan::TriviaPieceKind;
 use std::collections::VecDeque;
 
@@ -33,6 +33,8 @@ struct Lookahead {
     kind: CssSyntaxKind,
     after_newline: bool,
 }
+
+pub(crate) type CssTokenSourceCheckpoint = TokenSourceCheckpoint<CssSyntaxKind>;
 
 impl<'src> CssTokenSource<'src> {
     /// Creates a new token source.
@@ -138,6 +140,23 @@ impl<'src> CssTokenSource<'src> {
         }
 
         None
+    }
+
+    /// Creates a checkpoint to which it can later return using [Self::rewind].
+    pub fn checkpoint(&self) -> CssTokenSourceCheckpoint {
+        CssTokenSourceCheckpoint {
+            trivia_len: self.trivia_list.len() as u32,
+            lexer_checkpoint: self.lexer.checkpoint(),
+        }
+    }
+
+    /// Restores the token source to a previous state
+    pub fn rewind(&mut self, checkpoint: CssTokenSourceCheckpoint) {
+        assert!(self.trivia_list.len() >= checkpoint.trivia_len as usize);
+        self.trivia_list.truncate(checkpoint.trivia_len as usize);
+        self.lexer.rewind(checkpoint.lexer_checkpoint);
+        self.non_trivia_lookahead.clear();
+        self.lookahead_offset = 0;
     }
 }
 

--- a/crates/biome_js_parser/src/lib.rs
+++ b/crates/biome_js_parser/src/lib.rs
@@ -139,7 +139,7 @@ use biome_js_factory::JsSyntaxFactory;
 use biome_js_syntax::{JsLanguage, JsSyntaxKind, LanguageVariant};
 use biome_parser::tree_sink::LosslessTreeSink;
 pub(crate) use parser::{JsParser, ParseRecoveryTokenSet};
-pub(crate) use state::{ParserState, StrictMode};
+pub(crate) use state::{JsParserState, StrictMode};
 use std::fmt::Debug;
 
 pub enum JsSyntaxFeature {

--- a/crates/biome_js_parser/src/parser.rs
+++ b/crates/biome_js_parser/src/parser.rs
@@ -15,7 +15,7 @@ use crate::prelude::*;
 use crate::state::{ChangeParserState, ParserStateGuard};
 use crate::token_source::JsTokenSourceCheckpoint;
 use crate::*;
-use crate::{state::ParserStateCheckpoint, token_source::JsTokenSource};
+use crate::{state::JsParserStateCheckpoint, token_source::JsTokenSource};
 use biome_js_syntax::{
     JsFileSource,
     JsSyntaxKind::{self},
@@ -31,7 +31,7 @@ pub(crate) use parsed_syntax::ParsedSyntax;
 /// The Parser yields lower level events instead of nodes.
 /// These events are then processed into a syntax tree through a [`TreeSink`] implementation.
 pub struct JsParser<'source> {
-    pub(super) state: ParserState,
+    pub(super) state: JsParserState,
     pub source_type: JsFileSource,
     context: ParserContext<JsSyntaxKind>,
     source: JsTokenSource<'source>,
@@ -44,7 +44,7 @@ impl<'source> JsParser<'source> {
         let source = JsTokenSource::from_str(source);
 
         JsParser {
-            state: ParserState::new(&source_type),
+            state: JsParserState::new(&source_type),
             source_type,
             context: ParserContext::default(),
             source,
@@ -52,7 +52,7 @@ impl<'source> JsParser<'source> {
         }
     }
 
-    pub(crate) fn state(&self) -> &ParserState {
+    pub(crate) fn state(&self) -> &JsParserState {
         &self.state
     }
 
@@ -60,7 +60,7 @@ impl<'source> JsParser<'source> {
         &self.options
     }
 
-    pub(crate) fn state_mut(&mut self) -> &mut ParserState {
+    pub(crate) fn state_mut(&mut self) -> &mut JsParserState {
         &mut self.state
     }
 
@@ -212,7 +212,7 @@ impl<'source> Parser for JsParser<'source> {
 pub struct JsParserCheckpoint {
     pub(super) context: ParserContextCheckpoint,
     pub(super) source: JsTokenSourceCheckpoint,
-    state: ParserStateCheckpoint,
+    state: JsParserStateCheckpoint,
 }
 
 #[cfg(test)]

--- a/crates/biome_js_parser/src/parser.rs
+++ b/crates/biome_js_parser/src/parser.rs
@@ -13,11 +13,9 @@ pub(crate) use crate::parser::parse_recovery::{
 };
 use crate::prelude::*;
 use crate::state::{ChangeParserState, ParserStateGuard};
+use crate::token_source::JsTokenSourceCheckpoint;
 use crate::*;
-use crate::{
-    state::ParserStateCheckpoint,
-    token_source::{JsTokenSource, TokenSourceCheckpoint},
-};
+use crate::{state::ParserStateCheckpoint, token_source::JsTokenSource};
 use biome_js_syntax::{
     JsFileSource,
     JsSyntaxKind::{self},
@@ -213,7 +211,7 @@ impl<'source> Parser for JsParser<'source> {
 
 pub struct JsParserCheckpoint {
     pub(super) context: ParserContextCheckpoint,
-    pub(super) source: TokenSourceCheckpoint,
+    pub(super) source: JsTokenSourceCheckpoint,
     state: ParserStateCheckpoint,
 }
 

--- a/crates/biome_js_parser/src/parser/rewrite_parser.rs
+++ b/crates/biome_js_parser/src/parser/rewrite_parser.rs
@@ -1,5 +1,4 @@
-use crate::parser::JsParser;
-use crate::token_source::TokenSourceCheckpoint;
+use crate::{parser::JsParser, token_source::JsTokenSourceCheckpoint};
 
 use crate::prelude::*;
 use biome_console::fmt::Display;
@@ -34,7 +33,7 @@ pub(crate) struct RewriteParser<'parser, 'source> {
 }
 
 impl<'parser, 'source> RewriteParser<'parser, 'source> {
-    pub fn new(p: &'parser mut JsParser<'source>, checkpoint: TokenSourceCheckpoint) -> Self {
+    pub fn new(p: &'parser mut JsParser<'source>, checkpoint: JsTokenSourceCheckpoint) -> Self {
         Self {
             inner: p,
             offset: checkpoint.current_start(),

--- a/crates/biome_parser/src/token_source.rs
+++ b/crates/biome_parser/src/token_source.rs
@@ -1,4 +1,4 @@
-use crate::diagnostic::ParseDiagnostic;
+use crate::{diagnostic::ParseDiagnostic, lexer::LexerCheckpoint};
 use biome_rowan::{SyntaxKind, TextRange, TextSize, TriviaPieceKind};
 
 /// A comment or a whitespace trivia in the source code.
@@ -92,4 +92,30 @@ pub trait NthToken: TokenSource {
 
     /// Returns true if the nth non-trivia token is preceded by a line break
     fn has_nth_preceding_line_break(&mut self, n: usize) -> bool;
+}
+
+#[derive(Debug)]
+pub struct TokenSourceCheckpoint<K>
+where
+    K: SyntaxKind,
+{
+    pub lexer_checkpoint: LexerCheckpoint<K>,
+    /// A `u32` should be enough because `TextSize` is also limited to `u32`.
+    /// The worst case is a document where every character is its own token. This would
+    /// result in `u32::MAX` tokens
+    pub trivia_len: u32,
+}
+
+impl<K> TokenSourceCheckpoint<K>
+where
+    K: SyntaxKind,
+{
+    /// byte offset in the source text
+    pub fn current_start(&self) -> TextSize {
+        self.lexer_checkpoint.current_start()
+    }
+
+    pub fn trivia_position(&self) -> usize {
+        self.trivia_len as usize
+    }
 }


### PR DESCRIPTION
## Summary

From https://github.com/biomejs/biome/issues/268#issuecomment-1874820626, this implements checkpoint rewinding for the CSS parser to set up for attempting to parse property values and then falling back to generics if the parse fails for any reason.

I think there's another possibility of using `rewrite_events` the way that the `JsParser` does to avoid the need for rewinding, but I think it's actually okay to just rewind since there's little cost to it, and we aren't enforcing a particular structure on the re-parsed content (it could be either `GenericComponentValueList` or `Bogus`, we don't actually know at the point of rewinding).



## Test Plan

Added a test around `try_parse` to ensure it rewinds as expected on error and preserves the position on success. Future PRs will start actually using it in the parser logic itself.