### PR TITLE
refactor(backend-jsonrpc): remove unused types

### DIFF
--- a/packages/@biomejs/backend-jsonrpc/src/index.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/index.ts
@@ -1,11 +1,7 @@
 import { getCommand } from "./command";
 import { createSocket } from "./socket";
 import { Transport } from "./transport";
-import {
-	createWorkspace as wrapTransport,
-	type Workspace,
-	type RomePath,
-} from "./workspace";
+import { type Workspace, createWorkspace as wrapTransport } from "./workspace";
 
 /**
  * Create an instance of the Workspace client connected to a remote daemon


### PR DESCRIPTION
## Summary

'RomePath' type was removed because it was not used in the file.
