### PR TITLE
chore: move `nhedger` to core contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -408,12 +408,12 @@ Members are listed in alphabetical order. Members are free to use the full name,
 - [Denis Bezrukov @denbezrukov](https://github.com/denbezrukov)
 - [Hiroki Ihoriya @unvalley](https://github.com/unvalley)
 - [Jon Egeland @faultyserver](https://github.com/faultyserver)
+- [Nicolas Hedger @nhedger](https://github.com/nhedger)
 
 ### Maintainers team
 
 - [Arend van Beelen @arendjr](https://github.com/arendjr)
 - [Madeline Gurriarán @SuperchupuDev](https://github.com/SuperchupuDev)
-- [Nicolas Hedger @nhedger](https://github.com/nhedger)
 - [Takayuki Maeda @TaKO8Ki](https://github.com/TaKO8Ki)
 - [Vasu Singh @vasucp1207](https://github.com/vasucp1207)
 - [Victor Teles @victor-teles](https://github.com/victor-teles)


### PR DESCRIPTION
This PR moves myself from the `Maintainers team` section to the `Core Contributors team` section.