### PR TITLE
refactor(linter): add source metadata

### DIFF
--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -36,7 +36,7 @@ pub use crate::registry::{
 };
 pub use crate::rule::{
     CategoryLanguage, FixKind, GroupCategory, GroupLanguage, Rule, RuleAction, RuleDiagnostic,
-    RuleGroup, RuleMeta, RuleMetadata, Source, SourceKind, SuppressAction,
+    RuleGroup, RuleMeta, RuleMetadata, RuleSource, RuleSourceKind, SuppressAction,
 };
 pub use crate::services::{FromServices, MissingServicesDiagnostic, ServiceBag};
 pub use crate::signals::{

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -32,9 +32,9 @@ pub struct RuleMetadata {
     /// The kind of fix
     pub fix_kind: Option<FixKind>,
     /// The source URL of the rule
-    pub source: Option<Source>,
+    pub source: Option<RuleSource>,
     /// The source kind of the rule
-    pub source_kind: Option<SourceKind>,
+    pub source_kind: Option<RuleSourceKind>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -57,7 +57,7 @@ impl Display for FixKind {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Source {
+pub enum RuleSource {
     /// Rules from [Rust Clippy](https://rust-lang.github.io/rust-clippy/master/index.html)
     Clippy(&'static str),
     /// Rules from [Eslint](https://eslint.org/)
@@ -78,7 +78,7 @@ pub enum Source {
     EslintMysticatea(&'static str),
 }
 
-impl Source {
+impl RuleSource {
     pub fn as_rule_name(&self) -> &'static str {
         match self {
             Self::Clippy(rule_name) => rule_name,
@@ -113,7 +113,7 @@ impl Source {
 }
 
 #[derive(Debug, Clone)]
-pub enum SourceKind {
+pub enum RuleSourceKind {
     /// The rule implements the same logic of the source
     SameLogic,
     /// The rule deviate of the logic of the source
@@ -149,12 +149,15 @@ impl RuleMetadata {
         self
     }
 
-    pub const fn source(mut self, source: Source) -> Self {
+    pub const fn source(mut self, source: RuleSource) -> Self {
         self.source = Some(source);
+        if self.source_kind.is_none() {
+            self.source_kind = Some(RuleSourceKind::SameLogic);
+        }
         self
     }
 
-    pub const fn source_kind(mut self, source_kind: SourceKind) -> Self {
+    pub const fn source_kind(mut self, source_kind: RuleSourceKind) -> Self {
         self.source_kind = Some(source_kind);
         self
     }

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -62,6 +62,10 @@ pub enum RuleSource {
     Clippy(&'static str),
     /// Rules from [Eslint](https://eslint.org/)
     Eslint(&'static str),
+    /// Rules from [Eslint Plugin Import](https://github.com/import-js/eslint-plugin-import)
+    EslintImport(&'static str),
+    /// Rules from [Eslint Plugin Import Access](https://github.com/uhyo/eslint-plugin-import-access)
+    EslintImportAccess(&'static str),
     /// Rules from [Eslint Plugin Jest](https://github.com/jest-community/eslint-plugin-jest)
     EslintJest(&'static str),
     /// Rules from [Eslint Plugin JSX A11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y)
@@ -70,7 +74,11 @@ pub enum RuleSource {
     EslintReact(&'static str),
     /// Rules from [Eslint Plugin React Hooks](https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md)
     EslintReactHooks(&'static str),
-    /// Rules from [Typescript Eslint Plugin](https://typescript-eslint.io)
+    /// Rules from [Eslint Plugin Sonar](https://github.com/SonarSource/eslint-plugin-sonarjs)
+    EslintSonarJs(&'static str),
+    /// Rules from [Eslint Plugin Stylistic](https://eslint.style)
+    EslintStylistic(&'static str),
+    /// Rules from [Eslint Plugin Typescript](https://typescript-eslint.io)
     EslintTypeScript(&'static str),
     /// Rules from [Eslint Plugin Unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn)
     EslintUnicorn(&'static str),
@@ -81,27 +89,35 @@ pub enum RuleSource {
 impl RuleSource {
     pub fn as_rule_name(&self) -> &'static str {
         match self {
-            Self::Clippy(rule_name) => rule_name,
-            Self::Eslint(rule_name) => rule_name,
-            Self::EslintJest(rule_name) => rule_name,
-            Self::EslintJsxA11y(rule_name) => rule_name,
-            Self::EslintReact(rule_name) => rule_name,
-            Self::EslintReactHooks(rule_name) => rule_name,
-            Self::EslintTypeScript(rule_name) => rule_name,
-            Self::EslintUnicorn(rule_name) => rule_name,
-            Self::EslintMysticatea(rule_name) => rule_name,
+            Self::Clippy(rule_name)
+            | Self::Eslint(rule_name)
+            | Self::EslintImport(rule_name)
+            | Self::EslintImportAccess(rule_name)
+            | Self::EslintJest(rule_name)
+            | Self::EslintJsxA11y(rule_name)
+            | Self::EslintReact(rule_name)
+            | Self::EslintReactHooks(rule_name)
+            | Self::EslintTypeScript(rule_name)
+            | Self::EslintSonarJs(rule_name)
+            | Self::EslintStylistic(rule_name)
+            | Self::EslintUnicorn(rule_name)
+            | Self::EslintMysticatea(rule_name) => rule_name,
         }
     }
 
     pub fn as_rule_url(&self) -> String {
         match self {
             Self::Clippy(rule_name) => format!("https://rust-lang.github.io/rust-clippy/master/#/{rule_name}"),
-            Self::Eslint(rule_name) => format!( "https://eslint.org/docs/latest/rules/{rule_name}"),
+            Self::Eslint(rule_name) => format!("https://eslint.org/docs/latest/rules/{rule_name}"),
+            Self::EslintImport(rule_name) => format!("https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/{rule_name}.md"),
+            Self::EslintImportAccess(rule_name) => format!("https://github.com/uhyo/eslint-plugin-import-access/blob/main/docs/rules/{rule_name}.md"),
             Self::EslintJest(rule_name) => format!("https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/{rule_name}.md"),
             Self::EslintJsxA11y(rule_name) => format!("https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/{rule_name}.md"),
             Self::EslintReact(rule_name) => format!("https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/{rule_name}.md"),
             Self::EslintReactHooks(_) =>  "https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md".to_string(),
             Self::EslintTypeScript(rule_name) => format!("https://typescript-eslint.io/rules/{rule_name}"),
+            Self::EslintSonarJs(rule_name) => format!("https://github.com/SonarSource/eslint-plugin-sonarjs/blob/HEAD/docs/rules/{rule_name}.md"),
+            Self::EslintStylistic(rule_name) => format!("https://eslint.style/rules/default/{rule_name}"),
             Self::EslintUnicorn(rule_name) => format!("https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/{rule_name}.md"),
             Self::EslintMysticatea(rule_name) => format!("https://github.com/mysticatea/eslint-plugin/blob/master/docs/rules/{rule_name}.md"),
         }
@@ -112,9 +128,10 @@ impl RuleSource {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub enum RuleSourceKind {
     /// The rule implements the same logic of the source
+    #[default]
     SameLogic,
     /// The rule deviate of the logic of the source
     Inspired,
@@ -151,9 +168,9 @@ impl RuleMetadata {
 
     pub const fn source(mut self, source: RuleSource) -> Self {
         self.source = Some(source);
-        if self.source_kind.is_none() {
-            self.source_kind = Some(RuleSourceKind::SameLogic);
-        }
+        //if self.source_kind.is_none() {
+        //    self.source_kind = Some(RuleSourceKind::SameLogic);
+        //}
         self
     }
 

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_access_key.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_access_key.rs
@@ -1,6 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -39,6 +40,7 @@ declare_rule! {
     pub(crate) NoAccessKey {
         version: "1.0.0",
         name: "noAccessKey",
+        source: RuleSource::EslintJsxA11y("no-access-key"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_auto_focus.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_auto_focus.rs
@@ -1,6 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -59,6 +60,7 @@ declare_rule! {
     pub(crate) NoAutoFocus {
         version: "1.0.0",
         name: "noAutofocus",
+        source: RuleSource::EslintJsxA11y("no-autofocus"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_blank_target.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_blank_target.rs
@@ -1,6 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make::{
@@ -51,6 +51,7 @@ declare_rule! {
     pub(crate) NoBlankTarget {
         version: "1.0.0",
         name: "noBlankTarget",
+        source: RuleSource::EslintJsxA11y("jsx-no-target-blank"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_distracting_elements.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_distracting_elements.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
@@ -40,6 +40,7 @@ declare_rule! {
     pub(crate) NoDistractingElements {
         version: "1.0.0",
         name: "noDistractingElements",
+        source: RuleSource::EslintJsxA11y("no-distracting-elements"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_header_scope.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_header_scope.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
@@ -40,6 +40,7 @@ declare_rule! {
     pub(crate) NoHeaderScope {
         version: "1.0.0",
         name: "noHeaderScope",
+        source: RuleSource::EslintJsxA11y("scope"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_redundant_alt.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_redundant_alt.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::{
@@ -42,6 +42,7 @@ declare_rule! {
     pub(crate) NoRedundantAlt {
         version: "1.0.0",
         name: "noRedundantAlt",
+        source: RuleSource::EslintJsxA11y("no-redundant-roles"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_alt_text.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_alt_text.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::{fmt::Display, fmt::Formatter, markup};
 use biome_js_syntax::{jsx_ext::AnyJsxElement, TextRange};
 use biome_rowan::AstNode;
@@ -46,6 +46,7 @@ declare_rule! {
     pub(crate) UseAltText {
         version: "1.0.0",
         name: "useAltText",
+        source: RuleSource::EslintJsxA11y("alt-text"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_anchor_content.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_anchor_content.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
@@ -67,6 +67,7 @@ declare_rule! {
     pub(crate) UseAnchorContent {
         version: "1.0.0",
         name: "useAnchorContent",
+        source: RuleSource::EslintJsxA11y("anchor-has-content"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_heading_content.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_heading_content.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, JsxElement};
 use biome_rowan::AstNode;
@@ -47,6 +47,7 @@ declare_rule! {
     pub(crate) UseHeadingContent {
         version: "1.0.0",
         name: "useHeadingContent",
+        source: RuleSource::EslintJsxA11y("heading-has-content"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_html_lang.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_html_lang.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, TextRange};
 use biome_rowan::AstNode;
@@ -55,6 +55,7 @@ declare_rule! {
     pub(crate) UseHtmlLang {
         version: "1.0.0",
         name: "useHtmlLang",
+        source: RuleSource::EslintJsxA11y("html-has-lang"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_iframe_title.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_iframe_title.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::AstNode;
@@ -61,6 +61,7 @@ declare_rule! {
     pub(crate) UseIframeTitle {
         version: "1.0.0",
         name: "useIframeTitle",
+        source: RuleSource::EslintJsxA11y("iframe-has-title"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_key_with_click_events.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_key_with_click_events.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, AnyJsxAttribute, AnyJsxElementName};
 use biome_rowan::AstNode;
@@ -59,6 +59,7 @@ declare_rule! {
     pub(crate) UseKeyWithClickEvents {
         version: "1.0.0",
         name: "useKeyWithClickEvents",
+        source: RuleSource::EslintJsxA11y("click-events-have-key-events"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_key_with_mouse_events.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_key_with_mouse_events.rs
@@ -1,6 +1,6 @@
 use crate::semantic_services::Semantic;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::{markup, MarkupBuf};
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::AstNode;
@@ -42,6 +42,7 @@ declare_rule! {
     pub(crate) UseKeyWithMouseEvents {
         version: "1.0.0",
         name: "useKeyWithMouseEvents",
+        source: RuleSource::EslintJsxA11y("mouse-events-have-key-events"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_media_caption.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_media_caption.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::{AnyJsxChild, JsxElement, TextRange};
@@ -7,8 +7,6 @@ use biome_rowan::AstNode;
 
 declare_rule! {
     /// Enforces that `audio` and `video` elements must have a `track` for captions.
-    ///
-    /// **ESLint Equivalent:** [media-has-caption](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/media-has-caption.md)
     ///
     /// ## Examples
     ///
@@ -35,6 +33,7 @@ declare_rule! {
     pub(crate) UseMediaCaption {
         version: "1.0.0",
         name: "useMediaCaption",
+        source: RuleSource::EslintJsxA11y("media-has-caption"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_valid_anchor.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_valid_anchor.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::{markup, MarkupBuf};
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::{AstNode, TextRange};
@@ -66,6 +66,7 @@ declare_rule! {
     pub(crate) UseValidAnchor {
         version: "1.0.0",
         name: "useValidAnchor",
+        source: RuleSource::EslintJsxA11y("anchor-is-valid"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_excessive_cognitive_complexity.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_excessive_cognitive_complexity.rs
@@ -1,6 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, AddVisitor, Phases, QueryMatch, Queryable, Rule,
-    RuleDiagnostic, ServiceBag, Visitor, VisitorContext,
+    RuleDiagnostic, RuleSource, ServiceBag, Visitor, VisitorContext,
 };
 use biome_console::markup;
 use biome_deserialize::{
@@ -36,10 +36,6 @@ declare_rule! {
     ///
     /// The complexity score is calculated based on the Cognitive Complexity
     /// algorithm: http://redirect.sonarsource.com/doc/cognitive-complexity.html
-    ///
-    /// Source:
-    ///
-    /// * https://github.com/SonarSource/eslint-plugin-sonarjs/blob/HEAD/docs/rules/cognitive-complexity.md
     ///
     /// ## Examples
     ///
@@ -79,6 +75,7 @@ declare_rule! {
     pub(crate) NoExcessiveCognitiveComplexity {
         version: "1.0.0",
         name: "noExcessiveCognitiveComplexity",
+        source: RuleSource::EslintSonarJs("cognitive-complexity"),
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_extra_boolean_cast.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_extra_boolean_cast.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -55,10 +56,10 @@ declare_rule! {
     /// !x;
     /// !!x;
     /// ```
-
     pub(crate) NoExtraBooleanCast {
         version: "1.0.0",
         name: "noExtraBooleanCast",
+        source: RuleSource::Eslint("no-extra-boolean-cast"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_for_each.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_for_each.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{AnyJsExpression, AnyJsMemberExpression, JsCallExpression};
 use biome_rowan::{AstNode, AstSeparatedList};
@@ -54,6 +54,7 @@ declare_rule! {
     pub(crate) NoForEach {
         version: "1.0.0",
         name: "noForEach",
+        source: RuleSource::EslintUnicorn("no-array-for-each"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_multiple_spaces_in_regular_expression_literals.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_multiple_spaces_in_regular_expression_literals.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -11,8 +12,6 @@ use crate::JsRuleAction;
 
 declare_rule! {
     /// Disallow unclear usage of consecutive space characters in regular expression literals
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-regex-spaces/
     ///
     /// ## Examples
     ///
@@ -50,6 +49,7 @@ declare_rule! {
     pub(crate) NoMultipleSpacesInRegularExpressionLiterals {
         version: "1.0.0",
         name: "noMultipleSpacesInRegularExpressionLiterals",
+        source: RuleSource::Eslint("no-regex-spaces"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_static_only_class.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_static_only_class.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{
     AnyJsClass, AnyJsClassMember, JsGetterClassMember, JsMethodClassMember, JsPropertyClassMember,
@@ -19,8 +19,6 @@ declare_rule! {
     /// 	- As an alternative, you can import * as ... the module to get all of them in a single object.
     /// - IDEs can't provide as good suggestions for static class or namespace imported properties when you start typing property names
     /// - It's more difficult to statically analyze code for unused variables, etc. when they're all on the class (see: Finding dead code (and dead types) in TypeScript).
-    ///
-    /// Source: https://typescript-eslint.io/rules/no-extraneous-class
     ///
     /// ## Examples
     ///
@@ -93,6 +91,7 @@ declare_rule! {
     pub(crate) NoStaticOnlyClass {
         version: "1.0.0",
         name: "noStaticOnlyClass",
+        source: RuleSource::EslintTypeScript("no-extraneous-class"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_catch.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_catch.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{JsCatchClause, TextRange};
 use biome_rowan::{AstNode, AstNodeList};
@@ -10,8 +10,6 @@ declare_rule! {
     /// and has no effect on the runtime behavior of the program.
     /// These redundant clauses can be a source of confusion and code bloat,
     /// so it’s better to disallow these unnecessary `catch` clauses.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-useless-catch
     ///
     /// ## Examples
     ///
@@ -55,6 +53,7 @@ declare_rule! {
     pub(crate) NoUselessCatch {
         version: "1.0.0",
         name: "noUselessCatch",
+        source: RuleSource::Eslint("no-useless-catch"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_constructor.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_constructor.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -22,8 +23,6 @@ declare_rule! {
     /// - decorated classes;
     /// - constructors with at least one [parameter property](https://www.typescriptlang.org/docs/handbook/classes.html#parameter-properties);
     /// - `private` and `protected` constructors.
-    ///
-    /// Source: https://typescript-eslint.io/rules/no-useless-constructor
     ///
     /// ## Caveat
     ///
@@ -106,6 +105,7 @@ declare_rule! {
     pub(crate) NoUselessConstructor {
         version: "1.0.0",
         name: "noUselessConstructor",
+        source: RuleSource::EslintTypeScript("no-useless-constructor"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_empty_export.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_empty_export.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -20,8 +21,6 @@ declare_rule! {
     /// > whose contents are available in the global scope.
     ///
     /// However, an `export {}` statement does nothing if there are any other top-level import or export in the file.
-    ///
-    /// Source: https://typescript-eslint.io/rules/no-useless-empty-export/
     ///
     /// ## Examples
     ///
@@ -46,6 +45,7 @@ declare_rule! {
     pub(crate) NoUselessEmptyExport {
         version: "1.0.0",
         name: "noUselessEmptyExport",
+        source: RuleSource::EslintTypeScript("no-useless-empty-export"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_label.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_label.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_syntax::{AnyJsStatement, JsLabeledStatement, JsSyntaxKind};
@@ -11,8 +11,6 @@ declare_rule! {
     /// Disallow unnecessary labels.
     ///
     /// If a loop contains no nested loops or switches, labeling the loop is unnecessary.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-extra-label
     ///
     /// ## Examples
     ///
@@ -37,6 +35,7 @@ declare_rule! {
     pub(crate) NoUselessLabel {
         version: "1.0.0",
         name: "noUselessLabel",
+        source: RuleSource::Eslint("no-extra-label"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_rename.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_rename.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
@@ -26,8 +26,6 @@ declare_rule! {
     ///
     /// With this syntax, it is possible to rename a reference to the same name.
     /// This is a completely redundant operation, as this is the same as not renaming at all.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-useless-rename
     ///
     /// ## Examples
     ///
@@ -62,6 +60,7 @@ declare_rule! {
     pub(crate) NoUselessRename {
         version: "1.0.0",
         name: "noUselessRename",
+        source: RuleSource::Eslint("no-useless-rename"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_switch_case.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_switch_case.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_syntax::{AnyJsSwitchClause, JsCaseClause, JsDefaultClause};
@@ -14,8 +14,6 @@ declare_rule! {
     ///
     /// The `default` clause will be still executed only if there is no match in the `case` clauses.
     /// An empty `case` clause that precedes the `default` clause is thus useless.
-    ///
-    /// Source: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-switch-case.md
     ///
     /// ## Examples
     ///
@@ -62,6 +60,7 @@ declare_rule! {
     pub(crate) NoUselessSwitchCase {
         version: "1.0.0",
         name: "noUselessSwitchCase",
+        source: RuleSource::EslintUnicorn("no-useless-switch-case"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_type_constraint.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_type_constraint.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 
 use biome_diagnostics::Applicability;
@@ -21,8 +21,6 @@ declare_rule! {
     /// A supplied type must then be a subtype of the supplied constraint.
     /// All types are subtypes of `any` and `unknown`.
     /// It is thus useless to extend from `any` or `unknown`.
-    ///
-    /// Source: https://typescript-eslint.io/rules/no-unnecessary-type-constraint/
     ///
     /// ## Examples
     ///
@@ -81,6 +79,7 @@ declare_rule! {
     pub(crate) NoUselessTypeConstraint {
         version: "1.0.0",
         name: "noUselessTypeConstraint",
+        source: RuleSource::EslintTypeScript("no-unnecessary-type-constraint"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_void.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_void.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::JsUnaryExpression;
 use biome_rowan::AstNode;
@@ -8,8 +8,6 @@ declare_rule! {
     ///
     /// > The `void` operator is often used merely to obtain the undefined primitive value,
     /// > usually using `void(0)` (which is equivalent to `void 0`). In these cases, the global variable `undefined` can be used.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-void
     ///
     /// ## Examples
     ///
@@ -22,6 +20,7 @@ declare_rule! {
     pub(crate) NoVoid {
         version: "1.0.0",
         name: "noVoid",
+        source: RuleSource::Eslint("no-void"),
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_with.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_with.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::JsWithStatement;
 
@@ -25,6 +25,7 @@ declare_rule! {
     pub(crate) NoWith {
         version: "1.0.0",
         name: "noWith",
+        source: RuleSource::Eslint("no-with"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_arrow_function.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_arrow_function.rs
@@ -1,7 +1,8 @@
 use crate::JsRuleAction;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, AddVisitor, FixKind, Phases, QueryMatch,
-    Queryable, Rule, RuleDiagnostic, ServiceBag, Visitor, VisitorContext,
+    Queryable, Rule, RuleDiagnostic, RuleSource, RuleSourceKind, ServiceBag, Visitor,
+    VisitorContext,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -69,6 +70,8 @@ declare_rule! {
     pub(crate) UseArrowFunction {
         version: "1.0.0",
         name: "useArrowFunction",
+        source: RuleSource::Eslint("prefer-arrow-callback"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_flat_map.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_flat_map.rs
@@ -1,6 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make::{ident, js_name};
@@ -9,7 +9,6 @@ use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt};
 
 declare_rule! {
     /// Promotes the use of `.flatMap()` when `map().flat()` are used together.
-    ///
     ///
     /// ## Examples
     ///
@@ -35,6 +34,7 @@ declare_rule! {
     pub(crate) UseFlatMap {
         version: "1.0.0",
         name: "useFlatMap",
+        source: RuleSource::EslintUnicorn("prefer-array-flat-map"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_literal_keys.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_literal_keys.rs
@@ -1,6 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -51,6 +52,7 @@ declare_rule! {
     pub(crate) UseLiteralKeys {
         version: "1.0.0",
         name: "useLiteralKeys",
+        source: RuleSource::Eslint("dot-notation"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_optional_chain.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_optional_chain.rs
@@ -1,3 +1,4 @@
+use biome_analyze::RuleSource;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
 };
@@ -75,6 +76,7 @@ declare_rule! {
     pub(crate) UseOptionalChain {
         version: "1.0.0",
         name: "useOptionalChain",
+        source: RuleSource::EslintTypeScript("prefer-optional-chain"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_regex_literals.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_regex_literals.rs
@@ -1,5 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -29,8 +29,6 @@ declare_rule! {
     /// Using regular expression literals avoids some escaping required in a string literal,
     /// and are easier to analyze statically.
     ///
-    /// Source: https://eslint.org/docs/latest/rules/prefer-regex-literals/
-    ///
     /// ## Examples
     ///
     /// ### Invalid
@@ -50,6 +48,7 @@ declare_rule! {
     pub(crate) UseRegexLiterals {
         version: "1.3.0",
         name: "useRegexLiterals",
+        source: RuleSource::Eslint("prefer-regex-literals"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_constructor_return.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_constructor_return.rs
@@ -1,4 +1,5 @@
 use biome_analyze::context::RuleContext;
+use biome_analyze::RuleSource;
 use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_syntax::{JsConstructorClassMember, JsReturnStatement};
@@ -13,8 +14,6 @@ declare_rule! {
     /// Forbidding this pattern prevents errors resulting from unfamiliarity with JavaScript or a copy-paste error.
     ///
     /// Only returning without a value is allowed, as it’s a control flow statement.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-constructor-return
     ///
     /// ## Examples
     ///
@@ -47,6 +46,7 @@ declare_rule! {
     pub(crate) NoConstructorReturn {
         version: "1.0.0",
         name: "noConstructorReturn",
+        source: RuleSource::Eslint("no-constructor-return"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_empty_character_class_in_regex.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_empty_character_class_in_regex.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::JsRegexLiteralExpression;
 use biome_rowan::{TextRange, TextSize};
@@ -11,8 +11,6 @@ declare_rule! {
     /// Empty character classes don't match anything.
     /// In contrast, negated empty classes match any character.
     /// They are often the result of a typing mistake.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-empty-character-class/
     ///
     /// ## Examples
     ///
@@ -43,6 +41,7 @@ declare_rule! {
     pub(crate) NoEmptyCharacterClassInRegex {
         version: "1.3.0",
         name: "noEmptyCharacterClassInRegex",
+        source: RuleSource::Eslint("no-empty-character-class"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_empty_pattern.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_empty_pattern.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{JsArrayBindingPattern, JsObjectBindingPattern};
 use biome_rowan::{declare_node_union, AstNode, AstSeparatedList};
@@ -35,6 +35,7 @@ declare_rule! {
     pub(crate) NoEmptyPattern {
         version: "1.0.0",
         name: "noEmptyPattern",
+        source: RuleSource::Eslint("no-empty-pattern"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_inner_declarations.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_inner_declarations.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{AnyJsDeclaration, JsFileSource, JsStatementList, JsSyntaxKind};
 use biome_rowan::AstNode;
@@ -18,8 +18,6 @@ declare_rule! {
     /// Note that `const` and `let` declarations are block-scoped,
     /// and therefore they are not affected by this rule.
     /// Moreover, `function` declarations in nested blocks are allowed inside _ES modules_.
-    ///
-    /// Source: https://eslint.org/docs/rules/no-inner-declarations
     ///
     /// ## Examples
     ///
@@ -90,6 +88,7 @@ declare_rule! {
     pub(crate) NoInnerDeclarations {
         version: "1.0.0",
         name: "noInnerDeclarations",
+        source: RuleSource::Eslint("no-inner-declarations"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_invalid_constructor_super.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_invalid_constructor_super.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::{markup, MarkupBuf};
 use biome_js_syntax::{
     AnyJsClass, AnyJsExpression, JsAssignmentOperator, JsConstructorClassMember, JsLogicalOperator,
@@ -48,6 +48,7 @@ declare_rule! {
     pub(crate) NoInvalidConstructorSuper {
         version: "1.0.0",
         name: "noInvalidConstructorSuper",
+        source: RuleSource::Eslint("constructor-super"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_nonoctal_decimal_escape.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_nonoctal_decimal_escape.rs
@@ -1,6 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -25,8 +26,6 @@ declare_rule! {
     /// If the ECMAScript host is not a web browser, this syntax is optional.
     /// However, web browsers are still required to support it, but only in non-strict mode.
     /// Regardless of your targeted environment, it is recommended to avoid using these escape sequences in new code.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-nonoctal-decimal-escape
     ///
     /// ## Examples
     ///
@@ -57,6 +56,7 @@ declare_rule! {
     pub(crate) NoNonoctalDecimalEscape {
         version: "1.0.0",
         name: "noNonoctalDecimalEscape",
+        source: RuleSource::Eslint("no-nonoctal-decimal-escape"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_precision_loss.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_precision_loss.rs
@@ -2,7 +2,7 @@ use std::num::IntErrorKind;
 use std::ops::RangeInclusive;
 
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 
 use biome_js_syntax::numbers::split_into_radix_and_number;
@@ -56,6 +56,7 @@ declare_rule! {
     pub(crate) NoPrecisionLoss {
         version: "1.0.0",
         name: "noPrecisionLoss",
+        source: RuleSource::Eslint("no-loss-of-precision"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_self_assign.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_self_assign.rs
@@ -1,3 +1,4 @@
+use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_syntax::{
@@ -19,8 +20,6 @@ declare_rule! {
     /// Disallow assignments where both sides are exactly the same.
     ///
     /// Self assignments have no effect, so probably those are an error due to incomplete refactoring.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-self-assign
     ///
     /// ## Examples
     ///
@@ -67,6 +66,7 @@ declare_rule! {
     pub(crate) NoSelfAssign {
         version: "1.0.0",
         name: "noSelfAssign",
+        source: RuleSource::Eslint("no-self-assign"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_setter_return.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_setter_return.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{JsReturnStatement, JsSetterClassMember, JsSetterObjectMember};
 use biome_rowan::{declare_node_union, AstNode};
@@ -67,6 +67,7 @@ declare_rule! {
     pub(crate) NoSetterReturn {
         version: "1.0.0",
         name: "noSetterReturn",
+        source: RuleSource::Eslint("no-setter-return"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_string_case_mismatch.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_string_case_mismatch.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
@@ -34,6 +34,7 @@ declare_rule! {
     pub(crate) NoStringCaseMismatch {
         version: "1.0.0",
         name: "noStringCaseMismatch",
+        source: RuleSource::Clippy("match_str_case_mismatch"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_switch_declarations.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_switch_declarations.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
@@ -17,8 +17,6 @@ declare_rule! {
     /// However, it only gets initialized when it is assigned, which will only happen if the `switch` clause where it is defined is reached.
     ///
     /// To ensure that the lexical declarations only apply to the current `switch` clause wrap your declarations in a block.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-case-declarations
     ///
     /// ## Examples
     ///
@@ -74,6 +72,7 @@ declare_rule! {
     pub(crate) NoSwitchDeclarations {
         version: "1.0.0",
         name: "noSwitchDeclarations",
+        source: RuleSource::Eslint("no-case-declarations"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_unreachable.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_unreachable.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, collections::VecDeque, num::NonZeroU32, vec::IntoIter};
 
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_control_flow::{
     builder::{BlockId, ROOT_BLOCK_ID},
     ExceptionHandler, ExceptionHandlerKind, Instruction, InstructionKind,
@@ -50,6 +50,7 @@ declare_rule! {
     pub(crate) NoUnreachable {
         version: "1.0.0",
         name: "noUnreachable",
+        source: RuleSource::Eslint("no-unreachable"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_unreachable_super.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_unreachable_super.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_control_flow::{
     builder::{BlockId, ROOT_BLOCK_ID},
@@ -64,6 +64,7 @@ declare_rule! {
     pub(crate) NoUnreachableSuper {
         version: "1.0.0",
         name: "noUnreachableSuper",
+        source: RuleSource::Eslint("no-this-before-super"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_unsafe_finally.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_unsafe_finally.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::*;
 use biome_rowan::{declare_node_union, AstNode};
@@ -127,6 +127,7 @@ declare_rule! {
     pub(crate) NoUnsafeFinally {
         version: "1.0.0",
         name: "noUnsafeFinally",
+        source: RuleSource::Eslint("no-unsafe-finally"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_unsafe_optional_chaining.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_unsafe_optional_chaining.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{
     AnyJsAssignmentPattern, AnyJsBindingPattern, AnyJsOptionalChainExpression,
@@ -64,6 +64,7 @@ declare_rule! {
     pub(crate) NoUnsafeOptionalChaining {
         version: "1.0.0",
         name: "noUnsafeOptionalChaining",
+        source: RuleSource::Eslint("no-unsafe-optional-chaining"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_unused_labels.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_unused_labels.rs
@@ -1,7 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{
     declare_rule, ActionCategory, AddVisitor, FixKind, Phases, QueryMatch, Queryable, Rule,
-    RuleDiagnostic, ServiceBag, Visitor, VisitorContext,
+    RuleDiagnostic, RuleSource, ServiceBag, Visitor, VisitorContext,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -20,8 +20,6 @@ declare_rule! {
     /// Disallow unused labels.
     ///
     /// Labels that are declared and never used are most likely an error due to incomplete refactoring.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-unused-labels
     ///
     /// ## Examples
     ///
@@ -56,6 +54,7 @@ declare_rule! {
     pub(crate) NoUnusedLabels {
         version: "1.0.0",
         name: "noUnusedLabels",
+        source: RuleSource::Eslint("no-unused-labels"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/correctness/use_valid_for_direction.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/use_valid_for_direction.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{
     AnyJsExpression, JsAssignmentOperator, JsBinaryOperator, JsForStatement,
@@ -41,6 +41,7 @@ declare_rule! {
     pub(crate) UseValidForDirection {
         version: "1.0.0",
         name: "useValidForDirection",
+        source: RuleSource::Eslint("for-direction"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/use_yield.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/use_yield.rs
@@ -1,7 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{
-    declare_rule, AddVisitor, Phases, QueryMatch, Queryable, Rule, RuleDiagnostic, ServiceBag,
-    Visitor, VisitorContext,
+    declare_rule, AddVisitor, Phases, QueryMatch, Queryable, Rule, RuleDiagnostic, RuleSource,
+    ServiceBag, Visitor, VisitorContext,
 };
 use biome_console::markup;
 use biome_js_syntax::{AnyFunctionLike, JsLanguage, JsYieldExpression, TextRange, WalkEvent};
@@ -11,8 +11,6 @@ declare_rule! {
     /// Require generator functions to contain `yield`.
     ///
     /// This rule generates warnings for generator functions that do not have the `yield` keyword.
-    ///
-    /// Source: [require-yield](https://eslint.org/docs/latest/rules/require-yield).
     ///
     /// ## Examples
     ///
@@ -41,6 +39,7 @@ declare_rule! {
     pub(crate) UseYield {
         version: "1.0.0",
         name: "useYield",
+        source: RuleSource::Eslint("require-yield"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_empty_block_statements.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_empty_block_statements.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{
     JsBlockStatement, JsFunctionBody, JsStaticInitializationBlockClassMember, JsSwitchStatement,
@@ -12,9 +12,6 @@ declare_rule! {
     ///
     /// This rule disallows empty block statements and static blocks.
     /// This rule ignores block statements or static blocks which contain a comment (for example, in an empty catch or finally block of a try statement to indicate that execution should continue regardless of errors).
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-empty-static-block/
-    /// Source: https://eslint.org/docs/latest/rules/no-empty/
     ///
     /// ## Examples
     ///
@@ -57,6 +54,8 @@ declare_rule! {
     pub(crate) NoEmptyBlockStatements {
         version: "1.3.0",
         name: "noEmptyBlockStatements",
+        // Include also `eslint/no-empty-static-block`
+        source: RuleSource::Eslint("no-empty"),
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_nodejs_modules.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_nodejs_modules.rs
@@ -1,5 +1,5 @@
 use crate::globals::node::is_node_builtin_module;
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::inner_string_text;
 use biome_rowan::TextRange;
@@ -10,8 +10,6 @@ declare_rule! {
     /// Forbid the use of Node.js builtin modules.
     ///
     /// This can be useful for client-side web projects that don't have access to those modules.
-    ///
-    /// Source: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-nodejs-modules.md
     ///
     /// ## Examples
     ///
@@ -33,6 +31,7 @@ declare_rule! {
     pub(crate) NoNodejsModules {
         version: "1.5.0",
         name: "noNodejsModules",
+        source: RuleSource::EslintImport("no-nodejs-modules"),
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_unused_private_class_members.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_unused_private_class_members.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -21,8 +22,6 @@ declare_rule! {
     ///
     /// Private class members that are declared and not used anywhere in the code are most likely an error due to incomplete refactoring.
     /// Such class members take up space in the code and can lead to confusion by readers.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-unused-private-class-members/
     ///
     /// ## Examples
     ///
@@ -65,6 +64,7 @@ declare_rule! {
     pub(crate) NoUnusedPrivateClassMembers {
         version: "1.3.3",
         name: "noUnusedPrivateClassMembers",
+        source: RuleSource::Eslint("no-unused-private-class-members"),
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_useless_lone_block_statements.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_useless_lone_block_statements.rs
@@ -1,7 +1,7 @@
 use crate::semantic_services::Semantic;
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -17,8 +17,6 @@ declare_rule! {
     ///
     /// > In JavaScript, prior to ES6, standalone code blocks delimited by curly braces do not create a new scope and have no use.
     /// > In ES6, code blocks may create a new scope if a block-level binding (let and const), a class declaration or a function declaration (in strict mode) are present. A block is not considered redundant in these cases.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-lone-blocks
     ///
     /// ## Examples
     ///
@@ -48,6 +46,7 @@ declare_rule! {
     pub(crate) NoUselessLoneBlockStatements {
         version: "1.3.3",
         name: "noUselessLoneBlockStatements",
+        source: RuleSource::Eslint("no-lone-blocks"),
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_useless_ternary.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_useless_ternary.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{AnyJsExpression, JsConditionalExpression, JsSyntaxKind};
 use biome_rowan::AstNode;
@@ -8,9 +8,6 @@ declare_rule! {
     ///
     /// It’s a common mistake in JavaScript to use a conditional expression to select between two
     /// boolean values instead of using the logical NOT (`!`) or double NOT (`!!`) to convert the test to a boolean.
-    /// Here are some examples:
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-unneeded-ternary/
     ///
     /// ## Examples
     ///
@@ -49,6 +46,7 @@ declare_rule! {
     pub(crate) NoUselessTernary {
         version: "1.5.0",
         name: "noUselessTernary",
+        source: RuleSource::Eslint("no-unneeded-ternary"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_await.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_await.rs
@@ -1,6 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, AddVisitor, Phases, QueryMatch, Queryable, Rule,
-    RuleDiagnostic, ServiceBag, Visitor, VisitorContext,
+    RuleDiagnostic, RuleSource, ServiceBag, Visitor, VisitorContext,
 };
 use biome_console::markup;
 use biome_js_syntax::{AnyFunctionLike, JsAwaitExpression, JsLanguage, TextRange, WalkEvent};
@@ -14,8 +14,6 @@ declare_rule! {
     /// resolved value and handle the asynchronous operation appropriately. Without `await`,
     /// the function operates synchronously and might not leverage the advantages of async
     /// functions.
-    ///
-    /// Source: [require-await](https://eslint.org/docs/latest/rules/require-await)
     ///
     /// ## Examples
     ///
@@ -48,6 +46,7 @@ declare_rule! {
     pub(crate) UseAwait {
         version: "1.4.0",
         name: "useAwait",
+        source: RuleSource::Eslint("require-await"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_consistent_array_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_consistent_array_type.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::{markup, Markup, MarkupBuf};
 use biome_deserialize::{
@@ -29,8 +30,6 @@ declare_rule! {
     /// _TypeScript_ provides two equivalent ways to define an array type: `T[]` and `Array<T>`.
     /// The two styles are functionally equivalent.
     /// Using the same style consistently across your codebase makes it easier for developers to read and understand array types.
-    ///
-    /// Source: https://typescript-eslint.io/rules/array-type
     ///
     /// ## Example
     ///
@@ -78,6 +77,7 @@ declare_rule! {
     pub(crate) UseConsistentArrayType {
         version: "1.5.0",
         name: "useConsistentArrayType",
+        source: RuleSource::EslintTypeScript("array-type"),
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_filenaming_convention.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_filenaming_convention.rs
@@ -1,7 +1,9 @@
 use std::{hash::Hash, str::FromStr};
 
 use crate::{semantic_services::SemanticServices, utils::case::Case};
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{
+    context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource, RuleSourceKind,
+};
 use biome_console::markup;
 use biome_deserialize::{
     Deserializable, DeserializationDiagnostic, DeserializationVisitor, Text, VisitableType,
@@ -68,6 +70,8 @@ declare_rule! {
     pub(crate) UseFilenamingConvention {
         version: "1.5.0",
         name: "useFilenamingConvention",
+        source: RuleSource::EslintUnicorn("filename-case"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_grouped_type_import.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_grouped_type_import.rs
@@ -1,6 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -39,8 +40,6 @@ declare_rule! {
     /// import type { A, B } from "mod";
     /// ```
     ///
-    /// Source: https://typescript-eslint.io/rules/no-import-type-side-effects/
-    ///
     /// ## Examples
     ///
     /// ### Invalid
@@ -61,6 +60,7 @@ declare_rule! {
     pub(crate) UseGroupedTypeImport {
         version: "1.0.0",
         name: "useGroupedTypeImport",
+        source: RuleSource::EslintTypeScript("no-import-type-side-effects"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_import_restrictions.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_import_restrictions.rs
@@ -1,4 +1,6 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{
+    context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource, RuleSourceKind,
+};
 use biome_console::markup;
 use biome_js_syntax::JsModuleSource;
 use biome_rowan::{AstNode, TokenText};
@@ -73,6 +75,8 @@ declare_rule! {
     pub(crate) UseImportRestrictions {
         version: "1.0.0",
         name: "useImportRestrictions",
+        source: RuleSource::EslintImport("jsdoc"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_nodejs_import_protocol.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_nodejs_import_protocol.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -16,8 +17,6 @@ declare_rule! {
     ///
     /// The rule marks traditional imports like `import fs from "fs";` as invalid,
     /// suggesting the format `import fs from "node:fs";` instead.
-    ///
-    /// Source: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md
     ///
     /// ## Examples
     ///
@@ -48,6 +47,7 @@ declare_rule! {
     pub(crate) UseNodejsImportProtocol {
         version: "1.5.0",
         name: "useNodejsImportProtocol",
+        source: RuleSource::EslintUnicorn("prefer-node-protocol"),
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_shorthand_function_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_shorthand_function_type.rs
@@ -1,4 +1,5 @@
 use crate::JsRuleAction;
+use biome_analyze::RuleSource;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
 };
@@ -24,8 +25,6 @@ declare_rule! {
     /// The function type form is generally preferred when possible for being more succinct.
     ///
     /// This rule suggests using a function type instead of an interface or object type literal with a single call signature.
-    ///
-    /// Source: https://typescript-eslint.io/rules/prefer-function-type/
     ///
     /// ## Examples
     ///
@@ -82,6 +81,7 @@ declare_rule! {
     pub(crate) UseShorthandFunctionType {
         version: "1.5.0",
         name: "useShorthandFunctionType",
+        source: RuleSource::EslintTypeScript("prefer-function-type"),
         recommended: false,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/no_comma_operator.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_comma_operator.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_js_syntax::{JsForStatement, JsSequenceExpression};
 use biome_rowan::AstNode;
 
@@ -11,8 +11,6 @@ declare_rule! {
     /// It frequently obscures side effects, and its use is often an accident.
     ///
     /// The use of the comma operator in the initialization and update parts of a `for` is still allowed.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-sequences
     ///
     /// ## Examples
     ///
@@ -41,6 +39,7 @@ declare_rule! {
     pub(crate) NoCommaOperator {
         version: "1.0.0",
         name: "noCommaOperator",
+        source: RuleSource::Eslint("no-sequences"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/style/no_default_export.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_default_export.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::AnyJsExportClause;
 use biome_rowan::{AstNode, AstSeparatedList, TextRange};
@@ -20,8 +20,6 @@ declare_rule! {
     ///
     /// Note that this rule disallows only default exports in EcmaScript Module.
     /// It ignores CommonJS default exports.
-    ///
-    /// Source: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md
     ///
     /// ## Examples
     ///
@@ -61,6 +59,7 @@ declare_rule! {
     pub(crate) NoDefaultExport {
         version: "1.4.0",
         name: "noDefaultExport",
+        source: RuleSource::EslintImport("no-default-export"),
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/style/no_implicit_boolean.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_implicit_boolean.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -46,6 +47,7 @@ declare_rule! {
     pub(crate) NoImplicitBoolean {
         version: "1.0.0",
         name: "noImplicitBoolean",
+        source: RuleSource::EslintReact("jsx-boolean-value"),
         recommended: false,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/no_inferrable_types.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_inferrable_types.rs
@@ -1,4 +1,5 @@
 use crate::JsRuleAction;
+use biome_analyze::RuleSource;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
 };
@@ -24,8 +25,6 @@ declare_rule! {
     /// In contrast to ESLint's rule, this rule allows to use a wide type for `const` declarations.
     /// Moreover, the rule does not recognize `undefined` values, primitive type constructors (String, Number, ...), and `RegExp` type.
     /// These global variables could be shadowed by local ones.
-    ///
-    /// Source: https://typescript-eslint.io/rules/no-inferrable-types
     ///
     /// ## Examples
     ///
@@ -99,6 +98,7 @@ declare_rule! {
     pub(crate) NoInferrableTypes {
         version: "1.0.0",
         name: "noInferrableTypes",
+        source: RuleSource::EslintTypeScript("no-inferrable-types"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/no_namespace.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_namespace.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::TsModuleDeclaration;
 use biome_rowan::AstNode;
@@ -9,8 +9,6 @@ declare_rule! {
     /// Namespaces are an old way to organize your code in TypeScript.
     /// They are not recommended anymore and should be replaced by ES6 modules
     /// (the `import`/`export` syntax).
-    ///
-    /// Source: https://typescript-eslint.io/rules/no-namespace
     ///
     /// ## Examples
     ///
@@ -50,6 +48,7 @@ declare_rule! {
     pub(crate) NoNamespace {
         version: "1.0.0",
         name: "noNamespace",
+        source: RuleSource::EslintTypeScript("no-namespace"),
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/style/no_negation_else.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_negation_else.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -13,8 +14,6 @@ use crate::JsRuleAction;
 
 declare_rule! {
     /// Disallow negation in the condition of an `if` statement if it has an `else` clause.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-negated-condition/
     ///
     /// ## Examples
     ///
@@ -48,6 +47,7 @@ declare_rule! {
     pub(crate) NoNegationElse {
         version: "1.0.0",
         name: "noNegationElse",
+        source: RuleSource::Eslint("no-negated-condition"),
         recommended: false,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/no_non_null_assertion.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_non_null_assertion.rs
@@ -1,6 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -47,6 +48,7 @@ declare_rule! {
     pub(crate) NoNonNullAssertion {
         version: "1.0.0",
         name: "noNonNullAssertion",
+        source: RuleSource::EslintTypeScript("no-non-null-assertion"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/no_parameter_properties.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_parameter_properties.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource, RuleSourceKind};
 use biome_console::markup;
 use biome_js_syntax::TsPropertyParameter;
 use biome_rowan::AstNode;
@@ -11,8 +11,6 @@ declare_rule! {
     /// Parameter properties can confuse those new to TypeScript as they are less explicit than other ways of declaring and initializing class members.
     /// Moreover, private class properties, starting with `#`, cannot be turned into "parameter properties".
     /// This questions the future of this feature.
-    ///
-    /// Source: https://typescript-eslint.io/rules/parameter-properties
     ///
     /// ## Examples
     ///
@@ -35,6 +33,8 @@ declare_rule! {
     pub(crate) NoParameterProperties {
         version: "1.0.0",
         name: "noParameterProperties",
+        source: RuleSource::EslintTypeScript("parameter-properties"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/style/no_unused_template_literal.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_unused_template_literal.rs
@@ -1,6 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
@@ -41,6 +41,7 @@ declare_rule! {
     pub(crate) NoUnusedTemplateLiteral {
         version: "1.0.0",
         name: "noUnusedTemplateLiteral",
+        source: RuleSource::EslintTypeScript("no-useless-template-literals"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/no_useless_else.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_useless_else.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource, RuleSourceKind,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -87,6 +88,8 @@ declare_rule! {
     pub(crate) NoUselessElse {
         version: "1.3.0",
         name: "noUselessElse",
+        source: RuleSource::Eslint("no-else-return"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/use_as_const_assertion.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_as_const_assertion.rs
@@ -1,6 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -22,8 +23,6 @@ declare_rule! {
     /// 3. type annotation: explicitly telling the literal type to TypeScript when declare variables
     ///
     /// The rule suggests to use `as const` when you're using `as` with a literal type or type annotation, since `as const` is simpler and doesn't require retyping the value.
-    ///
-    /// Source: https://typescript-eslint.io/rules/prefer-as-const/
     ///
     /// ## Examples
     ///
@@ -49,6 +48,7 @@ declare_rule! {
     pub(crate) UseAsConstAssertion {
         version: "1.3.0",
         name: "useAsConstAssertion",
+        source: RuleSource::EslintTypeScript("prefer-as-const"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/use_block_statements.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_block_statements.rs
@@ -1,5 +1,7 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleAction, RuleDiagnostic};
+use biome_analyze::{
+    declare_rule, ActionCategory, Ast, FixKind, Rule, RuleAction, RuleDiagnostic, RuleSource,
+};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
@@ -66,6 +68,7 @@ declare_rule! {
     pub(crate) UseBlockStatements {
         version: "1.0.0",
         name: "useBlockStatements",
+        source: RuleSource::Eslint("curly"),
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/use_collapsed_else_if.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_collapsed_else_if.rs
@@ -1,6 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -11,8 +12,6 @@ declare_rule! {
     /// Enforce using `else if` instead of nested `if` in `else` clauses.
     ///
     /// If an `if` statement is the only statement in the `else` block, it is often clearer to use an `else if` form.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-lonely-if
     ///
     /// ## Examples
     ///
@@ -85,6 +84,7 @@ declare_rule! {
     pub(crate) UseCollapsedElseIf {
         version: "1.1.0",
         name: "useCollapsedElseIf",
+        source: RuleSource::Eslint("no-lonely-if"),
         recommended: false,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/use_default_parameter_last.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_default_parameter_last.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_syntax::{JsFormalParameter, JsInitializerClause, JsSyntaxToken, TsPropertyParameter};
@@ -51,6 +51,7 @@ declare_rule! {
     pub(crate) UseDefaultParameterLast {
         version: "1.0.0",
         name: "useDefaultParameterLast",
+        source: RuleSource::Eslint("default-param-last"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/use_enum_initializers.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_enum_initializers.rs
@@ -1,6 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
@@ -15,8 +15,6 @@ declare_rule! {
     ///
     /// When the value of enum members are important,
     /// allowing implicit values for enum members can cause bugs if enum declarations are modified over time.
-    ///
-    /// Source: https://typescript-eslint.io/rules/prefer-enum-initializers
     ///
     /// ## Examples
     ///
@@ -69,6 +67,7 @@ declare_rule! {
     pub(crate) UseEnumInitializers {
         version: "1.0.0",
         name: "useEnumInitializers",
+        source: RuleSource::EslintTypeScript("prefer-enum-initializers"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/use_exponentiation_operator.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_exponentiation_operator.rs
@@ -1,7 +1,7 @@
 use crate::semantic_services::Semantic;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::{make, syntax::T};
@@ -20,8 +20,6 @@ declare_rule! {
     ///
     /// Introduced in ES2016, the infix exponentiation operator `**` is an alternative for the standard `Math.pow` function.
     /// Infix notation is considered to be more readable and thus more preferable than the function notation.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/prefer-exponentiation-operator
     ///
     /// ## Examples
     ///
@@ -58,6 +56,7 @@ declare_rule! {
     pub(crate) UseExponentiationOperator {
         version: "1.0.0",
         name: "useExponentiationOperator",
+        source: RuleSource::Eslint("prefer-exponentiation-operator"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/use_literal_enum_members.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_literal_enum_members.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, AnyJsMemberExpression, JsUnaryOperator,
@@ -16,8 +16,6 @@ declare_rule! {
     /// This rule requires the initialization of enum members with constant expressions.
     /// It allows numeric and bitwise expressions for supporting [enum flags](https://stackoverflow.com/questions/39359740/what-are-enum-flags-in-typescript/39359953#39359953).
     /// It also allows referencing previous enum members.
-    ///
-    /// Source: https://typescript-eslint.io/rules/prefer-literal-enum-member/
     ///
     /// ## Examples
     ///
@@ -66,6 +64,7 @@ declare_rule! {
     pub(crate) UseLiteralEnumMembers {
         version: "1.0.0",
         name: "useLiteralEnumMembers",
+        source: RuleSource::EslintTypeScript("prefer-literal-enum-member"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/style/use_numeric_literals.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_numeric_literals.rs
@@ -1,7 +1,7 @@
 use crate::semantic_services::Semantic;
 use crate::{ast_utils, JsRuleAction};
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
@@ -57,6 +57,7 @@ declare_rule! {
     pub(crate) UseNumericLiterals {
         version: "1.0.0",
         name: "useNumericLiterals",
+        source: RuleSource::Eslint("prefer-numeric-literals"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/use_self_closing_elements.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_self_closing_elements.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -56,6 +57,7 @@ declare_rule! {
     pub(crate) UseSelfClosingElements {
         version: "1.0.0",
         name: "useSelfClosingElements",
+        source: RuleSource::EslintStylistic("jsx-self-closing-comp"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/use_shorthand_array_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_shorthand_array_type.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource, RuleSourceKind,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -13,8 +14,6 @@ use crate::JsRuleAction;
 
 declare_rule! {
     /// When expressing array types, this rule promotes the usage of `T[]` shorthand instead of `Array<T>`.
-    ///
-    /// ESLint (typescript-eslint) equivalent: [array-type/array-simple](https://typescript-eslint.io/rules/array-type/#array-simple)
     ///
     /// ## Examples
     ///
@@ -53,6 +52,8 @@ declare_rule! {
     pub(crate) UseShorthandArrayType  {
         version: "1.0.0",
         name: "useShorthandArrayType",
+        source: RuleSource::EslintTypeScript("array-type"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/use_shorthand_assign.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_shorthand_assign.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -19,8 +20,6 @@ declare_rule! {
     /// Require assignment operator shorthand where possible.
     ///
     /// JavaScript provides shorthand operators combining a variable assignment and simple mathematical operation.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/operator-assignment/
     ///
     /// ## Examples
     ///
@@ -54,6 +53,7 @@ declare_rule! {
     pub(crate) UseShorthandAssign {
         version: "1.3.0",
         name: "useShorthandAssign",
+        source: RuleSource::Eslint("operator-assignment"),
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/use_single_var_declarator.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_single_var_declarator.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -20,8 +21,6 @@ declare_rule! {
     /// In JavaScript, multiple variables can be declared within a single `var`, `const` or `let` declaration.
     /// It is often considered a best practice to declare every variable separately.
     /// That is what this rule enforces.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/one-var
     ///
     /// ## Examples
     ///
@@ -45,6 +44,7 @@ declare_rule! {
     pub(crate) UseSingleVarDeclarator {
         version: "1.0.0",
         name: "useSingleVarDeclarator",
+        source: RuleSource::Eslint("one-var"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/style/use_template.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_template.rs
@@ -1,3 +1,4 @@
+use biome_analyze::RuleSource;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
 };
@@ -49,6 +50,7 @@ declare_rule! {
     pub(crate) UseTemplate {
         version: "1.0.0",
         name: "useTemplate",
+        source: RuleSource::Eslint("prefer-template"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_approximative_numeric_constant.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_approximative_numeric_constant.rs
@@ -1,14 +1,12 @@
 use std::f64::consts as f64;
 
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::JsNumberLiteralExpression;
 use biome_rowan::AstNode;
 
 declare_rule! {
     /// Usually, the definition in the standard library is more precise than what people come up with or the used constant exceeds the maximum precision of the number type.
-    ///
-    /// Source: https://rust-lang.github.io/rust-clippy/master/#approx_constant
     ///
     /// ## Examples
     ///
@@ -32,6 +30,7 @@ declare_rule! {
     pub(crate) NoApproximativeNumericConstant {
         version: "1.3.0",
         name: "noApproximativeNumericConstant",
+        source: RuleSource::Clippy("approx_constant"),
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_assign_in_expressions.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_assign_in_expressions.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource, RuleSourceKind};
 use biome_console::markup;
 use biome_js_syntax::{
     JsAssignmentExpression, JsExpressionStatement, JsForStatement, JsParenthesizedExpression,
@@ -44,6 +44,8 @@ declare_rule! {
     pub(crate) NoAssignInExpressions {
         version: "1.0.0",
         name: "noAssignInExpressions",
+        source: RuleSource::Eslint("no-cond-assign"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_async_promise_executor.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_async_promise_executor.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{
     AnyJsCallArgument, AnyJsExpression, AnyJsFunction, JsNewExpression, JsNewExpressionFields,
@@ -39,6 +39,7 @@ declare_rule! {
     pub(crate) NoAsyncPromiseExecutor {
         version: "1.0.0",
         name: "noAsyncPromiseExecutor",
+        source: RuleSource::Eslint("no-async-promise-executor"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_comment_text.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_comment_text.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -37,6 +38,7 @@ declare_rule! {
     pub(crate) NoCommentText {
         version: "1.0.0",
         name: "noCommentText",
+        source: RuleSource::EslintReact("jsx-no-comment-textnodes"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_compare_neg_zero.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_compare_neg_zero.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -36,6 +37,7 @@ declare_rule! {
     pub(crate) NoCompareNegZero {
         version: "1.0.0",
         name: "noCompareNegZero",
+        source: RuleSource::Eslint("no-compare-neg-zero"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_labels.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_labels.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource, RuleSourceKind};
 use biome_console::markup;
 use biome_js_syntax::{AnyJsStatement, JsLabeledStatement};
 
@@ -8,8 +8,6 @@ declare_rule! {
     ///
     /// Labeled statements in JavaScript are used in conjunction with `break` and `continue` to control flow around multiple loops.
     /// Their use for other statements is suspicious and unfamiliar.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-labels
     ///
     /// ## Examples
     ///
@@ -52,6 +50,8 @@ declare_rule! {
     pub(crate) NoConfusingLabels {
         version: "1.0.0",
         name: "noConfusingLabels",
+        source: RuleSource::Eslint("no-labels"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_void_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_void_type.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{JsLanguage, JsSyntaxKind, TsVoidType};
 use biome_rowan::{AstNode, SyntaxNode};
@@ -49,6 +49,7 @@ declare_rule! {
     pub(crate) NoConfusingVoidType {
         version: "1.2.0",
         name: "noConfusingVoidType",
+        source: RuleSource::EslintTypeScript("no-invalid-void-type"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_control_characters_in_regex.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_control_characters_in_regex.rs
@@ -1,5 +1,5 @@
 use crate::utils::escape_string;
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{
     AnyJsExpression, JsCallArguments, JsCallExpression, JsNewExpression, JsRegexLiteralExpression,
@@ -22,8 +22,6 @@ declare_rule! {
     /// - Unescaped raw characters from U+0000 to U+001F
     ///
     /// Control escapes such as `\t` and `\n` are allowed by this rule.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-control-regex
     ///
     /// ## Examples
     ///
@@ -63,6 +61,7 @@ declare_rule! {
     pub(crate) NoControlCharactersInRegex {
         version: "1.0.0",
         name: "noControlCharactersInRegex",
+        source: RuleSource::Eslint("no-control-regex"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_debugger.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_debugger.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -28,6 +29,7 @@ declare_rule! {
     pub(crate) NoDebugger {
         version: "1.0.0",
         name: "noDebugger",
+        source: RuleSource::Eslint("no-debugger"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_double_equals.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_double_equals.rs
@@ -1,3 +1,4 @@
+use biome_analyze::RuleSource;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
 };
@@ -49,6 +50,7 @@ declare_rule! {
     pub(crate) NoDoubleEquals {
         version: "1.0.0",
         name: "noDoubleEquals",
+        source: RuleSource::Eslint("eqeqeq"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_case.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_case.rs
@@ -1,6 +1,6 @@
 use crate::utils::is_node_equal;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_js_syntax::{AnyJsExpression, AnyJsSwitchClause, JsSwitchStatement};
 use biome_rowan::{AstNode, TextRange};
 
@@ -8,8 +8,6 @@ declare_rule! {
     /// Disallow duplicate case labels.
     ///
     /// If a switch statement has duplicate test expressions in case clauses, it is likely that a programmer copied a case clause but forgot to change the test expression.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-duplicate-case
     ///
     /// ## Examples
     ///
@@ -85,6 +83,7 @@ declare_rule! {
     pub(crate) NoDuplicateCase {
         version: "1.0.0",
         name: "noDuplicateCase",
+        source: RuleSource::Eslint("no-duplicate-case"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_class_members.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_class_members.rs
@@ -1,3 +1,4 @@
+use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 use biome_js_syntax::{
     AnyJsClassMemberName, JsClassMemberList, JsGetterClassMember, JsMethodClassMember,
@@ -86,6 +87,7 @@ declare_rule! {
     pub(crate) NoDuplicateClassMembers {
         version: "1.0.0",
         name: "noDuplicateClassMembers",
+        source: RuleSource::Eslint("no-dupe-class-members"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_jsx_props.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_jsx_props.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::{AnyJsxAttribute, JsxAttribute};
@@ -33,6 +33,7 @@ declare_rule! {
  pub(crate) NoDuplicateJsxProps {
         version: "1.0.0",
         name: "noDuplicateJsxProps",
+        source: RuleSource::EslintReact("jsx-no-duplicate-props"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_object_keys.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_object_keys.rs
@@ -1,6 +1,6 @@
 use crate::utils::batch::JsBatchMutation;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{
     AnyJsObjectMember, JsGetterObjectMember, JsObjectExpression, JsSetterObjectMember,
@@ -57,6 +57,7 @@ declare_rule! {
     pub(crate) NoDuplicateObjectKeys {
         version: "1.0.0",
         name: "noDuplicateObjectKeys",
+        source: RuleSource::Eslint("no-dupe-keys"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_empty_interface.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_empty_interface.rs
@@ -1,6 +1,8 @@
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{
+    declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource, RuleSourceKind,
+};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::{
@@ -19,8 +21,6 @@ declare_rule! {
     /// Using an empty interface is often a sign of programmer error, such as misunderstanding the concept of `{}` or forgetting to fill in fields.
     ///
     /// The rule ignores empty interfaces that `extends` one or multiple types.
-    ///
-    /// Inspired by: https://typescript-eslint.io/rules/no-empty-interface
     ///
     /// ## Examples
     ///
@@ -43,6 +43,8 @@ declare_rule! {
     pub(crate) NoEmptyInterface {
         version: "1.0.0",
         name: "noEmptyInterface",
+        source: RuleSource::EslintTypeScript("no-empty-interface"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_explicit_any.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_explicit_any.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{TsAnyType, TsTypeConstraintClause};
 use biome_rowan::AstNode;
@@ -15,8 +15,6 @@ declare_rule! {
     ///
     /// Sometimes you can use the type `unknown` instead of the type `any`.
     /// It also accepts any value, however it requires to check that a property exists before calling it.
-    ///
-    /// Source: https://typescript-eslint.io/rules/no-explicit-any
     ///
     /// ## Examples
     ///
@@ -56,6 +54,7 @@ declare_rule! {
     pub(crate) NoExplicitAny {
         version: "1.0.0",
         name: "noExplicitAny",
+        source: RuleSource::EslintTypeScript("no-explicit-any"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_extra_non_null_assertion.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_extra_non_null_assertion.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_syntax::{
@@ -13,8 +13,6 @@ declare_rule! {
     /// Prevents the wrong usage of the non-null assertion operator (`!`) in TypeScript files.
     ///
     /// > The `!` non-null assertion operator in TypeScript is used to assert that a value's type does not include `null` or `undefined`. Using the operator any more than once on a single value does nothing.
-    ///
-    /// Source: https://typescript-eslint.io/rules/no-extra-non-null-assertion
     ///
     /// ## Examples
     ///
@@ -50,6 +48,7 @@ declare_rule! {
     pub(crate) NoExtraNonNullAssertion {
         version: "1.0.0",
         name: "noExtraNonNullAssertion",
+        source: RuleSource::EslintTypeScript("no-extra-non-null-assertion"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_fallthrough_switch_clause.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_fallthrough_switch_clause.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_control_flow::{
     builder::{BlockId, ROOT_BLOCK_ID},
@@ -18,8 +18,6 @@ declare_rule! {
     ///
     /// Switch clauses in `switch` statements fall through by default.
     /// This can lead to unexpected behavior when forgotten.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-fallthrough
     ///
     /// ## Examples
     ///
@@ -57,6 +55,7 @@ declare_rule! {
     pub(crate) NoFallthroughSwitchClause {
         version: "1.0.0",
         name: "noFallthroughSwitchClause",
+        source: RuleSource::Eslint("no-fallthrough"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_implicit_any_let.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_implicit_any_let.rs
@@ -8,11 +8,7 @@ declare_rule! {
     /// TypeScript variable declaration without any type annotation and initialization have the `any` type.
     /// The any type in TypeScript is a dangerous “escape hatch” from the type system.
     /// Using any disables many type checking rules and is generally best used only as a last resort or when prototyping code.
-    /// TypeScript’s `--noImplicitAny` compiler option doesn't report this case.
-    ///
-    ///
-    ///
-    /// Source: https://www.typescriptlang.org/tsconfig#noImplicitAny
+    /// TypeScript’s [`--noImplicitAny` compiler option](https://www.typescriptlang.org/tsconfig#noImplicitAny) doesn't report this case.
     ///
     /// ## Examples
     ///

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_misleading_instantiator.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_misleading_instantiator.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::{markup, MarkupBuf};
 use biome_js_syntax::{
     AnyJsClassMember, AnyTsType, AnyTsTypeMember, JsClassDeclaration, JsLanguage,
@@ -16,8 +16,6 @@ declare_rule! {
     /// - When a type alias has a `constructor` method.
     ///
     /// You should not use this rule if you intentionally want a class with a `new` method, and you're confident nobody working in your code will mistake it with an `constructor`.
-    ///
-    /// Source: https://typescript-eslint.io/rules/no-misused-new/
     ///
     /// ## Examples
     ///
@@ -50,6 +48,7 @@ declare_rule! {
     pub(crate) NoMisleadingInstantiator {
         version: "1.3.0",
         name: "noMisleadingInstantiator",
+        source: RuleSource::EslintTypeScript("no-misused-new"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_misrefactored_shorthand_assign.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_misrefactored_shorthand_assign.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -18,8 +19,6 @@ declare_rule! {
     ///
     /// This rule helps to avoid potential bugs related to incorrect assignments or unintended
     /// side effects that may occur during refactoring.
-    ///
-    /// Source: https://rust-lang.github.io/rust-clippy/master/#/misrefactored_assign_op
     ///
     /// ## Examples
     ///
@@ -53,6 +52,7 @@ declare_rule! {
     pub(crate) NoMisrefactoredShorthandAssign {
         version: "1.3.0",
         name: "noMisrefactoredShorthandAssign",
+        source: RuleSource::Clippy("misrefactored_assign_op"),
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_prototype_builtins.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_prototype_builtins.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{AnyJsMemberExpression, JsCallExpression, TextRange};
 use biome_rowan::AstNode;
@@ -42,6 +42,7 @@ declare_rule! {
     pub(crate) NoPrototypeBuiltins {
         version: "1.0.0",
         name: "noPrototypeBuiltins",
+        source: RuleSource::Eslint("no-prototype-builtins"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_self_compare.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_self_compare.rs
@@ -1,6 +1,6 @@
 use crate::utils::is_node_equal;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_js_syntax::JsBinaryExpression;
 use biome_rowan::AstNode;
 
@@ -11,8 +11,6 @@ declare_rule! {
     ///
     /// > The only time you would compare a variable against itself is when you are testing for `NaN`.
     /// However, it is far more appropriate to use `typeof x === 'number' && Number.isNaN(x)` for that use case rather than leaving the reader of the code to determine the intent of self comparison.
-    ///
-    /// Source: [no-self-compare](https://eslint.org/docs/latest/rules/no-self-compare).
     ///
     /// ## Examples
     ///
@@ -29,6 +27,7 @@ declare_rule! {
     pub(crate) NoSelfCompare {
         version: "1.0.0",
         name: "noSelfCompare",
+        source: RuleSource::Eslint("no-self-compare"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_shadow_restricted_names.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_shadow_restricted_names.rs
@@ -1,5 +1,5 @@
 use crate::globals::runtime::BUILTIN;
-use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::JsIdentifierBinding;
 use biome_rowan::AstNode;
@@ -33,6 +33,7 @@ declare_rule! {
     pub(crate) NoShadowRestrictedNames {
         version: "1.0.0",
         name: "noShadowRestrictedNames",
+        source: RuleSource::Eslint("no-shadow-restricted-names"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_sparse_array.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_sparse_array.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -22,6 +23,7 @@ declare_rule! {
     pub(crate) NoSparseArray {
         version: "1.0.0",
         name: "noSparseArray",
+        source: RuleSource::Eslint("no-sparse-array"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_unsafe_negation.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_unsafe_negation.rs
@@ -1,6 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -35,6 +36,7 @@ declare_rule! {
     pub(crate) NoUnsafeNegation {
         version: "1.0.0",
         name: "noUnsafeNegation",
+        source: RuleSource::Eslint("no-unsafe-negation"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/use_default_switch_clause_last.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/use_default_switch_clause_last.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{JsCaseClause, JsDefaultClause};
 use biome_rowan::{AstNode, Direction};
@@ -17,8 +17,6 @@ declare_rule! {
     /// However, such flow is not common and it would be confusing to the readers.
     ///
     /// Even if there is no "fall through" logic, it’s still unexpected to see the default clause before or between the case clauses. By convention, it is expected to be the last clause.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/default-case-last
     ///
     /// ## Examples
     ///
@@ -74,6 +72,7 @@ declare_rule! {
     pub(crate) UseDefaultSwitchClauseLast {
         version: "1.0.0",
         name: "useDefaultSwitchClauseLast",
+        source: RuleSource::Eslint("default-case-last"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/use_getter_return.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/use_getter_return.rs
@@ -1,5 +1,5 @@
 use crate::ControlFlowGraph;
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_control_flow::{builder::ROOT_BLOCK_ID, ExceptionHandlerKind, InstructionKind};
 use biome_js_syntax::{JsGetterClassMember, JsGetterObjectMember, JsReturnStatement};
@@ -8,8 +8,6 @@ use roaring::RoaringBitmap;
 
 declare_rule! {
     /// Enforce `get` methods to always return a value.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/getter-return
     ///
     /// ## Examples
     ///
@@ -62,6 +60,7 @@ declare_rule! {
     pub(crate) UseGetterReturn {
         version: "1.0.0",
         name: "useGetterReturn",
+        source: RuleSource::Eslint("getter-return"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/use_namespace_keyword.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/use_namespace_keyword.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -19,8 +20,6 @@ declare_rule! {
     /// The `module` keyword is deprecated to avoid any confusion with the _ECMAScript modules_ which are often called _modules_.
     ///
     /// Note that TypeScript `module` declarations to describe external APIs (`declare module "foo" {}`) are still allowed.
-    ///
-    /// Source: https://typescript-eslint.io/rules/prefer-namespace-keyword
     ///
     /// See also: https://www.typescriptlang.org/docs/handbook/namespaces-and-modules.html
     ///
@@ -45,6 +44,7 @@ declare_rule! {
     pub(crate) UseNamespaceKeyword {
         version: "1.0.0",
         name: "useNamespaceKeyword",
+        source: RuleSource::EslintTypeScript("prefer-namespace-keyword"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/use_valid_typeof.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/use_valid_typeof.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -71,6 +72,7 @@ declare_rule! {
     pub(crate) UseValidTypeof {
         version: "1.0.0",
         name: "useValidTypeof",
+        source: RuleSource::Eslint("valid-typeof"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/no_aria_hidden_on_focusable.rs
@@ -1,6 +1,6 @@
 use crate::{aria_services::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -13,8 +13,6 @@ declare_rule! {
     /// `aria-hidden="true"` can be used to hide purely decorative content from screen reader users.
     /// A focusable element with `aria-hidden="true"` can be reached by keyboard.
     /// This can lead to confusion or unexpected behavior for screen reader users.
-    ///
-    /// Source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-aria-hidden-on-focusable.md
     ///
     /// ## Example
     ///
@@ -47,6 +45,7 @@ declare_rule! {
     pub(crate) NoAriaHiddenOnFocusable {
         version: "1.4.0",
         name: "noAriaHiddenOnFocusable",
+        source: RuleSource::EslintJsxA11y("no-aria-hidden-on-focusable"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/no_aria_unsupported_elements.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/no_aria_unsupported_elements.rs
@@ -1,6 +1,6 @@
 use crate::{aria_services::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -9,8 +9,6 @@ use biome_rowan::{AstNode, AstNodeList, BatchMutationExt};
 
 declare_rule! {
     /// Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.
-    ///
-    /// Source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-unsupported-elements.md
     ///
     /// ## Examples
     ///
@@ -38,6 +36,7 @@ declare_rule! {
     pub(crate) NoAriaUnsupportedElements {
         version: "1.0.0",
         name: "noAriaUnsupportedElements",
+        source: RuleSource::EslintJsxA11y("aria-unsupported-elements"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/no_interactive_element_to_noninteractive_role.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/no_interactive_element_to_noninteractive_role.rs
@@ -1,6 +1,6 @@
 use crate::{aria_services::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -17,8 +17,6 @@ declare_rule! {
     ///
     /// [WAI-ARIA roles](https://www.w3.org/TR/wai-aria-1.1/#usage_intro) should not be used to convert an interactive element to a non-interactive element.
     /// Non-interactive ARIA roles include `article`, `banner`, `complementary`, `img`, `listitem`, `main`, `region` and `tooltip`.
-    ///
-    /// Source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-interactive-element-to-noninteractive-role.md
     ///
     /// ## Examples
     ///
@@ -37,6 +35,7 @@ declare_rule! {
     pub(crate) NoInteractiveElementToNoninteractiveRole {
         version: "1.3.0",
         name: "noInteractiveElementToNoninteractiveRole",
+        source: RuleSource::EslintJsxA11y("no-interactive-element-to-noninteractive-role"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/no_noninteractive_element_to_interactive_role.rs
@@ -1,7 +1,7 @@
 use crate::aria_services::Aria;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
@@ -48,6 +48,7 @@ declare_rule! {
     pub(crate) NoNoninteractiveElementToInteractiveRole {
         version: "1.0.0",
         name: "noNoninteractiveElementToInteractiveRole",
+        source: RuleSource::EslintJsxA11y("no-noninteractive-element-to-interactive-role"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/no_noninteractive_tabindex.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/no_noninteractive_tabindex.rs
@@ -1,6 +1,6 @@
 use crate::{aria_services::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_aria::AriaRoles;
 use biome_console::markup;
@@ -17,8 +17,6 @@ declare_rule! {
     /// When using the tab key to navigate a webpage, limit it to interactive elements.
     /// You don't need to add tabindex to items in an unordered list as assistive technology can navigate through the HTML.
     /// Keep the tab ring small, which is the order of elements when tabbing, for a more efficient and accessible browsing experience.
-    ///
-    /// ESLint (eslint-plugin-jsx-a11y) Equivalent: [no-noninteractive-tabindex](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-tabindex.md)
     ///
     /// ## Examples
     ///
@@ -53,6 +51,7 @@ declare_rule! {
     pub(crate) NoNoninteractiveTabindex {
         version: "1.0.0",
         name: "noNoninteractiveTabindex",
+        source: RuleSource::EslintJsxA11y("no-noninteractive-tabindex"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/no_redundant_roles.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/no_redundant_roles.rs
@@ -1,6 +1,6 @@
 use crate::{aria_services::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_aria::{roles::AriaRoleDefinition, AriaRoles};
 use biome_console::markup;
@@ -12,8 +12,6 @@ use biome_rowan::{AstNode, BatchMutationExt};
 
 declare_rule! {
     /// Enforce explicit `role` property is not the same as implicit/default role property on an element.
-    ///
-    /// ESLint (eslint-plugin-jsx-a11y) Equivalent: [no-redundant-roles](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-redundant-roles.md)
     ///
     /// ## Examples
     ///
@@ -48,6 +46,7 @@ declare_rule! {
     pub(crate) NoRedundantRoles {
         version: "1.0.0",
         name: "noRedundantRoles",
+        source: RuleSource::EslintJsxA11y("no-redundant-roles"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/use_aria_activedescendant_with_tabindex.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/use_aria_activedescendant_with_tabindex.rs
@@ -1,6 +1,6 @@
 use crate::{aria_services::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -30,8 +30,6 @@ declare_rule! {
     /// Because an element with `aria-activedescendant` must be tabbable,
     /// it must either have an inherent tabIndex of zero or declare a tabIndex attribute.
     ///
-    /// Source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-activedescendant-has-tabindex.md
-    ///
     /// ## Examples
     ///
     /// ### Invalid
@@ -53,6 +51,7 @@ declare_rule! {
     pub(crate) UseAriaActivedescendantWithTabindex {
         version: "1.3.0",
         name: "useAriaActivedescendantWithTabindex",
+        source: RuleSource::EslintJsxA11y("aria-activedescendant-has-tabindex"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/use_aria_props_for_role.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/use_aria_props_for_role.rs
@@ -1,6 +1,6 @@
 use crate::aria_services::Aria;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::JsxAttribute;
@@ -41,6 +41,7 @@ declare_rule! {
     pub(crate) UseAriaPropsForRole {
         version: "1.0.0",
         name: "useAriaPropsForRole",
+        source: RuleSource::EslintJsxA11y("role-has-required-aria-props"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_aria_props.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_aria_props.rs
@@ -1,7 +1,7 @@
 use crate::aria_services::Aria;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
@@ -28,6 +28,7 @@ declare_rule! {
     pub(crate) UseValidAriaProps {
         version: "1.0.0",
         name: "useValidAriaProps",
+        source: RuleSource::EslintJsxA11y("aria-props"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_aria_role.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_aria_role.rs
@@ -1,6 +1,6 @@
 use crate::{aria_services::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_deserialize::{
@@ -13,8 +13,6 @@ use serde::{Deserialize, Serialize};
 
 declare_rule! {
     /// Elements with ARIA roles must use a valid, non-abstract ARIA role.
-    ///
-    /// Source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-role.md
     ///
     /// ## Examples
     ///
@@ -71,6 +69,7 @@ declare_rule! {
     pub(crate) UseValidAriaRole {
         version: "1.4.0",
         name: "useValidAriaRole",
+        source: RuleSource::EslintJsxA11y("aria-role"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_aria_values.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_aria_values.rs
@@ -1,6 +1,6 @@
 use crate::aria_services::Aria;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_aria::AriaPropertyTypeEnum;
 use biome_console::markup;
 use biome_js_syntax::{JsSyntaxToken, JsxAttribute, TextRange};
@@ -9,7 +9,6 @@ use std::slice::Iter;
 
 declare_rule! {
     /// Enforce that ARIA state and property values are valid.
-    ///
     ///
     /// ## Examples
     ///
@@ -41,14 +40,17 @@ declare_rule! {
     /// ```
     ///
     /// ## Accessibility guidelines
+    ///
     /// - [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
     ///
     /// ### Resources
+    ///
     /// - [ARIA Spec, States and Properties](https://www.w3.org/TR/wai-aria/#states_and_properties)
     /// - [Chrome Audit Rules, AX_ARIA_04](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_04)
     pub(crate) UseValidAriaValues {
         version: "1.0.0",
         name: "useValidAriaValues",
+        source: RuleSource::EslintJsxA11y("aria-proptypes"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_lang.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_lang.rs
@@ -1,6 +1,6 @@
 use crate::aria_services::Aria;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::{AstNode, TextRange};
@@ -31,6 +31,7 @@ declare_rule! {
     pub(crate) UseValidLang {
         version: "1.0.0",
         name: "useValidLang",
+        source: RuleSource::EslintJsxA11y("lang"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/a11y/no_positive_tabindex.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/a11y/no_positive_tabindex.rs
@@ -2,7 +2,7 @@ use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::semantic_services::Semantic;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
@@ -51,6 +51,7 @@ declare_rule! {
     pub(crate) NoPositiveTabindex {
         version: "1.0.0",
         name: "noPositiveTabindex",
+        source: RuleSource::EslintJsxA11y("tabindex-no-positive"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/a11y/use_button_type.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/a11y/use_button_type.rs
@@ -1,5 +1,6 @@
 use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::semantic_services::Semantic;
+use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_syntax::{
@@ -38,6 +39,7 @@ declare_rule! {
     pub(crate) UseButtonType {
         version: "1.0.0",
         name: "useButtonType",
+        source: RuleSource::EslintReact("button-has-type"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_banned_types.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_banned_types.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
@@ -62,8 +62,6 @@ declare_rule! {
     ///   type NonNullableMyType = NonNullable<MyType>;
     ///   ```
     ///
-    /// Source: https://typescript-eslint.io/rules/ban-types
-    ///
     /// ## Examples
     ///
     /// ### Invalid
@@ -93,6 +91,7 @@ declare_rule! {
     pub(crate) NoBannedTypes {
         version: "1.0.0",
         name: "noBannedTypes",
+        source: RuleSource::EslintTypeScript("ban-types"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_this_in_static.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_this_in_static.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -25,8 +26,6 @@ declare_rule! {
     /// This rule enforces the use of the class name itself to access static methods,
     /// which can make the code clearer and less prone to errors. It helps to prevent
     /// misunderstandings and bugs that can arise from the unique behavior of `this` and `super` in static contexts.
-    ///
-    /// Source: https://github.com/mysticatea/eslint-plugin/blob/master/docs/rules/no-this-in-static.md
     ///
     /// ## Example
     ///
@@ -82,6 +81,7 @@ declare_rule! {
     pub(crate) NoThisInStatic {
         version: "1.3.1",
         name: "noThisInStatic",
+        source: RuleSource::EslintMysticatea("no-this-in-static"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_useless_fragments.rs
@@ -2,7 +2,7 @@ use crate::react::{jsx_member_name_is_react_fragment, jsx_reference_identifier_i
 use crate::semantic_services::Semantic;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make::{
@@ -60,6 +60,7 @@ declare_rule! {
     pub(crate) NoUselessFragments {
         version: "1.0.0",
         name: "noUselessFragments",
+        source: RuleSource::EslintReact("jsx-no-useless-fragment"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_useless_this_alias.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_useless_this_alias.rs
@@ -1,6 +1,7 @@
 use crate::{control_flow::AnyJsControlFlowRoot, semantic_services::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -18,8 +19,6 @@ declare_rule! {
     ///
     /// Arrow functions inherits `this` from their enclosing scope;
     /// this makes `this` aliasing useless in this situation.
-    ///
-    /// Credits: https://typescript-eslint.io/rules/no-this-alias/
     ///
     /// ## Examples
     ///
@@ -53,6 +52,8 @@ declare_rule! {
     pub(crate) NoUselessThisAlias {
         version: "1.0.0",
         name: "noUselessThisAlias",
+        source: RuleSource::EslintTypeScript("no-this-alias"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_children_prop.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_children_prop.rs
@@ -1,7 +1,7 @@
 use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::semantic_services::Semantic;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{JsCallExpression, JsxAttribute};
 use biome_rowan::{declare_node_union, AstNode, TextRange};
@@ -25,6 +25,7 @@ declare_rule! {
     pub(crate) NoChildrenProp {
         version: "1.0.0",
         name: "noChildrenProp",
+        source: RuleSource::EslintReact("no-children-prop"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_const_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_const_assign.rs
@@ -1,7 +1,7 @@
 use crate::semantic_services::Semantic;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make::{self};
@@ -55,6 +55,7 @@ declare_rule! {
     pub(crate) NoConstAssign {
         version: "1.0.0",
         name: "noConstAssign",
+        source: RuleSource::Eslint("no-const-assign"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_constant_condition.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_constant_condition.rs
@@ -1,5 +1,5 @@
 use crate::{semantic_services::Semantic, utils::rename::RenamableNode};
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
@@ -82,6 +82,7 @@ declare_rule! {
     pub(crate) NoConstantCondition    {
         version: "1.0.0",
         name: "noConstantCondition",
+        source: RuleSource::Eslint("no-constant-condition"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_global_object_calls.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_global_object_calls.rs
@@ -1,5 +1,5 @@
 use crate::semantic_services::Semantic;
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{global_identifier, AnyJsExpression, JsCallExpression, JsNewExpression};
 use biome_rowan::{declare_node_union, SyntaxResult, TextRange};
@@ -86,6 +86,7 @@ declare_rule! {
     pub(crate) NoGlobalObjectCalls {
         version: "1.0.0",
         name: "noGlobalObjectCalls",
+        source: RuleSource::Eslint("no-obj-calls"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_invalid_new_builtin.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_invalid_new_builtin.rs
@@ -1,6 +1,6 @@
 use crate::{semantic_services::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -19,8 +19,6 @@ declare_rule! {
     ///
     /// - [`Symbol`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol)
     /// - [`BigInt`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt)
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-new-native-nonconstructor/
     ///
     /// ## Examples
     ///
@@ -54,6 +52,7 @@ declare_rule! {
     pub(crate) NoInvalidNewBuiltin {
         version: "1.3.0",
         name: "noInvalidNewBuiltin",
+        source: RuleSource::Eslint("no-new-native-nonconstructor"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_new_symbol.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_new_symbol.rs
@@ -1,6 +1,6 @@
 use crate::{semantic_services::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -12,8 +12,6 @@ declare_rule! {
     /// Disallow `new` operators with the `Symbol` object.
     ///
     /// `Symbol` cannot be instantiated. This results in throwing a `TypeError`.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-new-symbol
     ///
     /// ## Examples
     ///
@@ -36,6 +34,7 @@ declare_rule! {
         version: "1.0.0",
         name: "noNewSymbol",
         recommended: false,
+        source: RuleSource::Eslint("no-new-symbol"),
         deprecated: "Use `noInvalidNewBuiltin` instead.",
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
@@ -4,7 +4,7 @@ use crate::globals::runtime::{BUILTIN, ES_2021};
 use crate::globals::typescript::TYPESCRIPT_BUILTIN;
 use crate::semantic_services::SemanticServices;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{JsFileSource, Language, TextRange, TsAsExpression, TsReferenceType};
 use biome_rowan::AstNode;
@@ -34,6 +34,7 @@ declare_rule! {
     pub(crate) NoUndeclaredVariables {
         version: "1.0.0",
         name: "noUndeclaredVariables",
+        source: RuleSource::Eslint("no-undef"),
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_unused_variables.rs
@@ -1,5 +1,6 @@
 use crate::JsRuleAction;
 use crate::{semantic_services::Semantic, utils::rename::RenameSymbolExtensions};
+use biome_analyze::RuleSource;
 use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
 };
@@ -98,6 +99,7 @@ declare_rule! {
     pub(crate) NoUnusedVariables {
         version: "1.0.0",
         name: "noUnusedVariables",
+        source: RuleSource::Eslint("no-unused-vars"),
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_void_elements_with_children.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_void_elements_with_children.rs
@@ -2,7 +2,7 @@ use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::semantic_services::Semantic;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::{markup, MarkupBuf};
 use biome_diagnostics::Applicability;
 use biome_js_factory::make::{jsx_attribute_list, jsx_self_closing_element};
@@ -33,6 +33,7 @@ declare_rule! {
     pub(crate) NoVoidElementsWithChildren {
         version: "1.0.0",
         name: "noVoidElementsWithChildren",
+        source: RuleSource::EslintReact("void-dom-elements-no-children"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
@@ -1,5 +1,6 @@
 use crate::react::hooks::*;
 use crate::semantic_services::Semantic;
+use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_deserialize::{
@@ -167,6 +168,7 @@ declare_rule! {
     pub(crate) UseExhaustiveDependencies {
         version: "1.0.0",
         name: "useExhaustiveDependencies",
+        source: RuleSource::EslintReactHooks("exhaustive-deps"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_hook_at_top_level.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_hook_at_top_level.rs
@@ -1,5 +1,6 @@
 use crate::react::hooks::is_react_hook_call;
 use crate::semantic_services::{SemanticModelBuilderVisitor, SemanticServices};
+use biome_analyze::RuleSource;
 use biome_analyze::{
     context::RuleContext, declare_rule, AddVisitor, FromServices, MissingServicesDiagnostic, Phase,
     Phases, QueryMatch, Queryable, Rule, RuleDiagnostic, RuleKey, ServiceBag, Visitor,
@@ -63,6 +64,7 @@ declare_rule! {
     pub(crate) UseHookAtTopLevel {
         version: "1.0.0",
         name: "useHookAtTopLevel",
+        source: RuleSource::EslintReactHooks("rules-of-hooks"),
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_is_nan.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_is_nan.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
@@ -28,8 +28,6 @@ declare_rule! {
     /// When the argument to `isNaN()` is not a number, the value is first coerced to a number.
     /// `Number.isNaN()` does not perform this coercion.
     /// Therefore, it is a more reliable way to test whether a value is `NaN`.
-    ///
-    /// Source: [use-isnan](https://eslint.org/docs/latest/rules/use-isnan).
     ///
     /// ## Examples
     ///
@@ -64,6 +62,7 @@ declare_rule! {
     pub(crate) UseIsNan {
         version: "1.0.0",
         name: "useIsNan",
+        source: RuleSource::Eslint("use-isnan"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_global_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_global_assign.rs
@@ -3,6 +3,7 @@ use crate::globals::node::NODE;
 use crate::globals::runtime::{BUILTIN, ES_2021};
 
 use crate::semantic_services::SemanticServices;
+use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_syntax::{JsSyntaxKind, TextRange};
@@ -12,8 +13,6 @@ declare_rule! {
     ///
     /// _JavaScript environments contain numerous built-in global variables, such as `window` in browsers and `process` in _Node.js.
     /// Assigning values to these global variables can be problematic as it can override essential functionality.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-global-assign
     ///
     /// ## Examples
     ///
@@ -44,6 +43,7 @@ declare_rule! {
     pub(crate) NoGlobalAssign {
         version: "1.5.0",
         name: "noGlobalAssign",
+        source: RuleSource::Eslint("no-global-assign"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_global_eval.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_global_eval.rs
@@ -1,5 +1,5 @@
 use crate::semantic_services::Semantic;
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{global_identifier, AnyJsExpression};
 use biome_rowan::AstNode;
@@ -14,8 +14,6 @@ declare_rule! {
     /// If the executed code is somehow affected by a malicious party,
     /// then you may end up executing malicious code with the privileges of the caller.
     /// Moreover, changing variables in the caller's scope is expensive in modern _JavaScript_ interpreters.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-eval
     ///
     /// ## Examples
     ///
@@ -54,6 +52,7 @@ declare_rule! {
     pub(crate) NoGlobalEval {
         version: "1.5.0",
         name: "noGlobalEval",
+        source: RuleSource::Eslint("no-eval"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_invalid_use_before_declaration.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_invalid_use_before_declaration.rs
@@ -1,5 +1,5 @@
 use crate::{control_flow::AnyJsControlFlowRoot, semantic_services::SemanticServices};
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{
     binding_ext::{AnyJsBindingDeclaration, AnyJsIdentifierBinding},
@@ -60,6 +60,7 @@ declare_rule! {
     pub(crate) NoInvalidUseBeforeDeclaration {
         version: "1.5.0",
         name: "noInvalidUseBeforeDeclaration",
+        source: RuleSource::EslintTypeScript("no-use-before-define"),
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_misleading_character_class.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_misleading_character_class.rs
@@ -1,6 +1,6 @@
 use crate::{semantic_services::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -22,8 +22,6 @@ declare_rule! {
     /// For example, the character `❇️` consists of two code points: `❇` (U+2747) and `VARIATION SELECTOR-16` (U+FE0F).
     /// If this character is in a RegExp character class, it will match to either `❇` or `VARIATION SELECTOR-16` rather than `❇️`.
     /// This rule reports the regular expressions which include multiple code point characters in character class syntax.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-misleading-character-class
     ///
     /// ## Examples
     ///
@@ -65,6 +63,7 @@ declare_rule! {
     pub(crate) NoMisleadingCharacterClass {
         version: "1.5.0",
         name: "noMisleadingCharacterClass",
+        source: RuleSource::Eslint("no-misleading-character-class"),
         recommended: false,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_then_property.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_then_property.rs
@@ -1,4 +1,5 @@
 use crate::semantic_services::Semantic;
+use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use biome_console::{markup, MarkupBuf};
 use biome_js_syntax::{
@@ -17,8 +18,6 @@ declare_rule! {
     ///
     /// When combining objects with a `then` method (thenable objects) with await expressions or dynamic imports, caution is necessary.
     /// These syntaxes interpret the object's then method as intended for the resolution or rejection of a promise, which can lead to unexpected behavior or errors.
-    ///
-    /// Source: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-thenable.md
     ///
     /// ## Examples
     ///
@@ -87,6 +86,7 @@ declare_rule! {
     pub(crate) NoThenProperty {
         version: "1.5.0",
         name: "noThenProperty",
+        source: RuleSource::EslintUnicorn("no-thenable"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_export_type.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_export_type.rs
@@ -1,6 +1,7 @@
 use crate::{semantic_services::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -59,6 +60,8 @@ declare_rule! {
     pub(crate) UseExportType {
         version: "1.5.0",
         name: "useExportType",
+        source: RuleSource::EslintTypeScript("consistent-type-exports"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_for_of.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_for_of.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_semantic::{ReferencesExtensions, SemanticModel};
 use biome_js_syntax::{
@@ -14,9 +14,6 @@ use crate::{semantic_services::Semantic, utils::is_node_equal};
 
 declare_rule! {
     /// This rule recommends a `for-of` loop when in a `for` loop, the index used to extract an item from the iterated array.
-    ///
-    ///
-    /// Source: https://typescript-eslint.io/rules/prefer-for-of/
     ///
     /// ## Examples
     ///
@@ -45,6 +42,7 @@ declare_rule! {
     pub(crate) UseForOf {
         version: "1.5.0",
         name: "useForOf",
+        source: RuleSource::EslintTypeScript("prefer-for-of"),
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_import_type.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_import_type.rs
@@ -1,6 +1,7 @@
 use crate::{semantic_services::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -28,8 +29,6 @@ declare_rule! {
     ///
     /// The rule ensures that all imports used only as a type use a type-only `import`.
     /// It also groups inline type imports into a grouped `import type`.
-    ///
-    /// Source: https://typescript-eslint.io/rules/consistent-type-imports
     ///
     /// ## Examples
     ///
@@ -68,6 +67,8 @@ declare_rule! {
     pub(crate) UseImportType {
         version: "1.5.0",
         name: "useImportType",
+        source: RuleSource::EslintTypeScript("consistent-type-imports"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_number_namespace.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_number_namespace.rs
@@ -1,6 +1,6 @@
 use crate::{semantic_services::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -18,8 +18,6 @@ declare_rule! {
     ///
     /// The rule doesn't report the globals `isFinite` and `isNan` because they have a slightly different behabior to their corresponding `Number`'s properties `Number.isFinite` and `Number.isNan`.
     /// You can use the dedicated rules [noGlobalIsFinite](https://biomejs.dev/linter/rules/no-global-is-finite/) and  [noGlobalIsNan](https://biomejs.dev/linter/rules/no-global-is-nan/) to enforce the use of `Number.isFinite` and `Number.isNan`.
-    ///
-    /// Source: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-number-properties.md
     ///
     /// ## Examples
     ///
@@ -70,6 +68,7 @@ declare_rule! {
     pub(crate) UseNumberNamespace {
         version: "1.5.0",
         name: "useNumberNamespace",
+        source: RuleSource::EslintUnicorn("prefer-number-properties"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/security/no_dangerously_set_inner_html.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/security/no_dangerously_set_inner_html.rs
@@ -1,7 +1,7 @@
 use crate::react::ReactCreateElementCall;
 use crate::semantic_services::Semantic;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{AnyJsxAttributeName, JsCallExpression, JsxAttribute};
 use biome_rowan::{declare_node_union, AstNode, TextRange};
@@ -28,6 +28,7 @@ declare_rule! {
     pub(crate) NoDangerouslySetInnerHtml {
         version: "1.0.0",
         name: "noDangerouslySetInnerHtml",
+        source: RuleSource::EslintReact("no-danger-with-children"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/security/no_dangerously_set_inner_html_with_children.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/security/no_dangerously_set_inner_html_with_children.rs
@@ -1,7 +1,7 @@
 use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::semantic_services::Semantic;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
@@ -37,6 +37,7 @@ declare_rule! {
     pub(crate) NoDangerouslySetInnerHtmlWithChildren {
         version: "1.0.0",
         name: "noDangerouslySetInnerHtmlWithChildren",
+        source: RuleSource::EslintReact("no-danger"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/no_arguments.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/no_arguments.rs
@@ -1,10 +1,10 @@
 use crate::semantic_services::SemanticServices;
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::TextRange;
 
 declare_rule! {
-    /// Disallow the use of ```arguments```
+    /// Disallow the use of `arguments`.
     ///
     /// ## Examples
     ///
@@ -27,6 +27,7 @@ declare_rule! {
     pub(crate) NoArguments {
         version: "1.0.0",
         name: "noArguments",
+        source: RuleSource::Eslint("prefer-rest-params"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/no_parameter_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/no_parameter_assign.rs
@@ -1,5 +1,5 @@
 use crate::semantic_services::Semantic;
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_semantic::{AllBindingWriteReferencesIter, Reference, ReferencesExtensions};
 use biome_js_syntax::{AnyJsBinding, AnyJsBindingPattern, AnyJsFormalParameter, AnyJsParameter};
@@ -11,8 +11,6 @@ declare_rule! {
     /// Assignment to a `function` parameters can be misleading and confusing,
     /// as modifying parameters will also mutate the `arguments` object.
     /// It is often unintended and indicative of a programmer error.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-param-reassign
     ///
     /// In contrast to the _ESLint_ rule, this rule cannot be configured to report
     /// assignments to a property of a parameter.
@@ -58,6 +56,7 @@ declare_rule! {
     pub(crate) NoParameterAssign {
         version: "1.0.0",
         name: "noParameterAssign",
+        source: RuleSource::Eslint("no-param-reassign"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/no_restricted_globals.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/no_restricted_globals.rs
@@ -1,6 +1,6 @@
 use crate::semantic_services::SemanticServices;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_deserialize::{
     Deserializable, DeserializableValue, DeserializationDiagnostic, DeserializationVisitor, Text,
@@ -51,6 +51,7 @@ declare_rule! {
     pub(crate) NoRestrictedGlobals {
         version: "1.0.0",
         name: "noRestrictedGlobals",
+        source: RuleSource::Eslint("no-restricted-globals"),
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/no_var.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/no_var.rs
@@ -1,6 +1,6 @@
 use crate::{control_flow::AnyJsControlFlowRoot, semantic_services::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -17,8 +17,6 @@ declare_rule! {
     /// ECMAScript 6 allows programmers to create variables with block scope instead of function scope using the let and const keywords.
     ///
     /// Block scope is common in many other programming languages and helps programmers avoid mistakes.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-var
     ///
     /// ## Examples
     ///
@@ -37,6 +35,7 @@ declare_rule! {
     pub(crate) NoVar {
         version: "1.0.0",
         name: "noVar",
+        source: RuleSource::Eslint("no-var"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/use_const.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/use_const.rs
@@ -1,6 +1,6 @@
 use crate::{semantic_services::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 
@@ -59,6 +59,7 @@ declare_rule! {
     pub(crate) UseConst {
         version: "1.0.0",
         name: "useConst",
+        source: RuleSource::Eslint("prefer-const"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/use_fragment_syntax.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/use_fragment_syntax.rs
@@ -2,7 +2,7 @@ use crate::react::{jsx_member_name_is_react_fragment, jsx_reference_identifier_i
 use crate::semantic_services::Semantic;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make::{
@@ -30,6 +30,7 @@ declare_rule! {
     pub(crate) UseFragmentSyntax {
         version: "1.0.0",
         name: "useFragmentSyntax",
+        source: RuleSource::EslintReact("jsx-fragments"),
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
@@ -8,7 +8,8 @@ use crate::{
     JsRuleAction,
 };
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_deserialize::{
@@ -276,6 +277,8 @@ declare_rule! {
     pub(crate)  UseNamingConvention {
         version: "1.0.0",
         name: "useNamingConvention",
+        source: RuleSource::EslintTypeScript("naming-convention"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: false,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_array_index_key.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_array_index_key.rs
@@ -1,7 +1,7 @@
 use crate::react::{is_react_call_api, ReactLibrary};
 use crate::semantic_services::Semantic;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{
     AnyJsFunction, AnyJsMemberExpression, JsCallArgumentList, JsCallArguments, JsCallExpression,
@@ -39,6 +39,7 @@ declare_rule! {
     pub(crate) NoArrayIndexKey {
         version: "1.0.0",
         name: "noArrayIndexKey",
+        source: RuleSource::EslintReact("no-array-index-key"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_catch_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_catch_assign.rs
@@ -1,5 +1,5 @@
 use crate::semantic_services::Semantic;
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_semantic::ReferencesExtensions;
 use biome_js_syntax::JsCatchClause;
@@ -10,8 +10,6 @@ declare_rule! {
     ///
     /// Assignment to a `catch` parameter can be misleading and confusing.
     /// It is often unintended and indicative of a programmer error.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-ex-assign
     ///
     /// ## Examples
     ///
@@ -39,6 +37,7 @@ declare_rule! {
     pub(crate) NoCatchAssign {
         version: "1.0.0",
         name: "noCatchAssign",
+        source: RuleSource::Eslint("no-ex-assign"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_class_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_class_assign.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_semantic::{Reference, ReferencesExtensions};
 use biome_js_syntax::AnyJsClass;
@@ -68,6 +68,7 @@ declare_rule! {
     pub(crate) NoClassAssign {
         version: "1.0.0",
         name: "noClassAssign",
+        source: RuleSource::Eslint("no-class-assign"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_console_log.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_console_log.rs
@@ -1,6 +1,7 @@
 use crate::{semantic_services::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -33,6 +34,8 @@ declare_rule! {
     pub(crate) NoConsoleLog {
         version: "1.0.0",
         name: "noConsoleLog",
+        source: RuleSource::Eslint("no-console"),
+        source_kind: RuleSourceKind::Inspired,
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_duplicate_parameters.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_duplicate_parameters.rs
@@ -1,3 +1,4 @@
+use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_syntax::parameter_ext::{AnyJsParameterList, AnyJsParameters, AnyParameter};
@@ -14,8 +15,6 @@ declare_rule! {
     /// If more than one parameter has the same name in a function definition,
     /// the last occurrence overrides the preceding occurrences.
     /// A duplicated name might be a typing error.
-    ///
-    /// Source: https://eslint.org/docs/latest/rules/no-dupe-args
     ///
     /// ## Examples
     ///
@@ -41,6 +40,7 @@ declare_rule! {
     pub(crate) NoDuplicateParameters {
         version: "1.0.0",
         name: "noDuplicateParameters",
+        source: RuleSource::Eslint("no-dupe-args"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_function_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_function_assign.rs
@@ -1,5 +1,5 @@
 use crate::semantic_services::Semantic;
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_semantic::{Reference, ReferencesExtensions};
 use biome_js_syntax::{JsFunctionDeclaration, JsIdentifierBinding};
@@ -96,6 +96,7 @@ declare_rule! {
     pub(crate) NoFunctionAssign {
         version: "1.0.0",
         name: "noFunctionAssign",
+        source: RuleSource::Eslint("no-func-assign"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_import_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_import_assign.rs
@@ -1,5 +1,5 @@
 use crate::semantic_services::Semantic;
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_semantic::ReferencesExtensions;
 use biome_js_syntax::{
@@ -52,6 +52,7 @@ declare_rule! {
     pub(crate) NoImportAssign {
         version: "1.0.0",
         name: "noImportAssign",
+        source: RuleSource::Eslint("no-import-assign"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_label_var.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_label_var.rs
@@ -1,5 +1,5 @@
 use crate::semantic_services::Semantic;
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{JsLabeledStatement, JsSyntaxNode, JsSyntaxToken};
 use biome_rowan::AstNode;
@@ -25,6 +25,7 @@ declare_rule! {
     pub(crate) NoLabelVar {
         version: "1.0.0",
         name: "noLabelVar",
+        source: RuleSource::Eslint("no-label-var"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_redeclare.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_redeclare.rs
@@ -1,6 +1,6 @@
 use crate::semantic_services::SemanticServices;
-use biome_analyze::declare_rule;
 use biome_analyze::{context::RuleContext, Rule, RuleDiagnostic};
+use biome_analyze::{declare_rule, RuleSource};
 use biome_console::markup;
 use biome_js_semantic::Scope;
 use biome_js_syntax::binding_ext::AnyJsBindingDeclaration;
@@ -10,8 +10,6 @@ use rustc_hash::FxHashMap;
 
 declare_rule! {
     /// Disallow variable, function, class, and type redeclarations in the same scope.
-    ///
-    /// Source: https://typescript-eslint.io/rules/no-redeclare
     ///
     /// ## Examples
     ///
@@ -63,6 +61,7 @@ declare_rule! {
     pub(crate) NoRedeclare {
         version: "1.0.0",
         name: "noRedeclare",
+        source: RuleSource::EslintTypeScript("no-redeclare"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_unsafe_declaration_merging.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_unsafe_declaration_merging.rs
@@ -1,5 +1,5 @@
 use crate::semantic_services::Semantic;
-use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{binding_ext::AnyJsBindingDeclaration, TsInterfaceDeclaration};
 use biome_rowan::{AstNode, TextRange};
@@ -12,8 +12,6 @@ declare_rule! {
     /// _Declaration merging_ between classes and interfaces is unsafe.
     /// The _TypeScript Compiler_ doesn't check whether properties defined in the interface are initialized in the class.
     /// This can cause lead to _TypeScript_ not detecting code that will cause runtime errors.
-    ///
-    /// Source: https://typescript-eslint.io/rules/no-unsafe-declaration-merging/
     ///
     /// ## Examples
     ///
@@ -45,6 +43,7 @@ declare_rule! {
     pub(crate) NoUnsafeDeclarationMerging {
         version: "1.0.0",
         name: "noUnsafeDeclarationMerging",
+        source: RuleSource::EslintTypeScript("no-unsafe-declaration-merging"),
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/use_is_array.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/use_is_array.rs
@@ -1,6 +1,6 @@
 use crate::{semantic_services::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -19,8 +19,6 @@ declare_rule! {
     /// Passing arrays across these contexts, results in arrays that are not instances of the contextual global `Array` class.
     /// To avoid these issues, use `Array.isArray()` instead of `instanceof Array`.
     /// See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray) for more details.
-    ///
-    /// Source: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-instanceof-array.md
     ///
     /// ## Examples
     ///
@@ -41,6 +39,7 @@ declare_rule! {
     pub(crate) UseIsArray {
         version: "1.0.0",
         name: "useIsArray",
+        source: RuleSource::EslintUnicorn("no-instanceof-array"),
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -3395,7 +3395,7 @@ pub struct Style {
     #[doc = r" It enables ALL rules for this group."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub all: Option<bool>,
-    #[doc = "Disallow the use of arguments"]
+    #[doc = "Disallow the use of arguments."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_arguments: Option<RuleConfiguration>,
     #[doc = "Disallow comma operator."]

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1006,7 +1006,7 @@ export interface Style {
 	 */
 	all?: boolean;
 	/**
-	 * Disallow the use of arguments
+	 * Disallow the use of arguments.
 	 */
 	noArguments?: RuleConfiguration;
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1788,7 +1788,7 @@
 					"type": ["boolean", "null"]
 				},
 				"noArguments": {
-					"description": "Disallow the use of arguments",
+					"description": "Disallow the use of arguments.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }

--- a/website/src/content/docs/linter/rules/index.mdx
+++ b/website/src/content/docs/linter/rules/index.mdx
@@ -135,7 +135,7 @@ Rules that detect potential security flaws.
 Rules enforcing a consistent and idiomatic way of writing your code.
 | Rule name | Description | Properties |
 | --- | --- | --- |
-| [noArguments](/linter/rules/no-arguments) | Disallow the use of <code>arguments</code> | <span aria-label="Recommended" role="img" title="Recommended">✅ </span> |
+| [noArguments](/linter/rules/no-arguments) | Disallow the use of <code>arguments</code>. | <span aria-label="Recommended" role="img" title="Recommended">✅ </span> |
 | [noCommaOperator](/linter/rules/no-comma-operator) | Disallow comma operator. | <span aria-label="Recommended" role="img" title="Recommended">✅ </span> |
 | [noDefaultExport](/linter/rules/no-default-export) | Disallow default exports. |  |
 | [noImplicitBoolean](/linter/rules/no-implicit-boolean) | Disallow implicit <code>true</code> values on JSX boolean attributes | <span aria-label="The rule has a safe fix" role="img" title="The rule has a safe fix">🔧 </span> |

--- a/website/src/content/docs/linter/rules/no-access-key.md
+++ b/website/src/content/docs/linter/rules/no-access-key.md
@@ -8,6 +8,8 @@ title: noAccessKey (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-access-key.md" target="_blank"><code>no-access-key</code></a>
+
 Enforce that the `accessKey` attribute is not used on any HTML element.
 
 The `accessKey` assigns a keyboard shortcut to the current element. However, the `accessKey` value

--- a/website/src/content/docs/linter/rules/no-approximative-numeric-constant.md
+++ b/website/src/content/docs/linter/rules/no-approximative-numeric-constant.md
@@ -4,9 +4,9 @@ title: noApproximativeNumericConstant (since v1.3.0)
 
 **Diagnostic Category: `lint/suspicious/noApproximativeNumericConstant`**
 
-Usually, the definition in the standard library is more precise than what people come up with or the used constant exceeds the maximum precision of the number type.
+Source: <a href="https://rust-lang.github.io/rust-clippy/master/#/approx_constant" target="_blank"><code>approx_constant</code></a>
 
-Source: https://rust-lang.github.io/rust-clippy/master/#approx_constant
+Usually, the definition in the standard library is more precise than what people come up with or the used constant exceeds the maximum precision of the number type.
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-arguments.md
+++ b/website/src/content/docs/linter/rules/no-arguments.md
@@ -8,7 +8,9 @@ title: noArguments (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
-Disallow the use of `arguments`
+Source: <a href="https://eslint.org/docs/latest/rules/prefer-rest-params" target="_blank"><code>prefer-rest-params</code></a>
+
+Disallow the use of `arguments`.
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-aria-hidden-on-focusable.md
+++ b/website/src/content/docs/linter/rules/no-aria-hidden-on-focusable.md
@@ -8,13 +8,13 @@ title: noAriaHiddenOnFocusable (since v1.4.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-aria-hidden-on-focusable.md" target="_blank"><code>no-aria-hidden-on-focusable</code></a>
+
 Enforce that aria-hidden="true" is not set on focusable elements.
 
 `aria-hidden="true"` can be used to hide purely decorative content from screen reader users.
 A focusable element with `aria-hidden="true"` can be reached by keyboard.
 This can lead to confusion or unexpected behavior for screen reader users.
-
-Source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-aria-hidden-on-focusable.md
 
 ## Example
 

--- a/website/src/content/docs/linter/rules/no-aria-unsupported-elements.md
+++ b/website/src/content/docs/linter/rules/no-aria-unsupported-elements.md
@@ -8,9 +8,9 @@ title: noAriaUnsupportedElements (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
-Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-unsupported-elements.md" target="_blank"><code>aria-unsupported-elements</code></a>
 
-Source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-unsupported-elements.md
+Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-array-index-key.md
+++ b/website/src/content/docs/linter/rules/no-array-index-key.md
@@ -8,6 +8,8 @@ title: noArrayIndexKey (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md" target="_blank"><code>no-array-index-key</code></a>
+
 Discourage the usage of Array index in keys.
 
 >We don’t recommend using indexes for keys if the order of items may change.

--- a/website/src/content/docs/linter/rules/no-assign-in-expressions.md
+++ b/website/src/content/docs/linter/rules/no-assign-in-expressions.md
@@ -8,6 +8,8 @@ title: noAssignInExpressions (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Inspired from: <a href="https://eslint.org/docs/latest/rules/no-cond-assign" target="_blank"><code>no-cond-assign</code></a>
+
 Disallow assignments in expressions.
 
 In expressions, it is common to mistype a comparison operator (such as `==`) as an assignment operator (such as `=`).

--- a/website/src/content/docs/linter/rules/no-async-promise-executor.md
+++ b/website/src/content/docs/linter/rules/no-async-promise-executor.md
@@ -8,6 +8,8 @@ title: noAsyncPromiseExecutor (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-async-promise-executor" target="_blank"><code>no-async-promise-executor</code></a>
+
 Disallows using an async function as a Promise executor.
 
 The executor function can also be an async function. However, this is usually a mistake, for a few reasons:

--- a/website/src/content/docs/linter/rules/no-autofocus.md
+++ b/website/src/content/docs/linter/rules/no-autofocus.md
@@ -8,6 +8,8 @@ title: noAutofocus (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-autofocus.md" target="_blank"><code>no-autofocus</code></a>
+
 Enforce that autoFocus prop is not used on elements.
 
 Autofocusing elements can cause usability issues for sighted and non-sighted users, alike.

--- a/website/src/content/docs/linter/rules/no-banned-types.md
+++ b/website/src/content/docs/linter/rules/no-banned-types.md
@@ -8,6 +8,8 @@ title: noBannedTypes (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/ban-types" target="_blank"><code>ban-types</code></a>
+
 Disallow primitive type aliases and misleading types.
 
 - Enforce consistent names for primitive types
@@ -70,8 +72,6 @@ type NonNullableMyType = NonNullable<MyType>;
 ```
 
 
-
-Source: https://typescript-eslint.io/rules/ban-types
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-blank-target.md
+++ b/website/src/content/docs/linter/rules/no-blank-target.md
@@ -8,6 +8,8 @@ title: noBlankTarget (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/jsx-no-target-blank.md" target="_blank"><code>jsx-no-target-blank</code></a>
+
 Disallow `target="_blank"` attribute without `rel="noreferrer"`
 
 When creating anchor `a` element, there are times when its link has to be opened in a new browser tab

--- a/website/src/content/docs/linter/rules/no-catch-assign.md
+++ b/website/src/content/docs/linter/rules/no-catch-assign.md
@@ -8,12 +8,12 @@ title: noCatchAssign (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-ex-assign" target="_blank"><code>no-ex-assign</code></a>
+
 Disallow reassigning exceptions in catch clauses.
 
 Assignment to a `catch` parameter can be misleading and confusing.
 It is often unintended and indicative of a programmer error.
-
-Source: https://eslint.org/docs/latest/rules/no-ex-assign
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-children-prop.md
+++ b/website/src/content/docs/linter/rules/no-children-prop.md
@@ -8,6 +8,8 @@ title: noChildrenProp (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-children-prop.md" target="_blank"><code>no-children-prop</code></a>
+
 Prevent passing of **children** as props.
 
 When using JSX, the children should be nested between the opening and closing tags.

--- a/website/src/content/docs/linter/rules/no-class-assign.md
+++ b/website/src/content/docs/linter/rules/no-class-assign.md
@@ -8,6 +8,8 @@ title: noClassAssign (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-class-assign" target="_blank"><code>no-class-assign</code></a>
+
 Disallow reassigning class members.
 
 A class declaration creates a variable that we can modify, however, the modification is a mistake in most cases.

--- a/website/src/content/docs/linter/rules/no-comma-operator.md
+++ b/website/src/content/docs/linter/rules/no-comma-operator.md
@@ -8,6 +8,8 @@ title: noCommaOperator (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-sequences" target="_blank"><code>no-sequences</code></a>
+
 Disallow comma operator.
 
 The comma operator includes multiple expressions where only one is expected.
@@ -15,8 +17,6 @@ It evaluates every operand from left to right and returns the value of the last 
 It frequently obscures side effects, and its use is often an accident.
 
 The use of the comma operator in the initialization and update parts of a `for` is still allowed.
-
-Source: https://eslint.org/docs/latest/rules/no-sequences
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-comment-text.md
+++ b/website/src/content/docs/linter/rules/no-comment-text.md
@@ -8,6 +8,8 @@ title: noCommentText (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md" target="_blank"><code>jsx-no-comment-textnodes</code></a>
+
 Prevent comments from being inserted as text nodes
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-compare-neg-zero.md
+++ b/website/src/content/docs/linter/rules/no-compare-neg-zero.md
@@ -8,6 +8,8 @@ title: noCompareNegZero (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-compare-neg-zero" target="_blank"><code>no-compare-neg-zero</code></a>
+
 Disallow comparing against `-0`
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-confusing-labels.md
+++ b/website/src/content/docs/linter/rules/no-confusing-labels.md
@@ -8,12 +8,12 @@ title: noConfusingLabels (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Inspired from: <a href="https://eslint.org/docs/latest/rules/no-labels" target="_blank"><code>no-labels</code></a>
+
 Disallow labeled statements that are not loops.
 
 Labeled statements in JavaScript are used in conjunction with `break` and `continue` to control flow around multiple loops.
 Their use for other statements is suspicious and unfamiliar.
-
-Source: https://eslint.org/docs/latest/rules/no-labels
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-confusing-void-type.md
+++ b/website/src/content/docs/linter/rules/no-confusing-void-type.md
@@ -8,6 +8,8 @@ title: noConfusingVoidType (since v1.2.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-invalid-void-type" target="_blank"><code>no-invalid-void-type</code></a>
+
 Disallow `void` type outside of generic or return types.
 
 `void` in TypeScript refers to a function return that is meant to be ignored. Attempting to use a void type outside of a return type or generic type argument is often a sign of programmer error. `void` can also be misleading for other developers even if used correctly.

--- a/website/src/content/docs/linter/rules/no-console-log.md
+++ b/website/src/content/docs/linter/rules/no-console-log.md
@@ -4,6 +4,8 @@ title: noConsoleLog (since v1.0.0)
 
 **Diagnostic Category: `lint/suspicious/noConsoleLog`**
 
+Inspired from: <a href="https://eslint.org/docs/latest/rules/no-console" target="_blank"><code>no-console</code></a>
+
 Disallow the use of `console.log`
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-const-assign.md
+++ b/website/src/content/docs/linter/rules/no-const-assign.md
@@ -8,6 +8,8 @@ title: noConstAssign (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-const-assign" target="_blank"><code>no-const-assign</code></a>
+
 Prevents from having `const` variables being re-assigned.
 
 Trying to assign a value to a `const` will cause an `TypeError` when the code is executed.

--- a/website/src/content/docs/linter/rules/no-constant-condition.md
+++ b/website/src/content/docs/linter/rules/no-constant-condition.md
@@ -8,6 +8,8 @@ title: noConstantCondition (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-constant-condition" target="_blank"><code>no-constant-condition</code></a>
+
 Disallow constant expressions in conditions
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-constructor-return.md
+++ b/website/src/content/docs/linter/rules/no-constructor-return.md
@@ -8,14 +8,14 @@ title: noConstructorReturn (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-constructor-return" target="_blank"><code>no-constructor-return</code></a>
+
 Disallow returning a value from a `constructor`.
 
 Returning a value from a `constructor` of a class is a possible error.
 Forbidding this pattern prevents errors resulting from unfamiliarity with JavaScript or a copy-paste error.
 
 Only returning without a value is allowed, as it’s a control flow statement.
-
-Source: https://eslint.org/docs/latest/rules/no-constructor-return
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-control-characters-in-regex.md
+++ b/website/src/content/docs/linter/rules/no-control-characters-in-regex.md
@@ -8,6 +8,8 @@ title: noControlCharactersInRegex (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-control-regex" target="_blank"><code>no-control-regex</code></a>
+
 Prevents from having control characters and some escape sequences that match control characters in regular expressions.
 
 Control characters are hidden special characters that are numbered from 0 to 31 in the ASCII system.
@@ -21,8 +23,6 @@ The following elements of regular expression patterns are considered possible er
 - Unescaped raw characters from U+0000 to U+001F
 
 Control escapes such as `\t` and `\n` are allowed by this rule.
-
-Source: https://eslint.org/docs/latest/rules/no-control-regex
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-dangerously-set-inner-html-with-children.md
+++ b/website/src/content/docs/linter/rules/no-dangerously-set-inner-html-with-children.md
@@ -8,6 +8,8 @@ title: noDangerouslySetInnerHtmlWithChildren (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md" target="_blank"><code>no-danger</code></a>
+
 Report when a DOM element or a component uses both `children` and `dangerouslySetInnerHTML` prop.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-dangerously-set-inner-html.md
+++ b/website/src/content/docs/linter/rules/no-dangerously-set-inner-html.md
@@ -8,6 +8,8 @@ title: noDangerouslySetInnerHtml (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger-with-children.md" target="_blank"><code>no-danger-with-children</code></a>
+
 Prevent the usage of dangerous JSX props
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-debugger.md
+++ b/website/src/content/docs/linter/rules/no-debugger.md
@@ -8,6 +8,8 @@ title: noDebugger (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-debugger" target="_blank"><code>no-debugger</code></a>
+
 Disallow the use of `debugger`
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-default-export.md
+++ b/website/src/content/docs/linter/rules/no-default-export.md
@@ -4,6 +4,8 @@ title: noDefaultExport (since v1.4.0)
 
 **Diagnostic Category: `lint/style/noDefaultExport`**
 
+Source: <a href="https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md" target="_blank"><code>no-default-export</code></a>
+
 Disallow default exports.
 
 Default exports cannot be easily discovered inside an editor:
@@ -20,8 +22,6 @@ For all these reasons, a team may want to disallow default exports.
 
 Note that this rule disallows only default exports in EcmaScript Module.
 It ignores CommonJS default exports.
-
-Source: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-distracting-elements.md
+++ b/website/src/content/docs/linter/rules/no-distracting-elements.md
@@ -8,6 +8,8 @@ title: noDistractingElements (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-distracting-elements.md" target="_blank"><code>no-distracting-elements</code></a>
+
 Enforces that no distracting elements are used.
 
 Elements that can be visually distracting can cause accessibility issues with visually impaired users.

--- a/website/src/content/docs/linter/rules/no-double-equals.md
+++ b/website/src/content/docs/linter/rules/no-double-equals.md
@@ -8,6 +8,8 @@ title: noDoubleEquals (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/eqeqeq" target="_blank"><code>eqeqeq</code></a>
+
 Require the use of `===` and `!==`
 
 It is generally bad practice to use `==` for comparison instead of

--- a/website/src/content/docs/linter/rules/no-duplicate-case.md
+++ b/website/src/content/docs/linter/rules/no-duplicate-case.md
@@ -8,11 +8,11 @@ title: noDuplicateCase (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-duplicate-case" target="_blank"><code>no-duplicate-case</code></a>
+
 Disallow duplicate case labels.
 
 If a switch statement has duplicate test expressions in case clauses, it is likely that a programmer copied a case clause but forgot to change the test expression.
-
-Source: https://eslint.org/docs/latest/rules/no-duplicate-case
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-duplicate-class-members.md
+++ b/website/src/content/docs/linter/rules/no-duplicate-class-members.md
@@ -8,6 +8,8 @@ title: noDuplicateClassMembers (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-dupe-class-members" target="_blank"><code>no-dupe-class-members</code></a>
+
 Disallow duplicate class members.
 
 If there are declarations of the same name among class members,

--- a/website/src/content/docs/linter/rules/no-duplicate-jsx-props.md
+++ b/website/src/content/docs/linter/rules/no-duplicate-jsx-props.md
@@ -8,6 +8,8 @@ title: noDuplicateJsxProps (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md" target="_blank"><code>jsx-no-duplicate-props</code></a>
+
 Prevents JSX properties to be assigned multiple times.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-duplicate-object-keys.md
+++ b/website/src/content/docs/linter/rules/no-duplicate-object-keys.md
@@ -8,6 +8,8 @@ title: noDuplicateObjectKeys (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-dupe-keys" target="_blank"><code>no-dupe-keys</code></a>
+
 Prevents object literals having more than one property declaration for the same name.
 
 If an object property with the same name is defined multiple times (except when combining a getter with a setter), only the last definition makes it into the object and previous definitions are ignored, which is likely a mistake.

--- a/website/src/content/docs/linter/rules/no-duplicate-parameters.md
+++ b/website/src/content/docs/linter/rules/no-duplicate-parameters.md
@@ -8,13 +8,13 @@ title: noDuplicateParameters (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-dupe-args" target="_blank"><code>no-dupe-args</code></a>
+
 Disallow duplicate function parameter name.
 
 If more than one parameter has the same name in a function definition,
 the last occurrence overrides the preceding occurrences.
 A duplicated name might be a typing error.
-
-Source: https://eslint.org/docs/latest/rules/no-dupe-args
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-empty-block-statements.md
+++ b/website/src/content/docs/linter/rules/no-empty-block-statements.md
@@ -8,15 +8,14 @@ title: noEmptyBlockStatements (since v1.3.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-empty" target="_blank"><code>no-empty</code></a>
+
 Disallow empty block statements and static blocks.
 
 Empty static blocks and block statements, while not technically errors, usually occur due to refactoring that wasn’t completed. They can cause confusion when reading code.
 
 This rule disallows empty block statements and static blocks.
 This rule ignores block statements or static blocks which contain a comment (for example, in an empty catch or finally block of a try statement to indicate that execution should continue regardless of errors).
-
-Source: https://eslint.org/docs/latest/rules/no-empty-static-block/
-Source: https://eslint.org/docs/latest/rules/no-empty/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-empty-character-class-in-regex.md
+++ b/website/src/content/docs/linter/rules/no-empty-character-class-in-regex.md
@@ -8,13 +8,13 @@ title: noEmptyCharacterClassInRegex (since v1.3.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-empty-character-class" target="_blank"><code>no-empty-character-class</code></a>
+
 Disallow empty character classes in regular expression literals.
 
 Empty character classes don't match anything.
 In contrast, negated empty classes match any character.
 They are often the result of a typing mistake.
-
-Source: https://eslint.org/docs/latest/rules/no-empty-character-class/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-empty-interface.md
+++ b/website/src/content/docs/linter/rules/no-empty-interface.md
@@ -8,14 +8,14 @@ title: noEmptyInterface (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Inspired from: <a href="https://typescript-eslint.io/rules/no-empty-interface" target="_blank"><code>no-empty-interface</code></a>
+
 Disallow the declaration of empty interfaces.
 
 An empty interface in TypeScript does very little: any non-nullable value is assignable to `{}`.
 Using an empty interface is often a sign of programmer error, such as misunderstanding the concept of `{}` or forgetting to fill in fields.
 
 The rule ignores empty interfaces that `extends` one or multiple types.
-
-Inspired by: https://typescript-eslint.io/rules/no-empty-interface
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-empty-pattern.md
+++ b/website/src/content/docs/linter/rules/no-empty-pattern.md
@@ -8,6 +8,8 @@ title: noEmptyPattern (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-empty-pattern" target="_blank"><code>no-empty-pattern</code></a>
+
 Disallows empty destructuring patterns.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-excessive-cognitive-complexity.md
+++ b/website/src/content/docs/linter/rules/no-excessive-cognitive-complexity.md
@@ -4,6 +4,8 @@ title: noExcessiveCognitiveComplexity (since v1.0.0)
 
 **Diagnostic Category: `lint/complexity/noExcessiveCognitiveComplexity`**
 
+Source: <a href="https://github.com/SonarSource/eslint-plugin-sonarjs/blob/HEAD/docs/rules/cognitive-complexity.md" target="_blank"><code>cognitive-complexity</code></a>
+
 Disallow functions that exceed a given Cognitive Complexity score.
 
 The more complexity a function contains, the harder it is to understand
@@ -18,10 +20,6 @@ those that exceed a configured complexity threshold (default: 15).
 
 The complexity score is calculated based on the Cognitive Complexity
 algorithm: http://redirect.sonarsource.com/doc/cognitive-complexity.html
-
-Source:
-
-- https://github.com/SonarSource/eslint-plugin-sonarjs/blob/HEAD/docs/rules/cognitive-complexity.md
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-explicit-any.md
+++ b/website/src/content/docs/linter/rules/no-explicit-any.md
@@ -8,6 +8,8 @@ title: noExplicitAny (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-explicit-any" target="_blank"><code>no-explicit-any</code></a>
+
 Disallow the `any` type usage.
 
 The `any` type in TypeScript is a dangerous "escape hatch" from the type system.
@@ -18,8 +20,6 @@ but doesn't prevent `any` from being explicitly used the way this rule does.
 
 Sometimes you can use the type `unknown` instead of the type `any`.
 It also accepts any value, however it requires to check that a property exists before calling it.
-
-Source: https://typescript-eslint.io/rules/no-explicit-any
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-extra-boolean-cast.md
+++ b/website/src/content/docs/linter/rules/no-extra-boolean-cast.md
@@ -8,6 +8,8 @@ title: noExtraBooleanCast (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-extra-boolean-cast" target="_blank"><code>no-extra-boolean-cast</code></a>
+
 Disallow unnecessary boolean casts
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-extra-non-null-assertion.md
+++ b/website/src/content/docs/linter/rules/no-extra-non-null-assertion.md
@@ -8,12 +8,12 @@ title: noExtraNonNullAssertion (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-extra-non-null-assertion" target="_blank"><code>no-extra-non-null-assertion</code></a>
+
 Prevents the wrong usage of the non-null assertion operator (`!`) in TypeScript files.
 
 >The `!` non-null assertion operator in TypeScript is used to assert that a value's type does not include `null` or `undefined`. Using the operator any more than once on a single value does nothing.
 
-
-Source: https://typescript-eslint.io/rules/no-extra-non-null-assertion
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-fallthrough-switch-clause.md
+++ b/website/src/content/docs/linter/rules/no-fallthrough-switch-clause.md
@@ -8,12 +8,12 @@ title: noFallthroughSwitchClause (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-fallthrough" target="_blank"><code>no-fallthrough</code></a>
+
 Disallow fallthrough of `switch` clauses.
 
 Switch clauses in `switch` statements fall through by default.
 This can lead to unexpected behavior when forgotten.
-
-Source: https://eslint.org/docs/latest/rules/no-fallthrough
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-for-each.md
+++ b/website/src/content/docs/linter/rules/no-for-each.md
@@ -8,6 +8,8 @@ title: noForEach (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-for-each.md" target="_blank"><code>no-array-for-each</code></a>
+
 Prefer `for...of` statement instead of `Array.forEach`.
 
 Here's a summary of why `forEach` may be disallowed, and why `for...of` is preferred for almost any use-case of `forEach`:

--- a/website/src/content/docs/linter/rules/no-function-assign.md
+++ b/website/src/content/docs/linter/rules/no-function-assign.md
@@ -8,6 +8,8 @@ title: noFunctionAssign (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-func-assign" target="_blank"><code>no-func-assign</code></a>
+
 Disallow reassigning function declarations.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-global-assign.md
+++ b/website/src/content/docs/linter/rules/no-global-assign.md
@@ -8,12 +8,12 @@ title: noGlobalAssign (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-global-assign" target="_blank"><code>no-global-assign</code></a>
+
 Disallow assignments to native objects and read-only global variables.
 
 _JavaScript environments contain numerous built-in global variables, such as `window` in browsers and `process` in _Node.js.
 Assigning values to these global variables can be problematic as it can override essential functionality.
-
-Source: https://eslint.org/docs/latest/rules/no-global-assign
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-global-eval.md
+++ b/website/src/content/docs/linter/rules/no-global-eval.md
@@ -8,6 +8,8 @@ title: noGlobalEval (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-eval" target="_blank"><code>no-eval</code></a>
+
 Disallow the use of global `eval()`.
 
 The `eval()` function evaluates the passed string as a _JavaScript_ code.
@@ -17,8 +19,6 @@ The use of `eval()` exposes to [security risks and performance issues](https://d
 If the executed code is somehow affected by a malicious party,
 then you may end up executing malicious code with the privileges of the caller.
 Moreover, changing variables in the caller's scope is expensive in modern _JavaScript_ interpreters.
-
-Source: https://eslint.org/docs/latest/rules/no-eval
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-global-object-calls.md
+++ b/website/src/content/docs/linter/rules/no-global-object-calls.md
@@ -8,6 +8,8 @@ title: noGlobalObjectCalls (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-obj-calls" target="_blank"><code>no-obj-calls</code></a>
+
 Disallow calling global object properties as functions
 
 ECMAScript provides several global objects that are intended to be used as-is.

--- a/website/src/content/docs/linter/rules/no-header-scope.md
+++ b/website/src/content/docs/linter/rules/no-header-scope.md
@@ -8,6 +8,8 @@ title: noHeaderScope (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/scope.md" target="_blank"><code>scope</code></a>
+
 The scope prop should be used only on `<th>` elements.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-implicit-any-let.md
+++ b/website/src/content/docs/linter/rules/no-implicit-any-let.md
@@ -13,9 +13,7 @@ Disallow use of implicit `any` type on variable declarations.
 TypeScript variable declaration without any type annotation and initialization have the `any` type.
 The any type in TypeScript is a dangerous “escape hatch” from the type system.
 Using any disables many type checking rules and is generally best used only as a last resort or when prototyping code.
-TypeScript’s `--noImplicitAny` compiler option doesn't report this case.
-
-Source: https://www.typescriptlang.org/tsconfig#noImplicitAny
+TypeScript’s [`--noImplicitAny` compiler option](https://www.typescriptlang.org/tsconfig#noImplicitAny) doesn't report this case.
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-implicit-boolean.md
+++ b/website/src/content/docs/linter/rules/no-implicit-boolean.md
@@ -4,6 +4,8 @@ title: noImplicitBoolean (since v1.0.0)
 
 **Diagnostic Category: `lint/style/noImplicitBoolean`**
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md" target="_blank"><code>jsx-boolean-value</code></a>
+
 Disallow implicit `true` values on JSX boolean attributes
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-import-assign.md
+++ b/website/src/content/docs/linter/rules/no-import-assign.md
@@ -8,6 +8,8 @@ title: noImportAssign (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-import-assign" target="_blank"><code>no-import-assign</code></a>
+
 Disallow assigning to imported bindings
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-inferrable-types.md
+++ b/website/src/content/docs/linter/rules/no-inferrable-types.md
@@ -8,6 +8,8 @@ title: noInferrableTypes (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-inferrable-types" target="_blank"><code>no-inferrable-types</code></a>
+
 Disallow type annotations for variables, parameters, and class properties initialized with a literal expression.
 
 TypeScript is able to infer the types of parameters, properties, and variables from their default or initial values.
@@ -17,8 +19,6 @@ Doing so adds unnecessary verbosity to code making it harder to read.
 In contrast to ESLint's rule, this rule allows to use a wide type for `const` declarations.
 Moreover, the rule does not recognize `undefined` values, primitive type constructors (String, Number, ...), and `RegExp` type.
 These global variables could be shadowed by local ones.
-
-Source: https://typescript-eslint.io/rules/no-inferrable-types
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-inner-declarations.md
+++ b/website/src/content/docs/linter/rules/no-inner-declarations.md
@@ -8,6 +8,8 @@ title: noInnerDeclarations (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-inner-declarations" target="_blank"><code>no-inner-declarations</code></a>
+
 Disallow `function` and `var` declarations that are accessible outside their block.
 
 A `var` is accessible in the whole body of the nearest root (function, module, script, static block).
@@ -20,8 +22,6 @@ In ES2015, inside an _ES module_, a `function` declaration is always block-scope
 Note that `const` and `let` declarations are block-scoped,
 and therefore they are not affected by this rule.
 Moreover, `function` declarations in nested blocks are allowed inside _ES modules_.
-
-Source: https://eslint.org/docs/rules/no-inner-declarations
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-interactive-element-to-noninteractive-role.md
+++ b/website/src/content/docs/linter/rules/no-interactive-element-to-noninteractive-role.md
@@ -8,6 +8,8 @@ title: noInteractiveElementToNoninteractiveRole (since v1.3.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-interactive-element-to-noninteractive-role.md" target="_blank"><code>no-interactive-element-to-noninteractive-role</code></a>
+
 Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements.
 
 Interactive HTML elements indicate controls in the user interface.
@@ -17,8 +19,6 @@ Non-interactive elements include `<main>`, `<area>`, `<h1>` (,`<h2>`, etc), `<im
 
 [WAI-ARIA roles](https://www.w3.org/TR/wai-aria-1.1/#usage_intro) should not be used to convert an interactive element to a non-interactive element.
 Non-interactive ARIA roles include `article`, `banner`, `complementary`, `img`, `listitem`, `main`, `region` and `tooltip`.
-
-Source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-interactive-element-to-noninteractive-role.md
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-invalid-constructor-super.md
+++ b/website/src/content/docs/linter/rules/no-invalid-constructor-super.md
@@ -8,6 +8,8 @@ title: noInvalidConstructorSuper (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/constructor-super" target="_blank"><code>constructor-super</code></a>
+
 Prevents the incorrect use of `super()` inside classes. It also checks whether a call `super()` is missing from classes that extends other constructors.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-invalid-new-builtin.md
+++ b/website/src/content/docs/linter/rules/no-invalid-new-builtin.md
@@ -8,6 +8,8 @@ title: noInvalidNewBuiltin (since v1.3.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-new-native-nonconstructor" target="_blank"><code>no-new-native-nonconstructor</code></a>
+
 Disallow `new` operators with global non-constructor functions.
 
 Some global functions cannot be called using the new operator and
@@ -15,8 +17,6 @@ will throw a `TypeError` if you attempt to do so. These functions are:
 
 - [`Symbol`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol)
 - [`BigInt`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt)
-
-Source: https://eslint.org/docs/latest/rules/no-new-native-nonconstructor/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-invalid-use-before-declaration.md
+++ b/website/src/content/docs/linter/rules/no-invalid-use-before-declaration.md
@@ -8,6 +8,8 @@ title: noInvalidUseBeforeDeclaration (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-use-before-define" target="_blank"><code>no-use-before-define</code></a>
+
 Disallow the use of variables and function parameters before their declaration
 
 JavaScript doesn't allow the use of block-scoped variables (`let`, `const`) and function parameters before their declaration.

--- a/website/src/content/docs/linter/rules/no-label-var.md
+++ b/website/src/content/docs/linter/rules/no-label-var.md
@@ -8,6 +8,8 @@ title: noLabelVar (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-label-var" target="_blank"><code>no-label-var</code></a>
+
 Disallow labels that share a name with a variable
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-misleading-character-class.md
+++ b/website/src/content/docs/linter/rules/no-misleading-character-class.md
@@ -8,6 +8,8 @@ title: noMisleadingCharacterClass (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-misleading-character-class" target="_blank"><code>no-misleading-character-class</code></a>
+
 Disallow characters made with multiple code points in character class syntax.
 
 Unicode includes the characters which are made with multiple code points. e.g. Á, 🇯🇵, 👨‍👩‍👦.
@@ -15,8 +17,6 @@ A RegExp character class `/[abc]/` cannot handle characters with multiple code p
 For example, the character `❇️` consists of two code points: `❇` (U+2747) and `VARIATION SELECTOR-16` (U+FE0F).
 If this character is in a RegExp character class, it will match to either `❇` or `VARIATION SELECTOR-16` rather than `❇️`.
 This rule reports the regular expressions which include multiple code point characters in character class syntax.
-
-Source: https://eslint.org/docs/latest/rules/no-misleading-character-class
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-misleading-instantiator.md
+++ b/website/src/content/docs/linter/rules/no-misleading-instantiator.md
@@ -8,6 +8,8 @@ title: noMisleadingInstantiator (since v1.3.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-misused-new" target="_blank"><code>no-misused-new</code></a>
+
 Enforce proper usage of `new` and `constructor`.
 
 In JavaScript, classes utilize the `constructor` method to initialize a new instance. On the other hand, TypeScript interfaces can describe a class type with a `new()` method signature, though this pattern is not commonly seen in real-world code. Developers, especially those new to JavaScript or TypeScript, might occasionally confuse the use of `constructor` with `new`.
@@ -18,8 +20,6 @@ This rule triggers warnings in the following scenarios:
 - When a type alias has a `constructor` method.
 
 You should not use this rule if you intentionally want a class with a `new` method, and you're confident nobody working in your code will mistake it with an `constructor`.
-
-Source: https://typescript-eslint.io/rules/no-misused-new/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-misrefactored-shorthand-assign.md
+++ b/website/src/content/docs/linter/rules/no-misrefactored-shorthand-assign.md
@@ -4,12 +4,12 @@ title: noMisrefactoredShorthandAssign (since v1.3.0)
 
 **Diagnostic Category: `lint/suspicious/noMisrefactoredShorthandAssign`**
 
+Source: <a href="https://rust-lang.github.io/rust-clippy/master/#/misrefactored_assign_op" target="_blank"><code>misrefactored_assign_op</code></a>
+
 Disallow shorthand assign when variable appears on both sides.
 
 This rule helps to avoid potential bugs related to incorrect assignments or unintended
 side effects that may occur during refactoring.
-
-Source: https://rust-lang.github.io/rust-clippy/master/#/misrefactored_assign_op
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-multiple-spaces-in-regular-expression-literals.md
+++ b/website/src/content/docs/linter/rules/no-multiple-spaces-in-regular-expression-literals.md
@@ -8,9 +8,9 @@ title: noMultipleSpacesInRegularExpressionLiterals (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
-Disallow unclear usage of consecutive space characters in regular expression literals
+Source: <a href="https://eslint.org/docs/latest/rules/no-regex-spaces" target="_blank"><code>no-regex-spaces</code></a>
 
-Source: https://eslint.org/docs/latest/rules/no-regex-spaces/
+Disallow unclear usage of consecutive space characters in regular expression literals
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-namespace.md
+++ b/website/src/content/docs/linter/rules/no-namespace.md
@@ -4,13 +4,13 @@ title: noNamespace (since v1.0.0)
 
 **Diagnostic Category: `lint/style/noNamespace`**
 
+Source: <a href="https://typescript-eslint.io/rules/no-namespace" target="_blank"><code>no-namespace</code></a>
+
 Disallow the use of TypeScript's `namespace`s.
 
 Namespaces are an old way to organize your code in TypeScript.
 They are not recommended anymore and should be replaced by ES6 modules
 (the `import`/`export` syntax).
-
-Source: https://typescript-eslint.io/rules/no-namespace
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-negation-else.md
+++ b/website/src/content/docs/linter/rules/no-negation-else.md
@@ -4,9 +4,9 @@ title: noNegationElse (since v1.0.0)
 
 **Diagnostic Category: `lint/style/noNegationElse`**
 
-Disallow negation in the condition of an `if` statement if it has an `else` clause.
+Source: <a href="https://eslint.org/docs/latest/rules/no-negated-condition" target="_blank"><code>no-negated-condition</code></a>
 
-Source: https://eslint.org/docs/latest/rules/no-negated-condition/
+Disallow negation in the condition of an `if` statement if it has an `else` clause.
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-new-symbol.md
+++ b/website/src/content/docs/linter/rules/no-new-symbol.md
@@ -4,11 +4,11 @@ title: noNewSymbol (since v1.0.0)
 
 **Diagnostic Category: `lint/correctness/noNewSymbol`**
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-new-symbol" target="_blank"><code>no-new-symbol</code></a>
+
 Disallow `new` operators with the `Symbol` object.
 
 `Symbol` cannot be instantiated. This results in throwing a `TypeError`.
-
-Source: https://eslint.org/docs/latest/rules/no-new-symbol
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-nodejs-modules.md
+++ b/website/src/content/docs/linter/rules/no-nodejs-modules.md
@@ -8,11 +8,11 @@ title: noNodejsModules (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-nodejs-modules.md" target="_blank"><code>no-nodejs-modules</code></a>
+
 Forbid the use of Node.js builtin modules.
 
 This can be useful for client-side web projects that don't have access to those modules.
-
-Source: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-nodejs-modules.md
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-non-null-assertion.md
+++ b/website/src/content/docs/linter/rules/no-non-null-assertion.md
@@ -8,6 +8,8 @@ title: noNonNullAssertion (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-non-null-assertion" target="_blank"><code>no-non-null-assertion</code></a>
+
 Disallow non-null assertions using the `!` postfix operator.
 
 TypeScript's `!` non-null assertion operator asserts to the type system that an expression is non-nullable, as

--- a/website/src/content/docs/linter/rules/no-noninteractive-element-to-interactive-role.md
+++ b/website/src/content/docs/linter/rules/no-noninteractive-element-to-interactive-role.md
@@ -8,6 +8,8 @@ title: noNoninteractiveElementToInteractiveRole (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-element-to-interactive-role.md" target="_blank"><code>no-noninteractive-element-to-interactive-role</code></a>
+
 Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.
 
 Non-interactive HTML elements indicate _content_ and _containers_ in the user interface.

--- a/website/src/content/docs/linter/rules/no-noninteractive-tabindex.md
+++ b/website/src/content/docs/linter/rules/no-noninteractive-tabindex.md
@@ -8,13 +8,13 @@ title: noNoninteractiveTabindex (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-tabindex.md" target="_blank"><code>no-noninteractive-tabindex</code></a>
+
 Enforce that `tabIndex` is not assigned to non-interactive HTML elements.
 
 When using the tab key to navigate a webpage, limit it to interactive elements.
 You don't need to add tabindex to items in an unordered list as assistive technology can navigate through the HTML.
 Keep the tab ring small, which is the order of elements when tabbing, for a more efficient and accessible browsing experience.
-
-ESLint (eslint-plugin-jsx-a11y) Equivalent: [no-noninteractive-tabindex](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-tabindex.md)
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-nonoctal-decimal-escape.md
+++ b/website/src/content/docs/linter/rules/no-nonoctal-decimal-escape.md
@@ -8,6 +8,8 @@ title: noNonoctalDecimalEscape (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-nonoctal-decimal-escape" target="_blank"><code>no-nonoctal-decimal-escape</code></a>
+
 Disallow `\8` and `\9` escape sequences in string literals.
 
 Since ECMAScript 2021, the escape sequences \8 and \9 have been defined as non-octal decimal escape sequences.
@@ -22,8 +24,6 @@ Although this syntax is deprecated, it is still supported for compatibility reas
 If the ECMAScript host is not a web browser, this syntax is optional.
 However, web browsers are still required to support it, but only in non-strict mode.
 Regardless of your targeted environment, it is recommended to avoid using these escape sequences in new code.
-
-Source: https://eslint.org/docs/latest/rules/no-nonoctal-decimal-escape
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-parameter-assign.md
+++ b/website/src/content/docs/linter/rules/no-parameter-assign.md
@@ -8,13 +8,13 @@ title: noParameterAssign (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-param-reassign" target="_blank"><code>no-param-reassign</code></a>
+
 Disallow reassigning `function` parameters.
 
 Assignment to a `function` parameters can be misleading and confusing,
 as modifying parameters will also mutate the `arguments` object.
 It is often unintended and indicative of a programmer error.
-
-Source: https://eslint.org/docs/latest/rules/no-param-reassign
 
 In contrast to the _ESLint_ rule, this rule cannot be configured to report
 assignments to a property of a parameter.

--- a/website/src/content/docs/linter/rules/no-parameter-properties.md
+++ b/website/src/content/docs/linter/rules/no-parameter-properties.md
@@ -4,14 +4,14 @@ title: noParameterProperties (since v1.0.0)
 
 **Diagnostic Category: `lint/style/noParameterProperties`**
 
+Inspired from: <a href="https://typescript-eslint.io/rules/parameter-properties" target="_blank"><code>parameter-properties</code></a>
+
 Disallow the use of parameter properties in class constructors.
 
 TypeScript includes a "parameter properties" shorthand for declaring a class constructor parameter and class property in one location.
 Parameter properties can confuse those new to TypeScript as they are less explicit than other ways of declaring and initializing class members.
 Moreover, private class properties, starting with `#`, cannot be turned into "parameter properties".
 This questions the future of this feature.
-
-Source: https://typescript-eslint.io/rules/parameter-properties
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-positive-tabindex.md
+++ b/website/src/content/docs/linter/rules/no-positive-tabindex.md
@@ -8,6 +8,8 @@ title: noPositiveTabindex (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/tabindex-no-positive.md" target="_blank"><code>tabindex-no-positive</code></a>
+
 Prevent the usage of positive integers on `tabIndex` property
 
 Avoid positive `tabIndex` property values to synchronize the flow of the page with keyboard tab order.

--- a/website/src/content/docs/linter/rules/no-precision-loss.md
+++ b/website/src/content/docs/linter/rules/no-precision-loss.md
@@ -8,6 +8,8 @@ title: noPrecisionLoss (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-loss-of-precision" target="_blank"><code>no-loss-of-precision</code></a>
+
 Disallow literal numbers that lose precision
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-prototype-builtins.md
+++ b/website/src/content/docs/linter/rules/no-prototype-builtins.md
@@ -8,6 +8,8 @@ title: noPrototypeBuiltins (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-prototype-builtins" target="_blank"><code>no-prototype-builtins</code></a>
+
 Disallow direct use of `Object.prototype` builtins.
 
 ECMAScript 5.1 added `Object.create` which allows the creation of an object with a custom prototype.

--- a/website/src/content/docs/linter/rules/no-redeclare.md
+++ b/website/src/content/docs/linter/rules/no-redeclare.md
@@ -8,9 +8,9 @@ title: noRedeclare (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
-Disallow variable, function, class, and type redeclarations in the same scope.
+Source: <a href="https://typescript-eslint.io/rules/no-redeclare" target="_blank"><code>no-redeclare</code></a>
 
-Source: https://typescript-eslint.io/rules/no-redeclare
+Disallow variable, function, class, and type redeclarations in the same scope.
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-redundant-alt.md
+++ b/website/src/content/docs/linter/rules/no-redundant-alt.md
@@ -8,6 +8,8 @@ title: noRedundantAlt (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-redundant-roles.md" target="_blank"><code>no-redundant-roles</code></a>
+
 Enforce `img` alt prop does not contain the word "image", "picture", or "photo".
 
 The rule will first check if `aria-hidden` is truthy to determine whether to enforce the rule. If the image is

--- a/website/src/content/docs/linter/rules/no-redundant-roles.md
+++ b/website/src/content/docs/linter/rules/no-redundant-roles.md
@@ -8,9 +8,9 @@ title: noRedundantRoles (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
-Enforce explicit `role` property is not the same as implicit/default role property on an element.
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-redundant-roles.md" target="_blank"><code>no-redundant-roles</code></a>
 
-ESLint (eslint-plugin-jsx-a11y) Equivalent: [no-redundant-roles](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-redundant-roles.md)
+Enforce explicit `role` property is not the same as implicit/default role property on an element.
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-restricted-globals.md
+++ b/website/src/content/docs/linter/rules/no-restricted-globals.md
@@ -4,6 +4,8 @@ title: noRestrictedGlobals (since v1.0.0)
 
 **Diagnostic Category: `lint/style/noRestrictedGlobals`**
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-restricted-globals" target="_blank"><code>no-restricted-globals</code></a>
+
 This rule allows you to specify global variable names that you don’t want to use in your application.
 
 >Disallowing usage of specific global variables can be useful if you want to allow a set of

--- a/website/src/content/docs/linter/rules/no-self-assign.md
+++ b/website/src/content/docs/linter/rules/no-self-assign.md
@@ -8,11 +8,11 @@ title: noSelfAssign (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-self-assign" target="_blank"><code>no-self-assign</code></a>
+
 Disallow assignments where both sides are exactly the same.
 
 Self assignments have no effect, so probably those are an error due to incomplete refactoring.
-
-Source: https://eslint.org/docs/latest/rules/no-self-assign
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-self-compare.md
+++ b/website/src/content/docs/linter/rules/no-self-compare.md
@@ -8,6 +8,8 @@ title: noSelfCompare (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-self-compare" target="_blank"><code>no-self-compare</code></a>
+
 Disallow comparisons where both sides are exactly the same.
 
 >Comparing a variable against itself is usually an error, either a typo or refactoring error. It is confusing to the reader and may potentially introduce a runtime error.
@@ -16,8 +18,6 @@ Disallow comparisons where both sides are exactly the same.
 >The only time you would compare a variable against itself is when you are testing for `NaN`.
 However, it is far more appropriate to use `typeof x === 'number' && Number.isNaN(x)` for that use case rather than leaving the reader of the code to determine the intent of self comparison.
 
-
-Source: [no-self-compare](https://eslint.org/docs/latest/rules/no-self-compare).
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-setter-return.md
+++ b/website/src/content/docs/linter/rules/no-setter-return.md
@@ -8,6 +8,8 @@ title: noSetterReturn (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-setter-return" target="_blank"><code>no-setter-return</code></a>
+
 Disallow returning a value from a setter
 
 While returning a value from a setter does not produce an error, the returned value is being ignored. Therefore, returning a value from a setter is either unnecessary or a possible error.

--- a/website/src/content/docs/linter/rules/no-shadow-restricted-names.md
+++ b/website/src/content/docs/linter/rules/no-shadow-restricted-names.md
@@ -8,6 +8,8 @@ title: noShadowRestrictedNames (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-shadow-restricted-names" target="_blank"><code>no-shadow-restricted-names</code></a>
+
 Disallow identifiers from shadowing restricted names.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-sparse-array.md
+++ b/website/src/content/docs/linter/rules/no-sparse-array.md
@@ -8,6 +8,8 @@ title: noSparseArray (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-sparse-array" target="_blank"><code>no-sparse-array</code></a>
+
 Disallow sparse arrays
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-static-only-class.md
+++ b/website/src/content/docs/linter/rules/no-static-only-class.md
@@ -8,6 +8,8 @@ title: noStaticOnlyClass (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-extraneous-class" target="_blank"><code>no-extraneous-class</code></a>
+
 This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace.
 
 Users who come from a [OOP](https://en.wikipedia.org/wiki/Object-oriented_programming) paradigm may wrap their utility functions in an extra class,
@@ -19,8 +21,6 @@ instead of putting them at the top level of an ECMAScript module. Doing so is ge
 
 - IDEs can't provide as good suggestions for static class or namespace imported properties when you start typing property names
 - It's more difficult to statically analyze code for unused variables, etc. when they're all on the class (see: Finding dead code (and dead types) in TypeScript).
-
-Source: https://typescript-eslint.io/rules/no-extraneous-class
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-string-case-mismatch.md
+++ b/website/src/content/docs/linter/rules/no-string-case-mismatch.md
@@ -8,6 +8,8 @@ title: noStringCaseMismatch (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://rust-lang.github.io/rust-clippy/master/#/match_str_case_mismatch" target="_blank"><code>match_str_case_mismatch</code></a>
+
 Disallow comparison of expressions modifying the string case with non-compliant value.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-switch-declarations.md
+++ b/website/src/content/docs/linter/rules/no-switch-declarations.md
@@ -8,14 +8,14 @@ title: noSwitchDeclarations (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-case-declarations" target="_blank"><code>no-case-declarations</code></a>
+
 Disallow lexical declarations in `switch` clauses.
 
 Lexical declarations in `switch` clauses are accessible in the entire `switch`.
 However, it only gets initialized when it is assigned, which will only happen if the `switch` clause where it is defined is reached.
 
 To ensure that the lexical declarations only apply to the current `switch` clause wrap your declarations in a block.
-
-Source: https://eslint.org/docs/latest/rules/no-case-declarations
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-then-property.md
+++ b/website/src/content/docs/linter/rules/no-then-property.md
@@ -8,12 +8,12 @@ title: noThenProperty (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-thenable.md" target="_blank"><code>no-thenable</code></a>
+
 Disallow `then` property.
 
 When combining objects with a `then` method (thenable objects) with await expressions or dynamic imports, caution is necessary.
 These syntaxes interpret the object's then method as intended for the resolution or rejection of a promise, which can lead to unexpected behavior or errors.
-
-Source: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-thenable.md
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-this-in-static.md
+++ b/website/src/content/docs/linter/rules/no-this-in-static.md
@@ -8,6 +8,8 @@ title: noThisInStatic (since v1.3.1)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/mysticatea/eslint-plugin/blob/master/docs/rules/no-this-in-static.md" target="_blank"><code>no-this-in-static</code></a>
+
 Disallow `this` and `super` in `static` contexts.
 
 In JavaScript, the `this` keyword in static contexts refers to the class (the constructor) instance,
@@ -20,8 +22,6 @@ This can lead to unexpected behavior if not properly understood.
 This rule enforces the use of the class name itself to access static methods,
 which can make the code clearer and less prone to errors. It helps to prevent
 misunderstandings and bugs that can arise from the unique behavior of `this` and `super` in static contexts.
-
-Source: https://github.com/mysticatea/eslint-plugin/blob/master/docs/rules/no-this-in-static.md
 
 ## Example
 

--- a/website/src/content/docs/linter/rules/no-undeclared-variables.md
+++ b/website/src/content/docs/linter/rules/no-undeclared-variables.md
@@ -4,6 +4,8 @@ title: noUndeclaredVariables (since v1.0.0)
 
 **Diagnostic Category: `lint/correctness/noUndeclaredVariables`**
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-undef" target="_blank"><code>no-undef</code></a>
+
 Prevents the usage of variables that haven't been declared inside the document.
 
 If you need to allow-list some global bindings, you can use the [`javascript.globals`](/reference/configuration/#javascriptglobals) configuration.

--- a/website/src/content/docs/linter/rules/no-unreachable-super.md
+++ b/website/src/content/docs/linter/rules/no-unreachable-super.md
@@ -8,6 +8,8 @@ title: noUnreachableSuper (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-this-before-super" target="_blank"><code>no-this-before-super</code></a>
+
 Ensures the `super()` constructor is called exactly once on every code  path in a class constructor before `this` is accessed if the class has a superclass
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-unreachable.md
+++ b/website/src/content/docs/linter/rules/no-unreachable.md
@@ -8,6 +8,8 @@ title: noUnreachable (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-unreachable" target="_blank"><code>no-unreachable</code></a>
+
 Disallow unreachable code
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-unsafe-declaration-merging.md
+++ b/website/src/content/docs/linter/rules/no-unsafe-declaration-merging.md
@@ -8,6 +8,8 @@ title: noUnsafeDeclarationMerging (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-unsafe-declaration-merging" target="_blank"><code>no-unsafe-declaration-merging</code></a>
+
 Disallow unsafe declaration merging between interfaces and classes.
 
 _TypeScript_'s [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) supports merging separate declarations with the same name.
@@ -15,8 +17,6 @@ _TypeScript_'s [declaration merging](https://www.typescriptlang.org/docs/handboo
 _Declaration merging_ between classes and interfaces is unsafe.
 The _TypeScript Compiler_ doesn't check whether properties defined in the interface are initialized in the class.
 This can cause lead to _TypeScript_ not detecting code that will cause runtime errors.
-
-Source: https://typescript-eslint.io/rules/no-unsafe-declaration-merging/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-unsafe-finally.md
+++ b/website/src/content/docs/linter/rules/no-unsafe-finally.md
@@ -8,6 +8,8 @@ title: noUnsafeFinally (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-unsafe-finally" target="_blank"><code>no-unsafe-finally</code></a>
+
 Disallow control flow statements in finally blocks.
 
 JavaScript suspends the control flow statements of `try` and `catch` blocks until

--- a/website/src/content/docs/linter/rules/no-unsafe-negation.md
+++ b/website/src/content/docs/linter/rules/no-unsafe-negation.md
@@ -8,6 +8,8 @@ title: noUnsafeNegation (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-unsafe-negation" target="_blank"><code>no-unsafe-negation</code></a>
+
 Disallow using unsafe negation.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-unsafe-optional-chaining.md
+++ b/website/src/content/docs/linter/rules/no-unsafe-optional-chaining.md
@@ -8,6 +8,8 @@ title: noUnsafeOptionalChaining (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-unsafe-optional-chaining" target="_blank"><code>no-unsafe-optional-chaining</code></a>
+
 Disallow the use of optional chaining in contexts where the undefined value is not allowed.
 
 The optional chaining (?.) expression can short-circuit with a return value of undefined.

--- a/website/src/content/docs/linter/rules/no-unused-labels.md
+++ b/website/src/content/docs/linter/rules/no-unused-labels.md
@@ -8,11 +8,11 @@ title: noUnusedLabels (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-unused-labels" target="_blank"><code>no-unused-labels</code></a>
+
 Disallow unused labels.
 
 Labels that are declared and never used are most likely an error due to incomplete refactoring.
-
-Source: https://eslint.org/docs/latest/rules/no-unused-labels
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-unused-private-class-members.md
+++ b/website/src/content/docs/linter/rules/no-unused-private-class-members.md
@@ -8,12 +8,12 @@ title: noUnusedPrivateClassMembers (since v1.3.3)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-unused-private-class-members" target="_blank"><code>no-unused-private-class-members</code></a>
+
 Disallow unused private class members
 
 Private class members that are declared and not used anywhere in the code are most likely an error due to incomplete refactoring.
 Such class members take up space in the code and can lead to confusion by readers.
-
-Source: https://eslint.org/docs/latest/rules/no-unused-private-class-members/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-unused-template-literal.md
+++ b/website/src/content/docs/linter/rules/no-unused-template-literal.md
@@ -8,6 +8,8 @@ title: noUnusedTemplateLiteral (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-useless-template-literals" target="_blank"><code>no-useless-template-literals</code></a>
+
 Disallow template literals if interpolation and special-character handling are not needed
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-unused-variables.md
+++ b/website/src/content/docs/linter/rules/no-unused-variables.md
@@ -4,6 +4,8 @@ title: noUnusedVariables (since v1.0.0)
 
 **Diagnostic Category: `lint/correctness/noUnusedVariables`**
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-unused-vars" target="_blank"><code>no-unused-vars</code></a>
+
 Disallow unused variables.
 
 There are two exceptions to this rule:

--- a/website/src/content/docs/linter/rules/no-useless-catch.md
+++ b/website/src/content/docs/linter/rules/no-useless-catch.md
@@ -8,14 +8,14 @@ title: noUselessCatch (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-useless-catch" target="_blank"><code>no-useless-catch</code></a>
+
 Disallow unnecessary `catch` clauses.
 
 A `catch` clause that only rethrows the original error is redundant,
 and has no effect on the runtime behavior of the program.
 These redundant clauses can be a source of confusion and code bloat,
 so it’s better to disallow these unnecessary `catch` clauses.
-
-Source: https://eslint.org/docs/latest/rules/no-useless-catch
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-useless-constructor.md
+++ b/website/src/content/docs/linter/rules/no-useless-constructor.md
@@ -8,6 +8,8 @@ title: noUselessConstructor (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-useless-constructor" target="_blank"><code>no-useless-constructor</code></a>
+
 Disallow unnecessary constructors.
 
 _ES2015_ provides a default class constructor if one is not specified.
@@ -18,8 +20,6 @@ The rule ignores:
 - decorated classes;
 - constructors with at least one [parameter property](https://www.typescriptlang.org/docs/handbook/classes.html#parameter-properties);
 - `private` and `protected` constructors.
-
-Source: https://typescript-eslint.io/rules/no-useless-constructor
 
 ## Caveat
 

--- a/website/src/content/docs/linter/rules/no-useless-else.md
+++ b/website/src/content/docs/linter/rules/no-useless-else.md
@@ -8,6 +8,8 @@ title: noUselessElse (since v1.3.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Inspired from: <a href="https://eslint.org/docs/latest/rules/no-else-return" target="_blank"><code>no-else-return</code></a>
+
 Disallow `else` block when the `if` block breaks early.
 
 If an `if` block breaks early using a breaking statement (`return`, `break`, `continue`, or `throw`),

--- a/website/src/content/docs/linter/rules/no-useless-empty-export.md
+++ b/website/src/content/docs/linter/rules/no-useless-empty-export.md
@@ -8,6 +8,8 @@ title: noUselessEmptyExport (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-useless-empty-export" target="_blank"><code>no-useless-empty-export</code></a>
+
 Disallow empty exports that don't change anything in a module file.
 
 An empty `export {}` is sometimes useful to turn a file that would otherwise be a script into a module.
@@ -20,8 +22,6 @@ whose contents are available in the global scope.
 
 
 However, an `export {}` statement does nothing if there are any other top-level import or export in the file.
-
-Source: https://typescript-eslint.io/rules/no-useless-empty-export/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-useless-fragments.md
+++ b/website/src/content/docs/linter/rules/no-useless-fragments.md
@@ -8,6 +8,8 @@ title: noUselessFragments (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md" target="_blank"><code>jsx-no-useless-fragment</code></a>
+
 Disallow unnecessary fragments
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-useless-label.md
+++ b/website/src/content/docs/linter/rules/no-useless-label.md
@@ -8,11 +8,11 @@ title: noUselessLabel (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-extra-label" target="_blank"><code>no-extra-label</code></a>
+
 Disallow unnecessary labels.
 
 If a loop contains no nested loops or switches, labeling the loop is unnecessary.
-
-Source: https://eslint.org/docs/latest/rules/no-extra-label
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-useless-lone-block-statements.md
+++ b/website/src/content/docs/linter/rules/no-useless-lone-block-statements.md
@@ -8,13 +8,13 @@ title: noUselessLoneBlockStatements (since v1.3.3)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-lone-blocks" target="_blank"><code>no-lone-blocks</code></a>
+
 Disallow unnecessary nested block statements.
 
 >In JavaScript, prior to ES6, standalone code blocks delimited by curly braces do not create a new scope and have no use.
 In ES6, code blocks may create a new scope if a block-level binding (let and const), a class declaration or a function declaration (in strict mode) are present. A block is not considered redundant in these cases.
 
-
-Source: https://eslint.org/docs/latest/rules/no-lone-blocks
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-useless-rename.md
+++ b/website/src/content/docs/linter/rules/no-useless-rename.md
@@ -8,6 +8,8 @@ title: noUselessRename (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-useless-rename" target="_blank"><code>no-useless-rename</code></a>
+
 Disallow renaming import, export, and destructured assignments to the same name.
 
 ES2015 allows for the renaming of references in import and export statements as well as destructuring assignments.
@@ -21,8 +23,6 @@ let { foo: bar } = baz;
 
 With this syntax, it is possible to rename a reference to the same name.
 This is a completely redundant operation, as this is the same as not renaming at all.
-
-Source: https://eslint.org/docs/latest/rules/no-useless-rename
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-useless-switch-case.md
+++ b/website/src/content/docs/linter/rules/no-useless-switch-case.md
@@ -8,14 +8,14 @@ title: noUselessSwitchCase (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-switch-case.md" target="_blank"><code>no-useless-switch-case</code></a>
+
 Disallow useless `case` in `switch` statements.
 
 A `switch` statement can optionally have a `default` clause.
 
 The `default` clause will be still executed only if there is no match in the `case` clauses.
 An empty `case` clause that precedes the `default` clause is thus useless.
-
-Source: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-switch-case.md
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-useless-ternary.md
+++ b/website/src/content/docs/linter/rules/no-useless-ternary.md
@@ -8,13 +8,12 @@ title: noUselessTernary (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-unneeded-ternary" target="_blank"><code>no-unneeded-ternary</code></a>
+
 Disallow ternary operators when simpler alternatives exist.
 
 It’s a common mistake in JavaScript to use a conditional expression to select between two
 boolean values instead of using the logical NOT (`!`) or double NOT (`!!`) to convert the test to a boolean.
-Here are some examples:
-
-Source: https://eslint.org/docs/latest/rules/no-unneeded-ternary/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-useless-this-alias.md
+++ b/website/src/content/docs/linter/rules/no-useless-this-alias.md
@@ -8,12 +8,12 @@ title: noUselessThisAlias (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Inspired from: <a href="https://typescript-eslint.io/rules/no-this-alias" target="_blank"><code>no-this-alias</code></a>
+
 Disallow useless `this` aliasing.
 
 Arrow functions inherits `this` from their enclosing scope;
 this makes `this` aliasing useless in this situation.
-
-Credits: https://typescript-eslint.io/rules/no-this-alias/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-useless-type-constraint.md
+++ b/website/src/content/docs/linter/rules/no-useless-type-constraint.md
@@ -8,14 +8,14 @@ title: noUselessTypeConstraint (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-unnecessary-type-constraint" target="_blank"><code>no-unnecessary-type-constraint</code></a>
+
 Disallow using `any` or `unknown` as type constraint.
 
 Generic type parameters (`<T>`) in TypeScript may be **constrained** with [`extends`](https://www.typescriptlang.org/docs/handbook/generics.html#generic-constraints).
 A supplied type must then be a subtype of the supplied constraint.
 All types are subtypes of `any` and `unknown`.
 It is thus useless to extend from `any` or `unknown`.
-
-Source: https://typescript-eslint.io/rules/no-unnecessary-type-constraint/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-var.md
+++ b/website/src/content/docs/linter/rules/no-var.md
@@ -8,13 +8,13 @@ title: noVar (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-var" target="_blank"><code>no-var</code></a>
+
 Disallow the use of `var`
 
 ECMAScript 6 allows programmers to create variables with block scope instead of function scope using the let and const keywords.
 
 Block scope is common in many other programming languages and helps programmers avoid mistakes.
-
-Source: https://eslint.org/docs/latest/rules/no-var
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-void-elements-with-children.md
+++ b/website/src/content/docs/linter/rules/no-void-elements-with-children.md
@@ -8,6 +8,8 @@ title: noVoidElementsWithChildren (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/void-dom-elements-no-children.md" target="_blank"><code>void-dom-elements-no-children</code></a>
+
 This rules prevents void elements (AKA self-closing elements) from having children.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-void.md
+++ b/website/src/content/docs/linter/rules/no-void.md
@@ -4,13 +4,13 @@ title: noVoid (since v1.0.0)
 
 **Diagnostic Category: `lint/complexity/noVoid`**
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-void" target="_blank"><code>no-void</code></a>
+
 Disallow the use of `void` operators, which is not a familiar operator.
 
 >The `void` operator is often used merely to obtain the undefined primitive value,
 usually using `void(0)` (which is equivalent to `void 0`). In these cases, the global variable `undefined` can be used.
 
-
-Source: https://eslint.org/docs/latest/rules/no-void
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/no-with.md
+++ b/website/src/content/docs/linter/rules/no-with.md
@@ -8,6 +8,8 @@ title: noWith (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-with" target="_blank"><code>no-with</code></a>
+
 Disallow `with` statements in non-strict contexts.
 
 The `with` statement is potentially problematic because it adds members of an object to the current

--- a/website/src/content/docs/linter/rules/use-alt-text.md
+++ b/website/src/content/docs/linter/rules/use-alt-text.md
@@ -8,6 +8,8 @@ title: useAltText (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/alt-text.md" target="_blank"><code>alt-text</code></a>
+
 Enforce that all elements that require alternative text have meaningful information to relay back to the end user.
 
 This is a critical component of accessibility for screen reader users in order for them to understand the content's purpose on the page.

--- a/website/src/content/docs/linter/rules/use-anchor-content.md
+++ b/website/src/content/docs/linter/rules/use-anchor-content.md
@@ -8,6 +8,8 @@ title: useAnchorContent (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/anchor-has-content.md" target="_blank"><code>anchor-has-content</code></a>
+
 Enforce that anchors have content and that the content is accessible to screen readers.
 
 Accessible means the content is not hidden using the `aria-hidden` attribute.

--- a/website/src/content/docs/linter/rules/use-aria-activedescendant-with-tabindex.md
+++ b/website/src/content/docs/linter/rules/use-aria-activedescendant-with-tabindex.md
@@ -8,6 +8,8 @@ title: useAriaActivedescendantWithTabindex (since v1.3.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-activedescendant-has-tabindex.md" target="_blank"><code>aria-activedescendant-has-tabindex</code></a>
+
 Enforce that `tabIndex` is assigned to non-interactive HTML elements with `aria-activedescendant`.
 
 `aria-activedescendant` is used to manage to focus within a [composite widget](https://www.w3.org/TR/wai-aria/#composite).
@@ -22,8 +24,6 @@ as the value of `aria-activedescendant` on the input element.
 
 Because an element with `aria-activedescendant` must be tabbable,
 it must either have an inherent tabIndex of zero or declare a tabIndex attribute.
-
-Source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-activedescendant-has-tabindex.md
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-aria-props-for-role.md
+++ b/website/src/content/docs/linter/rules/use-aria-props-for-role.md
@@ -8,6 +8,8 @@ title: useAriaPropsForRole (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/role-has-required-aria-props.md" target="_blank"><code>role-has-required-aria-props</code></a>
+
 Enforce that elements with ARIA roles must have all required ARIA attributes for that role.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-arrow-function.md
+++ b/website/src/content/docs/linter/rules/use-arrow-function.md
@@ -8,6 +8,8 @@ title: useArrowFunction (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Inspired from: <a href="https://eslint.org/docs/latest/rules/prefer-arrow-callback" target="_blank"><code>prefer-arrow-callback</code></a>
+
 Use arrow functions over function expressions.
 
 An arrow function expression is a compact alternative to a regular function expression,

--- a/website/src/content/docs/linter/rules/use-as-const-assertion.md
+++ b/website/src/content/docs/linter/rules/use-as-const-assertion.md
@@ -8,6 +8,8 @@ title: useAsConstAssertion (since v1.3.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/prefer-as-const" target="_blank"><code>prefer-as-const</code></a>
+
 Enforce the use of `as const` over literal type and type annotation.
 
 In TypeScript, there are three common ways to specify that a value is of a specific type such as `2` and not a general type such as `number`:
@@ -17,8 +19,6 @@ In TypeScript, there are three common ways to specify that a value is of a speci
 3. type annotation: explicitly telling the literal type to TypeScript when declare variables
 
 The rule suggests to use `as const` when you're using `as` with a literal type or type annotation, since `as const` is simpler and doesn't require retyping the value.
-
-Source: https://typescript-eslint.io/rules/prefer-as-const/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-await.md
+++ b/website/src/content/docs/linter/rules/use-await.md
@@ -8,6 +8,8 @@ title: useAwait (since v1.4.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/require-await" target="_blank"><code>require-await</code></a>
+
 Ensure `async` functions utilize `await`.
 
 This rule reports `async` functions that lack an `await` expression. As `async`
@@ -15,8 +17,6 @@ functions return a promise, the use of `await` is often necessary to capture the
 resolved value and handle the asynchronous operation appropriately. Without `await`,
 the function operates synchronously and might not leverage the advantages of async
 functions.
-
-Source: [require-await](https://eslint.org/docs/latest/rules/require-await)
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-block-statements.md
+++ b/website/src/content/docs/linter/rules/use-block-statements.md
@@ -4,6 +4,8 @@ title: useBlockStatements (since v1.0.0)
 
 **Diagnostic Category: `lint/style/useBlockStatements`**
 
+Source: <a href="https://eslint.org/docs/latest/rules/curly" target="_blank"><code>curly</code></a>
+
 Requires following curly brace conventions.
 
 JavaScript allows the omission of curly braces when a block contains only one statement. However, it is considered by many to be best practice to never omit curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity.

--- a/website/src/content/docs/linter/rules/use-button-type.md
+++ b/website/src/content/docs/linter/rules/use-button-type.md
@@ -8,6 +8,8 @@ title: useButtonType (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md" target="_blank"><code>button-has-type</code></a>
+
 Enforces the usage of the attribute `type` for the element `button`
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-collapsed-else-if.md
+++ b/website/src/content/docs/linter/rules/use-collapsed-else-if.md
@@ -4,11 +4,11 @@ title: useCollapsedElseIf (since v1.1.0)
 
 **Diagnostic Category: `lint/style/useCollapsedElseIf`**
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-lonely-if" target="_blank"><code>no-lonely-if</code></a>
+
 Enforce using `else if` instead of nested `if` in `else` clauses.
 
 If an `if` statement is the only statement in the `else` block, it is often clearer to use an `else if` form.
-
-Source: https://eslint.org/docs/latest/rules/no-lonely-if
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-consistent-array-type.md
+++ b/website/src/content/docs/linter/rules/use-consistent-array-type.md
@@ -8,13 +8,13 @@ title: useConsistentArrayType (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/array-type" target="_blank"><code>array-type</code></a>
+
 Require consistently using either `T[]` or `Array<T>`
 
 _TypeScript_ provides two equivalent ways to define an array type: `T[]` and `Array<T>`.
 The two styles are functionally equivalent.
 Using the same style consistently across your codebase makes it easier for developers to read and understand array types.
-
-Source: https://typescript-eslint.io/rules/array-type
 
 ## Example
 

--- a/website/src/content/docs/linter/rules/use-const.md
+++ b/website/src/content/docs/linter/rules/use-const.md
@@ -8,6 +8,8 @@ title: useConst (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/prefer-const" target="_blank"><code>prefer-const</code></a>
+
 Require `const` declarations for variables that are never reassigned after declared.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-default-parameter-last.md
+++ b/website/src/content/docs/linter/rules/use-default-parameter-last.md
@@ -8,6 +8,8 @@ title: useDefaultParameterLast (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/default-param-last" target="_blank"><code>default-param-last</code></a>
+
 Enforce default function parameters and optional function parameters to be last.
 
 Default and optional parameters that precede a required parameter cannot be omitted at call site.

--- a/website/src/content/docs/linter/rules/use-default-switch-clause-last.md
+++ b/website/src/content/docs/linter/rules/use-default-switch-clause-last.md
@@ -8,6 +8,8 @@ title: useDefaultSwitchClauseLast (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/default-case-last" target="_blank"><code>default-case-last</code></a>
+
 Enforce default clauses in switch statements to be last
 
 A switch statement can optionally have a default clause.
@@ -20,8 +22,6 @@ but there is also the ability to “fall through” from the default clause to t
 However, such flow is not common and it would be confusing to the readers.
 
 Even if there is no "fall through" logic, it’s still unexpected to see the default clause before or between the case clauses. By convention, it is expected to be the last clause.
-
-Source: https://eslint.org/docs/latest/rules/default-case-last
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-enum-initializers.md
+++ b/website/src/content/docs/linter/rules/use-enum-initializers.md
@@ -8,6 +8,8 @@ title: useEnumInitializers (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/prefer-enum-initializers" target="_blank"><code>prefer-enum-initializers</code></a>
+
 Require that each enum member value be explicitly initialized.
 
 _TypeScript_ enums are a practical way to organize semantically related constant values.
@@ -15,8 +17,6 @@ Members of enums that don't have explicit values are by default given sequential
 
 When the value of enum members are important,
 allowing implicit values for enum members can cause bugs if enum declarations are modified over time.
-
-Source: https://typescript-eslint.io/rules/prefer-enum-initializers
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
+++ b/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
@@ -8,6 +8,8 @@ title: useExhaustiveDependencies (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md" target="_blank"><code>exhaustive-deps</code></a>
+
 Enforce all dependencies are correctly specified in a React hook.
 
 This rule is a port of the rule [react-hooks/exhaustive-deps](https://legacy.reactjs.org/docs/hooks-rules.html#eslint-plugin), and it's meant to target projects that uses React.

--- a/website/src/content/docs/linter/rules/use-exponentiation-operator.md
+++ b/website/src/content/docs/linter/rules/use-exponentiation-operator.md
@@ -8,12 +8,12 @@ title: useExponentiationOperator (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/prefer-exponentiation-operator" target="_blank"><code>prefer-exponentiation-operator</code></a>
+
 Disallow the use of `Math.pow` in favor of the `**` operator.
 
 Introduced in ES2016, the infix exponentiation operator `**` is an alternative for the standard `Math.pow` function.
 Infix notation is considered to be more readable and thus more preferable than the function notation.
-
-Source: https://eslint.org/docs/latest/rules/prefer-exponentiation-operator
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-export-type.md
+++ b/website/src/content/docs/linter/rules/use-export-type.md
@@ -8,6 +8,8 @@ title: useExportType (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Inspired from: <a href="https://typescript-eslint.io/rules/consistent-type-exports" target="_blank"><code>consistent-type-exports</code></a>
+
 Promotes the use of `export type` for types.
 
 _TypeScript_ allows specifying a `type` marker on an `export` to indicate that the `export` doesn't exist at runtime.

--- a/website/src/content/docs/linter/rules/use-filenaming-convention.md
+++ b/website/src/content/docs/linter/rules/use-filenaming-convention.md
@@ -8,6 +8,8 @@ title: useFilenamingConvention (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Inspired from: <a href="https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/filename-case.md" target="_blank"><code>filename-case</code></a>
+
 Enforce naming conventions for JavaScript and TypeScript filenames.
 
 Enforcing [naming conventions](https://en.wikipedia.org/wiki/Naming_convention_(programming)) helps to keep the codebase consistent.

--- a/website/src/content/docs/linter/rules/use-flat-map.md
+++ b/website/src/content/docs/linter/rules/use-flat-map.md
@@ -8,6 +8,8 @@ title: useFlatMap (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat-map.md" target="_blank"><code>prefer-array-flat-map</code></a>
+
 Promotes the use of `.flatMap()` when `map().flat()` are used together.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-for-of.md
+++ b/website/src/content/docs/linter/rules/use-for-of.md
@@ -8,9 +8,9 @@ title: useForOf (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
-This rule recommends a `for-of` loop when in a `for` loop, the index used to extract an item from the iterated array.
+Source: <a href="https://typescript-eslint.io/rules/prefer-for-of" target="_blank"><code>prefer-for-of</code></a>
 
-Source: https://typescript-eslint.io/rules/prefer-for-of/
+This rule recommends a `for-of` loop when in a `for` loop, the index used to extract an item from the iterated array.
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-fragment-syntax.md
+++ b/website/src/content/docs/linter/rules/use-fragment-syntax.md
@@ -4,6 +4,8 @@ title: useFragmentSyntax (since v1.0.0)
 
 **Diagnostic Category: `lint/style/useFragmentSyntax`**
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md" target="_blank"><code>jsx-fragments</code></a>
+
 This rule enforces the use of `<>...</>` over `<Fragment>...</Fragment>`.
 
 The shorthand fragment syntax saves keystrokes and is only inapplicable when keys are required.

--- a/website/src/content/docs/linter/rules/use-getter-return.md
+++ b/website/src/content/docs/linter/rules/use-getter-return.md
@@ -8,9 +8,9 @@ title: useGetterReturn (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
-Enforce `get` methods to always return a value.
+Source: <a href="https://eslint.org/docs/latest/rules/getter-return" target="_blank"><code>getter-return</code></a>
 
-Source: https://eslint.org/docs/latest/rules/getter-return
+Enforce `get` methods to always return a value.
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-grouped-type-import.md
+++ b/website/src/content/docs/linter/rules/use-grouped-type-import.md
@@ -8,6 +8,8 @@ title: useGroupedTypeImport (since v1.0.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/no-import-type-side-effects" target="_blank"><code>no-import-type-side-effects</code></a>
+
 Enforce the use of `import type` when an `import` only has specifiers with `type` qualifier.
 
 The [`--verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) _TypeScript_'s compiler option causes _TypeScript_ to do simple and predictable transpilation on `import` declarations.
@@ -57,8 +59,6 @@ In teh remaining cases, it is often preferable to explicitly use a side-effect `
 import "mod"; // side-effect import
 import type { A, B } from "mod";
 ```
-
-Source: https://typescript-eslint.io/rules/no-import-type-side-effects/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-heading-content.md
+++ b/website/src/content/docs/linter/rules/use-heading-content.md
@@ -8,6 +8,8 @@ title: useHeadingContent (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/heading-has-content.md" target="_blank"><code>heading-has-content</code></a>
+
 Enforce that heading elements (h1, h2, etc.) have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the aria-hidden prop.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-hook-at-top-level.md
+++ b/website/src/content/docs/linter/rules/use-hook-at-top-level.md
@@ -4,6 +4,8 @@ title: useHookAtTopLevel (since v1.0.0)
 
 **Diagnostic Category: `lint/correctness/useHookAtTopLevel`**
 
+Source: <a href="https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md" target="_blank"><code>rules-of-hooks</code></a>
+
 Enforce that all React hooks are being called from the Top Level component functions.
 
 To understand why this required see https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level

--- a/website/src/content/docs/linter/rules/use-html-lang.md
+++ b/website/src/content/docs/linter/rules/use-html-lang.md
@@ -8,6 +8,8 @@ title: useHtmlLang (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/html-has-lang.md" target="_blank"><code>html-has-lang</code></a>
+
 Enforce that `html` element has `lang` attribute.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-iframe-title.md
+++ b/website/src/content/docs/linter/rules/use-iframe-title.md
@@ -8,6 +8,8 @@ title: useIframeTitle (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/iframe-has-title.md" target="_blank"><code>iframe-has-title</code></a>
+
 Enforces the usage of the attribute `title` for the element `iframe`.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-import-restrictions.md
+++ b/website/src/content/docs/linter/rules/use-import-restrictions.md
@@ -8,6 +8,8 @@ title: useImportRestrictions (since v1.0.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Inspired from: <a href="https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/jsdoc.md" target="_blank"><code>jsdoc</code></a>
+
 Disallows package private imports.
 
 This rules enforces the following restrictions:

--- a/website/src/content/docs/linter/rules/use-import-type.md
+++ b/website/src/content/docs/linter/rules/use-import-type.md
@@ -8,6 +8,8 @@ title: useImportType (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Inspired from: <a href="https://typescript-eslint.io/rules/consistent-type-imports" target="_blank"><code>consistent-type-imports</code></a>
+
 Promotes the use of `import type` for types.
 
 _TypeScript_ allows specifying a `type` qualifier on an `import` to indicate that the `import` doesn't exist at runtime.
@@ -16,8 +18,6 @@ This also ensures that some modules are not loaded at runtime.
 
 The rule ensures that all imports used only as a type use a type-only `import`.
 It also groups inline type imports into a grouped `import type`.
-
-Source: https://typescript-eslint.io/rules/consistent-type-imports
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-is-array.md
+++ b/website/src/content/docs/linter/rules/use-is-array.md
@@ -8,6 +8,8 @@ title: useIsArray (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-instanceof-array.md" target="_blank"><code>no-instanceof-array</code></a>
+
 Use `Array.isArray()` instead of `instanceof Array`.
 
 In _JavaScript_ some array-like objects such as _arguments_ are not instances of the `Array` class.    ///
@@ -16,8 +18,6 @@ For instance, two frames in a web browser have a distinct `Array` class.
 Passing arrays across these contexts, results in arrays that are not instances of the contextual global `Array` class.
 To avoid these issues, use `Array.isArray()` instead of `instanceof Array`.
 See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray) for more details.
-
-Source: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-instanceof-array.md
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-is-nan.md
+++ b/website/src/content/docs/linter/rules/use-is-nan.md
@@ -8,6 +8,8 @@ title: useIsNan (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/use-isnan" target="_blank"><code>use-isnan</code></a>
+
 Require calls to `isNaN()` when checking for `NaN`.
 
 In JavaScript, `NaN` is a special value of the `Number` type.
@@ -24,8 +26,6 @@ Note that `Number.isNaN()` and `isNaN()` [have not the same behavior](https://de
 When the argument to `isNaN()` is not a number, the value is first coerced to a number.
 `Number.isNaN()` does not perform this coercion.
 Therefore, it is a more reliable way to test whether a value is `NaN`.
-
-Source: [use-isnan](https://eslint.org/docs/latest/rules/use-isnan).
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-key-with-click-events.md
+++ b/website/src/content/docs/linter/rules/use-key-with-click-events.md
@@ -8,6 +8,8 @@ title: useKeyWithClickEvents (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/click-events-have-key-events.md" target="_blank"><code>click-events-have-key-events</code></a>
+
 Enforce onClick is accompanied by at least one of the following: `onKeyUp`, `onKeyDown`, `onKeyPress`.
 
 Coding for the keyboard is important for users with physical disabilities who cannot use a mouse, AT compatibility, and screenreader users.

--- a/website/src/content/docs/linter/rules/use-key-with-mouse-events.md
+++ b/website/src/content/docs/linter/rules/use-key-with-mouse-events.md
@@ -8,6 +8,8 @@ title: useKeyWithMouseEvents (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/mouse-events-have-key-events.md" target="_blank"><code>mouse-events-have-key-events</code></a>
+
 Enforce `onMouseOver` / `onMouseOut` are accompanied by `onFocus` / `onBlur`.
 
 Coding for the keyboard is important for users with physical disabilities who cannot use a mouse, AT compatibility, and screenreader users.

--- a/website/src/content/docs/linter/rules/use-literal-enum-members.md
+++ b/website/src/content/docs/linter/rules/use-literal-enum-members.md
@@ -8,6 +8,8 @@ title: useLiteralEnumMembers (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/prefer-literal-enum-member" target="_blank"><code>prefer-literal-enum-member</code></a>
+
 Require all enum members to be literal values.
 
 Usually, an enum member is initialized with a literal number or a literal string.
@@ -16,8 +18,6 @@ Using a computed enum member is often error-prone and confusing.
 This rule requires the initialization of enum members with constant expressions.
 It allows numeric and bitwise expressions for supporting [enum flags](https://stackoverflow.com/questions/39359740/what-are-enum-flags-in-typescript/39359953#39359953).
 It also allows referencing previous enum members.
-
-Source: https://typescript-eslint.io/rules/prefer-literal-enum-member/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-literal-keys.md
+++ b/website/src/content/docs/linter/rules/use-literal-keys.md
@@ -8,6 +8,8 @@ title: useLiteralKeys (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/dot-notation" target="_blank"><code>dot-notation</code></a>
+
 Enforce the usage of a literal access to properties over computed property access.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-media-caption.md
+++ b/website/src/content/docs/linter/rules/use-media-caption.md
@@ -8,9 +8,9 @@ title: useMediaCaption (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
-Enforces that `audio` and `video` elements must have a `track` for captions.
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/media-has-caption.md" target="_blank"><code>media-has-caption</code></a>
 
-**ESLint Equivalent:** [media-has-caption](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/media-has-caption.md)
+Enforces that `audio` and `video` elements must have a `track` for captions.
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-namespace-keyword.md
+++ b/website/src/content/docs/linter/rules/use-namespace-keyword.md
@@ -8,6 +8,8 @@ title: useNamespaceKeyword (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/prefer-namespace-keyword" target="_blank"><code>prefer-namespace-keyword</code></a>
+
 Require using the `namespace` keyword over the `module` keyword to declare TypeScript namespaces.
 
 TypeScript historically allowed a code organization called _namespace_.
@@ -17,8 +19,6 @@ For projects still using _namespaces_, it's preferred to use the `namespace` key
 The `module` keyword is deprecated to avoid any confusion with the _ECMAScript modules_ which are often called _modules_.
 
 Note that TypeScript `module` declarations to describe external APIs (`declare module "foo" {}`) are still allowed.
-
-Source: https://typescript-eslint.io/rules/prefer-namespace-keyword
 
 See also: https://www.typescriptlang.org/docs/handbook/namespaces-and-modules.html
 

--- a/website/src/content/docs/linter/rules/use-naming-convention.md
+++ b/website/src/content/docs/linter/rules/use-naming-convention.md
@@ -4,6 +4,8 @@ title: useNamingConvention (since v1.0.0)
 
 **Diagnostic Category: `lint/style/useNamingConvention`**
 
+Inspired from: <a href="https://typescript-eslint.io/rules/naming-convention" target="_blank"><code>naming-convention</code></a>
+
 Enforce naming conventions for everything across a codebase.
 
 Enforcing [naming conventions](https://en.wikipedia.org/wiki/Naming_convention_(programming)) helps to keep the codebase consistent,

--- a/website/src/content/docs/linter/rules/use-nodejs-import-protocol.md
+++ b/website/src/content/docs/linter/rules/use-nodejs-import-protocol.md
@@ -8,12 +8,12 @@ title: useNodejsImportProtocol (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md" target="_blank"><code>prefer-node-protocol</code></a>
+
 Enforces using the `node:` protocol for Node.js builtin modules.
 
 The rule marks traditional imports like `import fs from "fs";` as invalid,
 suggesting the format `import fs from "node:fs";` instead.
-
-Source: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-number-namespace.md
+++ b/website/src/content/docs/linter/rules/use-number-namespace.md
@@ -8,14 +8,14 @@ title: useNumberNamespace (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-number-properties.md" target="_blank"><code>prefer-number-properties</code></a>
+
 Use the `Number` properties instead of global ones.
 
 _ES2015_ moved some globals into the `Number` properties for consistency.
 
 The rule doesn't report the globals `isFinite` and `isNan` because they have a slightly different behabior to their corresponding `Number`'s properties `Number.isFinite` and `Number.isNan`.
 You can use the dedicated rules [noGlobalIsFinite](https://biomejs.dev/linter/rules/no-global-is-finite/) and  [noGlobalIsNan](https://biomejs.dev/linter/rules/no-global-is-nan/) to enforce the use of `Number.isFinite` and `Number.isNan`.
-
-Source: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-number-properties.md
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-numeric-literals.md
+++ b/website/src/content/docs/linter/rules/use-numeric-literals.md
@@ -8,6 +8,8 @@ title: useNumericLiterals (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/prefer-numeric-literals" target="_blank"><code>prefer-numeric-literals</code></a>
+
 Disallow `parseInt()` and `Number.parseInt()` in favor of binary, octal, and hexadecimal literals
 
 _JavaScript_ provides literal forms for binary, octal, and hexadecimal numbers.

--- a/website/src/content/docs/linter/rules/use-optional-chain.md
+++ b/website/src/content/docs/linter/rules/use-optional-chain.md
@@ -8,6 +8,8 @@ title: useOptionalChain (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/prefer-optional-chain" target="_blank"><code>prefer-optional-chain</code></a>
+
 Enforce using concise optional chain instead of chained logical expressions.
 
 TypeScript 3.7 added support for the optional chain operator.

--- a/website/src/content/docs/linter/rules/use-regex-literals.md
+++ b/website/src/content/docs/linter/rules/use-regex-literals.md
@@ -8,6 +8,8 @@ title: useRegexLiterals (since v1.3.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/prefer-regex-literals" target="_blank"><code>prefer-regex-literals</code></a>
+
 Enforce the use of the regular expression literals instead of the RegExp constructor if possible.
 
 There are two ways to create a regular expression:
@@ -20,8 +22,6 @@ because it takes string arguments.
 
 Using regular expression literals avoids some escaping required in a string literal,
 and are easier to analyze statically.
-
-Source: https://eslint.org/docs/latest/rules/prefer-regex-literals/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-self-closing-elements.md
+++ b/website/src/content/docs/linter/rules/use-self-closing-elements.md
@@ -8,6 +8,8 @@ title: useSelfClosingElements (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.style/rules/default/jsx-self-closing-comp" target="_blank"><code>jsx-self-closing-comp</code></a>
+
 Prevent extra closing tags for components without children
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-shorthand-array-type.md
+++ b/website/src/content/docs/linter/rules/use-shorthand-array-type.md
@@ -4,9 +4,9 @@ title: useShorthandArrayType (since v1.0.0)
 
 **Diagnostic Category: `lint/style/useShorthandArrayType`**
 
-When expressing array types, this rule promotes the usage of `T[]` shorthand instead of `Array<T>`.
+Inspired from: <a href="https://typescript-eslint.io/rules/array-type" target="_blank"><code>array-type</code></a>
 
-ESLint (typescript-eslint) equivalent: [array-type/array-simple](https://typescript-eslint.io/rules/array-type/#array-simple)
+When expressing array types, this rule promotes the usage of `T[]` shorthand instead of `Array<T>`.
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-shorthand-assign.md
+++ b/website/src/content/docs/linter/rules/use-shorthand-assign.md
@@ -4,11 +4,11 @@ title: useShorthandAssign (since v1.3.0)
 
 **Diagnostic Category: `lint/style/useShorthandAssign`**
 
+Source: <a href="https://eslint.org/docs/latest/rules/operator-assignment" target="_blank"><code>operator-assignment</code></a>
+
 Require assignment operator shorthand where possible.
 
 JavaScript provides shorthand operators combining a variable assignment and simple mathematical operation.
-
-Source: https://eslint.org/docs/latest/rules/operator-assignment/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-shorthand-function-type.md
+++ b/website/src/content/docs/linter/rules/use-shorthand-function-type.md
@@ -8,6 +8,8 @@ title: useShorthandFunctionType (since v1.5.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
+Source: <a href="https://typescript-eslint.io/rules/prefer-function-type" target="_blank"><code>prefer-function-type</code></a>
+
 Enforce using function types instead of object type with call signatures.
 
 TypeScript allows for two common ways to declare a type for a function:
@@ -18,8 +20,6 @@ TypeScript allows for two common ways to declare a type for a function:
 The function type form is generally preferred when possible for being more succinct.
 
 This rule suggests using a function type instead of an interface or object type literal with a single call signature.
-
-Source: https://typescript-eslint.io/rules/prefer-function-type/
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-single-var-declarator.md
+++ b/website/src/content/docs/linter/rules/use-single-var-declarator.md
@@ -8,13 +8,13 @@ title: useSingleVarDeclarator (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/one-var" target="_blank"><code>one-var</code></a>
+
 Disallow multiple variable declarations in the same variable statement
 
 In JavaScript, multiple variables can be declared within a single `var`, `const` or `let` declaration.
 It is often considered a best practice to declare every variable separately.
 That is what this rule enforces.
-
-Source: https://eslint.org/docs/latest/rules/one-var
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-template.md
+++ b/website/src/content/docs/linter/rules/use-template.md
@@ -8,6 +8,8 @@ title: useTemplate (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/prefer-template" target="_blank"><code>prefer-template</code></a>
+
 Prefer template literals over string concatenation.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-valid-anchor.md
+++ b/website/src/content/docs/linter/rules/use-valid-anchor.md
@@ -8,6 +8,8 @@ title: useValidAnchor (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/anchor-is-valid.md" target="_blank"><code>anchor-is-valid</code></a>
+
 Enforce that all anchors are valid, and they are navigable elements.
 
 The anchor element (`<a></a>`) - also called **hyperlink** - is an important element

--- a/website/src/content/docs/linter/rules/use-valid-aria-props.md
+++ b/website/src/content/docs/linter/rules/use-valid-aria-props.md
@@ -8,6 +8,8 @@ title: useValidAriaProps (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-props.md" target="_blank"><code>aria-props</code></a>
+
 Ensures that ARIA properties `aria-*` are all valid.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-valid-aria-role.md
+++ b/website/src/content/docs/linter/rules/use-valid-aria-role.md
@@ -8,9 +8,9 @@ title: useValidAriaRole (since v1.4.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
-Elements with ARIA roles must use a valid, non-abstract ARIA role.
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-role.md" target="_blank"><code>aria-role</code></a>
 
-Source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-role.md
+Elements with ARIA roles must use a valid, non-abstract ARIA role.
 
 ## Examples
 

--- a/website/src/content/docs/linter/rules/use-valid-aria-values.md
+++ b/website/src/content/docs/linter/rules/use-valid-aria-values.md
@@ -8,6 +8,8 @@ title: useValidAriaValues (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-proptypes.md" target="_blank"><code>aria-proptypes</code></a>
+
 Enforce that ARIA state and property values are valid.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-valid-for-direction.md
+++ b/website/src/content/docs/linter/rules/use-valid-for-direction.md
@@ -8,6 +8,8 @@ title: useValidForDirection (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/for-direction" target="_blank"><code>for-direction</code></a>
+
 Enforce "for" loop update clause moving the counter in the right direction.
 
 A for loop with a stop condition that can never be reached,

--- a/website/src/content/docs/linter/rules/use-valid-lang.md
+++ b/website/src/content/docs/linter/rules/use-valid-lang.md
@@ -8,6 +8,8 @@ title: useValidLang (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/lang.md" target="_blank"><code>lang</code></a>
+
 Ensure that the attribute passed to the `lang` attribute is a correct ISO language and/or country.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-valid-typeof.md
+++ b/website/src/content/docs/linter/rules/use-valid-typeof.md
@@ -8,6 +8,8 @@ title: useValidTypeof (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/valid-typeof" target="_blank"><code>valid-typeof</code></a>
+
 This rule verifies the result of `typeof $expr` unary expressions is being compared to valid values, either string literals containing valid type names or other `typeof` expressions
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-yield.md
+++ b/website/src/content/docs/linter/rules/use-yield.md
@@ -8,11 +8,11 @@ title: useYield (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/require-yield" target="_blank"><code>require-yield</code></a>
+
 Require generator functions to contain `yield`.
 
 This rule generates warnings for generator functions that do not have the `yield` keyword.
-
-Source: [require-yield](https://eslint.org/docs/latest/rules/require-yield).
 
 ## Examples
 

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -323,7 +323,7 @@ fn generate_rule(
 
     if let Some(source) = source {
         let (source_rule_url, source_rule_name) = source.as_url_and_rule_name();
-        match source_kind.unwrap() {
+        match source_kind.cloned().unwrap_or_default() {
             RuleSourceKind::Inspired => {
                 write!(content, "Inspired from: ")?;
             }

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -1,6 +1,7 @@
 use biome_analyze::{
     AnalysisFilter, AnalyzerOptions, ControlFlow, FixKind, GroupCategory, Queryable,
-    RegistryVisitor, Rule, RuleCategory, RuleFilter, RuleGroup, RuleMetadata, Source, SourceKind,
+    RegistryVisitor, Rule, RuleCategory, RuleFilter, RuleGroup, RuleMetadata, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::fmt::Termcolor;
 use biome_console::{
@@ -275,8 +276,8 @@ fn generate_rule(
     version: &'static str,
     is_recommended: bool,
     has_fix_kind: bool,
-    source: Option<&Source>,
-    source_kind: Option<&SourceKind>,
+    source: Option<&RuleSource>,
+    source_kind: Option<&RuleSourceKind>,
 ) -> Result<Vec<Event<'static>>> {
     let mut content = Vec::new();
 
@@ -323,10 +324,10 @@ fn generate_rule(
     if let Some(source) = source {
         let (source_rule_url, source_rule_name) = source.as_url_and_rule_name();
         match source_kind.unwrap() {
-            SourceKind::Inspired => {
+            RuleSourceKind::Inspired => {
                 write!(content, "Inspired from: ")?;
             }
-            SourceKind::SameLogic => {
+            RuleSourceKind::SameLogic => {
                 write!(content, "Source: ")?;
             }
         };


### PR DESCRIPTION
## Summary

Fix #1200

- Rename `Source` to `RuleSource`
- Rename `SourceKind` to `RuleSourceKind`
- Add missing rule sources
- Use `RuleSourceKind::SameLogic` as default value
  Most of the rules use the same logic, this looks like a good default.
- Add source metadata for all rules

## Test Plan

I checked that this appears correctly on the rule pages.
