### PR TITLE
fix(lint): pull syntax rules when pulling diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Fix [#1173](https://github.com/biomejs/biome/issues/1173). Fix the formatting of a single instruction with commented in a control flow body to ensure consistency. Contributed by @mdm317
 
 - Fix overriding of `javascript.globals`. Contributed by @arendjr
+- Fix a bug where syntax rules weren't run when pulling the diagnostics. Now Biome will emit more parsing diagnostics, e.g.
+  ```
+  check.js:1:17 parse/noDuplicatePrivateClassMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+    × Duplicate private class member "#foo"
+
+    > 1 │ class A { #foo; #foo }
+        │                 ^^^^
+
+  ```
+  Contributed by @ematipico
 
 ### Configuration
 
@@ -40,6 +51,19 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Fix a regression where ignored files where formatted in the editor. Contributed by @ematipico
+- Fix a bug where syntax rules weren't run when pulling the diagnostics. Now Biome will emit more parsing diagnostics, e.g.
+  ```
+  check.js:1:17 parse/noDuplicatePrivateClassMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+    × Duplicate private class member "#foo"
+
+    > 1 │ class A { #foo; #foo }
+        │                 ^^^^
+
+  ```
+  Contributed by @ematipico
+
+
 
 ### Formatter
 

--- a/crates/biome_cli/src/execute/process_file/lint.rs
+++ b/crates/biome_cli/src/execute/process_file/lint.rs
@@ -45,7 +45,10 @@ pub(crate) fn lint_with_guard<'ctx>(
             let max_diagnostics = ctx.remaining_diagnostics.load(Ordering::Relaxed);
             let pull_diagnostics_result = workspace_file
                 .guard()
-                .pull_diagnostics(RuleCategories::LINT, max_diagnostics.into())
+                .pull_diagnostics(
+                    RuleCategories::LINT | RuleCategories::SYNTAX,
+                    max_diagnostics.into(),
+                )
                 .with_file_path_and_code(
                     workspace_file.path.display().to_string(),
                     category!("lint"),

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -2639,3 +2639,28 @@ fn should_not_process_ignored_file_even_if_its_changed() {
         result,
     ));
 }
