### PR TITLE
docs: change 'ecnontrar' to 'encontrar' word in pt-br lang

### DIFF
--- a/website/src/content/docs/pt-br/guides/big-projects.mdx
+++ b/website/src/content/docs/pt-br/guides/big-projects.mdx
@@ -9,7 +9,7 @@ O Biome disponibiliza algumas ferramentas que podem ajudar você a utilizá-lo e
 
 Quando você utiliza o Biome - seja com a CLI ou com o LSP - ele busca o arquivo de configuração mais próximo usando o diretório de trabalho atual.
 
-Se o Biome não encontrar o arquivo de configuração no diretório, ele começa a procurar nos **diretórios pai** até ecnontrar um arquivo de configuração.
+Se o Biome não encontrar o arquivo de configuração no diretório, ele começa a procurar nos **diretórios pai** até encontrar um arquivo de configuração.
 
 Você pode aproveitar essa funcionalidade para aplicar diferentes configuração baseado no projeto/pasta.
 


### PR DESCRIPTION
## Summary

Correction of a spelling mistake in the Portuguese documentation

## Test Plan

To verify the correction, follow these steps:

1. Visit the [Big Projects guide page](https://biomejs.dev/pt-br/guides/big-projects/).
2. Look for the section related to "Usando múltiplos arquivos de configuração".
3. Check for the corrected spelling in the text.
4. Ensure that the corrected word is now spelled correctly and fits contextually.
5. Confirm that the surrounding content and formatting remain unaffected.
6. If applicable, test any links or code snippets in the vicinity of the correction to ensure they still function as intended.

This test plan helps confirm that the spelling correction has been successfully implemented without introducing new issues.

