### PR TITLE
fix(lint/noNonNullAssertion): dont create an incorrect unsafe fix for `x[y.z!]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Analyzer
 
+#### Bug fixed
+
+- Fix [#1748](https://github.com/biomejs/biome/issues/1748). Now for the following case we won't provide an unsafe fix for the `noNonNullAssertion` rule:
+
+  ```ts
+  x[y.z!];
+  ```
+
+  Contributed by @ah-yu
+
 ### CLI
 
 #### New features

--- a/crates/biome_js_analyze/src/analyzers/style/no_non_null_assertion.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_non_null_assertion.rs
@@ -102,7 +102,13 @@ impl Rule for NoNonNullAssertion {
                 let old_node = AnyJsExpression::TsNonNullAssertionExpression(node.clone());
 
                 match node.parent::<AnyJsExpression>()? {
-                    AnyJsExpression::JsComputedMemberExpression(parent) => {
+                    AnyJsExpression::JsComputedMemberExpression(parent)
+                        if parent.object().is_ok_and(|object| {
+                            object
+                                .as_ts_non_null_assertion_expression()
+                                .is_some_and(|object| object == node)
+                        }) =>
+                    {
                         if parent.is_optional() {
                             // object!?["prop"] --> object?.["prop"]
                             mutation.replace_node(old_node, assertion_less_expr);

--- a/crates/biome_js_analyze/tests/specs/style/noNonNullAssertion/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/noNonNullAssertion/invalid.ts
@@ -18,3 +18,4 @@ x.y.z!?.();
 x.y.z!!!?.();
 (b! as number) = "test";
 (b!! as number) = "test";
+x[y.z!];

--- a/crates/biome_js_analyze/tests/specs/style/noNonNullAssertion/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noNonNullAssertion/invalid.ts.snap
@@ -24,6 +24,7 @@ x.y.z!?.();
 x.y.z!!!?.();
 (b! as number) = "test";
 (b!! as number) = "test";
+x[y.z!];
 
 ```
 
@@ -405,7 +406,7 @@ invalid.ts:19:2 lint/style/noNonNullAssertion ━━━━━━━━━━━�
   > 19 │ (b! as number) = "test";
        │  ^^
     20 │ (b!! as number) = "test";
-    21 │ 
+    21 │ x[y.z!];
   
 
 ```
@@ -419,7 +420,22 @@ invalid.ts:20:2 lint/style/noNonNullAssertion ━━━━━━━━━━━�
     19 │ (b! as number) = "test";
   > 20 │ (b!! as number) = "test";
        │  ^^^
-    21 │ 
+    21 │ x[y.z!];
+    22 │ 
+  
+
+```
+
+```
+invalid.ts:21:3 lint/style/noNonNullAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Forbidden non-null assertion.
+  
+    19 │ (b! as number) = "test";
+    20 │ (b!! as number) = "test";
+  > 21 │ x[y.z!];
+       │   ^^^^
+    22 │ 
   
 
 ```

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -18,6 +18,16 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Analyzer
 
+#### Bug fixed
+
+- Fix [#1748](https://github.com/biomejs/biome/issues/1748). Now for the following case we won't provide an unsafe fix for the `noNonNullAssertion` rule:
+
+  ```ts
+  x[y.z!];
+  ```
+
+  Contributed by @ah-yu
+
 ### CLI
 
 #### New features


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/1748

Now we won't create an unsafe fix for the `NoNonNullAssertion` rule for the following case
```ts
x[y.z!]
```

## Test Plan

Add a new test case
<!-- What demonstrates that your implementation is correct? -->
