### PR TITLE
fix(website): generate RSS feed again

### DIFF
--- a/website/src/pages/feed.xml.js
+++ b/website/src/pages/feed.xml.js
@@ -1,7 +1,7 @@
 import rss from "@astrojs/rss";
 import { getCollection } from "astro:content";
 
-export async function get(context) {
+export async function GET(context) {
 	const posts = (await getCollection("blog")).sort(
 		(a, b) =>
 			new Date(b.data.pubDate).valueOf() - new Date(a.data.pubDate).valueOf(),


### PR DESCRIPTION
## Summary

The RSS feed stopped working when we updated Astro and its dependencies, now that Endpoints expect a `GET` function instead of the former, `get`. This PR solves this by renaming the function.

## Test Plan

You can see currently that https://biomejs.dev/feed.xml will go to a 404 page, locally (or in the deploy preview), if you go to `/feed.xml` you should now see the RSS feed being returned.
