### PR TITLE
docs(website): add third-party tool in continuous integration section

### DIFF
--- a/website/src/content/docs/recipes/continuous-integration.mdx
+++ b/website/src/content/docs/recipes/continuous-integration.mdx
@@ -30,3 +30,27 @@ jobs:
       - name: Run Biome
         run: biome ci .
 ```
+
+### Third-party actions
+
+These are actions maintained by other communities, that you use in your runner:
+
+- [reviewdog-action-biome](https://github.com/marketplace/actions/run-biome-with-reviewdog): run Biome with reviewdog and make comments and commit suggestions on the pull request. 
+
+```yaml title="pull_request.yml"
+name: reviewdog
+on: [pull_request]
+jobs:
+  biome:
+    name: runner / Biome
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mongolyy/reviewdog-action-biome@v0
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+```


### PR DESCRIPTION
## Summary

I have created github actions that work with [reviewdog](https://github.com/reviewdog/reviewdog) to utilize the pull request commenting and commit suggestion functionality.

https://github.com/marketplace/actions/run-biome-with-reviewdog
https://github.com/mongolyy/reviewdog-action-biome

I believe this action will improve the usability of the combination of biome and github actions.

## Test Plan

Check the [deployment preview](https://deploy-preview-1585--biomejs.netlify.app/recipes/continuous-integration/).