+
+#[test]
+fn lint_syntax_rules() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("check.js");
+    fs.insert(file_path.into(), r#"class A { #foo; #foo }"#.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("lint"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "lint_syntax_rules",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_syntax_rules.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_syntax_rules.snap
@@ -1,0 +1,47 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `check.js`
+
+```js
+class A { #foo; #foo }
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+check.js:1:17 parse/noDuplicatePrivateClassMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Duplicate private class member "#foo"
+  
+  > 1 │ class A { #foo; #foo }
+      │                 ^^^^
+  
+
+```
+
+```block
+check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The file contains diagnostics that needs to be addressed.
+  
+
+```
+
+```block
+Checked 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_lsp/tests/server.rs
+++ b/crates/biome_lsp/tests/server.rs
@@ -48,7 +48,7 @@ use tower_lsp::lsp_types::{DidChangeConfigurationParams, DidChangeTextDocumentPa
 use tower_lsp::LspService;
 use tower_lsp::{jsonrpc::Request, lsp_types::InitializeParams};
 
-/// Statically build an [lsp::Url] instance that points to the file at `$path`
+/// Statically build an [Url] instance that points to the file at `$path`
 /// within the workspace. The filesystem path contained in the return URI is
 /// guaranteed to be a valid path for the underlying operating system, but
 /// doesn't have to refer to an existing file on the host machine.
@@ -595,12 +595,12 @@ async fn pull_diagnostics() -> Result<()> {
                 uri: url!("document.js"),
                 version: Some(0),
                 diagnostics: vec![lsp::Diagnostic {
-                    range: lsp::Range {
-                        start: lsp::Position {
+                    range: Range {
+                        start: Position {
                             line: 0,
                             character: 5,
                         },
-                        end: lsp::Position {
+                        end: Position {
                             line: 0,
                             character: 7,
                         },
@@ -620,12 +620,12 @@ async fn pull_diagnostics() -> Result<()> {
                     related_information: Some(vec![lsp::DiagnosticRelatedInformation {
                         location: lsp::Location {
                             uri: url!("document.js"),
-                            range: lsp::Range {
-                                start: lsp::Position {
+                            range: Range {
+                                start: Position {
                                     line: 0,
                                     character: 5,
                                 },
-                                end: lsp::Position {
+                                end: Position {
                                     line: 0,
                                     character: 7,
                                 },
@@ -633,6 +633,68 @@ async fn pull_diagnostics() -> Result<()> {
                         },
                         message: String::new(),
                     }]),
+                    tags: None,
+                    data: None,
+                }],
+            }
+        ))
+    );
+
+    server.close_document().await?;
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pull_diagnostics_of_syntax_rules() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create(None).into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, mut receiver) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    server.open_document("class A { #foo; #foo }").await?;
+
+    let notification = tokio::select! {
+        msg = receiver.next() => msg,
+        _ = sleep(Duration::from_secs(1)) => {
+            panic!("timed out waiting for the server to send diagnostics")
+        }
+    };
+
+    assert_eq!(
+        notification,
+        Some(ServerNotification::PublishDiagnostics(
+            PublishDiagnosticsParams {
+                uri: url!("document.js"),
+                version: Some(0),
+                diagnostics: vec![lsp::Diagnostic {
+                    range: Range {
+                        start: Position {
+                            line: 0,
+                            character: 16,
+                        },
+                        end: Position {
+                            line: 0,
+                            character: 20,
+                        },
+                    },
+                    severity: Some(lsp::DiagnosticSeverity::ERROR),
+                    code: Some(lsp::NumberOrString::String(String::from(
+                        "parse/noDuplicatePrivateClassMembers",
+                    ))),
+                    code_description: None,
+                    source: Some(String::from("biome")),
+                    message: String::from("Duplicate private class member \"#foo\"",),
+                    related_information: None,
                     tags: None,
                     data: None,
                 }],
@@ -677,12 +739,12 @@ async fn pull_diagnostics_from_new_file() -> Result<()> {
                 uri: url!("untitled-1"),
                 version: Some(0),
                 diagnostics: vec![lsp::Diagnostic {
-                    range: lsp::Range {
-                        start: lsp::Position {
+                    range: Range {
+                        start: Position {
                             line: 0,
                             character: 5,
                         },
-                        end: lsp::Position {
+                        end: Position {
                             line: 0,
                             character: 7,
                         },
@@ -702,12 +764,12 @@ async fn pull_diagnostics_from_new_file() -> Result<()> {
                     related_information: Some(vec![lsp::DiagnosticRelatedInformation {
                         location: lsp::Location {
                             uri: url!("untitled-1"),
-                            range: lsp::Range {
-                                start: lsp::Position {
+                            range: Range {
+                                start: Position {
                                     line: 0,
                                     character: 5,
                                 },
-                                end: lsp::Position {
+                                end: Position {
                                     line: 0,
                                     character: 7,
                                 },
@@ -732,9 +794,9 @@ async fn pull_diagnostics_from_new_file() -> Result<()> {
 
 fn fixable_diagnostic(line: u32) -> Result<lsp::Diagnostic> {
     Ok(lsp::Diagnostic {
-        range: lsp::Range {
-            start: lsp::Position { line, character: 3 },
-            end: lsp::Position {
+        range: Range {
+            start: Position { line, character: 3 },
+            end: Position {
                 line,
                 character: 11,
             },
@@ -772,15 +834,15 @@ async fn pull_quick_fixes() -> Result<()> {
             "textDocument/codeAction",
             "pull_code_actions",
             lsp::CodeActionParams {
-                text_document: lsp::TextDocumentIdentifier {
+                text_document: TextDocumentIdentifier {
                     uri: url!("document.js"),
                 },
-                range: lsp::Range {
-                    start: lsp::Position {
+                range: Range {
+                    start: Position {
                         line: 0,
                         character: 6,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 0,
                         character: 6,
                     },
@@ -790,7 +852,7 @@ async fn pull_quick_fixes() -> Result<()> {
                     only: Some(vec![lsp::CodeActionKind::QUICKFIX]),
                     ..Default::default()
                 },
-                work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
                 partial_result_params: lsp::PartialResultParams {
@@ -804,13 +866,13 @@ async fn pull_quick_fixes() -> Result<()> {
     let mut changes = HashMap::default();
     changes.insert(
         url!("document.js"),
-        vec![lsp::TextEdit {
-            range: lsp::Range {
-                start: lsp::Position {
+        vec![TextEdit {
+            range: Range {
+                start: Position {
                     line: 0,
                     character: 9,
                 },
-                end: lsp::Position {
+                end: Position {
                     line: 0,
                     character: 10,
                 },
@@ -839,13 +901,13 @@ async fn pull_quick_fixes() -> Result<()> {
     let mut suppression_changes = HashMap::default();
     suppression_changes.insert(
         url!("document.js"),
-        vec![lsp::TextEdit {
-            range: lsp::Range {
-                start: lsp::Position {
+        vec![TextEdit {
+            range: Range {
+                start: Position {
                     line: 0,
                     character: 0,
                 },
-                end: lsp::Position {
+                end: Position {
                     line: 0,
                     character: 0,
                 },
@@ -891,12 +953,12 @@ async fn pull_biome_quick_fixes_ignore_unsafe() -> Result<()> {
     let mut server = Server::new(service);
 
     let unsafe_fixable = lsp::Diagnostic {
-        range: lsp::Range {
-            start: lsp::Position {
+        range: Range {
+            start: Position {
                 line: 0,
                 character: 6,
             },
-            end: lsp::Position {
+            end: Position {
                 line: 0,
                 character: 9,
             },
@@ -926,15 +988,15 @@ async fn pull_biome_quick_fixes_ignore_unsafe() -> Result<()> {
             "textDocument/codeAction",
             "pull_code_actions",
             lsp::CodeActionParams {
-                text_document: lsp::TextDocumentIdentifier {
+                text_document: TextDocumentIdentifier {
                     uri: url!("document.js"),
                 },
-                range: lsp::Range {
-                    start: lsp::Position {
+                range: Range {
+                    start: Position {
                         line: 0,
                         character: 6,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 0,
                         character: 6,
                     },
@@ -944,7 +1006,7 @@ async fn pull_biome_quick_fixes_ignore_unsafe() -> Result<()> {
                     only: Some(vec![lsp::CodeActionKind::new("quickfix.biome")]),
                     ..Default::default()
                 },
-                work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
                 partial_result_params: lsp::PartialResultParams {
@@ -985,15 +1047,15 @@ async fn pull_biome_quick_fixes() -> Result<()> {
             "textDocument/codeAction",
             "pull_code_actions",
             lsp::CodeActionParams {
-                text_document: lsp::TextDocumentIdentifier {
+                text_document: TextDocumentIdentifier {
                     uri: url!("document.js"),
                 },
-                range: lsp::Range {
-                    start: lsp::Position {
+                range: Range {
+                    start: Position {
                         line: 0,
                         character: 6,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 0,
                         character: 10,
                     },
@@ -1003,7 +1065,7 @@ async fn pull_biome_quick_fixes() -> Result<()> {
                     only: Some(vec![lsp::CodeActionKind::new("quickfix.biome")]),
                     ..Default::default()
                 },
-                work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
                 partial_result_params: lsp::PartialResultParams {
@@ -1017,13 +1079,13 @@ async fn pull_biome_quick_fixes() -> Result<()> {
     let mut changes = HashMap::default();
     changes.insert(
         url!("document.js"),
-        vec![lsp::TextEdit {
-            range: lsp::Range {
-                start: lsp::Position {
+        vec![TextEdit {
+            range: Range {
+                start: Position {
                     line: 0,
                     character: 9,
                 },
-                end: lsp::Position {
+                end: Position {
                     line: 0,
                     character: 10,
                 },
@@ -1067,12 +1129,12 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
     let mut server = Server::new(service);
 
     let unsafe_fixable = lsp::Diagnostic {
-        range: lsp::Range {
-            start: lsp::Position {
+        range: Range {
+            start: Position {
                 line: 0,
                 character: 6,
             },
-            end: lsp::Position {
+            end: Position {
                 line: 0,
                 character: 9,
             },
@@ -1102,15 +1164,15 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
             "textDocument/codeAction",
             "pull_code_actions",
             lsp::CodeActionParams {
-                text_document: lsp::TextDocumentIdentifier {
+                text_document: TextDocumentIdentifier {
                     uri: url!("document.js"),
                 },
-                range: lsp::Range {
-                    start: lsp::Position {
+                range: Range {
+                    start: Position {
                         line: 0,
                         character: 6,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 0,
                         character: 6,
                     },
@@ -1120,7 +1182,7 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
                     only: Some(vec![]),
                     ..Default::default()
                 },
-                work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
                 partial_result_params: lsp::PartialResultParams {
@@ -1134,13 +1196,13 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
     let mut changes = HashMap::default();
     changes.insert(
         url!("document.js"),
-        vec![lsp::TextEdit {
-            range: lsp::Range {
-                start: lsp::Position {
+        vec![TextEdit {
+            range: Range {
+                start: Position {
                     line: 0,
                     character: 7,
                 },
-                end: lsp::Position {
+                end: Position {
                     line: 0,
                     character: 7,
                 },
@@ -1169,13 +1231,13 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
     let mut suppression_changes = HashMap::default();
     suppression_changes.insert(
         url!("document.js"),
-        vec![lsp::TextEdit {
-            range: lsp::Range {
-                start: lsp::Position {
+        vec![TextEdit {
+            range: Range {
+                start: Position {
                     line: 0,
                     character: 0,
                 },
-                end: lsp::Position {
+                end: Position {
                     line: 0,
                     character: 0,
                 },
@@ -1249,12 +1311,12 @@ async fn pull_diagnostics_for_rome_json() -> Result<()> {
                 uri: url!("biome.json"),
                 version: Some(0),
                 diagnostics: vec![lsp::Diagnostic {
-                    range: lsp::Range {
-                        start: lsp::Position {
+                    range: Range {
+                        start: Position {
                             line: 2,
                             character: 27,
                         },
-                        end: lsp::Position {
+                        end: Position {
                             line: 2,
                             character: 34,
                         },
@@ -1326,15 +1388,15 @@ async fn no_code_actions_for_ignored_json_files() -> Result<()> {
             "textDocument/codeAction",
             "pull_code_actions",
             lsp::CodeActionParams {
-                text_document: lsp::TextDocumentIdentifier {
+                text_document: TextDocumentIdentifier {
                     uri: url!("./node_modules/preact/package.json"),
                 },
-                range: lsp::Range {
-                    start: lsp::Position {
+                range: Range {
+                    start: Position {
                         line: 0,
                         character: 7,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 0,
                         character: 7,
                     },
@@ -1343,7 +1405,7 @@ async fn no_code_actions_for_ignored_json_files() -> Result<()> {
                     diagnostics: vec![],
                     ..Default::default()
                 },
-                work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
                 partial_result_params: lsp::PartialResultParams {
@@ -1394,15 +1456,15 @@ if(a === -0) {}
             "textDocument/codeAction",
             "pull_code_actions",
             lsp::CodeActionParams {
-                text_document: lsp::TextDocumentIdentifier {
+                text_document: TextDocumentIdentifier {
                     uri: url!("document.js"),
                 },
-                range: lsp::Range {
-                    start: lsp::Position {
+                range: Range {
+                    start: Position {
                         line: 0,
                         character: 6,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 0,
                         character: 10,
                     },
@@ -1411,7 +1473,7 @@ if(a === -0) {}
                     diagnostics: vec![fixable_diagnostic(0)?],
                     ..Default::default()
                 },
-                work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
                 partial_result_params: lsp::PartialResultParams {
@@ -1426,91 +1488,91 @@ if(a === -0) {}
     changes.insert(
         url!("document.js"),
         vec![
-            lsp::TextEdit {
-                range: lsp::Range {
-                    start: lsp::Position {
+            TextEdit {
+                range: Range {
+                    start: Position {
                         line: 1,
                         character: 7,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 1,
                         character: 8,
                     },
                 },
                 new_text: String::from("{ describe }"),
             },
-            lsp::TextEdit {
-                range: lsp::Range {
-                    start: lsp::Position {
+            TextEdit {
+                range: Range {
+                    start: Position {
                         line: 1,
                         character: 15,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 1,
                         character: 18,
                     },
                 },
                 new_text: String::from("node:test"),
             },
-            lsp::TextEdit {
-                range: lsp::Range {
-                    start: lsp::Position {
+            TextEdit {
+                range: Range {
+                    start: Position {
                         line: 2,
                         character: 7,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 2,
                         character: 13,
                     },
                 },
                 new_text: String::from("z"),
             },
-            lsp::TextEdit {
-                range: lsp::Range {
-                    start: lsp::Position {
+            TextEdit {
+                range: Range {
+                    start: Position {
                         line: 2,
                         character: 14,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 2,
                         character: 16,
                     },
                 },
                 new_text: String::new(),
             },
-            lsp::TextEdit {
-                range: lsp::Range {
-                    start: lsp::Position {
+            TextEdit {
+                range: Range {
+                    start: Position {
                         line: 2,
                         character: 22,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 2,
                         character: 28,
                     },
                 },
                 new_text: String::from("zod"),
             },
-            lsp::TextEdit {
-                range: lsp::Range {
-                    start: lsp::Position {
+            TextEdit {
+                range: Range {
+                    start: Position {
                         line: 3,
                         character: 9,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 3,
                         character: 17,
                     },
                 },
                 new_text: String::from("test"),
             },
-            lsp::TextEdit {
-                range: lsp::Range {
-                    start: lsp::Position {
+            TextEdit {
+                range: Range {
+                    start: Position {
                         line: 3,
                         character: 26,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 3,
                         character: 35,
                     },
@@ -1567,15 +1629,15 @@ async fn pull_refactors() -> Result<()> {
             "textDocument/codeAction",
             "pull_code_actions",
             lsp::CodeActionParams {
-                text_document: lsp::TextDocumentIdentifier {
+                text_document: TextDocumentIdentifier {
                     uri: url!("document.js"),
                 },
-                range: lsp::Range {
-                    start: lsp::Position {
+                range: Range {
+                    start: Position {
                         line: 0,
                         character: 7,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 0,
                         character: 7,
                     },
@@ -1585,7 +1647,7 @@ async fn pull_refactors() -> Result<()> {
                     only: Some(vec![lsp::CodeActionKind::REFACTOR]),
                     ..Default::default()
                 },
-                work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
                 partial_result_params: lsp::PartialResultParams {
@@ -1601,26 +1663,26 @@ async fn pull_refactors() -> Result<()> {
     changes.insert(
         url!("document.js"),
         vec![
-            lsp::TextEdit {
-                range: lsp::Range {
-                    start: lsp::Position {
+            TextEdit {
+                range: Range {
+                    start: Position {
                         line: 0,
                         character: 0,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 0,
                         character: 15,
                     },
                 },
                 new_text: String::from("func("),
             },
-            lsp::TextEdit {
-                range: lsp::Range {
-                    start: lsp::Position {
+            TextEdit {
+                range: Range {
+                    start: Position {
                         line: 0,
                         character: 22,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 0,
                         character: 37,
                     },
@@ -1679,15 +1741,15 @@ async fn pull_fix_all() -> Result<()> {
             "textDocument/codeAction",
             "pull_code_actions",
             lsp::CodeActionParams {
-                text_document: lsp::TextDocumentIdentifier {
+                text_document: TextDocumentIdentifier {
                     uri: url!("document.js"),
                 },
-                range: lsp::Range {
-                    start: lsp::Position {
+                range: Range {
+                    start: Position {
                         line: 0,
                         character: 7,
                     },
-                    end: lsp::Position {
+                    end: Position {
                         line: 0,
                         character: 7,
                     },
@@ -1701,7 +1763,7 @@ async fn pull_fix_all() -> Result<()> {
                     only: Some(vec![lsp::CodeActionKind::new("source.fixAll")]),
                     ..Default::default()
                 },
-                work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
                 partial_result_params: lsp::PartialResultParams {
@@ -1716,13 +1778,13 @@ async fn pull_fix_all() -> Result<()> {
 
     changes.insert(
         url!("document.js"),
-        vec![lsp::TextEdit {
-            range: lsp::Range {
-                start: lsp::Position {
+        vec![TextEdit {
+            range: Range {
+                start: Position {
                     line: 0,
                     character: 0,
                 },
-                end: lsp::Position {
+                end: Position {
                     line: 3,
                     character: 0,
                 },

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -371,7 +371,7 @@ fn lint(params: LintParams) -> LintResults {
                                 }
                             }
 
-                            let error = diagnostic.with_severity(severity.clone());
+                            let error = diagnostic.with_severity(severity);
 
                             diagnostics.push(biome_diagnostics::serde::Diagnostic::new(error));
                         }

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -283,6 +283,7 @@ fn debug_formatter_ir(
 fn lint(params: LintParams) -> LintResults {
     debug_span!("Linting JavaScript file", path =? params.path, language =? params.language)
         .in_scope(move || {
+            let settings = params.settings.as_ref();
             let file_source = match params.parse.file_source(params.path) {
                 Ok(file_source) => file_source,
                 Err(_) => {
@@ -299,9 +300,31 @@ fn lint(params: LintParams) -> LintResults {
             };
             let tree = params.parse.tree();
             let mut diagnostics = params.parse.into_diagnostics();
-
             let analyzer_options =
                 compute_analyzer_options(&params.settings, PathBuf::from(params.path.as_path()));
+
+            // Compute final rules (taking `overrides` into account)
+            let rules = settings.as_rules(params.path.as_path());
+            let mut rule_filter_list = rules
+                .as_ref()
+                .map(|rules| rules.as_enabled_rules())
+                .unwrap_or_default()
+                .into_iter()
+                .collect::<Vec<_>>();
+            if settings.organize_imports.enabled && !params.categories.is_syntax() {
+                rule_filter_list.push(RuleFilter::Rule("correctness", "organizeImports"));
+            }
+
+            rule_filter_list.push(RuleFilter::Rule(
+                "correctness",
+                "noDuplicatePrivateClassMembers",
+            ));
+            rule_filter_list.push(RuleFilter::Rule("correctness", "noInitializerWithDefinite"));
+            rule_filter_list.push(RuleFilter::Rule("correctness", "noSuperWithoutExtends"));
+            rule_filter_list.push(RuleFilter::Rule("nursery", "noSuperWithoutExtends"));
+
+            let mut filter = AnalysisFilter::from_enabled_rules(Some(rule_filter_list.as_slice()));
+            filter.categories = params.categories;
 
             let mut diagnostic_count = diagnostics.len() as u64;
             let mut errors = diagnostics
@@ -309,15 +332,11 @@ fn lint(params: LintParams) -> LintResults {
                 .filter(|diag| diag.severity() <= Severity::Error)
                 .count();
 
-            let has_lint = params.filter.categories.contains(RuleCategories::LINT);
+            let has_lint = filter.categories.contains(RuleCategories::LINT);
 
             info!("Analyze file {}", params.path.display());
-            let (_, analyze_diagnostics) = analyze(
-                &tree,
-                params.filter,
-                &analyzer_options,
-                file_source,
-                |signal| {
+            let (_, analyze_diagnostics) =
+                analyze(&tree, filter, &analyzer_options, file_source, |signal| {
                     if let Some(mut diagnostic) = signal.diagnostic() {
                         // Do not report unused suppression comment diagnostics if this is a syntax-only analyzer pass
                         if !has_lint
@@ -334,8 +353,8 @@ fn lint(params: LintParams) -> LintResults {
                             .category()
                             .filter(|category| category.name().starts_with("lint/"))
                             .map(|category| {
-                                params
-                                    .rules
+                                rules
+                                    .as_ref()
                                     .and_then(|rules| rules.get_severity_from_code(category))
                                     .unwrap_or(Severity::Warning)
                             })
@@ -352,15 +371,14 @@ fn lint(params: LintParams) -> LintResults {
                                 }
                             }
 
-                            let error = diagnostic.with_severity(severity);
+                            let error = diagnostic.with_severity(severity.clone());
 
                             diagnostics.push(biome_diagnostics::serde::Diagnostic::new(error));
                         }
                     }
 
                     ControlFlow::<Never>::Continue(())
-                },
-            );
+                });
 
             diagnostics.extend(
                 analyze_diagnostics

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -13,7 +13,9 @@ use crate::workspace::{
     FixFileResult, GetSyntaxTreeResult, OrganizeImportsResult, PullActionsResult,
 };
 use crate::{Rules, WorkspaceError};
-use biome_analyze::{AnalyzerConfiguration, AnalyzerOptions, ControlFlow, Never, RuleCategories};
+use biome_analyze::{
+    AnalysisFilter, AnalyzerConfiguration, AnalyzerOptions, ControlFlow, Never, RuleCategories,
+};
 use biome_deserialize::json::deserialize_from_json_ast;
 use biome_diagnostics::{category, Diagnostic, DiagnosticExt, Severity};
 use biome_formatter::{FormatError, IndentStyle, IndentWidth, LineEnding, LineWidth, Printed};
@@ -276,6 +278,7 @@ fn lint(params: LintParams) -> LintResults {
         .in_scope(move || {
             let root: JsonRoot = params.parse.tree();
             let mut diagnostics = params.parse.into_diagnostics();
+            let settings = params.settings.as_ref();
 
             // if we're parsing the `biome.json` file, we deserialize it, so we can emit diagnostics for
             // malformed configuration
@@ -298,54 +301,62 @@ fn lint(params: LintParams) -> LintResults {
 
             let skipped_diagnostics = diagnostic_count - diagnostics.len() as u64;
 
-            let has_lint = params.filter.categories.contains(RuleCategories::LINT);
+            let rules = settings.as_rules(params.path.as_path());
+            let rule_filter_list = rules
+                .as_ref()
+                .map(|rules| rules.as_enabled_rules())
+                .unwrap_or_default()
+                .into_iter()
+                .collect::<Vec<_>>();
+
             let analyzer_options =
                 compute_analyzer_options(&params.settings, PathBuf::from(params.path.as_path()));
+            let mut filter = AnalysisFilter::from_enabled_rules(Some(rule_filter_list.as_slice()));
+            filter.categories = params.categories;
+            let has_lint = filter.categories.contains(RuleCategories::LINT);
 
-            let (_, analyze_diagnostics) =
-                analyze(&root, params.filter, &analyzer_options, |signal| {
-                    if let Some(mut diagnostic) = signal.diagnostic() {
-                        // Do not report unused suppression comment diagnostics if this is a syntax-only analyzer pass
-                        if !has_lint
-                            && diagnostic.category() == Some(category!("suppressions/unused"))
-                        {
-                            return ControlFlow::<Never>::Continue(());
-                        }
-
-                        diagnostic_count += 1;
-
-                        // We do now check if the severity of the diagnostics should be changed.
-                        // The configuration allows to change the severity of the diagnostics emitted by rules.
-                        let severity = diagnostic
-                            .category()
-                            .filter(|category| category.name().starts_with("lint/"))
-                            .map(|category| {
-                                params
-                                    .rules
-                                    .and_then(|rules| rules.get_severity_from_code(category))
-                                    .unwrap_or(Severity::Warning)
-                            })
-                            .unwrap_or_else(|| diagnostic.severity());
-
-                        if severity <= Severity::Error {
-                            errors += 1;
-                        }
-
-                        if diagnostic_count <= params.max_diagnostics {
-                            for action in signal.actions() {
-                                if !action.is_suppression() {
-                                    diagnostic = diagnostic.add_code_suggestion(action.into());
-                                }
-                            }
-
-                            let error = diagnostic.with_severity(severity);
-
-                            diagnostics.push(biome_diagnostics::serde::Diagnostic::new(error));
-                        }
+            let (_, analyze_diagnostics) = analyze(&root, filter, &analyzer_options, |signal| {
+                if let Some(mut diagnostic) = signal.diagnostic() {
+                    // Do not report unused suppression comment diagnostics if this is a syntax-only analyzer pass
+                    if !has_lint && diagnostic.category() == Some(category!("suppressions/unused"))
+                    {
+                        return ControlFlow::<Never>::Continue(());
                     }
 
-                    ControlFlow::<Never>::Continue(())
-                });
+                    diagnostic_count += 1;
+
+                    // We do now check if the severity of the diagnostics should be changed.
+                    // The configuration allows to change the severity of the diagnostics emitted by rules.
+                    let severity = diagnostic
+                        .category()
+                        .filter(|category| category.name().starts_with("lint/"))
+                        .map(|category| {
+                            rules
+                                .as_ref()
+                                .and_then(|rules| rules.get_severity_from_code(category))
+                                .unwrap_or(Severity::Warning)
+                        })
+                        .unwrap_or_else(|| diagnostic.severity());
+
+                    if severity <= Severity::Error {
+                        errors += 1;
+                    }
+
+                    if diagnostic_count <= params.max_diagnostics {
+                        for action in signal.actions() {
+                            if !action.is_suppression() {
+                                diagnostic = diagnostic.add_code_suggestion(action.into());
+                            }
+                        }
+
+                        let error = diagnostic.with_severity(severity);
+
+                        diagnostics.push(biome_diagnostics::serde::Diagnostic::new(error));
+                    }
+                }
+
+                ControlFlow::<Never>::Continue(())
+            });
 
             diagnostics.extend(
                 analyze_diagnostics

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     workspace::{FixFileResult, GetSyntaxTreeResult, PullActionsResult, RenameResult},
     Rules, WorkspaceError,
 };
-use biome_analyze::{AnalysisFilter, AnalyzerDiagnostic};
+use biome_analyze::{AnalysisFilter, AnalyzerDiagnostic, RuleCategories};
 use biome_console::fmt::Formatter;
 use biome_console::markup;
 use biome_css_formatter::can_format_css_yet;
@@ -277,12 +277,11 @@ pub struct DebugCapabilities {
 
 pub(crate) struct LintParams<'a> {
     pub(crate) parse: AnyParse,
-    pub(crate) filter: AnalysisFilter<'a>,
-    pub(crate) rules: Option<&'a Rules>,
     pub(crate) settings: SettingsHandle<'a>,
     pub(crate) language: Language,
     pub(crate) max_diagnostics: u64,
     pub(crate) path: &'a RomePath,
+    pub(crate) categories: RuleCategories,
 }
 
 pub(crate) struct LintResults {

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -38,6 +38,17 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Fix [#1173](https://github.com/biomejs/biome/issues/1173). Fix the formatting of a single instruction with commented in a control flow body to ensure consistency. Contributed by @mdm317
 
 - Fix overriding of `javascript.globals`. Contributed by @arendjr
+- Fix a bug where syntax rules weren't run when pulling the diagnostics. Now Biome will emit more parsing diagnostics, e.g.
+  ```
+  check.js:1:17 parse/noDuplicatePrivateClassMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+    × Duplicate private class member "#foo"
+
+    > 1 │ class A { #foo; #foo }
+        │                 ^^^^
+
+  ```
+  Contributed by @ematipico
 
 ### Configuration
 
@@ -46,6 +57,19 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 #### Bug fixes
 
 - Fix a regression where ignored files where formatted in the editor. Contributed by @ematipico
+- Fix a bug where syntax rules weren't run when pulling the diagnostics. Now Biome will emit more parsing diagnostics, e.g.
+  ```
+  check.js:1:17 parse/noDuplicatePrivateClassMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+    × Duplicate private class member "#foo"
+
+    > 1 │ class A { #foo; #foo }
+        │                 ^^^^
+
+  ```
+  Contributed by @ematipico
+
+
 
 ### Formatter
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/1245

I moved the generation of the `AnalysisFilter` inside the language itself. This makes more sense now, because - for example - we don't enable import sorting for a language that doesn't implement it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added two new test cases: CLI and LSP

<!-- What demonstrates that your implementation is correct? -->
