### PR TITLE
refcator(lint/noInvalidUseBeforeDeclaration): allow use before as a type

### DIFF
--- a/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.js
@@ -9,4 +9,4 @@ export { X }; const X = 1;
 
 let a; console.log(a);
 
-function h() { X; }; const X = 0;
+function h() { Y; }; const Y = 0;

--- a/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.js.snap
@@ -15,7 +15,7 @@ export { X }; const X = 1;
 
 let a; console.log(a);
 
-function h() { X; }; const X = 0;
+function h() { Y; }; const Y = 0;
 
 ```
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.ts
@@ -12,3 +12,5 @@ let n = N.X;
 namespace N {
     export const X = 0;
 }
+
+type X = typeof X; const X = 0;

--- a/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noInvalidUseBeforeDeclaration/valid.ts.snap
@@ -19,6 +19,8 @@ namespace N {
     export const X = 0;
 }
 
+type X = typeof X; const X = 0;
+
 ```
 
 


### PR DESCRIPTION
## Summary

Allow use-before declarations when the variable is used as a type.
This removes many false positives.

## Test Plan

New test included.
