### PR TITLE
chore(justfile): fix typo and minor improvements

### DIFF
--- a/justfile
+++ b/justfile
@@ -24,8 +24,8 @@ gen:
   cargo codegen-configuration
   cargo lintdoc
   just gen-bindings
-  jest gen-web
-  cargo format
+  just gen-web
+  just format
 
 # Generates TypeScript types and JSON schema of the configuration
 gen-bindings:
@@ -37,6 +37,7 @@ gen-lint:
   cargo codegen analyzer
   cargo codegen-configuration
   just gen-bindings
+  just format
   cargo lintdoc
 
 # Generates code generated files for the website
@@ -114,10 +115,10 @@ lint:
 # When you finished coding, run this command to run the same commands in the CI.
 ready:
   git diff --exit-code --quiet
-  just codegen
+  just gen
   just documentation
-  just format
+  #just format # fromat is already run in `just gen`
   just lint
-  just t
-  cargo test --doc
+  just test
+  just test-doc
   git diff --exit-code --quiet


### PR DESCRIPTION
## Summary

- Fix a typo
- Format on `just gen-lint`
- Remove double formatting when running `just ready`

## Test Plan

Locally tested
