### PR TITLE
fix(lint/useHookAtTopLevel): stricter checking for conditional hook calls

### DIFF
--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js
@@ -10,7 +10,7 @@ function Component1({ a }) {
         }
     }
 
-    for (;a < 10;) {
+    for (; a < 10;) {
         useEffect();
     }
 
@@ -22,13 +22,13 @@ function Component1({ a }) {
         useEffect();
     }
 
-    while(a < 10) {
+    while (a < 10) {
         useEffect();
     }
 
     do {
         useEffect();
-    } while(a < 10)
+    } while (a < 10)
 
     a && useEffect();
 
@@ -44,7 +44,7 @@ function helper2() {
     helper1();
 }
 
-function Component2({a}) {
+function Component2({ a }) {
     if (a) {
         helper2(1);
     }
@@ -125,4 +125,33 @@ function Component14() {
     }
 
     Component13();
+}
+
+function useHookInsideTryClause() {
+    try {
+        useState();
+    } catch { }
+}
+
+function useHookInsideCatchClause() {
+    try {
+    } catch (error) {
+        useErrorHandler(error);
+    }
+}
+
+function useHookInsideObjectBindingInitializer(props) {
+    const { value = useDefaultValue() } = props;
+}
+
+function useHookInsideObjectBindingInitializerInArgument({ value = useDefaultValue() }) {
+}
+
+function useHookInsideArrayAssignmentInitializer(props) {
+    let item;
+    [item = useDefaultItem()] = props.array;
+}
+
+function useHookInsideArrayBindingInitializer(props) {
+    const [item = useDefaultItem()] = props.array;
 }

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js.snap
@@ -16,7 +16,7 @@ function Component1({ a }) {
         }
     }
 
-    for (;a < 10;) {
+    for (; a < 10;) {
         useEffect();
     }
 
@@ -28,13 +28,13 @@ function Component1({ a }) {
         useEffect();
     }
 
-    while(a < 10) {
+    while (a < 10) {
         useEffect();
     }
 
     do {
         useEffect();
-    } while(a < 10)
+    } while (a < 10)
 
     a && useEffect();
 
@@ -50,7 +50,7 @@ function helper2() {
     helper1();
 }
 
-function Component2({a}) {
+function Component2({ a }) {
     if (a) {
         helper2(1);
     }
@@ -133,6 +133,35 @@ function Component14() {
     Component13();
 }
 
+function useHookInsideTryClause() {
+    try {
+        useState();
+    } catch { }
+}
+
+function useHookInsideCatchClause() {
+    try {
+    } catch (error) {
+        useErrorHandler(error);
+    }
+}
+
+function useHookInsideObjectBindingInitializer(props) {
+    const { value = useDefaultValue() } = props;
+}
+
+function useHookInsideObjectBindingInitializerInArgument({ value = useDefaultValue() }) {
+}
+
+function useHookInsideArrayAssignmentInitializer(props) {
+    let item;
+    [item = useDefaultItem()] = props.array;
+}
+
+function useHookInsideArrayBindingInitializer(props) {
+    const [item = useDefaultItem()] = props.array;
+}
+
 ```
 
 # Diagnostics
@@ -179,7 +208,7 @@ invalid.js:14:9 lint/correctness/useHookAtTopLevel ━━━━━━━━━�
 
   ! This hook is being called conditionally, but all hooks must be called in the exact same order in every component render.
   
-    13 │     for (;a < 10;) {
+    13 │     for (; a < 10;) {
   > 14 │         useEffect();
        │         ^^^^^^^^^
     15 │     }
@@ -233,7 +262,7 @@ invalid.js:26:9 lint/correctness/useHookAtTopLevel ━━━━━━━━━�
 
   ! This hook is being called conditionally, but all hooks must be called in the exact same order in every component render.
   
-    25 │     while(a < 10) {
+    25 │     while (a < 10) {
   > 26 │         useEffect();
        │         ^^^^^^^^^
     27 │     }
@@ -254,7 +283,7 @@ invalid.js:30:9 lint/correctness/useHookAtTopLevel ━━━━━━━━━�
     29 │     do {
   > 30 │         useEffect();
        │         ^^^^^^^^^
-    31 │     } while(a < 10)
+    31 │     } while (a < 10)
     32 │ 
   
   i For React to preserve state between calls, hooks needs to be called unconditionally and always in the same order.
@@ -269,7 +298,7 @@ invalid.js:33:10 lint/correctness/useHookAtTopLevel ━━━━━━━━━�
 
   ! This hook is being called conditionally, but all hooks must be called in the exact same order in every component render.
   
-    31 │     } while(a < 10)
+    31 │     } while (a < 10)
     32 │ 
   > 33 │     a && useEffect();
        │          ^^^^^^^^^
@@ -327,7 +356,7 @@ invalid.js:40:5 lint/correctness/useHookAtTopLevel ━━━━━━━━━�
   
   i 
   
-    47 │ function Component2({a}) {
+    47 │ function Component2({ a }) {
   > 48 │     if (a) {
        │             
   > 49 │         helper2(1);
@@ -621,6 +650,118 @@ invalid.js:119:5 lint/correctness/useHookAtTopLevel ━━━━━━━━━�
         │         ^^^^^^^
     125 │     }
     126 │ 
+  
+  i For React to preserve state between calls, hooks needs to be called unconditionally and always in the same order.
+  
+  i See https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+  
+
+```
+
+```
+invalid.js:132:9 lint/correctness/useHookAtTopLevel ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook is being called conditionally, but all hooks must be called in the exact same order in every component render.
+  
+    130 │ function useHookInsideTryClause() {
+    131 │     try {
+  > 132 │         useState();
+        │         ^^^^^^^^
+    133 │     } catch { }
+    134 │ }
+  
+  i For React to preserve state between calls, hooks needs to be called unconditionally and always in the same order.
+  
+  i See https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+  
+
+```
+
+```
+invalid.js:139:9 lint/correctness/useHookAtTopLevel ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook is being called conditionally, but all hooks must be called in the exact same order in every component render.
+  
+    137 │     try {
+    138 │     } catch (error) {
+  > 139 │         useErrorHandler(error);
+        │         ^^^^^^^^^^^^^^^
+    140 │     }
+    141 │ }
+  
+  i For React to preserve state between calls, hooks needs to be called unconditionally and always in the same order.
+  
+  i See https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+  
+
+```
+
+```
+invalid.js:144:21 lint/correctness/useHookAtTopLevel ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook is being called conditionally, but all hooks must be called in the exact same order in every component render.
+  
+    143 │ function useHookInsideObjectBindingInitializer(props) {
+  > 144 │     const { value = useDefaultValue() } = props;
+        │                     ^^^^^^^^^^^^^^^
+    145 │ }
+    146 │ 
+  
+  i For React to preserve state between calls, hooks needs to be called unconditionally and always in the same order.
+  
+  i See https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+  
+
+```
+
+```
+invalid.js:147:68 lint/correctness/useHookAtTopLevel ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook is being called conditionally, but all hooks must be called in the exact same order in every component render.
+  
+    145 │ }
+    146 │ 
+  > 147 │ function useHookInsideObjectBindingInitializerInArgument({ value = useDefaultValue() }) {
+        │                                                                    ^^^^^^^^^^^^^^^
+    148 │ }
+    149 │ 
+  
+  i For React to preserve state between calls, hooks needs to be called unconditionally and always in the same order.
+  
+  i See https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+  
+
+```
+
+```
+invalid.js:152:13 lint/correctness/useHookAtTopLevel ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook is being called conditionally, but all hooks must be called in the exact same order in every component render.
+  
+    150 │ function useHookInsideArrayAssignmentInitializer(props) {
+    151 │     let item;
+  > 152 │     [item = useDefaultItem()] = props.array;
+        │             ^^^^^^^^^^^^^^
+    153 │ }
+    154 │ 
+  
+  i For React to preserve state between calls, hooks needs to be called unconditionally and always in the same order.
+  
+  i See https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+  
+
+```
+
+```
+invalid.js:156:19 lint/correctness/useHookAtTopLevel ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook is being called conditionally, but all hooks must be called in the exact same order in every component render.
+  
+    155 │ function useHookInsideArrayBindingInitializer(props) {
+  > 156 │     const [item = useDefaultItem()] = props.array;
+        │                   ^^^^^^^^^^^^^^
+    157 │ }
+    158 │ 
   
   i For React to preserve state between calls, hooks needs to be called unconditionally and always in the same order.
   

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js
@@ -6,6 +6,8 @@ function Component1({ a }) {
     const value = useContext();
     const memoizedCallback = useCallback();
 
+    const otherValue = useValue() || defaultValue;
+
     {
         useEffect();
     }
@@ -15,14 +17,43 @@ const implicitReturn = (x) => useMemo(() => x, [x]);
 
 const implicitReturnInsideWrappedComponent = forwardRef((x) => useMemo(() => x, [x]));
 
-function useStuff() {
+function useHookInsideObjectLiteral() {
     return {
         abc: useCallback(() => null, [])
     };
 }
 
-function useStuff2() {
+function useHookInsideArrayLiteral() {
     return [useCallback(() => null, [])];
+}
+
+function useHookInsideFinallyClause() {
+    try {
+    } finally {
+        useCleanUp();
+    }
+}
+
+function useHookInsideFinallyClause2() {
+    try {
+    } catch (error) {
+    } finally {
+        useCleanUp();
+    }
+}
+
+function useHookToCalculateKey(key) {
+    const object = {};
+    object[useObjectKey(key)] = true;
+    return object;
+}
+
+function useKeyOfHookResult(key) {
+    return useContext(Context)[key];
+}
+
+function usePropertyOfHookResult() {
+    return useContext(Context).someProp;
 }
 
 const obj = {

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js.snap
@@ -12,6 +12,8 @@ function Component1({ a }) {
     const value = useContext();
     const memoizedCallback = useCallback();
 
+    const otherValue = useValue() || defaultValue;
+
     {
         useEffect();
     }
@@ -21,14 +23,43 @@ const implicitReturn = (x) => useMemo(() => x, [x]);
 
 const implicitReturnInsideWrappedComponent = forwardRef((x) => useMemo(() => x, [x]));
 
-function useStuff() {
+function useHookInsideObjectLiteral() {
     return {
         abc: useCallback(() => null, [])
     };
 }
 
-function useStuff2() {
+function useHookInsideArrayLiteral() {
     return [useCallback(() => null, [])];
+}
+
+function useHookInsideFinallyClause() {
+    try {
+    } finally {
+        useCleanUp();
+    }
+}
+
+function useHookInsideFinallyClause2() {
+    try {
+    } catch (error) {
+    } finally {
+        useCleanUp();
+    }
+}
+
+function useHookToCalculateKey(key) {
+    const object = {};
+    object[useObjectKey(key)] = true;
+    return object;
+}
+
+function useKeyOfHookResult(key) {
+    return useContext(Context)[key];
+}
+
+function usePropertyOfHookResult() {
+    return useContext(Context).someProp;
 }
 
 const obj = {


### PR DESCRIPTION
## Summary

Given there was a small regression in #610, I added a test case for it and tried to come up with some more test cases that might be giving false positives still. 

Fixing the one specific regression was easy, but as I added more test cases, I realized our current approach of whitelisting safe nodes wasn't the best way forward. There are many more types of nodes that needed whitelisting than node types that actually introduce conditional branches. But the one that really tipped the scales was this test case:

```js
const otherValue = useValue() || defaultValue;
```

Intuitively this code should be valid since we call `useValue()` from the top-level of the component. Technically there is also no reason to disallow it, since it is being called unconditionally and doesn't violate the rules of hooks. But the previous implementation would trigger a false positive since it's inside a logical expression.

To resolve this, I've implemented a more sophisticated `is_conditional_expression` function that also considers the position of a node inside its parent.

Fixes #610 for real this time.

## Test Plan

I have added a bunch of new test cases again, including one that represents the issue that remained with #610 :)

No existing test cases were affected.
