### PR TITLE
feat(codegen,css_formatter): autogenerate property formattting boilerplate

### DIFF
--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -295,6 +295,7 @@ fn generate_formatter(repo: &GitRepo, language_kind: LanguageKind) {
         modules.insert(repo, &path);
 
         let node_id = Ident::new(&name, Span::call_site());
+        let node_fields_id = Ident::new(&format!("{name}Fields"), Span::call_site());
         let format_id = Ident::new(&format!("Format{name}"), Span::call_site());
 
         let qualified_format_id = {
@@ -358,18 +359,49 @@ fn generate_formatter(repo: &GitRepo, language_kind: LanguageKind) {
                 }
             },
             NodeKind::Node => {
-                quote! {
-                    use crate::prelude::*;
+                // TODO: This is CSS-specific and would be nice to handle in a
+                // per-language generator somehow.
+                if language_kind == LanguageKind::Css
+                    && matches!(
+                        get_node_concept(&kind, &module.dialect, &language_kind, &name),
+                        NodeConcept::Property
+                    )
+                {
+                    quote! {
+                        use crate::prelude::*;
 
-                    use biome_rowan::AstNode;
-                    use #syntax_crate_ident::#node_id;
+                        use #syntax_crate_ident::{#node_id, #node_fields_id};
+                        use biome_formatter::write;
 
-                    #[derive(Debug, Clone, Default)]
-                    pub(crate) struct #format_id;
+                        #[derive(Debug, Clone, Default)]
+                        pub(crate) struct #format_id;
 
-                    impl FormatNodeRule<#node_id> for #format_id {
-                        fn fmt_fields(&self, node: &#node_id, f: &mut #formatter_ident) -> FormatResult<()> {
-                            format_verbatim_node(node.syntax()).fmt(f)
+                        impl FormatNodeRule<#node_id> for #format_id {
+                            fn fmt_fields(&self, node: &#node_id, f: &mut #formatter_ident) -> FormatResult<()> {
+                                let #node_fields_id {
+                                    name,
+                                    colon_token,
+                                    value
+                                } = node.as_fields();
+
+                                write!(f, [name.format(), colon_token.format(), space(), value.format()])
+                            }
+                        }
+                    }
+                } else {
+                    quote! {
+                        use crate::prelude::*;
+
+                        use biome_rowan::AstNode;
+                        use #syntax_crate_ident::#node_id;
+
+                        #[derive(Debug, Clone, Default)]
+                        pub(crate) struct #format_id;
+
+                        impl FormatNodeRule<#node_id> for #format_id {
+                            fn fmt_fields(&self, node: &#node_id, f: &mut #formatter_ident) -> FormatResult<()> {
+                                format_verbatim_node(node.syntax()).fmt(f)
+                            }
                         }
                     }
                 }
@@ -642,25 +674,13 @@ impl NodeModuleInformation {
     }
 }
 
-/// Convert an AstNode name to a path / Rust module name
-fn name_to_module(kind: &NodeKind, in_name: &str, language: LanguageKind) -> NodeModuleInformation {
-    let mut upper_case_indices = in_name.match_indices(|c: char| c.is_uppercase());
-
-    assert!(matches!(upper_case_indices.next(), Some((0, _))));
-
-    let (second_upper_start, _) = upper_case_indices.next().expect("Node name malformed");
-    let (mut dialect_prefix, mut name) = in_name.split_at(second_upper_start);
-
-    // AnyJsX
-    if dialect_prefix == "Any" {
-        let (third_upper_start, _) = upper_case_indices.next().expect("Node name malformed");
-        (dialect_prefix, name) = name.split_at(third_upper_start - dialect_prefix.len());
-    }
-
-    let dialect = NodeDialect::from_str(dialect_prefix);
-
-    // Classify nodes by concept
-    let concept = if matches!(kind, NodeKind::Bogus) {
+fn get_node_concept(
+    kind: &NodeKind,
+    dialect: &NodeDialect,
+    language: &LanguageKind,
+    name: &str,
+) -> NodeConcept {
+    if matches!(kind, NodeKind::Bogus) {
         NodeConcept::Bogus
     } else if matches!(kind, NodeKind::List { .. }) {
         NodeConcept::List
@@ -761,7 +781,28 @@ fn name_to_module(kind: &NodeKind, in_name: &str, language: LanguageKind) -> Nod
                 _ => NodeConcept::Auxiliary,
             },
         }
-    };
+    }
+}
+
+/// Convert an AstNode name to a path / Rust module name
+fn name_to_module(kind: &NodeKind, in_name: &str, language: LanguageKind) -> NodeModuleInformation {
+    let mut upper_case_indices = in_name.match_indices(|c: char| c.is_uppercase());
+
+    assert!(matches!(upper_case_indices.next(), Some((0, _))));
+
+    let (second_upper_start, _) = upper_case_indices.next().expect("Node name malformed");
+    let (mut dialect_prefix, mut name) = in_name.split_at(second_upper_start);
+
+    // AnyJsX
+    if dialect_prefix == "Any" {
+        let (third_upper_start, _) = upper_case_indices.next().expect("Node name malformed");
+        (dialect_prefix, name) = name.split_at(third_upper_start - dialect_prefix.len());
+    }
+
+    let dialect = NodeDialect::from_str(dialect_prefix);
+
+    // Classify nodes by concept
+    let concept = get_node_concept(kind, &dialect, &language, name);
 
     // Convert the names from CamelCase to snake_case
     let mut stem = String::new();


### PR DESCRIPTION
## Summary

As we start to implement exact parsing for all of the properties, we're going to start having formatter files for each one (multiple actually. an `any`, a `property`, and at least one `property_value` file to cover each added node.

Each of the overall Property nodes will have _exactly_ the same structure and get formatted exactly the same way:

```rust
use crate::prelude::*;
use biome_css_syntax::{CssBorderProperty, CssBorderPropertyFields};
use biome_formatter::write;
#[derive(Debug, Clone, Default)]
pub(crate) struct FormatCssBorderProperty;
impl FormatNodeRule<CssBorderProperty> for FormatCssBorderProperty {
    fn fmt_fields(&self, node: &CssBorderProperty, f: &mut CssFormatter) -> FormatResult<()> {
        let CssBorderPropertyFields {
            name,
            colon_token,
            value,
        } = node.as_fields();
        write!(
            f,
            [name.format(), colon_token.format(), space(), value.format()]
        )
    }
}
```

It simply destructures the `name`, `colon_token`, and `value` fields, then formats them with a space between the colon and the value. Every property value will do this exactly. So why not put it in the code generation by default!

We can detect that a property node is being generated by checking the language, node concept, and name, and then use this template rather than the `format_verbatim_node` one. This way adding a new property _should_ only require devs to implement the value formatting. That _could_ also be autogenerated most of the time, but I think it's best left as-is.

If we decide to implement the general `CssKeyword` node for values, that'll also make it quite a bit easier to manage since most of the time there will only be one node type to format.

## Test Plan

I deleted one of the existing property formatter files, ran the codegen, and got the exact same output, so it works!