### PR TITLE
feat(formatter): partial formatting for `svelte` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,17 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   <template></template>
   ```
 
+- Add partial for `.svelte` files. Biome is able to format the script block of Svelte files. Contributed by @ematipico
+
+  ```diff
+  <script setup lang="ts">
+  - statement ( );
+  + statement();
+  </script/>
+
+  <div></div>
+  ```
+
 #### Bug fixes
 
 - Fix [#1039](https://github.com/biomejs/biome/issues/1039). Check unicode width instead of number of bytes when checking if regex expression is a simple argument. Contributed by @kalleep

--- a/crates/biome_cli/src/execute/process_file/format.rs
+++ b/crates/biome_cli/src/execute/process_file/format.rs
@@ -5,7 +5,7 @@ use crate::execute::process_file::{
 };
 use crate::execute::TraversalMode;
 use biome_diagnostics::{category, DiagnosticExt};
-use biome_service::file_handlers::{ASTRO_FENCE, VUE_FENCE};
+use biome_service::file_handlers::{ASTRO_FENCE, SVELTE_FENCE, VUE_FENCE};
 use biome_service::workspace::RuleCategories;
 use std::path::Path;
 use std::sync::atomic::Ordering;
@@ -89,6 +89,23 @@ pub(crate) fn format_with_guard<'ctx>(
                     return Ok(FileStatus::Ignored);
                 }
                 if let Some(script) = VUE_FENCE
+                    .captures(&input)
+                    .and_then(|captures| captures.name("script"))
+                {
+                    output = format!(
+                        "{}{}{}",
+                        &input[..script.start()],
+                        output.as_str(),
+                        &input[script.end()..]
+                    );
+                }
+            }
+
+            if workspace_file.as_extension() == Some("svelte") {
+                if output.is_empty() {
+                    return Ok(FileStatus::Ignored);
+                }
+                if let Some(script) = SVELTE_FENCE
                     .captures(&input)
                     .and_then(|captures| captures.name("script"))
                 {

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -94,6 +94,42 @@ const hello: string = "world";
 </script>
 <template></template>"#;
 
+const SVELTE_IMPLICIT_JS_FILE_UNFORMATTED: &str = r#"<script>
+import {    something } from "file.svelte";
+statement ( ) ;
+</script>
+<div></div>"#;
+
+const SVELTE_IMPLICIT_JS_FILE_FORMATTED: &str = r#"<script>
+import { something } from "file.svelte";
+statement();
+</script>
+<div></div>"#;
+
+const SVELTE_EXPLICIT_JS_FILE_UNFORMATTED: &str = r#"<script lang="js">
+import {    something } from "file.svelte";
+statement ( ) ;
+</script>
+<div></div>"#;
+
+const SVELTE_EXPLICIT_JS_FILE_FORMATTED: &str = r#"<script lang="js">
+import { something } from "file.svelte";
+statement();
+</script>
+<div></div>"#;
+
+const SVELTE_TS_FILE_UNFORMATTED: &str = r#"<script setup lang="ts">
+import     { type     something } from "file.svelte";
+const hello  :      string      = "world";
+</script>
+<div></div>"#;
+
+const SVELTE_TS_FILE_FORMATTED: &str = r#"<script setup lang="ts">
+import { type something } from "file.svelte";
+const hello: string = "world";
+</script>
+<div></div>"#;
+
 const APPLY_TRAILING_COMMA_BEFORE: &str = r#"
 const a = [
 	longlonglonglongItem1longlonglonglongItem1,
@@ -3322,6 +3358,274 @@ fn format_empty_vue_ts_files_write() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "format_empty_vue_ts_files_write",
+        fs,
+        console,
+        result,
+    ));
+}
+#[test]
+fn format_svelte_implicit_js_files() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let svelte_file_path = Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        SVELTE_IMPLICIT_JS_FILE_UNFORMATTED.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), svelte_file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, svelte_file_path, SVELTE_IMPLICIT_JS_FILE_UNFORMATTED);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_svelte_implicit_js_files",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_svelte_implicit_js_files_write() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let svelte_file_path = Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        VUE_IMPLICIT_JS_FILE_UNFORMATTED.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                "format",
+                "--write",
+                svelte_file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, svelte_file_path, SVELTE_IMPLICIT_JS_FILE_FORMATTED);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_svelte_implicit_js_files_write",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_svelte_explicit_js_files() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let svelte_file_path = Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        SVELTE_EXPLICIT_JS_FILE_UNFORMATTED.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), svelte_file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, svelte_file_path, SVELTE_EXPLICIT_JS_FILE_UNFORMATTED);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_svelte_explicit_js_files",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_svelte_explicit_js_files_write() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let svelte_file_path = Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        SVELTE_EXPLICIT_JS_FILE_UNFORMATTED.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                "format",
+                "--write",
+                svelte_file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, svelte_file_path, SVELTE_EXPLICIT_JS_FILE_FORMATTED);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_svelte_explicit_js_files_write",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_empty_svelte_js_files_write() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let svelte_file_path = Path::new("file.svelte");
+    fs.insert(svelte_file_path.into(), "<div></div>".as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                "format",
+                "--write",
+                svelte_file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, svelte_file_path, "<div></div>");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_empty_svelte_js_files_write",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_svelte_ts_files() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let svelte_file_path = Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        SVELTE_TS_FILE_UNFORMATTED.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), svelte_file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, svelte_file_path, SVELTE_TS_FILE_UNFORMATTED);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_svelte_ts_files",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_svelte_ts_files_write() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let svelte_file_path = Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        SVELTE_TS_FILE_UNFORMATTED.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                "format",
+                "--write",
+                svelte_file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, svelte_file_path, SVELTE_TS_FILE_FORMATTED);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_svelte_ts_files_write",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_empty_svelte_ts_files_write() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let svelte_file_path = Path::new("file.svelte");
+    fs.insert(svelte_file_path.into(), "<div></div>".as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                "format",
+                "--write",
+                svelte_file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, svelte_file_path, "<div></div>");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_empty_svelte_ts_files_write",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -3401,7 +3401,7 @@ fn format_svelte_implicit_js_files_write() {
     let svelte_file_path = Path::new("file.svelte");
     fs.insert(
         svelte_file_path.into(),
-        VUE_IMPLICIT_JS_FILE_UNFORMATTED.as_bytes(),
+        SVELTE_IMPLICIT_JS_FILE_UNFORMATTED.as_bytes(),
     );
 
     let result = run_cli(

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_empty_svelte_js_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_empty_svelte_js_files_write.snap
@@ -1,0 +1,17 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.svelte`
+
+```svelte
+<div></div>
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_empty_svelte_ts_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_empty_svelte_ts_files_write.snap
@@ -1,0 +1,17 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.svelte`
+
+```svelte
+<div></div>
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_explicit_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_explicit_js_files.snap
@@ -1,0 +1,48 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.svelte`
+
+```svelte
+<script lang="js">
+import {    something } from "file.svelte";
+statement ( ) ;
+</script>
+<div></div>
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.svelte format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1 1 │   <script lang="js">
+    2   │ - import·{····something·}·from·"file.svelte";
+    3   │ - statement·(·)·;
+      2 │ + import·{·something·}·from·"file.svelte";
+      3 │ + statement();
+    4 4 │   </script>
+    5 5 │   <div></div>
+  
+
+```
+
+```block
+Compared 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_explicit_js_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_explicit_js_files_write.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.svelte`
+
+```svelte
+<script lang="js">
+import { something } from "file.svelte";
+statement();
+</script>
+<div></div>
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_implicit_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_implicit_js_files.snap
@@ -1,0 +1,48 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.svelte`
+
+```svelte
+<script>
+import {    something } from "file.svelte";
+statement ( ) ;
+</script>
+<div></div>
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.svelte format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1 1 │   <script>
+    2   │ - import·{····something·}·from·"file.svelte";
+    3   │ - statement·(·)·;
+      2 │ + import·{·something·}·from·"file.svelte";
+      3 │ + statement();
+    4 4 │   </script>
+    5 5 │   <div></div>
+  
+
+```
+
+```block
+Compared 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_implicit_js_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_implicit_js_files_write.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.svelte`
+
+```svelte
+<script>
+import { something } from "file.svelte";
+statement();
+</script>
+<div></div>
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_ts_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_ts_files.snap
@@ -1,0 +1,48 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.svelte`
+
+```svelte
+<script setup lang="ts">
+import     { type     something } from "file.svelte";
+const hello  :      string      = "world";
+</script>
+<div></div>
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.svelte format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1 1 │   <script setup lang="ts">
+    2   │ - import·····{·type·····something·}·from·"file.svelte";
+    3   │ - const·hello··:······string······=·"world";
+      2 │ + import·{·type·something·}·from·"file.svelte";
+      3 │ + const·hello:·string·=·"world";
+    4 4 │   </script>
+    5 5 │   <div></div>
+  
+
+```
+
+```block
+Compared 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_ts_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_ts_files_write.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.svelte`
+
+```svelte
+<script setup lang="ts">
+import { type something } from "file.svelte";
+const hello: string = "world";
+</script>
+<div></div>
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file(s) in <TIME>
+```
+
+

