### PR TITLE
fix(lsp): register formatter dynamically if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### LSP
 
+#### Bug fixes
+
 - Fix [#1584](https://github.com/biomejs/biome/issues/1584). Ensure the LSP only registers the formatter once. Contributed by @nhedger
 
 ### Configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### CLI
 
+### LSP
+
+- Fix [#1584](https://github.com/biomejs/biome/issues/1584). Ensure the LSP only registers the formatter once. Contributed by @nhedger
+
 ### Configuration
 
 ### Editors

--- a/crates/biome_lsp/src/capabilities.rs
+++ b/crates/biome_lsp/src/capabilities.rs
@@ -13,21 +13,42 @@ pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCa
         .as_ref()
         .and_then(|text_document| text_document.formatting.as_ref())
         .and_then(|formatting| formatting.dynamic_registration)
-        .unwrap_or(false);
+        .map(|supported| {
+            if supported {
+                None
+            } else {
+                Some(OneOf::Left(true))
+            }
+        });
 
     let supports_range_formatter_dynamic_registration = capabilities
         .text_document
         .as_ref()
         .and_then(|text_document| text_document.range_formatting.as_ref())
         .and_then(|range_formatting| range_formatting.dynamic_registration)
-        .unwrap_or(false);
+        .map(|supported| {
+            if supported {
+                None
+            } else {
+                Some(OneOf::Left(true))
+            }
+        });
 
     let supports_on_type_formatter_dynamic_registration = capabilities
         .text_document
         .as_ref()
         .and_then(|text_document| text_document.on_type_formatting.as_ref())
         .and_then(|on_type_formatting| on_type_formatting.dynamic_registration)
-        .unwrap_or(false);
+        .map(|supported| {
+            if supported {
+                None
+            } else {
+                Some(DocumentOnTypeFormattingOptions {
+                    first_trigger_character: String::from("}"),
+                    more_trigger_character: Some(vec![String::from("]"), String::from(")")]),
+                })
+            }
+        });
 
     ServerCapabilities {
         position_encoding: Some(match negotiated_encoding(capabilities) {
@@ -40,24 +61,10 @@ pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCa
         text_document_sync: Some(TextDocumentSyncCapability::Kind(
             TextDocumentSyncKind::INCREMENTAL,
         )),
-        document_formatting_provider: if supports_formatter_dynamic_registration {
-            None
-        } else {
-            Some(OneOf::Left(true))
-        },
-        document_range_formatting_provider: if supports_range_formatter_dynamic_registration {
-            None
-        } else {
-            Some(OneOf::Left(true))
-        },
-        document_on_type_formatting_provider: if supports_on_type_formatter_dynamic_registration {
-            None
-        } else {
-            Some(DocumentOnTypeFormattingOptions {
-                first_trigger_character: String::from("}"),
-                more_trigger_character: Some(vec![String::from("]"), String::from(")")]),
-            })
-        },
+        document_formatting_provider: supports_formatter_dynamic_registration.unwrap(),
+        document_range_formatting_provider: supports_range_formatter_dynamic_registration.unwrap(),
+        document_on_type_formatting_provider: supports_on_type_formatter_dynamic_registration
+            .unwrap(),
         code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
         rename_provider: None,
         ..Default::default()

--- a/crates/biome_lsp/src/capabilities.rs
+++ b/crates/biome_lsp/src/capabilities.rs
@@ -13,7 +13,7 @@ pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCa
         .as_ref()
         .and_then(|text_document| text_document.formatting.as_ref())
         .and_then(|formatting| formatting.dynamic_registration)
-        .map(|supported| {
+        .and_then(|supported| {
             if supported {
                 None
             } else {
@@ -26,7 +26,7 @@ pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCa
         .as_ref()
         .and_then(|text_document| text_document.range_formatting.as_ref())
         .and_then(|range_formatting| range_formatting.dynamic_registration)
-        .map(|supported| {
+        .and_then(|supported| {
             if supported {
                 None
             } else {
@@ -39,7 +39,7 @@ pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCa
         .as_ref()
         .and_then(|text_document| text_document.on_type_formatting.as_ref())
         .and_then(|on_type_formatting| on_type_formatting.dynamic_registration)
-        .map(|supported| {
+        .and_then(|supported| {
             if supported {
                 None
             } else {
@@ -61,10 +61,9 @@ pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCa
         text_document_sync: Some(TextDocumentSyncCapability::Kind(
             TextDocumentSyncKind::INCREMENTAL,
         )),
-        document_formatting_provider: supports_formatter_dynamic_registration.unwrap(),
-        document_range_formatting_provider: supports_range_formatter_dynamic_registration.unwrap(),
-        document_on_type_formatting_provider: supports_on_type_formatter_dynamic_registration
-            .unwrap(),
+        document_formatting_provider: supports_formatter_dynamic_registration,
+        document_range_formatting_provider: supports_range_formatter_dynamic_registration,
+        document_on_type_formatting_provider: supports_on_type_formatter_dynamic_registration,
         code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
         rename_provider: None,
         ..Default::default()

--- a/crates/biome_lsp/src/capabilities.rs
+++ b/crates/biome_lsp/src/capabilities.rs
@@ -8,21 +8,21 @@ use tower_lsp::lsp_types::{
 ///
 /// [`InitializeResult`]: lspower::lsp::InitializeResult
 pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCapabilities {
-    let supports_formatting_dynamic_registration = capabilities
+    let supports_formatter_dynamic_registration = capabilities
         .text_document
         .as_ref()
         .and_then(|text_document| text_document.formatting.as_ref())
         .and_then(|formatting| formatting.dynamic_registration)
         .unwrap_or(false);
 
-    let supports_range_formatting_dynamic_registration = capabilities
+    let supports_range_formatter_dynamic_registration = capabilities
         .text_document
         .as_ref()
         .and_then(|text_document| text_document.range_formatting.as_ref())
         .and_then(|range_formatting| range_formatting.dynamic_registration)
         .unwrap_or(false);
 
-    let supports_on_type_formatting_dynamic_registration = capabilities
+    let supports_on_type_formatter_dynamic_registration = capabilities
         .text_document
         .as_ref()
         .and_then(|text_document| text_document.on_type_formatting.as_ref())
@@ -40,17 +40,17 @@ pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCa
         text_document_sync: Some(TextDocumentSyncCapability::Kind(
             TextDocumentSyncKind::INCREMENTAL,
         )),
-        document_formatting_provider: if supports_formatting_dynamic_registration {
+        document_formatting_provider: if supports_formatter_dynamic_registration {
             None
         } else {
             Some(OneOf::Left(true))
         },
-        document_range_formatting_provider: if supports_range_formatting_dynamic_registration {
+        document_range_formatting_provider: if supports_range_formatter_dynamic_registration {
             None
         } else {
             Some(OneOf::Left(true))
         },
-        document_on_type_formatting_provider: if supports_on_type_formatting_dynamic_registration {
+        document_on_type_formatting_provider: if supports_on_type_formatter_dynamic_registration {
             None
         } else {
             Some(DocumentOnTypeFormattingOptions {

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -20,6 +20,12 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### CLI
 
+### LSP
+
+#### Bug fixes
+
+- Fix [#1584](https://github.com/biomejs/biome/issues/1584). Ensure the LSP only registers the formatter once. Contributed by @nhedger
+
 ### Configuration
 
 ### Editors


### PR DESCRIPTION
## Summary

This PR changes the way the formatting providers are registered by the LSP to prevent registering a formatter twice.

### The problem

Some LSP clients do not support dynamic registration for formatting providers, so in PR #1042 , we explicitly enabled static registration of the formatters. Unfortunately, this caused clients that support dynamic registration to show two formatters (the statically registered one, and the dynamically registered one).

### The solution

This PR adds logic to detect whether the clients supports dynamic registration of formatters, and skips the static registration when they do.

## Test Plan

- Ensure only one formatter is registered in VS Code's `Format Document with...` menu.

Fixes #1584 
