### PR TITLE
feat(website): improve formatter performance progress bar

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -32,7 +32,7 @@ hero:
 import { Card, CardGrid } from "@astrojs/starlight/components";
 import Inputf from "@/components/formatter/input.md";
 import Outputf from "@/components/formatter/output.md";
-import ProgressBar from "@/playground/components/Progress.tsx";
+import ProgressBarContainer from "@/playground/components/Progress.tsx";
 import Community from "@/components/Community.astro";
 import { Icon } from "@astrojs/starlight/components";
 import arrow from "@/assets/svg/arrow-right.svg";
@@ -70,8 +70,13 @@ import LinterExample from "@/components/linter/example.md";
         <div class="bench-comp">
           <div class="bench">
             <div>
-              <ProgressBar client:visible duration={0.41} label="Biome" />
-              <ProgressBar client:visible duration={14.35} label="Prettier" />
+              <ProgressBarContainer
+                client:visible
+                data={[
+                  { duration: 0.41, label: "Biome", color: "#33ff66" },
+                  { duration: 14.35, label: "Prettier", color: "#ff0033" }
+                ]}
+              />
             </div>
           </div>
           <div class="perf-comp">

--- a/website/src/content/docs/pt-br/index.mdx
+++ b/website/src/content/docs/pt-br/index.mdx
@@ -28,7 +28,7 @@ hero:
 import { Card, CardGrid } from "@astrojs/starlight/components";
 import Inputf from "@/components/formatter/input.md";
 import Outputf from "@/components/formatter/output.md";
-import ProgressBar from "@/playground/components/Progress.tsx";
+import ProgressBarContainer from "@/playground/components/Progress.tsx";
 import Community from "@/components/Community.astro";
 import { Icon } from "@astrojs/starlight/components";
 import arrow from "@/assets/svg/arrow-right.svg";
@@ -66,8 +66,13 @@ import LinterExample from "@/components/linter/example.md";
         <div class="bench-comp">
           <div class="bench">
             <div>
-              <ProgressBar client:visible duration={0.41} label="Biome" />
-              <ProgressBar client:visible duration={14.35} label="Prettier" />
+              <ProgressBarContainer
+                client:visible
+                data={[
+                  { duration: 0.41, label: "Biome", color: "#33ff66" },
+                  { duration: 14.35, label: "Prettier", color: "#ff0033" }
+                ]}
+              />
             </div>
           </div>
           <div class="perf-comp">

--- a/website/src/playground/components/Progress.tsx
+++ b/website/src/playground/components/Progress.tsx
@@ -2,25 +2,35 @@ import "@/styles/_progress.scss";
 import { useEffect, useState } from "react";
 
 const ProgressBar = ({
-	duration,
 	label,
+	duration,
+	maxDuration,
+	color,
 }: {
-	duration: number;
 	label: string;
+	duration: number;
+	maxDuration: number;
+	color: string
 }) => {
 	const [progress, setProgress] = useState(0);
+	// Calculate the relative progress based on maxDuration
+	const maxRelativeProgress = (duration / maxDuration) * 100;
 
 	useEffect(() => {
 		const startTime = Date.now();
 
 		const updateProgress = () => {
 			const elapsed = Date.now() - startTime;
-			const newProgress = elapsed / 1000;
+			const elapsedSeconds = elapsed / 1000;
+			// Calculate current progress based on elapsed time and relative maximum
+			const newProgress = (elapsedSeconds / duration) * maxRelativeProgress;
 
-			if (Math.floor(newProgress) >= duration) {
+			if (newProgress >= maxRelativeProgress) {
+				// Ensure progress does not exceed calculated relative maximum
+				setProgress(maxRelativeProgress);
 				clearInterval(interval);
 			} else {
-				setProgress(Math.min(newProgress, duration));
+				setProgress(newProgress);
 			}
 		};
 
@@ -29,18 +39,32 @@ const ProgressBar = ({
 		return () => {
 			clearInterval(interval);
 		};
-	}, [duration]);
+	}, [duration, maxRelativeProgress]);
 
 	return (
 		<div className="prog-cont">
 			<span className="label">{label}</span>
 			<div className="progress-bar-container">
-				<div className="bar" style={{ width: `calc(3 * ${progress}%)` }}>
-					<span className="time">{progress.toFixed(2)}s</span>
+				<div className="bar" style={{ width: `${progress}%`, backgroundColor: `${color}` }}>
+					<span className="time">
+						{((progress / maxRelativeProgress) * duration).toFixed(2)}s
+					</span>
 				</div>
 			</div>
 		</div>
 	);
 };
 
-export default ProgressBar;
+const ProgressBarContainer = ({ data }: {data: Array<{duration: number, label: string, color: string}>}) => {
+	const maxDuration = data.reduce((max, { duration }) => Math.max(max, duration), 0);
+
+	return (
+		<div>
+			{data.map(({ duration, label, color }) => (
+				<ProgressBar duration={duration} label={label} maxDuration={maxDuration} color={color} key={label} />
+			))}
+		</div>
+	);
+};
+
+export default ProgressBarContainer;

--- a/website/src/playground/components/Progress.tsx
+++ b/website/src/playground/components/Progress.tsx
@@ -10,7 +10,7 @@ const ProgressBar = ({
 	label: string;
 	duration: number;
 	maxDuration: number;
-	color: string
+	color: string;
 }) => {
 	const [progress, setProgress] = useState(0);
 	// Calculate the relative progress based on maxDuration
@@ -45,7 +45,10 @@ const ProgressBar = ({
 		<div className="prog-cont">
 			<span className="label">{label}</span>
 			<div className="progress-bar-container">
-				<div className="bar" style={{ width: `${progress}%`, backgroundColor: `${color}` }}>
+				<div
+					className="bar"
+					style={{ width: `${progress}%`, backgroundColor: `${color}` }}
+				>
 					<span className="time">
 						{((progress / maxRelativeProgress) * duration).toFixed(2)}s
 					</span>
@@ -55,13 +58,24 @@ const ProgressBar = ({
 	);
 };
 
-const ProgressBarContainer = ({ data }: {data: Array<{duration: number, label: string, color: string}>}) => {
-	const maxDuration = data.reduce((max, { duration }) => Math.max(max, duration), 0);
+const ProgressBarContainer = ({
+	data,
+}: { data: Array<{ duration: number; label: string; color: string }> }) => {
+	const maxDuration = data.reduce(
+		(max, { duration }) => Math.max(max, duration),
+		0,
+	);
 
 	return (
 		<div>
 			{data.map(({ duration, label, color }) => (
-				<ProgressBar duration={duration} label={label} maxDuration={maxDuration} color={color} key={label} />
+				<ProgressBar
+					duration={duration}
+					label={label}
+					maxDuration={maxDuration}
+					color={color}
+					key={label}
+				/>
 			))}
 		</div>
 	);


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR improves a progress bar that shows formatter performance on the landing page.

- The progress reaches the right end upon completion
- Change the colors

![Screenshot 2024-02-17 at 4 56 07](https://github.com/biomejs/biome/assets/38400669/ad64b4f0-c5d9-48f0-b9e5-9be13885d705)


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
