### PR TITLE
docs(website): fix formatter configuration to website page

### DIFF
--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -455,18 +455,6 @@ How many characters can be written on a single line.
 
 > Default: `80`
 
-### `formatter.bracketSameLine`
-
-Choose whether the ending `>` of a multi-line JSX element should be on the last attribute line or not
-
-> Default: false
-
-### `formatter.bracketSpacing`
-
-Choose whether spaces should be added between brackets and inner values
-
-> Default: true
-
 ## `organizeImports`
 
 ### `organizeImports.enabled`


### PR DESCRIPTION
## Summary

I found a setting that is not used in the formatter configuration. So, I removed the unused settings from the document.

You can refer to this code. [Link source code](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/backend-jsonrpc/src/workspace.ts)
<img width="394" alt="image" src="https://github.com/biomejs/biome/assets/55759551/42cb92f3-66a6-4d7e-b1be-4a382dd39fe2">
According to the types defined here, "bracketSameLine" and "bracketSpacing" are not being used.

