### PR TITLE
fix(linter): useEnumInitializers action with comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   ```
   Contributed by @DaniGuardiola
 
+#### Bug fixes
+
+- Fix [#1640](https://github.com/biomejs/biome/issues/1640). [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers) code action now generates valid code when last member has a comment but no comma. Contributed by @kalleep
+
 ### Parser
 
 ## 1.5.3 (2024-01-22)

--- a/crates/biome_js_analyze/src/analyzers/style/use_enum_initializers.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_enum_initializers.rs
@@ -1,5 +1,3 @@
-use std::i64;
-
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};

--- a/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid.ts
@@ -65,3 +65,10 @@ export enum RgbColor3 {
 	Green = GREEN,
 	Blue,
 }
+
+// https://github.com/biomejs/biome/issues/1640
+export enum WithComment {
+  First = 1, // Comment1
+  Second, // Comment2
+  Third // Comment3
+}

--- a/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid.ts.snap
@@ -72,6 +72,13 @@ export enum RgbColor3 {
 	Blue,
 }
 
+// https://github.com/biomejs/biome/issues/1640
+export enum WithComment {
+  First = 1, // Comment1
+  Second, // Comment2
+  Third // Comment3
+}
+
 ```
 
 # Diagnostics
@@ -112,7 +119,7 @@ invalid.ts:1:13 lint/style/useEnumInitializers  FIXABLE  ━━━━━━━�
      3  3 │   	MidClose = 1,
      4  4 │   	MidOpen = 10,
      5    │ - → /*·implicit·*/·Open·/*·11·*/,
-        5 │ + → /*·implicit·*/·Open·/*·11·*/·=·11,
+        5 │ + → /*·implicit·*/·Open·=·11·/*·11·*/,
      6  6 │   }
      7  7 │   
   
@@ -448,6 +455,51 @@ invalid.ts:63:13 lint/style/useEnumInitializers  FIXABLE  ━━━━━━━�
   
     64 │ → Red·=·0,
        │      ++++ 
+
+```
+
+```
+invalid.ts:70:13 lint/style/useEnumInitializers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This enum declaration contains members that are implicitly initialized.
+  
+    69 │ // https://github.com/biomejs/biome/issues/1640
+  > 70 │ export enum WithComment {
+       │             ^^^^^^^^^^^
+    71 │   First = 1, // Comment1
+    72 │   Second, // Comment2
+  
+  i This enum member should be explicitly initialized.
+  
+    70 │ export enum WithComment {
+    71 │   First = 1, // Comment1
+  > 72 │   Second, // Comment2
+       │   ^^^^^^
+    73 │   Third // Comment3
+    74 │ }
+  
+  i This enum member should be explicitly initialized.
+  
+    71 │   First = 1, // Comment1
+    72 │   Second, // Comment2
+  > 73 │   Third // Comment3
+       │   ^^^^^
+    74 │ }
+    75 │ 
+  
+  i Allowing implicit initializations for enum members can cause bugs if enum declarations are modified over time.
+  
+  i Safe fix: Initialize all enum members.
+  
+    70 70 │   export enum WithComment {
+    71 71 │     First = 1, // Comment1
+    72    │ - ··Second,·//·Comment2
+    73    │ - ··Third·//·Comment3
+       72 │ + ··Second·=·2,·//·Comment2
+       73 │ + ··Third·=·3·//·Comment3
+    74 74 │   }
+    75 75 │   
+  
 
 ```
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -70,6 +70,10 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   ```
   Contributed by @DaniGuardiola
 
+#### Bug fixes
+
+- Fix [#1640](https://github.com/biomejs/biome/issues/1640). [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers) code action now generates valid code when last member has a comment but no comma. Contributed by @kalleep
+
 ### Parser
 
 ## 1.5.3 (2024-01-22)


### PR DESCRIPTION
## Summary
Code action suggested by useEnumInitializers suggests [invalid code](https://biomejs.dev/playground/?code=ZQBuAHUAbQAgAFQAZQBzAHQAIAB7AAoAIAAgAE8AbgBlACAAPQAgADEALAAKACAAIABUAHcAbwAgAC8ALwAgAEMAcgBpAHQAaQBjAGEAbAAgAGUAcgByAG8AcgAsACAAcAByAGUAdgBlAG4AdABzACAAZABlAHYAIABhAG4AZAAgAHAAcgBvAGQAdQBjAHQAaQBvAG4ACgB9AA%3D%3D) if last member has a comment an no comma.


## Test Plan
Added new test case
