### PR TITLE
refactor(deserializable_macros): idiomatic attribute parsing

### DIFF
--- a/crates/biome_deserialize_macros/src/deserializable_derive/enum_variant_attrs.rs
+++ b/crates/biome_deserialize_macros/src/deserializable_derive/enum_variant_attrs.rs
@@ -1,8 +1,8 @@
-use proc_macro2::Ident;
 use quote::ToTokens;
-use syn::ext::IdentExt;
-use syn::parse::{Parse, ParseStream, Result};
-use syn::{parenthesized, Attribute, Error, LitStr, Token};
+use syn::spanned::Spanned;
+use syn::{Attribute, Error, Lit, Meta, MetaNameValue};
+
+use crate::util::parse_meta_list;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct EnumVariantAttrs {
@@ -12,62 +12,47 @@ pub struct EnumVariantAttrs {
     pub rename: Option<String>,
 }
 
-impl EnumVariantAttrs {
-    pub fn from_attrs(attrs: &[Attribute]) -> Self {
+impl TryFrom<&Vec<Attribute>> for EnumVariantAttrs {
+    type Error = Error;
+
+    fn try_from(attrs: &Vec<Attribute>) -> std::prelude::v1::Result<Self, Self::Error> {
         let mut opts = Self::default();
         for attr in attrs {
-            if attr.path.is_ident("deserializable") || attr.path.is_ident("serde") {
-                opts.merge_with(
-                    syn::parse2::<Self>(attr.tokens.clone())
-                        .expect("Could not parse variant attributes"),
-                );
+            if attr.path.is_ident("deserializable") {
+                parse_meta_list(&attr.parse_meta()?, |meta| {
+                    match meta {
+                        Meta::NameValue(MetaNameValue {
+                            path,
+                            lit: Lit::Str(s),
+                            ..
+                        }) if path.is_ident("rename") => opts.rename = Some(s.value()),
+                        val => {
+                            let val_str = val.to_token_stream().to_string();
+                            return Err(Error::new(
+                                val.span(),
+                                format!("Unexpected attribute: {val_str}"),
+                            ));
+                        }
+                    }
+                    Ok(())
+                })?;
+            } else if attr.path.is_ident("serde") {
+                parse_meta_list(&attr.parse_meta()?, |meta| {
+                    match meta {
+                        Meta::NameValue(MetaNameValue {
+                            path,
+                            lit: Lit::Str(s),
+                            ..
+                        }) if opts.rename.is_none() && path.is_ident("rename") => {
+                            opts.rename = Some(s.value())
+                        }
+                        _ => {} // Don't fail on unrecognized Serde attrs
+                    }
+                    Ok(())
+                })
+                .ok();
             }
         }
-        opts
-    }
-
-    fn merge_with(&mut self, other: Self) {
-        if other.rename.is_some() {
-            self.rename = other.rename;
-        }
-    }
-}
-
-impl Parse for EnumVariantAttrs {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let content;
-        parenthesized!(content in input);
-
-        let parse_value = || -> Result<String> {
-            content.parse::<Token![=]>()?;
-            Ok(content
-                .parse::<LitStr>()?
-                .to_token_stream()
-                .to_string()
-                .trim_matches('"')
-                .to_owned())
-        };
-
-        let mut result = Self::default();
-        loop {
-            let key: Ident = content.call(IdentExt::parse_any)?;
-            match key.to_string().as_ref() {
-                "rename" => result.rename = Some(parse_value()?),
-                other => {
-                    return Err(Error::new(
-                        content.span(),
-                        format!("Unexpected variant attribute: {other}"),
-                    ))
-                }
-            }
-
-            if content.is_empty() {
-                break;
-            }
-
-            content.parse::<Token![,]>()?;
-        }
-
-        Ok(result)
+        Ok(opts)
     }
 }

--- a/crates/biome_deserialize_macros/src/deserializable_derive/struct_field_attrs.rs
+++ b/crates/biome_deserialize_macros/src/deserializable_derive/struct_field_attrs.rs
@@ -1,8 +1,8 @@
-use proc_macro2::Ident;
 use quote::ToTokens;
-use syn::ext::IdentExt;
-use syn::parse::{Parse, ParseStream, Result};
-use syn::{parenthesized, Attribute, Error, LitStr, Token};
+use syn::spanned::Spanned;
+use syn::{Attribute, Error, Lit, Meta, MetaNameValue, Path};
+
+use crate::util::parse_meta_list;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct StructFieldAttrs {
@@ -34,7 +34,7 @@ pub struct StructFieldAttrs {
     pub required: bool,
 
     /// Optional validation function to be called on the field value.
-    pub validate: Option<String>,
+    pub validate: Option<Path>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -46,176 +46,105 @@ pub enum DeprecatedField {
     UseInstead(String),
 }
 
-impl StructFieldAttrs {
-    pub fn from_attrs(attrs: &[Attribute]) -> Self {
+impl TryFrom<&Vec<Attribute>> for StructFieldAttrs {
+    type Error = Error;
+
+    fn try_from(attrs: &Vec<Attribute>) -> std::prelude::v1::Result<Self, Self::Error> {
         let mut opts = Self::default();
         for attr in attrs {
             if attr.path.is_ident("deserializable") {
-                opts.merge_with(
-                    syn::parse2::<Self>(attr.tokens.clone())
-                        .expect("Could not parse field attributes"),
-                );
+                parse_meta_list(&attr.parse_meta()?, |meta| {
+                    match meta {
+                        Meta::Path(path) => {
+                            if path.is_ident("required") {
+                                opts.required = true;
+                            } else if path.is_ident("passthrough_name") {
+                                opts.passthrough_name = true;
+                            } else if path.is_ident("bail_on_error") {
+                                opts.bail_on_error = true;
+                            } else {
+                                let path_str = path.to_token_stream().to_string();
+                                return Err(Error::new(
+                                    path.span(),
+                                    format!("Unexpected attribute: {path_str}"),
+                                ));
+                            }
+                        }
+                        Meta::NameValue(MetaNameValue {
+                            path,
+                            lit: Lit::Str(s),
+                            ..
+                        }) => {
+                            if path.is_ident("rename") {
+                                opts.rename = Some(s.value())
+                            } else if path.is_ident("validate") {
+                                opts.validate = Some(s.parse()?)
+                            }
+                        }
+                        Meta::List(_) if meta.path().is_ident("deprecated") => {
+                            let mut deprecated = None;
+                            parse_meta_list(meta, |meta| {
+                                let Meta::NameValue(MetaNameValue {
+                                    path,
+                                    lit: Lit::Str(s),
+                                    ..
+                                }) = meta
+                                else {
+                                    let meta_text = meta.to_token_stream().to_string();
+                                    return Err(Error::new(
+                                        meta.span(),
+                                        format!("Unexpected attribute: {meta_text}"),
+                                    ));
+                                };
+                                deprecated = if deprecated.is_some() {
+                                    return Err(Error::new(
+                                        meta.span(),
+                                        "Only one attribute expected inside deprecated()",
+                                    ));
+                                } else if path.is_ident("message") {
+                                    Some(DeprecatedField::Message(s.value()))
+                                } else if path.is_ident("use_instead") {
+                                    Some(DeprecatedField::UseInstead(s.value()))
+                                } else {
+                                    let path_text = path.to_token_stream().to_string();
+                                    return Err(Error::new(
+                                        path.span(),
+                                        format!(
+                                            "Unexpected attribute inside deprecated(): {path_text}"
+                                        ),
+                                    ));
+                                };
+                                Ok(())
+                            })?;
+                            opts.deprecated = deprecated;
+                        }
+                        _ => {
+                            let meta_text = meta.to_token_stream().to_string();
+                            return Err(Error::new(
+                                meta.span(),
+                                format!("Unexpected attribute: {meta_text}"),
+                            ));
+                        }
+                    }
+                    Ok(())
+                })?;
             } else if attr.path.is_ident("serde") {
-                opts.merge_with_serde(
-                    syn::parse2::<SerdeStructFieldAttrs>(attr.tokens.clone())
-                        .expect("Could not parse Serde field attributes"),
-                );
+                parse_meta_list(&attr.parse_meta()?, |meta| {
+                    match meta {
+                        Meta::NameValue(MetaNameValue {
+                            path,
+                            lit: Lit::Str(s),
+                            ..
+                        }) if opts.rename.is_none() && path.is_ident("rename") => {
+                            opts.rename = Some(s.value())
+                        }
+                        _ => {} // Don't fail on unrecognized Serde attrs
+                    }
+                    Ok(())
+                })
+                .ok();
             }
         }
-        opts
-    }
-
-    fn merge_with(&mut self, other: Self) {
-        if other.bail_on_error {
-            self.bail_on_error = other.bail_on_error;
-        }
-        if other.deprecated.is_some() {
-            self.deprecated = other.deprecated;
-        }
-        if other.passthrough_name {
-            self.passthrough_name = other.passthrough_name;
-        }
-        if other.rename.is_some() {
-            self.rename = other.rename;
-        }
-        if other.required {
-            self.required = other.required;
-        }
-        if other.validate.is_some() {
-            self.validate = other.validate;
-        }
-    }
-
-    fn merge_with_serde(&mut self, other: SerdeStructFieldAttrs) {
-        if other.rename.is_some() {
-            self.rename = other.rename;
-        }
-    }
-}
-
-impl Parse for StructFieldAttrs {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let content;
-        parenthesized!(content in input);
-
-        let parse_value = || -> Result<String> {
-            content.parse::<Token![=]>()?;
-            Ok(content
-                .parse::<LitStr>()?
-                .to_token_stream()
-                .to_string()
-                .trim_matches('"')
-                .to_owned())
-        };
-
-        let mut result = Self::default();
-        loop {
-            let key: Ident = content.call(IdentExt::parse_any)?;
-            match key.to_string().as_ref() {
-                "bail_on_error" => result.bail_on_error = true,
-                "deprecated" => {
-                    result.deprecated = Some(content.parse::<DeprecatedField>()?);
-                }
-                "passthrough_name" => result.passthrough_name = true,
-                "rename" => result.rename = Some(parse_value()?),
-                "required" => result.required = true,
-                "validate" => result.validate = Some(parse_value()?),
-                other => {
-                    return Err(Error::new(
-                        content.span(),
-                        format!("Unexpected field attribute: {other}"),
-                    ))
-                }
-            }
-
-            if content.is_empty() {
-                break;
-            }
-
-            content.parse::<Token![,]>()?;
-        }
-
-        Ok(result)
-    }
-}
-
-impl Parse for DeprecatedField {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let content;
-        parenthesized!(content in input);
-
-        let parse_value = || -> Result<String> {
-            content.parse::<Token![=]>()?;
-            Ok(content
-                .parse::<LitStr>()?
-                .to_token_stream()
-                .to_string()
-                .trim_matches('"')
-                .to_owned())
-        };
-
-        let key: Ident = content.call(IdentExt::parse_any)?;
-        let result = match key.to_string().as_ref() {
-            "message" => Self::Message(parse_value()?),
-            "use_instead" => Self::UseInstead(parse_value()?),
-            other => {
-                return Err(Error::new(
-                    content.span(),
-                    format!("Unexpected field attribute inside deprecated(): {other}"),
-                ))
-            }
-        };
-
-        if !content.is_empty() {
-            return Err(Error::new(
-                content.span(),
-                "Only one attribute expected inside deprecated()",
-            ));
-        }
-
-        Ok(result)
-    }
-}
-
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-struct SerdeStructFieldAttrs {
-    rename: Option<String>,
-}
-
-impl Parse for SerdeStructFieldAttrs {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let content;
-        parenthesized!(content in input);
-
-        let parse_value = || -> Result<String> {
-            content.parse::<Token![=]>()?;
-            Ok(content
-                .parse::<LitStr>()?
-                .to_token_stream()
-                .to_string()
-                .trim_matches('"')
-                .to_owned())
-        };
-
-        let mut result = Self::default();
-        loop {
-            let key: Ident = content.call(IdentExt::parse_any)?;
-            match key.to_string().as_ref() {
-                "rename" => result.rename = Some(parse_value()?),
-                _ => {
-                    // Don't fail on unrecognized Serde attrs,
-                    // but consume values to advance the parser.
-                    let _result = parse_value();
-                }
-            }
-
-            if content.is_empty() {
-                break;
-            }
-
-            content.parse::<Token![,]>()?;
-        }
-
-        Ok(result)
+        Ok(opts)
     }
 }

--- a/crates/biome_deserialize_macros/src/lib.rs
+++ b/crates/biome_deserialize_macros/src/lib.rs
@@ -1,6 +1,7 @@
 mod deserializable_derive;
 mod merge_derive;
 mod partial_derive;
+mod util;
 
 use proc_macro::TokenStream;
 use proc_macro_error::*;

--- a/crates/biome_deserialize_macros/src/partial_derive.rs
+++ b/crates/biome_deserialize_macros/src/partial_derive.rs
@@ -26,7 +26,7 @@ impl DeriveInput {
         let ident = input.ident.clone();
         let partial_ident = Ident::new(&format!("Partial{}", input.ident), Span::call_site());
 
-        let attrs = Attrs::from_attrs(&input.attrs);
+        let attrs = Attrs::try_from(&input.attrs).expect("Could not parse attributes");
 
         let fields = match input.data {
             Data::Struct(data) => data
@@ -65,7 +65,8 @@ impl DeriveInput {
                             ident: ident.clone(),
                             ty: ty.clone(),
                             should_wrap,
-                            attrs: FieldAttrs::from_attrs(attrs),
+                            attrs: FieldAttrs::try_from(attrs)
+                                .expect("Could not parse field attributes"),
                         }
                     },
                 )
@@ -92,9 +93,9 @@ pub(crate) fn generate_partial(input: DeriveInput) -> TokenStream {
         quote! { #[doc #tokens] }
     });
 
-    let attrs = input.attrs.nested_attrs.iter().map(|(ident, nested)| {
+    let attrs = input.attrs.nested_attrs.iter().map(|nested| {
         quote! {
-            #[#ident #nested]
+            #[#nested]
         }
     });
 
@@ -121,9 +122,9 @@ pub(crate) fn generate_partial(input: DeriveInput) -> TokenStream {
                 None => ty.clone(),
             };
 
-            let attrs = attrs.nested_attrs.iter().map(|(ident, nested)| {
+            let attrs = attrs.nested_attrs.iter().map(|nested| {
                 quote! {
-                    #[#ident #nested]
+                    #[#nested]
                 }
             });
 

--- a/crates/biome_deserialize_macros/src/partial_derive/attrs.rs
+++ b/crates/biome_deserialize_macros/src/partial_derive/attrs.rs
@@ -1,18 +1,15 @@
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::TokenStream;
 use quote::ToTokens;
-use std::collections::{BTreeMap, HashSet};
-use syn::buffer::Cursor;
-use syn::ext::IdentExt;
-use syn::parse::{Parse, ParseStream, Result};
-use syn::{
-    parenthesized, parse_quote, parse_str, token, AttrStyle, Attribute, Error, LitStr, Token, Type,
-};
+use std::collections::HashSet;
+use syn::{parse_quote, AttrStyle, Attribute, Error, Lit, Meta, MetaNameValue, Path, Type};
+
+use crate::util::parse_meta_list;
 
 #[derive(Clone, Debug)]
 pub struct Attrs {
-    pub derives: HashSet<Type>,
+    pub derives: HashSet<Path>,
     pub doc_lines: Vec<TokenStream>,
-    pub nested_attrs: BTreeMap<Ident, NestedAttrs>,
+    pub nested_attrs: Vec<TokenStream>,
 }
 
 impl Default for Attrs {
@@ -30,89 +27,32 @@ impl Default for Attrs {
     }
 }
 
-impl Attrs {
-    pub fn from_attrs(attrs: &[Attribute]) -> Self {
+impl TryFrom<&Vec<Attribute>> for Attrs {
+    type Error = Error;
+
+    fn try_from(attrs: &Vec<Attribute>) -> std::prelude::v1::Result<Self, Self::Error> {
         let mut opts = Self::default();
         for attr in attrs {
             if attr.path.is_ident("partial") {
-                opts.merge_with(
-                    syn::parse2::<Self>(attr.tokens.clone()).expect("Could not parse attributes"),
-                );
+                parse_meta_list(&attr.parse_meta()?, |meta| {
+                    match meta {
+                        Meta::List(_) if meta.path().is_ident("derive") => {
+                            parse_meta_list(meta, |meta| {
+                                opts.derives.insert(meta.path().clone());
+                                Ok(())
+                            })?;
+                        }
+                        _ => {
+                            opts.nested_attrs.push(meta.into_token_stream());
+                        }
+                    }
+                    Ok(())
+                })?;
             } else if attr.style == AttrStyle::Outer && attr.path.is_ident("doc") {
                 opts.doc_lines.push(attr.tokens.clone());
             }
         }
-        opts
-    }
-
-    fn merge_with(&mut self, other: Self) {
-        self.derives.extend(other.derives);
-        self.nested_attrs.extend(other.nested_attrs);
-    }
-}
-
-impl Parse for Attrs {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let content;
-        parenthesized!(content in input);
-
-        let mut result = Self::default();
-        loop {
-            let key: Ident = content.call(IdentExt::parse_any)?;
-            match key.to_string().as_ref() {
-                "derive" => result.derives = Derives::parse(&content)?.into_set(),
-                _ => {
-                    if content.peek(token::Paren) {
-                        result
-                            .nested_attrs
-                            .insert(key, NestedAttrs::parse(&content)?);
-                    } else {
-                        return Err(Error::new(
-                            content.span(),
-                            "Attributes for other macros must be wrapped in parentheses.",
-                        ));
-                    }
-                }
-            }
-
-            if content.is_empty() {
-                break;
-            }
-
-            content.parse::<Token![,]>()?;
-        }
-
-        Ok(result)
-    }
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct Derives(HashSet<Type>);
-
-impl Derives {
-    fn into_set(self) -> HashSet<Type> {
-        self.0
-    }
-}
-
-impl Parse for Derives {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let content;
-        parenthesized!(content in input);
-
-        let mut result = HashSet::default();
-        loop {
-            let ty: Type = content.call(Type::parse)?;
-            result.insert(ty);
-
-            if content.is_empty() {
-                break;
-            }
-
-            content.parse::<Token![,]>()?;
-        }
-
-        Ok(Self(result))
+        Ok(opts)
     }
 }
 
@@ -120,107 +60,45 @@ impl Parse for Derives {
 pub struct FieldAttrs {
     pub ty: Option<PartialType>,
     pub doc_lines: Vec<TokenStream>,
-    pub nested_attrs: BTreeMap<Ident, NestedAttrs>,
+    pub nested_attrs: Vec<TokenStream>,
 }
 
-impl FieldAttrs {
-    pub fn from_attrs(attrs: &[Attribute]) -> Self {
+impl TryFrom<&Vec<Attribute>> for FieldAttrs {
+    type Error = Error;
+
+    fn try_from(attrs: &Vec<Attribute>) -> std::prelude::v1::Result<Self, Self::Error> {
         let mut opts = Self::default();
         for attr in attrs {
             if attr.path.is_ident("partial") {
-                opts.merge_with(
-                    syn::parse2::<Self>(attr.tokens.clone())
-                        .expect("Could not parse field attributes"),
-                );
+                parse_meta_list(&attr.parse_meta()?, |meta| {
+                    match meta {
+                        syn::Meta::Path(path) if opts.ty.is_none() && path.is_ident("type") => {
+                            opts.ty = Some(PartialType::Prefixed);
+                        }
+                        syn::Meta::NameValue(MetaNameValue {
+                            path,
+                            lit: Lit::Str(s),
+                            ..
+                        }) if opts.ty.is_none() && path.is_ident("type") => {
+                            opts.ty = Some(PartialType::Literal(s.parse()?));
+                        }
+                        _ => {
+                            opts.nested_attrs.push(meta.into_token_stream());
+                        }
+                    }
+                    Ok(())
+                })?;
             } else if attr.style == AttrStyle::Outer && attr.path.is_ident("doc") {
                 opts.doc_lines.push(attr.tokens.clone());
             }
         }
-        opts
-    }
-
-    fn merge_with(&mut self, other: Self) {
-        if other.ty.is_some() {
-            self.ty = other.ty;
-        }
-        self.nested_attrs.extend(other.nested_attrs);
-    }
-}
-
-impl Parse for FieldAttrs {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let content;
-        parenthesized!(content in input);
-
-        let parse_value = || -> Result<String> {
-            content.parse::<Token![=]>()?;
-            Ok(content
-                .parse::<LitStr>()?
-                .to_token_stream()
-                .to_string()
-                .trim_matches('"')
-                .to_owned())
-        };
-
-        let mut result = Self::default();
-        loop {
-            let key: Ident = content.call(IdentExt::parse_any)?;
-            match key.to_string().as_str() {
-                "type" => {
-                    result.ty = if content.peek(Token![=]) {
-                        Some(PartialType::Literal(parse_str::<Type>(&parse_value()?)?))
-                    } else {
-                        Some(PartialType::Prefixed)
-                    };
-                }
-                _ => {
-                    if content.peek(token::Paren) {
-                        result
-                            .nested_attrs
-                            .insert(key, NestedAttrs::parse(&content)?);
-                    } else {
-                        return Err(Error::new(
-                            content.span(),
-                            "Attributes for other macros must be wrapped in parentheses.",
-                        ));
-                    }
-                }
-            }
-
-            if content.is_empty() {
-                break;
-            }
-
-            content.parse::<Token![,]>()?;
-        }
-
-        Ok(result)
-    }
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct NestedAttrs(TokenStream);
-
-impl Parse for NestedAttrs {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let tokens = input.step(|cursor| match cursor.token_tree() {
-            Some((tt, next)) => Ok((tt.into_token_stream(), next)),
-            None => Ok((TokenStream::default(), Cursor::empty())),
-        })?;
-
-        Ok(Self(tokens))
-    }
-}
-
-impl ToTokens for NestedAttrs {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.extend(self.0.clone())
+        Ok(opts)
     }
 }
 
 #[derive(Clone, Debug, Default)]
 pub enum PartialType {
-    Literal(Type),
     #[default]
     Prefixed,
+    Literal(Type),
 }

--- a/crates/biome_deserialize_macros/src/util.rs
+++ b/crates/biome_deserialize_macros/src/util.rs
@@ -1,0 +1,17 @@
+use syn::{spanned::Spanned, Error, Meta, MetaList, NestedMeta};
+
+pub(crate) fn parse_meta_list(
+    meta: &Meta,
+    mut consume: impl FnMut(&Meta) -> Result<(), Error>,
+) -> Result<(), Error> {
+    let Meta::List(MetaList { nested, .. }) = meta else {
+        return Err(Error::new(meta.span(), "A list of attribute is expected"));
+    };
+    for nested_meta in nested {
+        let NestedMeta::Meta(meta) = nested_meta else {
+            return Err(Error::new(nested_meta.span(), "Literals are not allowed"));
+        };
+        consume(meta)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

While investigating how to implement #1846, I took some time to learn more about derive macro and attribute parsing.
It is hard to find good examples and guides for implementing derive macros. Digging into the internals of the relevant crates, I discovered some types that can help to parse macro attributes (Meta, MetaList, ...).

I refactored the code that parses our derived macro attribute to use these types.
The implementation should be more robust and more helpful in case of an error.

## Test Plan

`just test`