### PR TITLE
fix(linter): correctly override linter presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Configuration
 
+#### Bug fixes
+
+- Override correctly the recommended preset ([#1349](https://github.com/biomejs/biome/issues/1349)).
+
+  Previously, if unspecified, Biome turned on the recommended preset in overrides.
+  This resulted in reporting diagnostics with a severity level set to `off`.
+  This in turn caused Biome to fail.
+
+  Now Biome won't switch on the recommended preset in `overrides` unless told to do so.
+
+  Contributed by @Conaclos
+
 ### Editors
 
 ### Formatter

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_merge_all_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_merge_all_overrides.snap
@@ -1,0 +1,59 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "suspicious": {
+        "noDebugger": "error"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "include": ["*.js"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noDebugger": "warn"
+          }
+        }
+      }
+    },
+    {
+      "include": ["test.js"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noDebugger": "off"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+## `test.js`
+
+```js
+debugger
+```
+
+## `test2.js`
+
+```js
+
+```
+
+# Emitted Messages
+
+```block
+Fixed 3 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_override_groupe_recommended.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_override_groupe_recommended.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "suspicious": {
+        "recommended": true
+      }
+    }
+  },
+  "overrides": [
+    {
+      "include": ["test.js"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "recommended": false
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+## `test.js`
+
+```js
+debugger
+```
+
+## `test2.js`
+
+```js
+
+```
+
+# Emitted Messages
+
+```block
+Fixed 3 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_override_recommended.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_override_recommended.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "recommended": true
+    }
+  },
+  "overrides": [
+    {
+      "include": ["test.js"],
+      "linter": {
+        "rules": {
+          "recommended": false
+        }
+      }
+    }
+  ]
+}
+```
+
+## `test.js`
+
+```js
+debugger
+```
+
+## `test2.js`
+
+```js
+
+```
+
+# Emitted Messages
+
+```block
+Fixed 3 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_preserve_group_recommended_when_override_global_recommened.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_preserve_group_recommended_when_override_global_recommened.snap
@@ -1,0 +1,47 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "suspicious": {
+        "recommended": false
+      }
+    }
+  },
+  "overrides": [
+    {
+      "include": ["test.js"],
+      "linter": {
+        "rules": {
+          "recommended": true
+        }
+      }
+    }
+  ]
+}
+```
+
+## `test.js`
+
+```js
+debugger
+```
+
+## `test2.js`
+
+```js
+debugger
+```
+
+# Emitted Messages
+
+```block
+Fixed 3 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_preserve_individually_diabled_rules_in_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_preserve_individually_diabled_rules_in_overrides.snap
@@ -1,0 +1,47 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "suspicious": {
+        "noDebugger": "off"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "include": ["test.js"],
+      "linter": {
+        "rules": {
+          "suspicious": {}
+        }
+      }
+    }
+  ]
+}
+```
+
+## `test.js`
+
+```js
+debugger
+```
+
+## `test2.js`
+
+```js
+debugger
+```
+
+# Emitted Messages
+
+```block
+Fixed 3 file(s) in <TIME>
+```
+
+

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -352,35 +352,6 @@ impl Rules {
         }
         enabled_rules.difference(&disabled_rules).copied().collect()
     }
-    #[doc = r" It returns only the disabled rules"]
-    pub fn as_disabled_rules(&self) -> IndexSet<RuleFilter> {
-        let mut disabled_rules = IndexSet::new();
-        if let Some(group) = self.a11y.as_ref() {
-            disabled_rules.extend(&group.get_disabled_rules());
-        }
-        if let Some(group) = self.complexity.as_ref() {
-            disabled_rules.extend(&group.get_disabled_rules());
-        }
-        if let Some(group) = self.correctness.as_ref() {
-            disabled_rules.extend(&group.get_disabled_rules());
-        }
-        if let Some(group) = self.nursery.as_ref() {
-            disabled_rules.extend(&group.get_disabled_rules());
-        }
-        if let Some(group) = self.performance.as_ref() {
-            disabled_rules.extend(&group.get_disabled_rules());
-        }
-        if let Some(group) = self.security.as_ref() {
-            disabled_rules.extend(&group.get_disabled_rules());
-        }
-        if let Some(group) = self.style.as_ref() {
-            disabled_rules.extend(&group.get_disabled_rules());
-        }
-        if let Some(group) = self.suspicious.as_ref() {
-            disabled_rules.extend(&group.get_disabled_rules());
-        }
-        disabled_rules
-    }
 }
 #[derive(
     Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, NoneState, PartialEq, Serialize,

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -30,6 +30,18 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Configuration
 
+#### Bug fixes
+
+- Override correctly the recommended preset ([#1349](https://github.com/biomejs/biome/issues/1349)).
+
+  Previously, if unspecified, Biome turned on the recommended preset in overrides.
+  This resulted in reporting diagnostics with a severity level set to `off`.
+  This in turn caused Biome to fail.
+
+  Now Biome won't switch on the recommended preset in `overrides` unless told to do so.
+
+  Contributed by @Conaclos
+
 ### Editors
 
 ### Formatter

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -70,7 +70,6 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
     let mut line_groups = Vec::new();
     let mut default_for_groups = Vec::new();
     let mut group_as_default_rules = Vec::new();
-    let mut group_as_disabled_rules = Vec::new();
     let mut group_match_code = Vec::new();
     let mut group_get_severity = Vec::new();
     let mut group_name_list = vec!["recommended", "all"];
@@ -109,12 +108,6 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
                 disabled_rules.extend(#group_struct_name::all_rules_as_filters());
             } else if #global_recommended {
                 enabled_rules.extend(#group_struct_name::recommended_rules_as_filters());
-            }
-        });
-
-        group_as_disabled_rules.push(quote! {
-            if let Some(group) = self.#property_group_name.as_ref() {
-                disabled_rules.extend(&group.get_disabled_rules());
             }
         });
 
@@ -264,14 +257,6 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
                 #( #group_as_default_rules )*
 
                 enabled_rules.difference(&disabled_rules).copied().collect()
-            }
-
-            /// It returns only the disabled rules
-            pub fn as_disabled_rules(&self) -> IndexSet<RuleFilter> {
-                let mut disabled_rules = IndexSet::new();
-                #( #group_as_disabled_rules )*
-
-                disabled_rules
             }
         }
 


### PR DESCRIPTION
## Summary

Fix #1349

The issue was coming from the default value of `recommended` that resulted in adding disabled rules in the rule's filter.
I solved the issue by first merging config with overrides before extracting the enabled rules.
This makes the code simpler and more robust because we reuse the config merge logic.

To reduce the potential cost of cloning the config for every file, I used `Cow`. Thus, the config is only cloned when a file has at least one override.

- [x] Add tests
- [x] Add Changelog entry

<!-- ## Test Plan -->