--- a/crates/biome_service/src/file_handlers/astro.rs
+++ b/crates/biome_service/src/file_handlers/astro.rs
@@ -1,19 +1,17 @@
 use crate::file_handlers::{
-    AnalyzerCapabilities, Capabilities, DebugCapabilities, ExtensionHandler, FormatterCapabilities,
-    Language, Mime, ParserCapabilities,
+    javascript, AnalyzerCapabilities, Capabilities, DebugCapabilities, ExtensionHandler,
+    FormatterCapabilities, Language, Mime, ParserCapabilities,
 };
 use crate::settings::SettingsHandle;
 use crate::WorkspaceError;
 use biome_formatter::Printed;
 use biome_fs::RomePath;
-use biome_js_formatter::format_node;
 use biome_js_parser::{parse_js_with_cache, JsParserOptions};
-use biome_js_syntax::{JsFileSource, JsLanguage};
+use biome_js_syntax::JsFileSource;
 use biome_parser::AnyParse;
 use biome_rowan::{FileSource, NodeCache};
 use lazy_static::lazy_static;
 use regex::{Regex, RegexBuilder};
-use tracing::{debug, error, info};
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct AstroFileHandler;
@@ -93,17 +91,5 @@ fn format(
     parse: AnyParse,
     settings: SettingsHandle,
 ) -> Result<Printed, WorkspaceError> {
-    let options = settings.format_options::<JsLanguage>(rome_path);
-    debug!("Options used for format: \n{}", options);
-
-    let tree = parse.syntax();
-    info!("Format file {}", rome_path.display());
-    let formatted = format_node(options, &tree)?;
-    match formatted.print() {
-        Ok(printed) => Ok(printed),
-        Err(error) => {
-            error!("The file {} couldn't be formatted", rome_path.display());
-            Err(WorkspaceError::FormatError(error.into()))
-        }
-    }
+    javascript::format(rome_path, parse, settings)
 }

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -627,7 +627,7 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
 }
 
 #[tracing::instrument(level = "trace", skip(parse, settings))]
