### PR TITLE
feat(cli): add prettier migrate sub command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### CLI
 
+#### New features
+
+- Add a new command `biome migrate prettier`. The command will read the file `.prettierrc`/`prettier.json` and `.prettierignore` and map its configuration to Biome's one.
+  Due to the different nature of `.prettierignore` globs and Biome's globs, it's **highly** advised to make sure that those still work under Biome.
+
 #### Bug fixes
 
 - Don't process files under an ignored directory.

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -300,7 +300,7 @@ pub enum MigrateSubCommand {
 }
 
 impl MigrateSubCommand {
-    pub const fn is_prettier(self) -> bool {
+    pub const fn is_prettier(&self) -> bool {
         matches!(self, MigrateSubCommand::Prettier)
     }
 }

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -251,17 +251,15 @@ pub enum BiomeCommand {
     /// It updates the configuration when there are breaking changes
     #[bpaf(command)]
     Migrate {
-        /// It attempts to find the files `.prettierrc`/`prettier.json` and `.prettierignore`, and map
-        /// Prettier's configuration into `biome.json`
-        #[bpaf(long("prettier"), switch, hide, hide_usage)]
-        prettier: bool,
-
         #[bpaf(external, hide_usage)]
         cli_options: CliOptions,
 
         /// Writes the new configuration file to disk
         #[bpaf(long("write"), switch)]
         write: bool,
+
+        #[bpaf(external(migrate_sub_command), optional)]
+        sub_command: Option<MigrateSubCommand>,
     },
 
     /// A command to retrieve the documentation of various aspects of the CLI.
@@ -292,6 +290,19 @@ pub enum BiomeCommand {
     },
     #[bpaf(command("__print_socket"), hide)]
     PrintSocket,
+}
+
+#[derive(Debug, Bpaf, Clone)]
+pub enum MigrateSubCommand {
+    /// It attempts to find the files `.prettierrc`/`prettier.json` and `.prettierignore`, and map the Prettier's configuration into Biome's configuration file.
+    #[bpaf(command)]
+    Prettier,
+}
+
+impl MigrateSubCommand {
+    pub const fn is_prettier(self) -> bool {
+        matches!(self, MigrateSubCommand::Prettier)
+    }
 }
 
 impl BiomeCommand {

--- a/crates/biome_cli/src/execute/migrate.rs
+++ b/crates/biome_cli/src/execute/migrate.rs
@@ -153,6 +153,11 @@ pub(crate) fn run(migrate_payload: MigratePayload) -> Result<(), CliDiagnostic> 
                     console.log(markup!{
                         <Info>"The configuration "<Emphasis>{{configuration_file_path.display().to_string()}}</Emphasis>" has been successfully migrated."</Info>
                     });
+                    if prettier_configuration.has_ignore_file() {
+                        console.log(markup!{
+                            <Warn>"Please make sure that the globs of the "<Emphasis>".prettierignore"</Emphasis>" file still work in Biome. Prettier's globs use git globs, while Biome's globs use uni-style globs. They both seem similar, but their semantics differ."</Warn>
+                        })
+                    }
                 } else {
                     let file_name = configuration_file_path.display().to_string();
                     let diagnostic = MigrateDiffDiagnostic {

--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -271,6 +271,10 @@ impl FromPrettierConfiguration {
         self.formatter_configuration.is_some() || self.javascript_formatter_configuration.is_some()
     }
 
+    pub(crate) fn has_ignore_file(&self) -> bool {
+        self.ignore_path.is_some()
+    }
+
     pub(crate) fn get_configuration_path(&self) -> Option<&Path> {
         self.configuration_path.as_deref()
     }

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -40,7 +40,6 @@ pub use service::{open_transport, SocketTransport};
 
 #[cfg(debug_assertions)]
 pub use crate::commands::daemon::biome_log_dir;
-use crate::commands::MigrateSubCommand;
 
 pub(crate) const VERSION: &str = match option_env!("BIOME_VERSION") {
     Some(version) => version,
@@ -197,7 +196,7 @@ impl<'app> CliSession<'app> {
                 cli_options,
                 write,
                 sub_command
-                    .map(MigrateSubCommand::is_prettier)
+                    .map(|sub_command| sub_command.is_prettier())
                     .unwrap_or_default(),
             ),
             BiomeCommand::RunServer {

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -40,6 +40,7 @@ pub use service::{open_transport, SocketTransport};
 
 #[cfg(debug_assertions)]
 pub use crate::commands::daemon::biome_log_dir;
+use crate::commands::MigrateSubCommand;
 
 pub(crate) const VERSION: &str = match option_env!("BIOME_VERSION") {
     Some(version) => version,
@@ -190,8 +191,15 @@ impl<'app> CliSession<'app> {
             BiomeCommand::Migrate {
                 cli_options,
                 write,
-                prettier,
-            } => commands::migrate::migrate(self, cli_options, write, prettier),
+                sub_command,
+            } => commands::migrate::migrate(
+                self,
+                cli_options,
+                write,
+                sub_command
+                    .map(MigrateSubCommand::is_prettier)
+                    .unwrap_or_default(),
+            ),
             BiomeCommand::RunServer {
                 stop_on_disconnect,
                 config_path,

--- a/crates/biome_cli/tests/commands/migrate.rs
+++ b/crates/biome_cli/tests/commands/migrate.rs
@@ -150,7 +150,7 @@ fn prettier_migrate() {
     let result = run_cli(
         DynRef::Borrowed(&mut fs),
         &mut console,
-        Args::from([("migrate"), "--prettier"].as_slice()),
+        Args::from([("migrate"), "prettier"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -192,7 +192,7 @@ generated/*.spec.js
     let result = run_cli(
         DynRef::Borrowed(&mut fs),
         &mut console,
-        Args::from([("migrate"), "--prettier"].as_slice()),
+        Args::from([("migrate"), "prettier"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -219,7 +219,7 @@ fn prettier_migrate_no_file() {
     let result = run_cli(
         DynRef::Borrowed(&mut fs),
         &mut console,
-        Args::from([("migrate"), "--prettier"].as_slice()),
+        Args::from([("migrate"), "prettier"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -250,7 +250,7 @@ fn prettier_migrate_yml_file() {
     let result = run_cli(
         DynRef::Borrowed(&mut fs),
         &mut console,
-        Args::from([("migrate"), "--prettier"].as_slice()),
+        Args::from([("migrate"), "prettier"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -281,7 +281,7 @@ fn prettier_migrate_write() {
     let result = run_cli(
         DynRef::Borrowed(&mut fs),
         &mut console,
-        Args::from([("migrate"), "--prettier", "--write"].as_slice()),
+        Args::from([("migrate"), "prettier", "--write"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -323,7 +323,7 @@ generated/*.spec.js
     let result = run_cli(
         DynRef::Borrowed(&mut fs),
         &mut console,
-        Args::from([("migrate"), "--prettier", "--write"].as_slice()),
+        Args::from([("migrate"), "prettier", "--write"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
@@ -7,7 +7,7 @@ expression: content
 ```block
 It updates the configuration when there are breaking changes
 
-Usage: migrate [--write]
+Usage: migrate [--write] [COMMAND ...]
 
 Global options applied to all commands
         --colors=<off|force>  Set the formatting mode for markup: "off" prints everything as plain text,
@@ -37,6 +37,10 @@ Global options applied to all commands
 Available options:
         --write               Writes the new configuration file to disk
     -h, --help                Prints help information
+
+Available commands:
+    prettier                  It attempts to find the files `.prettierrc`/`prettier.json` and `.prettierignore`,
+                              and map the Prettier's configuration into Biome's configuration file.
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/prettier_migrate_write_with_ignore_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/prettier_migrate_write_with_ignore_file.snap
@@ -56,4 +56,8 @@ generated/*.spec.js
 The configuration biome.json has been successfully migrated.
 ```
 
+```block
+Please make sure that the globs of the .prettierignore file still work in Biome. Prettier's globs use git globs, while Biome's globs use uni-style globs. They both seem similar, but their semantics differ.
+```
+
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -20,6 +20,11 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### CLI
 
+#### New features
+
+- Add a new command `biome migrate prettier`. The command will read the file `.prettierrc`/`prettier.json` and `.prettierignore` and map its configuration to Biome's one.
+  Due to the different nature of `.prettierignore` globs and Biome's globs, it's **highly** advised to make sure that those still work under Biome.
+
 #### Bug fixes
 
 - Don't process files under an ignored directory.


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR create a new command called `biome migrate prettier`, which essentially runs the migration that I wrote so far :)

Question: should we also do a FS traversal and change `// prettier-ignore` to `// biome-ignore`? While useful, it's **not** that easy to do. Replacing the trivia isn't an easy task.

A user could search and replace very quickly.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Updated the current diagnostics.

<!-- What demonstrates that your implementation is correct? -->
