### PR TITLE
fix(cli): don't print loaded config on error

### DIFF
--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -417,7 +417,6 @@ pub(crate) fn validate_configuration_diagnostics(
     }
 
     if loaded_configuration.has_errors() {
-        println!("{:#?}", loaded_configuration);
         return Err(CliDiagnostic::workspace_error(
             WorkspaceError::Configuration(ConfigurationDiagnostic::invalid_configuration(
                 "Biome exited because the configuration resulted in errors. Please fix them.",


### PR DESCRIPTION
## Summary

Fix a forgotten debug print.

## Test Plan

I tested locally.
