### PR TITLE
feat(project): support `biome.jsonc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,7 @@ dependencies = [
  "crossbeam",
  "directories",
  "indexmap",
+ "lazy_static",
  "parking_lot",
  "rayon",
  "rustc-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,6 @@ dependencies = [
  "crossbeam",
  "directories",
  "indexmap",
- "lazy_static",
  "parking_lot",
  "rayon",
  "rustc-hash",

--- a/crates/biome_cli/src/commands/init.rs
+++ b/crates/biome_cli/src/commands/init.rs
@@ -1,17 +1,23 @@
 use crate::{CliDiagnostic, CliSession};
 use biome_console::{markup, ConsoleExt, HorizontalLine};
+use biome_fs::ConfigName;
 use biome_service::{create_config, PartialConfiguration};
 
-pub(crate) fn init(mut session: CliSession) -> Result<(), CliDiagnostic> {
+pub(crate) fn init(mut session: CliSession, emit_jsonc: bool) -> Result<(), CliDiagnostic> {
     let fs = &mut session.app.fs;
-    create_config(fs, PartialConfiguration::init())?;
+    create_config(fs, PartialConfiguration::init(), emit_jsonc)?;
+    let file_created = if emit_jsonc {
+        format!("{}: ", ConfigName::biome_jsonc())
+    } else {
+        format!("{}: ", ConfigName::biome_json())
+    };
 
     session.app.console.log(markup! {
 "\n"<Inverse>"Welcome to Biome! Let's get you started..."</Inverse>"
 
 "<Info><Emphasis>"Files created "</Emphasis></Info>{HorizontalLine::new(106)}"
 
-  "<Dim>"- "</Dim><Emphasis>"biome.json: "</Emphasis>"Your project configuration. Documentation: "<Hyperlink href="https://biomejs.dev/reference/configuration">"https://biomejs.dev/reference/configuration"</Hyperlink>"
+  "<Dim>"- "</Dim><Emphasis>{file_created}</Emphasis>"Your project configuration. Documentation: "<Hyperlink href="https://biomejs.dev/reference/configuration">"https://biomejs.dev/reference/configuration"</Hyperlink>"
 
 "<Info><Emphasis>"Next Steps "</Emphasis></Info>{HorizontalLine::new(109)}"
 

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -240,7 +240,11 @@ pub enum BiomeCommand {
 
     /// Bootstraps a new biome project. Creates a configuration file with some defaults.
     #[bpaf(command)]
-    Init,
+    Init(
+        /// Tells Biome to emit a `biome.jsonc` file.
+        #[bpaf(long("jsonc"), switch)]
+        bool,
+    ),
     /// Acts as a server for the Language Server Protocol over stdin/stdout
     #[bpaf(command("lsp-proxy"))]
     LspProxy(
@@ -307,7 +311,7 @@ impl BiomeCommand {
             BiomeCommand::LspProxy(_)
             | BiomeCommand::Start(_)
             | BiomeCommand::Stop
-            | BiomeCommand::Init
+            | BiomeCommand::Init(_)
             | BiomeCommand::Explain { .. }
             | BiomeCommand::RunServer { .. }
             | BiomeCommand::PrintSocket => None,
@@ -323,7 +327,7 @@ impl BiomeCommand {
             | BiomeCommand::Ci { cli_options, .. }
             | BiomeCommand::Format { cli_options, .. }
             | BiomeCommand::Migrate { cli_options, .. } => cli_options.use_server,
-            BiomeCommand::Init
+            BiomeCommand::Init(_)
             | BiomeCommand::Start(_)
             | BiomeCommand::Stop
             | BiomeCommand::Explain { .. }
@@ -348,7 +352,7 @@ impl BiomeCommand {
             | BiomeCommand::Rage(..)
             | BiomeCommand::Start(_)
             | BiomeCommand::Stop
-            | BiomeCommand::Init
+            | BiomeCommand::Init(_)
             | BiomeCommand::Explain { .. }
             | BiomeCommand::LspProxy(_)
             | BiomeCommand::RunServer { .. }
@@ -368,7 +372,7 @@ impl BiomeCommand {
             | BiomeCommand::Rage(..)
             | BiomeCommand::Start(_)
             | BiomeCommand::Stop
-            | BiomeCommand::Init
+            | BiomeCommand::Init(_)
             | BiomeCommand::Explain { .. }
             | BiomeCommand::RunServer { .. }
             | BiomeCommand::PrintSocket => LoggingLevel::default(),
@@ -386,7 +390,7 @@ impl BiomeCommand {
             | BiomeCommand::LspProxy(_)
             | BiomeCommand::Start(_)
             | BiomeCommand::Stop
-            | BiomeCommand::Init
+            | BiomeCommand::Init(_)
             | BiomeCommand::Explain { .. }
             | BiomeCommand::RunServer { .. }
             | BiomeCommand::PrintSocket => LoggingKind::default(),

--- a/crates/biome_cli/src/execute/migrate.rs
+++ b/crates/biome_cli/src/execute/migrate.rs
@@ -9,7 +9,7 @@ use biome_deserialize::json::deserialize_from_json_str;
 use biome_deserialize::Merge;
 use biome_diagnostics::Diagnostic;
 use biome_diagnostics::{category, PrintDiagnostic};
-use biome_fs::{FileSystemExt, OpenOptions, RomePath};
+use biome_fs::{ConfigName, FileSystemExt, OpenOptions, RomePath};
 use biome_json_parser::{parse_json_with_cache, JsonParserOptions};
 use biome_json_syntax::JsonRoot;
 use biome_migrate::{migrate_configuration, ControlFlow};
@@ -173,7 +173,7 @@ pub(crate) fn run(migrate_payload: MigratePayload) -> Result<(), CliDiagnostic> 
     } else if configuration_content != new_configuration_content || has_deprecated_configuration {
         if write {
             let mut configuration_file = if has_deprecated_configuration {
-                let biome_file_path = configuration_directory_path.join(fs.config_name());
+                let biome_file_path = configuration_directory_path.join(ConfigName::biome_json());
                 fs.create_new(biome_file_path.as_path())?
             } else {
                 configuration_file

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -185,7 +185,7 @@ impl<'app> CliSession<'app> {
                 },
             ),
             BiomeCommand::Explain { doc } => commands::explain::explain(self, doc),
-            BiomeCommand::Init => commands::init::init(self),
+            BiomeCommand::Init(emit_jsonc) => commands::init::init(self, emit_jsonc),
             BiomeCommand::LspProxy(config_path) => commands::daemon::lsp_proxy(config_path),
             BiomeCommand::Migrate {
                 cli_options,

--- a/crates/biome_cli/tests/commands/ci.rs
+++ b/crates/biome_cli/tests/commands/ci.rs
@@ -1,4 +1,7 @@
-use crate::configs::{CONFIG_DISABLED_FORMATTER, CONFIG_FILE_SIZE_LIMIT, CONFIG_LINTER_DISABLED};
+use crate::configs::{
+    CONFIG_DISABLED_FORMATTER, CONFIG_DISABLED_FORMATTER_JSONC, CONFIG_FILE_SIZE_LIMIT,
+    CONFIG_LINTER_DISABLED,
+};
 use crate::snap_test::{assert_file_contents, SnapshotPayload};
 use crate::{
     assert_cli_snapshot, run_cli, CUSTOM_FORMAT_BEFORE, FORMATTED, LINT_ERROR, PARSE_ERROR,
@@ -182,6 +185,39 @@ fn ci_does_not_run_formatter() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "ci_does_not_run_formatter",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn ci_does_not_run_formatter_biome_jsonc() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        PathBuf::from("biome.jsonc"),
+        CONFIG_DISABLED_FORMATTER_JSONC.as_bytes(),
+    );
+
+    let input_file = Path::new("file.js");
+
+    fs.insert(input_file.into(), UNFORMATTED.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("ci"), input_file.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, input_file, UNFORMATTED);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "ci_does_not_run_formatter_biome_jsonc",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/commands/init.rs
+++ b/crates/biome_cli/tests/commands/init.rs
@@ -63,6 +63,42 @@ fn creates_config_file() {
 }
 
 #[test]
+fn creates_config_jsonc_file() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("init"), "--jsonc"].as_slice()),
+    );
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    let file_path = Path::new("biome.jsonc");
+    let parsed = parse_json(
+        CONFIG_INIT_DEFAULT,
+        JsonParserOptions::default()
+            .with_allow_comments()
+            .with_allow_trailing_commas(),
+    );
+    let formatted =
+        biome_json_formatter::format_node(JsonFormatOptions::default(), &parsed.syntax())
+            .expect("valid format document")
+            .print()
+            .expect("valid format document");
+
+    assert_file_contents(&fs, file_path, formatted.as_code());
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "creates_config_jsonc_file",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn creates_config_file_when_biome_installed_via_package_manager() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 
 use crate::configs::{
     CONFIG_FILE_SIZE_LIMIT, CONFIG_IGNORE_SYMLINK, CONFIG_LINTER_AND_FILES_IGNORE,
-    CONFIG_LINTER_DISABLED, CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC, CONFIG_LINTER_IGNORED_FILES,
-    CONFIG_LINTER_SUPPRESSED_GROUP, CONFIG_LINTER_SUPPRESSED_RULE,
+    CONFIG_LINTER_DISABLED, CONFIG_LINTER_DISABLED_JSONC, CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC,
+    CONFIG_LINTER_IGNORED_FILES, CONFIG_LINTER_SUPPRESSED_GROUP, CONFIG_LINTER_SUPPRESSED_RULE,
     CONFIG_LINTER_UPGRADE_DIAGNOSTIC, CONFIG_RECOMMENDED_GROUP,
 };
 use crate::snap_test::{assert_file_contents, markup_to_string, SnapshotPayload};
@@ -433,6 +433,49 @@ fn no_lint_if_linter_is_disabled_when_run_apply() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "no_lint_if_linter_is_disabled_when_run_apply",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn no_lint_if_linter_is_disabled_when_run_apply_biome_jsonc() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("fix.js");
+    fs.insert(file_path.into(), FIX_BEFORE.as_bytes());
+
+    let config_path = Path::new("biome.jsonc");
+    fs.insert(config_path.into(), CONFIG_LINTER_DISABLED_JSONC.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("lint"),
+                ("--apply"),
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    let mut buffer = String::new();
+    fs.open(file_path)
+        .unwrap()
+        .read_to_string(&mut buffer)
+        .unwrap();
+
+    assert_eq!(buffer, FIX_BEFORE);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "no_lint_if_linter_is_disabled_when_run_apply_biome_jsonc",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/commands/migrate.rs
+++ b/crates/biome_cli/tests/commands/migrate.rs
@@ -207,6 +207,37 @@ generated/*.spec.js
 }
 
 #[test]
+fn prettier_migrate_jsonc() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let configuration = r#"{ "linter": { "enabled": true } }"#;
+    let prettier = r#"{ "useTabs": false, "semi": true, "singleQuote": true }"#;
+
+    let configuration_path = Path::new("biome.jsonc");
+    fs.insert(configuration_path.into(), configuration.as_bytes());
+
+    let prettier_path = Path::new(".prettierrc");
+    fs.insert(prettier_path.into(), prettier.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("migrate"), "--prettier"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "prettier_migrate_jsonc",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn prettier_migrate_no_file() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
@@ -331,6 +362,37 @@ generated/*.spec.js
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "prettier_migrate_write_with_ignore_file",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn prettier_migrate_write_biome_jsonc() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let configuration = r#"{ "linter": { "enabled": true } }"#;
+    let prettier = r#"{ "useTabs": false, "semi": true, "singleQuote": true }"#;
+
+    let configuration_path = Path::new("biome.jsonc");
+    fs.insert(configuration_path.into(), configuration.as_bytes());
+
+    let prettier_path = Path::new(".prettierrc");
+    fs.insert(prettier_path.into(), prettier.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("migrate"), "--prettier", "--write"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "prettier_migrate_write_biome_jsonc",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/configs.rs
+++ b/crates/biome_cli/tests/configs.rs
@@ -8,6 +8,16 @@ pub const CONFIG_FORMAT: &str = r#"{
 }
 "#;
 
+pub const CONFIG_FORMAT_JSONC: &str = r#"{
+  // Formatting options
+  "formatter": {
+    "lineWidth": 10,
+    "indentStyle": "space",
+    "indentWidth": 8
+  }
+}
+"#;
+
 pub const CONFIG_INIT_DEFAULT: &str = r#"{
 	"organizeImports": {
 	 	 "enabled": true
@@ -36,6 +46,14 @@ pub const CONFIG_INIT_DEFAULT_WHEN_INSTALLED: &str = r#"{
 "#;
 
 pub const CONFIG_DISABLED_FORMATTER: &str = r#"{
+  "formatter": {
+    "enabled": false
+  }
+}
+"#;
+
+pub const CONFIG_DISABLED_FORMATTER_JSONC: &str = r#"{
+ // I am a comment
   "formatter": {
     "enabled": false
   }
@@ -89,6 +107,13 @@ pub const CONFIG_BAD_LINE_WIDTH: &str = r#"{
 }"#;
 
 pub const CONFIG_LINTER_DISABLED: &str = r#"{
+  "linter": {
+    "enabled": false
+  }
+}"#;
+
+pub const CONFIG_LINTER_DISABLED_JSONC: &str = r#"{
+  // I am a comment
   "linter": {
     "enabled": false
   }

--- a/crates/biome_cli/tests/snapshots/main_commands_check/no_lint_if_linter_is_disabled_when_run_apply_biome_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/no_lint_if_linter_is_disabled_when_run_apply_biome_jsonc.snap
@@ -1,0 +1,29 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.jsonc`
+
+```json
+{
+  // I am a comment
+  "linter": {
+    "enabled": false
+  }
+}
+```
+
+## `fix.js`
+
+```js
+1 >= -0;
+
+```
+
+# Emitted Messages
+
+```block
+Fixed 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_formatter_biome_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_formatter_biome_jsonc.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.jsonc`
+
+```json
+{
+ // I am a comment
+  "formatter": {
+    "enabled": false
+  }
+}
+```
+
+## `file.js`
+
+```js
+  statement(  )  
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_format/applies_configuration_from_biome_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/applies_configuration_from_biome_jsonc.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.jsonc`
+
+```json
+{
+  // Formatting options
+  "formatter": {
+    "lineWidth": 10,
+    "indentStyle": "space",
+    "indentWidth": 8
+  }
+}
+```
+
+## `file.js`
+
+```js
+function f() {
+        return {
+                a,
+                b,
+        };
+}
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_init/creates_config_jsonc_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_init/creates_config_jsonc_file.snap
@@ -1,0 +1,47 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.jsonc`
+
+```json
+{
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}
+```
+
+# Emitted Messages
+
+```block
+
+Welcome to Biome! Let's get you started...
+
+Files created ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  - biome.jsonc: Your project configuration. Documentation: https://biomejs.dev/reference/configuration
+
+Next Steps ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  1. Setup an editor extension
+     Get live errors as you type and format when you save. Learn more: https://biomejs.dev/guides/getting-started#editor-setup
+
+  2. Try a command
+     biome ci checks for lint errors and verifies formatting. Run biome --help for a full list of commands and options.
+
+  3. Read the documentation
+     Our website serves as a comprehensive source of guides and documentation: https://biomejs.dev
+
+  4. Get involved in the community
+     Ask questions, get support, or contribute by participating on GitHub (https://github.com/biomejs/biome),
+     or join our community Discord (https://discord.gg/BypW39g6Yc)
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_init/init_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_init/init_help.snap
@@ -7,10 +7,11 @@ expression: content
 ```block
 Bootstraps a new biome project. Creates a configuration file with some defaults.
 
