### PR TITLE
fix(js_formatter): fix formatting of multi-line member chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   s(/🚀🚀/).s().s();
   ```
 
+- Fix [#1218](https://github.com/biomejs/biome/issues/1218). Fix invalid formatting of multiline member chain. Contributed by @ah-yu
+
 ### JavaScript APIs
 
 ### Linter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   s(/🚀🚀/).s().s();
   ```
 
-- Fix [#1218](https://github.com/biomejs/biome/issues/1218). Fix invalid formatting of multiline member chain. Contributed by @ah-yu
+- Fix [#1218](https://github.com/biomejs/biome/issues/1218), by correctly preserving empty lines in member chains. Contributed by @ah-yu
 
 ### JavaScript APIs
 

--- a/crates/biome_js_formatter/src/utils/member_chain/chain_member.rs
+++ b/crates/biome_js_formatter/src/utils/member_chain/chain_member.rs
@@ -83,40 +83,10 @@ impl ChainMember {
     pub const fn is_computed_expression(&self) -> bool {
         matches!(self, ChainMember::ComputedMember { .. })
     }
-
-    pub(super) fn needs_empty_line_before(&self) -> bool {
-        match self {
-            ChainMember::StaticMember { expression } => {
-                let operator = expression.operator_token();
-
-                match operator {
-                    Ok(operator) => get_lines_before_token(&operator) > 1,
-                    _ => false,
-                }
-            }
-            ChainMember::ComputedMember { expression } => {
-                let l_brack_token = expression.l_brack_token();
-
-                match l_brack_token {
-                    Ok(l_brack_token) => {
-                        get_lines_before_token(
-                            &expression.optional_chain_token().unwrap_or(l_brack_token),
-                        ) > 1
-                    }
-                    _ => false,
-                }
-            }
-            _ => false,
-        }
-    }
 }
 
 impl Format<JsFormatContext> for ChainMember {
     fn fmt(&self, f: &mut JsFormatter) -> FormatResult<()> {
-        if self.needs_empty_line_before() {
-            write!(f, [empty_line()])?;
-        }
-
         match self {
             ChainMember::StaticMember { expression } => {
                 let JsStaticMemberExpressionFields {

--- a/crates/biome_js_formatter/src/utils/member_chain/groups.rs
+++ b/crates/biome_js_formatter/src/utils/member_chain/groups.rs
@@ -220,6 +220,33 @@ impl MemberChainGroup {
             }
         })
     }
+
+    pub(super) fn needs_empty_line_before(&self) -> bool {
+        let first = self.members.first();
+        first.map_or(false, |first| match first {
+            ChainMember::StaticMember { expression } => {
+                let operator = expression.operator_token();
+
+                match operator {
+                    Ok(operator) => get_lines_before_token(&operator) > 1,
+                    _ => false,
+                }
+            }
+            ChainMember::ComputedMember { expression } => {
+                let l_brack_token = expression.l_brack_token();
+
+                match l_brack_token {
+                    Ok(l_brack_token) => {
+                        get_lines_before_token(
+                            &expression.optional_chain_token().unwrap_or(l_brack_token),
+                        ) > 1
+                    }
+                    _ => false,
+                }
+            }
+            _ => false,
+        })
+    }
 }
 
 impl From<Vec<ChainMember>> for MemberChainGroup {

--- a/crates/biome_js_formatter/src/utils/member_chain/mod.rs
+++ b/crates/biome_js_formatter/src/utils/member_chain/mod.rs
@@ -302,8 +302,7 @@ impl MemberChain {
             .tail
             .iter()
             .skip(1)
-            .find(|group| group.needs_empty_line_before())
-            .is_some();
+            .any(|group| group.needs_empty_line_before());
 
         if has_empty_line_inside_tail {
             return Ok(true);

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/multi_line.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/multi_line.js
@@ -1,0 +1,73 @@
+// These should all collapse
+foo
+    .bar
+
+    .baz;
+foo
+    .bar
+
+    .baz
+
+    .bar()
+foo
+
+    .bar()
+
+    .baz;
+foo
+
+    .bar[1]
+
+    .baz();
+foo
+
+    .bar().baz
+
+    .bar();
+foo.bar
+
+    .baz()
+    .bar
+
+    .baz();
+foo
+
+[1]
+
+    .bar();
+foo
+
+    .bar
+
+[1]
+
+    .bar();
+
+// These should all preserve empty lines in some way
+foo.bar()
+
+    .baz();
+foo.bar()
+
+    .baz.bar();
+foo
+
+    .bar()
+
+    .baz();
+
+foo
+
+    .bar.what().foo
+    .what()
+
+    .baz();
+foo.bar
+
+    .baz()
+
+    .bar
+    .baz()
+
+    .foo();
+

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/multi_line.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/multi_line.js.snap
@@ -1,0 +1,147 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/expression/member-chain/multi_line.js
+---
+
+# Input
+
+```js
+// These should all collapse
+foo
+    .bar
+
+    .baz;
+foo
+    .bar
+
+    .baz
+
+    .bar()
+foo
+
+    .bar()
+
+    .baz;
+foo
+
+    .bar[1]
+
+    .baz();
+foo
+
+    .bar().baz
+
+    .bar();
+foo.bar
+
+    .baz()
+    .bar
+
+    .baz();
+foo
+
+[1]
+
+    .bar();
+foo
+
+    .bar
+
+[1]
+
+    .bar();
+
+// These should all preserve empty lines in some way
+foo.bar()
+
+    .baz();
+foo.bar()
+
+    .baz.bar();
+foo
+
+    .bar()
+
+    .baz();
+
+foo
+
+    .bar.what().foo
+    .what()
+
+    .baz();
+foo.bar
+
+    .baz()
+
+    .bar
+    .baz()
+
+    .foo();
+
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+-----
+
+```js
+// These should all collapse
+foo.bar.baz;
+foo.bar.baz.bar();
+foo.bar().baz;
+foo.bar[1].baz();
+foo.bar().baz.bar();
+foo.bar.baz().bar.baz();
+foo[1].bar();
+foo.bar[1].bar();
+
+// These should all preserve empty lines in some way
+foo
+	.bar()
+
+	.baz();
+foo
+	.bar()
+
+	.baz.bar();
+foo
+
+	.bar()
+
+	.baz();
+
+foo.bar
+	.what()
+	.foo.what()
+
+	.baz();
+foo.bar
+
+	.baz()
+
+	.bar.baz()
+
+	.foo();
+```
+
+

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -52,7 +52,7 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   s(/🚀🚀/).s().s();
   ```
 
-- Fix [#1218](https://github.com/biomejs/biome/issues/1218). Fix invalid formatting of multiline member chain. Contributed by @ah-yu
+- Fix [#1218](https://github.com/biomejs/biome/issues/1218), by correctly preserving empty lines in member chains. Contributed by @ah-yu
 
 ### JavaScript APIs
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -52,6 +52,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   s(/🚀🚀/).s().s();
   ```
 
+- Fix [#1218](https://github.com/biomejs/biome/issues/1218). Fix invalid formatting of multiline member chain. Contributed by @ah-yu
+
 ### JavaScript APIs
 
 ### Linter


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/1218

When formatting a member chain, the chain is split into several groups, each containing multiple members. However, there is a distinction in the logic of preserving empty lines. Biome preserves empty lines at the member level regardless of whether they are in the same group, whereas Prettier preserves empty lines at the group level, meaning it only preserves empty lines between groups.

Consider the following case:
```js
foo

.bar()

.baz

.qux()
```
Here, there are three groups: `foo`, `bar()`, and `baz.qux()`. Biome preserves the empty lines between `baz` and `qux`:
```js
foo

  .bar()

  .baz

  .qux();
```
On the other hand, Prettier only preserves empty lines between groups:
```js
foo

  .bar()

  .baz.qux();
```
To address this specific issue, we can adopt the approach used by Prettier.
## Test Plan
Thank you for the test cases provided by @faultyserver in https://github.com/biomejs/biome/issues/1218#issuecomment-1859034478, we can use these test cases for validation.
<!-- What demonstrates that your implementation is correct? -->
