### PR TITLE
fix(lint/noConfusingVoidType): accept `void` as the extends type in conditional types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,16 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Bug fixes
 
+- [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type) no longer reports valid use of the void type in conditional types ([#1812](https://github.com/biomejs/biome/issues/1812)).
+
+  The rule no longer reports the following code:
+
+  ```ts
+  type Conditional<T> = T extends void ? Record<string, never> : T
+  ```
+
+  Contributed by @lucasweng
+
 - [noInvalidUseBeforeDeclaration](https://biomejs.dev/linter/rules/no-invalid-use-before-declaration) no longer reports valid use of binding patterns ([#1648](https://github.com/biomejs/biome/issues/1648)).
 
   The rule no longer reports the following code:

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts
@@ -40,3 +40,5 @@ class Test {
 }
 
 functionGeneric<void>(undefined);
+
+type Conditional<T> = T extends void ? Record<string, never> : T

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingVoidType/valid.ts.snap
@@ -46,6 +46,9 @@ class Test {
 }
 
 functionGeneric<void>(undefined);
+
+type Conditional<T> = T extends void ? Record<string, never> : T
+
 ```
 
 

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -274,6 +274,16 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
 
 #### Bug fixes
 
+- [noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type) no longer reports valid use of the void type in conditional types ([#1812](https://github.com/biomejs/biome/issues/1812)).
+
+  The rule no longer reports the following code:
+
+  ```ts
+  type Conditional<T> = T extends void ? Record<string, never> : T
+  ```
+
+  Contributed by @lucasweng
+
 - [noInvalidUseBeforeDeclaration](https://biomejs.dev/linter/rules/no-invalid-use-before-declaration) no longer reports valid use of binding patterns ([#1648](https://github.com/biomejs/biome/issues/1648)).
 
   The rule no longer reports the following code:


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

- Closes https://github.com/biomejs/biome/issues/1812

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added a new test case and other existing tests should pass.