### PR TITLE
chore: upgrade to rust 1.76.0

### DIFF
--- a/crates/biome_cli/src/diagnostics.rs
+++ b/crates/biome_cli/src/diagnostics.rs
@@ -716,7 +716,7 @@ mod test {
     fn termination_diagnostic_size() {
         assert_eq!(
             std::mem::size_of::<CliDiagnostic>(),
-            104,
+            96,
             "you successfully decreased the size of the diagnostic!"
         )
     }

--- a/crates/biome_diagnostics/tests/macros/location_eq.stderr
+++ b/crates/biome_diagnostics/tests/macros/location_eq.stderr
@@ -4,7 +4,7 @@ error: failed to parse "location" attribute: expected parentheses
 5 |     #[location = Identifier]
   |                ^
 
-error: unexpected expression: `Identifier`
+error: attribute value must be a literal
  --> tests/macros/location_eq.rs:5:18
   |
 5 |     #[location = Identifier]

--- a/crates/biome_formatter/src/printer/line_suffixes.rs
+++ b/crates/biome_formatter/src/printer/line_suffixes.rs
@@ -21,8 +21,7 @@ impl<'a> LineSuffixes<'a> {
     /// Takes all the pending line suffixes.
     pub(super) fn take_pending<'l>(
         &'l mut self,
-    ) -> impl Iterator<Item = LineSuffixEntry<'a>> + DoubleEndedIterator + 'l + ExactSizeIterator
-    {
+    ) -> impl DoubleEndedIterator<Item = LineSuffixEntry<'a>> + 'l + ExactSizeIterator {
         self.suffixes.drain(..)
     }
 

--- a/crates/biome_js_formatter/src/utils/member_chain/groups.rs
+++ b/crates/biome_js_formatter/src/utils/member_chain/groups.rs
@@ -134,7 +134,7 @@ impl TailChainGroups {
     }
 
     /// Returns an iterator over the groups.
-    pub(super) fn iter(&self) -> impl Iterator<Item = &MemberChainGroup> + DoubleEndedIterator {
+    pub(super) fn iter(&self) -> impl DoubleEndedIterator<Item = &MemberChainGroup> {
         self.groups.iter()
     }
 
@@ -150,7 +150,7 @@ impl TailChainGroups {
     }
 
     /// Returns an iterator over all members
-    pub(super) fn members(&self) -> impl Iterator<Item = &ChainMember> + DoubleEndedIterator {
+    pub(super) fn members(&self) -> impl DoubleEndedIterator<Item = &ChainMember> {
         self.groups.iter().flat_map(|group| group.members().iter())
     }
 }

--- a/crates/biome_js_formatter/src/utils/member_chain/mod.rs
+++ b/crates/biome_js_formatter/src/utils/member_chain/mod.rs
@@ -328,7 +328,7 @@ impl MemberChain {
     }
 
     /// Returns an iterator over all members in the member chain
-    fn members(&self) -> impl Iterator<Item = &ChainMember> + DoubleEndedIterator {
+    fn members(&self) -> impl DoubleEndedIterator<Item = &ChainMember> {
         self.head.members().iter().chain(self.tail.members())
     }
 

--- a/crates/biome_rowan/src/arc.rs
+++ b/crates/biome_rowan/src/arc.rs
@@ -86,7 +86,7 @@ impl<T: ?Sized> Arc<T> {
     /// allocation
     #[inline]
     pub(crate) fn ptr_eq(this: &Self, other: &Self) -> bool {
-        this.ptr() == other.ptr()
+        std::ptr::addr_eq(this.ptr(), other.ptr())
     }
 
     pub(crate) fn ptr(&self) -> *mut ArcInner<T> {

--- a/crates/biome_rowan/src/cursor/node.rs
+++ b/crates/biome_rowan/src/cursor/node.rs
@@ -176,7 +176,7 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn tokens(&self) -> impl Iterator<Item = SyntaxToken> + DoubleEndedIterator + '_ {
+    pub fn tokens(&self) -> impl DoubleEndedIterator<Item = SyntaxToken> + '_ {
         self.green().children().filter_map(|child| {
             child.element().into_token().map(|token| {
                 SyntaxToken::new(

--- a/crates/biome_rowan/src/syntax/node.rs
+++ b/crates/biome_rowan/src/syntax/node.rs
@@ -287,7 +287,7 @@ impl<L: Language> SyntaxNode<L> {
         }
     }
 
-    pub fn tokens(&self) -> impl Iterator<Item = SyntaxToken<L>> + DoubleEndedIterator + '_ {
+    pub fn tokens(&self) -> impl DoubleEndedIterator<Item = SyntaxToken<L>> + '_ {
         self.raw.tokens().map(SyntaxToken::from)
     }
 

--- a/crates/biome_rowan/src/syntax_node_text.rs
+++ b/crates/biome_rowan/src/syntax_node_text.rs
@@ -107,20 +107,21 @@ impl SyntaxNodeText {
 
     pub fn for_each_chunk<F: FnMut(&str)>(&self, mut f: F) {
         enum Void {}
-        match self.try_for_each_chunk(|chunk| {
+        let out = self.try_for_each_chunk(|chunk| {
             f(chunk);
             Ok::<(), Void>(())
-        }) {
+        });
+        match out {
             Ok(()) => (),
             Err(void) => match void {},
         }
     }
 
-    fn tokens_with_ranges(&self) -> impl Iterator<Item = (SyntaxToken, TextRange)> + FusedIterator {
+    fn tokens_with_ranges(&self) -> impl FusedIterator<Item = (SyntaxToken, TextRange)> {
         SyntaxNodeTokenWithRanges::new(self)
     }
 
-    pub fn chars(&self) -> impl Iterator<Item = char> + FusedIterator {
+    pub fn chars(&self) -> impl FusedIterator<Item = char> {
         SyntaxNodeTextChars::new(self)
     }
 }

--- a/crates/biome_service/src/configuration/diagnostics.rs
+++ b/crates/biome_service/src/configuration/diagnostics.rs
@@ -304,7 +304,7 @@ mod test {
 
     #[test]
     fn diagnostic_size() {
-        assert_eq!(std::mem::size_of::<ConfigurationDiagnostic>(), 104);
+        assert_eq!(std::mem::size_of::<ConfigurationDiagnostic>(), 96);
     }
 
     #[test]

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -734,7 +734,7 @@ mod test {
 
     #[test]
     fn diagnostic_size() {
-        assert_eq!(std::mem::size_of::<WorkspaceError>(), 104)
+        assert_eq!(std::mem::size_of::<WorkspaceError>(), 96)
     }
 
     #[test]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-channel = "1.75.0"
+channel = "1.76.0"


### PR DESCRIPTION
Updates Rust to latest version https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html