### PR TITLE
feat(project): resolve extends from `node_modules`

### DIFF
--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -27,8 +27,27 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Cache pnpm modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+      - name: Cache pnpm modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+      - uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 8
       - name: Run Biome Format
-        run: cargo biome-cli-dev ci editors website packages/@biomejs/js-api
+        run: |
+          pnpm i
+          pnpm run check
 
   type-check:
     name: Type-check JS Files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,30 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Configuration
 
+#### New features
+
+- Add the ability to resolve the configuration files defined inside `extends` from the `node_modules/` directory.
+
+  If you want to resolve a configuration file that matches the specifier `@org/configs/biome`, then your `package.json` file must look this:
+
+  ```json
+  {
+    "name": "@org/configs",
+    "exports": {
+      "./biome": "./biome.json"
+    }
+  }
+  ```
+
+  And the `biome.json` file that "imports" said configuration, will look like this:
+  ```json
+  {
+    "extends": "@org/configs/biome"
+  }
+  ```
+  Read the [documentation](https://biomejs.dev/guides/how-biome-works#the-extends-option) to better understand how it works, expectations and restrictions.
+
+
 ### Editors
 
 #### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
  "crossbeam",
  "dashmap",
  "hdrhistogram",
- "indexmap",
+ "indexmap 1.9.3",
  "insta",
  "lazy_static",
  "libc",
@@ -313,7 +313,7 @@ dependencies = [
  "biome_json_syntax",
  "biome_rowan",
  "bitflags 2.3.1",
- "indexmap",
+ "indexmap 1.9.3",
  "schemars",
  "serde",
  "serde_json",
@@ -344,6 +344,7 @@ dependencies = [
  "biome_text_size",
  "bitflags 2.3.1",
  "bpaf",
+ "oxc_resolver",
  "schemars",
  "serde",
  "serde_json",
@@ -389,7 +390,7 @@ dependencies = [
  "cfg-if",
  "countme",
  "drop_bomb",
- "indexmap",
+ "indexmap 1.9.3",
  "insta",
  "rustc-hash",
  "schemars",
@@ -424,7 +425,8 @@ dependencies = [
  "biome_diagnostics",
  "crossbeam",
  "directories",
- "indexmap",
+ "indexmap 1.9.3",
+ "oxc_resolver",
  "parking_lot",
  "rayon",
  "rustc-hash",
@@ -541,7 +543,7 @@ dependencies = [
  "cfg-if",
  "drop_bomb",
  "expect-test",
- "indexmap",
+ "indexmap 1.9.3",
  "quickcheck",
  "quickcheck_macros",
  "rustc-hash",
@@ -688,7 +690,7 @@ dependencies = [
  "biome_service",
  "biome_text_edit",
  "futures",
- "indexmap",
+ "indexmap 1.9.3",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -763,7 +765,7 @@ dependencies = [
  "biome_text_edit",
  "biome_text_size",
  "countme",
- "hashbrown",
+ "hashbrown 0.12.3",
  "iai",
  "memoffset",
  "quickcheck",
@@ -807,9 +809,10 @@ dependencies = [
  "bpaf",
  "dashmap",
  "ignore",
- "indexmap",
+ "indexmap 1.9.3",
  "insta",
  "lazy_static",
+ "oxc_resolver",
  "regex",
  "rustc-hash",
  "schemars",
@@ -928,7 +931,7 @@ checksum = "22cbaba260bbcbb69b0d54e9f0d83038a4568f3a5d1c95591fed5e8fee964539"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1044,7 +1047,7 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags 1.3.2",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "textwrap",
 ]
 
@@ -1309,12 +1312,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1360,6 +1363,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1395,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -1666,6 +1681,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,7 +1774,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -1847,6 +1879,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-strip-comments"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d129799327c8f80861e467c59b825ba24c277dba6ad0d71a141dc98f9e04ee"
+
+[[package]]
 name = "json_comments"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,9 +1961,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1994,7 +2032,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2114,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -2149,6 +2187,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "oxc_resolver"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11131bb4c6c7a4e6b019995ecb1a0dcb7853af1667eb77f9fac4cced10ace18e"
+dependencies = [
+ "dashmap",
+ "dunce",
+ "indexmap 2.2.2",
+ "json-strip-comments",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,15 +2216,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.4.1",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2287,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -2339,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -2630,7 +2686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
 dependencies = [
  "dyn-clone",
- "indexmap",
+ "indexmap 1.9.3",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -2666,9 +2722,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
@@ -2686,13 +2742,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2708,10 +2764,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
+ "indexmap 2.2.2",
  "itoa",
  "ryu",
  "serde",
@@ -2743,7 +2800,7 @@ version = "0.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f82e6c8c047aa50a7328632d067bcae6ef38772a79e28daf32f735e0e4f3dd10"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "ryu",
  "serde",
@@ -2857,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2884,7 +2941,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2895,22 +2952,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ serde_json        = "1.0.96"
 smallvec          = { version = "1.10.0", features = ["union", "const_new"] }
 tracing           = { version = "0.1.37", default-features = false, features = ["std"] }
 unicode-bom       = "2.0.3"
+oxc_resolver = "1.4.0"
 # pinning to version 1.18 to avoid multiple versions of windows-sys as dependency
 tokio = { version = "~1.18.5" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ ignore            = "0.4.21"
 indexmap          = "1.9.3"
 insta             = "1.29.0"
 lazy_static       = "1.4.0"
+oxc_resolver      = "1.4.0"
 quickcheck        = "1.0.3"
 quickcheck_macros = "1.0.0"
 quote             = { version = "1.0.28" }
@@ -142,7 +143,6 @@ serde_json        = "1.0.96"
 smallvec          = { version = "1.10.0", features = ["union", "const_new"] }
 tracing           = { version = "0.1.37", default-features = false, features = ["std"] }
 unicode-bom       = "2.0.3"
-oxc_resolver = "1.4.0"
 # pinning to version 1.18 to avoid multiple versions of windows-sys as dependency
 tokio = { version = "~1.18.5" }
 

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,8 @@
 			"public/**",
 			"**/__snapshots__",
 			"**/editors/intellij/**",
-			"**/undefined/**"
+			"**/undefined/**",
+			"_fonts/**"
 		]
 	},
 	"formatter": {

--- a/biome.json
+++ b/biome.json
@@ -1,10 +1,6 @@
 {
 	"$schema": "./packages/@biomejs/biome/configuration_schema.json",
-	"vcs": {
-		"clientKind": "git",
-		"enabled": true,
-		"useIgnoreFile": true
-	},
+	"extends": ["shared/biome"],
 	"files": {
 		"ignore": [
 			"dist/**",
@@ -18,17 +14,5 @@
 	},
 	"formatter": {
 		"ignore": ["configuration-schema.json"]
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true,
-			"style": {
-				"noNonNullAssertion": "off"
-			}
-		}
-	},
-	"organizeImports": {
-		"enabled": true
 	}
 }

--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -840,7 +840,7 @@ fn fs_error_dereferenced_symlink() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
+        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
         &mut console,
         Args::from([("check"), root_path.display().to_string().as_str()].as_slice()),
     );
@@ -884,7 +884,7 @@ fn fs_error_infinite_symlink_expansion_to_dirs() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
+        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
         &mut console,
         Args::from([("check"), (root_path.display().to_string().as_str())].as_slice()),
     );
@@ -930,7 +930,7 @@ fn fs_error_infinite_symlink_expansion_to_files() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
+        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
         &mut console,
         Args::from([("check"), (root_path.display().to_string().as_str())].as_slice()),
     );
@@ -1110,7 +1110,7 @@ fn fs_files_ignore_symlink() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
+        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
         &mut console,
         Args::from(
             [

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -839,7 +839,7 @@ fn fs_error_dereferenced_symlink() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
+        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
         &mut console,
         Args::from([("lint"), root_path.display().to_string().as_str()].as_slice()),
     );
@@ -883,7 +883,7 @@ fn fs_error_infinite_symlink_expansion_to_dirs() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
+        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
         &mut console,
         Args::from([("lint"), (root_path.display().to_string().as_str())].as_slice()),
     );
@@ -929,7 +929,7 @@ fn fs_error_infinite_symlink_expansion_to_files() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
+        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
         &mut console,
         Args::from([("lint"), (root_path.display().to_string().as_str())].as_slice()),
     );
@@ -1110,7 +1110,7 @@ fn fs_files_ignore_symlink() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem(Some(root_path.clone())))),
+        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
         &mut console,
         Args::from(
             [

--- a/crates/biome_diagnostics/Cargo.toml
+++ b/crates/biome_diagnostics/Cargo.toml
@@ -38,6 +38,7 @@ bitflags                     = { workspace = true }
 bpaf                         = { workspace = true }
 schemars                     = { workspace = true, optional = true }
 serde                        = { workspace = true, features = ["derive"] }
+oxc_resolver =  { workspace = true }
 termcolor                    = "1.1.2"
 unicode-width                = "0.1.9"
 

--- a/crates/biome_diagnostics/Cargo.toml
+++ b/crates/biome_diagnostics/Cargo.toml
@@ -36,9 +36,9 @@ biome_text_edit              = { workspace = true }
 biome_text_size              = { workspace = true }
 bitflags                     = { workspace = true }
 bpaf                         = { workspace = true }
+oxc_resolver                 = { workspace = true }
 schemars                     = { workspace = true, optional = true }
 serde                        = { workspace = true, features = ["derive"] }
-oxc_resolver =  { workspace = true }
 termcolor                    = "1.1.2"
 unicode-width                = "0.1.9"
 

--- a/crates/biome_diagnostics/src/adapters.rs
+++ b/crates/biome_diagnostics/src/adapters.rs
@@ -106,3 +106,28 @@ impl Diagnostic for BpafError {
         Ok(())
     }
 }
+
+#[derive(Debug)]
+pub struct ResolveError {
+    error: oxc_resolver::ResolveError,
+}
+
+impl From<oxc_resolver::ResolveError> for ResolveError {
+    fn from(error: oxc_resolver::ResolveError) -> Self {
+        Self { error }
+    }
+}
+
+impl Diagnostic for ResolveError {
+    fn category(&self) -> Option<&'static Category> {
+        Some(category!("internalError/io"))
+    }
+
+    fn description(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(fmt, "{}", self.error)
+    }
+
+    fn message(&self, fmt: &mut fmt::Formatter<'_>) -> io::Result<()> {
+        fmt.write_markup(markup!({ AsConsoleDisplay(&self.error) }))
+    }
+}

--- a/crates/biome_fs/Cargo.toml
+++ b/crates/biome_fs/Cargo.toml
@@ -24,6 +24,7 @@ rustc-hash        = { workspace = true }
 schemars          = { workspace = true, optional = true }
 serde             = { workspace = true }
 tracing           = { workspace = true }
+oxc_resolver = { workspace = true }
 
 [features]
 serde = ["schemars", "biome_diagnostics/schema"]

--- a/crates/biome_fs/Cargo.toml
+++ b/crates/biome_fs/Cargo.toml
@@ -18,13 +18,13 @@ biome_diagnostics = { workspace = true }
 crossbeam         = "0.8.2"
 directories       = "5.0.1"
 indexmap          = { workspace = true }
+oxc_resolver      = { workspace = true }
 parking_lot       = { version = "0.12.0", features = ["arc_lock"] }
 rayon             = "1.7.0"
 rustc-hash        = { workspace = true }
 schemars          = { workspace = true, optional = true }
 serde             = { workspace = true }
 tracing           = { workspace = true }
-oxc_resolver = { workspace = true }
 
 [features]
 serde = ["schemars", "biome_diagnostics/schema"]

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -3,6 +3,7 @@ use biome_diagnostics::{console, Advices, Diagnostic, LogCategory, Visit};
 use biome_diagnostics::{Error, Severity};
 pub use memory::{ErrorEntry, MemoryFileSystem};
 pub use os::OsFileSystem;
+use oxc_resolver::{Resolution, ResolveError};
 use serde::{Deserialize, Serialize};
 use std::io;
 use std::panic::RefUnwindSafe;
@@ -157,6 +158,8 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
     }
 
     fn get_changed_files(&self, base: &str) -> io::Result<Vec<String>>;
+
+    fn resolve_configuration(&self, path: &str) -> Result<Resolution, ResolveError>;
 }
 
 /// Result of the auto search
@@ -323,6 +326,10 @@ where
 
     fn get_changed_files(&self, base: &str) -> io::Result<Vec<String>> {
         T::get_changed_files(self, base)
+    }
+
+    fn resolve_configuration(&self, path: &str) -> Result<Resolution, ResolveError> {
+        T::resolve_configuration(self, path)
     }
 }
 

--- a/crates/biome_fs/src/fs/memory.rs
+++ b/crates/biome_fs/src/fs/memory.rs
@@ -1,3 +1,4 @@
+use oxc_resolver::{Resolution, ResolveError};
 use rustc_hash::FxHashMap;
 use std::collections::hash_map::{Entry, IntoIter};
 use std::io;
@@ -196,6 +197,10 @@ impl FileSystem for MemoryFileSystem {
         let cb = cb_guard.take().unwrap();
 
         Ok(cb())
+    }
+
+    fn resolve_configuration(&self, _path: &str) -> Result<Resolution, ResolveError> {
+        todo!()
     }
 }
 

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -46,7 +46,7 @@ impl Default for OsFileSystem {
             working_directory: env::current_dir().ok(),
             configuration_resolver: AssertUnwindSafe(Resolver::new(ResolveOptions {
                 condition_names: vec!["node".to_string(), "import".to_string()],
-                extensions: vec!["*.json".to_string()],
+                extensions: vec!["*.json".to_string(), "*.jsonc".to_string()],
                 ..ResolveOptions::default()
             })),
         }

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -44,13 +44,13 @@ dashmap                  = { workspace = true }
 ignore                   = { workspace = true }
 indexmap                 = { workspace = true, features = ["serde"] }
 lazy_static              = { workspace = true }
