### PR TITLE
fix(website): fix dead links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,13 +40,13 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Add an unsafe code fix for [noConsoleLog](https://biomejs.dev/linter/rules/no-console-log/). Contributed by @vasucp1207
 
-- [useArrowFunction](https://biomejs.dev/rules/) no longer reports function in `extends` clauses or in a `new` expression. COntributed by @Conaclos
+- [useArrowFunction](https://biomejs.dev/linter/rules/use-arrow-function) no longer reports function in `extends` clauses or in a `new` expression. COntributed by @Conaclos
 
   This cases requires the presence of a prototype.
 
 #### Bug fixes
 
-- The fix of [useArrowFunction](https://biomejs.dev/rules/) now adds parentheses around the arrow function in more cases where it is needed ([#1524](https://github.com/biomejs/biome/issues/1524)).
+- The fix of [useArrowFunction](https://biomejs.dev/linter/rules/use-arrow-function) now adds parentheses around the arrow function in more cases where it is needed ([#1524](https://github.com/biomejs/biome/issues/1524)).
 
   A function expression doesn't need parentheses in most expressions where it can appear.
   This is not the case with the arrow function.
@@ -100,7 +100,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Fix [#1483](https://github.com/biomejs/biome/issues/1483). [useConsistentArrayType](https://biomejs.dev/linter/rules/use-consistent-array-type) now correctly handles its option. Contributed by @Conaclos
 
-- Fix [#1502](https://github.com/biomejs/biome/issues/1502). [useArrowFunction](https://biomejs.dev/rules/) now correctly handle functions that return a (comma) sequence expression. Contributed by @Conaclos
+- Fix [#1502](https://github.com/biomejs/biome/issues/1502). [useArrowFunction](https://biomejs.dev/linter/rules/use-arrow-function) now correctly handle functions that return a (comma) sequence expression. Contributed by @Conaclos
 
   Previously the rule made an erroneous suggestion:
 
@@ -520,7 +520,7 @@ The following rules are promoted:
 
 - Fix [#696](https://github.com/biomejs/biome/issues/696). [useHookAtTopLevel](https://biomejs.dev/linter/rules/use-hook-at-top-level) now correctly detects early returns before the calls to the hook.
 
-- The code fix of [noUselessTypeCOnstraint](https://biomejs.dev/linter/rules/no-useless-type-c-onstraint) now adds a trailing comma when needed to disambiguate a type parameter list from a JSX element. COntributed by @Conaclos
+- The code fix of [noUselessTypeCOnstraint](https://biomejs.dev/linter/rules/no-useless-type-constraint) now adds a trailing comma when needed to disambiguate a type parameter list from a JSX element. COntributed by @Conaclos
 
 - Fix [#578](https://github.com/biomejs/biome/issues/578). [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) now correctly recognizes hooks namespaced under the `React` namespace.  Contributed by @XiNiHa
 
@@ -711,7 +711,7 @@ The following rules are now recommended:
 
 - [a11y/noAccessKey](https://biomejs.dev/linter/rules/no-access-key)
 - [a11y/useHeadingContent](https://biomejs.dev/linter/rules/use-heading-content)
-- [complexity/useSimpleNumberKeys](https://biomejs.dev/linter/use-simple-number-keys)
+- [complexity/useSimpleNumberKeys](https://biomejs.dev/linter/rules/use-simple-number-keys)
 
 The following rules are now deprecated:
 
@@ -730,7 +730,7 @@ The following rules are now deprecated:
 
 - Add [useValidAriaRole](https://biomejs.dev/linter/rules/use-valid-aria-role). Contributed by @vasucp1207
 
-- Add [useRegexLiterals](https://biomejs.dev/linter/use-regex-literals) that suggests turning call to the regex constructor into regex literals. COntributed by @Yuiki
+- Add [useRegexLiterals](https://biomejs.dev/linter/rules/use-regex-literals) that suggests turning call to the regex constructor into regex literals. COntributed by @Yuiki
 
 #### Enhancements
 
@@ -760,9 +760,9 @@ The following rules are now deprecated:
 
 - Fix [#69](https://github.com/biomejs/biome/issues/69) that made [correctness/noUnnecessaryContinue](https://biomejs.dev/linter/rules/no-unnecessary-continue) incorrectly reports a `continue` used to break a switch clause. Contributed by @TaKO8Ki
 
-- Fix [#664](https://github.com/biomejs/biome/issues/664) by improving the diagnostic of [style/useNamingConvention](https://biomejs.dev/linter/use-naming-convention) when double capital are detected in strict camel case mode. Contributed by @vasucp1207
+- Fix [#664](https://github.com/biomejs/biome/issues/664) by improving the diagnostic of [style/useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention) when double capital are detected in strict camel case mode. Contributed by @vasucp1207
 
-- Fix [#643](https://github.com/biomejs/biome/issues/643) that erroneously parsed the option of [complexity/useExhaustiveDependencies](https://biomejs.dev/linter/use-naming-convention). Contributed by @arendjr
+- Fix [#643](https://github.com/biomejs/biome/issues/643) that erroneously parsed the option of [complexity/useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-naming-convention). Contributed by @arendjr
 
 ### Parser
 
@@ -1061,7 +1061,7 @@ The following rules are now recommended:
 
 - Add [noEmptyCharacterClassInRegex](https://biomejs.dev/linter/rules/no-empty-character-class-in-regex) rule. The rule reports empty character classes and empty negated character classes in regular expression literals. Contributed by @Conaclos
 
-- Add [noMisleadingInstantiator](https://biomejs.dev/linter/rules/no-mileading-instantiator) rule. The rule reports the misleading use of the `new` and `constructor` methods. Contributed by @unvalley
+- Add [noMisleadingInstantiator](https://biomejs.dev/linter/rules/no-misleading-instantiator) rule. The rule reports the misleading use of the `new` and `constructor` methods. Contributed by @unvalley
 
 - Add [noUselessElse](https://biomejs.dev/linter/rules/no-useless-else) rule.
   The rule reports `else` clauses that can be omitted because their `if` branches break.
@@ -1111,13 +1111,13 @@ The following rules are now recommended:
   - [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
   - [useWhile](https://biomejs.dev/linter/rules/use-while)
 
-- [noAccumulatingSpread](https://biomejs.dev/linter/no-accumulating-spread) makes more check in order to reduce potential false positives. Contributed by @Vivalldi
+- [noAccumulatingSpread](https://biomejs.dev/linter/rules/no-accumulating-spread) makes more check in order to reduce potential false positives. Contributed by @Vivalldi
 
 - [noConstAssign](https://biomejs.dev/linter/rules/no-const-assign) now provides an unsafe code fix that replaces `const` with `let`. Contributed by @vasucp1207
 
-- [noExcessiveComplexity](https://biomejs.dev/linter/rules/no-excessive-complexity) default complexity threshold is now `15`. Contributed by @arendjr
+- [noExcessiveComplexity](https://biomejs.dev/linter/rules/no-excessive-cognitive-complexity) default complexity threshold is now `15`. Contributed by @arendjr
 
-- [noPositiveTabindexValue](https://biomejs.dev/linter/rules/no-positive-tabindex-value) now provides an unsafe code fix that set to `0` the tab index. Contributed by @vasucp1207
+- [noPositiveTabindexValue](https://biomejs.dev/linter/rules/no-positive-tabindex) now provides an unsafe code fix that set to `0` the tab index. Contributed by @vasucp1207
 
 - [noUnusedLabels](https://biomejs.dev/linter/rules/no-unused-labels) no longer reports unbreakable labeled statements. Contributed by @Conaclos
 
@@ -1249,7 +1249,7 @@ The following rules are promoted:
 
 #### Removed rules
 
-- Remove [noConfusingArrow](https://biomejs.dev/linter/rules/no-confusing-arrow/).
+- Remove `noConfusingArrow`
 
   Code formatters, such as prettier and Biome, always adds parentheses around the parameter or the body of an arrow function.
   This makes the rule useless.
@@ -1554,7 +1554,7 @@ The following rules are promoted:
 
 - Fix [rome#4616](https://github.com/rome/tools/issues/4616)
 
-  Previously [noUnreachableSuper](https://biomejs.dev/linter/rules/no-unreacheable-super/) reported valid codes with complex nesting of control flow structures.
+  Previously [noUnreachableSuper](https://biomejs.dev/linter/rules/no-unreachable-super/) reported valid codes with complex nesting of control flow structures.
 
   Contributed by @Conaclos
 
@@ -1747,11 +1747,11 @@ The following rules are promoted:
 
 - Remove `useCamelCase`
 
-  Use [useNamingConvention](https://biomejs.dev/linter/rules/use-camel-case/) instead.
+  Use [useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention/) instead.
 
 #### New rules
 
-- Add [noExcessiveComplexity](https://biomejs.dev/linter/rules/no-excessive-complexity/)
+- Add [noExcessiveComplexity](https://biomejs.dev/linter/rules/no-excessive-cognitive-complexity/)
 
 - Add [useImportRestrictions](https://biomejs.dev/linter/rules/use-import-restrictions/)
 
@@ -1833,7 +1833,7 @@ The following rules are now recommended:
 
 - [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare/): allow redeclare of index signatures are in different type members [#4478](https://github.com/rome/tools/issues/4478)
 
-- Improve [noConsoleLog](https://biomejs.dev/linter/rules/no-console-log/), [noGlobalObjectCalls](https://biomejs.dev/linter/rules/no-global-object-calls/), [useIsNan](https://biomejs.dev/linter/rules/useisnan/), and [useNumericLiterals](https://biomejs.dev/linter/rules/use-numeric-literals/) by handling `globalThis` and `window` namespaces.
+- Improve [noConsoleLog](https://biomejs.dev/linter/rules/no-console-log/), [noGlobalObjectCalls](https://biomejs.dev/linter/rules/no-global-object-calls/), [useIsNan](https://biomejs.dev/linter/rules/use-is-nan/), and [useNumericLiterals](https://biomejs.dev/linter/rules/use-numeric-literals/) by handling `globalThis` and `window` namespaces.
 
   For instance, the following code is now reported by `noConsoleLog`:
 
@@ -2038,7 +2038,7 @@ The following rules are now recommended:
 
 - Fix [noInvalidConstructorSuper](https://biomejs.dev/linter/rules/no-invalid-constructor-super/) that erroneously reported generic parents [#4624](https://github.com/rome/tools/issues/4624).
 
--  Fix [noDuplicateCase](https://biomejs.dev/linter/rules/noDuplicateCase/) that erroneously reported as equals the strings literals `"'"` and `'"'` [#4706](https://github.com/rome/tools/issues/4706).
+-  Fix [noDuplicateCase](https://biomejs.dev/linter/rules/no-duplicate-case/) that erroneously reported as equals the strings literals `"'"` and `'"'` [#4706](https://github.com/rome/tools/issues/4706).
 
 - Fix [NoUnreachableSuper](https://biomejs.dev/linter/rules/no-unreachable-super/)'s false positive diagnostics ([#4483](https://github.com/rome/tools/issues/4483)) caused to nested if statement.
 
@@ -2051,7 +2051,7 @@ The following rules are now recommended:
 
 - Fix [noUselessConstructor](https://biomejs.dev/linter/rules/no-useless-constructor/) which erroneously reported constructors with default parameters [rome#4781](https://github.com/rome/tools/issues/4781)
 
-- Fix [noUselessFragments](https://biomejs.dev/linter/rules/nouselessfragments/)'s panics when running `biome check --apply-unsafe` ([#4637](https://github.com/rome/tools/issues/4639))
+- Fix [noUselessFragments](https://biomejs.dev/linter/rules/no-useless-fragments/)'s panics when running `biome check --apply-unsafe` ([#4637](https://github.com/rome/tools/issues/4639))
 
   This rule's code action emits an invalid AST, so I fixed using JsxString instead of JsStringLiteral
 

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_blank_target.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_blank_target.rs
@@ -51,7 +51,7 @@ declare_rule! {
     pub(crate) NoBlankTarget {
         version: "1.0.0",
         name: "noBlankTarget",
-        source: RuleSource::EslintJsxA11y("jsx-no-target-blank"),
+        source: RuleSource::EslintReact("jsx-no-target-blank"),
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_excessive_cognitive_complexity.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_excessive_cognitive_complexity.rs
@@ -35,7 +35,7 @@ declare_rule! {
     /// those that exceed a configured complexity threshold (default: 15).
     ///
     /// The complexity score is calculated based on the Cognitive Complexity
-    /// algorithm: http://redirect.sonarsource.com/doc/cognitive-complexity.html
+    /// algorithm: https://redirect.sonarsource.com/doc/cognitive-complexity.html
     ///
     /// ## Examples
     ///

--- a/website/src/content/blog/biome-v1.mdx
+++ b/website/src/content/blog/biome-v1.mdx
@@ -212,7 +212,7 @@ We **deleted** two rules:
 
   This rule disallows duplicate keys in a JSON object.
 
-- [`noExcessiveComplexity`](/linter/rules/no-excessive-complexity/)
+- [`noExcessiveComplexity`](/linter/rules/no-excessive-cognitive-complexity/)
 
   This rule computes a complexity score and reports code with a score above a configurable threshold.
 

--- a/website/src/content/blog/biome-wins-prettier-challenge.md
+++ b/website/src/content/blog/biome-wins-prettier-challenge.md
@@ -263,7 +263,7 @@ Biome is a linter too, and it features [177 rules](https://biomejs.dev/linter/ru
   <strong>  </strong><strong>    │ </strong>     <span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>
   </code></pre>
 
-- [useRegexLiterals](https://biomejs.dev/linter/use-regex-literals)
+- [useRegexLiterals](https://biomejs.dev/linter/rules/use-regex-literals)
 
 ```jsx
 new RegExp("abc", "u");
@@ -329,7 +329,7 @@ new RegExp("abc", "u");
 
   </code></pre>
 
-- [complexity/useSimpleNumberKeys](https://biomejs.dev/linter/use-simple-number-keys)
+- [complexity/useSimpleNumberKeys](https://biomejs.dev/linter/rules/use-simple-number-keys)
 
   ```jsx
   ({ 0x1: 1 });

--- a/website/src/content/docs/guides/integrate-in-editor.mdx
+++ b/website/src/content/docs/guides/integrate-in-editor.mdx
@@ -48,7 +48,7 @@ These are plugin maintained by other communities, that you install in your edito
 - [`neovim`](https://neovim.io/): you'll have to install [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/), and follow the [instructions](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#biome);
 - [`helix`](https://helix-editor.com/): follow the instruction of [this manual](https://github.com/biomejs/biome/blob/main/editors/helix/manual.md)
 - [`coc-biome`](https://github.com/fannheyward/coc-biome): Biome extension for [`coc.nvim`](https://github.com/neoclide/coc.nvim)
-- [`sublime text`](http://www.sublimetext.com/): follow the [`LSP-biome`](https://github.com/sublimelsp/LSP-biome) installation instructions
+- [`sublime text`](https://www.sublimetext.com/): follow the [`LSP-biome`](https://github.com/sublimelsp/LSP-biome) installation instructions
 - [`Emacs`](https://www.gnu.org/software/emacs/): ensure you have [`lsp-mode`](https://github.com/emacs-lsp/lsp-mode) installed, follow the [`lsp-biome`](https://github.com/cxa/lsp-biome) installation instructions to enable Biome support in `lsp-mode`
 
 :::note

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -46,13 +46,13 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Add an unsafe code fix for [noConsoleLog](https://biomejs.dev/linter/rules/no-console-log/). Contributed by @vasucp1207
 
-- [useArrowFunction](https://biomejs.dev/rules/) no longer reports function in `extends` clauses or in a `new` expression. COntributed by @Conaclos
+- [useArrowFunction](https://biomejs.dev/linter/rules/use-arrow-function) no longer reports function in `extends` clauses or in a `new` expression. COntributed by @Conaclos
 
   This cases requires the presence of a prototype.
 
 #### Bug fixes
 
-- The fix of [useArrowFunction](https://biomejs.dev/rules/) now adds parentheses around the arrow function in more cases where it is needed ([#1524](https://github.com/biomejs/biome/issues/1524)).
+- The fix of [useArrowFunction](https://biomejs.dev/linter/rules/use-arrow-function) now adds parentheses around the arrow function in more cases where it is needed ([#1524](https://github.com/biomejs/biome/issues/1524)).
 
   A function expression doesn't need parentheses in most expressions where it can appear.
   This is not the case with the arrow function.
@@ -106,7 +106,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Fix [#1483](https://github.com/biomejs/biome/issues/1483). [useConsistentArrayType](https://biomejs.dev/linter/rules/use-consistent-array-type) now correctly handles its option. Contributed by @Conaclos
 
-- Fix [#1502](https://github.com/biomejs/biome/issues/1502). [useArrowFunction](https://biomejs.dev/rules/) now correctly handle functions that return a (comma) sequence expression. Contributed by @Conaclos
+- Fix [#1502](https://github.com/biomejs/biome/issues/1502). [useArrowFunction](https://biomejs.dev/linter/rules/use-arrow-function) now correctly handle functions that return a (comma) sequence expression. Contributed by @Conaclos
 
   Previously the rule made an erroneous suggestion:
 
@@ -526,7 +526,7 @@ The following rules are promoted:
 
 - Fix [#696](https://github.com/biomejs/biome/issues/696). [useHookAtTopLevel](https://biomejs.dev/linter/rules/use-hook-at-top-level) now correctly detects early returns before the calls to the hook.
 
-- The code fix of [noUselessTypeCOnstraint](https://biomejs.dev/linter/rules/no-useless-type-c-onstraint) now adds a trailing comma when needed to disambiguate a type parameter list from a JSX element. COntributed by @Conaclos
+- The code fix of [noUselessTypeCOnstraint](https://biomejs.dev/linter/rules/no-useless-type-constraint) now adds a trailing comma when needed to disambiguate a type parameter list from a JSX element. COntributed by @Conaclos
 
 - Fix [#578](https://github.com/biomejs/biome/issues/578). [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) now correctly recognizes hooks namespaced under the `React` namespace.  Contributed by @XiNiHa
 
@@ -717,7 +717,7 @@ The following rules are now recommended:
 
 - [a11y/noAccessKey](https://biomejs.dev/linter/rules/no-access-key)
 - [a11y/useHeadingContent](https://biomejs.dev/linter/rules/use-heading-content)
-- [complexity/useSimpleNumberKeys](https://biomejs.dev/linter/use-simple-number-keys)
+- [complexity/useSimpleNumberKeys](https://biomejs.dev/linter/rules/use-simple-number-keys)
 
 The following rules are now deprecated:
 
@@ -736,7 +736,7 @@ The following rules are now deprecated:
 
 - Add [useValidAriaRole](https://biomejs.dev/linter/rules/use-valid-aria-role). Contributed by @vasucp1207
 
-- Add [useRegexLiterals](https://biomejs.dev/linter/use-regex-literals) that suggests turning call to the regex constructor into regex literals. COntributed by @Yuiki
+- Add [useRegexLiterals](https://biomejs.dev/linter/rules/use-regex-literals) that suggests turning call to the regex constructor into regex literals. COntributed by @Yuiki
 
 #### Enhancements
 
@@ -766,9 +766,9 @@ The following rules are now deprecated:
 
 - Fix [#69](https://github.com/biomejs/biome/issues/69) that made [correctness/noUnnecessaryContinue](https://biomejs.dev/linter/rules/no-unnecessary-continue) incorrectly reports a `continue` used to break a switch clause. Contributed by @TaKO8Ki
 
-- Fix [#664](https://github.com/biomejs/biome/issues/664) by improving the diagnostic of [style/useNamingConvention](https://biomejs.dev/linter/use-naming-convention) when double capital are detected in strict camel case mode. Contributed by @vasucp1207
+- Fix [#664](https://github.com/biomejs/biome/issues/664) by improving the diagnostic of [style/useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention) when double capital are detected in strict camel case mode. Contributed by @vasucp1207
 
-- Fix [#643](https://github.com/biomejs/biome/issues/643) that erroneously parsed the option of [complexity/useExhaustiveDependencies](https://biomejs.dev/linter/use-naming-convention). Contributed by @arendjr
+- Fix [#643](https://github.com/biomejs/biome/issues/643) that erroneously parsed the option of [complexity/useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-naming-convention). Contributed by @arendjr
 
 ### Parser
 
@@ -1067,7 +1067,7 @@ The following rules are now recommended:
 
 - Add [noEmptyCharacterClassInRegex](https://biomejs.dev/linter/rules/no-empty-character-class-in-regex) rule. The rule reports empty character classes and empty negated character classes in regular expression literals. Contributed by @Conaclos
 
-- Add [noMisleadingInstantiator](https://biomejs.dev/linter/rules/no-mileading-instantiator) rule. The rule reports the misleading use of the `new` and `constructor` methods. Contributed by @unvalley
+- Add [noMisleadingInstantiator](https://biomejs.dev/linter/rules/no-misleading-instantiator) rule. The rule reports the misleading use of the `new` and `constructor` methods. Contributed by @unvalley
 
 - Add [noUselessElse](https://biomejs.dev/linter/rules/no-useless-else) rule.
   The rule reports `else` clauses that can be omitted because their `if` branches break.
@@ -1117,13 +1117,13 @@ The following rules are now recommended:
   - [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
   - [useWhile](https://biomejs.dev/linter/rules/use-while)
 
-- [noAccumulatingSpread](https://biomejs.dev/linter/no-accumulating-spread) makes more check in order to reduce potential false positives. Contributed by @Vivalldi
+- [noAccumulatingSpread](https://biomejs.dev/linter/rules/no-accumulating-spread) makes more check in order to reduce potential false positives. Contributed by @Vivalldi
 
 - [noConstAssign](https://biomejs.dev/linter/rules/no-const-assign) now provides an unsafe code fix that replaces `const` with `let`. Contributed by @vasucp1207
 
-- [noExcessiveComplexity](https://biomejs.dev/linter/rules/no-excessive-complexity) default complexity threshold is now `15`. Contributed by @arendjr
+- [noExcessiveComplexity](https://biomejs.dev/linter/rules/no-excessive-cognitive-complexity) default complexity threshold is now `15`. Contributed by @arendjr
 
-- [noPositiveTabindexValue](https://biomejs.dev/linter/rules/no-positive-tabindex-value) now provides an unsafe code fix that set to `0` the tab index. Contributed by @vasucp1207
+- [noPositiveTabindexValue](https://biomejs.dev/linter/rules/no-positive-tabindex) now provides an unsafe code fix that set to `0` the tab index. Contributed by @vasucp1207
 
 - [noUnusedLabels](https://biomejs.dev/linter/rules/no-unused-labels) no longer reports unbreakable labeled statements. Contributed by @Conaclos
 
@@ -1255,7 +1255,7 @@ The following rules are promoted:
 
 #### Removed rules
 
-- Remove [noConfusingArrow](https://biomejs.dev/linter/rules/no-confusing-arrow/).
+- Remove `noConfusingArrow`
 
   Code formatters, such as prettier and Biome, always adds parentheses around the parameter or the body of an arrow function.
   This makes the rule useless.
@@ -1560,7 +1560,7 @@ The following rules are promoted:
 
 - Fix [rome#4616](https://github.com/rome/tools/issues/4616)
 
-  Previously [noUnreachableSuper](https://biomejs.dev/linter/rules/no-unreacheable-super/) reported valid codes with complex nesting of control flow structures.
+  Previously [noUnreachableSuper](https://biomejs.dev/linter/rules/no-unreachable-super/) reported valid codes with complex nesting of control flow structures.
 
   Contributed by @Conaclos
 
@@ -1753,11 +1753,11 @@ The following rules are promoted:
 
 - Remove `useCamelCase`
 
-  Use [useNamingConvention](https://biomejs.dev/linter/rules/use-camel-case/) instead.
+  Use [useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention/) instead.
 
 #### New rules
 
-- Add [noExcessiveComplexity](https://biomejs.dev/linter/rules/no-excessive-complexity/)
+- Add [noExcessiveComplexity](https://biomejs.dev/linter/rules/no-excessive-cognitive-complexity/)
 
 - Add [useImportRestrictions](https://biomejs.dev/linter/rules/use-import-restrictions/)
 
@@ -1839,7 +1839,7 @@ The following rules are now recommended:
 
 - [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare/): allow redeclare of index signatures are in different type members [#4478](https://github.com/rome/tools/issues/4478)
 
-- Improve [noConsoleLog](https://biomejs.dev/linter/rules/no-console-log/), [noGlobalObjectCalls](https://biomejs.dev/linter/rules/no-global-object-calls/), [useIsNan](https://biomejs.dev/linter/rules/useisnan/), and [useNumericLiterals](https://biomejs.dev/linter/rules/use-numeric-literals/) by handling `globalThis` and `window` namespaces.
+- Improve [noConsoleLog](https://biomejs.dev/linter/rules/no-console-log/), [noGlobalObjectCalls](https://biomejs.dev/linter/rules/no-global-object-calls/), [useIsNan](https://biomejs.dev/linter/rules/use-is-nan/), and [useNumericLiterals](https://biomejs.dev/linter/rules/use-numeric-literals/) by handling `globalThis` and `window` namespaces.
 
   For instance, the following code is now reported by `noConsoleLog`:
 
@@ -2044,7 +2044,7 @@ The following rules are now recommended:
 
 - Fix [noInvalidConstructorSuper](https://biomejs.dev/linter/rules/no-invalid-constructor-super/) that erroneously reported generic parents [#4624](https://github.com/rome/tools/issues/4624).
 
--  Fix [noDuplicateCase](https://biomejs.dev/linter/rules/noDuplicateCase/) that erroneously reported as equals the strings literals `"'"` and `'"'` [#4706](https://github.com/rome/tools/issues/4706).
+-  Fix [noDuplicateCase](https://biomejs.dev/linter/rules/no-duplicate-case/) that erroneously reported as equals the strings literals `"'"` and `'"'` [#4706](https://github.com/rome/tools/issues/4706).
 
 - Fix [NoUnreachableSuper](https://biomejs.dev/linter/rules/no-unreachable-super/)'s false positive diagnostics ([#4483](https://github.com/rome/tools/issues/4483)) caused to nested if statement.
 
@@ -2057,7 +2057,7 @@ The following rules are now recommended:
 
 - Fix [noUselessConstructor](https://biomejs.dev/linter/rules/no-useless-constructor/) which erroneously reported constructors with default parameters [rome#4781](https://github.com/rome/tools/issues/4781)
 
-- Fix [noUselessFragments](https://biomejs.dev/linter/rules/nouselessfragments/)'s panics when running `biome check --apply-unsafe` ([#4637](https://github.com/rome/tools/issues/4639))
+- Fix [noUselessFragments](https://biomejs.dev/linter/rules/no-useless-fragments/)'s panics when running `biome check --apply-unsafe` ([#4637](https://github.com/rome/tools/issues/4639))
 
   This rule's code action emits an invalid AST, so I fixed using JsxString instead of JsStringLiteral
 

--- a/website/src/content/docs/ja/guides/integrate-in-editor.mdx
+++ b/website/src/content/docs/ja/guides/integrate-in-editor.mdx
@@ -49,7 +49,7 @@ Biome IntelliJ 向けのプラグインをインストールするには、[プ�
 - [`neovim`](https://neovim.io/): [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/) をインストールして、[マニュアルの手順](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#biome) に従ってください
 - [`helix`](https://helix-editor.com/): [マニュアルの手順](https://github.com/biomejs/biome/blob/main/editors/helix/manual.md) に従ってください
 - [`coc-biome`](https://github.com/fannheyward/coc-biome): [`coc.nvim`](https://github.com/neoclide/coc.nvim) 向けの Biome 拡張機能
-- [`sublime text`](http://www.sublimetext.com/): [`LSP-biome`](https://github.com/sublimelsp/LSP-biome) のインストール手順に従ってください
+- [`sublime text`](https://www.sublimetext.com/): [`LSP-biome`](https://github.com/sublimelsp/LSP-biome) のインストール手順に従ってください
 
 :::note
 ここにのっていないエディタのプラグインがありますか？ぜひ PR を送って、ここに追加してください！

--- a/website/src/content/docs/linter/rules/no-blank-target.md
+++ b/website/src/content/docs/linter/rules/no-blank-target.md
@@ -8,7 +8,7 @@ title: noBlankTarget (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
-Source: <a href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/jsx-no-target-blank.md" target="_blank"><code>jsx-no-target-blank</code></a>
+Source: <a href="https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md" target="_blank"><code>jsx-no-target-blank</code></a>
 
 Disallow `target="_blank"` attribute without `rel="noreferrer"`
 

--- a/website/src/content/docs/linter/rules/no-excessive-cognitive-complexity.md
+++ b/website/src/content/docs/linter/rules/no-excessive-cognitive-complexity.md
@@ -19,7 +19,7 @@ This rule calculates a complexity score for every function and disallows
 those that exceed a configured complexity threshold (default: 15).
 
 The complexity score is calculated based on the Cognitive Complexity
-algorithm: http://redirect.sonarsource.com/doc/cognitive-complexity.html
+algorithm: https://redirect.sonarsource.com/doc/cognitive-complexity.html
 
 ## Examples
 

--- a/website/src/content/docs/pt-br/guides/integrate-in-editor.mdx
+++ b/website/src/content/docs/pt-br/guides/integrate-in-editor.mdx
@@ -49,7 +49,7 @@ Esses são plugins mantidos por outras comunidades, que você instala em seu edi
 - [`neovim`](https://neovim.io/): você vai precisar instalar o [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/), e seguir essas [instruções](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#biome);
 - [`helix`](https://helix-editor.com/): siga as instruções desse [manual](https://github.com/biomejs/biome/blob/main/editors/helix/manual.md)
 - [`coc-biome`](https://github.com/fannheyward/coc-biome): extensão Biome para [`coc.nvim`](https://github.com/neoclide/coc.nvim)
-- [`sublime text`](http://www.sublimetext.com/): siga as instruções de instalação do [`LSP-biome`](https://github.com/sublimelsp/LSP-biome)
+- [`sublime text`](https://www.sublimetext.com/): siga as instruções de instalação do [`LSP-biome`](https://github.com/sublimelsp/LSP-biome)
 
 :::note
 Existe um plugin para um editor que não está listado aqui? Por favor, abra um Pull Request e ficaremos felizes em adicioná-lo à lista.

--- a/website/src/content/docs/zh-cn/internals/changelog.mdx
+++ b/website/src/content/docs/zh-cn/internals/changelog.mdx
@@ -65,11 +65,11 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Fix [#1335](https://github.com/biomejs/biome/issues/1335). [noUselessFragments](https://biomejs.dev/linter/rules/no-useless-fragments/) now ignores code action on component props when the fragment is empty. Contributed by @vasucp1207
 
-- [useConsistentArrayType](https://biomejs.dev/rules/use-consistent-array-type) was accidentally placed in the `style` rule group instead of the `nursery` group. It is now correctly placed under `nursery`.
+- [useConsistentArrayType](https://biomejs.dev/linter/rules/use-consistent-array-type) was accidentally placed in the `style` rule group instead of the `nursery` group. It is now correctly placed under `nursery`.
 
-- Fix [#1483](https://github.com/biomejs/biome/issues/1483). [useConsistentArrayType](https://biomejs.dev/rules/use-consistent-array-type) now correctly handles its option. Contributed by @Conaclos
+- Fix [#1483](https://github.com/biomejs/biome/issues/1483). [useConsistentArrayType](https://biomejs.dev/linter/rules/use-consistent-array-type) now correctly handles its option. Contributed by @Conaclos
 
-- Fix [#1502](https://github.com/biomejs/biome/issues/1502). [useArrowFunction](https://biomejs.dev/rules/) now correctly handle functions that return a (comma) sequence expression. Contributed by @Conaclos
+- Fix [#1502](https://github.com/biomejs/biome/issues/1502). [useArrowFunction](https://biomejs.dev/linter/rules/use-arrow-function) now correctly handle functions that return a (comma) sequence expression. Contributed by @Conaclos
 
   Previously the rule made an erroneous suggestion:
 
@@ -487,7 +487,7 @@ The following rules are promoted:
 
 - Fix [#696](https://github.com/biomejs/biome/issues/696). [useHookAtTopLevel](https://biomejs.dev/linter/rules/use-hook-at-top-level) now correctly detects early returns before the calls to the hook.
 
-- The code fix of [noUselessTypeCOnstraint](https://biomejs.dev/linter/rules/no-useless-type-c-onstraint) now adds a trailing comma when needed to disambiguate a type parameter list from a JSX element. COntributed by @Conaclos
+- The code fix of [noUselessTypeCOnstraint](https://biomejs.dev/linter/rules/no-useless-type-constraint) now adds a trailing comma when needed to disambiguate a type parameter list from a JSX element. COntributed by @Conaclos
 
 - Fix [#578](https://github.com/biomejs/biome/issues/578). [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) now correctly recognizes hooks namespaced under the `React` namespace.  Contributed by @XiNiHa
 
@@ -678,7 +678,7 @@ The following rules are now recommended:
 
 - [a11y/noAccessKey](https://biomejs.dev/linter/rules/no-access-key)
 - [a11y/useHeadingContent](https://biomejs.dev/linter/rules/use-heading-content)
-- [complexity/useSimpleNumberKeys](https://biomejs.dev/linter/use-simple-number-keys)
+- [complexity/useSimpleNumberKeys](https://biomejs.dev/linter/rules/use-simple-number-keys)
 
 The following rules are now deprecated:
 
@@ -697,7 +697,7 @@ The following rules are now deprecated:
 
 - Add [useValidAriaRole](https://biomejs.dev/linter/rules/use-valid-aria-role). Contributed by @vasucp1207
 
-- Add [useRegexLiterals](https://biomejs.dev/linter/use-regex-literals) that suggests turning call to the regex constructor into regex literals. COntributed by @Yuiki
+- Add [useRegexLiterals](https://biomejs.dev/linter/rules/use-regex-literals) that suggests turning call to the regex constructor into regex literals. COntributed by @Yuiki
 
 #### Enhancements
 
@@ -727,9 +727,9 @@ The following rules are now deprecated:
 
 - Fix [#69](https://github.com/biomejs/biome/issues/69) that made [correctness/noUnnecessaryContinue](https://biomejs.dev/linter/rules/no-unnecessary-continue) incorrectly reports a `continue` used to break a switch clause. Contributed by @TaKO8Ki
 
-- Fix [#664](https://github.com/biomejs/biome/issues/664) by improving the diagnostic of [style/useNamingConvention](https://biomejs.dev/linter/use-naming-convention) when double capital are detected in strict camel case mode. Contributed by @vasucp1207
+- Fix [#664](https://github.com/biomejs/biome/issues/664) by improving the diagnostic of [style/useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention) when double capital are detected in strict camel case mode. Contributed by @vasucp1207
 
-- Fix [#643](https://github.com/biomejs/biome/issues/643) that erroneously parsed the option of [complexity/useExhaustiveDependencies](https://biomejs.dev/linter/use-naming-convention). Contributed by @arendjr
+- Fix [#643](https://github.com/biomejs/biome/issues/643) that erroneously parsed the option of [complexity/useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-naming-convention). Contributed by @arendjr
 
 ### Parser
 
@@ -1028,7 +1028,7 @@ The following rules are now recommended:
 
 - Add [noEmptyCharacterClassInRegex](https://biomejs.dev/linter/rules/no-empty-character-class-in-regex) rule. The rule reports empty character classes and empty negated character classes in regular expression literals. Contributed by @Conaclos
 
-- Add [noMisleadingInstantiator](https://biomejs.dev/linter/rules/no-mileading-instantiator) rule. The rule reports the misleading use of the `new` and `constructor` methods. Contributed by @unvalley
+- Add [noMisleadingInstantiator](https://biomejs.dev/linter/rules/no-misleading-instantiator) rule. The rule reports the misleading use of the `new` and `constructor` methods. Contributed by @unvalley
 
 - Add [noUselessElse](https://biomejs.dev/linter/rules/no-useless-else) rule.
   The rule reports `else` clauses that can be omitted because their `if` branches break.
@@ -1078,13 +1078,13 @@ The following rules are now recommended:
   - [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
   - [useWhile](https://biomejs.dev/linter/rules/use-while)
 
-- [noAccumulatingSpread](https://biomejs.dev/linter/no-accumulating-spread) makes more check in order to reduce potential false positives. Contributed by @Vivalldi
+- [noAccumulatingSpread](https://biomejs.dev/linter/rules/no-accumulating-spread) makes more check in order to reduce potential false positives. Contributed by @Vivalldi
 
 - [noConstAssign](https://biomejs.dev/linter/rules/no-const-assign) now provides an unsafe code fix that replaces `const` with `let`. Contributed by @vasucp1207
 
-- [noExcessiveComplexity](https://biomejs.dev/linter/rules/no-excessive-complexity) default complexity threshold is now `15`. Contributed by @arendjr
+- [noExcessiveComplexity](https://biomejs.dev/linter/rules/no-excessive-cognitive-complexity) default complexity threshold is now `15`. Contributed by @arendjr
 
-- [noPositiveTabindexValue](https://biomejs.dev/linter/rules/no-positive-tabindex-value) now provides an unsafe code fix that set to `0` the tab index. Contributed by @vasucp1207
+- [noPositiveTabindexValue](https://biomejs.dev/linter/rules/no-positive-tabindex) now provides an unsafe code fix that set to `0` the tab index. Contributed by @vasucp1207
 
 - [noUnusedLabels](https://biomejs.dev/linter/rules/no-unused-labels) no longer reports unbreakable labeled statements. Contributed by @Conaclos
 
@@ -1521,7 +1521,7 @@ The following rules are promoted:
 
 - Fix [rome#4616](https://github.com/rome/tools/issues/4616)
 
-  Previously [noUnreachableSuper](https://biomejs.dev/linter/rules/no-unreacheable-super/) reported valid codes with complex nesting of control flow structures.
+  Previously [noUnreachableSuper](https://biomejs.dev/linter/rules/no-unreachable-super/) reported valid codes with complex nesting of control flow structures.
 
   Contributed by @Conaclos
 
@@ -1714,11 +1714,11 @@ The following rules are promoted:
 
 - Remove `useCamelCase`
 
-  Use [useNamingConvention](https://biomejs.dev/linter/rules/use-camel-case/) instead.
+  Use [useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention/) instead.
 
 #### New rules
 
-- Add [noExcessiveComplexity](https://biomejs.dev/linter/rules/no-excessive-complexity/)
+- Add [noExcessiveComplexity](https://biomejs.dev/linter/rules/no-excessive-cognitive-complexity/)
 
 - Add [useImportRestrictions](https://biomejs.dev/linter/rules/use-import-restrictions/)
 
@@ -1800,7 +1800,7 @@ The following rules are now recommended:
 
 - [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare/): allow redeclare of index signatures are in different type members [#4478](https://github.com/rome/tools/issues/4478)
 
-- Improve [noConsoleLog](https://biomejs.dev/linter/rules/no-console-log/), [noGlobalObjectCalls](https://biomejs.dev/linter/rules/no-global-object-calls/), [useIsNan](https://biomejs.dev/linter/rules/useisnan/), and [useNumericLiterals](https://biomejs.dev/linter/rules/use-numeric-literals/) by handling `globalThis` and `window` namespaces.
+- Improve [noConsoleLog](https://biomejs.dev/linter/rules/no-console-log/), [noGlobalObjectCalls](https://biomejs.dev/linter/rules/no-global-object-calls/), [useIsNan](https://biomejs.dev/linter/rules/use-is-nan/), and [useNumericLiterals](https://biomejs.dev/linter/rules/use-numeric-literals/) by handling `globalThis` and `window` namespaces.
 
   For instance, the following code is now reported by `noConsoleLog`:
 
@@ -2005,7 +2005,7 @@ The following rules are now recommended:
 
 - Fix [noInvalidConstructorSuper](https://biomejs.dev/linter/rules/no-invalid-constructor-super/) that erroneously reported generic parents [#4624](https://github.com/rome/tools/issues/4624).
 
--  Fix [noDuplicateCase](https://biomejs.dev/linter/rules/noDuplicateCase/) that erroneously reported as equals the strings literals `"'"` and `'"'` [#4706](https://github.com/rome/tools/issues/4706).
+-  Fix [noDuplicateCase](https://biomejs.dev/linter/rules/no-duplicate-case/) that erroneously reported as equals the strings literals `"'"` and `'"'` [#4706](https://github.com/rome/tools/issues/4706).
 
 - Fix [NoUnreachableSuper](https://biomejs.dev/linter/rules/no-unreachable-super/)'s false positive diagnostics ([#4483](https://github.com/rome/tools/issues/4483)) caused to nested if statement.
 
@@ -2018,7 +2018,7 @@ The following rules are now recommended:
 
 - Fix [noUselessConstructor](https://biomejs.dev/linter/rules/no-useless-constructor/) which erroneously reported constructors with default parameters [rome#4781](https://github.com/rome/tools/issues/4781)
 
-- Fix [noUselessFragments](https://biomejs.dev/linter/rules/nouselessfragments/)'s panics when running `biome check --apply-unsafe` ([#4637](https://github.com/rome/tools/issues/4639))
+- Fix [noUselessFragments](https://biomejs.dev/linter/rules/no-useless-fragments/)'s panics when running `biome check --apply-unsafe` ([#4637](https://github.com/rome/tools/issues/4639))
 
   This rule's code action emits an invalid AST, so I fixed using JsxString instead of JsStringLiteral
 


### PR DESCRIPTION
## Summary

I used https://www.drlinkcheck.com to detect dead links and http links.

This PR fixes these dead links and replace `http` with `https` protocol.
