### PR TITLE
fix(cli): use biome instead of rome on pipe

### DIFF
--- a/crates/biome_cli/src/service/windows.rs
+++ b/crates/biome_cli/src/service/windows.rs
@@ -24,7 +24,7 @@ use tracing::Instrument;
 /// Returns the name of the global named pipe used to communicate with the
 /// server daemon
 fn get_pipe_name() -> String {
-    format!(r"\\.\pipe\rome-service-{}", biome_service::VERSION)
+    format!(r"\\.\pipe\biome-service-{}", biome_service::VERSION)
 }
 
 pub(crate) fn enumerate_pipes() -> io::Result<impl Iterator<Item = String>> {


### PR DESCRIPTION
## Summary

Renaming to avoid confusions on output of lsp.