+oxc_resolver             = "1.4.0"
 regex                    = { workspace = true }
 rustc-hash               = { workspace = true }
 schemars                 = { workspace = true, features = ["indexmap1"], optional = true }
 serde                    = { workspace = true, features = ["derive"] }
 serde_json               = { workspace = true, features = ["raw_value"] }
 tracing                  = { workspace = true, features = ["attributes", "log"] }
-oxc_resolver = "1.4.0"
 
 [features]
 schema = [

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -50,6 +50,7 @@ schemars                 = { workspace = true, features = ["indexmap1"], optiona
 serde                    = { workspace = true, features = ["derive"] }
 serde_json               = { workspace = true, features = ["raw_value"] }
 tracing                  = { workspace = true, features = ["attributes", "log"] }
+oxc_resolver = "1.4.0"
 
 [features]
 schema = [

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -44,7 +44,7 @@ dashmap                  = { workspace = true }
 ignore                   = { workspace = true }
 indexmap                 = { workspace = true, features = ["serde"] }
 lazy_static              = { workspace = true }
-oxc_resolver             = "1.4.0"
+oxc_resolver             = { workspace = true }
 regex                    = { workspace = true }
 rustc-hash               = { workspace = true }
 schemars                 = { workspace = true, features = ["indexmap1"], optional = true }

--- a/crates/biome_service/src/configuration/diagnostics.rs
+++ b/crates/biome_service/src/configuration/diagnostics.rs
@@ -2,9 +2,10 @@ use crate::WorkspaceError;
 use biome_console::fmt::Display;
 use biome_console::{markup, MarkupBuf};
 use biome_deserialize::DeserializationDiagnostic;
+use biome_diagnostics::adapters::ResolveError;
 use biome_diagnostics::{
-    Advices, Category, Diagnostic, DiagnosticTags, Location, LogCategory, MessageAndDescription,
-    Severity, Visit,
+    Advices, Category, Diagnostic, DiagnosticTags, Error, Location, LogCategory,
+    MessageAndDescription, Severity, Visit,
 };
 use biome_rowan::SyntaxError;
 use serde::{Deserialize, Serialize};
@@ -33,6 +34,8 @@ pub enum ConfigurationDiagnostic {
 
     /// Thrown when there's something wrong with the files specified inside `"extends"`
     CantLoadExtendFile(CantLoadExtendFile),
+
+    CantResolve(CantResolve),
 }
 
 impl From<SyntaxError> for ConfigurationDiagnostic {
@@ -76,6 +79,12 @@ impl ConfigurationDiagnostic {
             message: MessageAndDescription::from(markup! {{message}}.to_owned()),
         })
     }
+
+    pub fn cant_resolve(source: oxc_resolver::ResolveError) -> Self {
+        Self::CantResolve(CantResolve {
+            source: Some(Error::from(ResolveError::from(source))),
+        })
+    }
 }
 
 impl Debug for ConfigurationDiagnostic {
@@ -99,6 +108,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.severity(),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.severity(),
             ConfigurationDiagnostic::InvalidConfiguration(error) => error.severity(),
+            ConfigurationDiagnostic::CantResolve(error) => error.severity(),
         }
     }
 