-fn format(
+pub(crate) fn format(
     rome_path: &RomePath,
     parse: AnyParse,
     settings: SettingsHandle,

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -4,6 +4,8 @@ use self::{
 };
 use crate::file_handlers::astro::AstroFileHandler;
 pub use crate::file_handlers::astro::ASTRO_FENCE;
+use crate::file_handlers::svelte::SvelteFileHandler;
+pub use crate::file_handlers::svelte::SVELTE_FENCE;
 use crate::file_handlers::vue::VueFileHandler;
 pub use crate::file_handlers::vue::VUE_FENCE;
 use crate::workspace::{FixFileMode, OrganizeImportsResult};
@@ -31,6 +33,7 @@ mod astro;
 mod css;
 mod javascript;
 mod json;
+mod svelte;
 mod unknown;
 mod vue;
 
@@ -56,6 +59,8 @@ pub enum Language {
     Astro,
     ///
     Vue,
+    ///
+    Svelte,
     /// Any language that is not supported
     #[default]
     Unknown,
@@ -89,6 +94,7 @@ impl Language {
             "jsonc" => Language::Jsonc,
             "astro" => Language::Astro,
             "vue" => Language::Vue,
+            "svelte" => Language::Svelte,
             "css" => Language::Css,
             _ => Language::Unknown,
         }
@@ -142,6 +148,7 @@ impl Language {
             "jsonc" => Language::Jsonc,
             "astro" => Language::Astro,
             "vue" => Language::Vue,
+            "svelte" => Language::Svelte,
             // TODO: remove this when we are ready to handle CSS files
             "css" => Language::Unknown,
             _ => Language::Unknown,
@@ -204,6 +211,7 @@ impl Language {
             Language::TypeScriptReact => Some(JsFileSource::tsx()),
             Language::Astro => Some(JsFileSource::ts()),
             Language::Vue => Some(JsFileSource::ts()),
+            Language::Svelte => Some(JsFileSource::ts()),
             Language::Json | Language::Jsonc | Language::Css | Language::Unknown => None,
         }
     }
@@ -220,6 +228,7 @@ impl Language {
             | Language::Jsonc => true,
             Language::Astro => ASTRO_FENCE.is_match(content),
             Language::Vue => VUE_FENCE.is_match(content),
+            Language::Svelte => SVELTE_FENCE.is_match(content),
             Language::Unknown => false,
         }
     }
@@ -237,6 +246,7 @@ impl biome_console::fmt::Display for Language {
             Language::Css => fmt.write_markup(markup! { "CSS" }),
             Language::Astro => fmt.write_markup(markup! { "Astro" }),
             Language::Vue => fmt.write_markup(markup! { "Vue" }),
+            Language::Svelte => fmt.write_markup(markup! { "Svelte" }),
             Language::Unknown => fmt.write_markup(markup! { "Unknown" }),
         }
     }
@@ -407,6 +417,7 @@ pub(crate) struct Features {
     css: CssFileHandler,
     astro: AstroFileHandler,
     vue: VueFileHandler,
+    svelte: SvelteFileHandler,
     unknown: UnknownFileHandler,
 }
 
@@ -418,6 +429,7 @@ impl Features {
             css: CssFileHandler {},
             astro: AstroFileHandler {},
             vue: VueFileHandler {},
+            svelte: SvelteFileHandler {},
             unknown: UnknownFileHandler::default(),
         }
     }
