### PR TITLE
fix js-api wasm peer dep versions

### DIFF
--- a/packages/@biomejs/js-api/package.json
+++ b/packages/@biomejs/js-api/package.json
@@ -47,9 +47,9 @@
 		"@biomejs/wasm-web": "../wasm-web"
 	},
 	"peerDependencies": {
-		"@biomejs/wasm-bundler": "^10.0.0",
-		"@biomejs/wasm-nodejs": "^10.0.0",
-		"@biomejs/wasm-web": "^10.0.0"
+		"@biomejs/wasm-bundler": "^1.5.3",
+		"@biomejs/wasm-nodejs": "^1.5.3",
+		"@biomejs/wasm-web": "^1.5.3"
 	},
 	"peerDependenciesMeta": {
 		"@biomejs/wasm-bundler": {


### PR DESCRIPTION
## Summary

Currently js-api depends on @biomejs/wasm-X="^10.0.0". This is incorrect, as the latest released version is 1.5.3.


## Test Plan

I believe this doesn't need to be tested.