@@ -110,6 +120,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.category(),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.category(),
             ConfigurationDiagnostic::InvalidConfiguration(error) => error.category(),
+            ConfigurationDiagnostic::CantResolve(error) => error.category(),
         }
     }
 
@@ -121,6 +132,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.tags(),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.tags(),
             ConfigurationDiagnostic::InvalidConfiguration(error) => error.tags(),
+            ConfigurationDiagnostic::CantResolve(error) => error.tags(),
         }
     }
 
@@ -132,6 +144,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.location(),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.location(),
             ConfigurationDiagnostic::InvalidConfiguration(error) => error.location(),
+            ConfigurationDiagnostic::CantResolve(error) => error.location(),
         }
     }
 
@@ -143,6 +156,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.source(),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.source(),
             ConfigurationDiagnostic::InvalidConfiguration(error) => error.source(),
+            ConfigurationDiagnostic::CantResolve(error) => error.source(),
         }
     }
 
@@ -154,6 +168,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.message(fmt),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.message(fmt),
             ConfigurationDiagnostic::InvalidConfiguration(error) => error.message(fmt),
+            ConfigurationDiagnostic::CantResolve(error) => error.message(fmt),
         }
     }
 
@@ -165,6 +180,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.description(fmt),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.description(fmt),
             ConfigurationDiagnostic::InvalidConfiguration(error) => error.description(fmt),
