### PR TITLE
fix(website): rules sources page link

### DIFF
--- a/website/src/content/docs/linter/index.mdx
+++ b/website/src/content/docs/linter/index.mdx
@@ -180,4 +180,4 @@ When they do _accept_ some, you can pass them by shaping the value of the rule d
 
 ## Migrating from other linters
 
-Many of Biome lint rules are inspired from other linters. If you want to migrate from other linters such as ESLint or `typescript-eslint`, check the [rule sources page](/linter/rule)
+Many of Biome lint rules are inspired from other linters. If you want to migrate from other linters such as ESLint or `typescript-eslint`, check the [rules sources page](/linter/rules-sources)


### PR DESCRIPTION
## Summary

- rule sources page -> rules sources page
- /linter/rule -> /linter/rules-sources
