### PR TITLE
fix(website): show eslint-plugin-import-access link name

### DIFF
--- a/crates/biome_js_analyze/src/analyzers/nursery/use_import_restrictions.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_import_restrictions.rs
@@ -75,7 +75,7 @@ declare_rule! {
     pub(crate) UseImportRestrictions {
         version: "1.0.0",
         name: "useImportRestrictions",
-        source: RuleSource::EslintImportAccess(""),
+        source: RuleSource::EslintImportAccess("eslint-plugin-import-access"),
         source_kind: RuleSourceKind::Inspired,
         recommended: false,
     }

--- a/website/src/content/docs/linter/rules/use-import-restrictions.md
+++ b/website/src/content/docs/linter/rules/use-import-restrictions.md
@@ -8,7 +8,7 @@ title: useImportRestrictions (since v1.0.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
-Inspired from: <a href="https://github.com/uhyo/eslint-plugin-import-access" target="_blank"><code></code></a>
+Inspired from: <a href="https://github.com/uhyo/eslint-plugin-import-access" target="_blank"><code>eslint-plugin-import-access</code></a>
 
 Disallows package private imports.
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

On use-import-restrictions page, a link of eslint-plugin-import-access is not given a display name as below image, so I provided name 'eslint-plugin-import-access'.

before
![image](https://github.com/biomejs/biome/assets/83744975/e68b43fc-5842-437f-ab2a-48e71877c448)

after
![image](https://github.com/biomejs/biome/assets/83744975/c86721e2-9193-42a3-9d30-5d361e3398d3)


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Please see Netlify website preview.
<!-- What demonstrates that your implementation is correct? -->
