### PR TITLE
fix(website): json option key typo

### DIFF
--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -917,7 +917,7 @@ You can enable parsing features for certain JSON files:
       "json": {
         "parser": {
           "allowComments": true,
-          "allowTrailingComma": true
+          "allowTrailingCommas": true
         }
       }
     }

--- a/website/src/content/docs/zh-cn/reference/configuration.mdx
+++ b/website/src/content/docs/zh-cn/reference/configuration.mdx
@@ -801,7 +801,7 @@ JSON (和其超级语言) 文件的行结束类型。
       "json": {
         "parser": {
           "allowComments": true,
-          "allowTrailingComma": true
+          "allowTrailingCommas": true
         }
       }
     }


### PR DESCRIPTION
## Summary

`allowTrailingComma` -> `allowTrailingCommas`

----

Also, I have a question. Why use the singular form `trailingComma` in `javascript.formatter`, but plural form `semicolons`?
