### PR TITLE
fix(lint/useArrowFunction): handle fixes that needs parens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,8 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
 
 - The code action (fix) of [noMultipleSpacesInRegularExpressionLiterals](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals/) is now marked as safe. Contributed by @Conaclos
 
+- [useArrowFunction](https://biomejs.dev/linter/rules/use-arrow-function/) no longer reports function expressions that use `new.target`. Contributed by @Conaclos
+
 #### Bug fixes
 
 - Fix [#1061](https://github.com/biomejs/biome/issues/1061). [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare) no longer reports overloads of `export default function`. Contributed by @Conaclos
@@ -306,6 +308,22 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
 
   ```js
   `a${1}` + 2;
+  ```
+
+- Fix [#1436](https://github.com/biomejs/biome/issues/1436). [useArrowFunction](https://biomejs.dev/linter/rules/use-arrow-function/) now applies a correct fix when a function expression is used in a call expression or a member access. Contributed by @Conaclos
+
+  For example, the rule proposed the following fix:
+
+  ```diff
+  - const called = function() {}();
+  + const called = () => {}();
+  ```
+
+  It now proposes a fix that adds the needed parentheses:
+
+  ```diff
+  - const called = function() {}();
+  + const called = (() => {})();
   ```
 
 ### Parser

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_arrow_function.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_arrow_function.rs
@@ -11,11 +11,11 @@ use biome_js_syntax::{
     JsFunctionDeclaration, JsFunctionExportDefaultDeclaration, JsFunctionExpression,
     JsGetterClassMember, JsGetterObjectMember, JsLanguage, JsMethodClassMember,
     JsMethodObjectMember, JsModule, JsScript, JsSetterClassMember, JsSetterObjectMember,
-    JsStaticInitializationBlockClassMember, JsThisExpression, T,
+    JsStaticInitializationBlockClassMember, JsSyntaxKind, T,
 };
 use biome_rowan::{
     declare_node_union, AstNode, AstNodeList, AstSeparatedList, BatchMutationExt, Language,
-    SyntaxNode, TextRange, TriviaPieceKind, WalkEvent,
+    SyntaxNode, SyntaxNodeOptionExt, TextRange, TriviaPieceKind, WalkEvent,
 };
 
 declare_rule! {
@@ -92,17 +92,14 @@ impl Rule for UseArrowFunction {
             // Ignore generators and function with a name.
             return None;
         }
-        let has_this_parameter =
-            function_expression
-                .parameters()
-                .ok()?
-                .items()
-                .iter()
-                .any(|param| {
-                    param
-                        .map(|param| param.as_ts_this_parameter().is_some())
-                        .unwrap_or_default()
-                });
+        let has_this_parameter = function_expression
+            .parameters()
+            .ok()?
+            .items()
+            .iter()
+            .nth(0)
+            .and_then(|param| param.ok())
+            .is_some_and(|param| param.as_ts_this_parameter().is_some());
         if has_this_parameter {
             // Ignore functions that explicitly declare a `this` type.
             return None;
@@ -145,10 +142,16 @@ impl Rule for UseArrowFunction {
             arrow_function_builder =
                 arrow_function_builder.with_return_type_annotation(return_type_annotation);
         }
+        let arrow_function = arrow_function_builder.build();
+        let arrow_function = if needs_parentheses(function_expression) {
+            AnyJsExpression::from(make::parenthesized(arrow_function))
+        } else {
+            AnyJsExpression::from(arrow_function)
+        };
         let mut mutation = ctx.root().begin();
         mutation.replace_node(
             AnyJsExpression::from(function_expression.clone()),
-            AnyJsExpression::from(arrow_function_builder.build()),
+            arrow_function,
         );
         Some(JsRuleAction {
             category: ActionCategory::QuickFix,
@@ -158,6 +161,24 @@ impl Rule for UseArrowFunction {
             mutation,
         })
     }
+}
+
+/// Returns `true` if `function_expr` needs parenthesis when turned into an arrow function.
+fn needs_parentheses(function_expression: &JsFunctionExpression) -> bool {
+    function_expression
+        .syntax()
+        .parent()
+        .kind()
+        .is_some_and(|parent_kind| {
+            matches!(
+                parent_kind,
+                JsSyntaxKind::JS_CALL_EXPRESSION
+                    | JsSyntaxKind::JS_STATIC_MEMBER_ASSIGNMENT
+                    | JsSyntaxKind::JS_STATIC_MEMBER_EXPRESSION
+                    | JsSyntaxKind::JS_COMPUTED_MEMBER_ASSIGNMENT
+                    | JsSyntaxKind::JS_COMPUTED_MEMBER_EXPRESSION
+            )
+        })
 }
 
 declare_node_union! {
@@ -233,9 +254,12 @@ impl Visitor for AnyThisScopeVisitor {
                         has_this: false,
                     });
                 }
-                if JsThisExpression::can_cast(node.kind()) {
-                    // When the visitor enters a `this` expression, set the
-                    // `has_this` flag for the top entry on the stack to `true`
+                if matches!(
+                    node.kind(),
+                    JsSyntaxKind::JS_THIS_EXPRESSION | JsSyntaxKind::JS_NEW_TARGET_EXPRESSION
+                ) {
+                    // When the visitor enters a `this` expression or `new.target`,
+                    // set the `has_this` flag for the top entry on the stack to `true`.
                     if let Some(AnyThisScopeMetadata { has_this, .. }) = self.stack.last_mut() {
                         *has_this = true;
                     }

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.ts
@@ -35,3 +35,9 @@ function f7() {
         }
     };
 }
+
+const f8 = function(a) {}.bind(null, 0);
+
+const f9 = function(a) {}["bind"](null, 0);
+
+const called = function () {}();

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.ts.snap
@@ -42,6 +42,12 @@ function f7() {
     };
 }
 
+const f8 = function(a) {}.bind(null, 0);
+
+const f9 = function(a) {}["bind"](null, 0);
+
+const called = function () {}();
+
 ```
 
 # Diagnostics
@@ -253,6 +259,82 @@ invalid.ts:30:12 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━�
        30 │ + ····return·()·=>·{
     31 31 │           if (self instanceof Number) {
     32 32 │               return self;
+  
+
+```
+
+```
+invalid.ts:39:12 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+    37 │ }
+    38 │ 
+  > 39 │ const f8 = function(a) {}.bind(null, 0);
+       │            ^^^^^^^^^^^^^^
+    40 │ 
+    41 │ const f9 = function(a) {}["bind"](null, 0);
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    37 37 │   }
+    38 38 │   
+    39    │ - const·f8·=·function(a)·{}.bind(null,·0);
+       39 │ + const·f8·=·((a)·=>·{}).bind(null,·0);
+    40 40 │   
+    41 41 │   const f9 = function(a) {}["bind"](null, 0);
+  
+
+```
+
+```
+invalid.ts:41:12 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+    39 │ const f8 = function(a) {}.bind(null, 0);
+    40 │ 
+  > 41 │ const f9 = function(a) {}["bind"](null, 0);
+       │            ^^^^^^^^^^^^^^
+    42 │ 
+    43 │ const called = function () {}();
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    39 39 │   const f8 = function(a) {}.bind(null, 0);
+    40 40 │   
+    41    │ - const·f9·=·function(a)·{}["bind"](null,·0);
+       41 │ + const·f9·=·((a)·=>·{})["bind"](null,·0);
+    42 42 │   
+    43 43 │   const called = function () {}();
+  
+
+```
+
+```
+invalid.ts:43:16 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+    41 │ const f9 = function(a) {}["bind"](null, 0);
+    42 │ 
+  > 43 │ const called = function () {}();
+       │                ^^^^^^^^^^^^^^
+    44 │ 
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    41 41 │   const f9 = function(a) {}["bind"](null, 0);
+    42 42 │   
+    43    │ - const·called·=·function·()·{}();
+       43 │ + const·called·=·(()·=>·{})();
+    44 44 │   
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/valid.ts
@@ -80,3 +80,7 @@ export const DEFAULT_COUNTER = {
 export default function() {
     return 0;
 }
+
+const usingNewTarget = function () {
+    return new.target;
+}

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/valid.ts.snap
@@ -87,6 +87,10 @@ export default function() {
     return 0;
 }
 
+const usingNewTarget = function () {
+    return new.target;
+}
+
 ```
 
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -225,6 +225,8 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
 
 - The code action (fix) of [noMultipleSpacesInRegularExpressionLiterals](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals/) is now marked as safe. Contributed by @Conaclos
 
+- [useArrowFunction](https://biomejs.dev/linter/rules/use-arrow-function/) no longer reports function expressions that use `new.target`. Contributed by @Conaclos
+
 #### Bug fixes
 
 - Fix [#1061](https://github.com/biomejs/biome/issues/1061). [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare) no longer reports overloads of `export default function`. Contributed by @Conaclos
@@ -312,6 +314,22 @@ Biome now scores 97% compatibility with Prettier and features more than 180 lint
 
   ```js
   `a${1}` + 2;
+  ```
+
+- Fix [#1436](https://github.com/biomejs/biome/issues/1436). [useArrowFunction](https://biomejs.dev/linter/rules/use-arrow-function/) now applies a correct fix when a function expression is used in a call expression or a member access. Contributed by @Conaclos
+
+  For example, the rule proposed the following fix:
+
+  ```diff
+  - const called = function() {}();
+  + const called = () => {}();
+  ```
+
+  It now proposes a fix that adds the needed parentheses:
+
+  ```diff
+  - const called = function() {}();
+  + const called = (() => {})();
   ```
 
 ### Parser


### PR DESCRIPTION
## Summary

Fix #1436 and ignore function expressions using [`new.target`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target).

Additionally, we no longer check every function parameters for detecting the `this` parameter. 

## Test Plan

New tests included.
