### PR TITLE
fix: JsNumberLiteralExpression::as_number ignore trivia

### DIFF
--- a/crates/biome_js_analyze/tests/specs/style/useNumericLiterals/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericLiterals/invalid.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
-assertion_line: 83
 expression: invalid.js
 ---
 # Input

--- a/crates/biome_js_analyze/tests/specs/style/useNumericLiterals/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericLiterals/invalid.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 83
 expression: invalid.js
 ---
 # Input
@@ -1447,6 +1448,32 @@ invalid.js:59:1 lint/style/useNumericLiterals  FIXABLE  ━━━━━━━━
        59 │ + 0b11;
     60 60 │   parseInt('11', 2 /**/);
     61 61 │   parseInt('11', 2)//comment
+  
+
+```
+
+```
+invalid.js:60:1 lint/style/useNumericLiterals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This call to parseInt() can be replaced by a binary literal.
+  
+    58 │ parseInt('11'/**/, 2);
+    59 │ parseInt(`11`/**/, 2);
+  > 60 │ parseInt('11', 2 /**/);
+       │ ^^^^^^^^^^^^^^^^^^^^^^
+    61 │ parseInt('11', 2)//comment
+    62 │ ;
+  
+  i Using a literal avoids unnecessary computations.
+  
+  i Unsafe fix: Use the computed binary literal instead.
+  
+    58 58 │   parseInt('11'/**/, 2);
+    59 59 │   parseInt(`11`/**/, 2);
+    60    │ - parseInt('11',·2·/**/);
+       60 │ + 0b11;
+    61 61 │   parseInt('11', 2)//comment
+    62 62 │   ;
   
 
 ```

--- a/crates/biome_js_syntax/src/expr_ext.rs
+++ b/crates/biome_js_syntax/src/expr_ext.rs
@@ -534,8 +534,18 @@ impl JsObjectExpression {
 }
 
 impl JsNumberLiteralExpression {
+    /// ## Examples
+    ///
+    /// ```
+    /// use biome_js_factory::make;
+    /// use biome_rowan::TriviaPieceKind;
+    ///
+    /// let number = make::js_number_literal_expression(make::js_number_literal("1.23")
+    ///     .with_trailing_trivia(vec![(TriviaPieceKind::Whitespace, " ")]));
+    /// assert_eq!(number.as_number().unwrap(), 1.23);
+    /// ```
     pub fn as_number(&self) -> Option<f64> {
-        parse_js_number(self.value_token().unwrap().text())
+        parse_js_number(self.value_token().unwrap().text_trimmed())
     }
 }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

`JsNumberLiteralExpression::as_number` wasn't ignoring trivia of the interal token, so it was almost always returning `None`.

## Test Plan

Added a doctest, it failed without the change and now it passes.
