### PR TITLE
refactor(deserialize): allow setting name for root deserialized value

### DIFF
--- a/crates/biome_deserialize/src/lib.rs
+++ b/crates/biome_deserialize/src/lib.rs
@@ -86,14 +86,14 @@ pub use string_set::StringSet;
 /// use biome_json_parser::JsonParserOptions;
 ///
 /// let source = r#""A""#;
-/// let deserialized = deserialize_from_json_str::<Variant>(&source, JsonParserOptions::default());
+/// let deserialized = deserialize_from_json_str::<Variant>(&source, JsonParserOptions::default(), "");
 /// assert!(!deserialized.has_errors());
 /// assert!(matches!(deserialized.into_deserialized(), Some(Variant::A)));
 /// ```
 pub trait Deserializable: Sized {
     /// Returns the deserialized form of `value`, or `None` if it failed.
     /// Any diagnostics emitted during deserialization are appended to `diagnostics`.
-    /// `name` corresponds to the name used in a diagnostic to designate the value.
+    /// `name` corresponds to the name used in a diagnostic to designate the deserialized value.
     fn deserialize(
         value: &impl DeserializableValue,
         name: &str,
@@ -197,7 +197,7 @@ pub trait DeserializableValue: Sized {
 /// use biome_json_parser::JsonParserOptions;
 ///
 /// let source = r#"{ "name": "Isaac Asimov" }"#;
-/// let deserialized = deserialize_from_json_str::<Person>(&source, JsonParserOptions::default());
+/// let deserialized = deserialize_from_json_str::<Person>(&source, JsonParserOptions::default(), "");
 /// assert!(!deserialized.has_errors());
 /// assert_eq!(deserialized.into_deserialized(), Some(Person { name: "Isaac Asimov".to_string() }));
 /// ```
@@ -252,12 +252,12 @@ pub trait DeserializableValue: Sized {
 /// use biome_json_parser::JsonParserOptions;
 ///
 /// let source = r#" "string" "#;
-/// let deserialized = deserialize_from_json_str::<Union>(&source, JsonParserOptions::default());
+/// let deserialized = deserialize_from_json_str::<Union>(&source, JsonParserOptions::default(), "");
 /// assert!(!deserialized.has_errors());
 /// assert_eq!(deserialized.into_deserialized(), Some(Union::Str("string".to_string())));
 ///
 /// let source = "true";
-/// let deserialized = deserialize_from_json_str::<Union>(&source, JsonParserOptions::default());
+/// let deserialized = deserialize_from_json_str::<Union>(&source, JsonParserOptions::default(), "");
 /// assert!(!deserialized.has_errors());
 /// assert_eq!(deserialized.into_deserialized(), Some(Union::Bool(true)));
 /// ```

--- a/crates/biome_project/src/node_js_project/package_json.rs
+++ b/crates/biome_project/src/node_js_project/package_json.rs
@@ -24,7 +24,7 @@ impl Manifest for PackageJson {
     type Language = JsonLanguage;
 
     fn deserialize_manifest(root: &LanguageRoot<Self::Language>) -> Deserialized<Self> {
-        deserialize_from_json_ast::<PackageJson>(root)
+        deserialize_from_json_ast::<PackageJson>(root, "")
     }
 }
 

--- a/crates/biome_service/src/configuration/diagnostics.rs
+++ b/crates/biome_service/src/configuration/diagnostics.rs
@@ -319,7 +319,7 @@ mod test {
     fn deserialization_error() {
         let content = "{ \n\n\"formatter\" }";
         let result =
-            deserialize_from_json_str::<Configuration>(content, JsonParserOptions::default());
+            deserialize_from_json_str::<Configuration>(content, JsonParserOptions::default(), "");
 
         assert!(result.has_errors());
         for diagnostic in result.into_diagnostics() {
@@ -343,7 +343,7 @@ mod test {
   }
 }"#;
         let _result =
-            deserialize_from_json_str::<Configuration>(content, JsonParserOptions::default())
+            deserialize_from_json_str::<Configuration>(content, JsonParserOptions::default(), "")
                 .into_deserialized()
                 .unwrap_or_default();
     }

--- a/crates/biome_service/src/configuration/mod.rs
+++ b/crates/biome_service/src/configuration/mod.rs
@@ -623,7 +623,7 @@ fn load_config(
             file_path,
         } = auto_search_result;
         let deserialized =
-            deserialize_from_json_str::<Configuration>(&content, JsonParserOptions::default());
+            deserialize_from_json_str::<Configuration>(&content, JsonParserOptions::default(), "");
         Ok(Some(ConfigurationPayload {
             deserialized,
             configuration_file_path: file_path,
@@ -803,6 +803,7 @@ impl LoadedConfiguration {
             let deserialized = deserialize_from_json_str::<Configuration>(
                 content.as_str(),
                 JsonParserOptions::default(),
+                "",
             );
             deserialized_configurations.push(deserialized)
         }

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -269,7 +269,7 @@ fn lint(params: LintParams) -> LintResults {
             // if we're parsing the `biome.json` file, we deserialize it, so we can emit diagnostics for
             // malformed configuration
             if params.path.ends_with(ROME_JSON) || params.path.ends_with(BIOME_JSON) {
-                let deserialized = deserialize_from_json_ast::<Configuration>(&root);
+                let deserialized = deserialize_from_json_ast::<Configuration>(&root, "");
                 diagnostics.extend(
                     deserialized
                         .into_diagnostics()

--- a/crates/biome_service/tests/spec_tests.rs
+++ b/crates/biome_service/tests/spec_tests.rs
@@ -20,12 +20,14 @@ fn run_invalid_configurations(input: &'static str, _: &str, _: &str, _: &str) {
         "json" => deserialize_from_json_str::<Configuration>(
             input_code.as_str(),
             JsonParserOptions::default(),
+            "",
         ),
         "jsonc" => deserialize_from_json_str::<Configuration>(
             input_code.as_str(),
             JsonParserOptions::default()
                 .with_allow_comments()
                 .with_allow_trailing_commas(),
+            "",
         ),
         _ => {
             panic!("Extension not supported");
@@ -69,10 +71,12 @@ fn run_valid_configurations(input: &'static str, _: &str, _: &str, _: &str) {
         "json" => deserialize_from_json_str::<Configuration>(
             input_code.as_str(),
             JsonParserOptions::default(),
+            "",
         ),
         "jsonc" => deserialize_from_json_str::<Configuration>(
             input_code.as_str(),
             JsonParserOptions::default().with_allow_comments(),
+            "",
         ),
         _ => {
             panic!("Extension not supported");
@@ -116,7 +120,8 @@ fn quick_test() {
             }
         }
     }"#;
-    let result = deserialize_from_json_str::<Configuration>(source, JsonParserOptions::default());
+    let result =
+        deserialize_from_json_str::<Configuration>(source, JsonParserOptions::default(), "");
 
     dbg!(result.diagnostics());
     assert!(!result.has_errors());

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -41,6 +41,7 @@ pub fn create_analyzer_options(
         let deserialized = biome_deserialize::json::deserialize_from_json_str::<Configuration>(
             json.as_str(),
             JsonParserOptions::default(),
+            "",
         );
         if deserialized.has_errors() {
             diagnostics.extend(


### PR DESCRIPTION
## Summary

Allow naming the root deserialized value.
This addresses some requests of #1250. 
