### PR TITLE
feat(cli): remove the hardcoded limit of 200 printable diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
   ```shell
   biome explain daemon-logs
   ```
+- Removed the hard coded limit of 200 printable diagnostics. Contributed by @ematipico
 
 #### Bug fixes
 

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -7,7 +7,7 @@ mod traverse;
 use crate::cli_options::CliOptions;
 use crate::execute::traverse::traverse;
 use crate::{CliDiagnostic, CliSession};
-use biome_diagnostics::{category, Category, MAXIMUM_DISPLAYABLE_DIAGNOSTICS};
+use biome_diagnostics::{category, Category};
 use biome_fs::RomePath;
 use biome_service::workspace::{FeatureName, FixFileMode};
 use std::ffi::OsString;
@@ -117,7 +117,7 @@ impl Execution {
         Self {
             report_mode: ReportMode::default(),
             traversal_mode: mode,
-            max_diagnostics: MAXIMUM_DISPLAYABLE_DIAGNOSTICS,
+            max_diagnostics: 20,
         }
     }
 
@@ -137,7 +137,7 @@ impl Execution {
                     None
                 },
             },
-            max_diagnostics: MAXIMUM_DISPLAYABLE_DIAGNOSTICS,
+            max_diagnostics: 20,
         }
     }
 
@@ -146,7 +146,7 @@ impl Execution {
         Self {
             traversal_mode,
             report_mode,
-            max_diagnostics: MAXIMUM_DISPLAYABLE_DIAGNOSTICS,
+            max_diagnostics: 20,
         }
     }
 
@@ -257,13 +257,6 @@ pub(crate) fn execute_mode(
     cli_options: &CliOptions,
     paths: Vec<OsString>,
 ) -> Result<(), CliDiagnostic> {
-    if cli_options.max_diagnostics > MAXIMUM_DISPLAYABLE_DIAGNOSTICS {
-        return Err(CliDiagnostic::overflown_argument(
-            "--max-diagnostics",
-            MAXIMUM_DISPLAYABLE_DIAGNOSTICS,
-        ));
-    }
-
     mode.max_diagnostics = cli_options.max_diagnostics;
 
     // don't do any traversal if there's some content coming from stdin

--- a/crates/biome_diagnostics/src/lib.rs
+++ b/crates/biome_diagnostics/src/lib.rs
@@ -69,8 +69,6 @@ impl DiagnosticTag {
     }
 }
 
-pub const MAXIMUM_DISPLAYABLE_DIAGNOSTICS: u16 = 200;
-
 /// Utility function for testing purpose. The function will print an [Error]
 /// to a string, which is then returned by the function.
 pub fn print_diagnostic_to_string(diagnostic: &Error) -> String {

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -46,6 +46,7 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
   ```shell
   biome explain daemon-logs
   ```
+- Removed the hard coded limit of 200 printable diagnostics. Contributed by @ematipico
 
 #### Bug fixes
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR removed the internal hard-coded limit we had when printing the diagnostics.

Many users were frustrated by this.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I locally ran `cargo biome-cli-dev format --max-diagnostics=10000` inside our repository and ensured that ALL diagnostics were printed. Usually, you have the message "Diagnostics not shown". It wasn't there during my test!

<!-- What demonstrates that your implementation is correct? -->
