### PR TITLE
feat(cli): add `--config-path` option to `__print_socket` command

### DIFF
--- a/crates/biome_cli/src/commands/daemon.rs
+++ b/crates/biome_cli/src/commands/daemon.rs
@@ -89,9 +89,9 @@ pub(crate) fn run_server(
     })
 }
 
-pub(crate) fn print_socket() -> Result<(), CliDiagnostic> {
+pub(crate) fn print_socket(config_path: Option<PathBuf>) -> Result<(), CliDiagnostic> {
     let rt = Runtime::new()?;
-    rt.block_on(service::print_socket())?;
+    rt.block_on(service::print_socket(config_path))?;
     Ok(())
 }
 

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -291,7 +291,11 @@ pub enum BiomeCommand {
         config_path: Option<PathBuf>,
     },
     #[bpaf(command("__print_socket"), hide)]
-    PrintSocket,
+    PrintSocket {
+        /// Allows to set a custom path when discovering the configuration file `biome.json`
+        #[bpaf(env("BIOME_CONFIG_PATH"), long("config-path"), argument("PATH"))]
+        config_path: Option<PathBuf>,
+    },
 }
 
 impl BiomeCommand {
@@ -310,7 +314,7 @@ impl BiomeCommand {
             | BiomeCommand::Init
             | BiomeCommand::Explain { .. }
             | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket => None,
+            | BiomeCommand::PrintSocket { .. } => None,
         }
     }
 
@@ -329,7 +333,7 @@ impl BiomeCommand {
             | BiomeCommand::Explain { .. }
             | BiomeCommand::LspProxy(_)
             | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket => false,
+            | BiomeCommand::PrintSocket { .. } => false,
         }
     }
 
@@ -352,7 +356,7 @@ impl BiomeCommand {
             | BiomeCommand::Explain { .. }
             | BiomeCommand::LspProxy(_)
             | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket => false,
+            | BiomeCommand::PrintSocket { .. } => false,
         }
     }
 
@@ -371,7 +375,7 @@ impl BiomeCommand {
             | BiomeCommand::Init
             | BiomeCommand::Explain { .. }
             | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket => LoggingLevel::default(),
+            | BiomeCommand::PrintSocket { .. } => LoggingLevel::default(),
         }
     }
     pub fn log_kind(&self) -> LoggingKind {
@@ -389,7 +393,7 @@ impl BiomeCommand {
             | BiomeCommand::Init
             | BiomeCommand::Explain { .. }
             | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket => LoggingKind::default(),
+            | BiomeCommand::PrintSocket { .. } => LoggingKind::default(),
         }
     }
 }

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -196,7 +196,9 @@ impl<'app> CliSession<'app> {
                 stop_on_disconnect,
                 config_path,
             } => commands::daemon::run_server(stop_on_disconnect, config_path),
-            BiomeCommand::PrintSocket => commands::daemon::print_socket(),
+            BiomeCommand::PrintSocket { config_path } => {
+                commands::daemon::print_socket(config_path)
+            }
         };
 
         if has_metrics {

--- a/crates/biome_cli/src/service/unix.rs
+++ b/crates/biome_cli/src/service/unix.rs
@@ -174,8 +174,8 @@ pub(crate) async fn ensure_daemon(
 
 /// Ensure the server daemon is running and ready to receive connections and
 /// print the global socket name in the standard output
-pub(crate) async fn print_socket() -> io::Result<()> {
-    ensure_daemon(true, None).await?;
+pub(crate) async fn print_socket(config_path: Option<PathBuf>) -> io::Result<()> {
+    ensure_daemon(true, config_path).await?;
     println!("{}", get_socket_name().display());
     Ok(())
 }

--- a/crates/biome_cli/src/service/windows.rs
+++ b/crates/biome_cli/src/service/windows.rs
@@ -196,8 +196,8 @@ pub(crate) async fn ensure_daemon(
 
 /// Ensure the server daemon is running and ready to receive connections and
 /// print the global pipe name in the standard output
-pub(crate) async fn print_socket() -> io::Result<()> {
-    ensure_daemon(true, None).await?;
+pub(crate) async fn print_socket(config_path: Option<PathBuf>) -> io::Result<()> {
+    ensure_daemon(true, config_path).await?;
     println!("{}", get_pipe_name());
     Ok(())
 }


### PR DESCRIPTION
## Summary

This PR introduces a new `--config-path` option to the internal `__print_socket` command. This new option allows for specifying a directory in which to look for the `biome.json` configuration file.
