### PR TITLE
refactor(biome_service): move gitignore from matcher to files settings

### DIFF
--- a/crates/biome_service/src/configuration/formatter.rs
+++ b/crates/biome_service/src/configuration/formatter.rs
@@ -102,8 +102,6 @@ impl FromStr for FormatterConfiguration {
 pub fn to_format_settings(
     working_directory: Option<PathBuf>,
     conf: FormatterConfiguration,
-    _vcs_path: Option<PathBuf>,
-    _gitignore_matches: &[String],
 ) -> Result<FormatSettings, WorkspaceError> {
     let indent_style = match conf.indent_style {
         Some(PlainIndentStyle::Tab) => IndentStyle::Tab,
@@ -123,8 +121,8 @@ pub fn to_format_settings(
         line_ending: conf.line_ending,
         line_width: conf.line_width,
         format_with_errors: conf.format_with_errors.unwrap_or_default(),
-        ignored_files: to_matcher(working_directory.clone(), conf.ignore.as_ref(), None, &[])?,
-        included_files: to_matcher(working_directory, conf.include.as_ref(), None, &[])?,
+        ignored_files: to_matcher(working_directory.clone(), conf.ignore.as_ref())?,
+        included_files: to_matcher(working_directory, conf.include.as_ref())?,
     })
 }
 

--- a/crates/biome_service/src/configuration/linter/mod.rs
+++ b/crates/biome_service/src/configuration/linter/mod.rs
@@ -69,14 +69,12 @@ impl Default for LinterConfiguration {
 pub fn to_linter_settings(
     working_directory: Option<PathBuf>,
     conf: LinterConfiguration,
-    _vcs_path: Option<PathBuf>,
-    _gitignore_matches: &[String],
 ) -> Result<LinterSettings, WorkspaceError> {
     Ok(LinterSettings {
         enabled: conf.enabled.unwrap_or_default(),
         rules: conf.rules,
-        ignored_files: to_matcher(working_directory.clone(), conf.ignore.as_ref(), None, &[])?,
-        included_files: to_matcher(working_directory.clone(), conf.include.as_ref(), None, &[])?,
+        ignored_files: to_matcher(working_directory.clone(), conf.ignore.as_ref())?,
+        included_files: to_matcher(working_directory.clone(), conf.include.as_ref())?,
     })
 }
 

--- a/crates/biome_service/src/configuration/organize_imports.rs
+++ b/crates/biome_service/src/configuration/organize_imports.rs
@@ -55,23 +55,11 @@ impl OrganizeImports {
 pub fn to_organize_imports_settings(
     working_directory: Option<PathBuf>,
     organize_imports: OrganizeImports,
-    _vcs_base_path: Option<PathBuf>,
-    _gitignore_matches: &[String],
 ) -> Result<OrganizeImportsSettings, WorkspaceError> {
     Ok(OrganizeImportsSettings {
         enabled: organize_imports.enabled.unwrap_or_default(),
-        ignored_files: to_matcher(
-            working_directory.clone(),
-            organize_imports.ignore.as_ref(),
-            None,
-            &[],
-        )?,
-        included_files: to_matcher(
-            working_directory,
-            organize_imports.include.as_ref(),
-            None,
-            &[],
-        )?,
+        ignored_files: to_matcher(working_directory.clone(), organize_imports.ignore.as_ref())?,
+        included_files: to_matcher(working_directory, organize_imports.include.as_ref())?,
     })
 }
 

--- a/crates/biome_service/src/configuration/overrides.rs
+++ b/crates/biome_service/src/configuration/overrides.rs
@@ -169,8 +169,6 @@ pub struct OverrideOrganizeImportsConfiguration {
 pub fn to_override_settings(
     working_directory: Option<PathBuf>,
     overrides: Overrides,
-    _vcs_base_path: Option<PathBuf>,
-    _gitignore_matches: &[String],
     current_settings: &WorkspaceSettings,
 ) -> Result<OverrideSettings, WorkspaceError> {
     let mut override_settings = OverrideSettings::default();
@@ -196,18 +194,8 @@ pub fn to_override_settings(
         languages.css = to_css_language_settings(css, &current_settings.languages.css);
 
         let pattern_setting = OverrideSettingPattern {
-            include: to_matcher(
-                working_directory.clone(),
-                pattern.include.as_ref(),
-                None,
-                &[],
-            )?,
-            exclude: to_matcher(
-                working_directory.clone(),
-                pattern.ignore.as_ref(),
-                None,
-                &[],
-            )?,
+            include: to_matcher(working_directory.clone(), pattern.include.as_ref())?,
+            exclude: to_matcher(working_directory.clone(), pattern.ignore.as_ref())?,
             formatter,
             linter,
             organize_imports,


### PR DESCRIPTION
## Summary

Move gitignore state to the files settings.
This avoids paying the cost of gitignore for every matcher.
