### PR TITLE
docs(website): update third-party tool version in continuous integration section

### DIFF
--- a/website/src/content/docs/recipes/continuous-integration.mdx
+++ b/website/src/content/docs/recipes/continuous-integration.mdx
@@ -35,7 +35,7 @@ jobs:
 
 These are actions maintained by other communities, that you use in your runner:
 
-- [reviewdog-action-biome](https://github.com/marketplace/actions/run-biome-with-reviewdog): run Biome with reviewdog and make comments and commit suggestions on the pull request. 
+- [reviewdog-action-biome](https://github.com/marketplace/actions/run-biome-with-reviewdog): run Biome with reviewdog and make comments and commit suggestions on the pull request.
 
 ```yaml title="pull_request.yml"
 name: reviewdog
@@ -49,7 +49,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: mongolyy/reviewdog-action-biome@v0
+      - uses: mongolyy/reviewdog-action-biome@v1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review


### PR DESCRIPTION
## Summary

I forgot that the version of github action was up when I created the #1585 pull request.

I will follow this.

## Test Plan

Check the deployment preview.
