### PR TITLE
fix(js_formatter): ensure comments before `*` are placed before `*` in generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Bug fixes
 
+- Fix placement of comments before `*` token in generator methods with decorators. [#1537](https://github.com/biomejs/biome/pull/1537) Contributed by @ah-yu
+
 - Fix [#1406](https://github.com/biomejs/biome/issues/1406). Ensure comments before the `async` keyword are placed before it. Contributed by @ah-yu
 
 - Fix [#1172](https://github.com/biomejs/biome/issues/1172). Fix placement of line comment after function expression parentheses, they are now attached to first statement in body. Contributed by @kalleep

--- a/crates/biome_js_formatter/src/comments.rs
+++ b/crates/biome_js_formatter/src/comments.rs
@@ -1270,7 +1270,10 @@ fn handle_class_method_comment(
     match enclosing_node.kind() {
         JsSyntaxKind::JS_METHOD_CLASS_MEMBER => {
             if let Some(following_token) = comment.following_token() {
-                if following_token.kind() == JsSyntaxKind::ASYNC_KW {
+                if matches!(
+                    following_token.kind(),
+                    JsSyntaxKind::ASYNC_KW | JsSyntaxKind::STAR
+                ) {
                     if let Some(preceding) = comment.preceding_node() {
                         return CommentPlacement::trailing(preceding.clone(), comment);
                     }

--- a/crates/biome_js_formatter/src/comments.rs
+++ b/crates/biome_js_formatter/src/comments.rs
@@ -1256,7 +1256,8 @@ fn handle_import_export_specifier_comment(
     }
 }
 
-/// Ensure that comments before the `async`` keyword are placed just before it.
+/// Attach comments before the `async` keyword or `*` token to the preceding node if it exists
+/// to ensure these comments are placed before the `async` keyword or `*` token.
 /// ```javascript
 /// class Foo {
 ///    @decorator()

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
@@ -214,7 +214,8 @@ class Foo {
 	/*after*/
 	async method() {}
 	@decorator.method(value) /*before*/
-	*/*after*/ method() {}
+	/*after*/
+	*method() {}
 	@decorator.method(value) /*before*/
 	get /*after*/ getter() {}
 	@decorator.method(value) /*before*/

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
@@ -212,7 +212,8 @@ class Foo {
 	/*after*/
 	async method() {}
 	@decorator /*before*/
-	*/*after*/ method() {}
+	/*after*/
+	*method() {}
 	@decorator.method(value) /*before*/
 	get /*after*/ getter() {}
 	@decorator /*before*/

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
@@ -202,7 +202,8 @@ class Foo {
 	/*after*/
 	async method() {}
 	@dec /*before*/
-	*/*after*/ method() {}
+	/*after*/
+	*method() {}
 	@dec /*before*/
 	get /*after*/ getter() {}
 	@dec /*before*/

--- a/crates/biome_js_formatter/tests/specs/prettier/typescript/decorators/decorators-comments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/prettier/typescript/decorators/decorators-comments.ts.snap
@@ -51,17 +51,6 @@ class Something2 {
 ```diff
 --- Prettier
 +++ Biome
-@@ -12,8 +12,8 @@
- 
- class Foo3 {
-   @foo
--  // comment
--  *method() {}
-+  *// comment
-+  method() {}
- }
- 
- class Foo4 {
 @@ -30,6 +30,6 @@
  
  class Something2 {
@@ -90,8 +79,8 @@ class Foo2 {
 
 class Foo3 {
   @foo
-  *// comment
-  method() {}
+  // comment
+  *method() {}
 }
 
 class Foo4 {

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -32,6 +32,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Bug fixes
 
+- Fix placement of comments before `*` token in generator methods with decorators. [#1537](https://github.com/biomejs/biome/pull/1537) Contributed by @ah-yu
+
 - Fix [#1406](https://github.com/biomejs/biome/issues/1406). Ensure comments before the `async` keyword are placed before it. Contributed by @ah-yu
 
 - Fix [#1172](https://github.com/biomejs/biome/issues/1172). Fix placement of line comment after function expression parentheses, they are now attached to first statement in body. Contributed by @kalleep


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Ensure the comments in front of the`*` token are placed in front of `*` for generators. If the following token of the comment is the `*` token then attach the comment to the preceding node.

```js
class Foo {
   @decorator()
   /* comment */ *method(){}
}

// before fix
class Foo {
  @decorator()
  */* comment */ method() {}
}

// after fix
class Foo {
  @decorator()
  /* comment */
  *method() {}
}

// prettier
class Foo {
  @decorator()
  /* comment */
  *method() {}
}
```
