### PR TITLE
fix(lint/useArrowFunction): enclose with parens when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,34 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Add an unsafe code fix for [noConsoleLog](https://biomejs.dev/linter/rules/no-console-log/). Contributed by @vasucp1207
 
+- [useArrowFunction](https://biomejs.dev/rules/) no longer reports function in `extends` clauses or in a `new` expression. COntributed by @Conaclos
+
+  This cases requires the presence of a prototype.
+
 #### Bug fixes
+
+- The fix of [useArrowFunction](https://biomejs.dev/rules/) now adds parentheses around the arrow function in more cases where it is needed ([#1524](https://github.com/biomejs/biome/issues/1524)).
+
+  A function expression doesn't need parentheses in most expressions where it can appear.
+  This is not the case with the arrow function.
+  We previously added parentheses when the function appears in a call or member expression.
+  We now add parentheses in binary-like expressions and other cases where they are needed, hopefully covering all cases.
+
+  Previously:
+
+  ```diff
+  - f = f ?? function() {};
+  + f = f ?? () => {};
+  ```
+
+  Now:
+
+  ```diff
+  - f = f ?? function() {};
+  + f = f ?? (() => {});
+  ```
+
+  Contributed by @Conaclos
 
 ### Parser
 

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_arrow_function.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_arrow_function.rs
@@ -15,7 +15,7 @@ use biome_js_syntax::{
 };
 use biome_rowan::{
     declare_node_union, AstNode, AstNodeList, AstSeparatedList, BatchMutationExt, Language,
-    SyntaxNode, SyntaxNodeOptionExt, TextRange, TriviaPieceKind, WalkEvent,
+    SyntaxNode, TextRange, TriviaPieceKind, WalkEvent,
 };
 
 declare_rule! {
@@ -104,6 +104,21 @@ impl Rule for UseArrowFunction {
             // Ignore functions that explicitly declare a `this` type.
             return None;
         }
+        let requires_prototype = function_expression
+            .syntax()
+            .ancestors()
+            .skip(1)
+            .find(|ancestor| ancestor.kind() != JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION)
+            .is_some_and(|ancestor| {
+                matches!(
+                    ancestor.kind(),
+                    JsSyntaxKind::JS_NEW_EXPRESSION | JsSyntaxKind::JS_EXTENDS_CLAUSE
+                )
+            });
+        if requires_prototype {
+            // Ignore cases where a prototype is required
+            return None;
+        }
         Some(())
     }
 
@@ -144,7 +159,7 @@ impl Rule for UseArrowFunction {
         }
         let arrow_function = arrow_function_builder.build();
         let arrow_function = if needs_parentheses(function_expression) {
-            AnyJsExpression::from(make::parenthesized(arrow_function))
+            AnyJsExpression::from(make::parenthesized(arrow_function.trim_trailing_trivia()?))
         } else {
             AnyJsExpression::from(arrow_function)
         };
@@ -165,20 +180,41 @@ impl Rule for UseArrowFunction {
 
 /// Returns `true` if `function_expr` needs parenthesis when turned into an arrow function.
 fn needs_parentheses(function_expression: &JsFunctionExpression) -> bool {
-    function_expression
-        .syntax()
-        .parent()
-        .kind()
-        .is_some_and(|parent_kind| {
-            matches!(
-                parent_kind,
-                JsSyntaxKind::JS_CALL_EXPRESSION
+    function_expression.syntax().parent().is_some_and(|parent| {
+        // Copied from the implementation of `NeedsParentheses` for `JsArrowFunctionExpression`
+        // in the `biome_js_formatter` crate.
+        // TODO: Should `NeedsParentheses` be moved in `biome_js_syntax`?
+        matches!(
+            parent.kind(),
+            JsSyntaxKind::TS_AS_EXPRESSION
+                    | JsSyntaxKind::TS_SATISFIES_EXPRESSION
+                    | JsSyntaxKind::JS_UNARY_EXPRESSION
+                    | JsSyntaxKind::JS_AWAIT_EXPRESSION
+                    | JsSyntaxKind::TS_TYPE_ASSERTION_EXPRESSION
+                    // Conditional expression
+                    // NOTE: parens are only needed when the arrow function appears in the test.
+                    // To simplify we always add parens.
+                    | JsSyntaxKind::JS_CONDITIONAL_EXPRESSION
+                    // Lower expression
+                    | JsSyntaxKind::JS_EXTENDS_CLAUSE
+                    | JsSyntaxKind::TS_NON_NULL_ASSERTION_EXPRESSION
+                    // Callee
+                    | JsSyntaxKind::JS_CALL_EXPRESSION
+                    | JsSyntaxKind::JS_NEW_EXPRESSION
+                    // Member-like
                     | JsSyntaxKind::JS_STATIC_MEMBER_ASSIGNMENT
                     | JsSyntaxKind::JS_STATIC_MEMBER_EXPRESSION
                     | JsSyntaxKind::JS_COMPUTED_MEMBER_ASSIGNMENT
                     | JsSyntaxKind::JS_COMPUTED_MEMBER_EXPRESSION
-            )
-        })
+                    // Template tag
+                    | JsSyntaxKind::JS_TEMPLATE_EXPRESSION
+                    // Binary-like
+                    | JsSyntaxKind::JS_LOGICAL_EXPRESSION
+                    | JsSyntaxKind::JS_BINARY_EXPRESSION
+                    | JsSyntaxKind::JS_INSTANCEOF_EXPRESSION
+                    | JsSyntaxKind::JS_IN_EXPRESSION
+        )
+    })
 }
 
 declare_node_union! {

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.ts
@@ -36,12 +36,18 @@ function f7() {
     };
 }
 
-const f8 = function(a) {}.bind(null, 0);
-
-const f9 = function(a) {}["bind"](null, 0);
-
-const called = function () {}();
-
 const f10 = function(x) {
     return 0, 1;
 }
+
+const as = function () {} as () => void;
+const satisfies = function () {} satisfies () => void;
+const unary = +function () {};
+const conditionalTest = function () {} ? true : false;
+class ExtendsClause extends function() {} {};
+const non_null_assertion = function () {}!;
+const call = function () {}();
+const staticMember = function(a) {}.bind(null, 0);
+const computedMember = function(a) {}["bind"](null, 0);
+const logical = false || function () {};
+const binary = false + function () {};

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.ts.snap
@@ -42,16 +42,21 @@ function f7() {
     };
 }
 
-const f8 = function(a) {}.bind(null, 0);
-
-const f9 = function(a) {}["bind"](null, 0);
-
-const called = function () {}();
-
 const f10 = function(x) {
     return 0, 1;
 }
 
+const as = function () {} as () => void;
+const satisfies = function () {} satisfies () => void;
+const unary = +function () {};
+const conditionalTest = function () {} ? true : false;
+class ExtendsClause extends function() {} {};
+const non_null_assertion = function () {}!;
+const call = function () {}();
+const staticMember = function(a) {}.bind(null, 0);
+const computedMember = function(a) {}["bind"](null, 0);
+const logical = false || function () {};
+const binary = false + function () {};
 ```
 
 # Diagnostics
@@ -268,16 +273,19 @@ invalid.ts:30:12 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━�
 ```
 
 ```
-invalid.ts:39:12 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:39:13 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This function expression can be turned into an arrow function.
   
     37 │ }
     38 │ 
-  > 39 │ const f8 = function(a) {}.bind(null, 0);
-       │            ^^^^^^^^^^^^^^
-    40 │ 
-    41 │ const f9 = function(a) {}["bind"](null, 0);
+  > 39 │ const f10 = function(x) {
+       │             ^^^^^^^^^^^^^
+  > 40 │     return 0, 1;
+  > 41 │ }
+       │ ^
+    42 │ 
+    43 │ const as = function () {} as () => void;
   
   i Function expressions that don't use this can be turned into arrow functions.
   
@@ -285,91 +293,265 @@ invalid.ts:39:12 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━�
   
     37 37 │   }
     38 38 │   
-    39    │ - const·f8·=·function(a)·{}.bind(null,·0);
-       39 │ + const·f8·=·((a)·=>·{}).bind(null,·0);
-    40 40 │   
-    41 41 │   const f9 = function(a) {}["bind"](null, 0);
+    39    │ - const·f10·=·function(x)·{
+    40    │ - ····return·0,·1;
+    41    │ - }
+       39 │ + const·f10·=·(x)·=>·(0,·1)
+    42 40 │   
+    43 41 │   const as = function () {} as () => void;
   
 
 ```
 
 ```
-invalid.ts:41:12 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:43:12 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This function expression can be turned into an arrow function.
   
-    39 │ const f8 = function(a) {}.bind(null, 0);
-    40 │ 
-  > 41 │ const f9 = function(a) {}["bind"](null, 0);
+    41 │ }
+    42 │ 
+  > 43 │ const as = function () {} as () => void;
        │            ^^^^^^^^^^^^^^
-    42 │ 
-    43 │ const called = function () {}();
+    44 │ const satisfies = function () {} satisfies () => void;
+    45 │ const unary = +function () {};
   
   i Function expressions that don't use this can be turned into arrow functions.
   
   i Safe fix: Use an arrow function instead.
   
-    39 39 │   const f8 = function(a) {}.bind(null, 0);
-    40 40 │   
-    41    │ - const·f9·=·function(a)·{}["bind"](null,·0);
-       41 │ + const·f9·=·((a)·=>·{})["bind"](null,·0);
+    41 41 │   }
     42 42 │   
-    43 43 │   const called = function () {}();
+    43    │ - const·as·=·function·()·{}·as·()·=>·void;
+       43 │ + const·as·=·(()·=>·{})·as·()·=>·void;
+    44 44 │   const satisfies = function () {} satisfies () => void;
+    45 45 │   const unary = +function () {};
   
 
 ```
 
 ```
-invalid.ts:43:16 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:44:19 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This function expression can be turned into an arrow function.
   
-    41 │ const f9 = function(a) {}["bind"](null, 0);
-    42 │ 
-  > 43 │ const called = function () {}();
+    43 │ const as = function () {} as () => void;
+  > 44 │ const satisfies = function () {} satisfies () => void;
+       │                   ^^^^^^^^^^^^^^
+    45 │ const unary = +function () {};
+    46 │ const conditionalTest = function () {} ? true : false;
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    42 42 │   
+    43 43 │   const as = function () {} as () => void;
+    44    │ - const·satisfies·=·function·()·{}·satisfies·()·=>·void;
+       44 │ + const·satisfies·=·(()·=>·{})·satisfies·()·=>·void;
+    45 45 │   const unary = +function () {};
+    46 46 │   const conditionalTest = function () {} ? true : false;
+  
+
+```
+
+```
+invalid.ts:45:16 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+    43 │ const as = function () {} as () => void;
+    44 │ const satisfies = function () {} satisfies () => void;
+  > 45 │ const unary = +function () {};
        │                ^^^^^^^^^^^^^^
-    44 │ 
-    45 │ const f10 = function(x) {
+    46 │ const conditionalTest = function () {} ? true : false;
+    47 │ class ExtendsClause extends function() {} {};
   
   i Function expressions that don't use this can be turned into arrow functions.
   
   i Safe fix: Use an arrow function instead.
   
-    41 41 │   const f9 = function(a) {}["bind"](null, 0);
-    42 42 │   
-    43    │ - const·called·=·function·()·{}();
-       43 │ + const·called·=·(()·=>·{})();
-    44 44 │   
-    45 45 │   const f10 = function(x) {
+    43 43 │   const as = function () {} as () => void;
+    44 44 │   const satisfies = function () {} satisfies () => void;
+    45    │ - const·unary·=·+function·()·{};
+       45 │ + const·unary·=·+(()·=>·{});
+    46 46 │   const conditionalTest = function () {} ? true : false;
+    47 47 │   class ExtendsClause extends function() {} {};
   
 
 ```
 
 ```
-invalid.ts:45:13 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:46:25 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This function expression can be turned into an arrow function.
   
-    43 │ const called = function () {}();
-    44 │ 
-  > 45 │ const f10 = function(x) {
-       │             ^^^^^^^^^^^^^
-  > 46 │     return 0, 1;
-  > 47 │ }
-       │ ^
-    48 │ 
+    44 │ const satisfies = function () {} satisfies () => void;
+    45 │ const unary = +function () {};
+  > 46 │ const conditionalTest = function () {} ? true : false;
+       │                         ^^^^^^^^^^^^^^
+    47 │ class ExtendsClause extends function() {} {};
+    48 │ const non_null_assertion = function () {}!;
   
   i Function expressions that don't use this can be turned into arrow functions.
   
   i Safe fix: Use an arrow function instead.
   
-    43 43 │   const called = function () {}();
-    44 44 │   
-    45    │ - const·f10·=·function(x)·{
-    46    │ - ····return·0,·1;
-    47    │ - }
-       45 │ + const·f10·=·(x)·=>·(0,·1)
-    48 46 │   
+    44 44 │   const satisfies = function () {} satisfies () => void;
+    45 45 │   const unary = +function () {};
+    46    │ - const·conditionalTest·=·function·()·{}·?·true·:·false;
+       46 │ + const·conditionalTest·=·(()·=>·{})·?·true·:·false;
+    47 47 │   class ExtendsClause extends function() {} {};
+    48 48 │   const non_null_assertion = function () {}!;
+  
+
+```
+
+```
+invalid.ts:48:28 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+    46 │ const conditionalTest = function () {} ? true : false;
+    47 │ class ExtendsClause extends function() {} {};
+  > 48 │ const non_null_assertion = function () {}!;
+       │                            ^^^^^^^^^^^^^^
+    49 │ const call = function () {}();
+    50 │ const staticMember = function(a) {}.bind(null, 0);
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    46 46 │   const conditionalTest = function () {} ? true : false;
+    47 47 │   class ExtendsClause extends function() {} {};
+    48    │ - const·non_null_assertion·=·function·()·{}!;
+       48 │ + const·non_null_assertion·=·(()·=>·{})!;
+    49 49 │   const call = function () {}();
+    50 50 │   const staticMember = function(a) {}.bind(null, 0);
+  
+
+```
+
+```
+invalid.ts:49:14 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+    47 │ class ExtendsClause extends function() {} {};
+    48 │ const non_null_assertion = function () {}!;
+  > 49 │ const call = function () {}();
+       │              ^^^^^^^^^^^^^^
+    50 │ const staticMember = function(a) {}.bind(null, 0);
+    51 │ const computedMember = function(a) {}["bind"](null, 0);
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    47 47 │   class ExtendsClause extends function() {} {};
+    48 48 │   const non_null_assertion = function () {}!;
+    49    │ - const·call·=·function·()·{}();
+       49 │ + const·call·=·(()·=>·{})();
+    50 50 │   const staticMember = function(a) {}.bind(null, 0);
+    51 51 │   const computedMember = function(a) {}["bind"](null, 0);
+  
+
+```
+
+```
+invalid.ts:50:22 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+    48 │ const non_null_assertion = function () {}!;
+    49 │ const call = function () {}();
+  > 50 │ const staticMember = function(a) {}.bind(null, 0);
+       │                      ^^^^^^^^^^^^^^
+    51 │ const computedMember = function(a) {}["bind"](null, 0);
+    52 │ const logical = false || function () {};
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    48 48 │   const non_null_assertion = function () {}!;
+    49 49 │   const call = function () {}();
+    50    │ - const·staticMember·=·function(a)·{}.bind(null,·0);
+       50 │ + const·staticMember·=·((a)·=>·{}).bind(null,·0);
+    51 51 │   const computedMember = function(a) {}["bind"](null, 0);
+    52 52 │   const logical = false || function () {};
+  
+
+```
+
+```
+invalid.ts:51:24 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+    49 │ const call = function () {}();
+    50 │ const staticMember = function(a) {}.bind(null, 0);
+  > 51 │ const computedMember = function(a) {}["bind"](null, 0);
+       │                        ^^^^^^^^^^^^^^
+    52 │ const logical = false || function () {};
+    53 │ const binary = false + function () {};
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    49 49 │   const call = function () {}();
+    50 50 │   const staticMember = function(a) {}.bind(null, 0);
+    51    │ - const·computedMember·=·function(a)·{}["bind"](null,·0);
+       51 │ + const·computedMember·=·((a)·=>·{})["bind"](null,·0);
+    52 52 │   const logical = false || function () {};
+    53 53 │   const binary = false + function () {};
+  
+
+```
+
+```
+invalid.ts:52:26 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+    50 │ const staticMember = function(a) {}.bind(null, 0);
+    51 │ const computedMember = function(a) {}["bind"](null, 0);
+  > 52 │ const logical = false || function () {};
+       │                          ^^^^^^^^^^^^^^
+    53 │ const binary = false + function () {};
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    50 50 │   const staticMember = function(a) {}.bind(null, 0);
+    51 51 │   const computedMember = function(a) {}["bind"](null, 0);
+    52    │ - const·logical·=·false·||·function·()·{};
+       52 │ + const·logical·=·false·||·(()·=>·{});
+    53 53 │   const binary = false + function () {};
+  
+
+```
+
+```
+invalid.ts:53:24 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+    51 │ const computedMember = function(a) {}["bind"](null, 0);
+    52 │ const logical = false || function () {};
+  > 53 │ const binary = false + function () {};
+       │                        ^^^^^^^^^^^^^^
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    51 51 │   const computedMember = function(a) {}["bind"](null, 0);
+    52 52 │   const logical = false || function () {};
+    53    │ - const·binary·=·false·+·function·()·{};
+       53 │ + const·binary·=·false·+·(()·=>·{});
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/valid.ts
@@ -84,3 +84,5 @@ export default function() {
 const usingNewTarget = function () {
     return new.target;
 }
+
+class ExtendsClause extends (function() {}) {}

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/valid.ts.snap
@@ -91,6 +91,8 @@ const usingNewTarget = function () {
     return new.target;
 }
 
+class ExtendsClause extends (function() {}) {}
+
 ```
 
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -45,7 +45,34 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Add an unsafe code fix for [noConsoleLog](https://biomejs.dev/linter/rules/no-console-log/). Contributed by @vasucp1207
 
+- [useArrowFunction](https://biomejs.dev/rules/) no longer reports function in `extends` clauses or in a `new` expression. COntributed by @Conaclos
+
+  This cases requires the presence of a prototype.
+
 #### Bug fixes
+
+- The fix of [useArrowFunction](https://biomejs.dev/rules/) now adds parentheses around the arrow function in more cases where it is needed ([#1524](https://github.com/biomejs/biome/issues/1524)).
+
+  A function expression doesn't need parentheses in most expressions where it can appear.
+  This is not the case with the arrow function.
+  We previously added parentheses when the function appears in a call or member expression.
+  We now add parentheses in binary-like expressions and other cases where they are needed, hopefully covering all cases.
+
+  Previously:
+
+  ```diff
+  - f = f ?? function() {};
+  + f = f ?? () => {};
+  ```
+
+  Now:
+
+  ```diff
+  - f = f ?? function() {};
+  + f = f ?? (() => {});
+  ```
+
+  Contributed by @Conaclos
 
 ### Parser
 


### PR DESCRIPTION
## Summary

Fix #1524

## Test Plan

New tests dded.