### PR TITLE
fix(lint): `useAwait` ignores `for await...of`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
   Contributed by @ah-yu
 
+- Fix [#1081](https://github.com/biomejs/biome/issues/1081). The `useAwait` rule does not report `for await...of`. Contributed by @unvalley
+
 ### CLI
 
 #### New features

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_await.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_await.rs
@@ -75,13 +75,11 @@ impl Visitor for MissingAwaitVisitor {
                         self.stack.push((node.range().start(), false));
                     }
                 }
-                if JsAwaitExpression::can_cast(node.kind()) {
-                    if let Some((_, has_await)) = self.stack.last_mut() {
+                if let Some((_, has_await)) = self.stack.last_mut() {
+                    if JsAwaitExpression::can_cast(node.kind()) {
                         *has_await = true;
-                    }
-                } else if let Some(for_of) = JsForOfStatement::cast_ref(node) {
-                    if let Some((_, has_await)) = self.stack.last_mut() {
-                        *has_await = for_of.await_token().is_some();
+                    } else if let Some(for_of) = JsForOfStatement::cast_ref(node) {
+                        *has_await = *has_await || for_of.await_token().is_some();
                     }
                 }
             }

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_await.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_await.rs
@@ -75,14 +75,11 @@ impl Visitor for MissingAwaitVisitor {
                         self.stack.push((node.range().start(), false));
                     }
                 }
-                // Check `await` expression
                 if JsAwaitExpression::can_cast(node.kind()) {
                     if let Some((_, has_await)) = self.stack.last_mut() {
                         *has_await = true;
                     }
-                }
-                // Check `for await...of`
-                if let Some(for_of) = JsForOfStatement::cast_ref(node) {
+                } else if let Some(for_of) = JsForOfStatement::cast_ref(node) {
                     if let Some((_, has_await)) = self.stack.last_mut() {
                         *has_await = for_of.await_token().is_some();
                     }

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwait/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwait/invalid.js
@@ -55,3 +55,11 @@ async function complexFunction() {
 		return fetch('condition-data');
 	}
 }
+
+async function withoutForAwait () {
+	let sum = 0;
+	for (const n of [1, 2, 3]) {
+		sum += n
+	}
+	return sum;
+};

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwait/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwait/invalid.js.snap
@@ -62,6 +62,14 @@ async function complexFunction() {
 	}
 }
 
+async function withoutForAwait () {
+	let sum = 0;
+	for (const n of [1, 2, 3]) {
+		sum += n
+	}
+	return sum;
+};
+
 ```
 
 # Diagnostics
@@ -430,11 +438,11 @@ invalid.js:41:1 lint/nursery/useAwait ━━━━━━━━━━━━━━
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   > 42 │ 	const obj = {
         ...
-  > 55 │ 		return fetch('condition-data');
   > 56 │ 	}
   > 57 │ }
        │ ^
     58 │ 
+    59 │ async function withoutForAwait () {
   
   i Remove this async modifier, or add an await expression in the function.
   
@@ -444,11 +452,49 @@ invalid.js:41:1 lint/nursery/useAwait ━━━━━━━━━━━━━━
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   > 42 │ 	const obj = {
         ...
-  > 55 │ 		return fetch('condition-data');
   > 56 │ 	}
   > 57 │ }
        │ ^
     58 │ 
+    59 │ async function withoutForAwait () {
+  
+  i Async functions without await expressions may not need to be declared async.
+  
+
+```
+
+```
+invalid.js:59:1 lint/nursery/useAwait ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This async function lacks an await expression.
+  
+    57 │ }
+    58 │ 
+  > 59 │ async function withoutForAwait () {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 60 │ 	let sum = 0;
+  > 61 │ 	for (const n of [1, 2, 3]) {
+  > 62 │ 		sum += n
+  > 63 │ 	}
+  > 64 │ 	return sum;
+  > 65 │ };
+       │ ^
+    66 │ 
+  
+  i Remove this async modifier, or add an await expression in the function.
+  
+    57 │ }
+    58 │ 
+  > 59 │ async function withoutForAwait () {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 60 │ 	let sum = 0;
+  > 61 │ 	for (const n of [1, 2, 3]) {
+  > 62 │ 		sum += n
+  > 63 │ 	}
+  > 64 │ 	return sum;
+  > 65 │ };
+       │ ^
+    66 │ 
   
   i Async functions without await expressions may not need to be declared async.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwait/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwait/valid.js
@@ -49,3 +49,11 @@ class NoOperationClass {
 async function wrapperFetchData() {
 	return await fetchDataAsync();
 }
+
+async () => {
+  let sum = 0;
+  for await (const n of [1, 2, 3]) {
+		sum += n
+  }
+  return sum;
+};

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwait/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwait/valid.js
@@ -58,3 +58,11 @@ async function forAwaitOf () {
 	return sum;
 };
 
+async function awaitExpressionWithForOf () {
+	let sum = await initialSum();
+	for (const n of [1, 2, 3]) {
+		sum += n
+	}
+	return sum;
+};
+

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwait/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwait/valid.js
@@ -50,10 +50,11 @@ async function wrapperFetchData() {
 	return await fetchDataAsync();
 }
 
-async () => {
-  let sum = 0;
-  for await (const n of [1, 2, 3]) {
+async function forAwaitOf () {
+	let sum = 0;
+	for await (const n of [1, 2, 3]) {
 		sum += n
-  }
-  return sum;
+	}
+	return sum;
 };
+

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwait/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwait/valid.js.snap
@@ -64,6 +64,14 @@ async function forAwaitOf () {
 	return sum;
 };
 
+async function awaitExpressionWithForOf () {
+	let sum = await initialSum();
+	for (const n of [1, 2, 3]) {
+		sum += n
+	}
+	return sum;
+};
+
 
 ```
 

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwait/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwait/valid.js.snap
@@ -56,13 +56,14 @@ async function wrapperFetchData() {
 	return await fetchDataAsync();
 }
 
-async () => {
-  let sum = 0;
-  for await (const n of [1, 2, 3]) {
+async function forAwaitOf () {
+	let sum = 0;
+	for await (const n of [1, 2, 3]) {
 		sum += n
-  }
-  return sum;
+	}
+	return sum;
 };
+
 
 ```
 

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwait/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwait/valid.js.snap
@@ -56,6 +56,14 @@ async function wrapperFetchData() {
 	return await fetchDataAsync();
 }
 
+async () => {
+  let sum = 0;
+  for await (const n of [1, 2, 3]) {
+		sum += n
+  }
+  return sum;
+};
+
 ```
 
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -28,6 +28,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
   Contributed by @ah-yu
 
+- Fix [#1081](https://github.com/biomejs/biome/issues/1081). The `useAwait` rule does not report `for await...of`. Contributed by @unvalley
+
 ### CLI
 
 #### New features


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #1081 

This PR fixes a false-positive in the `useAwait` lint rule. It should ignore `for await...of` in an async function.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Adds a test case for `for await...of` and execute `just test-lintrule useAwait`
<!-- What demonstrates that your implementation is correct? -->
