### PR TITLE
fix(config): apply global include/ignore before tools' include/ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Fix [#1512](https://github.com/biomejs/biome/issues/1512) by skipping verbose diagnostics from the count. Contributed by @ematipico
 
+- Correctly handle cascading `include` and `ignore`.
+
+  Previously Biome incorrectly included files that were included at tool level and ignored at global level.
+  In the following example, `file.js' was formatted when it should have been ignored.
+  Now, Biome correctly ignores the directory `./src/sub/`.
+
+  ```shell
+  ❯ tree src
+    src
+    └── sub
+        └── file.js
+
+  ❯ cat biome.json
+    {
+      "files": { "ignore": ["./src/sub/"] },
+      "formatter": { "include": ["./src"] }
+    }
+  ```
+
+  Contributed by @Conaclos
+
 - Don't emit verbose warnings when a protected file is ignored.
 
   Some files, such as `package.json` and `tsconfig.json`, are [protected](https://biomejs.dev/guides/how-biome-works/#protected-files).
@@ -27,6 +48,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   Now, it doesn't emit verbose warnings for protected files that are ignored.
 
   Contributed by @Conaclos
+
+- `overrides` no longer affect which files are ignored. Contributed by @Conaclos
 
 - The file `biome.json` can't be ignored anymore. Contributed by @ematipico
 

--- a/crates/biome_cli/tests/cases/included_files.rs
+++ b/crates/biome_cli/tests/cases/included_files.rs
@@ -1,7 +1,7 @@
 use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, assert_file_contents, SnapshotPayload};
 use biome_console::BufferConsole;
-use biome_fs::{FileSystemExt, MemoryFileSystem};
+use biome_fs::MemoryFileSystem;
 use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
@@ -116,42 +116,6 @@ fn does_not_handle_included_files_if_overridden_by_ignore() {
 }
 
 #[test]
-fn does_handle_if_included_in_formatter() {
-    let mut console = BufferConsole::default();
-    let mut fs = MemoryFileSystem::default();
-    let file_path = Path::new("biome.json");
-    fs.insert(
-        file_path.into(),
-        r#"{
-  "files": { "ignore": ["test.js"] }, "formatter": { "include": ["test.js"] }
-}
-"#
-        .as_bytes(),
-    );
-
-    let test = Path::new("test.js");
-    fs.insert(test.into(), UNFORMATTED.as_bytes());
-
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("format"), ("--write"), test.as_os_str().to_str().unwrap()].as_slice()),
-    );
-
-    assert!(result.is_ok(), "run_cli returned {result:?}");
-
-    assert_file_contents(&fs, test, FORMATTED);
-
-    assert_cli_snapshot(SnapshotPayload::new(
-        module_path!(),
-        "does_handle_if_included_in_formatter",
-        fs,
-        console,
-        result,
-    ));
-}
-
-#[test]
 fn does_not_handle_included_files_if_overridden_by_ignore_formatter() {
     let mut console = BufferConsole::default();
     let mut fs = MemoryFileSystem::default();
@@ -201,55 +165,6 @@ fn does_not_handle_included_files_if_overridden_by_ignore_formatter() {
 }
 
 #[test]
-fn does_lint_included_files() {
-    let mut fs = MemoryFileSystem::default();
-    let mut console = BufferConsole::default();
-
-    let file_path = Path::new("biome.json");
-    fs.insert(
-        file_path.into(),
-        r#"{
-  "files": { "ignore": ["test.js"] }, "linter": { "include": ["test.js"] }
-}
-"#,
-    );
-
-    let file_path = Path::new("test.js");
-    fs.insert(file_path.into(), FIX_BEFORE.as_bytes());
-
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from(
-            [
-                ("lint"),
-                ("--apply"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
-    );
-
-    assert!(result.is_ok(), "run_cli returned {result:?}");
-
-    let mut buffer = String::new();
-    fs.open(file_path)
-        .unwrap()
-        .read_to_string(&mut buffer)
-        .unwrap();
-
-    assert_eq!(buffer, FIX_AFTER);
-
-    assert_cli_snapshot(SnapshotPayload::new(
-        module_path!(),
-        "does_lint_included_files",
-        fs,
-        console,
-        result,
-    ));
-}
-
-#[test]
 fn does_not_handle_included_files_if_overridden_by_ignore_linter() {
     let mut console = BufferConsole::default();
     let mut fs = MemoryFileSystem::default();
@@ -292,57 +207,6 @@ fn does_not_handle_included_files_if_overridden_by_ignore_linter() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "does_not_handle_included_files_if_overridden_by_ignore_linter",
-        fs,
-        console,
-        result,
-    ));
-}
-
-#[test]
-fn does_organize_imports_of_included_files() {
-    let mut fs = MemoryFileSystem::default();
-    let mut console = BufferConsole::default();
-
-    let file_path = Path::new("biome.json");
-    fs.insert(
-        file_path.into(),
-        r#"{
-  "formatter": { "enabled": false },
-  "linter": { "enabled": false },
-   "files": { "ignore": ["test2.js", "test.js"] }, "organizeImports": { "include": ["test.js"] }
-}
-"#,
-    );
-
-    let test = Path::new("test.js");
-    fs.insert(test.into(), UNORGANIZED.as_bytes());
-
-    let test2 = Path::new("test2.js");
-    fs.insert(test2.into(), UNORGANIZED.as_bytes());
-
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--apply"),
-                test.as_os_str().to_str().unwrap(),
-                test2.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
-    );
-
-    assert!(result.is_ok(), "run_cli returned {result:?}");
-
-    assert_file_contents(&fs, test2, UNORGANIZED);
-
-    assert_file_contents(&fs, test, ORGANIZED);
-
-    assert_cli_snapshot(SnapshotPayload::new(
-        module_path!(),
-        "does_organize_imports_of_included_files",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -1341,54 +1341,6 @@ fn does_not_format_ignored_directories() {
 }
 
 #[test]
-fn does_not_format_non_included_and_ignored_files() {
-    let config = r#"{
-        "files": {
-          "include": ["file1.js", "file2.js", "file3.js"],
-          "ignore": ["file2.js"]
-        },
-        "formatter": {
-          "include": ["file2.js"],
-          "ignore": ["file3.js"]
-        }
-    }"#;
-    let files = [("file1.js", true), ("file2.js", true), ("file3.js", false)];
-
-    let mut console = BufferConsole::default();
-    let mut fs = MemoryFileSystem::default();
-    let file_path = Path::new("biome.json");
-    fs.insert(file_path.into(), config);
-    for (file_path, _) in files {
-        let file_path = Path::new(file_path);
-        fs.insert(file_path.into(), UNFORMATTED.as_bytes());
-    }
-
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("format"), ("."), ("--write")].as_slice()),
-    );
-    assert!(result.is_ok(), "run_cli returned {result:?}");
-
-    for (file_path, expect_formatted) in files {
-        let expected = if expect_formatted {
-            FORMATTED
-        } else {
-            UNFORMATTED
-        };
-        assert_file_contents(&fs, Path::new(file_path), expected);
-    }
-
-    assert_cli_snapshot(SnapshotPayload::new(
-        module_path!(),
-        "does_not_format_non_included_and_ignored_files",
-        fs,
-        console,
-        result,
-    ));
-}
-
-#[test]
 fn does_not_format_ignored_file_in_included_directory() {
     let config = r#"{
         "formatter": {
@@ -1426,6 +1378,63 @@ fn does_not_format_ignored_file_in_included_directory() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "does_not_format_ignored_file_in_included_directory",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn include_ignore_cascade() {
+    // Only `file1.js` will be formatted:
+    // - `file2.js` is ignored at top-level
+    // - `file3.js` is ignored at formatter-level
+    // - `file4.js` is not included at top-level
+    let config = r#"{
+        "files": {
+          "include": ["file1.js", "file2.js", "file3.js"],
+          "ignore": ["file2.js"]
+        },
+        "formatter": {
+          "include": ["file1.js", "file2.js"],
+          "ignore": ["file3.js"]
+        }
+    }"#;
+    let files = [
+        ("file1.js", true),
+        ("file2.js", false),
+        ("file3.js", false),
+        ("file4.js", false),
+    ];
+
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let file_path = Path::new("biome.json");
+    fs.insert(file_path.into(), config);
+    for (file_path, _) in files {
+        let file_path = Path::new(file_path);
+        fs.insert(file_path.into(), UNFORMATTED.as_bytes());
+    }
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), ("."), ("--write")].as_slice()),
+    );
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    for (file_path, expect_formatted) in files {
+        let expected = if expect_formatted {
+            FORMATTED
+        } else {
+            UNFORMATTED
+        };
+        assert_file_contents(&fs, Path::new(file_path), expected);
+    }
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "include_ignore_cascade",
         fs,
         console,
         result,
@@ -1873,6 +1882,118 @@ file2.js
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "ignore_vcs_ignored_file_via_cli",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn include_vcs_ignore_cascade() {
+    // Only `file1.js` will be formatted:
+    // - `file2.js` is ignored at top-level
+    // - `file3.js` is ignored at formatter-level
+    // - `file4.js` is ignored in `.gitignore`
+    let git_ignore = r#"file4.js"#;
+    let config = r#"{
+        "vcs": {
+            "enabled": true,
+            "clientKind": "git",
+            "useIgnoreFile": true
+        },
+        "files": {
+          "ignore": ["file2.js"]
+        },
+        "formatter": {
+          "include": ["file1.js", "file2.js", "file4.js"],
+          "ignore": ["file3.js"]
+        }
+    }"#;
+    let files = [
+        ("file1.js", true),
+        ("file2.js", false),
+        ("file3.js", false),
+        ("file4.js", false),
+    ];
+
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let gitignore_file = Path::new(".gitignore");
+    fs.insert(gitignore_file.into(), git_ignore.as_bytes());
+    let file_path = Path::new("biome.json");
+    fs.insert(file_path.into(), config);
+    for (file_path, _) in files {
+        let file_path = Path::new(file_path);
+        fs.insert(file_path.into(), UNFORMATTED.as_bytes());
+    }
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), ("."), ("--write")].as_slice()),
+    );
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    for (file_path, expect_formatted) in files {
+        let expected = if expect_formatted {
+            FORMATTED
+        } else {
+            UNFORMATTED
+        };
+        assert_file_contents(&fs, Path::new(file_path), expected);
+    }
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "include_vcs_ignore_cascade",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn vcs_absolute_path() {
+    let git_ignore = r#"file.js"#;
+    let config = r#"{
+        "vcs": {
+            "enabled": true,
+            "clientKind": "git",
+            "useIgnoreFile": true
+        }
+    }"#;
+    let files = [("/symbolic/link/to/path.js", true)];
+
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let gitignore_file = Path::new(".gitignore");
+    fs.insert(gitignore_file.into(), git_ignore.as_bytes());
+    let file_path = Path::new("biome.json");
+    fs.insert(file_path.into(), config);
+    for (file_path, _) in files {
+        let file_path = Path::new(file_path);
+        fs.insert(file_path.into(), UNFORMATTED.as_bytes());
+    }
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), ("."), ("--write")].as_slice()),
+    );
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    for (file_path, expect_formatted) in files {
+        let expected = if expect_formatted {
+            FORMATTED
+        } else {
+            UNFORMATTED
+        };
+        assert_file_contents(&fs, Path::new(file_path), expected);
+    }
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "vcs_absolute_path",
         fs,
         console,
         result,
@@ -2520,6 +2641,49 @@ const a = {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "should_apply_different_indent_style",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn override_don_t_affect_ignored_files() {
+    let config = r#"{
+        "overrides": [{
+            "ignore": ["file2.js"]
+        }]
+    }"#;
+    let files = [("file1.js", true), ("file2.js", true)];
+
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let file_path = Path::new("biome.json");
+    fs.insert(file_path.into(), config);
+    for (file_path, _) in files {
+        let file_path = Path::new(file_path);
+        fs.insert(file_path.into(), UNFORMATTED.as_bytes());
+    }
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), ("."), ("--write")].as_slice()),
+    );
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    for (file_path, expect_formatted) in files {
+        let expected = if expect_formatted {
+            FORMATTED
+        } else {
+            UNFORMATTED
+        };
+        assert_file_contents(&fs, Path::new(file_path), expected);
+    }
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "override_don_t_affect_ignored_files",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_commands_format/include_ignore_cascade.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/include_ignore_cascade.snap
@@ -1,0 +1,51 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "files": {
+    "include": ["file1.js", "file2.js", "file3.js"],
+    "ignore": ["file2.js"]
+  },
+  "formatter": {
+    "include": ["file1.js", "file2.js"],
+    "ignore": ["file3.js"]
+  }
+}
+```
+
+## `file1.js`
+
+```js
+statement();
+
+```
+
+## `file2.js`
+
+```js
+  statement(  )  
+```
+
+## `file3.js`
+
+```js
+  statement(  )  
+```
+
+## `file4.js`
+
+```js
+  statement(  )  
+```
+
+# Emitted Messages
+
+```block
+Formatted 2 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_format/include_vcs_ignore_cascade.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/include_vcs_ignore_cascade.snap
@@ -1,0 +1,61 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignore": ["file2.js"]
+  },
+  "formatter": {
+    "include": ["file1.js", "file2.js", "file4.js"],
+    "ignore": ["file3.js"]
+  }
+}
+```
+
+## `.gitignore`
+
+```gitignore
+file4.js
+```
+
+## `file1.js`
+
+```js
+statement();
+
+```
+
+## `file2.js`
+
+```js
+  statement(  )  
+```
+
+## `file3.js`
+
+```js
+  statement(  )  
+```
+
+## `file4.js`
+
+```js
+  statement(  )  
+```
+
+# Emitted Messages
+
+```block
+Formatted 2 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_format/override_don_t_affect_ignored_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/override_don_t_affect_ignored_files.snap
@@ -1,0 +1,37 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "overrides": [
+    {
+      "ignore": ["file2.js"]
+    }
+  ]
+}
+```
+
+## `file1.js`
+
+```js
+statement();
+
+```
+
+## `file2.js`
+
+```js
+statement();
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 3 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_format/vcs_absolute_path.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/vcs_absolute_path.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  }
+}
+```
+
+## `.gitignore`
+
+```gitignore
+file.js
+```
+
+## `/symbolic/link/to/path.js`
+
+```js
+statement();
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 2 file(s) in <TIME>
+```
+
+

