### PR TITLE
fix(cli): check for ignored dir and symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Bug fixes
 
+- Don't process files under an ignored directory.
+
+  Previously, Biome processed all files in the traversed hierarchy,
+  even the files under an ignored directory.
+  Now, it completly skip the content of ignored directories.
+
 - Fix [#1508](https://github.com/biomejs/biome/issues/1508) by excluding deleted files from being processed. Contributed by @ematipico
 
 - Fix [#1173](https://github.com/biomejs/biome/issues/1173). Fix the formatting of a single instruction with commented in a control flow body to ensure consistency. Contributed by @mdm317

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -632,7 +632,13 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
     }
 
     fn can_handle(&self, rome_path: &RomePath) -> bool {
-        if rome_path.is_dir() || rome_path.is_symlink() {
+        if !self.fs.path_is_file(rome_path.as_path()) {
+            // handle:
+            // - directories
+            // - symlinks
+            // - unresolved symlinks
+            //   e.g `symlink/subdir` where symlink points to a directory that includes `subdir`.
+            //   Note that `symlink/subdir` is not an existing file.
             let can_handle = !self
                 .workspace
                 .is_path_ignored(IsPathIgnoredParams {

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -632,7 +632,7 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
     }
 
     fn can_handle(&self, rome_path: &RomePath) -> bool {
-        if rome_path.is_dir() {
+        if rome_path.is_dir() || rome_path.is_symlink() {
             let can_handle = !self
                 .workspace
                 .is_path_ignored(IsPathIgnoredParams {

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -990,6 +990,7 @@ fn fs_error_unknown() {
 // │   └── test.js  // ok
 // └── src
 //     ├── symlink_testcase1_1 -> hidden_nested
+//     ├── symlink_testcase1_3 -> hidden_testcase1/test/test.js
 //     └── symlink_testcase2 -> hidden_testcase2
 #[test]
 #[ignore = "It regresses on linux since we added the ignore crate, to understand why"]

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/fs_files_ignore_symlink.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/fs_files_ignore_symlink.snap
@@ -13,7 +13,7 @@ rome.json internalError/fs ━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Fixed 4 file(s) in <TIME>
+Fixed 2 file(s) in <TIME>
 ```
 
 

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -43,6 +43,9 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
     /// Checks if the given path exists in the file system
     fn path_exists(&self, path: &Path) -> bool;
 
+    /// Checks if the given path is a regular file
+    fn path_is_file(&self, path: &Path) -> bool;
+
     /// Method that takes a path to a folder `file_path`, and a `file_name`. It attempts to find
     /// and read the file from that folder and if not found, it reads the parent directories recursively
     /// until:
@@ -292,6 +295,10 @@ where
 
     fn path_exists(&self, path: &Path) -> bool {
         T::path_exists(self, path)
+    }
+
+    fn path_is_file(&self, path: &Path) -> bool {
+        T::path_is_file(self, path)
     }
 
     fn get_changed_files(&self, base: &str) -> io::Result<Vec<String>> {

--- a/crates/biome_fs/src/fs/memory.rs
+++ b/crates/biome_fs/src/fs/memory.rs
@@ -180,6 +180,10 @@ impl FileSystem for MemoryFileSystem {
     }
 
     fn path_exists(&self, path: &Path) -> bool {
+        self.path_is_file(path)
+    }
+
+    fn path_is_file(&self, path: &Path) -> bool {
         let files = self.files.0.read();
         files.get(path).is_some()
     }

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -54,6 +54,10 @@ impl FileSystem for OsFileSystem {
         path.exists()
     }
 
+    fn path_is_file(&self, path: &Path) -> bool {
+        path.is_file()
+    }
+
     fn get_changed_files(&self, base: &str) -> io::Result<Vec<String>> {
         let output = Command::new("git")
             .arg("diff")
@@ -131,8 +135,8 @@ impl<'scope> OsTraversalScope<'scope> {
 }
 
 impl<'scope> TraversalScope<'scope> for OsTraversalScope<'scope> {
-    fn spawn(&self, ctx: &'scope dyn TraversalContext, mut path: PathBuf) {
-        let mut file_type = match path.metadata() {
+    fn spawn(&self, ctx: &'scope dyn TraversalContext, path: PathBuf) {
+        let file_type = match path.metadata() {
             Ok(meta) => meta.file_type(),
             Err(err) => {
                 ctx.push_diagnostic(
@@ -141,44 +145,7 @@ impl<'scope> TraversalScope<'scope> for OsTraversalScope<'scope> {
                 return;
             }
         };
-
-        if file_type.is_symlink() {
-            if !ctx.can_handle(&RomePath::new(path.clone())) {
-                return;
-            }
-            let Ok((target_path, target_file_type)) = expand_symbolic_link(path, ctx) else {
-                return;
-            };
-
-            path = target_path;
-            file_type = target_file_type;
-        }
-
-        let _ = ctx.interner().intern_path(path.clone());
-
-        if file_type.is_dir() {
-            if ctx.can_handle(&RomePath::new(path.clone())) {
-                self.scope.spawn(move |scope| {
-                    handle_dir(scope, ctx, &path, None);
-                });
-            }
-            return;
-        }
-
-        if file_type.is_file() {
-            if ctx.can_handle(&RomePath::new(path.clone())) {
-                self.scope.spawn(move |_| {
-                    ctx.handle_file(&path);
-                });
-            }
-            return;
-        }
-
-        ctx.push_diagnostic(Error::from(FileSystemDiagnostic {
-            path: path.to_string_lossy().to_string(),
-            error_kind: ErrorKind::from(file_type),
-            severity: Severity::Warning,
-        }));
+        handle_any_file(&self.scope, ctx, path, file_type, None);
     }
 }
 
@@ -225,11 +192,10 @@ fn handle_dir_entry<'scope>(
     ctx: &'scope dyn TraversalContext,
     entry: DirEntry,
     // The unresolved origin path in case the directory is behind a symbolic link
-    mut origin_path: Option<PathBuf>,
+    origin_path: Option<PathBuf>,
 ) {
-    let mut path = entry.path();
-
-    let mut file_type = match entry.file_type() {
+    let path = entry.path();
+    let file_type = match entry.file_type() {
         Ok(file_type) => file_type,
         Err(err) => {
             ctx.push_diagnostic(
@@ -238,7 +204,17 @@ fn handle_dir_entry<'scope>(
             return;
         }
     };
+    handle_any_file(scope, ctx, path, file_type, origin_path);
+}
 
+fn handle_any_file<'scope>(
+    scope: &Scope<'scope>,
+    ctx: &'scope dyn TraversalContext,
+    mut path: PathBuf,
+    mut file_type: FileType,
+    // The unresolved origin path in case the directory is behind a symbolic link
+    mut origin_path: Option<PathBuf>,
+) {
     if file_type.is_symlink() {
         if !ctx.can_handle(&RomePath::new(path.clone())) {
             return;
@@ -257,52 +233,58 @@ fn handle_dir_entry<'scope>(
     }
 
     let inserted = ctx.interner().intern_path(path.clone());
-
     if !inserted {
         // If the path was already inserted, it could have been pointed at by
         // multiple symlinks. No need to traverse again.
         return;
     }
 
-    if file_type.is_dir() {
-        if ctx.can_handle(&RomePath::new(path.clone())) {
-            scope.spawn(move |scope| {
-                handle_dir(scope, ctx, &path, origin_path);
-            });
+    // In case the file is inside a directory that is behind a symbolic link,
+    // the unresolved origin path is used to construct a new path.
+    // This is required to support ignore patterns to symbolic links.
+    let rome_path = if let Some(origin_path) = &origin_path {
+        if let Some(file_name) = path.file_name() {
+            RomePath::new(origin_path.join(file_name))
+        } else {
+            ctx.push_diagnostic(Error::from(FileSystemDiagnostic {
+                path: path.to_string_lossy().to_string(),
+                error_kind: ErrorKind::UnknownFileType,
+                severity: Severity::Warning,
+            }));
+            return;
         }
+    } else {
+        RomePath::new(&path)
+    };
+
+    // Performing this check here let's us skip unsupported
+    // files entirely, as well as silently ignore unsupported files when
+    // doing a directory traversal, but printing an error message if the
+    // user explicitly requests an unsupported file to be handled.
+    // This check also works for symbolic links.
+    if !ctx.can_handle(&rome_path) {
+        return;
+    }
+
+    if file_type.is_dir() {
+        scope.spawn(move |scope| {
+            handle_dir(scope, ctx, &path, origin_path);
+        });
         return;
     }
 
     if file_type.is_file() {
-        // In case the file is inside a directory that is behind a symbolic link,
-        // the unresolved origin path is used to construct a new path.
-        // This is required to support ignore patterns to symbolic links.
-        let rome_path = if let Some(origin_path) = origin_path {
-            if let Some(file_name) = path.file_name() {
-                RomePath::new(origin_path.join(file_name))
-            } else {
-                ctx.push_diagnostic(Error::from(FileSystemDiagnostic {
-                    path: path.to_string_lossy().to_string(),
-                    error_kind: ErrorKind::UnknownFileType,
-                    severity: Severity::Warning,
-                }));
-                return;
-            }
-        } else {
-            RomePath::new(&path)
-        };
-
-        // Performing this check here let's us skip skip unsupported
-        // files entirely, as well as silently ignore unsupported files when
-        // doing a directory traversal, but printing an error message if the
-        // user explicitly requests an unsupported file to be handled.
-        // This check also works for symbolic links.
-        if ctx.can_handle(&rome_path) {
-            scope.spawn(move |_| {
-                ctx.handle_file(&path);
-            });
-        }
+        scope.spawn(move |_| {
+            ctx.handle_file(&path);
+        });
+        return;
     }
+
+    ctx.push_diagnostic(Error::from(FileSystemDiagnostic {
+        path: path.to_string_lossy().to_string(),
+        error_kind: ErrorKind::from(file_type),
+        severity: Severity::Warning,
+    }));
 }
 
 /// Indicates a symbolic link could not be expanded.

--- a/crates/biome_fs/src/path.rs
+++ b/crates/biome_fs/src/path.rs
@@ -1,6 +1,6 @@
 //! This module is responsible to manage paths inside Biome.
 //! It is a small wrapper around [path::PathBuf] but it is also able to
-//! give additional information around the the file that holds:
+//! give additional information around the file that holds:
 //! - the [FileHandlers] for the specific file
 //! - shortcuts to open/write to the file
 use std::fs::read_to_string;

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -22,6 +22,12 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Bug fixes
 
+- Don't process files under an ignored directory.
+
+  Previously, Biome processed all files in the traversed hierarchy,
+  even the files under an ignored directory.
+  Now, it completly skip the content of ignored directories.
+
 - Fix [#1508](https://github.com/biomejs/biome/issues/1508) by excluding deleted files from being processed. Contributed by @ematipico
 
 - Fix [#1173](https://github.com/biomejs/biome/issues/1173). Fix the formatting of a single instruction with commented in a control flow body to ensure consistency. Contributed by @mdm317


### PR DESCRIPTION
## Summary

Check for ignored directories and symlinks.
This fixes the [bug reported by Jarred](https://twitter.com/jarredsumner/status/1750706365516177414).

This also fixes a snapshot where two files under a symlinked and ignored directory were not ignored, because `can_handle` handled wrongly symlinks. 

- [x] Manual tests
- [x] Updated snapshots