### PR TITLE
fix(lint/noConfusingVoidType): accept `void` in type param lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,14 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
     }
   ```
 
+- Fix [#1383](https://github.com/biomejs/biome/issues/1383). [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type) now accepts the `void` type in type parameter lists.
+
+  The rule no longer reports the following code:
+
+  ```ts
+  f<void>();
+  ```
+
 - Fix [#728](https://github.com/biomejs/biome/issues/728). [useSingleVarDeclarator](https://biomejs.dev/linter/rules/use-single-var-declarator) no longer outputs invalid code. Contributed by @Conaclos
 
 - Fix [#1167](https://github.com/biomejs/biome/issues/1167). [useValidAriaProps](https://biomejs.dev/linter/rules/use-valid-aria-props) no longer reports `aria-atomic` as invalid. Contributed by @unvalley

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_void_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_void_type.rs
@@ -122,24 +122,15 @@ fn decide_void_type_context(node: &SyntaxNode<JsLanguage>) -> Option<VoidTypeCon
             }
 
             // Promise<void>
-            JsSyntaxKind::TS_TYPE_ARGUMENT_LIST => {
-                // handle generic function that has a void type argument
-                // e.g. functionGeneric<void>(undefined);
-                let Some(grand_parent) = parent.grand_parent() else {
-                    continue;
-                };
-                if grand_parent.kind() == JsSyntaxKind::JS_CALL_EXPRESSION {
-                    return Some(VoidTypeContext::Unknown);
-                }
-                return None;
-            }
-
+            // functionGeneric<void>(undefined)
+            JsSyntaxKind::TS_TYPE_ARGUMENT_LIST
             // function fn(this: void) {}
-            // fn(): void;
-            // fn<T = void>() {}
-            JsSyntaxKind::TS_THIS_PARAMETER
+            | JsSyntaxKind::TS_THIS_PARAMETER
+            // function fn(): void;
             | JsSyntaxKind::TS_RETURN_TYPE_ANNOTATION
+            // function fn<T = void>() {}
             | JsSyntaxKind::TS_TYPE_PARAMETER
+            // () => void
             | JsSyntaxKind::TS_FUNCTION_TYPE => {
                 return None;
             }

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/invalid.ts
@@ -6,7 +6,7 @@ function functionGeneric<T extends void>(arg: T) {}
 function functionGeneric2<T extends void = void>(arg: T) {}
 declare function functionDeclaration<T extends void>(arg: T): void;
 declare function functionDeclaration2<T extends void = void>(arg: T): void;
-functionGeneric<void>(undefined);
+
 declare function voidArray(args: void[]): void[];
 let value = undefined as void;
 let value = <void>undefined;

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/invalid.ts.snap
@@ -12,7 +12,7 @@ function functionGeneric<T extends void>(arg: T) {}
 function functionGeneric2<T extends void = void>(arg: T) {}
 declare function functionDeclaration<T extends void>(arg: T): void;
 declare function functionDeclaration2<T extends void = void>(arg: T): void;
-functionGeneric<void>(undefined);
+
 declare function voidArray(args: void[]): void[];
 let value = undefined as void;
 let value = <void>undefined;
@@ -147,7 +147,7 @@ invalid.ts:7:48 lint/suspicious/noConfusingVoidType ━━━━━━━━━�
   > 7 │ declare function functionDeclaration<T extends void>(arg: T): void;
       │                                                ^^^^
     8 │ declare function functionDeclaration2<T extends void = void>(arg: T): void;
-    9 │ functionGeneric<void>(undefined);
+    9 │ 
   
   i Remove void
   
@@ -163,25 +163,8 @@ invalid.ts:8:49 lint/suspicious/noConfusingVoidType ━━━━━━━━━�
      7 │ declare function functionDeclaration<T extends void>(arg: T): void;
    > 8 │ declare function functionDeclaration2<T extends void = void>(arg: T): void;
        │                                                 ^^^^
-     9 │ functionGeneric<void>(undefined);
+     9 │ 
     10 │ declare function voidArray(args: void[]): void[];
-  
-  i Remove void
-  
-
-```
-
-```
-invalid.ts:9:17 lint/suspicious/noConfusingVoidType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! void is only valid as a return type or a type argument in generic type
-  
-     7 │ declare function functionDeclaration<T extends void>(arg: T): void;
-     8 │ declare function functionDeclaration2<T extends void = void>(arg: T): void;
-   > 9 │ functionGeneric<void>(undefined);
-       │                 ^^^^
-    10 │ declare function voidArray(args: void[]): void[];
-    11 │ let value = undefined as void;
   
   i Remove void
   
@@ -194,7 +177,7 @@ invalid.ts:10:34 lint/suspicious/noConfusingVoidType ━━━━━━━━━
   ! void is only valid as a return type or a type argument in generic type
   
      8 │ declare function functionDeclaration2<T extends void = void>(arg: T): void;
-     9 │ functionGeneric<void>(undefined);
+     9 │ 
   > 10 │ declare function voidArray(args: void[]): void[];
        │                                  ^^^^
     11 │ let value = undefined as void;
@@ -211,7 +194,7 @@ invalid.ts:10:43 lint/suspicious/noConfusingVoidType ━━━━━━━━━
   ! void is only valid as a return type or a type argument in generic type
   
      8 │ declare function functionDeclaration2<T extends void = void>(arg: T): void;
-     9 │ functionGeneric<void>(undefined);
+     9 │ 
   > 10 │ declare function voidArray(args: void[]): void[];
        │                                           ^^^^
     11 │ let value = undefined as void;
@@ -227,7 +210,6 @@ invalid.ts:11:26 lint/suspicious/noConfusingVoidType ━━━━━━━━━
 
   ! void is only valid as a return type or a type argument in generic type
   
-     9 │ functionGeneric<void>(undefined);
     10 │ declare function voidArray(args: void[]): void[];
   > 11 │ let value = undefined as void;
        │                          ^^^^

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts
@@ -38,3 +38,5 @@ class Test {
   public static helper(this: void) {}
   method(this: void) {}
 }
+
+functionGeneric<void>(undefined);

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts.snap
@@ -45,6 +45,7 @@ class Test {
   method(this: void) {}
 }
 
+functionGeneric<void>(undefined);
 ```
 
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -257,6 +257,14 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
     }
   ```
 
+- Fix [#1383](https://github.com/biomejs/biome/issues/1383). [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type) now accepts the `void` type in type parameter lists.
+
+  The rule no longer reports the following code:
+
+  ```ts
+  f<void>();
+  ```
+
 - Fix [#728](https://github.com/biomejs/biome/issues/728). [useSingleVarDeclarator](https://biomejs.dev/linter/rules/use-single-var-declarator) no longer outputs invalid code. Contributed by @Conaclos
 
 - Fix [#1167](https://github.com/biomejs/biome/issues/1167). [useValidAriaProps](https://biomejs.dev/linter/rules/use-valid-aria-props) no longer reports `aria-atomic` as invalid. Contributed by @unvalley


### PR DESCRIPTION
## Summary

Fix #1383

## Test Plan

Updated tests