-Usage: init 
+Usage: init [--jsonc]
 
 Available options:
-    -h, --help  Prints help information
+        --jsonc  Tells Biome to emit a `biome.jsonc` file.
+    -h, --help   Prints help information
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/no_lint_if_linter_is_disabled_when_run_apply_biome_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/no_lint_if_linter_is_disabled_when_run_apply_biome_jsonc.snap
@@ -1,0 +1,39 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.jsonc`
+
+```json
+{
+  // I am a comment
+  "linter": {
+    "enabled": false
+  }
+}
+```
+
+## `fix.js`
+
+```js
+(1 >= -0)
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × No files were processed in the specified paths.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Fixed 0 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/prettier_migrate_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/prettier_migrate_jsonc.snap
@@ -1,0 +1,57 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.jsonc`
+
+```json
+{ "linter": { "enabled": true } }
+```
+
+## `.prettierrc`
+
+```prettierrc
+{ "useTabs": false, "semi": true, "singleQuote": true }
+```
+
+# Emitted Messages
+
+```block
+biome.jsonc migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Configuration file can be updated.
+  
+    1    │ - {·"linter":·{·"enabled":·true·}·}
+       1 │ + {
+       2 │ + → "formatter":·{
+       3 │ + → → "enabled":·true,
+       4 │ + → → "formatWithErrors":·false,
+       5 │ + → → "indentStyle":·"space",
+       6 │ + → → "indentWidth":·2,
+       7 │ + → → "lineEnding":·"lf",
+       8 │ + → → "lineWidth":·80
+       9 │ + → },
+      10 │ + → "linter":·{·"enabled":·true·},
+      11 │ + → "javascript":·{
+      12 │ + → → "formatter":·{
+      13 │ + → → → "jsxQuoteStyle":·"double",
+      14 │ + → → → "quoteProperties":·"asNeeded",
+      15 │ + → → → "trailingComma":·"all",
+      16 │ + → → → "semicolons":·"always",
+      17 │ + → → → "arrowParentheses":·"always",
+      18 │ + → → → "bracketSpacing":·true,
+      19 │ + → → → "bracketSameLine":·false,
+      20 │ + → → → "quoteStyle":·"single"
+      21 │ + → → }
+      22 │ + → }
+      23 │ + }
+      24 │ + 
+  
+
+```
+
+```block
+Run the command with the option --write to apply the changes.
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/prettier_migrate_write_biome_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/prettier_migrate_write_biome_jsonc.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.jsonc`
+
+```json
+{
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80
+  },
+  "linter": { "enabled": true },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingComma": "all",
+      "semicolons": "always",
+      "arrowParentheses": "always",
+      "bracketSpacing": true,
+      "bracketSameLine": false,
+      "quoteStyle": "single"
+    }
+  }
+}
+```
+
+## `.prettierrc`
+
+```prettierrc
+{ "useTabs": false, "semi": true, "singleQuote": true }
+```
+
+# Emitted Messages
+
+```block
+The configuration biome.jsonc has been successfully migrated.
+```
+
+

--- a/crates/biome_fs/Cargo.toml
+++ b/crates/biome_fs/Cargo.toml
@@ -24,6 +24,7 @@ rustc-hash        = { workspace = true }
 schemars          = { workspace = true, optional = true }
 serde             = { workspace = true }
 tracing           = { workspace = true }
+lazy_static = { workspace = true}
 
 [features]
 serde = ["schemars", "biome_diagnostics/schema"]

--- a/crates/biome_fs/Cargo.toml
+++ b/crates/biome_fs/Cargo.toml
@@ -24,7 +24,6 @@ rustc-hash        = { workspace = true }
 schemars          = { workspace = true, optional = true }
 serde             = { workspace = true }
 tracing           = { workspace = true }
-lazy_static = { workspace = true}
 
 [features]
 serde = ["schemars", "biome_diagnostics/schema"]

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -14,7 +14,30 @@ mod memory;
 mod os;
 
 pub const ROME_JSON: &str = "rome.json";
-pub const BIOME_JSON: &str = "biome.json";
+
+pub struct ConfigName;
+
+impl ConfigName {
+    const BIOME_JSON: [&'static str; 2] = ["biome.json", "biome.jsonc"];
+
+    pub fn biome_json() -> &'static str {
+        Self::BIOME_JSON[0]
+    }
+
+    pub fn biome_jsonc() -> &'static str {
+        Self::BIOME_JSON[1]
+    }
+
+    pub fn file_names() -> [&'static str; 2] {
+        Self::BIOME_JSON
+    }
+}
+
+lazy_static::lazy_static! {
+    static ref CONFIG_NAME: ConfigName = ConfigName {};
+}
+
+type AutoSearchResultAlias = Result<Option<AutoSearchResult>, FileSystemDiagnostic>;
 
 pub trait FileSystem: Send + Sync + RefUnwindSafe {
     /// It opens a file with the given set of options
@@ -33,8 +56,8 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
     }
 
     /// Returns the name of the main configuration file
-    fn config_name(&self) -> &str {
-        BIOME_JSON
+    fn config_name(&self) -> &CONFIG_NAME {
+        &CONFIG_NAME
     }
 
     /// Return the path to the working directory
@@ -61,79 +84,85 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
     fn auto_search(
         &self,
         mut file_path: PathBuf,
-        file_name: &str,
+        file_names: &[&str],
         should_error_if_file_not_found: bool,
-    ) -> Result<Option<AutoSearchResult>, FileSystemDiagnostic> {
+    ) -> AutoSearchResultAlias {
         let mut from_parent = false;
-        let mut file_directory_path = file_path.join(file_name);
-        loop {
-            let options = OpenOptions::default().read(true);
-            let file = self.open_with_options(&file_directory_path, options);
-            return match file {
-                Ok(mut file) => {
-                    let mut buffer = String::new();
-                    file.read_to_string(&mut buffer)
-                        .map_err(|_| FileSystemDiagnostic {
-                            path: file_directory_path.display().to_string(),
-                            severity: Severity::Error,
-                            error_kind: ErrorKind::CantReadFile(
-                                file_directory_path.display().to_string(),
-                            ),
-                        })?;
+        let mut auto_search_result = None;
+        'alternatives_loop: for file_name in file_names {
+            let mut file_directory_path = file_path.join(file_name);
+            'search: loop {
+                let options = OpenOptions::default().read(true);
+                let file = self.open_with_options(&file_directory_path, options);
+                match file {
+                    Ok(mut file) => {
+                        let mut buffer = String::new();
+                        file.read_to_string(&mut buffer)
+                            .map_err(|_| FileSystemDiagnostic {
+                                path: file_directory_path.display().to_string(),
+                                severity: Severity::Error,
+                                error_kind: ErrorKind::CantReadFile(
+                                    file_directory_path.display().to_string(),
+                                ),
+                            })?;
 
-                    if from_parent {
-                        info!(
-                        "Biome auto discovered the file at following path that wasn't in the working directory: {}",
-                        file_path.display()
-                    );
+                        if from_parent {
+                            info!(
+                            "Biome auto discovered the file at following path that wasn't in the working directory: {}",
+                            file_path.display()
+                        );
+                        }
+
+                        auto_search_result = Some(AutoSearchResult {
+                            content: buffer,
+                            file_path: file_directory_path,
+                            directory_path: file_path,
+                        });
+                        break 'alternatives_loop;
                     }
-
-                    return Ok(Some(AutoSearchResult {
-                        content: buffer,
-                        file_path: file_directory_path,
-                        directory_path: file_path,
-                    }));
-                }
-                Err(err) => {
-                    // base paths from users are not eligible for auto discovery
-                    if !should_error_if_file_not_found {
-                        let parent_directory = if let Some(path) = file_path.parent() {
-                            if path.is_dir() {
-                                Some(PathBuf::from(path))
+                    Err(err) => {
+                        // base paths from users are not eligible for auto discovery
+                        if !should_error_if_file_not_found {
+                            let parent_directory = if let Some(path) = file_path.parent() {
+                                if path.is_dir() {
+                                    Some(PathBuf::from(path))
+                                } else {
+                                    None
+                                }
                             } else {
                                 None
+                            };
+                            if let Some(parent_directory) = parent_directory {
+                                file_path = parent_directory;
+                                file_directory_path = file_path.join(file_name);
+                                from_parent = true;
+                                continue 'search;
                             }
-                        } else {
-                            None
-                        };
-                        if let Some(parent_directory) = parent_directory {
-                            file_path = parent_directory;
-                            file_directory_path = file_path.join(file_name);
-                            from_parent = true;
-                            continue;
                         }
+                        // We skip the error when the configuration file is not found.
+                        // Not having a configuration file is only an error when the `base_path` is
+                        // set to `BasePath::FromUser`.
+                        if should_error_if_file_not_found || err.kind() != io::ErrorKind::NotFound {
+                            return Err(FileSystemDiagnostic {
+                                path: file_directory_path.display().to_string(),
+                                severity: Severity::Error,
+                                error_kind: ErrorKind::CantReadFile(
+                                    file_directory_path.display().to_string(),
+                                ),
+                            });
+                        }
+                        error!(
+                            "Could not read the file from {:?}, reason:\n {}",
+                            file_directory_path.display(),
+                            err
+                        );
+                        continue 'alternatives_loop;
                     }
-                    // We skip the error when the configuration file is not found.
-                    // Not having a configuration file is only an error when the `base_path` is
-                    // set to `BasePath::FromUser`.
-                    if should_error_if_file_not_found || err.kind() != io::ErrorKind::NotFound {
-                        return Err(FileSystemDiagnostic {
-                            path: file_directory_path.display().to_string(),
-                            severity: Severity::Error,
-                            error_kind: ErrorKind::CantReadFile(
-                                file_directory_path.display().to_string(),
-                            ),
-                        });
-                    }
-                    error!(
-                        "Could not read the file from {:?}, reason:\n {}",
-                        file_directory_path.display(),
-                        err
-                    );
-                    Ok(None)
                 }
-            };
+            }
         }
+
+        Ok(auto_search_result)
     }
 
     fn get_changed_files(&self, base: &str) -> io::Result<Vec<String>>;

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -20,21 +20,17 @@ pub struct ConfigName;
 impl ConfigName {
     const BIOME_JSON: [&'static str; 2] = ["biome.json", "biome.jsonc"];
 
-    pub fn biome_json() -> &'static str {
+    pub const fn biome_json() -> &'static str {
         Self::BIOME_JSON[0]
     }
 
-    pub fn biome_jsonc() -> &'static str {
+    pub const fn biome_jsonc() -> &'static str {
         Self::BIOME_JSON[1]
     }
 
-    pub fn file_names() -> [&'static str; 2] {
+    pub const fn file_names() -> [&'static str; 2] {
         Self::BIOME_JSON
     }
-}
-
-lazy_static::lazy_static! {
-    pub static ref CONFIG_NAME: ConfigName = ConfigName {};
 }
 
 type AutoSearchResultAlias = Result<Option<AutoSearchResult>, FileSystemDiagnostic>;
@@ -53,10 +49,6 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
     /// Returns the temporary configuration files that are supported
     fn deprecated_config_name(&self) -> &str {
         ROME_JSON
-    }
-
-    fn config_name(&self) -> &ConfigName {
-        &CONFIG_NAME
     }
 
     /// Return the path to the working directory

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -34,7 +34,7 @@ impl ConfigName {
 }
 
 lazy_static::lazy_static! {
-    static ref CONFIG_NAME: ConfigName = ConfigName {};
+    pub static ref CONFIG_NAME: ConfigName = ConfigName {};
 }
 
 type AutoSearchResultAlias = Result<Option<AutoSearchResult>, FileSystemDiagnostic>;
@@ -55,8 +55,7 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
         ROME_JSON
     }
 
-    /// Returns the name of the main configuration file
-    fn config_name(&self) -> &CONFIG_NAME {
+    fn config_name(&self) -> &ConfigName {
         &CONFIG_NAME
     }
 

--- a/crates/biome_fs/src/lib.rs
+++ b/crates/biome_fs/src/lib.rs
@@ -5,8 +5,8 @@ mod path;
 
 pub use dir::ensure_cache_dir;
 pub use fs::{
-    AutoSearchResult, ErrorEntry, File, FileSystem, FileSystemDiagnostic, FileSystemExt,
-    MemoryFileSystem, OpenOptions, OsFileSystem, TraversalContext, TraversalScope, BIOME_JSON,
+    AutoSearchResult, ConfigName, ErrorEntry, File, FileSystem, FileSystemDiagnostic,
+    FileSystemExt, MemoryFileSystem, OpenOptions, OsFileSystem, TraversalContext, TraversalScope,
     ROME_JSON,
 };
 pub use interner::PathInterner;

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -321,7 +321,7 @@ impl LanguageServer for LSPServer {
                         if let Ok(possible_rome_json) = possible_rome_json {
                             if possible_rome_json.display().to_string() == ROME_JSON
                                 || ConfigName::file_names()
-                                    .contains(&&**&possible_rome_json.display().to_string())
+                                    .contains(&&*possible_rome_json.display().to_string())
                             {
                                 self.session.load_workspace_settings().await;
                                 self.setup_capabilities().await;

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -8,7 +8,7 @@ use crate::utils::{into_lsp_error, panic_to_lsp_error};
 use crate::{handlers, requests};
 use biome_console::markup;
 use biome_diagnostics::panic::PanicError;
-use biome_fs::{FileSystem, OsFileSystem, BIOME_JSON, ROME_JSON};
+use biome_fs::{ConfigName, FileSystem, OsFileSystem, ROME_JSON};
 use biome_service::workspace::{RageEntry, RageParams, RageResult};
 use biome_service::{workspace, DynRef, Workspace};
 use futures::future::ready;
@@ -320,7 +320,8 @@ impl LanguageServer for LSPServer {
                         let possible_rome_json = file_path.strip_prefix(&base_path);
                         if let Ok(possible_rome_json) = possible_rome_json {
                             if possible_rome_json.display().to_string() == ROME_JSON
-                                || possible_rome_json.display().to_string() == BIOME_JSON
+                                || ConfigName::file_names()
+                                    .contains(&&**&possible_rome_json.display().to_string())
                             {
                                 self.session.load_workspace_settings().await;
                                 self.setup_capabilities().await;

--- a/crates/biome_service/src/configuration/mod.rs
+++ b/crates/biome_service/src/configuration/mod.rs
@@ -31,7 +31,7 @@ use biome_deserialize::json::deserialize_from_json_str;
 use biome_deserialize::{Deserialized, Merge, StringSet};
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use biome_diagnostics::{DiagnosticExt, Error, Severity};
-use biome_fs::{AutoSearchResult, FileSystem, OpenOptions};
+use biome_fs::{AutoSearchResult, ConfigName, FileSystem, OpenOptions};
 use biome_js_analyze::metadata;
 use biome_json_formatter::context::JsonFormatOptions;
 use biome_json_parser::{parse_json, JsonParserOptions};
@@ -261,7 +261,6 @@ fn load_config(
     file_system: &DynRef<'_, dyn FileSystem>,
     base_path: ConfigurationBasePath,
 ) -> LoadConfig {
-    let config_name = file_system.config_name();
     let deprecated_config_name = file_system.deprecated_config_name();
     let working_directory = file_system.working_directory();
     let configuration_directory = match base_path {
@@ -276,13 +275,16 @@ fn load_config(
     let should_error = base_path.is_from_user();
 
     let auto_search_result;
-    let result =
-        file_system.auto_search(configuration_directory.clone(), config_name, should_error);
+    let result = file_system.auto_search(
+        configuration_directory.clone(),
+        ConfigName::file_names().as_slice(),
+        should_error,
+    );
     if let Ok(result) = result {
         if result.is_none() {
             auto_search_result = file_system.auto_search(
                 configuration_directory.clone(),
-                deprecated_config_name,
+                [deprecated_config_name].as_slice(),
                 should_error,
             )?;
         } else {
@@ -291,7 +293,7 @@ fn load_config(
     } else {
         auto_search_result = file_system.auto_search(
             configuration_directory.clone(),
-            deprecated_config_name,
+            [deprecated_config_name].as_slice(),
             should_error,
         )?;
     }
@@ -328,7 +330,7 @@ pub fn create_config(
     fs: &mut DynRef<dyn FileSystem>,
     mut configuration: PartialConfiguration,
 ) -> Result<(), WorkspaceError> {
-    let path = PathBuf::from(fs.config_name());
+    let path = PathBuf::from(ConfigName::biome_json());
 
     let options = OpenOptions::default().write(true).create_new(true);
 

--- a/crates/biome_service/src/configuration/mod.rs
+++ b/crates/biome_service/src/configuration/mod.rs
@@ -641,7 +641,7 @@ impl PartialConfiguration {
             if let Some(client_kind) = &vcs.client_kind {
                 if !vcs.ignore_file_disabled() {
                     let result = file_system
-                        .auto_search(vcs_base_path, client_kind.ignore_file(), false)
+                        .auto_search(vcs_base_path, &[client_kind.ignore_file()], false)
                         .map_err(WorkspaceError::from)?;
 
                     if let Some(result) = result {

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -17,7 +17,7 @@ use biome_analyze::{AnalyzerConfiguration, AnalyzerOptions, ControlFlow, Never, 
 use biome_deserialize::json::deserialize_from_json_ast;
 use biome_diagnostics::{category, Diagnostic, DiagnosticExt, Severity};
 use biome_formatter::{FormatError, IndentStyle, IndentWidth, LineEnding, LineWidth, Printed};
-use biome_fs::{RomePath, BIOME_JSON, ROME_JSON};
+use biome_fs::{ConfigName, RomePath, ROME_JSON};
 use biome_json_analyze::analyze;
 use biome_json_formatter::context::JsonFormatOptions;
 use biome_json_formatter::format_node;
@@ -279,7 +279,10 @@ fn lint(params: LintParams) -> LintResults {
 
             // if we're parsing the `biome.json` file, we deserialize it, so we can emit diagnostics for
             // malformed configuration
-            if params.path.ends_with(ROME_JSON) || params.path.ends_with(BIOME_JSON) {
+            if params.path.ends_with(ROME_JSON)
+                || params.path.ends_with(ConfigName::biome_json())
+                || params.path.ends_with(ConfigName::biome_jsonc())
+            {
                 let deserialized = deserialize_from_json_ast::<PartialConfiguration>(&root, "");
                 diagnostics.extend(
                     deserialized

--- a/website/src/content/docs/guides/how-biome-works.mdx
+++ b/website/src/content/docs/guides/how-biome-works.mdx
@@ -14,6 +14,12 @@ file to change those defaults.
 The Biome configuration file is named `biome.json` and should be placed in the root directory of your project. The root
 directory is usually the directory containing your project's `package.json`.
 
+Since version `1.6.0`, Biome accepts also the file `biome.jsonc`.
+
+:::note
+If both `biome.json` and `biome.jsonc` are present in the same folder, the priority will be given to `biome.json`
+:::
+
 This configuration file enables the formatter and sets the preferred indent style and width. The linter is disabled:
 
 ```json title="biome.json"


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds support for `biome.jsonc` file.

Here's the list of detailed changes and assumptions:
- if `biome.json` and `biome.jsonc` are present in the same folder, we prioritise `biome.json`. I preferred not to emit an error to avoid breaking existing projects. Plus, the auto-search function isn't meant to understand conflicts;
- I updated the `auto_search` function, which now uses two loops. It was fun! I got to use labels to break/continue different loops :)
- the command `init` now accepts a `--jsonc` to emit a `biome.jsonc` file
- the command `migrate` now handles the `biome.jsonc` file

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I created new test cases for each command, to make sure that Biome can read and apply the configuration from a `biome.jsonc` file. 

Plus, I added new test cases for the `migrate` command and `init` command.

I updated the documentation too.

<!-- What demonstrates that your implementation is correct? -->
