### PR TITLE
test(lint/noGlobalEval): address TODO

### DIFF
--- a/crates/biome_js_analyze/tests/specs/nursery/noGlobalEval/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noGlobalEval/valid.js
@@ -99,23 +99,3 @@ callbacks.findLastIndex(function (cb) {
 ["1+1"].flatMap(function (str) {
 	return this.eval(str);
 }, new Evaluator());
-
-// TODO Fix to prevent errors for these cases
-// function foo() {
-// 	var eval = "foo";
-// 	window[eval]("foo");
-// }
-
-// function foo() {
-// 	var eval = "foo";
-// 	global[eval]("foo");
-// }
-
-// function foo() {
-// 	var eval = "foo";
-// 	globalThis[eval]("foo");
-// }
-
-// function foo(eval) {
-// 	eval("var a = 0");
-// }

--- a/crates/biome_js_analyze/tests/specs/nursery/noGlobalEval/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noGlobalEval/valid.js.snap
@@ -106,26 +106,6 @@ callbacks.findLastIndex(function (cb) {
 	return this.eval(str);
 }, new Evaluator());
 
-// TODO Fix to prevent errors for these cases
-// function foo() {
-// 	var eval = "foo";
-// 	window[eval]("foo");
-// }
-
-// function foo() {
-// 	var eval = "foo";
-// 	global[eval]("foo");
-// }
-
-// function foo() {
-// 	var eval = "foo";
-// 	globalThis[eval]("foo");
-// }
-
-// function foo(eval) {
-// 	eval("var a = 0");
-// }
-
 ```
 
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noGlobalEval/validtest.cjs
+++ b/crates/biome_js_analyze/tests/specs/nursery/noGlobalEval/validtest.cjs
@@ -1,0 +1,18 @@
+function foo() {
+	var eval = "foo";
+	window[eval]("foo");
+}
+
+function foo() {
+	var eval = "foo";
+	global[eval]("foo");
+}
+
+function foo() {
+	var eval = "foo";
+	globalThis[eval]("foo");
+}
+
+function foo(eval) {
+	eval("var a = 0");
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noGlobalEval/validtest.cjs.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noGlobalEval/validtest.cjs.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validtest.cjs
+---
+# Input
+```js
+function foo() {
+	var eval = "foo";
+	window[eval]("foo");
+}
+
+function foo() {
+	var eval = "foo";
+	global[eval]("foo");
+}
+
+function foo() {
+	var eval = "foo";
+	globalThis[eval]("foo");
+}
+
+function foo(eval) {
+	eval("var a = 0");
+}
+
+```
+
+


### PR DESCRIPTION
## Summary

Address TODO.
The `eval` identifier is not allowed in strict mode.
Thus, I created a new test file with `cjs` extension to test in non-strict mode.