+            ConfigurationDiagnostic::CantResolve(error) => error.description(fmt),
         }
     }
 
@@ -176,6 +192,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.advices(visitor),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.advices(visitor),
             ConfigurationDiagnostic::InvalidConfiguration(error) => error.advices(visitor),
+            ConfigurationDiagnostic::CantResolve(error) => error.advices(visitor),
         }
     }
 
@@ -187,6 +204,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.verbose_advices(visitor),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.verbose_advices(visitor),
             ConfigurationDiagnostic::InvalidConfiguration(error) => error.verbose_advices(visitor),
+            ConfigurationDiagnostic::CantResolve(error) => error.verbose_advices(visitor),
         }
     }
 }
@@ -281,6 +299,17 @@ pub struct InvalidConfiguration {
     #[message]
     #[description]
     message: MessageAndDescription,
+}
+
+#[derive(Debug, Serialize, Deserialize, Diagnostic)]
+#[diagnostic(
+    category = "configuration",
+    severity = Error,
+)]
+pub struct CantResolve {
+    #[serde(skip)]
+    #[source]
+    source: Option<Error>,
 }
 
 #[cfg(test)]

--- a/crates/biome_service/src/configuration/diagnostics.rs
+++ b/crates/biome_service/src/configuration/diagnostics.rs
@@ -80,8 +80,14 @@ impl ConfigurationDiagnostic {
         })
     }
 
