### PR TITLE
fix(cli): ignore files and directories from working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - The diagnostics `files/missingHandler` are now shown only when the option `--verbose` is passed. Contributed by @ematipico
 - The diagnostics for protected files are now shown only when the option `--verbose` is passed. Contributed by @ematipico
+- Fix [#1465](https://github.com/biomejs/biome/issues/1465), by taking in consideration the workspace folder when matching a pattern. Contributed by @ematipico
+- Fix [#1465](https://github.com/biomejs/biome/issues/1465), by correctly process globs that contain file names. Contributed by @ematipico
 
 ### Configuration
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,6 @@ dependencies = [
  "biome_text_edit",
  "bpaf",
  "dashmap",
- "globset",
  "ignore",
  "indexmap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,6 @@ bitflags          = "2.3.1"
 bpaf              = { version = "0.9.5", features = ["derive"] }
 countme           = "3.0.1"
 dashmap           = "5.4.0"
-globset           = "0.4.14"
 ignore            = "0.4.21"
 indexmap          = "1.9.3"
 insta             = "1.29.0"

--- a/biome.json
+++ b/biome.json
@@ -7,10 +7,10 @@
 	},
 	"files": {
 		"ignore": [
-			"**/dist",
-			"**/.astro",
-			"**/assets",
-			"**/public",
+			"dist/**",
+			".astro/**",
+			"assets/**",
+			"public/**",
 			"**/__snapshots__",
 			"**/editors/intellij/**",
 			"*.astro",
@@ -22,11 +22,12 @@
 			"*.png",
 			"*.yml",
 			"*.yaml",
+			"*.snap",
 			"**/undefined/**",
-			"**LICENSE-MIT**",
-			"**LICENSE-APACHE**",
-			"**/ROME_LICENSE**",
-			"**ROME-LICENSE-MIT**"
+			"LICENSE-MIT",
+			"LICENSE-APACHE",
+			"ROME_LICENSE",
+			"ROME-LICENSE-MIT"
 		]
 	},
 	"formatter": {

--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -134,6 +134,7 @@ pub(crate) fn check(
         .app
         .workspace
         .update_settings(UpdateSettingsParams {
+            working_directory: session.app.fs.working_directory(),
             configuration: fs_configuration,
             vcs_base_path,
             gitignore_matches,

--- a/crates/biome_cli/src/commands/ci.rs
+++ b/crates/biome_cli/src/commands/ci.rs
@@ -108,6 +108,7 @@ pub(crate) fn ci(session: CliSession, mut payload: CiCommandPayload) -> Result<(
         .workspace
         .update_settings(UpdateSettingsParams {
             configuration,
+            working_directory: session.app.fs.working_directory(),
             vcs_base_path,
             gitignore_matches,
         })?;

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -148,6 +148,7 @@ pub(crate) fn format(
         .app
         .workspace
         .update_settings(UpdateSettingsParams {
+            working_directory: session.app.fs.working_directory(),
             configuration,
             vcs_base_path,
             gitignore_matches,

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -110,6 +110,7 @@ pub(crate) fn lint(
         .app
         .workspace
         .update_settings(UpdateSettingsParams {
+            working_directory: session.app.fs.working_directory(),
             configuration: fs_configuration,
             vcs_base_path,
             gitignore_matches,

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -59,7 +59,7 @@ impl<'app> CliSession<'app> {
     ) -> Result<Self, CliDiagnostic> {
         Ok(Self {
             app: App::new(
-                DynRef::Owned(Box::new(OsFileSystem)),
+                DynRef::Owned(Box::<OsFileSystem>::default()),
                 console,
                 WorkspaceRef::Borrowed(workspace),
             ),

--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -797,7 +797,7 @@ fn fs_error_dereferenced_symlink() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem)),
+        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
         &mut console,
         Args::from([("check"), root_path.display().to_string().as_str()].as_slice()),
     );
@@ -841,7 +841,7 @@ fn fs_error_infinite_symlink_expansion_to_dirs() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem)),
+        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
         &mut console,
         Args::from([("check"), (root_path.display().to_string().as_str())].as_slice()),
     );
@@ -887,7 +887,7 @@ fn fs_error_infinite_symlink_expansion_to_files() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem)),
+        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
         &mut console,
         Args::from([("check"), (root_path.display().to_string().as_str())].as_slice()),
     );
@@ -1067,7 +1067,7 @@ fn fs_files_ignore_symlink() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem)),
+        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
         &mut console,
         Args::from(
             [

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -1301,7 +1301,7 @@ fn does_not_format_ignored_directories() {
         ("test1.js", false),
         ("test2.js", false),
         ("test3/test.js", false),
-        ("test4/test.js", true),
+        ("test4/test.js", false),
         ("test5/test.js", false),
         ("test6/test.js", false),
         ("test/test.test7.js", false),
@@ -1322,24 +1322,12 @@ fn does_not_format_ignored_directories() {
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
     for (file_path, expect_formatted) in FILES {
-        let mut file = fs
-            .open(Path::new(file_path))
-            .expect("formatting target file was removed by the CLI");
-
-        let mut content = String::new();
-        file.read_to_string(&mut content)
-            .expect("failed to read file from memory FS");
-
         let expected = if expect_formatted {
             FORMATTED
         } else {
             UNFORMATTED
         };
-
-        assert_eq!(
-            content, expected,
-            "content of {file_path} doesn't match the expected content"
-        );
+        assert_file_contents(&fs, &Path::new(file_path), expected);
     }
 
     assert_cli_snapshot(SnapshotPayload::new(

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -1327,7 +1327,7 @@ fn does_not_format_ignored_directories() {
         } else {
             UNFORMATTED
         };
-        assert_file_contents(&fs, &Path::new(file_path), expected);
+        assert_file_contents(&fs, Path::new(file_path), expected);
     }
 
     assert_cli_snapshot(SnapshotPayload::new(

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -1301,7 +1301,7 @@ fn does_not_format_ignored_directories() {
         ("test1.js", false),
         ("test2.js", false),
         ("test3/test.js", false),
-        ("test4/test.js", false),
+        ("test4/test.js", true),
         ("test5/test.js", false),
         ("test6/test.js", false),
         ("test/test.test7.js", false),

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -796,7 +796,7 @@ fn fs_error_dereferenced_symlink() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem)),
+        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
         &mut console,
         Args::from([("lint"), root_path.display().to_string().as_str()].as_slice()),
     );
@@ -840,7 +840,7 @@ fn fs_error_infinite_symlink_expansion_to_dirs() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem)),
+        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
         &mut console,
         Args::from([("lint"), (root_path.display().to_string().as_str())].as_slice()),
     );
@@ -886,7 +886,7 @@ fn fs_error_infinite_symlink_expansion_to_files() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem)),
+        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
         &mut console,
         Args::from([("lint"), (root_path.display().to_string().as_str())].as_slice()),
     );
@@ -1066,7 +1066,7 @@ fn fs_files_ignore_symlink() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem)),
+        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
         &mut console,
         Args::from(
             [

--- a/crates/biome_cli/tests/snapshots/main_commands_check/fs_files_ignore_symlink.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/fs_files_ignore_symlink.snap
@@ -13,7 +13,7 @@ rome.json internalError/fs ━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Fixed 4 file(s) in <TIME>
+Fixed 2 file(s) in <TIME>
 ```
 
 

--- a/crates/biome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
@@ -60,8 +60,7 @@ statement();
 ## `test4/test.js`
 
 ```js
-statement();
-
+  statement(  )  
 ```
 
 ## `test5/test.js`
@@ -79,7 +78,7 @@ statement();
 # Emitted Messages
 
 ```block
-Formatted 3 file(s) in <TIME>
+Formatted 2 file(s) in <TIME>
 ```
 
 

--- a/crates/biome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
@@ -60,7 +60,8 @@ statement();
 ## `test4/test.js`
 
 ```js
-  statement(  )  
+statement();
+
 ```
 
 ## `test5/test.js`
@@ -78,7 +79,7 @@ statement();
 # Emitted Messages
 
 ```block
-Formatted 2 file(s) in <TIME>
+Formatted 3 file(s) in <TIME>
 ```
 
 

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -243,11 +243,9 @@ fn handle_dir_entry<'scope>(
     }
 
     if file_type.is_dir() {
-        if ctx.can_handle(&RomePath::new(path.clone())) {
-            scope.spawn(move |scope| {
-                handle_dir(scope, ctx, &path, origin_path);
-            });
-        }
+        scope.spawn(move |scope| {
+            handle_dir(scope, ctx, &path, origin_path);
+        });
         return;
     }
 

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -20,7 +20,13 @@ use std::{
 const MAX_SYMLINK_DEPTH: u8 = 3;
 
 /// Implementation of [FileSystem] that directly calls through to the underlying OS
-pub struct OsFileSystem;
+pub struct OsFileSystem(pub Option<PathBuf>);
+
+impl Default for OsFileSystem {
+    fn default() -> Self {
+        Self(env::current_dir().ok())
+    }
+}
 
 impl FileSystem for OsFileSystem {
     fn open_with_options(&self, path: &Path, options: OpenOptions) -> io::Result<Box<dyn File>> {
@@ -41,7 +47,7 @@ impl FileSystem for OsFileSystem {
     }
 
     fn working_directory(&self) -> Option<PathBuf> {
-        env::current_dir().ok()
+        self.0.clone()
     }
 
     fn path_exists(&self, path: &Path) -> bool {

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -432,6 +432,7 @@ impl Session {
                     match result {
                         Ok((vcs_base_path, gitignore_matches)) => {
                             let result = self.workspace.update_settings(UpdateSettingsParams {
+                                working_directory: fs.working_directory(),
                                 configuration,
                                 vcs_base_path,
                                 gitignore_matches,

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -147,7 +147,7 @@ impl Session {
             configuration_status: AtomicU8::new(ConfigurationStatus::Missing as u8),
             documents,
             extension_settings: config,
-            fs: DynRef::Owned(Box::new(OsFileSystem)),
+            fs: DynRef::Owned(Box::<OsFileSystem>::default()),
             cancellation,
             config_path: None,
         }

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -40,7 +40,6 @@ biome_rowan          = { workspace = true, features = ["serde"] }
 biome_text_edit      = { workspace = true }
 bpaf                 = { workspace = true }
 dashmap              = { workspace = true }
-globset              = { workspace = true }
 ignore               = { workspace = true }
 indexmap             = { workspace = true, features = ["serde"] }
 lazy_static          = { workspace = true }

--- a/crates/biome_service/src/configuration/formatter.rs
+++ b/crates/biome_service/src/configuration/formatter.rs
@@ -139,6 +139,7 @@ impl MergeWith<FormatterConfiguration> for FormatterConfiguration {
 }
 
 pub fn to_format_settings(
+    working_directory: Option<PathBuf>,
     conf: FormatterConfiguration,
     vcs_path: Option<PathBuf>,
     gitignore_matches: &[String],
@@ -161,8 +162,18 @@ pub fn to_format_settings(
         line_ending: conf.line_ending,
         line_width: conf.line_width,
         format_with_errors: conf.format_with_errors.unwrap_or_default(),
-        ignored_files: to_matcher(conf.ignore.as_ref(), vcs_path.clone(), gitignore_matches)?,
-        included_files: to_matcher(conf.include.as_ref(), vcs_path, gitignore_matches)?,
+        ignored_files: to_matcher(
+            working_directory.clone(),
+            conf.ignore.as_ref(),
+            vcs_path.clone(),
+            gitignore_matches,
+        )?,
+        included_files: to_matcher(
+            working_directory,
+            conf.include.as_ref(),
+            vcs_path,
+            gitignore_matches,
+        )?,
     })
 }
 

--- a/crates/biome_service/src/configuration/linter/mod.rs
+++ b/crates/biome_service/src/configuration/linter/mod.rs
@@ -79,6 +79,7 @@ impl Default for LinterConfiguration {
 }
 
 pub fn to_linter_settings(
+    working_directory: Option<PathBuf>,
     conf: LinterConfiguration,
     vcs_path: Option<PathBuf>,
     gitignore_matches: &[String],
@@ -86,8 +87,18 @@ pub fn to_linter_settings(
     Ok(LinterSettings {
         enabled: conf.enabled.unwrap_or_default(),
         rules: conf.rules,
-        ignored_files: to_matcher(conf.ignore.as_ref(), vcs_path.clone(), gitignore_matches)?,
-        included_files: to_matcher(conf.include.as_ref(), vcs_path, gitignore_matches)?,
+        ignored_files: to_matcher(
+            working_directory.clone(),
+            conf.ignore.as_ref(),
+            vcs_path.clone(),
+            gitignore_matches,
+        )?,
+        included_files: to_matcher(
+            working_directory.clone(),
+            conf.include.as_ref(),
+            vcs_path,
+            gitignore_matches,
+        )?,
     })
 }
 

--- a/crates/biome_service/src/configuration/organize_imports.rs
+++ b/crates/biome_service/src/configuration/organize_imports.rs
@@ -73,6 +73,7 @@ impl MergeWith<OrganizeImports> for OrganizeImports {
 }
 
 pub fn to_organize_imports_settings(
+    working_directory: Option<PathBuf>,
     organize_imports: OrganizeImports,
     vcs_base_path: Option<PathBuf>,
     gitignore_matches: &[String],
@@ -80,11 +81,13 @@ pub fn to_organize_imports_settings(
     Ok(OrganizeImportsSettings {
         enabled: organize_imports.enabled.unwrap_or_default(),
         ignored_files: to_matcher(
+            working_directory.clone(),
             organize_imports.ignore.as_ref(),
             vcs_base_path.clone(),
             gitignore_matches,
         )?,
         included_files: to_matcher(
+            working_directory,
             organize_imports.include.as_ref(),
             vcs_base_path,
             gitignore_matches,

--- a/crates/biome_service/src/configuration/overrides.rs
+++ b/crates/biome_service/src/configuration/overrides.rs
@@ -334,6 +334,7 @@ impl MergeWith<OverrideOrganizeImportsConfiguration> for OverrideOrganizeImports
 }
 
 pub fn to_override_settings(
+    working_directory: Option<PathBuf>,
     overrides: Overrides,
     vcs_base_path: Option<PathBuf>,
     gitignore_matches: &[String],
@@ -363,11 +364,13 @@ pub fn to_override_settings(
 
         let pattern_setting = OverrideSettingPattern {
             include: to_matcher(
+                working_directory.clone(),
                 pattern.include.as_ref(),
                 vcs_base_path.clone(),
                 gitignore_matches,
             )?,
             exclude: to_matcher(
+                working_directory.clone(),
                 pattern.ignore.as_ref(),
                 vcs_base_path.clone(),
                 gitignore_matches,

--- a/crates/biome_service/src/lib.rs
+++ b/crates/biome_service/src/lib.rs
@@ -46,7 +46,7 @@ pub struct App<'app> {
 
 impl<'app> App<'app> {
     pub fn with_console(console: &'app mut dyn Console) -> Self {
-        Self::with_filesystem_and_console(DynRef::Owned(Box::new(OsFileSystem)), console)
+        Self::with_filesystem_and_console(DynRef::Owned(Box::<OsFileSystem>::default()), console)
     }
 
     /// Create a new instance of the app using the specified [FileSystem] and [Console] implementation

--- a/crates/biome_service/src/matcher/LICENSE-APACHE
+++ b/crates/biome_service/src/matcher/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright (c) 2023 Biome Developers and Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crates/biome_service/src/matcher/LICENSE-MIT
+++ b/crates/biome_service/src/matcher/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/crates/biome_service/src/matcher/mod.rs
+++ b/crates/biome_service/src/matcher/mod.rs
@@ -116,14 +116,14 @@ impl Matcher {
             }
             let matches = self
                 .ignore
-                .matched(source_as_string, source.is_dir())
+                .matched_path_or_any_parents(source_as_string, source.is_dir())
                 .is_ignore()
                 || self
                     .git_ignore
                     .as_ref()
                     .map(|ignore| {
                         ignore
-                            .matched(source_as_string, source.is_dir())
+                            .matched_path_or_any_parents(source_as_string, source.is_dir())
                             .is_ignore()
                     })
                     .unwrap_or_default();
@@ -190,7 +190,7 @@ mod test {
 
     #[test]
     fn matches_single_path_2() {
-        let ignore = Matcher::try_from("./test/**/*.rs").unwrap();
+        let ignore = Matcher::try_from("test/").unwrap();
         let result = ignore.matches_path(Path::new("test/workspace.rs"));
 
         assert!(result);

--- a/crates/biome_service/src/matcher/mod.rs
+++ b/crates/biome_service/src/matcher/mod.rs
@@ -1,6 +1,11 @@
+pub mod pattern;
+
 use crate::configuration::diagnostics::InvalidIgnorePattern;
 use crate::{ConfigurationDiagnostic, WorkspaceError};
+use biome_console::markup;
+use biome_diagnostics::Diagnostic;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
+pub use pattern::{MatchOptions, Pattern, PatternError};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
@@ -9,60 +14,40 @@ use std::sync::RwLock;
 /// a unix shell style patterns
 #[derive(Debug)]
 pub struct Matcher {
+    root: Option<PathBuf>,
     git_ignore: Option<Gitignore>,
-    /// The globs
-    ignore: Gitignore,
+    patterns: Vec<Pattern>,
+    options: MatchOptions,
     /// Whether the string was already checked
     already_checked: RwLock<HashMap<String, bool>>,
 }
 
-impl TryFrom<&str> for Matcher {
-    type Error = WorkspaceError;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        let mut builder = GitignoreBuilder::new("");
-        builder
-            .add_line(
-                Some(PathBuf::new()),
-                value.strip_prefix("./").unwrap_or(value),
-            )
-            .map_err(|error| {
-                WorkspaceError::Configuration(ConfigurationDiagnostic::new_invalid_ignore_pattern(
-                    value.to_string(),
-                    error.to_string(),
-                ))
-            })?;
-
-        let ignore = builder.build().map_err(|error| {
-            WorkspaceError::Configuration(ConfigurationDiagnostic::InvalidIgnorePattern(
-                InvalidIgnorePattern {
-                    message: error.to_string(),
-                },
-            ))
-        })?;
-
-        Ok(Matcher::new(ignore))
-    }
-}
-
 impl Matcher {
-    pub fn empty() -> Self {
-        Self {
-            git_ignore: None,
-            ignore: Gitignore::empty(),
-            already_checked: RwLock::new(HashMap::default()),
-        }
-    }
-
     /// Creates a new Matcher with given options.
     ///
     /// Check [glob website](https://docs.rs/glob/latest/glob/struct.MatchOptions.html) for [MatchOptions]
-    pub fn new(ignore: Gitignore) -> Self {
+    pub fn new(options: MatchOptions) -> Self {
         Self {
-            ignore,
+            root: None,
             git_ignore: None,
+            patterns: Vec::new(),
+            options,
             already_checked: RwLock::new(HashMap::default()),
         }
+    }
+
+    pub fn empty() -> Self {
+        Self {
+            root: None,
+            git_ignore: None,
+            patterns: Vec::new(),
+            options: MatchOptions::default(),
+            already_checked: RwLock::new(HashMap::default()),
+        }
+    }
+
+    pub fn set_root(&mut self, root: PathBuf) {
+        self.root = Some(root);
     }
 
     pub fn add_gitignore_matches(
@@ -91,12 +76,37 @@ impl Matcher {
             ))
         })?;
         self.git_ignore = Some(gitignore);
+
         Ok(())
     }
 
-    /// If no globs haven't been stored, the function returns [true]
+    /// It adds a unix shell style pattern
+    pub fn add_pattern(&mut self, pattern: &str) -> Result<(), PatternError> {
+        let pattern = Pattern::new(pattern)?;
+        self.patterns.push(pattern);
+        Ok(())
+    }
+
+    /// It matches the given string against the stored patterns.
+    ///
+    /// It returns [true] if there's at least a match
+    pub fn matches(&self, source: &str) -> bool {
+        let mut already_ignored = self.already_checked.write().unwrap();
+        if let Some(matches) = already_ignored.get(source) {
+            return *matches;
+        }
+        for pattern in &self.patterns {
+            if pattern.matches_with(source, self.options) || source.contains(pattern.as_str()) {
+                already_ignored.insert(source.to_string(), true);
+                return true;
+            }
+        }
+        already_ignored.insert(source.to_string(), false);
+        false
+    }
+
     pub fn is_empty(&self) -> bool {
-        self.ignore.is_empty()
+        self.patterns.is_empty()
             && self
                 .git_ignore
                 .as_ref()
@@ -108,47 +118,104 @@ impl Matcher {
     ///
     /// It returns [true] if there's a lest a match
     pub fn matches_path(&self, source: &Path) -> bool {
+        if self.is_empty() {
+            return false;
+        }
         let mut already_checked = self.already_checked.write().unwrap();
         let source_as_string = source.to_str();
         if let Some(source_as_string) = source_as_string {
             if let Some(matches) = already_checked.get(source_as_string) {
                 return *matches;
             }
-            let matches = self
-                .ignore
-                .matched_path_or_any_parents(source_as_string, source.is_dir())
-                .is_ignore()
-                || self
-                    .git_ignore
-                    .as_ref()
-                    .map(|ignore| {
-                        ignore
-                            .matched(source_as_string, source.is_dir())
-                            .is_ignore()
-                    })
-                    .unwrap_or_default();
-
-            already_checked.insert(source_as_string.to_string(), matches);
-
-            matches
-        } else {
-            false
         }
+        let matches = self.run_match(source);
+
+        if let Some(source_as_string) = source_as_string {
+            already_checked.insert(source_as_string.to_string(), matches);
+        }
+
+        matches
+    }
+
+    fn run_match(&self, source: &Path) -> bool {
+        for pattern in &self.patterns {
+            let matches = if pattern.matches_path_with(source, self.options) {
+                true
+            } else {
+                // Here we cover cases where the user specifies single files inside the patterns.
+                // The pattern library doesn't support single files, we here we just do a check
+                // on contains
+                //
+                // Given the pattern `out`:
+                // - `out/index.html` -> matches
+                // - `out/` -> matches
+                // - `layout.tsx` -> does not match
+                // - `routes/foo.ts` -> does not match
+                source
+                    .ancestors()
+                    .any(|ancestor| ancestor.ends_with(pattern.as_str()))
+            };
+
+            if matches {
+                return true;
+            }
+        }
+
+        if let Some(source_as_string) = source.to_str() {
+            if self
+                .git_ignore
+                .as_ref()
+                .map(|ignore| {
+                    ignore
+                        .matched(source_as_string, source.is_dir())
+                        .is_ignore()
+                })
+                .unwrap_or_default()
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+impl Diagnostic for PatternError {
+    fn description(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(fmt, "{}", self.msg)
+    }
+
+    fn message(&self, fmt: &mut biome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
+        fmt.write_markup(markup!({ self.msg }))
     }
 }
 
 #[cfg(test)]
 mod test {
+    use crate::matcher::pattern::MatchOptions;
     use crate::matcher::Matcher;
-    use ignore::gitignore::GitignoreBuilder;
-    use std::path::Path;
+    use std::env;
 
     #[test]
     fn matches() {
-        let dir = "src/**/*.rs";
-        let ignore = Matcher::try_from(dir).unwrap();
-        let path = Path::new("src/workspace.rs");
-        let result = ignore.matches_path(path);
+        let current = env::current_dir().unwrap();
+        let dir = format!("{}/**/*.rs", current.display());
+        let mut ignore = Matcher::new(MatchOptions::default());
+        ignore.add_pattern(&dir).unwrap();
+        let path = env::current_dir().unwrap().join("src/workspace.rs");
+        let result = ignore.matches(path.to_str().unwrap());
+
+        assert!(result);
+    }
+
+    #[test]
+    fn matches_path() {
+        let current = env::current_dir().unwrap();
+        let dir = format!("{}/**/*.rs", current.display());
+        let mut ignore = Matcher::new(MatchOptions::default());
+        ignore.add_pattern(&dir).unwrap();
+        let path = env::current_dir().unwrap().join("src/workspace.rs");
+        let result = ignore.matches_path(path.as_path());
 
         assert!(result);
     }
@@ -156,23 +223,17 @@ mod test {
     #[test]
     fn matches_path_for_single_file_or_directory_name() {
         let dir = "inv";
-        let valid_test_dir = "**/valid";
-        let ignore = Matcher::new(
-            GitignoreBuilder::new("")
-                .add_line(None, dir)
-                .unwrap()
-                .add_line(None, valid_test_dir)
-                .unwrap()
-                .build()
-                .unwrap(),
-        );
+        let valid_test_dir = "valid/";
+        let mut ignore = Matcher::new(MatchOptions::default());
+        ignore.add_pattern(dir).unwrap();
+        ignore.add_pattern(valid_test_dir).unwrap();
 
-        let path = Path::new("tests").join("invalid");
+        let path = env::current_dir().unwrap().join("tests").join("invalid");
         let result = ignore.matches_path(path.as_path());
 
         assert!(!result);
 
-        let path = Path::new("tests").join("valid");
+        let path = env::current_dir().unwrap().join("tests").join("valid");
         let result = ignore.matches_path(path.as_path());
 
         assert!(result);
@@ -180,18 +241,15 @@ mod test {
 
     #[test]
     fn matches_single_path() {
-        let dir = Path::new("src/workspace.rs");
-        let ignore = Matcher::try_from(dir.to_str().unwrap()).unwrap();
-        let path = Path::new("src/workspace.rs");
-        let result = ignore.matches_path(path);
-
-        assert!(result);
-    }
-
-    #[test]
-    fn matches_single_path_2() {
-        let ignore = Matcher::try_from("test/").unwrap();
-        let result = ignore.matches_path(Path::new("test/workspace.rs"));
+        let dir = "workspace.rs";
+        let mut ignore = Matcher::new(MatchOptions {
+            require_literal_separator: true,
+            case_sensitive: true,
+            require_literal_leading_dot: true,
+        });
+        ignore.add_pattern(dir).unwrap();
+        let path = env::current_dir().unwrap().join("src/workspace.rs");
+        let result = ignore.matches(path.to_str().unwrap());
 
         assert!(result);
     }

--- a/crates/biome_service/src/matcher/mod.rs
+++ b/crates/biome_service/src/matcher/mod.rs
@@ -167,7 +167,7 @@ impl Matcher {
                 .as_ref()
                 .map(|ignore| {
                     ignore
-                        .matched(source_as_string, source.is_dir())
+                        .matched_path_or_any_parents(source_as_string, source.is_dir())
                         .is_ignore()
                 })
                 .unwrap_or_default()

--- a/crates/biome_service/src/matcher/mod.rs
+++ b/crates/biome_service/src/matcher/mod.rs
@@ -166,9 +166,9 @@ mod test {
         let valid_test_dir = "**/valid";
         let ignore = Matcher::new(
             GitignoreBuilder::new("")
-                .add_line(None, &dir)
+                .add_line(None, dir)
                 .unwrap()
-                .add_line(None, &valid_test_dir)
+                .add_line(None, valid_test_dir)
                 .unwrap()
                 .build()
                 .unwrap(),

--- a/crates/biome_service/src/matcher/mod.rs
+++ b/crates/biome_service/src/matcher/mod.rs
@@ -141,27 +141,14 @@ impl Matcher {
 mod test {
     use crate::matcher::Matcher;
     use ignore::gitignore::GitignoreBuilder;
-    use std::env;
     use std::path::Path;
 
     #[test]
     fn matches() {
-        let current = env::current_dir().unwrap();
-        let dir = format!("{}/**/*.rs", current.display());
-        let ignore = Matcher::try_from(dir.as_str()).unwrap();
-        let path = env::current_dir().unwrap().join("src/workspace.rs");
-        let result = ignore.matches_path(path.as_path());
-
-        assert!(result);
-    }
-
-    #[test]
-    fn matches_path() {
-        let current = env::current_dir().unwrap();
-        let dir = format!("{}/**/*.rs", current.display());
-        let ignore = Matcher::try_from(dir.as_str()).unwrap();
-        let path = env::current_dir().unwrap().join("src/workspace.rs");
-        let result = ignore.matches_path(path.as_path());
+        let dir = "src/**/*.rs";
+        let ignore = Matcher::try_from(dir).unwrap();
+        let path = Path::new("src/workspace.rs");
+        let result = ignore.matches_path(path);
 
         assert!(result);
     }
@@ -180,12 +167,12 @@ mod test {
                 .unwrap(),
         );
 
-        let path = env::current_dir().unwrap().join("tests").join("invalid");
+        let path = Path::new("tests").join("invalid");
         let result = ignore.matches_path(path.as_path());
 
         assert!(!result);
 
-        let path = env::current_dir().unwrap().join("tests").join("valid");
+        let path = Path::new("tests").join("valid");
         let result = ignore.matches_path(path.as_path());
 
         assert!(result);
@@ -193,19 +180,17 @@ mod test {
 
     #[test]
     fn matches_single_path() {
-        let dir = env::current_dir().unwrap().join("src/workspace.rs");
+        let dir = Path::new("src/workspace.rs");
         let ignore = Matcher::try_from(dir.to_str().unwrap()).unwrap();
-        let path = env::current_dir().unwrap().join("src/workspace.rs");
-        let result = ignore.matches_path(path.as_path());
+        let path = Path::new("src/workspace.rs");
+        let result = ignore.matches_path(path);
 
         assert!(result);
     }
 
     #[test]
     fn matches_single_path_2() {
-        let dir = env::current_dir().unwrap().join("./test/**/*.rs");
         let ignore = Matcher::try_from("./test/**/*.rs").unwrap();
-        let path = env::current_dir().unwrap().join("test/workspace.rs");
         let result = ignore.matches_path(Path::new("test/workspace.rs"));
 
         assert!(result);

--- a/crates/biome_service/src/matcher/mod.rs
+++ b/crates/biome_service/src/matcher/mod.rs
@@ -123,7 +123,7 @@ impl Matcher {
                     .as_ref()
                     .map(|ignore| {
                         ignore
-                            .matched_path_or_any_parents(source_as_string, source.is_dir())
+                            .matched(source_as_string, source.is_dir())
                             .is_ignore()
                     })
                     .unwrap_or_default();

--- a/crates/biome_service/src/matcher/pattern.rs
+++ b/crates/biome_service/src/matcher/pattern.rs
@@ -286,8 +286,8 @@ impl Pattern {
     ///
     /// # Examples
     ///
-    /// ```rust
-    /// use crate::biome_service::Pattern;
+    /// ```rust,ignore
+    /// use crate::Pattern;
     ///
     /// assert!(Pattern::new("c?t").unwrap().matches("cat"));
     /// assert!(Pattern::new("k[!e]tteh").unwrap().matches("kitteh"));

--- a/crates/biome_service/src/matcher/pattern.rs
+++ b/crates/biome_service/src/matcher/pattern.rs
@@ -1,0 +1,927 @@
+use crate::matcher::pattern::CharSpecifier::{CharRange, SingleChar};
+use crate::matcher::pattern::MatchResult::{
+    EntirePatternDoesntMatch, Match, SubPatternDoesntMatch,
+};
+use crate::matcher::pattern::PatternToken::{
+    AnyChar, AnyExcept, AnyRecursiveSequence, AnySequence, AnyWithin, Char,
+};
+use std::error::Error;
+use std::path::Path;
+use std::str::FromStr;
+use std::{fmt, path};
+
+/// A pattern parsing error.
+#[derive(Debug)]
+#[allow(missing_copy_implementations)]
+pub struct PatternError {
+    /// The approximate character index of where the error occurred.
+    pub pos: usize,
+
+    /// A message describing the error.
+    pub msg: &'static str,
+}
+
+impl Error for PatternError {
+    fn description(&self) -> &str {
+        self.msg
+    }
+}
+
+impl fmt::Display for PatternError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Pattern syntax error near position {}: {}",
+            self.pos, self.msg
+        )
+    }
+}
+
+/// A compiled Unix shell style pattern.
+///
+/// - `?` matches any single character.
+///
+/// - `*` matches any (possibly empty) sequence of characters.
+///
+/// - `**` matches the current directory and arbitrary subdirectories. This
+///   sequence **must** form a single path component, so both `**a` and `b**`
+///   are invalid and will result in an error.  A sequence of more than two
+///   consecutive `*` characters is also invalid.
+///
+/// - `[...]` matches any character inside the brackets.  Character sequences
+///   can also specify ranges of characters, as ordered by Unicode, so e.g.
+///   `[0-9]` specifies any character between 0 and 9 inclusive. An unclosed
+///   bracket is invalid.
+///
+/// - `[!...]` is the negation of `[...]`, i.e. it matches any characters
+///   **not** in the brackets.
+///
+/// - The metacharacters `?`, `*`, `[`, `]` can be matched by using brackets
+///   (e.g. `[?]`).  When a `]` occurs immediately following `[` or `[!` then it
+///   is interpreted as being part of, rather then ending, the character set, so
+///   `]` and NOT `]` can be matched by `[]]` and `[!]]` respectively.  The `-`
+///   character can be specified inside a character sequence pattern by placing
+///   it at the start or the end, e.g. `[abc-]`.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
+pub struct Pattern {
+    original: String,
+    tokens: Vec<PatternToken>,
+    is_recursive: bool,
+}
+
+/// Show the original glob pattern.
+impl fmt::Display for Pattern {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.original.fmt(f)
+    }
+}
+
+impl FromStr for Pattern {
+    type Err = PatternError;
+
+    fn from_str(s: &str) -> Result<Self, PatternError> {
+        Self::new(s)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+enum PatternToken {
+    Char(char),
+    AnyChar,
+    AnySequence,
+    AnyRecursiveSequence,
+    AnyWithin(Vec<CharSpecifier>),
+    AnyExcept(Vec<CharSpecifier>),
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+enum CharSpecifier {
+    SingleChar(char),
+    CharRange(char, char),
+}
+
+#[derive(Copy, Clone, PartialEq)]
+enum MatchResult {
+    Match,
+    SubPatternDoesntMatch,
+    EntirePatternDoesntMatch,
+}
+
+const ERROR_WILDCARDS: &str = "wildcards are either regular `*` or recursive `**`";
+const ERROR_RECURSIVE_WILDCARDS: &str = "recursive wildcards must form a single path \
+                                         component";
+const ERROR_INVALID_RANGE: &str = "invalid range pattern";
+
+impl Pattern {
+    /// This function compiles Unix shell style patterns.
+    ///
+    /// An invalid glob pattern will yield a `PatternError`.
+    pub fn new(pattern: &str) -> Result<Self, PatternError> {
+        let chars = pattern.chars().collect::<Vec<_>>();
+        let mut tokens = Vec::new();
+        let mut is_recursive = false;
+        let mut i = 0;
+
+        // A pattern is relative if it starts with "." followed by a separator,
+        // eg. "./test" or ".\test"
+        let is_relative = matches!(chars.get(..2), Some(['.', sep]) if path::is_separator(*sep));
+        if is_relative {
+            // If a pattern starts with a relative prefix, strip it from the
+            // pattern and replace it with a "**" sequence
+            i += 2;
+            tokens.push(AnyRecursiveSequence);
+        } else {
+            // A pattern is absolute if it starts with a path separator, eg. "/home" or "\\?\C:\Users"
+            let mut is_absolute = chars.first().map_or(false, |c| path::is_separator(*c));
+
+            // On windows a pattern may also be absolute if it starts with a
+            // drive letter, a colon and a separator, eg. "c:/Users" or "G:\Users"
+            if cfg!(windows) && !is_absolute {
+                is_absolute = matches!(chars.get(..3), Some(['a'..='z' | 'A'..='Z', ':', sep]) if path::is_separator(*sep));
+            }
+
+            // If a pattern is not absolute, insert a "**" sequence in front
+            if !is_absolute {
+                tokens.push(AnyRecursiveSequence);
+            }
+        }
+
+        while i < chars.len() {
+            match chars[i] {
+                '?' => {
+                    tokens.push(AnyChar);
+                    i += 1;
+                }
+                '*' => {
+                    let old = i;
+
+                    while i < chars.len() && chars[i] == '*' {
+                        i += 1;
+                    }
+
+                    let count = i - old;
+
+                    match count {
+                        count if count > 2 => {
+                            return Err(PatternError {
+                                pos: old + 2,
+                                msg: ERROR_WILDCARDS,
+                            });
+                        }
+                        count if count == 2 => {
+                            // ** can only be an entire path component
+                            // i.e. a/**/b is valid, but a**/b or a/**b is not
+                            // invalid matches are treated literally
+                            let is_valid = if i == 2 || path::is_separator(chars[i - count - 1]) {
+                                // it ends in a '/'
+                                if i < chars.len() && path::is_separator(chars[i]) {
+                                    i += 1;
+                                    true
+                                    // or the pattern ends here
+                                    // this enables the existing globbing mechanism
+                                } else if i == chars.len() {
+                                    true
+                                    // `**` ends in non-separator
+                                } else {
+                                    return Err(PatternError {
+                                        pos: i,
+                                        msg: ERROR_RECURSIVE_WILDCARDS,
+                                    });
+                                }
+                                // `**` begins with non-separator
+                            } else {
+                                return Err(PatternError {
+                                    pos: old - 1,
+                                    msg: ERROR_RECURSIVE_WILDCARDS,
+                                });
+                            };
+
+                            if is_valid {
+                                // collapse consecutive AnyRecursiveSequence to a
+                                // single one
+
+                                let tokens_len = tokens.len();
+
+                                if !(tokens_len > 1
+                                    && tokens[tokens_len - 1] == AnyRecursiveSequence)
+                                {
+                                    is_recursive = true;
+                                    tokens.push(AnyRecursiveSequence);
+                                }
+                            }
+                        }
+                        _ => {
+                            tokens.push(AnySequence);
+                        }
+                    }
+                }
+                '[' => {
+                    if i + 4 <= chars.len() && chars[i + 1] == '!' {
+                        match chars[i + 3..].iter().position(|x| *x == ']') {
+                            None => (),
+                            Some(j) => {
+                                let chars = &chars[i + 2..i + 3 + j];
+                                let cs = parse_char_specifiers(chars);
+                                tokens.push(AnyExcept(cs));
+                                i += j + 4;
+                                continue;
+                            }
+                        }
+                    } else if i + 3 <= chars.len() && chars[i + 1] != '!' {
+                        match chars[i + 2..].iter().position(|x| *x == ']') {
+                            None => (),
+                            Some(j) => {
+                                let cs = parse_char_specifiers(&chars[i + 1..i + 2 + j]);
+                                tokens.push(AnyWithin(cs));
+                                i += j + 3;
+                                continue;
+                            }
+                        }
+                    }
+
+                    // if we get here then this is not a valid range pattern
+                    return Err(PatternError {
+                        pos: i,
+                        msg: ERROR_INVALID_RANGE,
+                    });
+                }
+                c => {
+                    tokens.push(Char(c));
+                    i += 1;
+                }
+            }
+        }
+
+        Ok(Self {
+            tokens,
+            original: pattern.to_string(),
+            is_recursive,
+        })
+    }
+
+    /// Escape metacharacters within the given string by surrounding them in
+    /// brackets. The resulting string will, when compiled into a `Pattern`,
+    /// match the input string and nothing else.
+    pub fn escape(s: &str) -> String {
+        let mut escaped = String::new();
+        for c in s.chars() {
+            match c {
+                // note that ! does not need escaping because it is only special
+                // inside brackets
+                '?' | '*' | '[' | ']' => {
+                    escaped.push('[');
+                    escaped.push(c);
+                    escaped.push(']');
+                }
+                c => {
+                    escaped.push(c);
+                }
+            }
+        }
+        escaped
+    }
+
+    /// Return if the given `str` matches this `Pattern` using the default
+    /// match options (i.e. `MatchOptions::new()`).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use crate::biome_service::Pattern;
+    ///
+    /// assert!(Pattern::new("c?t").unwrap().matches("cat"));
+    /// assert!(Pattern::new("k[!e]tteh").unwrap().matches("kitteh"));
+    /// assert!(Pattern::new("d*g").unwrap().matches("doog"));
+    /// ```
+    pub fn matches(&self, str: &str) -> bool {
+        self.matches_with(str, MatchOptions::new())
+    }
+
+    /// Return if the given `Path`, when converted to a `str`, matches this
+    /// `Pattern` using the default match options (i.e. `MatchOptions::new()`).
+    pub fn matches_path(&self, path: &Path) -> bool {
+        // FIXME (#9639): This needs to handle non-utf8 paths
+        path.to_str().map_or(false, |s| self.matches(s))
+    }
+
+    /// Return if the given `str` matches this `Pattern` using the specified
+    /// match options.
+    pub fn matches_with(&self, str: &str, options: MatchOptions) -> bool {
+        self.matches_from(true, str.chars(), 0, options) == Match
+    }
+
+    /// Return if the given `Path`, when converted to a `str`, matches this
+    /// `Pattern` using the specified match options.
+    pub fn matches_path_with(&self, path: &Path, options: MatchOptions) -> bool {
+        // FIXME (#9639): This needs to handle non-utf8 paths
+        path.to_str()
+            .map_or(false, |s| self.matches_with(s, options))
+    }
+
+    /// Access the original glob pattern.
+    pub fn as_str(&self) -> &str {
+        &self.original
+    }
+
+    fn matches_from(
+        &self,
+        mut follows_separator: bool,
+        mut file: std::str::Chars,
+        i: usize,
+        options: MatchOptions,
+    ) -> MatchResult {
+        for (ti, token) in self.tokens[i..].iter().enumerate() {
+            match *token {
+                AnySequence | AnyRecursiveSequence => {
+                    // ** must be at the start.
+                    debug_assert!(match *token {
+                        AnyRecursiveSequence => follows_separator,
+                        _ => true,
+                    });
+
+                    // Empty match
+                    match self.matches_from(follows_separator, file.clone(), i + ti + 1, options) {
+                        SubPatternDoesntMatch => (), // keep trying
+                        m => return m,
+                    };
+
+                    while let Some(c) = file.next() {
+                        if follows_separator && options.require_literal_leading_dot && c == '.' {
+                            return SubPatternDoesntMatch;
+                        }
+                        follows_separator = path::is_separator(c);
+                        match *token {
+                            AnyRecursiveSequence if !follows_separator => continue,
+                            AnySequence
+                                if options.require_literal_separator && follows_separator =>
+                            {
+                                return SubPatternDoesntMatch
+                            }
+                            _ => (),
+                        }
+                        match self.matches_from(
+                            follows_separator,
+                            file.clone(),
+                            i + ti + 1,
+                            options,
+                        ) {
+                            SubPatternDoesntMatch => (), // keep trying
+                            m => return m,
+                        }
+                    }
+                }
+                _ => {
+                    let c = match file.next() {
+                        Some(c) => c,
+                        None => return EntirePatternDoesntMatch,
+                    };
+
+                    let is_sep = path::is_separator(c);
+
+                    if !match *token {
+                        AnyChar | AnyWithin(..) | AnyExcept(..)
+                            if (options.require_literal_separator && is_sep)
+                                || (follows_separator
+                                    && options.require_literal_leading_dot
+                                    && c == '.') =>
+                        {
+                            false
+                        }
+                        AnyChar => true,
+                        AnyWithin(ref specifiers) => in_char_specifiers(specifiers, c, options),
+                        AnyExcept(ref specifiers) => !in_char_specifiers(specifiers, c, options),
+                        Char(c2) => chars_eq(c, c2, options.case_sensitive),
+                        AnySequence | AnyRecursiveSequence => unreachable!(),
+                    } {
+                        return SubPatternDoesntMatch;
+                    }
+                    follows_separator = is_sep;
+                }
+            }
+        }
+
+        // Iter is fused.
+        if file.next().is_none() {
+            Match
+        } else {
+            SubPatternDoesntMatch
+        }
+    }
+}
+
+fn parse_char_specifiers(s: &[char]) -> Vec<CharSpecifier> {
+    let mut cs = Vec::new();
+    let mut i = 0;
+    while i < s.len() {
+        if i + 3 <= s.len() && s[i + 1] == '-' {
+            cs.push(CharRange(s[i], s[i + 2]));
+            i += 3;
+        } else {
+            cs.push(SingleChar(s[i]));
+            i += 1;
+        }
+    }
+    cs
+}
+
+fn in_char_specifiers(specifiers: &[CharSpecifier], c: char, options: MatchOptions) -> bool {
+    for &specifier in specifiers.iter() {
+        match specifier {
+            SingleChar(sc) => {
+                if chars_eq(c, sc, options.case_sensitive) {
+                    return true;
+                }
+            }
+            CharRange(start, end) => {
+                // FIXME: work with non-ascii chars properly (issue #1347)
+                if !options.case_sensitive && c.is_ascii() && start.is_ascii() && end.is_ascii() {
+                    let start = start.to_ascii_lowercase();
+                    let end = end.to_ascii_lowercase();
+
+                    let start_up = start.to_uppercase().next().unwrap();
+                    let end_up = end.to_uppercase().next().unwrap();
+
+                    // only allow case insensitive matching when
+                    // both start and end are within a-z or A-Z
+                    if start != start_up && end != end_up {
+                        let c = c.to_ascii_lowercase();
+                        if c >= start && c <= end {
+                            return true;
+                        }
+                    }
+                }
+
+                if c >= start && c <= end {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+/// A helper function to determine if two chars are (possibly case-insensitively) equal.
+fn chars_eq(a: char, b: char, case_sensitive: bool) -> bool {
+    if cfg!(windows) && path::is_separator(a) && path::is_separator(b) {
+        true
+    } else if !case_sensitive && a.is_ascii() && b.is_ascii() {
+        // FIXME: work with non-ascii chars properly (issue #9084)
+        a.to_ascii_lowercase() == b.to_ascii_lowercase()
+    } else {
+        a == b
+    }
+}
+
+/// Configuration options to modify the behaviour of `Pattern::matches_with(..)`.
+#[allow(missing_copy_implementations)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct MatchOptions {
+    /// Whether or not patterns should be matched in a case-sensitive manner.
+    /// This currently only considers upper/lower case relationships between
+    /// ASCII characters, but in future this might be extended to work with
+    /// Unicode.
+    pub case_sensitive: bool,
+
+    /// Whether or not path-component separator characters (e.g. `/` on
+    /// Posix) must be matched by a literal `/`, rather than by `*` or `?` or
+    /// `[...]`.
+    pub require_literal_separator: bool,
+
+    /// Whether or not paths that contain components that start with a `.`
+    /// will require that `.` appears literally in the pattern; `*`, `?`, `**`,
+    /// or `[...]` will not match. This is useful because such files are
+    /// conventionally considered hidden on Unix systems and it might be
+    /// desirable to skip them when listing files.
+    pub require_literal_leading_dot: bool,
+}
+
+impl MatchOptions {
+    /// Constructs a new `MatchOptions` with default field values. This is used
+    /// when calling functions that do not take an explicit `MatchOptions`
+    /// parameter.
+    ///
+    /// This function always returns this value:
+    ///
+    /// ```rust,ignore
+    /// MatchOptions {
+    ///     case_sensitive: true,
+    ///     require_literal_separator: false,
+    ///     require_literal_leading_dot: false
+    /// }
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            case_sensitive: true,
+            require_literal_separator: false,
+            require_literal_leading_dot: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{MatchOptions, Pattern};
+    use std::path::Path;
+
+    #[test]
+    fn test_pattern_from_str() {
+        assert!("a*b".parse::<Pattern>().unwrap().matches("a_b"));
+        assert!("a/**b".parse::<Pattern>().unwrap_err().pos == 4);
+    }
+
+    #[test]
+    fn test_wildcard_errors() {
+        assert!(Pattern::new("a/**b").unwrap_err().pos == 4);
+        assert!(Pattern::new("a/bc**").unwrap_err().pos == 3);
+        assert!(Pattern::new("a/*****").unwrap_err().pos == 4);
+        assert!(Pattern::new("a/b**c**d").unwrap_err().pos == 2);
+        assert!(Pattern::new("a**b").unwrap_err().pos == 0);
+    }
+
+    #[test]
+    fn test_unclosed_bracket_errors() {
+        assert!(Pattern::new("abc[def").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[!def").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[!").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[d").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[!d").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[]").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[!]").unwrap_err().pos == 3);
+    }
+
+    #[test]
+    fn test_wildcards() {
+        assert!(Pattern::new("a*b").unwrap().matches("a_b"));
+        assert!(Pattern::new("a*b*c").unwrap().matches("abc"));
+        assert!(!Pattern::new("a*b*c").unwrap().matches("abcd"));
+        assert!(Pattern::new("a*b*c").unwrap().matches("a_b_c"));
+        assert!(Pattern::new("a*b*c").unwrap().matches("a___b___c"));
+        assert!(Pattern::new("abc*abc*abc")
+            .unwrap()
+            .matches("abcabcabcabcabcabcabc"));
+        assert!(!Pattern::new("abc*abc*abc")
+            .unwrap()
+            .matches("abcabcabcabcabcabcabca"));
+        assert!(Pattern::new("a*a*a*a*a*a*a*a*a")
+            .unwrap()
+            .matches("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+        assert!(Pattern::new("a*b[xyz]c*d").unwrap().matches("abxcdbxcddd"));
+    }
+
+    #[test]
+    fn test_recursive_wildcards() {
+        let pat = Pattern::new("some/**/needle.txt").unwrap();
+        assert!(pat.matches("some/needle.txt"));
+        assert!(pat.matches("some/one/needle.txt"));
+        assert!(pat.matches("some/one/two/needle.txt"));
+        assert!(pat.matches("some/other/needle.txt"));
+        assert!(!pat.matches("some/other/notthis.txt"));
+
+        // a single ** should be valid, for globs
+        // Should accept anything
+        let pat = Pattern::new("**").unwrap();
+        assert!(pat.is_recursive);
+        assert!(pat.matches("abcde"));
+        assert!(pat.matches(""));
+        assert!(pat.matches(".asdf"));
+        assert!(pat.matches("/x/.asdf"));
+
+        // collapse consecutive wildcards
+        let pat = Pattern::new("some/**/**/needle.txt").unwrap();
+        assert!(pat.matches("some/needle.txt"));
+        assert!(pat.matches("some/one/needle.txt"));
+        assert!(pat.matches("some/one/two/needle.txt"));
+        assert!(pat.matches("some/other/needle.txt"));
+        assert!(!pat.matches("some/other/notthis.txt"));
+
+        // ** can begin the pattern
+        let pat = Pattern::new("**/test").unwrap();
+        assert!(pat.matches("one/two/test"));
+        assert!(pat.matches("one/test"));
+        assert!(pat.matches("test"));
+
+        // /** can begin the pattern
+        let pat = Pattern::new("/**/test").unwrap();
+        assert!(pat.matches("/one/two/test"));
+        assert!(pat.matches("/one/test"));
+        assert!(pat.matches("/test"));
+        assert!(!pat.matches("/one/notthis"));
+        assert!(!pat.matches("/notthis"));
+
+        // Only start sub-patterns on start of path segment.
+        let pat = Pattern::new("**/.*").unwrap();
+        assert!(pat.matches(".abc"));
+        assert!(pat.matches("abc/.abc"));
+        assert!(!pat.matches("ab.c"));
+        assert!(!pat.matches("abc/ab.c"));
+    }
+
+    #[test]
+    fn test_range_pattern() {
+        let pat = Pattern::new("a[0-9]b").unwrap();
+        for i in 0..10 {
+            assert!(pat.matches(&format!("a{}b", i)));
+        }
+        assert!(!pat.matches("a_b"));
+
+        let pat = Pattern::new("a[!0-9]b").unwrap();
+        for i in 0..10 {
+            assert!(!pat.matches(&format!("a{}b", i)));
+        }
+        assert!(pat.matches("a_b"));
+
+        let pats = ["[a-z123]", "[1a-z23]", "[123a-z]"];
+        for &p in pats.iter() {
+            let pat = Pattern::new(p).unwrap();
+            for c in "abcdefghijklmnopqrstuvwxyz".chars() {
+                assert!(pat.matches(&c.to_string()));
+            }
+            for c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
+                let options = MatchOptions {
+                    case_sensitive: false,
+                    ..MatchOptions::new()
+                };
+                assert!(pat.matches_with(&c.to_string(), options));
+            }
+            assert!(pat.matches("1"));
+            assert!(pat.matches("2"));
+            assert!(pat.matches("3"));
+        }
+
+        let pats = ["[abc-]", "[-abc]", "[a-c-]"];
+        for &p in pats.iter() {
+            let pat = Pattern::new(p).unwrap();
+            assert!(pat.matches("a"));
+            assert!(pat.matches("b"));
+            assert!(pat.matches("c"));
+            assert!(pat.matches("-"));
+            assert!(!pat.matches("d"));
+        }
+
+        let pat = Pattern::new("[2-1]").unwrap();
+        assert!(!pat.matches("1"));
+        assert!(!pat.matches("2"));
+
+        assert!(Pattern::new("[-]").unwrap().matches("-"));
+        assert!(!Pattern::new("[!-]").unwrap().matches("-"));
+    }
+
+    #[test]
+    fn test_pattern_matches() {
+        let txt_pat = Pattern::new("*hello.txt").unwrap();
+        assert!(txt_pat.matches("hello.txt"));
+        assert!(txt_pat.matches("gareth_says_hello.txt"));
+        assert!(txt_pat.matches("some/path/to/hello.txt"));
+        assert!(txt_pat.matches("some\\path\\to\\hello.txt"));
+        assert!(txt_pat.matches("/an/absolute/path/to/hello.txt"));
+        assert!(!txt_pat.matches("hello.txt-and-then-some"));
+        assert!(!txt_pat.matches("goodbye.txt"));
+
+        let dir_pat = Pattern::new("*some/path/to/hello.txt").unwrap();
+        assert!(dir_pat.matches("some/path/to/hello.txt"));
+        assert!(dir_pat.matches("a/bigger/some/path/to/hello.txt"));
+        assert!(!dir_pat.matches("some/path/to/hello.txt-and-then-some"));
+        assert!(!dir_pat.matches("some/other/path/to/hello.txt"));
+    }
+
+    #[test]
+    fn test_pattern_escape() {
+        let s = "_[_]_?_*_!_";
+        assert_eq!(Pattern::escape(s), "_[[]_[]]_[?]_[*]_!_".to_string());
+        assert!(Pattern::new(&Pattern::escape(s)).unwrap().matches(s));
+    }
+
+    #[test]
+    fn test_pattern_matches_case_insensitive() {
+        let pat = Pattern::new("aBcDeFg").unwrap();
+        let options = MatchOptions {
+            case_sensitive: false,
+            require_literal_separator: false,
+            require_literal_leading_dot: false,
+        };
+
+        assert!(pat.matches_with("aBcDeFg", options));
+        assert!(pat.matches_with("abcdefg", options));
+        assert!(pat.matches_with("ABCDEFG", options));
+        assert!(pat.matches_with("AbCdEfG", options));
+    }
+
+    #[test]
+    fn test_pattern_matches_case_insensitive_range() {
+        let pat_within = Pattern::new("[a]").unwrap();
+        let pat_except = Pattern::new("[!a]").unwrap();
+
+        let options_case_insensitive = MatchOptions {
+            case_sensitive: false,
+            require_literal_separator: false,
+            require_literal_leading_dot: false,
+        };
+        let options_case_sensitive = MatchOptions {
+            case_sensitive: true,
+            require_literal_separator: false,
+            require_literal_leading_dot: false,
+        };
+
+        assert!(pat_within.matches_with("a", options_case_insensitive));
+        assert!(pat_within.matches_with("A", options_case_insensitive));
+        assert!(!pat_within.matches_with("A", options_case_sensitive));
+
+        assert!(!pat_except.matches_with("a", options_case_insensitive));
+        assert!(!pat_except.matches_with("A", options_case_insensitive));
+        assert!(pat_except.matches_with("A", options_case_sensitive));
+    }
+
+    #[test]
+    fn test_pattern_matches_require_literal_separator() {
+        let options_require_literal = MatchOptions {
+            case_sensitive: true,
+            require_literal_separator: true,
+            require_literal_leading_dot: false,
+        };
+        let options_not_require_literal = MatchOptions {
+            case_sensitive: true,
+            require_literal_separator: false,
+            require_literal_leading_dot: false,
+        };
+
+        assert!(Pattern::new("abc/def")
+            .unwrap()
+            .matches_with("abc/def", options_require_literal));
+        assert!(!Pattern::new("abc?def")
+            .unwrap()
+            .matches_with("abc/def", options_require_literal));
+        assert!(!Pattern::new("abc*def")
+            .unwrap()
+            .matches_with("abc/def", options_require_literal));
+        assert!(!Pattern::new("abc[/]def")
+            .unwrap()
+            .matches_with("abc/def", options_require_literal));
+
+        assert!(Pattern::new("abc/def")
+            .unwrap()
+            .matches_with("abc/def", options_not_require_literal));
+        assert!(Pattern::new("abc?def")
+            .unwrap()
+            .matches_with("abc/def", options_not_require_literal));
+        assert!(Pattern::new("abc*def")
+            .unwrap()
+            .matches_with("abc/def", options_not_require_literal));
+        assert!(Pattern::new("abc[/]def")
+            .unwrap()
+            .matches_with("abc/def", options_not_require_literal));
+    }
+
+    #[test]
+    fn test_pattern_matches_require_literal_leading_dot() {
+        let options_require_literal_leading_dot = MatchOptions {
+            case_sensitive: true,
+            require_literal_separator: false,
+            require_literal_leading_dot: true,
+        };
+        let options_not_require_literal_leading_dot = MatchOptions {
+            case_sensitive: true,
+            require_literal_separator: false,
+            require_literal_leading_dot: false,
+        };
+
+        let f = |options| {
+            Pattern::new("*.txt")
+                .unwrap()
+                .matches_with(".hello.txt", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(!f(options_require_literal_leading_dot));
+
+        let f = |options| {
+            Pattern::new(".*.*")
+                .unwrap()
+                .matches_with(".hello.txt", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(f(options_require_literal_leading_dot));
+
+        let f = |options| {
+            Pattern::new("aaa/bbb/*")
+                .unwrap()
+                .matches_with("aaa/bbb/.ccc", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(!f(options_require_literal_leading_dot));
+
+        let f = |options| {
+            Pattern::new("aaa/bbb/*")
+                .unwrap()
+                .matches_with("aaa/bbb/c.c.c.", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(f(options_require_literal_leading_dot));
+
+        let f = |options| {
+            Pattern::new("aaa/bbb/.*")
+                .unwrap()
+                .matches_with("aaa/bbb/.ccc", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(f(options_require_literal_leading_dot));
+
+        let f = |options| {
+            Pattern::new("aaa/?bbb")
+                .unwrap()
+                .matches_with("aaa/.bbb", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(!f(options_require_literal_leading_dot));
+
+        let f = |options| {
+            Pattern::new("aaa/[.]bbb")
+                .unwrap()
+                .matches_with("aaa/.bbb", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(!f(options_require_literal_leading_dot));
+
+        let f = |options| Pattern::new("**/*").unwrap().matches_with(".bbb", options);
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(!f(options_require_literal_leading_dot));
+    }
+
+    #[test]
+    fn test_matches_path() {
+        // on windows, (Path::new("a/b").as_str().unwrap() == "a\\b"), so this
+        // tests that / and \ are considered equivalent on windows
+        assert!(Pattern::new("a/b").unwrap().matches_path(Path::new("a/b")));
+    }
+
+    #[test]
+    fn test_path_join() {
+        let pattern = Path::new("one").join(Path::new("**/*.rs"));
+        assert!(Pattern::new(pattern.to_str().unwrap()).is_ok());
+    }
+
+    #[test]
+    fn test_pattern_relative() {
+        assert!(Pattern::new("./b").unwrap().matches_path(Path::new("a/b")));
+        assert!(Pattern::new("b").unwrap().matches_path(Path::new("a/b")));
+
+        if cfg!(windows) {
+            assert!(Pattern::new(".\\b")
+                .unwrap()
+                .matches_path(Path::new("a\\b")));
+            assert!(Pattern::new("b").unwrap().matches_path(Path::new("a\\b")));
+        }
+    }
+
+    #[test]
+    fn test_pattern_absolute() {
+        assert!(Pattern::new("/a/b")
+            .unwrap()
+            .matches_path(Path::new("/a/b")));
+
+        if cfg!(windows) {
+            assert!(Pattern::new("c:/a/b")
+                .unwrap()
+                .matches_path(Path::new("c:/a/b")));
+            assert!(Pattern::new("C:\\a\\b")
+                .unwrap()
+                .matches_path(Path::new("C:\\a\\b")));
+
+            assert!(Pattern::new("\\\\?\\c:\\a\\b")
+                .unwrap()
+                .matches_path(Path::new("\\\\?\\c:\\a\\b")));
+            assert!(Pattern::new("\\\\?\\C:/a/b")
+                .unwrap()
+                .matches_path(Path::new("\\\\?\\C:/a/b")));
+        }
+    }
+
+    #[test]
+    fn test_pattern_glob() {
+        assert!(Pattern::new("*.js")
+            .unwrap()
+            .matches_path(Path::new("b/c.js")));
+
+        assert!(Pattern::new("**/*.js")
+            .unwrap()
+            .matches_path(Path::new("b/c.js")));
+
+        assert!(Pattern::new("*.js")
+            .unwrap()
+            .matches_path(Path::new("/a/b/c.js")));
+
+        assert!(Pattern::new("**/*.js")
+            .unwrap()
+            .matches_path(Path::new("/a/b/c.js")));
+
+        if cfg!(windows) {
+            assert!(Pattern::new("*.js")
+                .unwrap()
+                .matches_path(Path::new("C:\\a\\b\\c.js")));
+
+            assert!(Pattern::new("**/*.js")
+                .unwrap()
+                .matches_path(Path::new("\\\\?\\C:\\a\\b\\c.js")));
+        }
+    }
+}

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -25,7 +25,7 @@ use biome_js_syntax::JsLanguage;
 use biome_json_formatter::context::JsonFormatOptions;
 use biome_json_parser::JsonParserOptions;
 use biome_json_syntax::JsonLanguage;
-use globset::{Glob, GlobSetBuilder};
+use ignore::gitignore::GitignoreBuilder;
 use indexmap::IndexSet;
 use std::ops::{BitOr, Sub};
 use std::path::{Path, PathBuf};
@@ -90,28 +90,43 @@ impl WorkspaceSettings {
     pub fn merge_with_configuration(
         &mut self,
         configuration: Configuration,
+        working_directory: Option<PathBuf>,
         vcs_path: Option<PathBuf>,
         gitignore_matches: &[String],
     ) -> Result<(), WorkspaceError> {
         // formatter part
         if let Some(formatter) = configuration.formatter {
-            self.formatter = to_format_settings(formatter, vcs_path.clone(), gitignore_matches)?;
+            self.formatter = to_format_settings(
+                working_directory.clone(),
+                formatter,
+                vcs_path.clone(),
+                gitignore_matches,
+            )?;
         }
 
         // linter part
         if let Some(linter) = configuration.linter {
-            self.linter = to_linter_settings(linter, vcs_path.clone(), gitignore_matches)?;
+            self.linter = to_linter_settings(
+                working_directory.clone(),
+                linter,
+                vcs_path.clone(),
+                gitignore_matches,
+            )?;
         }
 
         // Filesystem settings
-        if let Some(files) =
-            to_file_settings(configuration.files, vcs_path.clone(), gitignore_matches)?
-        {
+        if let Some(files) = to_file_settings(
+            working_directory.clone(),
+            configuration.files,
+            vcs_path.clone(),
+            gitignore_matches,
+        )? {
             self.files = files;
         }
 
         if let Some(organize_imports) = configuration.organize_imports {
             self.organize_imports = to_organize_imports_settings(
+                working_directory.clone(),
                 organize_imports,
                 vcs_path.clone(),
                 gitignore_matches,
@@ -133,8 +148,13 @@ impl WorkspaceSettings {
 
         // NOTE: keep this last. Computing the overrides require reading the settings computed by the parent settings.
         if let Some(overrides) = configuration.overrides {
-            self.override_settings =
-                to_override_settings(overrides, vcs_path, gitignore_matches, self)?;
+            self.override_settings = to_override_settings(
+                working_directory.clone(),
+                overrides,
+                vcs_path,
+                gitignore_matches,
+                self,
+            )?;
         }
 
         Ok(())
@@ -444,6 +464,7 @@ impl Default for FilesSettings {
 }
 
 fn to_file_settings(
+    working_directory: Option<PathBuf>,
     config: Option<FilesConfiguration>,
     vcs_config_path: Option<PathBuf>,
     gitignore_matches: &[String],
@@ -460,11 +481,13 @@ fn to_file_settings(
         Some(FilesSettings {
             max_size: config.max_size.unwrap_or(DEFAULT_FILE_SIZE_LIMIT),
             ignored_files: to_matcher(
+                working_directory.clone(),
                 config.ignore.as_ref(),
                 vcs_config_path.clone(),
                 gitignore_matches,
             )?,
             included_files: to_matcher(
+                working_directory,
                 config.include.as_ref(),
                 vcs_config_path,
                 gitignore_matches,
@@ -845,22 +868,28 @@ pub struct OverrideSettingPattern {
 ///
 /// It can raise an error if the patterns aren't valid
 pub fn to_matcher(
+    working_directory: Option<PathBuf>,
     string_set: Option<&StringSet>,
     vcs_path: Option<PathBuf>,
     git_ignore_matches: &[String],
 ) -> Result<Matcher, WorkspaceError> {
-    let mut builder = GlobSetBuilder::new();
+    let mut git_builder =
+        GitignoreBuilder::new(working_directory.clone().unwrap_or(PathBuf::new()));
     if let Some(string_set) = string_set {
         for pattern in string_set.iter() {
-            builder.add(Glob::new(pattern).map_err(|err| {
-                WorkspaceError::Configuration(ConfigurationDiagnostic::new_invalid_ignore_pattern(
-                    pattern.to_string(),
-                    err.to_string(),
-                ))
-            })?);
+            git_builder
+                .add_line(working_directory.clone(), pattern)
+                .map_err(|error| {
+                    WorkspaceError::Configuration(
+                        ConfigurationDiagnostic::new_invalid_ignore_pattern(
+                            pattern.to_string(),
+                            error.to_string(),
+                        ),
+                    )
+                })?;
         }
     }
-    let mut matcher = Matcher::new(builder.build().map_err(|err| {
+    let mut matcher = Matcher::new(git_builder.build().map_err(|err| {
         WorkspaceError::Configuration(ConfigurationDiagnostic::InvalidIgnorePattern(
             InvalidIgnorePattern {
                 message: err.to_string(),

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -877,7 +877,10 @@ pub fn to_matcher(
     if let Some(string_set) = string_set {
         for pattern in string_set.iter() {
             git_builder
-                .add_line(working_directory.clone(), pattern)
+                .add_line(
+                    working_directory.clone(),
+                    pattern.strip_prefix("./").unwrap_or(pattern),
+                )
                 .map_err(|error| {
                     WorkspaceError::Configuration(
                         ConfigurationDiagnostic::new_invalid_ignore_pattern(

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -873,8 +873,7 @@ pub fn to_matcher(
     vcs_path: Option<PathBuf>,
     git_ignore_matches: &[String],
 ) -> Result<Matcher, WorkspaceError> {
-    let mut git_builder =
-        GitignoreBuilder::new(working_directory.clone().unwrap_or(PathBuf::new()));
+    let mut git_builder = GitignoreBuilder::new(working_directory.clone().unwrap_or_default());
     if let Some(string_set) = string_set {
         for pattern in string_set.iter() {
             git_builder

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -378,7 +378,7 @@ pub struct UpdateSettingsParams {
     pub vcs_base_path: Option<PathBuf>,
     // @ematipico TODO: have a better data structure for this
     pub gitignore_matches: Vec<String>,
-    pub working_directory: Option<PathBuf>
+    pub working_directory: Option<PathBuf>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -378,6 +378,7 @@ pub struct UpdateSettingsParams {
     pub vcs_base_path: Option<PathBuf>,
     // @ematipico TODO: have a better data structure for this
     pub gitignore_matches: Vec<String>,
+    pub working_directory: Option<PathBuf>
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -269,7 +269,6 @@ impl Workspace for WorkspaceServer {
                     let language = self.get_language(&params.path);
                     if language == Language::Unknown {
                         file_features.ignore_not_supported();
-                        return Ok(entry.insert(file_features).clone());
                     }
                 }
                 for feature in params.feature {

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -349,6 +349,7 @@ impl Workspace for WorkspaceServer {
 
         settings.merge_with_configuration(
             params.configuration,
+            params.working_directory,
             params.vcs_base_path,
             params.gitignore_matches.as_slice(),
         )?;

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -62,7 +62,7 @@ pub fn create_analyzer_options(
             let configuration = deserialized.into_deserialized().unwrap_or_default();
             let mut settings = WorkspaceSettings::default();
             settings
-                .merge_with_configuration(configuration, None, &[])
+                .merge_with_configuration(configuration, None, None, &[])
                 .unwrap();
             let configuration = AnalyzerConfiguration {
                 rules: to_analyzer_rules(&settings, input_file),

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -21,6 +21,7 @@ export interface UpdateSettingsParams {
 	configuration: Configuration;
 	gitignore_matches: string[];
 	vcs_base_path?: string;
+	working_directory?: string;
 }
 /**
  * The configuration that is contained inside the file `biome.json`

--- a/website/src/content/docs/guides/how-biome-works.mdx
+++ b/website/src/content/docs/guides/how-biome-works.mdx
@@ -94,7 +94,57 @@ The following files are parsed as **`JSON` files** with  the options `json.parse
 - `.hintrc`
 - `.babelrc`
 
-## Syntax rules for `ignore` and `include`
+## `ignore` and `include` explained
+
+Biome will resolve the globs specified in `ignore` and `include` relatively from the working directory.
+
+The working directory is the directory where you usually run a CLI command. This means that you have to place **particular attention** when the configuration file is placed in a
+different directory that is different from where you execute your command.
+
+For example, you have a project that contains two directories called `backend/` and `frontend/`, and decide to place your `biome.json` at the root folder of the project. Inside the `frontend/` project, you have your `package.json` with some scripts that runs Biome:
+
+```
+├── backend
+├── biome.json
+└── frontend
+    └── package.json
+```
+
+```json title="biome.json"
+{
+  "files": {
+    "include": ["src/**/*.js", "src/**/*.ts"]
+  },
+  "formatter": {
+    "indentStyle": "space"
+  }
+}
+```
+
+```json title="frontend/package.json"
+{
+  "name": "frontend-project",
+  "scripts": {
+    "format": "biome format --write ./"
+  }
+}
+```
+
+When you run the script `format` inside `frontend/package.json`, the working directory resolved by that script will be `frontend/`, the globs `src/**/*.js` and `src/**/*.ts` will have as "base" directory `frontend/`.
+
+:::note
+When both `ignore` and `include` are specified, Biome gives **precedence** to `ignore`.
+:::
+
+:::caution
+`ignore` and `include` inside `overrides` have a **different** semantics:
+- for `ignore`: if a file matches the globs, **_don't_ apply** the configuration inside this override, and keep apply the next overrides;
+- for `include`: if a file matches the globs, **apply** the configuration inside this override, and keep apply the next overrides;
+:::
+
+
+### Glob syntax explained
+
 
 The syntax and meaning of these two options loosely follow the [globset rules](https://docs.rs/globset/latest/globset/#syntax) but without the ability to set options.
 
@@ -118,7 +168,6 @@ The syntax and meaning of these two options loosely follow the [globset rules](h
 > - Metacharacters such as `*` and `?` can be escaped with character class
 > notation. e.g., `[*]` matches `*`.
 
-### Ignore folders and ignore files
 
 
 

--- a/website/src/content/docs/guides/how-biome-works.mdx
+++ b/website/src/content/docs/guides/how-biome-works.mdx
@@ -168,6 +168,9 @@ The syntax and meaning of these two options loosely follow the [globset rules](h
 > - Metacharacters such as `*` and `?` can be escaped with character class
 > notation. e.g., `[*]` matches `*`.
 
+### Resources
 
+- https://www.atlassian.com/git/tutorials/saving-changes/gitignore#git-ignore-patterns
+- https://git-scm.com/docs/gitignore#_pattern_format
 
 

--- a/website/src/content/docs/guides/how-biome-works.mdx
+++ b/website/src/content/docs/guides/how-biome-works.mdx
@@ -168,9 +168,4 @@ The syntax and meaning of these two options loosely follow the [globset rules](h
 > - Metacharacters such as `*` and `?` can be escaped with character class
 > notation. e.g., `[*]` matches `*`.
 
-### Resources
-
-- https://www.atlassian.com/git/tutorials/saving-changes/gitignore#git-ignore-patterns
-- https://git-scm.com/docs/gitignore#_pattern_format
-
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -24,6 +24,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - The diagnostics `files/missingHandler` are now shown only when the option `--verbose` is passed. Contributed by @ematipico
 - The diagnostics for protected files are now shown only when the option `--verbose` is passed. Contributed by @ematipico
+- Fix [#1465](https://github.com/biomejs/biome/issues/1465), by taking in consideration the workspace folder when matching a pattern. Contributed by @ematipico
+- Fix [#1465](https://github.com/biomejs/biome/issues/1465), by correctly process globs that contain file names. Contributed by @ematipico
 
 ### Configuration
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/1465
Closes https://github.com/biomejs/biome/issues/1471
Closes https://github.com/biomejs/biome/issues/1495
Closes https://github.com/biomejs/biome/issues/1504

~I nuked `globset`; it doesn't have what we need. Luckily, `ignore::gitignore` **does** what we need. It correctly resolves the globs based on a specified path, which is our working directory.~

> [!NOTE]
> We decided to revert the changes made in the recent release. The recent release removed our internal fork of 
> `glob` in favour of `globset`; unfortunately, after two days of tries and conversations with @Conaclos , we decided to **revert** the changes and use our own fork.

> [!IMPORTANT]
> Also, we decided to **NOT** pursue the parity with `git` glob patterns, because their semantics are very different. Did you know that in git, a pattern like `dist` is equivalent to `**/dist`? This means that a file with a path like `dist/test.js` WON'T match the previous `dist` glob.

I am sure that some users are very skilled in git, but most users usually use unix-style globs, which are simpler and more widespread.

I took the chance to update the documentation page with a better explanation of how the globs work inside Biome.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

1. I tested it on an actual project that specifies `src/**/*.js` as including globs.
2. I updated one of the tests with an incorrect assertion. Even globs that start with `/` e.g. `/src/**/*.js` are resolved from the working directory.

<!-- What demonstrates that your implementation is correct? -->
