### PR TITLE
docs(website): Add copy button for commands

### DIFF
--- a/.github/workflows/release_js_api.yml
+++ b/.github/workflows/release_js_api.yml
@@ -120,7 +120,7 @@ jobs:
     needs: build
     environment: npm-publish
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4

--- a/website/src/assets/svg/copy-icon.svg
+++ b/website/src/assets/svg/copy-icon.svg
@@ -1,0 +1,3 @@
+<svg id="copy-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24">
+    <path stroke-linejoin="round" stroke-width="2" d="M14 4v3c0 .6-.4 1-1 1h-3m4 10v1c0 .6-.4 1-1 1H6a1 1 0 0 1-1-1V9c0-.6.4-1 1-1h2m11-3v10c0 .6-.4 1-1 1h-7a1 1 0 0 1-1-1V7.9c0-.3 0-.5.2-.7l2.5-2.9c.2-.2.5-.3.8-.3H18c.6 0 1 .4 1 1Z"/>
+  </svg>

--- a/website/src/assets/svg/tick-icon.svg
+++ b/website/src/assets/svg/tick-icon.svg
@@ -1,0 +1,3 @@
+<svg id="tick-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m5 12 4.7 4.5 9.3-9"/>
+  </svg>

--- a/website/src/components/PackageManagerBiomeCommand.astro
+++ b/website/src/components/PackageManagerBiomeCommand.astro
@@ -34,8 +34,8 @@ const biome = "@biomejs/biome";
 	</li>
 </ul>
 
-<pre data-name="npm" class="package-manager-command language-shellsession active"><code>npx {biome} {command}</code></pre>
-<pre data-name="yarn" class="package-manager-command language-shellsession"><code>yarn dlx {biome} {command}</code></pre>
-<pre data-name="pnpm" class="package-manager-command language-shellsession"><code>pnpm dlx {biome} {command}</code></pre>
-<pre data-name="bun" class="package-manager-command language-shellsession"><code>bunx {biome} {command}</code></pre>
-<pre data-name="deno" class="package-manager-command language-shellsession"><code>deno run -A npm:{biome} {command}</code></pre>
+<pre data-name="npm" class="package-manager-command language-shellsession active"><code>npx {biome} {command}</code><button><InlineSVG src="copy-icon" /><InlineSVG src="tick-icon" /></button></pre>
+<pre data-name="yarn" class="package-manager-command language-shellsession"><code>yarn dlx {biome} {command}</code><button><InlineSVG src="copy-icon" /><InlineSVG src="tick-icon" /></button></pre>
+<pre data-name="pnpm" class="package-manager-command language-shellsession"><code>pnpm dlx {biome} {command}</code><button><InlineSVG src="copy-icon" /><InlineSVG src="tick-icon" /></button></pre>
+<pre data-name="bun" class="package-manager-command language-shellsession"><code>bunx {biome} {command}</code><button><InlineSVG src="copy-icon" /><InlineSVG src="tick-icon" /></button></pre>
+<pre data-name="deno" class="package-manager-command language-shellsession"><code>deno run -A npm:{biome} {command}</code><button><InlineSVG src="copy-icon" /><InlineSVG src="tick-icon" /></button></pre>

--- a/website/src/components/PackageManagerCommand.astro
+++ b/website/src/components/PackageManagerCommand.astro
@@ -24,7 +24,7 @@ import InlineSVG from "@src/components/InlineSVG.astro";
   </li>
 </ul>
 
-<pre data-name="npm" class="package-manager-command language-shellsession active"><code>{Astro.props.npx ? "npx" : "npm"} {Astro.props.npx ?? Astro.props.npm ?? Astro.props.command}</code></pre>
-<pre data-name="yarn" class="package-manager-command language-shellsession"><code>yarn {Astro.props.yarn ?? Astro.props.command}</code></pre>
-<pre data-name="pnpm" class="package-manager-command language-shellsession"><code>pnpm {Astro.props.pnpm ?? Astro.props.command}</code></pre>
-<pre data-name="bun" class="package-manager-command language-shellsession"><code>bun{Astro.props.bun ? "" : "x"} {Astro.props.bunx ?? Astro.props.bun ?? Astro.props.command}</code></pre>
+<pre data-name="npm" class="package-manager-command language-shellsession active"><code>{Astro.props.npx ? "npx" : "npm"} {Astro.props.npx ?? Astro.props.npm ?? Astro.props.command}</code><button><InlineSVG src="copy-icon" /><InlineSVG src="tick-icon" /></button></pre>
+<pre data-name="yarn" class="package-manager-command language-shellsession"><code>yarn {Astro.props.yarn ?? Astro.props.command}</code><button><InlineSVG src="copy-icon" /><InlineSVG src="tick-icon" /></button></pre>
+<pre data-name="pnpm" class="package-manager-command language-shellsession"><code>pnpm {Astro.props.pnpm ?? Astro.props.command}</code><button><InlineSVG src="copy-icon" /><InlineSVG src="tick-icon" /></button></pre>
+<pre data-name="bun" class="package-manager-command language-shellsession"><code>bun{Astro.props.bun ? "" : "x"} {Astro.props.bunx ?? Astro.props.bun ?? Astro.props.command}</code><button><InlineSVG src="copy-icon" /><InlineSVG src="tick-icon" /></button></pre>