-    pub fn cant_resolve(source: oxc_resolver::ResolveError) -> Self {
+    pub fn cant_resolve(path: impl Display, source: oxc_resolver::ResolveError) -> Self {
         Self::CantResolve(CantResolve {
+            message: MessageAndDescription::from(
+                markup! {
+                   "Failed to resolve the configuration from "{{path}}
+                }
+                .to_owned(),
+            ),
             source: Some(Error::from(ResolveError::from(source))),
         })
     }
@@ -307,6 +313,10 @@ pub struct InvalidConfiguration {
     severity = Error,
 )]
 pub struct CantResolve {
+    #[message]
+    #[description]
+    message: MessageAndDescription,
+
     #[serde(skip)]
     #[source]
     source: Option<Error>,

--- a/crates/biome_service/src/configuration/diagnostics.rs
+++ b/crates/biome_service/src/configuration/diagnostics.rs
@@ -35,6 +35,7 @@ pub enum ConfigurationDiagnostic {
     /// Thrown when there's something wrong with the files specified inside `"extends"`
     CantLoadExtendFile(CantLoadExtendFile),
 
+    /// Thrown when a configuration file can't be resolved from `node_modules`
     CantResolve(CantResolve),
 }
 

--- a/crates/biome_service/src/configuration/mod.rs
+++ b/crates/biome_service/src/configuration/mod.rs
@@ -565,7 +565,10 @@ impl PartialConfiguration {
             let as_path = Path::new(path);
             let extension = as_path.extension().and_then(|ext| ext.to_str());
             // TODO: Remove extension in Biome 2.0
-            let config_path = if as_path.starts_with(".") || extension == Some("json") {
+            let config_path = if as_path.starts_with(".")
+                || extension == Some("json")
+                || extension == Some("jsonc")
+            {
                 directory_path.join(path)
             } else {
                 fs.resolve_configuration(path.as_str())

--- a/crates/biome_service/src/configuration/mod.rs
+++ b/crates/biome_service/src/configuration/mod.rs
@@ -572,7 +572,7 @@ impl PartialConfiguration {
                 directory_path.join(path)
             } else {
                 fs.resolve_configuration(path.as_str())
-                    .map_err(|err| ConfigurationDiagnostic::cant_resolve(err))?
+                    .map_err(ConfigurationDiagnostic::cant_resolve)?
                     .into_path_buf()
             };
 
@@ -696,24 +696,21 @@ mod test {
         struct Test;
 
         impl oxc_resolver::FileSystem for Test {
-            fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
-                dbg!("read to string", &path);
+            fn read_to_string(&self, _path: &Path) -> std::io::Result<String> {
                 Ok(String::from(
                     r#"{ "name": "example", "exports": { "./biome": "./biome.json" }}"#,
                 ))
             }
 
-            fn metadata(&self, path: &Path) -> std::io::Result<FileMetadata> {
-                dbg!(&path);
+            fn metadata(&self, _path: &Path) -> std::io::Result<FileMetadata> {
                 Ok(FileMetadata::new(true, false, false))
             }
 
-            fn symlink_metadata(&self, path: &Path) -> std::io::Result<FileMetadata> {
-                dbg!(&path);
+            fn symlink_metadata(&self, _path: &Path) -> std::io::Result<FileMetadata> {
                 Ok(FileMetadata::new(true, false, false))
             }
 
-            fn canonicalize(&self, path: &Path) -> std::io::Result<PathBuf> {
+            fn canonicalize(&self, _path: &Path) -> std::io::Result<PathBuf> {
                 env::current_dir().unwrap().canonicalize()
             }
         }

--- a/crates/biome_service/src/configuration/mod.rs
+++ b/crates/biome_service/src/configuration/mod.rs
@@ -572,7 +572,15 @@ impl PartialConfiguration {
                 directory_path.join(path)
             } else {
                 fs.resolve_configuration(path.as_str())
-                    .map_err(ConfigurationDiagnostic::cant_resolve)?
+                    .map_err(|error| {
+                        ConfigurationDiagnostic::cant_resolve(
+                            fs.working_directory()
+                                .unwrap_or_default()
+                                .display()
+                                .to_string(),
+                            error,
+                        )
+                    })?
                     .into_path_buf()
             };
 

--- a/crates/biome_service/src/configuration/mod.rs
+++ b/crates/biome_service/src/configuration/mod.rs
@@ -562,7 +562,17 @@ impl PartialConfiguration {
 
         let mut deserialized_configurations = vec![];
         for path in extends.iter() {
-            let config_path = directory_path.join(path);
+            let as_path = Path::new(path);
+            let extension = as_path.extension().and_then(|ext| ext.to_str());
+            // TODO: Remove extension in Biome 2.0
+            let config_path = if as_path.starts_with(".") || extension == Some("json") {
+                directory_path.join(path)
+            } else {
+                fs.resolve_configuration(path.as_str())
+                    .map_err(|err| ConfigurationDiagnostic::cant_resolve(err))?
+                    .into_path_buf()
+            };
+
             let mut file = fs
                 .open_with_options(config_path.as_path(), OpenOptions::default().read(true))
                 .map_err(|err| {
@@ -668,5 +678,64 @@ impl PartialConfiguration {
             }
         }
         Ok((None, vec![]))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use oxc_resolver::{FileMetadata, ResolveOptions, ResolverGeneric};
+    use std::env;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn resolver_test() {
+        #[derive(Debug, Default)]
+        struct Test;
+
+        impl oxc_resolver::FileSystem for Test {
+            fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
+                dbg!("read to string", &path);
+                Ok(String::from(
+                    r#"{ "name": "example", "exports": { "./biome": "./biome.json" }}"#,
+                ))
+            }
+
+            fn metadata(&self, path: &Path) -> std::io::Result<FileMetadata> {
+                dbg!(&path);
+                Ok(FileMetadata::new(true, false, false))
+            }
+
+            fn symlink_metadata(&self, path: &Path) -> std::io::Result<FileMetadata> {
+                dbg!(&path);
+                Ok(FileMetadata::new(true, false, false))
+            }
+
+            fn canonicalize(&self, path: &Path) -> std::io::Result<PathBuf> {
+                env::current_dir().unwrap().canonicalize()
+            }
+        }
+
+        let resolver = ResolverGeneric::new_with_file_system(
+            Test {},
+            ResolveOptions {
+                condition_names: vec!["node".to_string(), "import".to_string()],
+                extensions: vec!["*.json".to_string()],
+                ..ResolveOptions::default()
+            },
+        );
+
+        let result = resolver
+            .resolve(
+                env::current_dir()
+                    .unwrap()
+                    .canonicalize()
+                    .unwrap()
+                    .display()
+                    .to_string(),
+                "example/biome",
+            )
+            .unwrap();
+
+        dbg!(&result);
     }
 }

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -361,6 +361,12 @@ impl From<FileSystemDiagnostic> for WorkspaceError {
     }
 }
 
+impl From<ConfigurationDiagnostic> for WorkspaceError {
+    fn from(value: ConfigurationDiagnostic) -> Self {
+        Self::Configuration(value)
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]
 #[diagnostic(
     category = "internalError/fs",

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -46,12 +46,12 @@ pub(super) struct WorkspaceServer {
     project_handlers: ProjectHandlers,
 }
 
-/// The `Workspace` object is long lived, so we want it to be able to cross
+/// The `Workspace` object is long-lived, so we want it to be able to cross
 /// unwind boundaries.
-/// In return we have to make sure operations on the workspace either do not
+/// In return, we have to make sure operations on the workspace either do not
 /// panic, of that panicking will not result in any broken invariant (it would
 /// not result in any undefined behavior as catching an unwind is safe, but it
-/// could lead to hard to debug issues)
+/// could lead too hard to debug issues)
 impl RefUnwindSafe for WorkspaceServer {}
 
 #[derive(Debug)]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "scripts": {
     "check:apply": "cargo biome-cli-dev check --apply-unsafe editors website packages/@biomejs/js-api",
-		"check": "cargo biome-cli-dev check editors website packages/@biomejs/js-api --verbose"
+		"check": "cargo biome-cli-dev check editors website packages/@biomejs/js-api",
+		"ci": "cargo biome-cli-dev ci editors website packages/@biomejs/js-api"
 	},
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "keywords": [],
   "author": "",
   "devDependencies": {
+		"shared": "file:./shared",
     "@changesets/cli": "^2.26.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.26.2
         version: 2.26.2
+      shared:
+        specifier: file:./shared
+        version: file:shared
 
   packages/@biomejs/backend-jsonrpc:
     devDependencies:
@@ -8949,3 +8952,8 @@ packages:
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+  file:shared:
+    resolution: {directory: shared, type: directory}
+    name: shared
+    dev: true

--- a/shared/biome.json
+++ b/shared/biome.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "../packages/@biomejs/biome/configuration_schema.json",
-	"extends": ["shared/biome"],
 	"vcs": {
 		"clientKind": "git",
 		"enabled": true,

--- a/shared/biome.json
+++ b/shared/biome.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "../packages/@biomejs/biome/configuration_schema.json",
+	"extends": ["shared/biome"],
+	"vcs": {
+		"clientKind": "git",
+		"enabled": true,
+		"useIgnoreFile": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"style": {
+				"noNonNullAssertion": "off"
+			}
+		}
+	},
+	"organizeImports": {
+		"enabled": true
+	}
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "shared",
+	"version": "0.0.0",
+	"exports": {
+		"./biome": "./biome.json"
+	},
+	"keywords": [],
+	"license": "ISC"
+}

--- a/website/src/content/docs/guides/how-biome-works.mdx
+++ b/website/src/content/docs/guides/how-biome-works.mdx
@@ -68,6 +68,87 @@ Here's an example:
 - biome commands that run in `app/frontend/legacy/package.json` and `app/frontend/new/package.json`
 will use the configuration file `app/frontend/biome.json`;
 
+### The `extends` option
+
+The `extends` option allows to break down a configuration in multiple file and "share" common patterns among multiple projects/folders.
+
+```json title="biome.json"
+{
+  "$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
+  "extends": ["./formatter.json", "./linter.json"]
+}
+```
+
+```json title="formatter.json"
+{
+  "$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
+  "formatter": {
+    "indentSize": 2
+  },
+  "javascript": {
+    "formatter": {
+      "semicolons": "asNeeded"
+    }
+  }
+}
+```
+
+```json title="linter.json"
+{
+  "$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
+  "linter": {
+    "rules": {
+      "complexity": {
+        "noUselessConstructor": "off"
+      }
+    }
+  }
+}
+```
+
+The files defined in this array:
+- must exist in the file system;
+- are resolved from the path where the `biome.json` file is defined;
+- must be relative paths. Paths to libraries are not resolved;
+- must be reachable by Biome, e.g. symbolic links might not be resolved by Biome;
+- will be processed in order: from the first one to the last one;
+- can override the same properties, but ultimately only the last one will be used by Biome;
+
+
+#### Import `biome.json` from a library
+
+From version `v1.6.0`, Biome is able to resolve configuration files from `node_modules/`, so you can export your configuration file from a library, and import it in multiple projects.
+
+In order to do so, the first thing to do is to set up your "shared" Biome configuration in a certain way. Let's suppose that your library is called `@org/shared-configs`, and you want to import the Biome configuration using the specifier `@org/shared-configs/biome`. You have to set up the `package.json` is a specific way:
+
+```json title="package.json" ins={4}
+{
+  "name": "@org/shared-configs",
+  "exports": {
+    "./biome": "./biome.json"
+  }
+}
+```
+
+:::note
+You can also export `biome.jsonc` files. Just change `./biome.json` to `./biome.jsonc` and it should work.
+:::
+
+Make sure that `@org/shared-configs` is correctly installed in your project, and update the `biome.json` file to look like the following snippet:
+
+```json title="biome.json"
+{
+  "extends": ["@org/shared-configs/biome"]
+}
+```
+
+Biome will attempt to **resolve** your library `@org/shared-configs/` from your working directory. The working directory is:
+- when using the CLI, the directory where you execute your scripts from. Usually it matches the location of your `package.json` file;
+- when using the LSP, the root directory of your project.
+
+:::caution
+To avoid a breaking change with how the existing resolution works, paths that start with a dot `.` or contains `.json`/`.jsonc` in their name, they **won't** be resolved from `node_modules/`.
+:::
 
 ## Protected Files
 

--- a/website/src/content/docs/guides/how-biome-works.mdx
+++ b/website/src/content/docs/guides/how-biome-works.mdx
@@ -150,6 +150,8 @@ Biome will attempt to **resolve** your library `@org/shared-configs/` from your 
 To avoid a breaking change with how the existing resolution works, paths that start with a dot `.` or contains `.json`/`.jsonc` in their name, they **won't** be resolved from `node_modules/`.
 :::
 
+For more information about the resolution algorithm, read the [Node.js documentation](https://nodejs.org/api/esm.html#resolution-and-loading-algorithm).
+
 ## Protected Files
 
 The following files are currently ignored by Biome. This means that no diagnostics will be ever emitted by Biome for those files.

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -62,6 +62,30 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 ### Configuration
 
+#### New features
+
+- Add the ability to resolve the configuration files defined inside `extends` from the `node_modules/` directory.
+
+  If you want to resolve a configuration file that matches the specifier `@org/configs/biome`, then your `package.json` file must look this:
+
+  ```json
+  {
+    "name": "@org/configs",
+    "exports": {
+      "./biome": "./biome.json"
+    }
+  }
+  ```
+
+  And the `biome.json` file that "imports" said configuration, will look like this:
+  ```json
+  {
+    "extends": "@org/configs/biome"
+  }
+  ```
+  Read the [documentation](https://biomejs.dev/guides/how-biome-works#the-extends-option) to better understand how it works, expectations and restrictions.
+
+
 ### Editors
 
 #### Bug fixes

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -38,49 +38,6 @@ If you have problems with resolving the physical file, you can use the one publi
 
 A list of paths to other JSON files. Biome resolves and applies the options of the files contained in the `extends` list, and eventually applies the options contained in the `biome.json` file.
 
-
-```json title="biome.json"
-{
-  "$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
-  "extends": ["./formatter.json", "./linter.json"]
-}
-```
-
-```json title="formatter.json"
-{
-  "$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
-  "formatter": {
-    "indentSize": 2
-  },
-  "javascript": {
-    "formatter": {
-      "semicolons": "asNeeded"
-    }
-  }
-}
-```
-
-```json title="linter.json"
-{
-  "$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
-  "linter": {
-    "rules": {
-      "complexity": {
-        "noUselessConstructor": "off"
-      }
-    }
-  }
-}
-```
-
-The files defined in this array:
-- must exist in the file system;
-- are resolved from the path where the `biome.json` file is defined;
-- must be relative paths. Paths to libraries are not resolved;
-- must be reachable by Biome, e.g. symbolic links might not be resolved by Biome;
-- will be processed in order: from the first one to the last one;
-- can override the same properties, but ultimately only the last one will be used by Biome;
-
 ## `files`
 
 ### `files.maxSize`


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR allows resolving a configuration file from `node_modules`. To do so, we use `oxc_resolver` to resolve the configuration file.

Unfortunately, I couldn't implement a test case using our memory file system. While `oxc_resolver` allows to implement a `FileSytem` trait to implement any possible logic, unfortunately, the `Resolver` wants ownership of type struct that implements `FileSystem`, e.g.:

```rs
struct MemoryFs {};
impl FileSystem for MemoryFs {};
let resolver = ResolverGeneric::with_file_system(options, MemoryFs);
```

This doesn't work well with our infrastructure, where our memory file system must outlive the entire application. 


I updated the documentation to explain how Biome will resolve the files, please read it and let me know if it's clear enough. Please leave any questions.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I used our repository as a guinea pig. It means that the `check` command must pass.  

<!-- What demonstrates that your implementation is correct? -->
