### PR TITLE
feat(linter): show dependency variable name by useExhaustiveDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
   This cases requires the presence of a prototype.
 
+- Add dependency variable names on error message when useExhaustiveDependencies rule shows errors. Contributed by @mehm8128
+
 #### Bug fixes
 
 - The fix of [useArrowFunction](https://biomejs.dev/linter/rules/use-arrow-function) now adds parentheses around the arrow function in more cases where it is needed ([#1524](https://github.com/biomejs/biome/issues/1524)).

--- a/crates/biome_css_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_css_factory/src/generated/syntax_factory.rs
@@ -269,9 +269,7 @@ impl SyntaxFactory for CssSyntaxFactory {
                 let mut unmatched_count = 3usize;
                 let mut group_slot_map = [false; 3usize];
                 for _ in 0usize..3usize {
-                    let Some(element) = &current_element else {
-                        break;
-                    };
+                    let Some (element) = & current_element else { break ; } ;
                     if !group_slot_map[0usize] && AnyCssLineWidth::can_cast(element.kind()) {
                         group_slot_map[0usize] = true;
                     } else if !group_slot_map[1usize] && CssLineStyle::can_cast(element.kind()) {

--- a/crates/biome_css_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_css_factory/src/generated/syntax_factory.rs
@@ -269,7 +269,9 @@ impl SyntaxFactory for CssSyntaxFactory {
                 let mut unmatched_count = 3usize;
                 let mut group_slot_map = [false; 3usize];
                 for _ in 0usize..3usize {
-                    let Some (element) = & current_element else { break ; } ;
+                    let Some(element) = &current_element else {
+                        break;
+                    };
                     if !group_slot_map[0usize] && AnyCssLineWidth::can_cast(element.kind()) {
                         group_slot_map[0usize] = true;
                     } else if !group_slot_map[1usize] && CssLineStyle::can_cast(element.kind()) {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/checkHooksImportedFromReact.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/checkHooksImportedFromReact.js.snap
@@ -31,7 +31,7 @@ function MyComponent2() {
 ```
 checkHooksImportedFromReact.js:3:9 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     1 │ function MyComponent1() {
     2 │   let a = 1;

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/customHook.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/customHook.js.snap
@@ -27,7 +27,7 @@ function MyComponent() {
 ```
 customHook.js:5:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     3 │ function MyComponent() {
     4 │     let a = 1;
@@ -53,7 +53,7 @@ customHook.js:5:5 lint/correctness/useExhaustiveDependencies ━━━━━━�
 ```
 customHook.js:9:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
      7 │     }, []);
      8 │ 

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/extraDependenciesInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/extraDependenciesInvalid.js.snap
@@ -50,7 +50,7 @@ function MyComponent3() {
 ```
 extraDependenciesInvalid.js:5:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook specifies more dependencies than necessary.
+  ! This hook specifies more dependencies than necessary: a
   
     3 │ function MyComponent() {
     4 │   let a = 1;
@@ -74,7 +74,7 @@ extraDependenciesInvalid.js:5:3 lint/correctness/useExhaustiveDependencies ━�
 ```
 extraDependenciesInvalid.js:12:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook specifies more dependencies than necessary.
+  ! This hook specifies more dependencies than necessary: a, b
   
     10 │ function MyComponent2() {
     11 │   let a = 1, b = 1;
@@ -107,7 +107,7 @@ extraDependenciesInvalid.js:12:3 lint/correctness/useExhaustiveDependencies ━�
 ```
 extraDependenciesInvalid.js:19:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook specifies more dependencies than necessary.
+  ! This hook specifies more dependencies than necessary: a
   
     17 │ function MyComponent2() {
     18 │   const a = 1;
@@ -131,7 +131,7 @@ extraDependenciesInvalid.js:19:3 lint/correctness/useExhaustiveDependencies ━�
 ```
 extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook specifies a dependency more specific that its captures
+  ! This hook specifies a dependency more specific that its captures: someObj.id
   
     26 │ function MyComponent1() {
     27 │   let someObj = getObj();
@@ -164,7 +164,7 @@ extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies ━�
 ```
 extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: someObj
   
     26 │ function MyComponent1() {
     27 │   let someObj = getObj();
@@ -188,7 +188,7 @@ extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies ━�
 ```
 extraDependenciesInvalid.js:36:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook specifies more dependencies than necessary.
+  ! This hook specifies more dependencies than necessary: outer
   
     34 │ // Dependencies from outer scope should not be valid
     35 │ function MyComponent3() {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.js.snap
@@ -166,7 +166,7 @@ function MyComponent15() {
 ```
 missingDependenciesInvalid.js:18:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     16 │     let a = 1;
     17 │     const b = a + 1;
@@ -192,7 +192,7 @@ missingDependenciesInvalid.js:18:5 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:18:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: b
   
     16 │     let a = 1;
     17 │     const b = a + 1;
@@ -218,7 +218,7 @@ missingDependenciesInvalid.js:18:5 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:32:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: deferredValue
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -244,7 +244,7 @@ missingDependenciesInvalid.js:32:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:32:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: memoizedCallback
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -270,7 +270,7 @@ missingDependenciesInvalid.js:32:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:32:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: state
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -296,7 +296,7 @@ missingDependenciesInvalid.js:32:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:32:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: name
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -322,7 +322,7 @@ missingDependenciesInvalid.js:32:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:32:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: isPending
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -348,7 +348,7 @@ missingDependenciesInvalid.js:32:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:32:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: memoizedValue
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -373,7 +373,7 @@ missingDependenciesInvalid.js:32:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:52:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     50 │ function MyComponent3() {
     51 │   let a = 1;
@@ -399,7 +399,7 @@ missingDependenciesInvalid.js:52:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:53:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     51 │   let a = 1;
     52 │   useEffect(() => console.log(a), []);
@@ -425,7 +425,7 @@ missingDependenciesInvalid.js:53:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:54:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     52 │   useEffect(() => console.log(a), []);
     53 │   useCallback(() => console.log(a), []);
@@ -451,7 +451,7 @@ missingDependenciesInvalid.js:54:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:55:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     53 │   useCallback(() => console.log(a), []);
     54 │   useMemo(() => console.log(a), []);
@@ -477,7 +477,7 @@ missingDependenciesInvalid.js:55:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:56:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     54 │   useMemo(() => console.log(a), []);
     55 │   useImperativeHandle(ref, () => console.log(a), []);
@@ -503,7 +503,7 @@ missingDependenciesInvalid.js:56:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:57:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     55 │   useImperativeHandle(ref, () => console.log(a), []);
     56 │   useLayoutEffect(() => console.log(a), []);
@@ -529,7 +529,7 @@ missingDependenciesInvalid.js:57:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:64:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     62 │ function MyComponent4() {
     63 │   let a = 1;
@@ -555,7 +555,7 @@ missingDependenciesInvalid.js:64:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:73:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     71 │ function MyComponent5() {
     72 │   let a = 1;
@@ -590,7 +590,7 @@ missingDependenciesInvalid.js:73:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:83:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: someObj.name
   
     81 │ function MyComponent6() {
     82 │   let someObj = getObj();
@@ -616,7 +616,7 @@ missingDependenciesInvalid.js:83:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:89:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     88 │ const MyComponent7 = React.memo(function ({ a }) {
   > 89 │   useEffect(() => {
@@ -641,7 +641,7 @@ missingDependenciesInvalid.js:89:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:95:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     94 │ const MyComponent8 = React.memo(({ a }) => {
   > 95 │   useEffect(() => {
@@ -666,7 +666,7 @@ missingDependenciesInvalid.js:95:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:103:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     101 │ export function MyComponent9() {
     102 │   let a = 1;
@@ -692,7 +692,7 @@ missingDependenciesInvalid.js:103:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:110:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     108 │ export default function MyComponent10() {
     109 │   let a = 1;
@@ -718,7 +718,7 @@ missingDependenciesInvalid.js:110:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:118:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     116 │ function MyComponent11() {
     117 │   let a = 1;
@@ -744,7 +744,7 @@ missingDependenciesInvalid.js:118:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:125:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     123 │ function MyComponent12() {
     124 │   let a = 1;
@@ -770,7 +770,7 @@ missingDependenciesInvalid.js:125:3 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:133:9 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: a
   
     131 │ function MyComponent13() {
     132 │   let a = 1;
@@ -796,7 +796,7 @@ missingDependenciesInvalid.js:133:9 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:141:2 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: ref.current
   
     139 │ function MyComponent14() {
     140 │ 	const ref = useRef();
@@ -822,7 +822,7 @@ missingDependenciesInvalid.js:141:2 lint/correctness/useExhaustiveDependencies �
 ```
 missingDependenciesInvalid.js:152:2 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies.
+  ! This hook does not specify all of its dependencies: ref.current
   
     150 │ 	}
     151 │ 	const ref = useRef();

--- a/justfile
+++ b/justfile
@@ -117,7 +117,7 @@ ready:
   git diff --exit-code --quiet
   just gen
   just documentation
-  #just format # fromat is already run in `just gen`
+  #just format # format is already run in `just gen`
   just lint
   just test
   just test-doc

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -57,6 +57,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
   This cases requires the presence of a prototype.
 
+- Add dependency variable names on error message when useExhaustiveDependencies rule shows errors. Contributed by @mehm8128
+
 #### Bug fixes
 
 - The fix of [useArrowFunction](https://biomejs.dev/linter/rules/use-arrow-function) now adds parentheses around the arrow function in more cases where it is needed ([#1524](https://github.com/biomejs/biome/issues/1524)).

--- a/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
+++ b/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
@@ -50,7 +50,7 @@ function component() {
 
 <pre class="language-text"><code class="language-text">correctness/useExhaustiveDependencies.js:5:5 <a href="https://biomejs.dev/linter/rules/use-exhaustive-dependencies">lint/correctness/useExhaustiveDependencies</a> ━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook does not specify all of its dependencies.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook does not specify all of its dependencies: a</span>
   
     <strong>3 │ </strong>function component() {
     <strong>4 │ </strong>    let a = 1;
@@ -84,7 +84,7 @@ function component() {
 
 <pre class="language-text"><code class="language-text">correctness/useExhaustiveDependencies.js:5:5 <a href="https://biomejs.dev/linter/rules/use-exhaustive-dependencies">lint/correctness/useExhaustiveDependencies</a> ━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook specifies more dependencies than necessary.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook specifies more dependencies than necessary: b</span>
   
     <strong>3 │ </strong>function component() {
     <strong>4 │ </strong>    let b = 1;
@@ -118,7 +118,7 @@ function component() {
 
 <pre class="language-text"><code class="language-text">correctness/useExhaustiveDependencies.js:5:5 <a href="https://biomejs.dev/linter/rules/use-exhaustive-dependencies">lint/correctness/useExhaustiveDependencies</a> ━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook specifies more dependencies than necessary.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook specifies more dependencies than necessary: setName</span>
   
     <strong>3 │ </strong>function component() {
     <strong>4 │ </strong>    const [name, setName] = useState();
@@ -152,7 +152,7 @@ function component() {
 
 <pre class="language-text"><code class="language-text">correctness/useExhaustiveDependencies.js:6:5 <a href="https://biomejs.dev/linter/rules/use-exhaustive-dependencies">lint/correctness/useExhaustiveDependencies</a> ━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook does not specify all of its dependencies.</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook does not specify all of its dependencies: b</span>
   
     <strong>4 │ </strong>    let a = 1;
     <strong>5 │ </strong>    const b = a + 1;


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

As written below issue, I want `useExhaustiveDependencies` rule to show dependency variable names even when we look errors on VSCode, so I added dependency variable names on error message.
close https://github.com/biomejs/biome/issues/1391

I have no confidence in my PR, so if my approach isn't good or something wrong, please tell me.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Please look over changed snapshot test files.