--- a/website/src/frontend-scripts/package-manager-commands.ts
+++ b/website/src/frontend-scripts/package-manager-commands.ts
@@ -29,3 +29,25 @@ const stored = localStorage.getItem("package-manager");
 if (stored != null) {
 	setActivePackageManager(stored);
 }
+
+const copyButtons = document.querySelectorAll(
+	".package-manager-command button",
+);
+
+function commandCopyHandler(button: Element) {
+	button.classList.add("copied");
+	setTimeout(() => {
+		button.classList.remove("copied");
+	}, 1000);
+
+	if (button.parentElement !== null) {
+		const cmd = button.parentElement.querySelector("code")?.textContent ?? "";
+		navigator.clipboard.writeText(cmd);
+	}
+}
+
+for (const button of copyButtons) {
+	button.addEventListener("click", () => {
+		commandCopyHandler(button);
+	});
+}

--- a/website/src/styles/_pre.scss
+++ b/website/src/styles/_pre.scss
@@ -58,7 +58,9 @@ pre.package-manager-command {
   display: none;
 
   &.active {
-    display: block;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
   }
 }
 
@@ -67,3 +69,44 @@ pre.package-manager-command {
   border-top-right-radius: 0;
   margin-top: 0 !important;
 }
+
+//button copy style
+
+pre.package-manager-command button {
+  position: relative;
+  display: block;
+  cursor: pointer;
+  margin: 0;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background-color: transparent;
+}
+
+pre.package-manager-command button #tick-icon, 
+pre.package-manager-command button #copy-icon {
+  position: absolute;
+  margin: 0;
+  padding: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  transition: opacity .3s ease-in-out;
+  stroke: var(--sl-color-gray-4);
+}
+
+pre.package-manager-command button #tick-icon {
+  opacity: 0;
+  scale: 0;
+}
+
+pre.package-manager-command button.copied #copy-icon {
+  opacity: 0;
+  scale: 0;
+}
+
+pre.package-manager-command button.copied #tick-icon {
+  opacity: 1;
+  scale: 1;
+}
+

--- a/website/src/styles/_pre.scss
+++ b/website/src/styles/_pre.scss
@@ -75,23 +75,22 @@ pre.package-manager-command button {
   display: inline-block;
   cursor: pointer;
   margin: 0;
-  min-width: 32px;
-  min-height: 32px;
-  height: 32px;
-  width: 32px;
+  min-width: 20px;
+  height: 20px;
+  width: 20px;
   border: none;
   background-color: transparent;
 
   @include mobile-only {
-    margin-left: 32px;
+    margin-left: 20px;
   }
 }
 
 pre.package-manager-command button #tick-icon, 
 pre.package-manager-command button #copy-icon {
   position: absolute;
-  height: 32px;
-  width: 32px;
+  height: 20px;
+  width: 20px;
   margin: 0;
   padding: 0;
   top: 50%;

--- a/website/src/styles/_pre.scss
+++ b/website/src/styles/_pre.scss
@@ -72,18 +72,26 @@ pre.package-manager-command {
 
 pre.package-manager-command button {
   position: relative;
-  display: block;
+  display: inline-block;
   cursor: pointer;
   margin: 0;
-  width: 32px;
+  min-width: 32px;
+  min-height: 32px;
   height: 32px;
+  width: 32px;
   border: none;
   background-color: transparent;
+
+  @include mobile-only {
+    margin-left: 32px;
+  }
 }
 
 pre.package-manager-command button #tick-icon, 
 pre.package-manager-command button #copy-icon {
   position: absolute;
+  height: 32px;
+  width: 32px;
   margin: 0;
   padding: 0;
   top: 50%;

--- a/website/src/styles/_pre.scss
+++ b/website/src/styles/_pre.scss
@@ -70,8 +70,6 @@ pre.package-manager-command {
   margin-top: 0 !important;
 }
 
-//button copy style
-
 pre.package-manager-command button {
   position: relative;
   display: block;


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->
#### New features

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
I have found my self selecting the commands with the mouse and it will be nice to have a button to copy straight away the command.  

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Before: 
![Screenshot 2024-02-10 at 14 05 56](https://github.com/biomejs/biome/assets/66533853/c98110ab-cb95-42e1-8bd1-f02c2913ba3b)

After:
![Screenshot 2024-02-10 at 14 06 30](https://github.com/biomejs/biome/assets/66533853/02935857-7e78-43bf-a9d0-54efafcc6298)




https://github.com/biomejs/biome/assets/66533853/242d2fdd-8161-40fa-bd17-9dfeeb466abe


