### PR TITLE
refactor(lint/noFocusedTests): report `fdescribe` and `fit`

### DIFF
--- a/crates/biome_js_analyze/src/analyzers/nursery/no_focused_tests.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_focused_tests.rs
@@ -31,6 +31,8 @@ declare_rule! {
     }
 }
 
+const FUNCTION_NAMES: [&str; 3] = ["only", "fdescribe", "fit"];
+
 impl Rule for NoFocusedTests {
     type Query = Ast<JsCallExpression>;
     type State = TextRange;
@@ -45,7 +47,7 @@ impl Rule for NoFocusedTests {
             if callee.contains_a_test_pattern().ok()? {
                 let function_name = get_function_name(&callee)?;
 
-                if function_name.text_trimmed() == "only" {
+                if FUNCTION_NAMES.contains(&function_name.text_trimmed()) {
                     return Some(function_name.text_trimmed_range());
                 }
             }

--- a/crates/biome_js_analyze/tests/specs/nursery/noFocusedTests/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFocusedTests/invalid.js.snap
@@ -67,4 +67,41 @@ invalid.js:3:6 lint/nursery/noFocusedTests ━━━━━━━━━━━━�
 
 ```
 
+```
+invalid.js:4:1 lint/nursery/noFocusedTests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    2 │ it.only("test", () => {});
+    3 │ test.only("test", () => {});
+  > 4 │ fdescribe('foo', () => {});
+      │ ^^^^^^^^^
+    5 │ fit('foo', () => {});
+    6 │ 
+  
+  i This is likely a change done during debugging or implementation phases, but it's unlikely what you want in production.
+  
+  i Remove it.
+  
+
+```
+
+```
+invalid.js:5:1 lint/nursery/noFocusedTests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    3 │ test.only("test", () => {});
+    4 │ fdescribe('foo', () => {});
+  > 5 │ fit('foo', () => {});
+      │ ^^^
+    6 │ 
+  
+  i This is likely a change done during debugging or implementation phases, but it's unlikely what you want in production.
+  
+  i Remove it.
+  
+
+```
+
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noFocusedTests/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFocusedTests/valid.js
@@ -1,5 +1,5 @@
 describe.skip("test", () => {});
 it.skip("test", () => {});
 test.skip("test", () => {});
-fdescribe('foo', () => {});
-fit('foo', () => {});
+xdescribe('foo', () => {});
+xit('foo', () => {});

--- a/crates/biome_js_analyze/tests/specs/nursery/noFocusedTests/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFocusedTests/valid.js.snap
@@ -7,8 +7,8 @@ expression: valid.js
 describe.skip("test", () => {});
 it.skip("test", () => {});
 test.skip("test", () => {});
-fdescribe('foo', () => {});
-fit('foo', () => {});
+xdescribe('foo', () => {});
+xit('foo', () => {});
 
 ```
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

The rule now reports `fdescribe` and `fit`.
https://github.com/biomejs/biome/blob/c53f6d164f86297f04eaf721a48b71bc3a883320/crates/biome_js_analyze/tests/specs/nursery/noFocusedTests/invalid.js#L4-L5

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
I updated the existing tests.
