### PR TITLE
perf: cache computed overrides

### DIFF
--- a/crates/biome_service/src/configuration/overrides.rs
+++ b/crates/biome_service/src/configuration/overrides.rs
@@ -22,7 +22,6 @@ use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::RwLock;
 
 #[derive(
     Bpaf, Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize,

--- a/crates/biome_service/src/configuration/overrides.rs
+++ b/crates/biome_service/src/configuration/overrides.rs
@@ -22,6 +22,7 @@ use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::RwLock;
 
 #[derive(
     Bpaf, Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize,
@@ -206,8 +207,8 @@ pub fn to_override_settings(
             formatter,
             linter,
             organize_imports,
-
             languages,
+            ..OverrideSettingPattern::default()
         };
 
         override_settings.patterns.push(pattern_setting);

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -163,15 +163,15 @@ fn parse(
             LanguageId::Jsonc => JsonFileSource::jsonc(),
             _ => JsonFileSource::json(),
         });
-    let options: JsonParserOptions =
-        overrides
-            .as_json_parser_options(rome_path)
-            .unwrap_or(JsonParserOptions {
-                allow_comments: parser.allow_comments
-                    || source_type.is_jsonc()
-                    || is_file_allowed(rome_path),
-                allow_trailing_commas: parser.allow_trailing_commas || is_file_allowed(rome_path),
-            });
+    let options: JsonParserOptions = overrides.override_json_parser_options(
+        rome_path,
+        JsonParserOptions {
+            allow_comments: parser.allow_comments
+                || source_type.is_jsonc()
+                || is_file_allowed(rome_path),
+            allow_trailing_commas: parser.allow_trailing_commas || is_file_allowed(rome_path),
+        },
+    );
     let parse = biome_json_parser::parse_json_with_cache(text, cache, options);
     let root = parse.syntax();
     let diagnostics = parse.into_diagnostics();

