### PR TITLE
refactor(cli): do not emit warnings for protected ignored files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,25 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### CLI
 
+### Bug fixes
+
 - Fix [#1512](https://github.com/biomejs/biome/issues/1512) by skipping verbose diagnostics from the count. Contributed by @ematipico
-- Don't handle CSS files, the formatter isn't ready yet. Contributed by @ematipico
+
+- Don't emit verbose warnings when a protected file is ignored.
+
+  Some files, such as `package.json` and `tsconfig.json`, are [protected](https://biomejs.dev/guides/how-biome-works/#protected-files).
+  Biome emits a verbose warning when it encounters a protected file.
+
+  Previously, Biome emitted this verbose warning even if the file was ignored by the configuration.
+  Now, it doesn't emit verbose warnings for protected files that are ignored.
+
+  Contributed by @Conaclos
+
 - The file `biome.json` can't be ignored anymore. Contributed by @ematipico
+
 - Fix [#1541](https://github.com/biomejs/biome/issues/1541) where the content of protected files wasn't returned to `stdout`. Contributed by @ematipico
+
+- Don't handle CSS files, the formatter isn't ready yet. Contributed by @ematipico
 
 ### Configuration
 

--- a/crates/biome_cli/tests/cases/protected_files.rs
+++ b/crates/biome_cli/tests/cases/protected_files.rs
@@ -126,6 +126,7 @@ fn not_process_file_from_cli() {
         result,
     ));
 }
+
 #[test]
 fn not_process_file_from_cli_verbose() {
     let mut fs = MemoryFileSystem::default();
@@ -152,6 +153,88 @@ fn not_process_file_from_cli_verbose() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "not_process_file_from_cli_verbose",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn not_process_ignored_file_from_cli_verbose() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("package.json");
+    fs.insert(file_path.into(), r#"{ "name": "test" }"#.as_bytes());
+
+    let file_path = Path::new("other.json");
+    fs.insert(file_path.into(), r#"{}"#.as_bytes());
+
+    let file_path1 = Path::new("biome.json");
+    fs.insert(
+        file_path1.into(),
+        r#"{ "files": { "ignore": ["package.json"] } }"#.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                "--verbose",
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "not_process_ignored_file_from_cli_verbose",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn not_process_file_linter_disabled_from_cli_verbose() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("package.json");
+    fs.insert(file_path.into(), r#"{ "name": "test" }"#.as_bytes());
+
+    let file_path = Path::new("other.json");
+    fs.insert(file_path.into(), r#"{}"#.as_bytes());
+
+    let file_path1 = Path::new("biome.json");
+    fs.insert(
+        file_path1.into(),
+        r#"{ "linter": { "enabled": false } }"#.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                "--verbose",
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "not_process_file_linter_disabled_from_cli_verbose",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_linter_disabled_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_linter_disabled_from_cli_verbose.snap
@@ -1,0 +1,52 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{ "linter": { "enabled": false } }
+```
+
+## `other.json`
+
+```json
+{}
+```
+
+## `package.json`
+
+```json
+{ "name": "test" }
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+other.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - {}
+      1 │ + {}
+      2 │ + 
+  
+
+```
+
+```block
+Compared 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_ignored_file_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_ignored_file_from_cli_verbose.snap
@@ -1,0 +1,52 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{ "files": { "ignore": ["package.json"] } }
+```
+
+## `other.json`
+
+```json
+{}
+```
+
+## `package.json`
+
+```json
+{ "name": "test" }
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+other.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - {}
+      1 │ + {}
+      2 │ + 
+  
+
+```
+
+```block
+Compared 1 file(s) in <TIME>
+```
+
+

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -20,10 +20,25 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### CLI
 
+### Bug fixes
+
 - Fix [#1512](https://github.com/biomejs/biome/issues/1512) by skipping verbose diagnostics from the count. Contributed by @ematipico
-- Don't handle CSS files, the formatter isn't ready yet. Contributed by @ematipico
+
+- Don't emit verbose warnings when a protected file is ignored.
+
+  Some files, such as `package.json` and `tsconfig.json`, are [protected](https://biomejs.dev/guides/how-biome-works/#protected-files).
+  Biome emits a verbose warning when it encounters a protected file.
+
+  Previously, Biome emitted this verbose warning even if the file was ignored by the configuration.
+  Now, it doesn't emit verbose warnings for protected files that are ignored.
+
+  Contributed by @Conaclos
+
 - The file `biome.json` can't be ignored anymore. Contributed by @ematipico
+
 - Fix [#1541](https://github.com/biomejs/biome/issues/1541) where the content of protected files wasn't returned to `stdout`. Contributed by @ematipico
+
+- Don't handle CSS files, the formatter isn't ready yet. Contributed by @ematipico
 
 ### Configuration
 


### PR DESCRIPTION
## Summary

This PR improves file handling.

- Protected files that are ignored in the configuration (or with the feature disabled) no longer emits verbose warnings.
- I removed `.gitignore` from the protected list because the file language is not supported by Biome
  Thus, it should emit an unsuported file warning.

## Test Plan

- [x] Manual tests
- [x] add unit tests
