### PR TITLE
docs: fix `options` link for `useExhaustiveDependencies` linter rule

### DIFF
--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
@@ -43,7 +43,7 @@ declare_rule! {
     /// - `useDeferredValue`
     /// - `useTransition`
     ///
-    /// If you want to add more hooks to the rule, check the [#options](options).
+    /// If you want to add more hooks to the rule, check the [options](#options).
     ///
     /// ## Examples
     ///

--- a/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
+++ b/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
@@ -31,7 +31,7 @@ The rule will inspect the following **known** hooks:
 - `useDeferredValue`
 - `useTransition`
 
-If you want to add more hooks to the rule, check the [#options](options).
+If you want to add more hooks to the rule, check the [options](#options).
 
 ## Examples
 


### PR DESCRIPTION
## Summary

There is currently an invalid linking for the `options` at the `useExhaustiveDependencies` linter rule page. While the side navigation correctly refers to the hash anchor, the occurrence within the text does not so it leads to a `404` page. The adjustment resolves the issue.

![Screenshot 2024-02-05 at 19 06 52](https://github.com/biomejs/biome/assets/1060490/9b20ede9-e2e4-4797-ac87-76624014c4aa)

## Test Plan

To verify the corrected behavior, follow these steps:

1. Visit the `useExhaustiveDependencies` linter rule page (https://biomejs.dev/linter/rules/use-exhaustive-dependencies)
2. Find the `options` link in the descriptions text (shortly before `Examples`)
3. Click on it and see that it navigates to the section further below at the same page