### PR TITLE
feat(css_formatter): CSS nesting

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_commands_format/should_apply_different_formatting.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/should_apply_different_formatting.snap
@@ -33,7 +33,9 @@ expression: content
 ## `input.css`
 
 ```css
-html {}
+html {
+}
+
 ```
 
 ## `input.js`
@@ -110,7 +112,7 @@ biome.json:20:17 deserialize  DEPRECATED  ━━━━━━━━━━━━�
 ```
 
 ```block
-Formatted 2 file(s) in <TIME>
+Formatted 3 file(s) in <TIME>
 ```
 
 

--- a/crates/biome_cli/tests/snapshots/main_commands_format/should_apply_different_formatting_with_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/should_apply_different_formatting_with_cli.snap
@@ -15,7 +15,9 @@ expression: content
 ## `input.css`
 
 ```css
-html {}
+html {
+}
+
 ```
 
 ## `input.js`
@@ -71,7 +73,7 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Formatted 2 file(s) in <TIME>
+Formatted 3 file(s) in <TIME>
 ```
 
 

--- a/crates/biome_css_formatter/src/css/auxiliary/declaration_with_semicolon.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/declaration_with_semicolon.rs
@@ -15,6 +15,13 @@ impl FormatNodeRule<CssDeclarationWithSemicolon> for FormatCssDeclarationWithSem
             semicolon_token,
         } = node.as_fields();
 
-        write!(f, [declaration.format(), semicolon_token.format()])
+        write!(f, [declaration.format()])?;
+
+        if semicolon_token.is_some() {
+            // if semicolon is present, use the token's format to keep the comments
+            write!(f, [semicolon_token.format()])
+        } else {
+            write!(f, [text(";")])
+        }
     }
 }

