### PR TITLE
fix(js_formatter): fix invalid formatting of nested multiline comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Formatter
 
+#### Bug fixed
+
+- Fix [#1571](https://github.com/biomejs/biome/issues/1571). Fix invalid formatting of nested multiline comments. Contributed by @ah-yu
+
 ### JavaScript APIs
 
 ### Linter

--- a/crates/biome_js_formatter/src/comments.rs
+++ b/crates/biome_js_formatter/src/comments.rs
@@ -47,21 +47,22 @@ impl FormatRule<SourceComment<JsLanguage>> for FormatJsLeadingComment {
             // Indent the remaining lines by one space so that all `*` are aligned.
             write!(
                 f,
-                [align(
-                    1,
-                    &format_once(|f| {
-                        for line in lines {
-                            write!(
-                                f,
-                                [hard_line_break(), dynamic_text(line.trim(), source_offset)]
-                            )?;
+                [&format_once(|f| {
+                    for line in lines {
+                        write!(
+                            f,
+                            [
+                                hard_line_break(),
+                                text(" "),
+                                dynamic_text(line.trim(), source_offset)
+                            ]
+                        )?;
 
-                            source_offset += line.text_len();
-                        }
+                        source_offset += line.text_len();
+                    }
 
-                        Ok(())
-                    })
-                )]
+                    Ok(())
+                })]
             )
         } else {
             write!(f, [comment.piece().as_piece()])

--- a/crates/biome_js_formatter/tests/specs/js/module/comments/nested_comments/nested_comments.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/comments/nested_comments/nested_comments.js
@@ -1,0 +1,8 @@
+condition ? {
+    a: 'a'
+} : {
+    /**
+    * comment
+    */
+    b: 'b'
+}

--- a/crates/biome_js_formatter/tests/specs/js/module/comments/nested_comments/nested_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/comments/nested_comments/nested_comments.js.snap
@@ -1,0 +1,84 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/comments/nested_comments/nested_comments.js
+---
+
+# Input
+
+```js
+condition ? {
+    a: 'a'
+} : {
+    /**
+    * comment
+    */
+    b: 'b'
+}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+-----
+
+```js
+condition
+	? {
+			a: "a",
+	  }
+	: {
+			/**
+			 * comment
+			 */
+			b: "b",
+	  };
+```
+
+## Output 2
+
+-----
+Indent style: Space
+Indent width: 4
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+-----
+
+```js
+condition
+    ? {
+          a: "a",
+      }
+    : {
+          /**
+           * comment
+           */
+          b: "b",
+      };
+```
+
+

--- a/crates/biome_js_formatter/tests/specs/js/module/comments/nested_comments/options.json
+++ b/crates/biome_js_formatter/tests/specs/js/module/comments/nested_comments/options.json
@@ -1,0 +1,8 @@
+{
+	"cases": [
+		{
+			"indent_style": "Space",
+			"indent_width": 4
+		}
+	]
+}

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -26,6 +26,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Formatter
 
+#### Bug fixed
+
+- Fix [#1571](https://github.com/biomejs/biome/issues/1571). Fix invalid formatting of nested multiline comments. Contributed by @ah-yu
+
 ### JavaScript APIs
 
 ### Linter


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/1571

The potential cause of the incorrect formatting of nested multiline comments may stem from nesting `Align`s. 
```
 align(2, [
    "{",
    group(expand: true, [
      indent([
        soft_line_break_or_space,
        group(expand: propagated, [
          "/**",
          align(1, [
            hard_line_break,
            "* blah",
            hard_line_break,
            "*/"
          ]),
          hard_line_break,
          "id: string"
        ]),
        if_group_breaks([";"])
      ]),
      soft_line_break_or_space
    ]),
    "}"
  ]),
  soft_line_break_or_space,
  "| ",
  align(2, ["boolean"])
])
```
Referencing the comment https://github.com/biomejs/biome/blob/1c91b03b2c3d0cf76da40d9b5f36a4d2d38ef7f2/crates/biome_formatter/src/format_element/tag.rs#L19 it provides an explanation of how nesting Align functions. In the reported issue, Transforming `Align(2) Indent Align(1)` to `Indent Indent Align(1)` results in an invalid formatting.

To address this, we can follow the approach used by `Prettier` and use `text(" ")` instead of `Align(1, ...)`.

## Test Plan

Add a new test case