### PR TITLE
feat(cli): make file in diagnostic clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Add a new command `biome migrate prettier`. The command will read the file `.prettierrc`/`prettier.json` and `.prettierignore` and map its configuration to Biome's one.
   Due to the different nature of `.prettierignore` globs and Biome's globs, it's **highly** advised to make sure that those still work under Biome.
 
+- Now the file name printed in the diagnostics is clickable. If you run the CLI from your editor, you can <kbd>Ctrl</kbd>/<kbd title="Cmd">⌘</kbd> + Click on the file name, and the editor will open said file. If row and columns are specified e.g. `file.js:32:7`, the editor will set the cursor right in that position. Contributed by @ematipico
+
 #### Bug fixes
 
 - Don't process files under an ignored directory.

--- a/crates/biome_diagnostics/src/display.rs
+++ b/crates/biome_diagnostics/src/display.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::{io, iter};
 
 use biome_console::{fmt, markup, HorizontalLine, Markup, MarkupBuf, MarkupElement, MarkupNode};
@@ -91,7 +92,15 @@ impl<'fmt, D: Diagnostic + ?Sized> fmt::Display for PrintHeader<'fmt, D> {
         };
 
         if let Some(name) = file_name {
-            fmt.write_str(name)?;
+            let path_name = Path::new(name);
+            if path_name.is_absolute() {
+                let link = format!("file://{}", name);
+                fmt.write_markup(markup! {
+                    <Hyperlink href={link}>{name}</Hyperlink>
+                })?;
+            } else {
+                fmt.write_str(name)?;
+            }
 
             // Print the line and column position if the location has a span and source code
             // (the source code is necessary to convert a byte offset into a line + column)

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -37,6 +37,8 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 - Add a new command `biome migrate prettier`. The command will read the file `.prettierrc`/`prettier.json` and `.prettierignore` and map its configuration to Biome's one.
   Due to the different nature of `.prettierignore` globs and Biome's globs, it's **highly** advised to make sure that those still work under Biome.
 
+- Now the file name printed in the diagnostics is clickable. If you run the CLI from your editor, you can <kbd>Ctrl</kbd>/<kbd title="Cmd">⌘</kbd> + Click on the file name, and the editor will open said file. If row and columns are specified e.g. `file.js:32:7`, the editor will set the cursor right in that position. Contributed by @ematipico
+
 #### Bug fixes
 
 - Don't process files under an ignored directory.


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Another QoL improvement. Now the files printed in a diagnostic are clickable. If biome is run from a terminal that is integrated in the IDE, the IDE will open that file in the specified row:column

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

The current tests should stay as is. I tested locally and it works like a charm: RustRover and VSCode

Unfortunately VSCode terminal isn't that good at underling the file, but if you hover it with the cursor, it get underlined. 
<img width="1025" alt="Screenshot 2024-02-14 at 09 16 50" src="https://github.com/biomejs/biome/assets/602478/07c30147-e81f-4e56-a3df-226e202440ea">

RustRover instead underlines it regardless.
![Screenshot 2024-02-14 at 09 17 17](https://github.com/biomejs/biome/assets/602478/2166eabc-7879-405f-adba-57f9bcb58644)

<!-- What demonstrates that your implementation is correct? -->