--- a/crates/biome_css_formatter/tests/specs/css/color/functional_colors.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/color/functional_colors.css.snap
@@ -64,19 +64,12 @@ Quote style: Double Quotes
 }
 
 .whitespace {
-    color: rgba(   51 
-    170
-     51 / 0.4);
-    color: rgba(
+	color: rgba(51 170 51 / 0.4);
+	color: rgba(
         51   170    51  /  40%);
-    color: hsl(270   60%   50% / .15);
-    color: hsla(240 100%   50% 
-    /   .05);
-    color: hsla(
-        240
-        100%
-        50% 
-        / 5%);
+	color: hsl(270 60% 50% / .15);
+	color: hsla(240 100% 50% / .05);
+	color: hsla(240 100% 50% / 5%);
 }
 ```
 

--- a/crates/biome_css_formatter/tests/specs/css/nesting/nesting.css
+++ b/crates/biome_css_formatter/tests/specs/css/nesting/nesting.css
@@ -1,0 +1,176 @@
+table.colortable {
+	& td {
+		text-align: center;
+		&.c { text-transform:uppercase }
+		&:first-child, &:first-child + td { border:1px solid black }
+	}
+
+	& th {
+		text-align:center;
+		background:black;
+		color:white;
+	}
+}
+
+.foo {
+	color: blue;
+	& > .bar { color: red; }
+}
+
+.foo {
+	color: blue;
+	&.bar { color: red; }
+}
+
+.foo, .bar {
+	color: blue;
+	& + .baz, &.qux { color: red; }
+}
+
+.foo {
+	color: blue;
+	& .bar & .baz & .qux { color: red; }
+}
+
+.foo {
+	color: blue;
+	& { padding: 2ch; }
+}
+
+/* TODO fix me */
+/*.foo {*/
+/*    color: blue;*/
+/*    && { padding: 2ch; }*/
+/*}*/
+
+.error, #test {
+	&:hover > .baz { color: red; }
+}
+
+.foo {
+	&:is(.bar, &.baz) { color: red; }
+}
+
+figure {
+	margin: 0;
+
+	& > figcaption {
+		background: hsl(0 0% 0% / 50%);
+
+		& > p {
+			font-size: .9rem;
+		}
+	}
+}
+
+.foo {
+	color: blue;
+	&__bar { color: red; }
+}
+
+.foo {
+	color: red;
+
+	.bar {
+		color: blue;
+	}
+}
+
+.foo {
+	color: red;
+
+	+ .bar {
+		color: blue;
+	}
+}
+
+.foo {
+	color: blue;
+	& > .bar { color: red; }
+	> .baz { color: green; }
+}
+
+div {
+	color: red;
+
+	& input { margin: 1em; }
+	/* valid, no longer starts with an identifier */
+
+	:is(input) { margin: 1em; }
+	/* valid, starts with a colon,
+		 and equivalent to the previous rule. */
+}
+
+.foo, .bar {
+	color: blue;
+	+ .baz, &.qux { color: red; }
+}
+
+.foo {
+	color: blue;
+	& .bar & .baz & .qux { color: red; }
+}
+
+.foo {
+	color: red;
+	.parent & {
+		color: blue;
+	}
+}
+
+.foo {
+	color: red;
+	:not(&) {
+		color: blue;
+	}
+}
+
+.foo {
+	color: red;
+	+ .bar + & { color: blue; }
+}
+
+.ancestor .el {
+	.other-ancestor & { color: red; }
+}
+
+.foo {
+	& :is(.bar, &.baz) { color: red; }
+}
+
+@layer base {
+	html {
+		block-size: 100%;
+
+		& body {
+			min-block-size: 100%;
+		}
+	}
+}
+
+@layer base {
+	html {
+		block-size: 100%;
+
+		@layer base.support {
+			& body {
+				min-block-size: 100%;
+			}
+		}
+	}
+}
+
+article {
+	color: green;
+	& { color: blue; }
+	color: red;
+}
+
+.foo {
+	color: red;
+	@media (min-width: 480px) {
+		& h1, & h2 {
+			color: blue;
+		}
+	}
+}

--- a/crates/biome_css_formatter/tests/specs/css/nesting/nesting.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/nesting/nesting.css.snap
@@ -1,0 +1,429 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/nesting/nesting.css
+---
+
+# Input
+
+```css
+table.colortable {
+	& td {
+		text-align: center;
+		&.c { text-transform:uppercase }
+		&:first-child, &:first-child + td { border:1px solid black }
+	}
+
+	& th {
+		text-align:center;
+		background:black;
+		color:white;
+	}
+}
+
+.foo {
+	color: blue;
+	& > .bar { color: red; }
+}
+
+.foo {
+	color: blue;
+	&.bar { color: red; }
+}
+
+.foo, .bar {
+	color: blue;
+	& + .baz, &.qux { color: red; }
+}
+
+.foo {
+	color: blue;
+	& .bar & .baz & .qux { color: red; }
+}
+
+.foo {
+	color: blue;
+	& { padding: 2ch; }
+}
+
+/* TODO fix me */
+/*.foo {*/
+/*    color: blue;*/
+/*    && { padding: 2ch; }*/
+/*}*/
+
+.error, #test {
+	&:hover > .baz { color: red; }
+}
+
+.foo {
+	&:is(.bar, &.baz) { color: red; }
+}
+
+figure {
+	margin: 0;
+
+	& > figcaption {
+		background: hsl(0 0% 0% / 50%);
+
+		& > p {
+			font-size: .9rem;
+		}
+	}
+}
+
+.foo {
+	color: blue;
+	&__bar { color: red; }
+}
+
+.foo {
+	color: red;
+
+	.bar {
+		color: blue;
+	}
+}
+
+.foo {
+	color: red;
+
+	+ .bar {
+		color: blue;
+	}
+}
+
+.foo {
+	color: blue;
+	& > .bar { color: red; }
+	> .baz { color: green; }
+}
+
+div {
+	color: red;
+
+	& input { margin: 1em; }
+	/* valid, no longer starts with an identifier */
+
+	:is(input) { margin: 1em; }
+	/* valid, starts with a colon,
+		 and equivalent to the previous rule. */
+}
+
+.foo, .bar {
+	color: blue;
+	+ .baz, &.qux { color: red; }
+}
+
+.foo {
+	color: blue;
+	& .bar & .baz & .qux { color: red; }
+}
+
+.foo {
+	color: red;
+	.parent & {
+		color: blue;
+	}
+}
+
+.foo {
+	color: red;
+	:not(&) {
+		color: blue;
+	}
+}
+
+.foo {
+	color: red;
+	+ .bar + & { color: blue; }
+}
+
+.ancestor .el {
+	.other-ancestor & { color: red; }
+}
+
+.foo {
+	& :is(.bar, &.baz) { color: red; }
+}
+
+@layer base {
+	html {
+		block-size: 100%;
+
+		& body {
+			min-block-size: 100%;
+		}
+	}
+}
+
+@layer base {
+	html {
+		block-size: 100%;
+
+		@layer base.support {
+			& body {
+				min-block-size: 100%;
+			}
+		}
+	}
+}
+
+article {
+	color: green;
+	& { color: blue; }
+	color: red;
+}
+
+.foo {
+	color: red;
+	@media (min-width: 480px) {
+		& h1, & h2 {
+			color: blue;
+		}
+	}
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+-----
+
+```css
+table.colortable {
+	&td {
+		text-align: center;
+		&.c {
+			text-transform: uppercase;
+		}
+		&:first-child,
+		&:first-child + td {
+			border: 1px solid black;
+		}
+	}
+
+	&th {
+		text-align: center;
+		background: black;
+		color: white;
+	}
+}
+
+.foo {
+	color: blue;
+	& > .bar {
+		color: red;
+	}
+}
+
+.foo {
+	color: blue;
+	&.bar {
+		color: red;
+	}
+}
+
+.foo,
+.bar {
+	color: blue;
+	& + .baz,
+	&.qux {
+		color: red;
+	}
+}
+
+.foo {
+	color: blue;
+	&.bar &.baz &.qux {
+		color: red;
+	}
+}
+
+.foo {
+	color: blue;
+	& {
+		padding: 2ch;
+	}
+}
+
+/* TODO fix me */
+/*.foo {*/
+/*    color: blue;*/
+/*    && { padding: 2ch; }*/
+/*}*/
+
+.error,
+#test {
+	&:hover > .baz {
+		color: red;
+	}
+}
+
+.foo {
+	&:is(.bar, &.baz) {
+		color: red;
+	}
+}
+
+figure {
+	margin: 0;
+
+	& > figcaption {
+		background: hsl(0 0% 0% / 50%);
+
+		& > p {
+			font-size: .9rem;
+		}
+	}
+}
+
+.foo {
+	color: blue;
+	&__bar {
+		color: red;
+	}
+}
+
+.foo {
+	color: red;
+
+	.bar {
+		color: blue;
+	}
+}
+
+.foo {
+	color: red;
+
+	+ .bar {
+		color: blue;
+	}
+}
+
+.foo {
+	color: blue;
+	& > .bar {
+		color: red;
+	}
+	> .baz {
+		color: green;
+	}
+}
+
+div {
+	color: red;
+
+	&input {
+		margin: 1em;
+	}
+	/* valid, no longer starts with an identifier */
+
+	:is(input) {
+		margin: 1em;
+	}
+	/* valid, starts with a colon,
+		 and equivalent to the previous rule. */
+}
+
+.foo,
+.bar {
+	color: blue;
+	+ .baz,
+	&.qux {
+		color: red;
+	}
+}
+
+.foo {
+	color: blue;
+	&.bar &.baz &.qux {
+		color: red;
+	}
+}
+
+.foo {
+	color: red;
+	.parent & {
+		color: blue;
+	}
+}
+
+.foo {
+	color: red;
+	:not(&) {
+		color: blue;
+	}
+}
+
+.foo {
+	color: red;
+	+ .bar + & {
+		color: blue;
+	}
+}
+
+.ancestor .el {
+	.other-ancestor & {
+		color: red;
+	}
+}
+
+.foo {
+	&:is(.bar, &.baz) {
+		color: red;
+	}
+}
+
+@layer base {
+	html {
+		block-size: 100%;
+
+		&body {
+			min-block-size: 100%;
+		}
+	}
+}
+
+@layer base {
+	html {
+		block-size: 100%;
+
+		@layer base.support {
+			&body {
+				min-block-size: 100%;
+			}
+		}
+	}
+}
+
+article {
+	color: green;
+	& {
+		color: blue;
+	}
+	color: red;
+}
+
+.foo {
+	color: red;
+	@media (min-width: 480px) {
+		&h1,
+		&h2 {
+			color: blue;
+		}
+	}
+}
+```
+
+

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 use biome_analyze::{AnalysisFilter, AnalyzerDiagnostic};
 use biome_console::fmt::Formatter;
 use biome_console::markup;
+use biome_css_formatter::can_format_css_yet;
 use biome_diagnostics::{Diagnostic, Severity};
 use biome_formatter::Printed;
 use biome_fs::RomePath;
@@ -385,8 +386,14 @@ impl Features {
             | Language::TypeScript
             | Language::TypeScriptReact => self.js.capabilities(),
             Language::Json | Language::Jsonc => self.json.capabilities(),
-            // TODO: change this when we are ready to handle CSS files
-            Language::Css => self.unknown.capabilities(),
+            Language::Css => {
+                // TODO: change this when we are ready to handle CSS files
+                if can_format_css_yet() {
+                    self.css.capabilities()
+                } else {
+                    self.unknown.capabilities()
+                }
+            }
             Language::Unknown => self.unknown.capabilities(),
         }
     }


### PR DESCRIPTION


## Summary

CSS nesting rules have been added to nesting.css and nesting.css.snap files. 
Minor changes have been made to the declaration_with_semicolon.rs file to handle the semicolon correctly. 
Moreover, `can_format_css_yet()` function has been used to check CSS formatting capabilities.

## Test Plan

new snapshots
