### PR TITLE
feat(css_formatter): Formatting for `border` property

### DIFF
--- a/crates/biome_css_formatter/src/css/auxiliary/border.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/border.rs
@@ -1,10 +1,25 @@
-use crate::prelude::*;
-use biome_css_syntax::CssBorder;
-use biome_rowan::AstNode;
+use crate::{prelude::*, utils::properties::FormatPropertyValueFields};
+use biome_css_syntax::{CssBorder, CssBorderFields};
+use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssBorder;
 impl FormatNodeRule<CssBorder> for FormatCssBorder {
     fn fmt_fields(&self, node: &CssBorder, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssBorderFields {
+            line_width,
+            line_style,
+            color,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [FormatPropertyValueFields::new(&format_args![
+                line_width.format(),
+                line_style.format(),
+                color.format(),
+            ])
+            .with_slot_map(node.concrete_order_slot_map())]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/line_style.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/line_style.rs
@@ -1,10 +1,13 @@
 use crate::prelude::*;
-use biome_css_syntax::CssLineStyle;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssLineStyle, CssLineStyleFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssLineStyle;
 impl FormatNodeRule<CssLineStyle> for FormatCssLineStyle {
     fn fmt_fields(&self, node: &CssLineStyle, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssLineStyleFields { keyword } = node.as_fields();
+
+        write!(f, [keyword.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/line_width_keyword.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/line_width_keyword.rs
@@ -1,10 +1,13 @@
 use crate::prelude::*;
-use biome_css_syntax::CssLineWidthKeyword;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssLineWidthKeyword, CssLineWidthKeywordFields};
+use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssLineWidthKeyword;
 impl FormatNodeRule<CssLineWidthKeyword> for FormatCssLineWidthKeyword {
     fn fmt_fields(&self, node: &CssLineWidthKeyword, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssLineWidthKeywordFields { keyword } = node.as_fields();
+
+        write!(f, [keyword.format()])
     }
 }

--- a/crates/biome_css_formatter/src/css/properties/border_property.rs
+++ b/crates/biome_css_formatter/src/css/properties/border_property.rs
@@ -1,10 +1,18 @@
 use crate::prelude::*;
-use biome_css_syntax::CssBorderProperty;
-use biome_rowan::AstNode;
+use biome_css_syntax::{CssBorderProperty, CssBorderPropertyFields};
+use biome_formatter::write;
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssBorderProperty;
 impl FormatNodeRule<CssBorderProperty> for FormatCssBorderProperty {
     fn fmt_fields(&self, node: &CssBorderProperty, f: &mut CssFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let CssBorderPropertyFields {
+            name,
+            colon_token,
+            value,
+        } = node.as_fields();
+        write!(
+            f,
+            [name.format(), colon_token.format(), space(), value.format()]
+        )
     }
 }

--- a/crates/biome_css_formatter/src/prelude.rs
+++ b/crates/biome_css_formatter/src/prelude.rs
@@ -7,6 +7,8 @@ pub(crate) use crate::{
 };
 pub(crate) use biome_formatter::prelude::*;
 #[allow(unused_imports)]
-pub(crate) use biome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};
+pub(crate) use biome_rowan::{
+    AstNode as _, AstNodeList as _, AstNodeSlotMap as _, AstSeparatedList as _,
+};
 
 pub(crate) use crate::separated::FormatAstSeparatedListExtension;

--- a/crates/biome_css_formatter/src/utils/mod.rs
+++ b/crates/biome_css_formatter/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod component_value_list;
+pub(crate) mod properties;
 pub(crate) mod string_utils;

--- a/crates/biome_css_formatter/src/utils/properties.rs
+++ b/crates/biome_css_formatter/src/utils/properties.rs
@@ -1,0 +1,172 @@
+use crate::prelude::*;
+use biome_formatter::{write, Arguments};
+
+/// Format all of the fields of a `PropertyValue` node in an arbitrary order,
+/// given by `slot_map`.
+///
+/// Because the CSS grammar allows rules to specify fields that can appear
+/// in any order, there isn't always a linear mapping between the _declared_
+/// order (how they appear in the grammar) and the _concrete_ order (how they
+/// appear in the source text) of the fields. The parser supports this by
+/// building a `slot_map` to map the declared order to the concrete order.
+///
+/// When formatting, by default we want to preserve the ordering of fields as
+/// they were written in the source, but just using the `AstNode` alone will
+/// naturally re-write the value in the _declared_ order. To preserve the
+/// _concrete_ order, we can invert the `slot_map` and sort it to re-determine
+/// the ordering of fields and then iterate that list to format each field
+/// individually.
+///
+/// ## Fields
+///
+/// The caller provides a list of _pre-formatted_ fields, using the
+/// [`biome_formatter::format_args!`] macro. This way, it can either pass
+/// through a field as-is with default formatting, or it can apply any other
+/// formatting it once for that field:
+///
+/// ```rust,ignore
+/// let formatted = format!(CssFormatContext::default(), [
+///     FormatPropertyValueFields::new(&format_args![
+///         text("a"),
+///         text("b"),
+///         group(&block_indent(&format_args![text("c"), hard_line_break(), text("d")]))
+///     ])
+///     .with_slot_map([1, 2, 0])
+/// ])?;
+///
+/// assert_eq!("b
+/// \tc
+/// \td
+/// a", formatted.print()?.as_code());
+/// ```
+///
+/// ## Concrete Ordering
+///
+/// By default, using this struct will format the fields of the node in order.
+/// This is sufficient for nodes that don't have any dynamically-ordered
+/// fields, but for dynamic nodes that want to preserve the order of fields as
+/// they were given in the input, or for any node that wants to change the
+/// ordering of the fields, the caller will need to provide a `slot_map` that
+/// this struct can use to re-order the fields.
+///
+/// To preserve the field order as it was written in the original source, use
+/// [biome_rowan::AstNodeSlotMap::concrete_order_slot_map], which will ensure
+/// the ordering matches what was given. This should be the default for most
+/// if not all dynamic nodes.
+///
+/// ```rust,ignore
+/// .with_slot_map(node.concrete_order_slot_map())
+/// ```
+///
+/// Any other method of building a slot map is also valid, but should generally
+/// be avoided, as ensuring consistency across formats is difficult without a
+/// strong heuristic.
+///
+/// ## Grouping Fields (Future)
+///
+/// In some cases, a property may want to group certain fields together in
+/// order to apply special formatting. As an example, consider a grammar like:
+///
+/// ```ebnf
+///     font =
+///         (style: CssFontStyle ||
+///         variant: CssFontVariant ||
+///         weight: CssFontWeight)?
+///         size: CssNumber ( '/' line_height: CssLineHeight)?
+/// ```
+///
+/// Here, the `style`, `variant`, and `weight` fields can appear conditionally
+/// and in any order, but if `line_height` is present, it (and the slash token)
+/// must appear immediately adjacent to the `size` field. While it would be
+/// valid to just have the fields fill and wrap over lines as needed, the
+/// formatter might want to preserve the adjacency and ensure that `size` and
+/// `line_height` always get written on the same line.
+///
+/// To do this, the value formatter can write both fields in a single group,
+/// and then use an `empty_field_slot` value in the slots where the other
+/// fields have been taken from:
+///
+/// ```rust,ignore
+/// FormatPropertyValueFields::new(&format_args![
+///         style.format(),
+///         variant.format(),
+///         weight.format(),
+///         group(&format_args![
+///             size.format(), slash_token.format(), line_height.format()
+///         ]),
+///         empty_field_slot(),
+///         empty_field_slot()
+///     ])
+///     .with_slot_map(node.concrete_order_slot_map())
+/// ```
+///
+/// The `empty_field_slot()` values will tell this struct to skip formatting
+/// for that field, with the assumption that another field includes its value.
+pub struct FormatPropertyValueFields<'fmt, const N: usize> {
+    slot_map: Option<[u8; N]>,
+    fields: &'fmt Arguments<'fmt, CssFormatContext>,
+}
+
+impl<'fmt, const N: usize> FormatPropertyValueFields<'fmt, N> {
+    pub fn new(fields: &'fmt Arguments<'fmt, CssFormatContext>) -> Self {
+        Self {
+            slot_map: None,
+            fields,
+        }
+    }
+
+    pub fn with_slot_map(mut self, slot_map: [u8; N]) -> Self {
+        debug_assert!(
+            self.fields.items().len() == N,
+            "slot_map must specify the same number of fields as this struct contains"
+        );
+        self.slot_map = Some(slot_map);
+        self
+    }
+}
+
+impl<'fmt, const N: usize> Format<CssFormatContext> for FormatPropertyValueFields<'fmt, N> {
+    fn fmt(&self, f: &mut CssFormatter) -> FormatResult<()> {
+        let values = format_with(|f: &mut Formatter<'_, CssFormatContext>| {
+            let mut filler = f.fill();
+
+            // First, determine the ordering of fields to use. If no slot_map is
+            // provided along with the fields, then they can just be used in the
+            // same order, but if a `slot_map` is present, then the fields are
+            // re-ordered to match the concrete ordering from the source syntax.
+            //
+            // The fields are wrapped with `Option` for two reasons: for nodes
+            // with slot maps, it simplifies how the re-ordered slice is built, and
+            // it also allows empty/missing fields to be removed in the next step.
+            match self.slot_map {
+                None => {
+                    for field in self.fields.items() {
+                        filler.entry(&soft_line_break_or_space(), field);
+                    }
+                }
+                Some(slot_map) => {
+                    for slot in slot_map {
+                        // This condition ensures that missing values are _not_ included in the
+                        // fill. The generated `slot_map` for an AstNode guarantees that all
+                        // present fields have a tangible value here, while all absent fields
+                        // have this sentinel value ([biome_css_syntax::SLOT_MAP_EMPTY_VALUE]).
+                        //
+                        // This check is important to ensure that we don't add empty values to
+                        // the fill, since that would add double separators when we don't want
+                        // them.
+                        if slot == u8::MAX {
+                            continue;
+                        }
+
+                        let field = &self.fields.items()[slot as usize];
+                        filler.entry(&soft_line_break_or_space(), field);
+                    }
+                }
+            };
+
+            filler.finish()
+        });
+
+        write!(f, [group(&indent(&values))])
+    }
+}

--- a/crates/biome_css_formatter/tests/quick_test.rs
+++ b/crates/biome_css_formatter/tests/quick_test.rs
@@ -14,9 +14,11 @@ mod language {
 fn quick_test() {
     let src = r#"
     div {
-        prod: fn(100px);
-        prod: --fn(100px);
-        prod: --fn--fn(100px);
+        border: #fff    solid
+        
+        2px;
+        border: THICK   #000;
+        border: medium;
     }
 
 "#;

--- a/crates/biome_css_formatter/tests/specs/css/properties/border.css
+++ b/crates/biome_css_formatter/tests/specs/css/properties/border.css
@@ -1,0 +1,39 @@
+div {
+    /* Generic property tests */
+    border: InItial;
+    border
+    :
+    inherit
+    ;
+
+    border  :   zzz-unknown-value  ;
+    border  : a,
+    value list ;
+
+
+    /* <line-style> */
+    border : SOLID;
+    border: none
+    ;
+
+    /* <line-width> */
+    border : ThIn;
+    border: 
+    medium
+    ;
+    border:   100px;
+
+    /* <color> */
+    border: 
+    #fff;
+
+    /* combinations */
+    border: 2px
+    dotted;
+    border  :   outset   #f33;
+    border:#000 medium  
+     
+    dashed
+        
+        ;
+}

--- a/crates/biome_css_formatter/tests/specs/css/properties/border.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/properties/border.css.snap
@@ -1,0 +1,94 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/properties/border.css
+---
+
+# Input
+
+```css
+div {
+    /* Generic property tests */
+    border: InItial;
+    border
+    :
+    inherit
+    ;
+
+    border  :   zzz-unknown-value  ;
+    border  : a,
+    value list ;
+
+
+    /* <line-style> */
+    border : SOLID;
+    border: none
+    ;
+
+    /* <line-width> */
+    border : ThIn;
+    border: 
+    medium
+    ;
+    border:   100px;
+
+    /* <color> */
+    border: 
+    #fff;
+
+    /* combinations */
+    border: 2px
+    dotted;
+    border  :   outset   #f33;
+    border:#000 medium  
+     
+    dashed
+        
+        ;
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+-----
+
+```css
+div {
+	/* Generic property tests */
+	border: initial;
+	border: inherit;
+
+	border: zzz-unknown-value;
+	border: a , value list;
+
+	/* <line-style> */
+	border: solid;
+	border: none;
+
+	/* <line-width> */
+	border: thin;
+	border: medium;
+	border: 100px;
+
+	/* <color> */
+	border: #fff;
+
+	/* combinations */
+	border: 2px dotted;
+	border: outset #f33;
+	border: #000 medium dashed;
+}
+```
+
+

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -12,7 +12,8 @@ use crate::{
 use biome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
 #[allow(unused)]
 use biome_rowan::{
-    AstNodeList, AstNodeListIterator, AstSeparatedList, AstSeparatedListNodesIterator,
+    AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
+    AstSeparatedListNodesIterator,
 };
 #[cfg(feature = "serde")]
 use serde::ser::SerializeSeq;
@@ -7927,6 +7928,11 @@ impl AstNode for CssBorder {
     }
     fn into_syntax(self) -> SyntaxNode {
         self.syntax
+    }
+}
+impl AstNodeSlotMap<3usize> for CssBorder {
+    fn slot_map(&self) -> &[u8; 3usize] {
+        &self.slot_map
     }
 }
 impl std::fmt::Debug for CssBorder {

--- a/crates/biome_formatter/src/arguments.rs
+++ b/crates/biome_formatter/src/arguments.rs
@@ -56,6 +56,13 @@ impl<'fmt, Context> Argument<'fmt, Context> {
     }
 }
 
+impl<'fmt, Context> Format<Context> for Argument<'fmt, Context> {
+    #[inline(always)]
+    fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
+        self.format(f)
+    }
+}
+
 /// Sequence of objects that should be formatted in the specified order.
 ///
 /// The [`format_args!`] macro will safely create an instance of this structure.
@@ -87,7 +94,7 @@ impl<'fmt, Context> Arguments<'fmt, Context> {
 
     /// Returns the arguments
     #[inline]
-    pub(super) fn items(&self) -> &'fmt [Argument<'fmt, Context>] {
+    pub fn items(&self) -> &'fmt [Argument<'fmt, Context>] {
         self.0
     }
 }

--- a/crates/biome_js_syntax/src/generated/nodes.rs
+++ b/crates/biome_js_syntax/src/generated/nodes.rs
@@ -12,7 +12,8 @@ use crate::{
 use biome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
 #[allow(unused)]
 use biome_rowan::{
-    AstNodeList, AstNodeListIterator, AstSeparatedList, AstSeparatedListNodesIterator,
+    AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
+    AstSeparatedListNodesIterator,
 };
 #[cfg(feature = "serde")]
 use serde::ser::SerializeSeq;

--- a/crates/biome_json_syntax/src/generated/nodes.rs
+++ b/crates/biome_json_syntax/src/generated/nodes.rs
@@ -12,7 +12,8 @@ use crate::{
 use biome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
 #[allow(unused)]
 use biome_rowan::{
-    AstNodeList, AstNodeListIterator, AstSeparatedList, AstSeparatedListNodesIterator,
+    AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
+    AstSeparatedListNodesIterator,
 };
 #[cfg(feature = "serde")]
 use serde::ser::SerializeSeq;

--- a/xtask/codegen/src/generate_nodes.rs
+++ b/xtask/codegen/src/generate_nodes.rs
@@ -223,6 +223,18 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
                 quote! { if Self::can_cast(syntax.kind()) { Some(Self { syntax }) } else { None } }
             };
 
+            let ast_node_slot_map_impl = if needs_dynamic_slots {
+                quote! {
+                    impl AstNodeSlotMap<#slot_count> for #name {
+                        fn slot_map(&self) -> &#slot_map_type {
+                            &self.slot_map
+                        }
+                    }
+                }
+            } else {
+                Default::default()
+            };
+
             (
                 quote! {
                     // TODO: review documentation
@@ -276,6 +288,8 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
                         fn syntax(&self) -> &SyntaxNode { &self.syntax }
                         fn into_syntax(self) -> SyntaxNode { self.syntax }
                     }
+
+                    #ast_node_slot_map_impl
 
                     impl std::fmt::Debug for #name {
                         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -883,9 +897,9 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
         };
         #[allow(unused)]
         use biome_rowan::{
-            AstNodeList, AstNodeListIterator, AstSeparatedList, AstSeparatedListNodesIterator
+            AstNodeList, AstNodeListIterator,  AstNodeSlotMap, AstSeparatedList, AstSeparatedListNodesIterator
         };
-        use biome_rowan::{support, AstNode, SyntaxKindSet, RawSyntaxKind, SyntaxResult};
+        use biome_rowan::{support, AstNode,SyntaxKindSet, RawSyntaxKind, SyntaxResult};
         use std::fmt::{Debug, Formatter};
         #serde_import
 


### PR DESCRIPTION
## Summary

#1285. Continuing on the demonstration of `border` being the first property to be _parsed_ exactly, this is a demonstration of how the property can be _formatted_` exactly as well.

Turns out it gets a little complicated! The primary addition here is the new `FormatPropertyValueFields` struct, which implements all of the logic. Given a list of fields, and optionally a slot map, it takes care of building up the `Fill` element with all of the values. This is what `write_component_value_list` was already doing for the generic versions, but for the new exact versions it needs to be a bit more involved (the generic ones will still use that function as the fallback).

When there's no `slot_map` given, the new struct just iterates the fields and adds them as entries to the `Fill` element. When there _is_ a `slot_map`, though, the struct iterates the indices of that map and uses the value at each one as the index to pull from the `fields` for that position in the list. It also handles skipping over empty and missing fields from the syntax, preventing empty elements from being formatted into the fill and causing double spaces or line breaks accidentally.

The `slot_map` in this case is _not_ the same as the slot_map that gets built when constructing an `AstNode`, though! Instead, it's the _inverse_ of that map (i.e., the value at _index 0_ of the inverted map is the index of the _value 0_ in the original map). This gives the `concrete_order_slot_map()`, which is implemented on a new `AstNodeSlotMap` trait that dynamic nodes implement, and is what gets passed to the formatting struct to use for iteration. More information about how this works can be found in the doc comment for `concrete_order_slot_map`.

The `border` formatter uses this new struct to easily implement formatting for the value with unordered fields, like:

```rust
write!(
    f,
    [FormatPropertyValueFields::new(&format_args![
        line_width.format(),
        line_style.format(),
        color.format(),
    ])
    .with_slot_map(node.concrete_order_slot_map())]
)
```

Notice that it uses `&format_args!` to group the slot map pieces together. This isn't _strictly_ necessary right now, but will probably make things in the future easier to deal with (exactly the reason it's used for things like `group` and `indent` now). Also note that it formats _all_ of the fields of the node, not just the unordered ones. That includes any tokens or other ordered fields as well. All of them must be present in the `format_args!` slice, but the nice thing is that extra formatting can still be applied to each, like wrapping one field with a `group` to preserve flattening/expansion, or indenting one specific field, or anything else.

One thing that I would like to enable in with that is added in the doc comment for the struct under `Grouping Fields (Future)`. The idea here would be that you could say that two fields in a node get formatted together, no matter what their original ordering was, or to be able to add additional formatting like grouping, line breaks, indents, or whatever else makes sense for the fields being put together. Right now that doesn't work with the slot_map iterator solution, since all of the fields _have_ to be present (the slice of args and the slot map have to have the same length), and iteration would cause the grouped field to be formatted twice: once when it comes up naturally, and again when it gets formatted as part of the group with another field.

I spent quite a while trying to make a clean solution work where the fields were wrapped as an `Option` type and you could insert `EmptyFieldSlot` values in the slots where a field was moved away from. Unfortunately, it just doesn't look good at all and would be super verbose, and macros aren't _quite_ powerful enough to make it work efficiently either. Since it's unlikely that we'll even need that behavior for a long time, I figure it's fine to leave out for now.

## Test Plan

Added a snapshot test for `border` that includes various permutations of all the allowed properties, including switching up their ordering, and the output matches exactly as expected, preserving the order from the input source!
