### PR TITLE
fix(docs): fix `biome_formatter::comments::following_token` example in rustdoc

### DIFF
--- a/crates/biome_formatter/src/comments.rs
+++ b/crates/biome_formatter/src/comments.rs
@@ -447,7 +447,7 @@ impl<L: Language> DecoratedComment<L> {
     /// and the token.
     ///
     /// ```ignore
-    /// a /* comment */ /* other b */
+    /// a /* comment */ /* other */ b
     /// ```
     ///
     /// The `following_token` for both comments is `b` because it's the token coming after the comments.


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Discussed in discord: https://discord.com/channels/1132231889290285117/1132602615570649110/1197890329559445587 but the existing example incorrectly has `b` inside the comment, and claims it is the next token.

## Test Plan

N/A