--- a/crates/biome_service/src/configuration/formatter.rs
+++ b/crates/biome_service/src/configuration/formatter.rs
@@ -98,8 +98,8 @@ impl FromStr for FormatterConfiguration {
 pub fn to_format_settings(
     working_directory: Option<PathBuf>,
     conf: FormatterConfiguration,
-    vcs_path: Option<PathBuf>,
-    gitignore_matches: &[String],
+    _vcs_path: Option<PathBuf>,
+    _gitignore_matches: &[String],
 ) -> Result<FormatSettings, WorkspaceError> {
     let indent_style = match conf.indent_style {
         Some(PlainIndentStyle::Tab) => IndentStyle::Tab,
@@ -119,18 +119,8 @@ pub fn to_format_settings(
         line_ending: conf.line_ending,
         line_width: conf.line_width,
         format_with_errors: conf.format_with_errors.unwrap_or_default(),
-        ignored_files: to_matcher(
-            working_directory.clone(),
-            conf.ignore.as_ref(),
-            vcs_path.clone(),
-            gitignore_matches,
-        )?,
-        included_files: to_matcher(
-            working_directory,
-            conf.include.as_ref(),
-            vcs_path,
-            gitignore_matches,
-        )?,
+        ignored_files: to_matcher(working_directory.clone(), conf.ignore.as_ref(), None, &[])?,
+        included_files: to_matcher(working_directory, conf.include.as_ref(), None, &[])?,
     })
 }
 

--- a/crates/biome_service/src/configuration/linter/mod.rs
+++ b/crates/biome_service/src/configuration/linter/mod.rs
@@ -64,24 +64,14 @@ impl Default for LinterConfiguration {
 pub fn to_linter_settings(
     working_directory: Option<PathBuf>,
     conf: LinterConfiguration,
-    vcs_path: Option<PathBuf>,
-    gitignore_matches: &[String],
+    _vcs_path: Option<PathBuf>,
+    _gitignore_matches: &[String],
 ) -> Result<LinterSettings, WorkspaceError> {
     Ok(LinterSettings {
         enabled: conf.enabled.unwrap_or_default(),
         rules: conf.rules,
-        ignored_files: to_matcher(
-            working_directory.clone(),
-            conf.ignore.as_ref(),
-            vcs_path.clone(),
-            gitignore_matches,
-        )?,
-        included_files: to_matcher(
-            working_directory.clone(),
-            conf.include.as_ref(),
-            vcs_path,
-            gitignore_matches,
-        )?,
+        ignored_files: to_matcher(working_directory.clone(), conf.ignore.as_ref(), None, &[])?,
+        included_files: to_matcher(working_directory.clone(), conf.include.as_ref(), None, &[])?,
     })
 }
 

--- a/crates/biome_service/src/configuration/organize_imports.rs
+++ b/crates/biome_service/src/configuration/organize_imports.rs
@@ -52,22 +52,22 @@ impl OrganizeImports {
 pub fn to_organize_imports_settings(
     working_directory: Option<PathBuf>,
     organize_imports: OrganizeImports,
-    vcs_base_path: Option<PathBuf>,
-    gitignore_matches: &[String],
+    _vcs_base_path: Option<PathBuf>,
+    _gitignore_matches: &[String],
 ) -> Result<OrganizeImportsSettings, WorkspaceError> {
     Ok(OrganizeImportsSettings {
         enabled: organize_imports.enabled.unwrap_or_default(),
         ignored_files: to_matcher(
             working_directory.clone(),
             organize_imports.ignore.as_ref(),
-            vcs_base_path.clone(),
-            gitignore_matches,
+            None,
+            &[],
         )?,
         included_files: to_matcher(
             working_directory,
             organize_imports.include.as_ref(),
-            vcs_base_path,
-            gitignore_matches,
+            None,
+            &[],
         )?,
     })
 }

--- a/crates/biome_service/src/configuration/overrides.rs
+++ b/crates/biome_service/src/configuration/overrides.rs
@@ -158,8 +158,8 @@ pub struct OverrideOrganizeImportsConfiguration {
 pub fn to_override_settings(
     working_directory: Option<PathBuf>,
     overrides: Overrides,
-    vcs_base_path: Option<PathBuf>,
-    gitignore_matches: &[String],
+    _vcs_base_path: Option<PathBuf>,
+    _gitignore_matches: &[String],
     current_settings: &WorkspaceSettings,
 ) -> Result<OverrideSettings, WorkspaceError> {
     let mut override_settings = OverrideSettings::default();
@@ -188,14 +188,14 @@ pub fn to_override_settings(
             include: to_matcher(
                 working_directory.clone(),
                 pattern.include.as_ref(),
-                vcs_base_path.clone(),
-                gitignore_matches,
+                None,
+                &[],
             )?,
             exclude: to_matcher(
                 working_directory.clone(),
                 pattern.ignore.as_ref(),
-                vcs_base_path.clone(),
-                gitignore_matches,
+                None,
+                &[],
             )?,
             formatter,
             linter,

--- a/crates/biome_service/src/matcher/mod.rs
+++ b/crates/biome_service/src/matcher/mod.rs
@@ -161,22 +161,22 @@ impl Matcher {
             }
         }
 
-        if let Some(source_as_string) = source.to_str() {
-            if self
-                .git_ignore
-                .as_ref()
-                .map(|ignore| {
+        self.git_ignore
+            .as_ref()
+            .map(|ignore| {
+                // `matched_path_or_any_parents` panics if `source` is not under the gitignore root.
+                // This checks excludes absolute paths that are not a prefix of the base root.
+                if !source.has_root() || source.starts_with(ignore.path()) {
+                    // Because Biome passes a list of paths,
+                    // we use `matched_path_or_any_parents` instead of `matched`.
                     ignore
-                        .matched_path_or_any_parents(source_as_string, source.is_dir())
+                        .matched_path_or_any_parents(source, source.is_dir())
                         .is_ignore()
-                })
-                .unwrap_or_default()
-            {
-                return true;
-            }
-        }
-
-        false
+                } else {
+                    false
+                }
+            })
+            .unwrap_or_default()
     }
 }
 

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -484,9 +484,6 @@ fn to_file_settings(
                 vcs_config_path.clone(),
                 gitignore_matches,
             )?,
-            // Don't set `gitignore` for the include matcher.
-            // TODO: it could better to create dedicated matcher types:
-            // one for ignore and the other for include.
             included_files: to_matcher(working_directory, config.include.as_ref(), None, &[])?,
             ignore_unknown: config.ignore_unknown.unwrap_or_default(),
         })

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -24,6 +24,27 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 - Fix [#1512](https://github.com/biomejs/biome/issues/1512) by skipping verbose diagnostics from the count. Contributed by @ematipico
 
+- Correctly handle cascading `include` and `ignore`.
+
+  Previously Biome incorrectly included files that were included at tool level and ignored at global level.
+  In the following example, `file.js' was formatted when it should have been ignored.
+  Now, Biome correctly ignores the directory `./src/sub/`.
+
+  ```shell
+  ❯ tree src
+    src
+    └── sub
+        └── file.js
+
+  ❯ cat biome.json
+    {
+      "files": { "ignore": ["./src/sub/"] },
+      "formatter": { "include": ["./src"] }
+    }
+  ```
+
+  Contributed by @Conaclos
+
 - Don't emit verbose warnings when a protected file is ignored.
 
   Some files, such as `package.json` and `tsconfig.json`, are [protected](https://biomejs.dev/guides/how-biome-works/#protected-files).
@@ -33,6 +54,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   Now, it doesn't emit verbose warnings for protected files that are ignored.
 
   Contributed by @Conaclos
+
+- `overrides` no longer affect which files are ignored. Contributed by @Conaclos
 
 - The file `biome.json` can't be ignored anymore. Contributed by @ematipico
 


### PR DESCRIPTION
## Summary

- `overrides` no longer affect which files got ignored
- Reverse application order of `include`/`ignore`.
  First apply global `include`/`ignore`, then tools' `include`/`ignore`

## Test Plan

- [x] Manual tests
- [x] I added new tests 
