### PR TITLE
fix: Use the correct diagnostic level in advice

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_cli_verbose.snap
@@ -28,7 +28,7 @@ package.json project ━━━━━━━━━━━━━━━━━━━�
   
   Verbose advice
   
-    i You can hide this diagnostic by using --diagnostic-level=warning to increase the diagnostic level shown by CLI.
+    i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
     
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_stdin_verbose_format.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_stdin_verbose_format.snap
@@ -17,7 +17,7 @@ package.json project ━━━━━━━━━━━━━━━━━━━�
   
   Verbose advice
   
-    i You can hide this diagnostic by using --diagnostic-level=warning to increase the diagnostic level shown by CLI.
+    i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
     
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_stdin_verbose_lint.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_stdin_verbose_lint.snap
@@ -17,7 +17,7 @@ package.json project ━━━━━━━━━━━━━━━━━━━�
   
   Verbose advice
   
-    i You can hide this diagnostic by using --diagnostic-level=warning to increase the diagnostic level shown by CLI.
+    i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
     
 
 ```

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -700,7 +700,7 @@ pub struct ProtectedFileAdvice;
 
 impl Advices for ProtectedFileAdvice {
     fn record(&self, visitor: &mut dyn Visit) -> std::io::Result<()> {
-        visitor.record_log(LogCategory::Info, &markup! { "You can hide this diagnostic by using "<Emphasis>"--diagnostic-level=warning"</Emphasis>" to increase the diagnostic level shown by CLI." })
+        visitor.record_log(LogCategory::Info, &markup! { "You can hide this diagnostic by using "<Emphasis>"--diagnostic-level=warn"</Emphasis>" to increase the diagnostic level shown by CLI." })
     }
 }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Currently, Biome tells users to use `--diagnostic-level=warning` instead of `--diagnostic-level=warn`. This change corrects it to the proper value.

Fixes #1467 