@@ -444,6 +456,7 @@ impl Features {
             }
             Language::Astro => self.astro.capabilities(),
             Language::Vue => self.vue.capabilities(),
+            Language::Svelte => self.svelte.capabilities(),
             Language::Unknown => self.unknown.capabilities(),
         }
     }

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -15,11 +15,11 @@ use regex::Regex;
 use tracing::debug;
 
 #[derive(Debug, Default, PartialEq, Eq)]
-pub(crate) struct VueFileHandler;
+pub(crate) struct SvelteFileHandler;
 
 lazy_static! {
     // https://regex101.com/r/E4n4hh/3
-    pub static ref VUE_FENCE: Regex = Regex::new(
+    pub static ref SVELTE_FENCE: Regex = Regex::new(
         r#"(?ixms)(?:<script[^>]?)
             (?:
             (?:(lang)\s*=\s*['"](?P<lang>[^'"]*)['"])
@@ -31,7 +31,7 @@ lazy_static! {
     .unwrap();
 }
 
-impl ExtensionHandler for VueFileHandler {
+impl ExtensionHandler for SvelteFileHandler {
     fn language(&self) -> Language {
         Language::TypeScript
     }
@@ -66,12 +66,12 @@ impl ExtensionHandler for VueFileHandler {
 
 fn parse(
     _rome_path: &RomePath,
-    _language_hint: crate::file_handlers::Language,
+    _language_hint: Language,
     text: &str,
     _settings: SettingsHandle,
     cache: &mut NodeCache,
 ) -> AnyParse {
-    let matches = VUE_FENCE.captures(text);
+    let matches = SVELTE_FENCE.captures(text);
     let script = match matches {
         Some(ref captures) => &text[captures.name("script").unwrap().range()],
         _ => "",

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1582,6 +1582,7 @@ export interface OpenFileParams {
 export type Language =
 	| "Astro"
 	| "Vue"
+	| "Svelte"
 	| "JavaScript"
 	| "JavaScriptReact"
 	| "TypeScript"

--- a/website/src/content/docs/internals/changelog.mdx
+++ b/website/src/content/docs/internals/changelog.mdx
@@ -149,6 +149,17 @@ Read our [guidelines for writing a good changelog entry](https://github.com/biom
   <template></template>
   ```
 
+- Add partial for `.svelte` files. Biome is able to format the script block of Svelte files. Contributed by @ematipico
+
+  ```diff
+  <script setup lang="ts">
+  - statement ( );
+  + statement();
+  </script/>
+
+  <div></div>
+  ```
+
 #### Bug fixes
 
 - Fix [#1039](https://github.com/biomejs/biome/issues/1039). Check unicode width instead of number of bytes when checking if regex expression is a simple argument. Contributed by @kalleep


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds formatting for the JS/TS code inside a `.svelte` file

Part of #1719 

Thank you @nhedger, for paving all the work for Vue; all I did was just copying what you did :)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added new tests.

<!-- What demonstrates that your implementation is correct? -->
