### PR TITLE
chore(linter): reduce string allocations

### DIFF
--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_sorted_classes.rs
@@ -13,6 +13,7 @@ use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make::{js_string_literal, js_string_literal_expression, jsx_string};
 use biome_rowan::{AstNode, BatchMutationExt};
+use lazy_static::lazy_static;
 
 use crate::JsRuleAction;
 
@@ -141,6 +142,13 @@ declare_rule! {
     }
 }
 
+lazy_static! {
+    static ref SORT_CONFIG: SortConfig = SortConfig::new(
+        get_utilities_preset(&UseSortedClassesPreset::default()),
+        Vec::new(),
+    );
+}
+
 impl Rule for UseSortedClasses {
     type Query = AnyClassStringLike;
     type State = String;
@@ -151,15 +159,11 @@ impl Rule for UseSortedClasses {
         // TODO: unsure if options are needed here. The sort config should ideally be created once
         // from the options and then reused for all queries.
         // let options = &ctx.options();
-        // TODO: the sort config should already exist at this point, and be generated from the options,
-        // including the preset and extended options as well.
-        let sort_config = SortConfig::new(
-            get_utilities_preset(&UseSortedClassesPreset::default()),
-            Vec::new(),
-        );
 
         let value = ctx.query().value()?;
-        let sorted_value = sort_class_name(&value, &sort_config);
+        // TODO: the sort config should already exist at this point, and be generated from the options,
+        // including the preset and extended options as well.
+        let sorted_value = sort_class_name(&value, &SORT_CONFIG);
         if value.text() != sorted_value {
             Some(sorted_value)
         } else {

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_sorted_classes/class_info.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_sorted_classes/class_info.rs
@@ -174,7 +174,7 @@ mod get_utility_info_tests {
             arbitrary: false,
         };
         assert_eq!(
-            get_utility_info(&utility_config.as_slice(), &utility_data),
+            get_utility_info(utility_config.as_slice(), &utility_data),
             Some(UtilityInfo {
                 layer: "layer",
                 index: 0,
@@ -185,7 +185,7 @@ mod get_utility_info_tests {
             arbitrary: false,
         };
         assert_eq!(
-            get_utility_info(&utility_config.as_slice(), &utility_data),
+            get_utility_info(utility_config.as_slice(), &utility_data),
             None
         );
     }
@@ -201,7 +201,7 @@ mod get_utility_info_tests {
             arbitrary: false,
         };
         assert_eq!(
-            get_utility_info(&utility_config.as_slice(), &utility_data),
+            get_utility_info(utility_config.as_slice(), &utility_data),
             Some(UtilityInfo {
                 layer: "layer",
                 index: 0,
@@ -212,7 +212,7 @@ mod get_utility_info_tests {
             arbitrary: false,
         };
         assert_eq!(
-            get_utility_info(&utility_config.as_slice(), &utility_data),
+            get_utility_info(utility_config.as_slice(), &utility_data),
             None
         );
     }
@@ -247,7 +247,7 @@ mod get_utility_info_tests {
             arbitrary: false,
         };
         assert_eq!(
-            get_utility_info(&utility_config.as_slice(), &utility_data),
+            get_utility_info(utility_config.as_slice(), &utility_data),
             Some(UtilityInfo {
                 layer: "layer",
                 index: 0,
@@ -266,7 +266,7 @@ mod get_utility_info_tests {
             arbitrary: true,
         };
         assert_eq!(
-            get_utility_info(&utility_config.as_slice(), &utility_data),
+            get_utility_info(utility_config.as_slice(), &utility_data),
             Some(UtilityInfo {
                 layer: "arbitrary",
                 index: 0,
@@ -295,7 +295,7 @@ pub struct ClassInfo {
 /// it is considered a custom class instead and `None` is returned.
 pub fn get_class_info(class_name: &str, sort_config: &SortConfig) -> Option<ClassInfo> {
     let utility_data = tokenize_class(class_name)?;
-    let utility_info = get_utility_info(&sort_config.utilities, &utility_data.utility);
+    let utility_info = get_utility_info(sort_config.utilities, &utility_data.utility);
     if let Some(utility_info) = utility_info {
         return Some(ClassInfo {
             text: class_name.to_string(),

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_sorted_classes/presets.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_sorted_classes/presets.rs
@@ -591,24 +591,20 @@ const UTILITIES_LAYER_CLASSES: [&str; 567] = [
 ];
 // TAILWIND-UTILITIES-LAYER-CLASSES-END
 
+const TAILWIND_LAYERS: [UtilityLayer; 2] = [
+    UtilityLayer {
+        name: "components",
+        classes: UTILITIES_COMPONENTS_CLASSES.as_slice(),
+    },
+    UtilityLayer {
+        name: "utilities",
+        classes: UTILITIES_LAYER_CLASSES.as_slice(),
+    },
+];
+
 pub fn get_utilities_preset(preset: &UseSortedClassesPreset) -> UtilitiesConfig {
     match preset {
-        UseSortedClassesPreset::None => {
-            vec![]
-        }
-        UseSortedClassesPreset::TailwindCSS => {
-            // TAILWIND-UTILITIES-PRESET-START
-            vec![
-                UtilityLayer {
-                    name: String::from("components"),
-                    classes: UTILITIES_COMPONENTS_CLASSES.as_slice(),
-                },
-                UtilityLayer {
-                    name: String::from("utilities"),
-                    classes: UTILITIES_LAYER_CLASSES.as_slice(),
-                },
-            ]
-            // TAILWIND-UTILITIES-PRESET-END
-        }
+        UseSortedClassesPreset::None => [].as_slice(),
+        UseSortedClassesPreset::TailwindCSS => TAILWIND_LAYERS.as_slice(),
     }
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_sorted_classes/sort_config.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_sorted_classes/sort_config.rs
@@ -9,34 +9,34 @@ use std::collections::HashMap;
 
 /// A utility layer, containing its name and an ordered list of classes.
 pub struct UtilityLayer {
-    pub name: String,
+    pub name: &'static str,
     pub classes: &'static [&'static str],
 }
 
 /// The utilities config, contains an ordered list of utility layers.
-pub type UtilitiesConfig = Vec<UtilityLayer>;
+pub type UtilitiesConfig = &'static [UtilityLayer];
 
 /// The variants config, contains an ordered list of variants.
 pub type VariantsConfig = Vec<String>;
 
 /// The sort config, containing the utility config and the variant config.
 pub struct SortConfig {
-    pub utilities: UtilitiesConfig,
+    pub utilities: &'static [UtilityLayer],
     pub variants: VariantsConfig,
-    pub layer_index_map: HashMap<String, usize>,
+    pub layer_index_map: HashMap<&'static str, usize>,
 }
 
 impl SortConfig {
     /// Creates a new sort config.
-    pub fn new(utilities_config: UtilitiesConfig, variants: VariantsConfig) -> Self {
+    pub fn new(utilities_config: &'static [UtilityLayer], variants: VariantsConfig) -> Self {
         // Compute the layer index map.
-        let mut layer_index_map: HashMap<String, usize> = HashMap::new();
+        let mut layer_index_map: HashMap<&'static str, usize> = HashMap::new();
         let mut index = 0;
         for layer in utilities_config.iter() {
-            layer_index_map.insert(layer.name.clone(), index);
+            layer_index_map.insert(layer.name, index);
             index += 1;
         }
-        layer_index_map.insert("arbitrary".to_string(), index);
+        layer_index_map.insert("arbitrary", index);
 
         Self {
             utilities: utilities_config,


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Since we don't have a structured way to pass the options, I decided to use `lazy_static` to reduce the allocation of strings. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

CI should pass, hopefully some gain in the analyzer. 

<!-- What demonstrates that your implementation is correct? -->
