### PR TITLE
Better diagnostics error when a user tries to format code that has parsing diagnostics.

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_commands_check/apply_bogus_argument.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/apply_bogus_argument.snap
@@ -43,7 +43,7 @@ fix.js lint ━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 fix.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Format with errors is disabled.
+  × Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/parse_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/parse_error.snap
@@ -51,7 +51,7 @@ check.js lint ━━━━━━━━━━━━━━━━━━━━━━
 ```block
 check.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Format with errors is disabled.
+  × Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_parse_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_parse_error.snap
@@ -51,7 +51,7 @@ ci.js lint ━━━━━━━━━━━━━━━━━━━━━━━
 ```block
 ci.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Format with errors is disabled.
+  × Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option.
   
 
 ```

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -389,7 +389,7 @@ pub struct ReportNotSerializable {
 pub struct NotFound;
 
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]
-#[diagnostic(category = "format", message = "Format with errors is disabled.")]
+#[diagnostic(category = "format", message = "Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithError' option.")]
 pub struct FormatWithErrorsDisabled;
 
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -389,7 +389,10 @@ pub struct ReportNotSerializable {
 pub struct NotFound;
 
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]
-#[diagnostic(category = "format", message = "Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option.")]
+#[diagnostic(
+    category = "format",
+    message = "Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option."
+)]
 pub struct FormatWithErrorsDisabled;
 
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -389,7 +389,7 @@ pub struct ReportNotSerializable {
 pub struct NotFound;
 
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]
-#[diagnostic(category = "format", message = "Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithError' option.")]
+#[diagnostic(category = "format", message = "Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option.")]
 pub struct FormatWithErrorsDisabled;
 
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]


### PR DESCRIPTION
This pull request addresses the issue outlined in [#1698](https://github.com/biomejs/biome/issues/1698#issue-2105338537), aiming to enhance the diagnostic message returned to the user when attempting to format code that contains parsing errors. 

Previously, the message was not very informative or actionable, potentially leaving users confused about why their code formatting failed and how they could resolve the issue.

Changes Made:
Updated the FormatWithErrorsDisabled diagnostic message in [biome/crates/biome_service/src/diagnostics.rs](https://github.com/biomejs/biome/blob/13ec78dc3bc4bded1bca8072f9a55a6756f32cf8/crates/biome_service/src/diagnostics.rs#L391-L393) to clearly explain why the formatting operation was aborted and provide users with guidance on how to enable formatting in the presence of parsing errors.

New Diagnostic Message:

```
#[derive(Debug, Serialize, Deserialize, Diagnostic)]
#[diagnostic(
    category = "format",
    message = "Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithError' option."
)]
pub struct FormatWithErrorsDisabled;
```

This pull request seeks to merge these changes into the main branch of the biome project, improving the clarity and usefulness of diagnostics related to formatting code with errors.