--- a/crates/biome_service/src/matcher/mod.rs
+++ b/crates/biome_service/src/matcher/mod.rs
@@ -9,7 +9,7 @@ use std::sync::RwLock;
 
 /// A data structure to use when there's need to match a string or a path a against
 /// a unix shell style patterns
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Matcher {
     root: Option<PathBuf>,
     patterns: Vec<Pattern>,

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -26,9 +26,7 @@ use biome_json_parser::JsonParserOptions;
 use biome_json_syntax::JsonLanguage;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use indexmap::IndexSet;
-use std::any::{Any, TypeId};
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::{
     num::NonZeroU64,
@@ -885,17 +883,17 @@ impl OverrideSettingPattern {
     fn json_parser_options(&self, options: &mut JsonParserOptions) {
         let cache = self.cached_json_parser_options.read().unwrap();
         if let Some(cached_options) = cache.as_ref() {
-            *options = cached_options.clone();
+            *options = *cached_options;
             return;
         }
         drop(cache);
         let json_parser = &self.languages.json.parser;
 
         options.allow_trailing_commas = json_parser.allow_trailing_commas;
-        options.allow_comments = options.allow_comments;
+        options.allow_comments = json_parser.allow_comments;
 
         let mut cache = self.cached_json_parser_options.write().unwrap();
-        let _ = cache.insert(options.clone());
+        let _ = cache.insert(*options);
     }
 
     #[allow(dead_code)]

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -26,7 +26,9 @@ use biome_json_parser::JsonParserOptions;
 use biome_json_syntax::JsonLanguage;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use indexmap::IndexSet;
+use std::any::{Any, TypeId};
 use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::{
     num::NonZeroU64,
@@ -222,7 +224,7 @@ impl Default for FormatSettings {
 }
 
 /// Formatter settings for the entire workspace
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct OverrideFormatSettings {
     /// Enabled by default
     pub enabled: Option<bool>,
@@ -263,7 +265,7 @@ impl Default for LinterSettings {
 }
 
 /// Linter settings for the entire workspace
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct OverrideLinterSettings {
     /// Enabled by default
     pub enabled: Option<bool>,
@@ -296,7 +298,7 @@ impl Default for OrganizeImportsSettings {
 }
 
 /// Linter settings for the entire workspace
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct OverrideOrganizeImportsSettings {
     /// Enabled by default
     pub enabled: Option<bool>,
@@ -555,42 +557,7 @@ impl OverrideSettings {
             }
 
             if included {
-                let js_formatter = &pattern.languages.javascript.formatter;
-                let formatter = &pattern.formatter;
-                if let Some(indent_style) = js_formatter.indent_style.or(formatter.indent_style) {
-                    options.set_indent_style(indent_style);
-                }
-
-                if let Some(indent_width) = js_formatter.indent_width.or(formatter.indent_width) {
-                    options.set_indent_width(indent_width)
-                }
-                if let Some(line_width) = js_formatter.line_width.or(formatter.line_width) {
-                    options.set_line_width(line_width);
-                }
-                if let Some(quote_style) = js_formatter.quote_style {
-                    options.set_quote_style(quote_style);
-                }
-                if let Some(trailing_comma) = js_formatter.trailing_comma {
-                    options.set_trailing_comma(trailing_comma);
-                }
-                if let Some(quote_properties) = js_formatter.quote_properties {
-                    options.set_quote_properties(quote_properties);
-                }
-                if let Some(jsx_quote_style) = js_formatter.jsx_quote_style {
-                    options.set_jsx_quote_style(jsx_quote_style);
-                }
-                if let Some(semicolons) = js_formatter.semicolons {
-                    options.set_semicolons(semicolons);
-                }
-                if let Some(arrow_parentheses) = js_formatter.arrow_parentheses {
-                    options.set_arrow_parentheses(arrow_parentheses);
-                }
-                if let Some(bracket_spacing) = js_formatter.bracket_spacing {
-                    options.set_bracket_spacing(bracket_spacing);
-                }
-                if let Some(bracket_same_line) = js_formatter.bracket_same_line {
-                    options.set_bracket_same_line(bracket_same_line);
-                }
+                pattern.js_format_options(&mut options);
             }
 
             options
@@ -631,25 +598,7 @@ impl OverrideSettings {
                 return options;
             }
             if included {
-                let json_formatter = &pattern.languages.json.formatter;
-
-                if let Some(indent_style) = json_formatter
-                    .indent_style
-                    .or(pattern.formatter.indent_style)
-                {
-                    options.set_indent_style(indent_style);
-                }
-
-                if let Some(indent_width) = json_formatter
-                    .indent_width
-                    .or(pattern.formatter.indent_width)
-                {
-                    options.set_indent_width(indent_width)
-                }
-                if let Some(line_width) = json_formatter.line_width.or(pattern.formatter.line_width)
-                {
-                    options.set_line_width(line_width);
-                }
+                pattern.json_format_options(&mut options);
             }
 
             options
@@ -669,21 +618,7 @@ impl OverrideSettings {
                 return options;
             }
             if included {
-                let css_formatter = &pattern.languages.css.formatter;
-                let formatter = &pattern.formatter;
-
-                if let Some(indent_style) = css_formatter.indent_style.or(formatter.indent_style) {
-                    options.set_indent_style(indent_style);
-                }
-                if let Some(indent_width) = css_formatter.indent_width.or(formatter.indent_width) {
-                    options.set_indent_width(indent_width)
-                }
-                if let Some(line_width) = css_formatter.line_width.or(formatter.line_width) {
-                    options.set_line_width(line_width);
-                }
-                if let Some(quote_style) = css_formatter.quote_style {
-                    options.set_quote_style(quote_style);
-                }
+                pattern.css_format_options(&mut options);
             }
 
             options
@@ -702,31 +637,28 @@ impl OverrideSettings {
                 return options;
             }
             if included {
-                let js_parser = &pattern.languages.javascript.parser;
-
-                options.parse_class_parameter_decorators =
-                    js_parser.parse_class_parameter_decorators;
+                pattern.js_parser_options(&mut options)
             }
             options
         })
     }
 
-    pub fn as_json_parser_options(&self, path: &Path) -> Option<JsonParserOptions> {
-        for pattern in &self.patterns {
+    pub fn override_json_parser_options(
+        &self,
+        path: &Path,
+        options: JsonParserOptions,
+    ) -> JsonParserOptions {
+        self.patterns.iter().fold(options, |mut options, pattern| {
             let included = !pattern.include.is_empty() && pattern.include.matches_path(path);
             let excluded = !pattern.exclude.is_empty() && pattern.exclude.matches_path(path);
-
-            if included || !excluded {
-                let json_parser = &pattern.languages.json.parser;
-
-                return Some(JsonParserOptions {
-                    allow_comments: json_parser.allow_comments,
-                    allow_trailing_commas: json_parser.allow_trailing_commas,
-                });
+            if excluded {
+                return options;
             }
-        }
-
-        None
+            if included {
+                pattern.json_parser_options(&mut options);
+            }
+            options
+        })
     }
 
     pub fn as_css_parser_options(&self, path: &Path) -> Option<CssParserOptions> {
@@ -814,7 +746,7 @@ impl OverrideSettings {
         None
     }
 }
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct OverrideSettingPattern {
     pub exclude: Matcher,
     pub include: Matcher,
@@ -826,6 +758,150 @@ pub struct OverrideSettingPattern {
     pub organize_imports: OverrideOrganizeImportsSettings,
     /// Language specific settings
     pub languages: LanguageListSettings,
+
+    // Cache
+    pub(crate) cached_js_format_options: RwLock<Option<JsFormatOptions>>,
+    pub(crate) cached_json_format_options: RwLock<Option<JsonFormatOptions>>,
+    pub(crate) cached_css_format_options: RwLock<Option<CssFormatOptions>>,
+    pub(crate) cached_js_parser_options: RwLock<Option<JsParserOptions>>,
+    pub(crate) cached_json_parser_options: RwLock<Option<JsonParserOptions>>,
+}
+
+impl OverrideSettingPattern {
+    fn js_format_options(&self, options: &mut JsFormatOptions) {
+        let cache = self.cached_js_format_options.read().unwrap();
+        if let Some(cached_options) = cache.as_ref() {
+            *options = cached_options.clone();
+            return;
+        }
+        drop(cache);
+
+        let js_formatter = &self.languages.javascript.formatter;
+        let formatter = &self.formatter;
+        if let Some(indent_style) = js_formatter.indent_style.or(formatter.indent_style) {
+            options.set_indent_style(indent_style);
+        }
+
+        if let Some(indent_width) = js_formatter.indent_width.or(formatter.indent_width) {
+            options.set_indent_width(indent_width)
+        }
+        if let Some(line_width) = js_formatter.line_width.or(formatter.line_width) {
+            options.set_line_width(line_width);
+        }
+        if let Some(quote_style) = js_formatter.quote_style {
+            options.set_quote_style(quote_style);
+        }
+        if let Some(trailing_comma) = js_formatter.trailing_comma {
+            options.set_trailing_comma(trailing_comma);
+        }
+        if let Some(quote_properties) = js_formatter.quote_properties {
+            options.set_quote_properties(quote_properties);
+        }
+        if let Some(jsx_quote_style) = js_formatter.jsx_quote_style {
+            options.set_jsx_quote_style(jsx_quote_style);
+        }
+        if let Some(semicolons) = js_formatter.semicolons {
+            options.set_semicolons(semicolons);
+        }
+        if let Some(arrow_parentheses) = js_formatter.arrow_parentheses {
+            options.set_arrow_parentheses(arrow_parentheses);
+        }
+        if let Some(bracket_spacing) = js_formatter.bracket_spacing {
+            options.set_bracket_spacing(bracket_spacing);
+        }
+        if let Some(bracket_same_line) = js_formatter.bracket_same_line {
+            options.set_bracket_same_line(bracket_same_line);
+        }
+        let mut cache = self.cached_js_format_options.write().unwrap();
+        let _ = cache.insert(options.clone());
+    }
+
+    fn json_format_options(&self, options: &mut JsonFormatOptions) {
+        let cache = self.cached_json_format_options.read().unwrap();
+        if let Some(cached_options) = cache.as_ref() {
+            *options = cached_options.clone();
+            return;
+        }
+        drop(cache);
+
+        let json_formatter = &self.languages.json.formatter;
+
+        if let Some(indent_style) = json_formatter.indent_style.or(self.formatter.indent_style) {
+            options.set_indent_style(indent_style);
+        }
+
+        if let Some(indent_width) = json_formatter.indent_width.or(self.formatter.indent_width) {
+            options.set_indent_width(indent_width)
+        }
+        if let Some(line_width) = json_formatter.line_width.or(self.formatter.line_width) {
+            options.set_line_width(line_width);
+        }
+        let mut cache = self.cached_json_format_options.write().unwrap();
+        let _ = cache.insert(options.clone());
+    }
+    fn css_format_options(&self, options: &mut CssFormatOptions) {
+        let cache = self.cached_css_format_options.read().unwrap();
+        if let Some(cached_options) = cache.as_ref() {
+            *options = cached_options.clone();
+            return;
+        }
+        drop(cache);
+
+        let css_formatter = &self.languages.css.formatter;
+        let formatter = &self.formatter;
+
+        if let Some(indent_style) = css_formatter.indent_style.or(formatter.indent_style) {
+            options.set_indent_style(indent_style);
+        }
+        if let Some(indent_width) = css_formatter.indent_width.or(formatter.indent_width) {
+            options.set_indent_width(indent_width)
+        }
+        if let Some(line_width) = css_formatter.line_width.or(formatter.line_width) {
+            options.set_line_width(line_width);
+        }
+        if let Some(quote_style) = css_formatter.quote_style {
+            options.set_quote_style(quote_style);
+        }
+        let mut cache = self.cached_css_format_options.write().unwrap();
+        let _ = cache.insert(options.clone());
+    }
+
+    fn js_parser_options(&self, options: &mut JsParserOptions) {
+        let cache = self.cached_js_parser_options.read().unwrap();
+        if let Some(cached_options) = cache.as_ref() {
+            *options = cached_options.clone();
+            return;
+        }
+        drop(cache);
+
+        let js_parser = &self.languages.javascript.parser;
+
+        options.parse_class_parameter_decorators = js_parser.parse_class_parameter_decorators;
+
+        let mut cache = self.cached_js_parser_options.write().unwrap();
+        let _ = cache.insert(options.clone());
+    }
+
+    fn json_parser_options(&self, options: &mut JsonParserOptions) {
+        let cache = self.cached_json_parser_options.read().unwrap();
+        if let Some(cached_options) = cache.as_ref() {
+            *options = cached_options.clone();
+            return;
+        }
+        drop(cache);
+        let json_parser = &self.languages.json.parser;
+
+        options.allow_trailing_commas = json_parser.allow_trailing_commas;
+        options.allow_comments = options.allow_comments;
+
+        let mut cache = self.cached_json_parser_options.write().unwrap();
+        let _ = cache.insert(options.clone());
+    }
+
+    #[allow(dead_code)]
+    // NOTE: Currently not used because the rule options are typed using TypeId and Any, which isn't thread safe.
+    // TODO: Find a way to cache this
+    fn analyzer_rules_mut(&self, _analyzer_rules: &mut AnalyzerRules) {}
 }
 
 /// Creates a [Matcher] from a [StringSet]


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #1795 

There's a small issue here, unfortunately. The analyzer rules can't be cached at the moment because `RuleOptions` are typed using `Any`, which can't be moved among threads.

We will have to come up with a different strategy to cache them.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

The current CI should pass

<!-- What demonstrates that your implementation is correct? -->
