### PR TITLE
refactor(config): reduce size by 350% using exact rule options

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_configuration.snap
@@ -76,7 +76,7 @@ Linter:
                                 correctness/all = true
                                 nursery/useConsistentArrayType = {"level":"warn","options":{"syntax":"shorthand"}}
                                 style/noNonNullAssertion = "off"
-                                suspicious/noCommentText = {"level":"warn"}
+                                suspicious/noCommentText = {"level":"warn","options":null}
 
 Server:
   Version:                      0.0.0

--- a/crates/biome_css_analyze/src/analyzers.rs
+++ b/crates/biome_css_analyze/src/analyzers.rs
@@ -1,4 +1,4 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-pub(crate) mod nursery;
-::biome_analyze::declare_category! { pub (crate) Analyzers { kind : Lint , groups : [self :: nursery :: Nursery ,] } }
+pub mod nursery;
+::biome_analyze::declare_category! { pub Analyzers { kind : Lint , groups : [self :: nursery :: Nursery ,] } }

--- a/crates/biome_css_analyze/src/analyzers/nursery.rs
+++ b/crates/biome_css_analyze/src/analyzers/nursery.rs
@@ -2,10 +2,10 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod noop;
+pub mod noop;
 
 declare_group! {
-    pub (crate) Nursery {
+    pub Nursery {
         name : "nursery" ,
         rules : [
             self :: noop :: Noop ,

--- a/crates/biome_css_analyze/src/analyzers/nursery/noop.rs
+++ b/crates/biome_css_analyze/src/analyzers/nursery/noop.rs
@@ -3,7 +3,7 @@ use biome_css_syntax::CssColor;
 
 declare_rule! {
     /// Noop rule
-    pub(crate) Noop {
+    pub Noop {
         version: "next",
         name: "noop",
     }

--- a/crates/biome_deserialize/src/impls.rs
+++ b/crates/biome_deserialize/src/impls.rs
@@ -483,6 +483,16 @@ impl Deserializable for PathBuf {
     }
 }
 
+impl<T: Deserializable> Deserializable for Box<T> {
+    fn deserialize(
+        value: &impl DeserializableValue,
+        name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self> {
+        T::deserialize(value, name, diagnostics).map(Box::new)
+    }
+}
+
 impl<T: Deserializable> Deserializable for Vec<T> {
     fn deserialize(
         value: &impl DeserializableValue,

--- a/crates/biome_deserialize_macros/src/deserializable_derive.rs
+++ b/crates/biome_deserialize_macros/src/deserializable_derive.rs
@@ -446,7 +446,7 @@ fn generate_deserializable_struct(
     let trait_bounds = generate_trait_bounds(&generics);
     let generics = generate_generics_without_trait_bounds(&generics);
 
-    let x = quote! {
+    quote! {
         impl #generics biome_deserialize::Deserializable for #ident #generics #trait_bounds {
             fn deserialize(
                 value: &impl biome_deserialize::DeserializableValue,
@@ -493,11 +493,7 @@ fn generate_deserializable_struct(
                 value.deserialize(Visitor(PhantomData), name, diagnostics)
             }
         }
-    };
-    //if ident == "RuleWithOptions" {
-    //    panic!("{}", x.to_string());
-    //}
-    x
+    }
 }
 
 fn generate_deserializable_from(

--- a/crates/biome_js_analyze/src/analyzers.rs
+++ b/crates/biome_js_analyze/src/analyzers.rs
@@ -1,10 +1,10 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-pub(crate) mod a11y;
-pub(crate) mod complexity;
-pub(crate) mod correctness;
-pub(crate) mod nursery;
-pub(crate) mod performance;
-pub(crate) mod style;
-pub(crate) mod suspicious;
-::biome_analyze::declare_category! { pub (crate) Analyzers { kind : Lint , groups : [self :: a11y :: A11y , self :: complexity :: Complexity , self :: correctness :: Correctness , self :: nursery :: Nursery , self :: performance :: Performance , self :: style :: Style , self :: suspicious :: Suspicious ,] } }
+pub mod a11y;
+pub mod complexity;
+pub mod correctness;
+pub mod nursery;
+pub mod performance;
+pub mod style;
+pub mod suspicious;
+::biome_analyze::declare_category! { pub Analyzers { kind : Lint , groups : [self :: a11y :: A11y , self :: complexity :: Complexity , self :: correctness :: Correctness , self :: nursery :: Nursery , self :: performance :: Performance , self :: style :: Style , self :: suspicious :: Suspicious ,] } }

--- a/crates/biome_js_analyze/src/analyzers/a11y.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y.rs
@@ -2,29 +2,29 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_access_key;
-pub(crate) mod no_auto_focus;
-pub(crate) mod no_blank_target;
-pub(crate) mod no_distracting_elements;
-pub(crate) mod no_header_scope;
-pub(crate) mod no_redundant_alt;
-pub(crate) mod no_svg_without_title;
-pub(crate) mod use_alt_text;
-pub(crate) mod use_anchor_content;
-pub(crate) mod use_heading_content;
-pub(crate) mod use_html_lang;
-pub(crate) mod use_iframe_title;
-pub(crate) mod use_key_with_click_events;
-pub(crate) mod use_key_with_mouse_events;
-pub(crate) mod use_media_caption;
-pub(crate) mod use_valid_anchor;
+pub mod no_access_key;
+pub mod no_autofocus;
+pub mod no_blank_target;
+pub mod no_distracting_elements;
+pub mod no_header_scope;
+pub mod no_redundant_alt;
+pub mod no_svg_without_title;
+pub mod use_alt_text;
+pub mod use_anchor_content;
+pub mod use_heading_content;
+pub mod use_html_lang;
+pub mod use_iframe_title;
+pub mod use_key_with_click_events;
+pub mod use_key_with_mouse_events;
+pub mod use_media_caption;
+pub mod use_valid_anchor;
 
 declare_group! {
-    pub (crate) A11y {
+    pub A11y {
         name : "a11y" ,
         rules : [
             self :: no_access_key :: NoAccessKey ,
-            self :: no_auto_focus :: NoAutoFocus ,
+            self :: no_autofocus :: NoAutofocus ,
             self :: no_blank_target :: NoBlankTarget ,
             self :: no_distracting_elements :: NoDistractingElements ,
             self :: no_header_scope :: NoHeaderScope ,

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_access_key.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_access_key.rs
@@ -37,7 +37,7 @@ declare_rule! {
     /// - [WebAIM: Keyboard Accessibility - Accesskey](https://webaim.org/techniques/keyboard/accesskey#spec)
     /// - [MDN `accesskey` documentation](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/accesskey)
     ///
-    pub(crate) NoAccessKey {
+    pub NoAccessKey {
         version: "1.0.0",
         name: "noAccessKey",
         source: RuleSource::EslintJsxA11y("no-access-key"),

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_autofocus.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_autofocus.rs
@@ -57,7 +57,7 @@ declare_rule! {
     /// - [WHATWG HTML Standard, The autofocus attribute](https://html.spec.whatwg.org/multipage/interaction.html#attr-fe-autofocus)
     /// - [The accessibility of HTML 5 autofocus](https://brucelawson.co.uk/2009/the-accessibility-of-html-5-autofocus/)
     ///
-    pub(crate) NoAutoFocus {
+    pub NoAutofocus {
         version: "1.0.0",
         name: "noAutofocus",
         source: RuleSource::EslintJsxA11y("no-autofocus"),
@@ -66,7 +66,7 @@ declare_rule! {
     }
 }
 
-impl Rule for NoAutoFocus {
+impl Rule for NoAutofocus {
     type Query = Ast<AnyJsxElement>;
     type State = JsxAttribute;
     type Signals = Option<Self::State>;

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_blank_target.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_blank_target.rs
@@ -48,7 +48,7 @@ declare_rule! {
     /// ```jsx
     /// <a href='http://external.link' target='_blank' rel="noopener" {...props}>child</a>
     /// ```
-    pub(crate) NoBlankTarget {
+    pub NoBlankTarget {
         version: "1.0.0",
         name: "noBlankTarget",
         source: RuleSource::EslintReact("jsx-no-target-blank"),

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_distracting_elements.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_distracting_elements.rs
@@ -37,7 +37,7 @@ declare_rule! {
     ///
     /// - [WCAG 2.2.2](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide)
     ///
-    pub(crate) NoDistractingElements {
+    pub NoDistractingElements {
         version: "1.0.0",
         name: "noDistractingElements",
         source: RuleSource::EslintJsxA11y("no-distracting-elements"),

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_header_scope.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_header_scope.rs
@@ -37,7 +37,7 @@ declare_rule! {
     /// - [WCAG 1.3.1](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
     /// - [WCAG 4.1.1](https://www.w3.org/WAI/WCAG21/Understanding/parsing)
     ///
-    pub(crate) NoHeaderScope {
+    pub NoHeaderScope {
         version: "1.0.0",
         name: "noHeaderScope",
         source: RuleSource::EslintJsxA11y("scope"),

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_redundant_alt.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_redundant_alt.rs
@@ -39,7 +39,7 @@ declare_rule! {
     /// </>
     /// ```
     ///
-    pub(crate) NoRedundantAlt {
+    pub NoRedundantAlt {
         version: "1.0.0",
         name: "noRedundantAlt",
         source: RuleSource::EslintJsxA11y("no-redundant-roles"),

--- a/crates/biome_js_analyze/src/analyzers/a11y/no_svg_without_title.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/no_svg_without_title.rs
@@ -79,7 +79,7 @@ declare_rule! {
     /// [Accessible SVGs | CSS-Tricks - CSS-Tricks](https://css-tricks.com/accessible-svgs/)
     /// [Contextually Marking up accessible images and SVGs | scottohara.me](https://www.scottohara.me/blog/2019/05/22/contextual-images-svgs-and-a11y.html)
     ///
-    pub(crate) NoSvgWithoutTitle {
+    pub NoSvgWithoutTitle {
         version: "1.0.0",
         name: "noSvgWithoutTitle",
         recommended: true,

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_alt_text.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_alt_text.rs
@@ -43,7 +43,7 @@ declare_rule! {
     ///
     /// - [WCAG 1.1.1](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)
     ///
-    pub(crate) UseAltText {
+    pub UseAltText {
         version: "1.0.0",
         name: "useAltText",
         source: RuleSource::EslintJsxA11y("alt-text"),

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_anchor_content.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_anchor_content.rs
@@ -64,7 +64,7 @@ declare_rule! {
     /// - [WCAG 2.4.4](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context)
     /// - [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
     ///
-    pub(crate) UseAnchorContent {
+    pub UseAnchorContent {
         version: "1.0.0",
         name: "useAnchorContent",
         source: RuleSource::EslintJsxA11y("anchor-has-content"),

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_heading_content.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_heading_content.rs
@@ -44,7 +44,7 @@ declare_rule! {
     ///
     /// - [WCAG 2.4.6](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html)
     ///
-    pub(crate) UseHeadingContent {
+    pub UseHeadingContent {
         version: "1.0.0",
         name: "useHeadingContent",
         source: RuleSource::EslintJsxA11y("heading-has-content"),

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_html_lang.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_html_lang.rs
@@ -52,7 +52,7 @@ declare_rule! {
     ///
     /// - [WCAG 3.1.1](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page)
     ///
-    pub(crate) UseHtmlLang {
+    pub UseHtmlLang {
         version: "1.0.0",
         name: "useHtmlLang",
         source: RuleSource::EslintJsxA11y("html-has-lang"),

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_iframe_title.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_iframe_title.rs
@@ -58,7 +58,7 @@ declare_rule! {
     /// - [WCAG 2.4.1](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks)
     /// - [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
     ///
-    pub(crate) UseIframeTitle {
+    pub UseIframeTitle {
         version: "1.0.0",
         name: "useIframeTitle",
         source: RuleSource::EslintJsxA11y("iframe-has-title"),

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_key_with_click_events.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_key_with_click_events.rs
@@ -56,7 +56,7 @@ declare_rule! {
     ///
     /// - [WCAG 2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard)
     ///
-    pub(crate) UseKeyWithClickEvents {
+    pub UseKeyWithClickEvents {
         version: "1.0.0",
         name: "useKeyWithClickEvents",
         source: RuleSource::EslintJsxA11y("click-events-have-key-events"),

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_key_with_mouse_events.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_key_with_mouse_events.rs
@@ -39,7 +39,7 @@ declare_rule! {
     ///
     /// - [WCAG 2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard)
     ///
-    pub(crate) UseKeyWithMouseEvents {
+    pub UseKeyWithMouseEvents {
         version: "1.0.0",
         name: "useKeyWithMouseEvents",
         source: RuleSource::EslintJsxA11y("mouse-events-have-key-events"),
@@ -47,7 +47,7 @@ declare_rule! {
     }
 }
 
-pub(crate) enum UseKeyWithMouseEventsState {
+pub enum UseKeyWithMouseEventsState {
     MissingOnFocus,
     MissingOnBlur,
 }

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_media_caption.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_media_caption.rs
@@ -30,7 +30,7 @@ declare_rule! {
     /// ```jsx
     /// 	<video muted {...props}></video>
     /// ```
-    pub(crate) UseMediaCaption {
+    pub UseMediaCaption {
         version: "1.0.0",
         name: "useMediaCaption",
         source: RuleSource::EslintJsxA11y("media-has-caption"),

--- a/crates/biome_js_analyze/src/analyzers/a11y/use_valid_anchor.rs
+++ b/crates/biome_js_analyze/src/analyzers/a11y/use_valid_anchor.rs
@@ -66,7 +66,7 @@ declare_rule! {
     ///
     /// - [WCAG 2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard)
     ///
-    pub(crate) UseValidAnchor {
+    pub UseValidAnchor {
         version: "1.0.0",
         name: "useValidAnchor",
         source: RuleSource::EslintJsxA11y("anchor-is-valid"),
@@ -77,7 +77,7 @@ declare_rule! {
 /// Representation of the various states
 ///
 /// The `TextRange` of each variant represents the range of where the issue is found.
-pub(crate) enum UseValidAnchorState {
+pub enum UseValidAnchorState {
     /// The anchor element has not `href` attribute
     MissingHrefAttribute(TextRange),
     /// The value assigned to attribute `href` is not valid

--- a/crates/biome_js_analyze/src/analyzers/complexity.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity.rs
@@ -2,30 +2,30 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_excessive_cognitive_complexity;
-pub(crate) mod no_extra_boolean_cast;
-pub(crate) mod no_for_each;
-pub(crate) mod no_multiple_spaces_in_regular_expression_literals;
-pub(crate) mod no_static_only_class;
-pub(crate) mod no_useless_catch;
-pub(crate) mod no_useless_constructor;
-pub(crate) mod no_useless_empty_export;
-pub(crate) mod no_useless_label;
-pub(crate) mod no_useless_rename;
-pub(crate) mod no_useless_switch_case;
-pub(crate) mod no_useless_type_constraint;
-pub(crate) mod no_void;
-pub(crate) mod no_with;
-pub(crate) mod use_arrow_function;
-pub(crate) mod use_flat_map;
-pub(crate) mod use_literal_keys;
-pub(crate) mod use_optional_chain;
-pub(crate) mod use_regex_literals;
-pub(crate) mod use_simple_number_keys;
-pub(crate) mod use_simplified_logic_expression;
+pub mod no_excessive_cognitive_complexity;
+pub mod no_extra_boolean_cast;
+pub mod no_for_each;
+pub mod no_multiple_spaces_in_regular_expression_literals;
+pub mod no_static_only_class;
+pub mod no_useless_catch;
+pub mod no_useless_constructor;
+pub mod no_useless_empty_export;
+pub mod no_useless_label;
+pub mod no_useless_rename;
+pub mod no_useless_switch_case;
+pub mod no_useless_type_constraint;
+pub mod no_void;
+pub mod no_with;
+pub mod use_arrow_function;
+pub mod use_flat_map;
+pub mod use_literal_keys;
+pub mod use_optional_chain;
+pub mod use_regex_literals;
+pub mod use_simple_number_keys;
+pub mod use_simplified_logic_expression;
 
 declare_group! {
-    pub (crate) Complexity {
+    pub Complexity {
         name : "complexity" ,
         rules : [
             self :: no_excessive_cognitive_complexity :: NoExcessiveCognitiveComplexity ,

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_excessive_cognitive_complexity.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_excessive_cognitive_complexity.rs
@@ -69,7 +69,7 @@ declare_rule! {
     ///
     /// The allowed values range from 1 through 254. The default is 15.
     ///
-    pub(crate) NoExcessiveCognitiveComplexity {
+    pub NoExcessiveCognitiveComplexity {
         version: "1.0.0",
         name: "noExcessiveCognitiveComplexity",
         source: RuleSource::EslintSonarJs("cognitive-complexity"),
@@ -133,7 +133,7 @@ impl Rule for NoExcessiveCognitiveComplexity {
 }
 
 #[derive(Clone)]
-pub(crate) struct CognitiveComplexity {
+pub struct CognitiveComplexity {
     function_like: AnyFunctionLike,
     score: ComplexityScore,
 }

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_extra_boolean_cast.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_extra_boolean_cast.rs
@@ -56,7 +56,7 @@ declare_rule! {
     /// !x;
     /// !!x;
     /// ```
-    pub(crate) NoExtraBooleanCast {
+    pub NoExtraBooleanCast {
         version: "1.0.0",
         name: "noExtraBooleanCast",
         source: RuleSource::Eslint("no-extra-boolean-cast"),

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_for_each.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_for_each.rs
@@ -51,7 +51,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoForEach {
+    pub NoForEach {
         version: "1.0.0",
         name: "noForEach",
         source: RuleSource::EslintUnicorn("no-array-for-each"),

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_multiple_spaces_in_regular_expression_literals.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_multiple_spaces_in_regular_expression_literals.rs
@@ -46,7 +46,7 @@ declare_rule! {
     /// ```js
     /// /foo bar	baz/
     ///```
-    pub(crate) NoMultipleSpacesInRegularExpressionLiterals {
+    pub NoMultipleSpacesInRegularExpressionLiterals {
         version: "1.0.0",
         name: "noMultipleSpacesInRegularExpressionLiterals",
         source: RuleSource::Eslint("no-regex-spaces"),

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_static_only_class.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_static_only_class.rs
@@ -88,7 +88,7 @@ declare_rule! {
     ///   mutableField += 1;
     /// }
     /// ```
-    pub(crate) NoStaticOnlyClass {
+    pub NoStaticOnlyClass {
         version: "1.0.0",
         name: "noStaticOnlyClass",
         source: RuleSource::EslintTypeScript("no-extraneous-class"),

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_catch.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_catch.rs
@@ -50,7 +50,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoUselessCatch {
+    pub NoUselessCatch {
         version: "1.0.0",
         name: "noUselessCatch",
         source: RuleSource::Eslint("no-useless-catch"),

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_constructor.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_constructor.rs
@@ -102,7 +102,7 @@ declare_rule! {
     ///     constructor (prop: number) {}
     /// }
     /// ```
-    pub(crate) NoUselessConstructor {
+    pub NoUselessConstructor {
         version: "1.0.0",
         name: "noUselessConstructor",
         source: RuleSource::EslintTypeScript("no-useless-constructor"),

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_empty_export.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_empty_export.rs
@@ -42,7 +42,7 @@ declare_rule! {
     /// export {};
     /// ```
     ///
-    pub(crate) NoUselessEmptyExport {
+    pub NoUselessEmptyExport {
         version: "1.0.0",
         name: "noUselessEmptyExport",
         source: RuleSource::EslintTypeScript("no-useless-empty-export"),

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_label.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_label.rs
@@ -32,7 +32,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoUselessLabel {
+    pub NoUselessLabel {
         version: "1.0.0",
         name: "noUselessLabel",
         source: RuleSource::Eslint("no-extra-label"),

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_rename.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_rename.rs
@@ -57,7 +57,7 @@ declare_rule! {
     /// let { foo: bar } = baz;
     /// ```
     ///
-    pub(crate) NoUselessRename {
+    pub NoUselessRename {
         version: "1.0.0",
         name: "noUselessRename",
         source: RuleSource::Eslint("no-useless-rename"),
@@ -67,7 +67,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) JsRenaming = JsExportNamedFromSpecifier | JsExportNamedSpecifier | JsNamedImportSpecifier | JsObjectBindingPatternProperty
+    pub JsRenaming = JsExportNamedFromSpecifier | JsExportNamedSpecifier | JsNamedImportSpecifier | JsObjectBindingPatternProperty
 }
 
 impl Rule for NoUselessRename {

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_switch_case.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_switch_case.rs
@@ -57,7 +57,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoUselessSwitchCase {
+    pub NoUselessSwitchCase {
         version: "1.0.0",
         name: "noUselessSwitchCase",
         source: RuleSource::EslintUnicorn("no-useless-switch-case"),

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_useless_type_constraint.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_useless_type_constraint.rs
@@ -76,7 +76,7 @@ declare_rule! {
     ///
     /// type Bar<T> = {};
     ///```
-    pub(crate) NoUselessTypeConstraint {
+    pub NoUselessTypeConstraint {
         version: "1.0.0",
         name: "noUselessTypeConstraint",
         source: RuleSource::EslintTypeScript("no-unnecessary-type-constraint"),

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_void.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_void.rs
@@ -17,7 +17,7 @@ declare_rule! {
     /// void 0;
     /// ```
     ///
-    pub(crate) NoVoid {
+    pub NoVoid {
         version: "1.0.0",
         name: "noVoid",
         source: RuleSource::Eslint("no-void"),

--- a/crates/biome_js_analyze/src/analyzers/complexity/no_with.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/no_with.rs
@@ -22,7 +22,7 @@ declare_rule! {
     ///   }
     /// }
     /// ```
-    pub(crate) NoWith {
+    pub NoWith {
         version: "1.0.0",
         name: "noWith",
         source: RuleSource::Eslint("no-with"),

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_arrow_function.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_arrow_function.rs
@@ -67,7 +67,7 @@ declare_rule! {
     ///     return 0;
     /// }
     /// ```
-    pub(crate) UseArrowFunction {
+    pub UseArrowFunction {
         version: "1.0.0",
         name: "useArrowFunction",
         source: RuleSource::Eslint("prefer-arrow-callback"),
@@ -221,7 +221,7 @@ fn needs_parentheses(function_expression: &JsFunctionExpression) -> bool {
 }
 
 declare_node_union! {
-    pub(crate) AnyThisScope =
+    pub AnyThisScope =
         JsConstructorClassMember
         | JsFunctionExpression
         | JsFunctionDeclaration
@@ -238,12 +238,12 @@ declare_node_union! {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct AnyThisScopeMetadata {
+pub struct AnyThisScopeMetadata {
     scope: AnyThisScope,
     has_this: bool,
 }
 
-pub(crate) struct ActualThisScope(AnyThisScopeMetadata);
+pub struct ActualThisScope(AnyThisScopeMetadata);
 
 impl QueryMatch for ActualThisScope {
     fn text_range(&self) -> TextRange {

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_flat_map.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_flat_map.rs
@@ -31,7 +31,7 @@ declare_rule! {
     /// array.map(sentence => sentence.split(' ')).flat(2);
     /// ```
     ///
-    pub(crate) UseFlatMap {
+    pub UseFlatMap {
         version: "1.0.0",
         name: "useFlatMap",
         source: RuleSource::EslintUnicorn("prefer-array-flat-map"),

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_literal_keys.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_literal_keys.rs
@@ -49,7 +49,7 @@ declare_rule! {
     /// a[d.c];
     /// ```
     ///
-    pub(crate) UseLiteralKeys {
+    pub UseLiteralKeys {
         version: "1.0.0",
         name: "useLiteralKeys",
         source: RuleSource::Eslint("dot-notation"),
@@ -178,5 +178,5 @@ impl Rule for UseLiteralKeys {
 }
 
 declare_node_union! {
-    pub(crate) AnyJsMember = AnyJsComputedMember | JsLiteralMemberName | JsComputedMemberName
+    pub AnyJsMember = AnyJsComputedMember | JsLiteralMemberName | JsComputedMemberName
 }

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_optional_chain.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_optional_chain.rs
@@ -73,7 +73,7 @@ declare_rule! {
     /// foo["some long"] && foo["some long string"].baz
     ///```
     ///
-    pub(crate) UseOptionalChain {
+    pub UseOptionalChain {
         version: "1.0.0",
         name: "useOptionalChain",
         source: RuleSource::EslintTypeScript("prefer-optional-chain"),
@@ -82,7 +82,7 @@ declare_rule! {
     }
 }
 
-pub(crate) enum UseOptionalChainState {
+pub enum UseOptionalChainState {
     LogicalAnd(VecDeque<AnyJsExpression>),
     LogicalOrLike(LogicalOrLikeChain),
 }
@@ -310,7 +310,7 @@ enum LogicalAndChainOrdering {
 /// Iterate buffer `[bar, zoo]` we need to make every `JsAnyExpression` optional: `foo?.bar.baz?.zoo;`
 ///
 #[derive(Debug)]
-pub(crate) struct LogicalAndChain {
+pub struct LogicalAndChain {
     head: AnyJsExpression,
     /// The buffer of `JsAnyExpression` which need to make optional chain.
     buf: VecDeque<AnyJsExpression>,
@@ -575,7 +575,7 @@ impl LogicalAndChain {
 /// `foo?.bar?.baz;`
 ///
 #[derive(Debug)]
-pub(crate) struct LogicalOrLikeChain {
+pub struct LogicalOrLikeChain {
     member: AnyJsMemberExpression,
 }
 

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_regex_literals.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_regex_literals.rs
@@ -45,7 +45,7 @@ declare_rule! {
     /// new RegExp("abc", flags);
     /// ```
     ///
-    pub(crate) UseRegexLiterals {
+    pub UseRegexLiterals {
         version: "1.3.0",
         name: "useRegexLiterals",
         source: RuleSource::Eslint("prefer-regex-literals"),
@@ -55,7 +55,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) JsNewOrCallExpression = JsNewExpression | JsCallExpression
+    pub JsNewOrCallExpression = JsNewExpression | JsCallExpression
 }
 
 pub struct UseRegexLiteralsState {

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_simple_number_keys.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_simple_number_keys.rs
@@ -45,7 +45,7 @@ declare_rule! {
     /// ({ 3.1e12: "floating point with e" });
     /// ```
     ///
-    pub(crate) UseSimpleNumberKeys {
+    pub UseSimpleNumberKeys {
         version: "1.0.0",
         name: "useSimpleNumberKeys",
         recommended: true,

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_simplified_logic_expression.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_simplified_logic_expression.rs
@@ -48,7 +48,7 @@ declare_rule! {
     /// const boolExpr6 = false;
     /// ```
     ///
-    pub(crate) UseSimplifiedLogicExpression {
+    pub UseSimplifiedLogicExpression {
         version: "1.0.0",
         name: "useSimplifiedLogicExpression",
         recommended: false,

--- a/crates/biome_js_analyze/src/analyzers/correctness.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness.rs
@@ -2,29 +2,29 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_constructor_return;
-pub(crate) mod no_empty_character_class_in_regex;
-pub(crate) mod no_empty_pattern;
-pub(crate) mod no_inner_declarations;
-pub(crate) mod no_invalid_constructor_super;
-pub(crate) mod no_nonoctal_decimal_escape;
-pub(crate) mod no_precision_loss;
-pub(crate) mod no_self_assign;
-pub(crate) mod no_setter_return;
-pub(crate) mod no_string_case_mismatch;
-pub(crate) mod no_switch_declarations;
-pub(crate) mod no_unnecessary_continue;
-pub(crate) mod no_unreachable;
-pub(crate) mod no_unreachable_super;
-pub(crate) mod no_unsafe_finally;
-pub(crate) mod no_unsafe_optional_chaining;
-pub(crate) mod no_unused_labels;
-pub(crate) mod no_void_type_return;
-pub(crate) mod use_valid_for_direction;
-pub(crate) mod use_yield;
+pub mod no_constructor_return;
+pub mod no_empty_character_class_in_regex;
+pub mod no_empty_pattern;
+pub mod no_inner_declarations;
+pub mod no_invalid_constructor_super;
+pub mod no_nonoctal_decimal_escape;
+pub mod no_precision_loss;
+pub mod no_self_assign;
+pub mod no_setter_return;
+pub mod no_string_case_mismatch;
+pub mod no_switch_declarations;
+pub mod no_unnecessary_continue;
+pub mod no_unreachable;
+pub mod no_unreachable_super;
+pub mod no_unsafe_finally;
+pub mod no_unsafe_optional_chaining;
+pub mod no_unused_labels;
+pub mod no_void_type_return;
+pub mod use_valid_for_direction;
+pub mod use_yield;
 
 declare_group! {
-    pub (crate) Correctness {
+    pub Correctness {
         name : "correctness" ,
         rules : [
             self :: no_constructor_return :: NoConstructorReturn ,

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_constructor_return.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_constructor_return.rs
@@ -43,7 +43,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoConstructorReturn {
+    pub NoConstructorReturn {
         version: "1.0.0",
         name: "noConstructorReturn",
         source: RuleSource::Eslint("no-constructor-return"),

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_empty_character_class_in_regex.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_empty_character_class_in_regex.rs
@@ -38,7 +38,7 @@ declare_rule! {
     /// /^a\[]/.test("a[]"); // true
     /// ```
     ///
-    pub(crate) NoEmptyCharacterClassInRegex {
+    pub NoEmptyCharacterClassInRegex {
         version: "1.3.0",
         name: "noEmptyCharacterClassInRegex",
         source: RuleSource::Eslint("no-empty-character-class"),

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_empty_pattern.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_empty_pattern.rs
@@ -32,7 +32,7 @@ declare_rule! {
     /// function foo({a = []}) {}
     /// var [a] = foo;
     /// ```
-    pub(crate) NoEmptyPattern {
+    pub NoEmptyPattern {
         version: "1.0.0",
         name: "noEmptyPattern",
         source: RuleSource::Eslint("no-empty-pattern"),
@@ -85,5 +85,5 @@ impl Rule for NoEmptyPattern {
 
 declare_node_union! {
     /// enum of `JsObjectBindingPattern` and `JsArrayBindingPattern`
-    pub(crate) JsAnyBindPatternLike = JsArrayBindingPattern | JsObjectBindingPattern
+    pub JsAnyBindPatternLike = JsArrayBindingPattern | JsObjectBindingPattern
 }

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_inner_declarations.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_inner_declarations.rs
@@ -85,7 +85,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoInnerDeclarations {
+    pub NoInnerDeclarations {
         version: "1.0.0",
         name: "noInnerDeclarations",
         source: RuleSource::Eslint("no-inner-declarations"),

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_invalid_constructor_super.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_invalid_constructor_super.rs
@@ -45,7 +45,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoInvalidConstructorSuper {
+    pub NoInvalidConstructorSuper {
         version: "1.0.0",
         name: "noInvalidConstructorSuper",
         source: RuleSource::Eslint("constructor-super"),
@@ -53,7 +53,7 @@ declare_rule! {
     }
 }
 
-pub(crate) enum NoInvalidConstructorSuperState {
+pub enum NoInvalidConstructorSuperState {
     UnexpectedSuper(TextRange),
     BadExtends {
         extends_range: TextRange,

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_nonoctal_decimal_escape.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_nonoctal_decimal_escape.rs
@@ -53,7 +53,7 @@ declare_rule! {
     /// const x = "Don't use \\8 and \\9 escapes.";
     /// ```
     ///
-    pub(crate) NoNonoctalDecimalEscape {
+    pub NoNonoctalDecimalEscape {
         version: "1.0.0",
         name: "noNonoctalDecimalEscape",
         source: RuleSource::Eslint("no-nonoctal-decimal-escape"),
@@ -63,12 +63,12 @@ declare_rule! {
 }
 
 #[derive(Debug)]
-pub(crate) enum FixSuggestionKind {
+pub enum FixSuggestionKind {
     Refactor,
 }
 
 #[derive(Debug)]
-pub(crate) struct RuleState {
+pub struct RuleState {
     kind: FixSuggestionKind,
     diagnostics_text_range: TextRange,
     replace_from: String,

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_precision_loss.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_precision_loss.rs
@@ -45,7 +45,7 @@ declare_rule! {
     /// const x = 9007_1992547409_91
     /// ```
     ///
-    pub(crate) NoPrecisionLoss {
+    pub NoPrecisionLoss {
         version: "1.0.0",
         name: "noPrecisionLoss",
         source: RuleSource::Eslint("no-loss-of-precision"),

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_self_assign.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_self_assign.rs
@@ -63,7 +63,7 @@ declare_rule! {
     /// [a, b] = [b, a];
     /// ```
     ///
-    pub(crate) NoSelfAssign {
+    pub NoSelfAssign {
         version: "1.0.0",
         name: "noSelfAssign",
         source: RuleSource::Eslint("no-self-assign"),
@@ -546,11 +546,11 @@ enum AnyAssignmentLike {
 }
 
 declare_node_union! {
-    pub(crate) AnyNameLike = AnyJsName | JsReferenceIdentifier | AnyJsLiteralExpression
+    pub AnyNameLike = AnyJsName | JsReferenceIdentifier | AnyJsLiteralExpression
 }
 
 declare_node_union! {
-    pub(crate) AnyAssignmentExpressionLike = JsStaticMemberExpression | JsComputedMemberExpression
+    pub AnyAssignmentExpressionLike = JsStaticMemberExpression | JsComputedMemberExpression
 }
 
 impl AnyAssignmentExpressionLike {
@@ -656,7 +656,7 @@ impl TryFrom<(AnyJsAssignmentPattern, AnyJsExpression)> for AnyAssignmentLike {
 /// - the first one is the identifier found in the left arm of the assignment;
 /// - the second one is the identifier found in the right arm of the assignment;
 #[derive(Debug, Clone)]
-pub(crate) enum IdentifiersLike {
+pub enum IdentifiersLike {
     /// To store identifiers found in code like:
     ///
     /// ```js

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_setter_return.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_setter_return.rs
@@ -64,7 +64,7 @@ declare_rule! {
     ///   }
     /// }
     /// ```
-    pub(crate) NoSetterReturn {
+    pub NoSetterReturn {
         version: "1.0.0",
         name: "noSetterReturn",
         source: RuleSource::Eslint("no-setter-return"),
@@ -73,7 +73,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) JsSetterMember = JsSetterClassMember | JsSetterObjectMember
+    pub JsSetterMember = JsSetterClassMember | JsSetterObjectMember
 }
 
 impl Rule for NoSetterReturn {

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_string_case_mismatch.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_string_case_mismatch.rs
@@ -31,7 +31,7 @@ declare_rule! {
     /// while (s.toLocaleUpperCase() === "abc") {}
     /// for (let s = "abc"; s === "abc"; s = s.toUpperCase()) {}
     /// ```
-    pub(crate) NoStringCaseMismatch {
+    pub NoStringCaseMismatch {
         version: "1.0.0",
         name: "noStringCaseMismatch",
         source: RuleSource::Clippy("match_str_case_mismatch"),
@@ -109,10 +109,10 @@ impl Rule for NoStringCaseMismatch {
 }
 
 declare_node_union! {
-    pub(crate) QueryCandidate = JsBinaryExpression | JsSwitchStatement
+    pub QueryCandidate = JsBinaryExpression | JsSwitchStatement
 }
 
-pub(crate) struct CaseMismatchInfo {
+pub struct CaseMismatchInfo {
     expected_case: ExpectedStringCase,
     expected_value: String,
     call: JsCallExpression,

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_switch_declarations.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_switch_declarations.rs
@@ -69,7 +69,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoSwitchDeclarations {
+    pub NoSwitchDeclarations {
         version: "1.0.0",
         name: "noSwitchDeclarations",
         source: RuleSource::Eslint("no-case-declarations"),

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_unnecessary_continue.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_unnecessary_continue.rs
@@ -71,7 +71,7 @@ declare_rule! {
     ///   }
     /// }
     /// ```
-    pub(crate) NoUnnecessaryContinue {
+    pub NoUnnecessaryContinue {
         version: "1.0.0",
         name: "noUnnecessaryContinue",
         recommended: true,

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_unreachable.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_unreachable.rs
@@ -47,7 +47,7 @@ declare_rule! {
     ///     }
     /// }
     /// ```
-    pub(crate) NoUnreachable {
+    pub NoUnreachable {
         version: "1.0.0",
         name: "noUnreachable",
         source: RuleSource::Eslint("no-unreachable"),
@@ -616,7 +616,7 @@ fn handle_return<'cfg>(
 
 /// Stores a list of unreachable code ranges, sorted in ascending source order
 #[derive(Debug)]
-pub(crate) struct UnreachableRanges {
+pub struct UnreachableRanges {
     ranges: Vec<UnreachableRange>,
 }
 
@@ -940,7 +940,7 @@ impl IntoIterator for UnreachableRanges {
 /// code, along with a list of secondary labels pointing to the dominating
 /// terminator instructions that cause it to be unreachable
 #[derive(Debug)]
-pub(crate) struct UnreachableRange {
+pub struct UnreachableRange {
     text_range: TextRange,
     text_trimmed_range: TextRange,
     terminators: Vec<PathTerminator>,

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_unreachable_super.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_unreachable_super.rs
@@ -61,7 +61,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoUnreachableSuper {
+    pub NoUnreachableSuper {
         version: "1.0.0",
         name: "noUnreachableSuper",
         source: RuleSource::Eslint("no-this-before-super"),
@@ -70,7 +70,7 @@ declare_rule! {
 }
 
 #[allow(clippy::enum_variant_names)]
-pub(crate) enum RuleState {
+pub enum RuleState {
     /// The constructor may call `super` multiple times
     DuplicateSuper { first: TextRange, second: TextRange },
     /// The constructor may read or write from `this` without calling `super`

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_unsafe_finally.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_unsafe_finally.rs
@@ -124,7 +124,7 @@ declare_rule! {
     /// };
     /// ```
     ///
-    pub(crate) NoUnsafeFinally {
+    pub NoUnsafeFinally {
         version: "1.0.0",
         name: "noUnsafeFinally",
         source: RuleSource::Eslint("no-unsafe-finally"),
@@ -133,7 +133,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) ControlFlowStatement = JsReturnStatement | JsThrowStatement | JsBreakStatement | JsContinueStatement
+    pub ControlFlowStatement = JsReturnStatement | JsThrowStatement | JsBreakStatement | JsContinueStatement
 }
 
 impl Rule for NoUnsafeFinally {

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_unsafe_optional_chaining.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_unsafe_optional_chaining.rs
@@ -61,7 +61,7 @@ declare_rule! {
     /// foo?.()?.bar;
     /// ```
     ///
-    pub(crate) NoUnsafeOptionalChaining {
+    pub NoUnsafeOptionalChaining {
         version: "1.0.0",
         name: "noUnsafeOptionalChaining",
         source: RuleSource::Eslint("no-unsafe-optional-chaining"),
@@ -309,7 +309,7 @@ impl Rule for NoUnsafeOptionalChaining {
 
 declare_node_union! {
     /// Only these variants of the union can be part of an unsafe optional chain.
-    pub(crate) RuleNode =
+    pub RuleNode =
     JsLogicalExpression
     | JsSequenceExpression
     | JsConditionalExpression

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_unused_labels.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_unused_labels.rs
@@ -51,7 +51,7 @@ declare_rule! {
     ///     return n;
     /// }
     /// ```
-    pub(crate) NoUnusedLabels {
+    pub NoUnusedLabels {
         version: "1.0.0",
         name: "noUnusedLabels",
         source: RuleSource::Eslint("no-unused-labels"),
@@ -122,7 +122,7 @@ impl Visitor for UnusedLabelVisitor {
     }
 }
 
-pub(crate) struct UnusedLabel(JsLabeledStatement);
+pub struct UnusedLabel(JsLabeledStatement);
 
 impl QueryMatch for UnusedLabel {
     fn text_range(&self) -> TextRange {

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_void_type_return.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_void_type_return.rs
@@ -84,7 +84,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoVoidTypeReturn {
+    pub NoVoidTypeReturn {
         version: "1.0.0",
         name: "noVoidTypeReturn",
         recommended: true,
@@ -92,7 +92,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) JsFunctionMethod = JsArrowFunctionExpression | JsFunctionDeclaration | JsFunctionExportDefaultDeclaration | JsFunctionExpression | JsGetterClassMember | JsGetterObjectMember | JsMethodClassMember | JsMethodObjectMember
+    pub JsFunctionMethod = JsArrowFunctionExpression | JsFunctionDeclaration | JsFunctionExportDefaultDeclaration | JsFunctionExpression | JsGetterClassMember | JsGetterObjectMember | JsMethodClassMember | JsMethodObjectMember
 }
 
 pub(crate) fn return_type(func: &JsFunctionMethod) -> Option<AnyTsReturnType> {

--- a/crates/biome_js_analyze/src/analyzers/correctness/use_valid_for_direction.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/use_valid_for_direction.rs
@@ -38,7 +38,7 @@ declare_rule! {
     /// for (var i = 0; i < 10; i++) {
     /// }
     /// ```
-    pub(crate) UseValidForDirection {
+    pub UseValidForDirection {
         version: "1.0.0",
         name: "useValidForDirection",
         source: RuleSource::Eslint("for-direction"),

--- a/crates/biome_js_analyze/src/analyzers/correctness/use_yield.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/use_yield.rs
@@ -36,7 +36,7 @@ declare_rule! {
     /// // This rule does not warn on empty generator functions.
     /// function* foo() { }
     /// ```
-    pub(crate) UseYield {
+    pub UseYield {
         version: "1.0.0",
         name: "useYield",
         source: RuleSource::Eslint("require-yield"),
@@ -94,7 +94,7 @@ impl Visitor for MissingYieldVisitor {
     }
 }
 
-pub(crate) struct MissingYield(AnyFunctionLike);
+pub struct MissingYield(AnyFunctionLike);
 
 impl QueryMatch for MissingYield {
     fn text_range(&self) -> TextRange {

--- a/crates/biome_js_analyze/src/analyzers/nursery.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery.rs
@@ -2,28 +2,28 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_empty_block_statements;
-pub(crate) mod no_empty_type_parameters;
-pub(crate) mod no_focused_tests;
-pub(crate) mod no_namespace_import;
-pub(crate) mod no_nodejs_modules;
-pub(crate) mod no_restricted_imports;
-pub(crate) mod no_skipped_tests;
-pub(crate) mod no_undeclared_dependencies;
-pub(crate) mod no_unused_private_class_members;
-pub(crate) mod no_useless_lone_block_statements;
-pub(crate) mod no_useless_ternary;
-pub(crate) mod use_await;
-pub(crate) mod use_consistent_array_type;
-pub(crate) mod use_filenaming_convention;
-pub(crate) mod use_grouped_type_import;
-pub(crate) mod use_import_restrictions;
-pub(crate) mod use_node_assert_strict;
-pub(crate) mod use_nodejs_import_protocol;
-pub(crate) mod use_shorthand_function_type;
+pub mod no_empty_block_statements;
+pub mod no_empty_type_parameters;
+pub mod no_focused_tests;
+pub mod no_namespace_import;
+pub mod no_nodejs_modules;
+pub mod no_restricted_imports;
+pub mod no_skipped_tests;
+pub mod no_undeclared_dependencies;
+pub mod no_unused_private_class_members;
+pub mod no_useless_lone_block_statements;
+pub mod no_useless_ternary;
+pub mod use_await;
+pub mod use_consistent_array_type;
+pub mod use_filenaming_convention;
+pub mod use_grouped_type_import;
+pub mod use_import_restrictions;
+pub mod use_node_assert_strict;
+pub mod use_nodejs_import_protocol;
+pub mod use_shorthand_function_type;
 
 declare_group! {
-    pub (crate) Nursery {
+    pub Nursery {
         name : "nursery" ,
         rules : [
             self :: no_empty_block_statements :: NoEmptyBlockStatements ,

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_empty_block_statements.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_empty_block_statements.rs
@@ -51,7 +51,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoEmptyBlockStatements {
+    pub NoEmptyBlockStatements {
         version: "1.3.0",
         name: "noEmptyBlockStatements",
         // Include also `eslint/no-empty-static-block`
@@ -61,7 +61,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) Query = JsBlockStatement | JsFunctionBody | JsStaticInitializationBlockClassMember | JsSwitchStatement
+    pub Query = JsBlockStatement | JsFunctionBody | JsStaticInitializationBlockClassMember | JsSwitchStatement
 }
 
 impl Rule for NoEmptyBlockStatements {

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_empty_type_parameters.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_empty_type_parameters.rs
@@ -34,7 +34,7 @@ declare_rule! {
     ///  bar: T;
     /// }
     /// ```
-    pub(crate) NoEmptyTypeParameters {
+    pub NoEmptyTypeParameters {
         version: "1.5.0",
         name: "noEmptyTypeParameters",
         recommended: true,

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_focused_tests.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_focused_tests.rs
@@ -33,7 +33,7 @@ declare_rule! {
     /// ```js
     /// test("foo", () => {});
     /// ```
-    pub(crate) NoFocusedTests {
+    pub NoFocusedTests {
         version: "next",
         name: "noFocusedTests",
         recommended: true,

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_namespace_import.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_namespace_import.rs
@@ -28,7 +28,7 @@ declare_rule! {
     /// import type * as baz from "baz"
     /// ```
     ///
-    pub(crate) NoNamespaceImport {
+    pub NoNamespaceImport {
         version: "next",
         name: "noNamespaceImport",
         recommended: false,

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_nodejs_modules.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_nodejs_modules.rs
@@ -26,7 +26,7 @@ declare_rule! {
     /// ```js
     /// import fs from "fs-custom";
     /// ```
-    pub(crate) NoNodejsModules {
+    pub NoNodejsModules {
         version: "1.5.0",
         name: "noNodejsModules",
         source: RuleSource::EslintImport("no-nodejs-modules"),

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_restricted_imports.rs
@@ -24,7 +24,7 @@ declare_rule! {
     ///     }
     /// }
     /// ```
-    pub(crate) NoRestrictedImports {
+    pub NoRestrictedImports {
         version: "next",
         name: "noRestrictedImports",
         source: RuleSource::Eslint("no-restricted-imports"),
@@ -46,7 +46,7 @@ impl Rule for NoRestrictedImports {
     type Query = Ast<AnyJsImportSpecifierLike>;
     type State = (TextRange, String);
     type Signals = Option<Self::State>;
-    type Options = RestrictedImportsOptions;
+    type Options = Box<RestrictedImportsOptions>;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let module_name = ctx.query().module_name_token()?;

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_skipped_tests.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_skipped_tests.rs
@@ -34,7 +34,7 @@ declare_rule! {
     /// test("test", () => {});
     /// ```
     ///
-    pub(crate) NoSkippedTests {
+    pub NoSkippedTests {
         version: "next",
         name: "noSkippedTests",
         recommended: false,

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_undeclared_dependencies.rs
@@ -18,7 +18,7 @@ declare_rule! {
     /// import "vite";
     /// ```
     ///
-    pub(crate) NoUndeclaredDependencies {
+    pub NoUndeclaredDependencies {
         version: "next",
         name: "noUndeclaredDependencies",
         recommended: false,

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_unused_private_class_members.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_unused_private_class_members.rs
@@ -61,7 +61,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoUnusedPrivateClassMembers {
+    pub NoUnusedPrivateClassMembers {
         version: "1.3.3",
         name: "noUnusedPrivateClassMembers",
         source: RuleSource::Eslint("no-unused-private-class-members"),
@@ -71,7 +71,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) AnyMember = AnyJsClassMember | TsPropertyParameter
+    pub AnyMember = AnyJsClassMember | TsPropertyParameter
 }
 
 impl Rule for NoUnusedPrivateClassMembers {

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_useless_lone_block_statements.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_useless_lone_block_statements.rs
@@ -43,7 +43,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoUselessLoneBlockStatements {
+    pub NoUselessLoneBlockStatements {
         version: "1.3.3",
         name: "noUselessLoneBlockStatements",
         source: RuleSource::Eslint("no-lone-blocks"),

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_useless_ternary.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_useless_ternary.rs
@@ -53,7 +53,7 @@ declare_rule! {
     ///
     /// Logical NOT: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT
     ///
-    pub(crate) NoUselessTernary {
+    pub NoUselessTernary {
         version: "1.5.0",
         name: "noUselessTernary",
         source: RuleSource::Eslint("no-unneeded-ternary"),

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_await.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_await.rs
@@ -45,7 +45,7 @@ declare_rule! {
     /// // Nor does it warn about empty `async` functions
     /// async function noop() { }
     /// ```
-    pub(crate) UseAwait {
+    pub UseAwait {
         version: "1.4.0",
         name: "useAwait",
         source: RuleSource::Eslint("require-await"),
@@ -99,7 +99,7 @@ impl Visitor for MissingAwaitVisitor {
     }
 }
 
-pub(crate) struct MissingAwait(AnyFunctionLike);
+pub struct MissingAwait(AnyFunctionLike);
 
 impl QueryMatch for MissingAwait {
     fn text_range(&self) -> TextRange {

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_consistent_array_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_consistent_array_type.rs
@@ -67,7 +67,7 @@ declare_rule! {
     /// By default, all array declarations will be converted to `T[]` or `readonly T[]`, which it means `shorthand`,
     /// or if the options is set to the "generic", that all will converted to `Array<T>` or `ReadonlyArray<T>`.
     ///
-    pub(crate) UseConsistentArrayType {
+    pub UseConsistentArrayType {
         version: "1.5.0",
         name: "useConsistentArrayType",
         source: RuleSource::EslintTypeScript("array-type"),

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_filenaming_convention.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_filenaming_convention.rs
@@ -75,7 +75,7 @@ declare_rule! {
     /// [`kebab-case`]: https://en.wikipedia.org/wiki/Letter_case#Kebab_case
     /// [`PascalCase`]: https://en.wikipedia.org/wiki/Camel_case
     /// [`snake_case`]: https://en.wikipedia.org/wiki/Snake_case
-    pub(crate) UseFilenamingConvention {
+    pub UseFilenamingConvention {
         version: "1.5.0",
         name: "useFilenamingConvention",
         source: RuleSource::EslintUnicorn("filename-case"),
@@ -88,7 +88,7 @@ impl Rule for UseFilenamingConvention {
     type Query = SemanticServices;
     type State = FileNamingConventionState;
     type Signals = Option<Self::State>;
-    type Options = FilenamingConventionOptions;
+    type Options = Box<FilenamingConventionOptions>;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let file_name = ctx.file_path().file_name()?.to_str()?;
@@ -226,7 +226,7 @@ impl Rule for UseFilenamingConvention {
 }
 
 #[derive(Debug)]
-pub(crate) enum FileNamingConventionState {
+pub enum FileNamingConventionState {
     /// The name is not in ASCII while `reuireAscii` is enabled.
     Ascii,
     /// The filename doesn't match the expected case

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_grouped_type_import.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_grouped_type_import.rs
@@ -57,7 +57,7 @@ declare_rule! {
     /// ```ts
     /// import { A, type B } from "mod";
     /// ```
-    pub(crate) UseGroupedTypeImport {
+    pub UseGroupedTypeImport {
         version: "1.0.0",
         name: "useGroupedTypeImport",
         source: RuleSource::EslintTypeScript("no-import-type-side-effects"),

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_import_restrictions.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_import_restrictions.rs
@@ -72,7 +72,7 @@ declare_rule! {
     /// import useAsync from "react-use/lib/useAsync";
     /// ```
     ///
-    pub(crate) UseImportRestrictions {
+    pub UseImportRestrictions {
         version: "1.0.0",
         name: "useImportRestrictions",
         source: RuleSource::EslintImportAccess("eslint-plugin-import-access"),
@@ -115,7 +115,7 @@ impl Rule for UseImportRestrictions {
     }
 }
 
-pub(crate) struct ImportRestrictionsState {
+pub struct ImportRestrictionsState {
     /// The path that is being restricted.
     path: String,
 

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_node_assert_strict.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_node_assert_strict.rs
@@ -26,7 +26,7 @@ declare_rule! {
     /// import * as assert from "node:assert/strict"
     /// ```
     ///
-    pub(crate) UseNodeAssertStrict {
+    pub UseNodeAssertStrict {
         version: "next",
         name: "useNodeAssertStrict",
         recommended: false,

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_nodejs_import_protocol.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_nodejs_import_protocol.rs
@@ -41,7 +41,7 @@ declare_rule! {
     /// import path from 'node:path';
     /// ```
     ///
-    pub(crate) UseNodejsImportProtocol {
+    pub UseNodejsImportProtocol {
         version: "1.5.0",
         name: "useNodejsImportProtocol",
         source: RuleSource::EslintUnicorn("prefer-node-protocol"),

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_shorthand_function_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_shorthand_function_type.rs
@@ -78,7 +78,7 @@ declare_rule! {
     /// type Intersection = ((data: string) => number) & ((id: number) => string);
     ///```
     ///
-    pub(crate) UseShorthandFunctionType {
+    pub UseShorthandFunctionType {
         version: "1.5.0",
         name: "useShorthandFunctionType",
         source: RuleSource::EslintTypeScript("prefer-function-type"),

--- a/crates/biome_js_analyze/src/analyzers/performance.rs
+++ b/crates/biome_js_analyze/src/analyzers/performance.rs
@@ -2,10 +2,10 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_delete;
+pub mod no_delete;
 
 declare_group! {
-    pub (crate) Performance {
+    pub Performance {
         name : "performance" ,
         rules : [
             self :: no_delete :: NoDelete ,

--- a/crates/biome_js_analyze/src/analyzers/performance/no_delete.rs
+++ b/crates/biome_js_analyze/src/analyzers/performance/no_delete.rs
@@ -58,7 +58,7 @@ declare_rule! {
     /// delete f(); // uncovered by this rule.
     ///```
     ///
-    pub(crate) NoDelete {
+    pub NoDelete {
         version: "1.0.0",
         name: "noDelete",
         recommended: true,

--- a/crates/biome_js_analyze/src/analyzers/style.rs
+++ b/crates/biome_js_analyze/src/analyzers/style.rs
@@ -2,34 +2,34 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_comma_operator;
-pub(crate) mod no_default_export;
-pub(crate) mod no_implicit_boolean;
-pub(crate) mod no_inferrable_types;
-pub(crate) mod no_namespace;
-pub(crate) mod no_negation_else;
-pub(crate) mod no_non_null_assertion;
-pub(crate) mod no_parameter_properties;
-pub(crate) mod no_unused_template_literal;
-pub(crate) mod no_useless_else;
-pub(crate) mod use_as_const_assertion;
-pub(crate) mod use_block_statements;
-pub(crate) mod use_collapsed_else_if;
-pub(crate) mod use_default_parameter_last;
-pub(crate) mod use_enum_initializers;
-pub(crate) mod use_exponentiation_operator;
-pub(crate) mod use_literal_enum_members;
-pub(crate) mod use_numeric_literals;
-pub(crate) mod use_self_closing_elements;
-pub(crate) mod use_shorthand_array_type;
-pub(crate) mod use_shorthand_assign;
-pub(crate) mod use_single_case_statement;
-pub(crate) mod use_single_var_declarator;
-pub(crate) mod use_template;
-pub(crate) mod use_while;
+pub mod no_comma_operator;
+pub mod no_default_export;
+pub mod no_implicit_boolean;
+pub mod no_inferrable_types;
+pub mod no_namespace;
+pub mod no_negation_else;
+pub mod no_non_null_assertion;
+pub mod no_parameter_properties;
+pub mod no_unused_template_literal;
+pub mod no_useless_else;
+pub mod use_as_const_assertion;
+pub mod use_block_statements;
+pub mod use_collapsed_else_if;
+pub mod use_default_parameter_last;
+pub mod use_enum_initializers;
+pub mod use_exponentiation_operator;
+pub mod use_literal_enum_members;
+pub mod use_numeric_literals;
+pub mod use_self_closing_elements;
+pub mod use_shorthand_array_type;
+pub mod use_shorthand_assign;
+pub mod use_single_case_statement;
+pub mod use_single_var_declarator;
+pub mod use_template;
+pub mod use_while;
 
 declare_group! {
-    pub (crate) Style {
+    pub Style {
         name : "style" ,
         rules : [
             self :: no_comma_operator :: NoCommaOperator ,

--- a/crates/biome_js_analyze/src/analyzers/style/no_comma_operator.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_comma_operator.rs
@@ -36,7 +36,7 @@ declare_rule! {
     /// for(a = 0, b = 0; (a + b) < 10; a++, b += 2) {}
     /// ```
     ///
-    pub(crate) NoCommaOperator {
+    pub NoCommaOperator {
         version: "1.0.0",
         name: "noCommaOperator",
         source: RuleSource::Eslint("no-sequences"),

--- a/crates/biome_js_analyze/src/analyzers/style/no_default_export.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_default_export.rs
@@ -56,7 +56,7 @@ declare_rule! {
     /// module.exports = class {};
     /// ```
     ///
-    pub(crate) NoDefaultExport {
+    pub NoDefaultExport {
         version: "1.4.0",
         name: "noDefaultExport",
         source: RuleSource::EslintImport("no-default-export"),

--- a/crates/biome_js_analyze/src/analyzers/style/no_implicit_boolean.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_implicit_boolean.rs
@@ -44,7 +44,7 @@ declare_rule! {
     /// ```jsx
     /// <input disabled='false' />
     ///```
-    pub(crate) NoImplicitBoolean {
+    pub NoImplicitBoolean {
         version: "1.0.0",
         name: "noImplicitBoolean",
         source: RuleSource::EslintReact("jsx-boolean-value"),

--- a/crates/biome_js_analyze/src/analyzers/style/no_inferrable_types.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_inferrable_types.rs
@@ -95,7 +95,7 @@ declare_rule! {
     /// function f(param: 1 | 2 = 1): void {}
     /// ```
     ///
-    pub(crate) NoInferrableTypes {
+    pub NoInferrableTypes {
         version: "1.0.0",
         name: "noInferrableTypes",
         source: RuleSource::EslintTypeScript("no-inferrable-types"),

--- a/crates/biome_js_analyze/src/analyzers/style/no_namespace.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_namespace.rs
@@ -45,7 +45,7 @@ declare_rule! {
     /// declare module 'foo' {}
     /// ```
     ///
-    pub(crate) NoNamespace {
+    pub NoNamespace {
         version: "1.0.0",
         name: "noNamespace",
         source: RuleSource::EslintTypeScript("no-namespace"),

--- a/crates/biome_js_analyze/src/analyzers/style/no_negation_else.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_negation_else.rs
@@ -44,7 +44,7 @@ declare_rule! {
     /// ```js
     /// if (!!val) { f(); } else { g(); }
     ///```
-    pub(crate) NoNegationElse {
+    pub NoNegationElse {
         version: "1.0.0",
         name: "noNegationElse",
         source: RuleSource::Eslint("no-negated-condition"),

--- a/crates/biome_js_analyze/src/analyzers/style/no_non_null_assertion.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_non_null_assertion.rs
@@ -45,7 +45,7 @@ declare_rule! {
     /// const includesBaz = foo.property?.includes('baz') ?? false;
     /// ```
     ///
-    pub(crate) NoNonNullAssertion {
+    pub NoNonNullAssertion {
         version: "1.0.0",
         name: "noNonNullAssertion",
         source: RuleSource::EslintTypeScript("no-non-null-assertion"),
@@ -55,7 +55,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) AnyTsNonNullAssertion = TsNonNullAssertionExpression | TsNonNullAssertionAssignment
+    pub AnyTsNonNullAssertion = TsNonNullAssertionExpression | TsNonNullAssertionAssignment
 }
 
 impl Rule for NoNonNullAssertion {

--- a/crates/biome_js_analyze/src/analyzers/style/no_parameter_properties.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_parameter_properties.rs
@@ -30,7 +30,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoParameterProperties {
+    pub NoParameterProperties {
         version: "1.0.0",
         name: "noParameterProperties",
         source: RuleSource::EslintTypeScript("parameter-properties"),

--- a/crates/biome_js_analyze/src/analyzers/style/no_unused_template_literal.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_unused_template_literal.rs
@@ -38,7 +38,7 @@ declare_rule! {
     /// ```js
     /// const foo = `'bar'`
     /// ```
-    pub(crate) NoUnusedTemplateLiteral {
+    pub NoUnusedTemplateLiteral {
         version: "1.0.0",
         name: "noUnusedTemplateLiteral",
         source: RuleSource::EslintTypeScript("no-useless-template-literals"),

--- a/crates/biome_js_analyze/src/analyzers/style/no_useless_else.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_useless_else.rs
@@ -85,7 +85,7 @@ declare_rule! {
     ///     }
     /// }
     /// ```
-    pub(crate) NoUselessElse {
+    pub NoUselessElse {
         version: "1.3.0",
         name: "noUselessElse",
         source: RuleSource::Eslint("no-else-return"),

--- a/crates/biome_js_analyze/src/analyzers/style/use_as_const_assertion.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_as_const_assertion.rs
@@ -45,7 +45,7 @@ declare_rule! {
     /// let bar = 'bar' as string;
     /// let foo = { bar: 'baz' };
     /// ```
-    pub(crate) UseAsConstAssertion {
+    pub UseAsConstAssertion {
         version: "1.3.0",
         name: "useAsConstAssertion",
         source: RuleSource::EslintTypeScript("prefer-as-const"),
@@ -55,10 +55,10 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) Query = JsVariableDeclarator | JsPropertyClassMember | TsAsExpression | TsTypeAssertionExpression
+    pub Query = JsVariableDeclarator | JsPropertyClassMember | TsAsExpression | TsTypeAssertionExpression
 }
 
-pub(crate) enum RuleState {
+pub enum RuleState {
     AsAssertion(TextRange),
     /// The angle bracket assertion is useful when the JSX option is None in tsconfig.json.
     AngleBracketAssertion(TextRange),

--- a/crates/biome_js_analyze/src/analyzers/style/use_block_statements.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_block_statements.rs
@@ -65,7 +65,7 @@ declare_rule! {
     /// ```js,expect_diagnostic
     ///   with (x);
     /// ```
-    pub(crate) UseBlockStatements {
+    pub UseBlockStatements {
         version: "1.0.0",
         name: "useBlockStatements",
         source: RuleSource::Eslint("curly"),
@@ -75,7 +75,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) AnyJsBlockStatement = JsIfStatement | JsElseClause | JsDoWhileStatement | JsForInStatement | JsForOfStatement | JsForStatement | JsWhileStatement | JsWithStatement
+    pub AnyJsBlockStatement = JsIfStatement | JsElseClause | JsDoWhileStatement | JsForInStatement | JsForOfStatement | JsForStatement | JsWhileStatement | JsWithStatement
 }
 
 impl Rule for UseBlockStatements {

--- a/crates/biome_js_analyze/src/analyzers/style/use_collapsed_else_if.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_collapsed_else_if.rs
@@ -81,7 +81,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) UseCollapsedElseIf {
+    pub UseCollapsedElseIf {
         version: "1.1.0",
         name: "useCollapsedElseIf",
         source: RuleSource::Eslint("no-lonely-if"),
@@ -90,7 +90,7 @@ declare_rule! {
     }
 }
 
-pub(crate) struct RuleState {
+pub struct RuleState {
     block_statement: JsBlockStatement,
     if_statement: JsIfStatement,
 }

--- a/crates/biome_js_analyze/src/analyzers/style/use_default_parameter_last.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_default_parameter_last.rs
@@ -48,7 +48,7 @@ declare_rule! {
     /// function f(a: number, b = 0, c?: number) {}
     /// ```
     ///
-    pub(crate) UseDefaultParameterLast {
+    pub UseDefaultParameterLast {
         version: "1.0.0",
         name: "useDefaultParameterLast",
         source: RuleSource::Eslint("default-param-last"),
@@ -58,7 +58,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) AnyFormalParameter = JsFormalParameter | TsPropertyParameter
+    pub AnyFormalParameter = JsFormalParameter | TsPropertyParameter
 }
 
 impl AnyFormalParameter {

--- a/crates/biome_js_analyze/src/analyzers/style/use_enum_initializers.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_enum_initializers.rs
@@ -64,7 +64,7 @@ declare_rule! {
     ///     Sunny,
     /// }
     /// ```
-    pub(crate) UseEnumInitializers {
+    pub UseEnumInitializers {
         version: "1.0.0",
         name: "useEnumInitializers",
         source: RuleSource::EslintTypeScript("prefer-enum-initializers"),

--- a/crates/biome_js_analyze/src/analyzers/style/use_exponentiation_operator.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_exponentiation_operator.rs
@@ -53,7 +53,7 @@ declare_rule! {
     /// let quux = (-1) ** n;
     /// ```
     ///
-    pub(crate) UseExponentiationOperator {
+    pub UseExponentiationOperator {
         version: "1.0.0",
         name: "useExponentiationOperator",
         source: RuleSource::Eslint("prefer-exponentiation-operator"),

--- a/crates/biome_js_analyze/src/analyzers/style/use_literal_enum_members.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_literal_enum_members.rs
@@ -61,7 +61,7 @@ declare_rule! {
     ///     All = Read | Write
     /// }
     /// ```
-    pub(crate) UseLiteralEnumMembers {
+    pub UseLiteralEnumMembers {
         version: "1.0.0",
         name: "useLiteralEnumMembers",
         source: RuleSource::EslintTypeScript("prefer-literal-enum-member"),

--- a/crates/biome_js_analyze/src/analyzers/style/use_numeric_literals.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_numeric_literals.rs
@@ -54,7 +54,7 @@ declare_rule! {
     /// Number.parseInt(foo);
     /// Number.parseInt(foo, 2);
     /// ```
-    pub(crate) UseNumericLiterals {
+    pub UseNumericLiterals {
         version: "1.0.0",
         name: "useNumericLiterals",
         source: RuleSource::Eslint("prefer-numeric-literals"),

--- a/crates/biome_js_analyze/src/analyzers/style/use_self_closing_elements.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_self_closing_elements.rs
@@ -54,7 +54,7 @@ declare_rule! {
     /// ```js
     /// <Foo.bar>child</Foo.bar>
     ///```
-    pub(crate) UseSelfClosingElements {
+    pub UseSelfClosingElements {
         version: "1.0.0",
         name: "useSelfClosingElements",
         source: RuleSource::EslintStylistic("jsx-self-closing-comp"),

--- a/crates/biome_js_analyze/src/analyzers/style/use_shorthand_array_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_shorthand_array_type.rs
@@ -49,7 +49,7 @@ declare_rule! {
     /// let valid: Array<keyof Bar>;
     /// let valid: Array<foo | bar>;
     /// ```
-    pub(crate) UseShorthandArrayType  {
+    pub UseShorthandArrayType  {
         version: "1.0.0",
         name: "useShorthandArrayType",
         source: RuleSource::EslintTypeScript("array-type"),

--- a/crates/biome_js_analyze/src/analyzers/style/use_shorthand_assign.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_shorthand_assign.rs
@@ -50,7 +50,7 @@ declare_rule! {
     ///  ```js
     /// a *= 1;
     /// ```
-    pub(crate) UseShorthandAssign {
+    pub UseShorthandAssign {
         version: "1.3.0",
         name: "useShorthandAssign",
         source: RuleSource::Eslint("operator-assignment"),

--- a/crates/biome_js_analyze/src/analyzers/style/use_single_case_statement.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_single_case_statement.rs
@@ -36,7 +36,7 @@ declare_rule! {
     ///     }
     /// }
     /// ```
-    pub(crate) UseSingleCaseStatement {
+    pub UseSingleCaseStatement {
         version: "1.0.0",
         name: "useSingleCaseStatement",
         recommended: false,

--- a/crates/biome_js_analyze/src/analyzers/style/use_single_var_declarator.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_single_var_declarator.rs
@@ -41,7 +41,7 @@ declare_rule! {
     /// ```js
     /// for (let i = 0, x = 1; i < arr.length; i++) {}
     /// ```
-    pub(crate) UseSingleVarDeclarator {
+    pub UseSingleVarDeclarator {
         version: "1.0.0",
         name: "useSingleVarDeclarator",
         source: RuleSource::Eslint("one-var"),

--- a/crates/biome_js_analyze/src/analyzers/style/use_template.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_template.rs
@@ -47,7 +47,7 @@ declare_rule! {
     /// ```js
     /// let s = `value: ${1}`;
     /// ```
-    pub(crate) UseTemplate {
+    pub UseTemplate {
         version: "1.0.0",
         name: "useTemplate",
         source: RuleSource::Eslint("prefer-template"),

--- a/crates/biome_js_analyze/src/analyzers/style/use_while.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_while.rs
@@ -38,7 +38,7 @@ declare_rule! {
     ///     i++
     /// }
     /// ```
-    pub(crate) UseWhile {
+    pub UseWhile {
         version: "1.0.0",
         name: "useWhile",
         recommended: true,

--- a/crates/biome_js_analyze/src/analyzers/suspicious.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious.rs
@@ -2,41 +2,41 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_approximative_numeric_constant;
-pub(crate) mod no_assign_in_expressions;
-pub(crate) mod no_async_promise_executor;
-pub(crate) mod no_comment_text;
-pub(crate) mod no_compare_neg_zero;
-pub(crate) mod no_confusing_labels;
-pub(crate) mod no_confusing_void_type;
-pub(crate) mod no_const_enum;
-pub(crate) mod no_control_characters_in_regex;
-pub(crate) mod no_debugger;
-pub(crate) mod no_double_equals;
-pub(crate) mod no_duplicate_case;
-pub(crate) mod no_duplicate_class_members;
-pub(crate) mod no_duplicate_jsx_props;
-pub(crate) mod no_duplicate_object_keys;
-pub(crate) mod no_empty_interface;
-pub(crate) mod no_explicit_any;
-pub(crate) mod no_extra_non_null_assertion;
-pub(crate) mod no_fallthrough_switch_clause;
-pub(crate) mod no_implicit_any_let;
-pub(crate) mod no_misleading_instantiator;
-pub(crate) mod no_misrefactored_shorthand_assign;
-pub(crate) mod no_prototype_builtins;
-pub(crate) mod no_redundant_use_strict;
-pub(crate) mod no_self_compare;
-pub(crate) mod no_shadow_restricted_names;
-pub(crate) mod no_sparse_array;
-pub(crate) mod no_unsafe_negation;
-pub(crate) mod use_default_switch_clause_last;
-pub(crate) mod use_getter_return;
-pub(crate) mod use_namespace_keyword;
-pub(crate) mod use_valid_typeof;
+pub mod no_approximative_numeric_constant;
+pub mod no_assign_in_expressions;
+pub mod no_async_promise_executor;
+pub mod no_comment_text;
+pub mod no_compare_neg_zero;
+pub mod no_confusing_labels;
+pub mod no_confusing_void_type;
+pub mod no_const_enum;
+pub mod no_control_characters_in_regex;
+pub mod no_debugger;
+pub mod no_double_equals;
+pub mod no_duplicate_case;
+pub mod no_duplicate_class_members;
+pub mod no_duplicate_jsx_props;
+pub mod no_duplicate_object_keys;
+pub mod no_empty_interface;
+pub mod no_explicit_any;
+pub mod no_extra_non_null_assertion;
+pub mod no_fallthrough_switch_clause;
+pub mod no_implicit_any_let;
+pub mod no_misleading_instantiator;
+pub mod no_misrefactored_shorthand_assign;
+pub mod no_prototype_builtins;
+pub mod no_redundant_use_strict;
+pub mod no_self_compare;
+pub mod no_shadow_restricted_names;
+pub mod no_sparse_array;
+pub mod no_unsafe_negation;
+pub mod use_default_switch_clause_last;
+pub mod use_getter_return;
+pub mod use_namespace_keyword;
+pub mod use_valid_typeof;
 
 declare_group! {
-    pub (crate) Suspicious {
+    pub Suspicious {
         name : "suspicious" ,
         rules : [
             self :: no_approximative_numeric_constant :: NoApproximativeNumericConstant ,

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_approximative_numeric_constant.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_approximative_numeric_constant.rs
@@ -43,7 +43,7 @@ declare_rule! {
     /// ```js
     /// let x = Math.LN10;
     /// ```
-    pub(crate) NoApproximativeNumericConstant {
+    pub NoApproximativeNumericConstant {
         version: "1.3.0",
         name: "noApproximativeNumericConstant",
         source: RuleSource::Clippy("approx_constant"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_assign_in_expressions.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_assign_in_expressions.rs
@@ -41,7 +41,7 @@ declare_rule! {
     /// let a;
     /// a = 1;
     /// ```
-    pub(crate) NoAssignInExpressions {
+    pub NoAssignInExpressions {
         version: "1.0.0",
         name: "noAssignInExpressions",
         source: RuleSource::Eslint("no-cond-assign"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_async_promise_executor.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_async_promise_executor.rs
@@ -36,7 +36,7 @@ declare_rule! {
     ///   new Foo(async (resolve, reject) => {})
     ///   new Foo((( (resolve, reject) => {} )))
     /// ```
-    pub(crate) NoAsyncPromiseExecutor {
+    pub NoAsyncPromiseExecutor {
         version: "1.0.0",
         name: "noAsyncPromiseExecutor",
         source: RuleSource::Eslint("no-async-promise-executor"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_comment_text.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_comment_text.rs
@@ -35,7 +35,7 @@ declare_rule! {
     /// const a1 = <div>{/** comment */}</div>;
     /// const a2 = <div className={"cls" /* comment */}></div>;
     /// ```
-    pub(crate) NoCommentText {
+    pub NoCommentText {
         version: "1.0.0",
         name: "noCommentText",
         source: RuleSource::EslintReact("jsx-no-comment-textnodes"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_compare_neg_zero.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_compare_neg_zero.rs
@@ -34,7 +34,7 @@ declare_rule! {
     /// ```js
     /// (1 >= 0)
     ///```
-    pub(crate) NoCompareNegZero {
+    pub NoCompareNegZero {
         version: "1.0.0",
         name: "noCompareNegZero",
         source: RuleSource::Eslint("no-compare-neg-zero"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_labels.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_labels.rs
@@ -47,7 +47,7 @@ declare_rule! {
     ///     }
     /// }
     /// ```
-    pub(crate) NoConfusingLabels {
+    pub NoConfusingLabels {
         version: "1.0.0",
         name: "noConfusingLabels",
         source: RuleSource::Eslint("no-labels"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_void_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_confusing_void_type.rs
@@ -46,7 +46,7 @@ declare_rule! {
     /// ```ts
     /// function printArg<T = void>(arg: T) {}
     /// ```
-    pub(crate) NoConfusingVoidType {
+    pub NoConfusingVoidType {
         version: "1.2.0",
         name: "noConfusingVoidType",
         source: RuleSource::EslintTypeScript("no-invalid-void-type"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_const_enum.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_const_enum.rs
@@ -35,7 +35,7 @@ declare_rule! {
     ///   Close,
     /// }
     /// ```
-    pub(crate) NoConstEnum {
+    pub NoConstEnum {
         version: "1.0.0",
         name: "noConstEnum",
         recommended: true,

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_control_characters_in_regex.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_control_characters_in_regex.rs
@@ -58,7 +58,7 @@ declare_rule! {
     /// var pattern6 = new RegExp("\x20");
     /// ```
     ///
-    pub(crate) NoControlCharactersInRegex {
+    pub NoControlCharactersInRegex {
         version: "1.0.0",
         name: "noControlCharactersInRegex",
         source: RuleSource::Eslint("no-control-regex"),
@@ -67,7 +67,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) RegexExpressionLike = JsNewExpression | JsCallExpression | JsRegexLiteralExpression
+    pub RegexExpressionLike = JsNewExpression | JsCallExpression | JsRegexLiteralExpression
 }
 
 fn decode_hex_character_to_code_point(iter: &mut Peekable<Chars>) -> Option<(String, i64)> {

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_debugger.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_debugger.rs
@@ -26,7 +26,7 @@ declare_rule! {
     /// const test = { debugger: 1 };
     /// test.debugger;
     ///```
-    pub(crate) NoDebugger {
+    pub NoDebugger {
         version: "1.0.0",
         name: "noDebugger",
         source: RuleSource::Eslint("no-debugger"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_double_equals.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_double_equals.rs
@@ -47,7 +47,7 @@ declare_rule! {
     /// ```js
     /// null != foo
     ///```
-    pub(crate) NoDoubleEquals {
+    pub NoDoubleEquals {
         version: "1.0.0",
         name: "noDoubleEquals",
         source: RuleSource::Eslint("eqeqeq"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_case.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_case.rs
@@ -80,7 +80,7 @@ declare_rule! {
     ///         break;
     /// }
     /// ```
-    pub(crate) NoDuplicateCase {
+    pub NoDuplicateCase {
         version: "1.0.0",
         name: "noDuplicateCase",
         source: RuleSource::Eslint("no-duplicate-case"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_class_members.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_class_members.rs
@@ -84,7 +84,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoDuplicateClassMembers {
+    pub NoDuplicateClassMembers {
         version: "1.0.0",
         name: "noDuplicateClassMembers",
         source: RuleSource::Eslint("no-dupe-class-members"),
@@ -110,7 +110,7 @@ fn is_static_member(node: JsSyntaxList) -> bool {
 }
 
 declare_node_union! {
-    pub(crate) AnyClassMemberDefinition = JsGetterClassMember | JsMethodClassMember | JsPropertyClassMember | JsSetterClassMember
+    pub AnyClassMemberDefinition = JsGetterClassMember | JsMethodClassMember | JsPropertyClassMember | JsSetterClassMember
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_jsx_props.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_jsx_props.rs
@@ -30,7 +30,7 @@ declare_rule! {
     /// ```js
     /// <label xml:lang="en-US" lang="en-US"></label>
     /// ```
- pub(crate) NoDuplicateJsxProps {
+ pub NoDuplicateJsxProps {
         version: "1.0.0",
         name: "noDuplicateJsxProps",
         source: RuleSource::EslintReact("jsx-no-duplicate-props"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_object_keys.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_duplicate_object_keys.rs
@@ -54,7 +54,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoDuplicateObjectKeys {
+    pub NoDuplicateObjectKeys {
         version: "1.0.0",
         name: "noDuplicateObjectKeys",
         source: RuleSource::Eslint("no-dupe-keys"),
@@ -185,7 +185,7 @@ impl From<MemberDefinition> for DefinedProperty {
     }
 }
 
-pub(crate) struct PropertyConflict(DefinedProperty, MemberDefinition);
+pub struct PropertyConflict(DefinedProperty, MemberDefinition);
 impl DefinedProperty {
     fn extend_with(
         &self,

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_empty_interface.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_empty_interface.rs
@@ -40,7 +40,7 @@ declare_rule! {
     /// // Allow empty interfaces that extend a type.
     /// interface B extends A {}
     /// ```
-    pub(crate) NoEmptyInterface {
+    pub NoEmptyInterface {
         version: "1.0.0",
         name: "noEmptyInterface",
         source: RuleSource::EslintTypeScript("no-empty-interface"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_explicit_any.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_explicit_any.rs
@@ -51,7 +51,7 @@ declare_rule! {
     /// function fn(param: Array<Array<unknown>>): Array<unknown> {}
     /// ```
     ///
-    pub(crate) NoExplicitAny {
+    pub NoExplicitAny {
         version: "1.0.0",
         name: "noExplicitAny",
         source: RuleSource::EslintTypeScript("no-explicit-any"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_extra_non_null_assertion.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_extra_non_null_assertion.rs
@@ -45,7 +45,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoExtraNonNullAssertion {
+    pub NoExtraNonNullAssertion {
         version: "1.0.0",
         name: "noExtraNonNullAssertion",
         source: RuleSource::EslintTypeScript("no-extra-non-null-assertion"),
@@ -55,7 +55,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) AnyTsNonNullAssertion = TsNonNullAssertionAssignment | TsNonNullAssertionExpression
+    pub AnyTsNonNullAssertion = TsNonNullAssertionAssignment | TsNonNullAssertionExpression
 }
 
 impl Rule for NoExtraNonNullAssertion {

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_fallthrough_switch_clause.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_fallthrough_switch_clause.rs
@@ -52,7 +52,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoFallthroughSwitchClause {
+    pub NoFallthroughSwitchClause {
         version: "1.0.0",
         name: "noFallthroughSwitchClause",
         source: RuleSource::Eslint("no-fallthrough"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_implicit_any_let.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_implicit_any_let.rs
@@ -33,7 +33,7 @@ declare_rule! {
     /// var b =10;
     /// ```
     ///
-    pub(crate) NoImplicitAnyLet {
+    pub NoImplicitAnyLet {
         version: "1.4.0",
         name: "noImplicitAnyLet",
         recommended: true,

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_misleading_instantiator.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_misleading_instantiator.rs
@@ -45,7 +45,7 @@ declare_rule! {
     ///   new (): C;
     /// }
     /// ```
-    pub(crate) NoMisleadingInstantiator {
+    pub NoMisleadingInstantiator {
         version: "1.3.0",
         name: "noMisleadingInstantiator",
         source: RuleSource::EslintTypeScript("no-misused-new"),
@@ -54,10 +54,10 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) DeclarationQuery = TsInterfaceDeclaration |  TsTypeAliasDeclaration | JsClassDeclaration | TsDeclareStatement
+    pub DeclarationQuery = TsInterfaceDeclaration |  TsTypeAliasDeclaration | JsClassDeclaration | TsDeclareStatement
 }
 
-pub(crate) enum RuleState {
+pub enum RuleState {
     ClassMisleadingNew(TextRange),
     InterfaceMisleadingNew(TextRange),
     InterfaceMisleadingConstructor(TextRange),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_misrefactored_shorthand_assign.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_misrefactored_shorthand_assign.rs
@@ -49,7 +49,7 @@ declare_rule! {
     /// ```js
     /// a = a - b
     /// ```
-    pub(crate) NoMisrefactoredShorthandAssign {
+    pub NoMisrefactoredShorthandAssign {
         version: "1.3.0",
         name: "noMisrefactoredShorthandAssign",
         source: RuleSource::Clippy("misrefactored_assign_op"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_prototype_builtins.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_prototype_builtins.rs
@@ -39,7 +39,7 @@ declare_rule! {
     /// var valid = {}.propertyIsEnumerable.call(foo, "bar");
     /// ```
     ///
-    pub(crate) NoPrototypeBuiltins {
+    pub NoPrototypeBuiltins {
         version: "1.0.0",
         name: "noPrototypeBuiltins",
         source: RuleSource::Eslint("no-prototype-builtins"),
@@ -47,7 +47,7 @@ declare_rule! {
     }
 }
 
-pub(crate) struct RuleState {
+pub struct RuleState {
     prototype_builtins_method_name: String,
     text_range: TextRange,
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_redundant_use_strict.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_redundant_use_strict.rs
@@ -67,7 +67,7 @@ declare_rule! {
  ///```
  ///
 
- pub(crate) NoRedundantUseStrict {
+ pub NoRedundantUseStrict {
         version: "1.0.0",
         name: "noRedundantUseStrict",
         recommended: true,
@@ -84,7 +84,7 @@ impl AnyNodeWithDirectives {
         }
     }
 }
-declare_node_union! { pub(crate) AnyJsStrictModeNode = AnyJsClass| JsModule | JsDirective  }
+declare_node_union! { pub AnyJsStrictModeNode = AnyJsClass| JsModule | JsDirective  }
 
 impl Rule for NoRedundantUseStrict {
     type Query = Ast<JsDirective>;

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_self_compare.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_self_compare.rs
@@ -24,7 +24,7 @@ declare_rule! {
     /// if (a.b.c() !== a.b .c()) {}
     /// ```
     ///
-    pub(crate) NoSelfCompare {
+    pub NoSelfCompare {
         version: "1.0.0",
         name: "noSelfCompare",
         source: RuleSource::Eslint("no-self-compare"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_shadow_restricted_names.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_shadow_restricted_names.rs
@@ -30,7 +30,7 @@ declare_rule! {
     /// ```js,expect_diagnostic
     /// function test(JSON) {console.log(JSON)}
     /// ```
-    pub(crate) NoShadowRestrictedNames {
+    pub NoShadowRestrictedNames {
         version: "1.0.0",
         name: "noShadowRestrictedNames",
         source: RuleSource::Eslint("no-shadow-restricted-names"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_sparse_array.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_sparse_array.rs
@@ -20,7 +20,7 @@ declare_rule! {
     /// ```js,expect_diagnostic
     /// [1,,2]
     /// ```
-    pub(crate) NoSparseArray {
+    pub NoSparseArray {
         version: "1.0.0",
         name: "noSparseArray",
         source: RuleSource::Eslint("no-sparse-array"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/no_unsafe_negation.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/no_unsafe_negation.rs
@@ -33,7 +33,7 @@ declare_rule! {
     /// delete 1 in [1,2];
     /// +1 instanceof [1,2];
     /// ```
-    pub(crate) NoUnsafeNegation {
+    pub NoUnsafeNegation {
         version: "1.0.0",
         name: "noUnsafeNegation",
         source: RuleSource::Eslint("no-unsafe-negation"),
@@ -151,5 +151,5 @@ impl Rule for NoUnsafeNegation {
 declare_node_union! {
     /// Enum for [JsInstanceofExpression] and [JsInExpression]
     #[allow(dead_code)]
-    pub(crate) JsInOrInstanceOfExpression  = JsInstanceofExpression  | JsInExpression
+    pub JsInOrInstanceOfExpression  = JsInstanceofExpression  | JsInExpression
 }

--- a/crates/biome_js_analyze/src/analyzers/suspicious/use_default_switch_clause_last.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/use_default_switch_clause_last.rs
@@ -69,7 +69,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) UseDefaultSwitchClauseLast {
+    pub UseDefaultSwitchClauseLast {
         version: "1.0.0",
         name: "useDefaultSwitchClauseLast",
         source: RuleSource::Eslint("default-case-last"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/use_getter_return.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/use_getter_return.rs
@@ -57,7 +57,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) UseGetterReturn {
+    pub UseGetterReturn {
         version: "1.0.0",
         name: "useGetterReturn",
         source: RuleSource::Eslint("getter-return"),
@@ -158,7 +158,7 @@ impl Rule for UseGetterReturn {
 }
 
 #[derive(Debug)]
-pub(crate) enum InvalidGetterReturn {
+pub enum InvalidGetterReturn {
     /// No `return` statement.
     MissingReturn,
     // A `return` statement without argument.

--- a/crates/biome_js_analyze/src/analyzers/suspicious/use_namespace_keyword.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/use_namespace_keyword.rs
@@ -41,7 +41,7 @@ declare_rule! {
     /// declare module "foo" {}
     /// ```
     ///
-    pub(crate) UseNamespaceKeyword {
+    pub UseNamespaceKeyword {
         version: "1.0.0",
         name: "useNamespaceKeyword",
         source: RuleSource::EslintTypeScript("prefer-namespace-keyword"),

--- a/crates/biome_js_analyze/src/analyzers/suspicious/use_valid_typeof.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/use_valid_typeof.rs
@@ -69,7 +69,7 @@ declare_rule! {
     /// ```js
     /// typeof bar === typeof qux
     /// ```
-    pub(crate) UseValidTypeof {
+    pub UseValidTypeof {
         version: "1.0.0",
         name: "useValidTypeof",
         source: RuleSource::Eslint("valid-typeof"),

--- a/crates/biome_js_analyze/src/aria_analyzers.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers.rs
@@ -1,4 +1,4 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-pub(crate) mod a11y;
-::biome_analyze::declare_category! { pub (crate) AriaAnalyzers { kind : Lint , groups : [self :: a11y :: A11y ,] } }
+pub mod a11y;
+::biome_analyze::declare_category! { pub AriaAnalyzers { kind : Lint , groups : [self :: a11y :: A11y ,] } }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y.rs
@@ -2,21 +2,21 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_aria_hidden_on_focusable;
-pub(crate) mod no_aria_unsupported_elements;
-pub(crate) mod no_interactive_element_to_noninteractive_role;
-pub(crate) mod no_noninteractive_element_to_interactive_role;
-pub(crate) mod no_noninteractive_tabindex;
-pub(crate) mod no_redundant_roles;
-pub(crate) mod use_aria_activedescendant_with_tabindex;
-pub(crate) mod use_aria_props_for_role;
-pub(crate) mod use_valid_aria_props;
-pub(crate) mod use_valid_aria_role;
-pub(crate) mod use_valid_aria_values;
-pub(crate) mod use_valid_lang;
+pub mod no_aria_hidden_on_focusable;
+pub mod no_aria_unsupported_elements;
+pub mod no_interactive_element_to_noninteractive_role;
+pub mod no_noninteractive_element_to_interactive_role;
+pub mod no_noninteractive_tabindex;
+pub mod no_redundant_roles;
+pub mod use_aria_activedescendant_with_tabindex;
+pub mod use_aria_props_for_role;
+pub mod use_valid_aria_props;
+pub mod use_valid_aria_role;
+pub mod use_valid_aria_values;
+pub mod use_valid_lang;
 
 declare_group! {
-    pub (crate) A11y {
+    pub A11y {
         name : "a11y" ,
         rules : [
             self :: no_aria_hidden_on_focusable :: NoAriaHiddenOnFocusable ,

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/no_aria_hidden_on_focusable.rs
@@ -42,7 +42,7 @@ declare_rule! {
     /// - [Element with aria-hidden has no content in sequential focus navigation](https://www.w3.org/WAI/standards-guidelines/act/rules/6cfa84/proposed/)
     /// - [MDN aria-hidden](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)
     ///
-    pub(crate) NoAriaHiddenOnFocusable {
+    pub NoAriaHiddenOnFocusable {
         version: "1.4.0",
         name: "noAriaHiddenOnFocusable",
         source: RuleSource::EslintJsxA11y("no-aria-hidden-on-focusable"),

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/no_aria_unsupported_elements.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/no_aria_unsupported_elements.rs
@@ -33,7 +33,7 @@ declare_rule! {
     /// ```
     ///
     ///
-    pub(crate) NoAriaUnsupportedElements {
+    pub NoAriaUnsupportedElements {
         version: "1.0.0",
         name: "noAriaUnsupportedElements",
         source: RuleSource::EslintJsxA11y("aria-unsupported-elements"),

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/no_interactive_element_to_noninteractive_role.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/no_interactive_element_to_noninteractive_role.rs
@@ -32,7 +32,7 @@ declare_rule! {
     /// <input role="button" />;
     /// ```
     ///
-    pub(crate) NoInteractiveElementToNoninteractiveRole {
+    pub NoInteractiveElementToNoninteractiveRole {
         version: "1.3.0",
         name: "noInteractiveElementToNoninteractiveRole",
         source: RuleSource::EslintJsxA11y("no-interactive-element-to-noninteractive-role"),

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/no_noninteractive_element_to_interactive_role.rs
@@ -45,7 +45,7 @@ declare_rule! {
     /// - [Fundamental Keyboard Navigation Conventions](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_generalnav)
     /// - [Mozilla Developer Network - ARIA Techniques](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Keyboard_and_focus)
     ///
-    pub(crate) NoNoninteractiveElementToInteractiveRole {
+    pub NoNoninteractiveElementToInteractiveRole {
         version: "1.0.0",
         name: "noNoninteractiveElementToInteractiveRole",
         source: RuleSource::EslintJsxA11y("no-noninteractive-element-to-interactive-role"),
@@ -54,7 +54,7 @@ declare_rule! {
     }
 }
 
-pub(crate) struct RuleState {
+pub struct RuleState {
     attribute_range: TextRange,
     element_name: String,
 }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/no_noninteractive_tabindex.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/no_noninteractive_tabindex.rs
@@ -48,7 +48,7 @@ declare_rule! {
     /// <article tabIndex="-1" />
     /// ```
     ///
-    pub(crate) NoNoninteractiveTabindex {
+    pub NoNoninteractiveTabindex {
         version: "1.0.0",
         name: "noNoninteractiveTabindex",
         source: RuleSource::EslintJsxA11y("no-noninteractive-tabindex"),
@@ -66,7 +66,7 @@ declare_node_union! {
     /// - `JsNumberLiteralExpression` &mdash; `5`
     /// - `JsUnaryExpression` &mdash; `+5` | `-5`
     ///
-    pub(crate) AnyNumberLikeExpression = JsStringLiteralExpression | JsNumberLiteralExpression | JsUnaryExpression
+    pub AnyNumberLikeExpression = JsStringLiteralExpression | JsNumberLiteralExpression | JsUnaryExpression
 }
 
 impl AnyNumberLikeExpression {
@@ -91,7 +91,7 @@ impl AnyNumberLikeExpression {
     }
 }
 
-pub(crate) struct RuleState {
+pub struct RuleState {
     attribute_range: TextRange,
     element_name: String,
 }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/no_redundant_roles.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/no_redundant_roles.rs
@@ -43,7 +43,7 @@ declare_rule! {
     /// <span></span>
     /// ```
     ///
-    pub(crate) NoRedundantRoles {
+    pub NoRedundantRoles {
         version: "1.0.0",
         name: "noRedundantRoles",
         source: RuleSource::EslintJsxA11y("no-redundant-roles"),
@@ -52,7 +52,7 @@ declare_rule! {
     }
 }
 
-pub(crate) struct RuleState {
+pub struct RuleState {
     redundant_attribute: JsxAttribute,
     redundant_attribute_value: AnyJsxAttributeValue,
     element_name: String,

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/use_aria_activedescendant_with_tabindex.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/use_aria_activedescendant_with_tabindex.rs
@@ -48,7 +48,7 @@ declare_rule! {
     /// <input aria-activedescendant={someID} />
     /// ```
     ///
-    pub(crate) UseAriaActivedescendantWithTabindex {
+    pub UseAriaActivedescendantWithTabindex {
         version: "1.3.0",
         name: "useAriaActivedescendantWithTabindex",
         source: RuleSource::EslintJsxA11y("aria-activedescendant-has-tabindex"),

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/use_aria_props_for_role.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/use_aria_props_for_role.rs
@@ -38,7 +38,7 @@ declare_rule! {
     /// ### Resources
     /// - [ARIA Spec, Roles](https://www.w3.org/TR/wai-aria/#roles)
     /// - [Chrome Audit Rules, AX_ARIA_03](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_03)
-    pub(crate) UseAriaPropsForRole {
+    pub UseAriaPropsForRole {
         version: "1.0.0",
         name: "useAriaPropsForRole",
         source: RuleSource::EslintJsxA11y("role-has-required-aria-props"),
@@ -47,7 +47,7 @@ declare_rule! {
 }
 
 #[derive(Default, Debug)]
-pub(crate) struct UseAriaPropsForRoleState {
+pub struct UseAriaPropsForRoleState {
     missing_aria_props: Vec<String>,
     attribute: Option<(JsxAttribute, String)>,
 }

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_aria_props.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_aria_props.rs
@@ -25,7 +25,7 @@ declare_rule! {
     ///
     /// ## Accessibility guidelines
     /// - [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
-    pub(crate) UseValidAriaProps {
+    pub UseValidAriaProps {
         version: "1.0.0",
         name: "useValidAriaProps",
         source: RuleSource::EslintJsxA11y("aria-props"),

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_aria_role.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_aria_role.rs
@@ -64,7 +64,7 @@ declare_rule! {
     /// - [DPUB-ARIA roles](https://www.w3.org/TR/dpub-aria-1.0/)
     /// - [MDN: Using ARIA: Roles, states, and properties](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques)
     ///
-    pub(crate) UseValidAriaRole {
+    pub UseValidAriaRole {
         version: "1.4.0",
         name: "useValidAriaRole",
         source: RuleSource::EslintJsxA11y("aria-role"),
@@ -85,7 +85,7 @@ impl Rule for UseValidAriaRole {
     type Query = Aria<AnyJsxElement>;
     type State = ();
     type Signals = Option<Self::State>;
-    type Options = ValidAriaRoleOptions;
+    type Options = Box<ValidAriaRoleOptions>;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_aria_values.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_aria_values.rs
@@ -47,7 +47,7 @@ declare_rule! {
     ///
     /// - [ARIA Spec, States and Properties](https://www.w3.org/TR/wai-aria/#states_and_properties)
     /// - [Chrome Audit Rules, AX_ARIA_04](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_04)
-    pub(crate) UseValidAriaValues {
+    pub UseValidAriaValues {
         version: "1.0.0",
         name: "useValidAriaValues",
         source: RuleSource::EslintJsxA11y("aria-proptypes"),
@@ -55,7 +55,7 @@ declare_rule! {
     }
 }
 
-pub(crate) struct UseValidAriaValuesState {
+pub struct UseValidAriaValuesState {
     attribute_value_range: TextRange,
     allowed_values: Iter<'static, &'static str>,
     attribute_name: JsSyntaxToken,

--- a/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_lang.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/a11y/use_valid_lang.rs
@@ -28,7 +28,7 @@ declare_rule! {
     /// ```jsx
     /// <Html lang="en-babab" />
     /// ```
-    pub(crate) UseValidLang {
+    pub UseValidLang {
         version: "1.0.0",
         name: "useValidLang",
         source: RuleSource::EslintJsxA11y("lang"),
@@ -42,7 +42,7 @@ enum InvalidKind {
     Value,
 }
 
-pub(crate) struct UseValidLangState {
+pub struct UseValidLangState {
     invalid_kind: InvalidKind,
     attribute_range: TextRange,
 }

--- a/crates/biome_js_analyze/src/aria_analyzers/nursery.rs
+++ b/crates/biome_js_analyze/src/aria_analyzers/nursery.rs
@@ -1,0 +1,16 @@
+//! Generated file, do not edit by hand, see `xtask/codegen`
+
+use biome_analyze::declare_group;
+
+pub mod no_aria_hidden_on_focusable;
+pub mod use_valid_aria_role;
+
+declare_group! {
+    pub Nursery {
+        name : "nursery" ,
+        rules : [
+            self :: no_aria_hidden_on_focusable :: NoAriaHiddenOnFocusable ,
+            self :: use_valid_aria_role :: UseValidAriaRole ,
+        ]
+     }
+}

--- a/crates/biome_js_analyze/src/aria_services.rs
+++ b/crates/biome_js_analyze/src/aria_services.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
-pub(crate) struct AriaServices {
+pub struct AriaServices {
     pub(crate) roles: Arc<AriaRoles>,
     pub(crate) properties: Arc<AriaProperties>,
 }
@@ -97,7 +97,7 @@ impl Phase for AriaServices {
 
 /// Query type usable by lint rules **that uses the semantic model** to match on specific [AstNode] types
 #[derive(Clone)]
-pub(crate) struct Aria<N>(pub N);
+pub struct Aria<N>(pub N);
 
 impl<N> Queryable for Aria<N>
 where

--- a/crates/biome_js_analyze/src/assists.rs
+++ b/crates/biome_js_analyze/src/assists.rs
@@ -1,4 +1,4 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-pub(crate) mod correctness;
-::biome_analyze::declare_category! { pub (crate) Assists { kind : Action , groups : [self :: correctness :: Correctness ,] } }
+pub mod correctness;
+::biome_analyze::declare_category! { pub Assists { kind : Action , groups : [self :: correctness :: Correctness ,] } }

--- a/crates/biome_js_analyze/src/assists/correctness.rs
+++ b/crates/biome_js_analyze/src/assists/correctness.rs
@@ -2,10 +2,10 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod organize_imports;
+pub mod organize_imports;
 
 declare_group! {
-    pub (crate) Correctness {
+    pub Correctness {
         name : "correctness" ,
         rules : [
             self :: organize_imports :: OrganizeImports ,

--- a/crates/biome_js_analyze/src/assists/correctness/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assists/correctness/organize_imports.rs
@@ -41,7 +41,7 @@ declare_rule! {
     /// import { Popup } from '@ui/Popup';
     /// import { createConnection } from '@server/database';
     /// ```
-    pub(crate) OrganizeImports {
+    pub OrganizeImports {
         version: "1.0.0",
         name: "organizeImports",
         recommended: false,
@@ -245,7 +245,7 @@ impl Rule for OrganizeImports {
 }
 
 #[derive(Debug)]
-pub(crate) struct ImportGroups {
+pub struct ImportGroups {
     /// The list of all the import groups in the file
     groups: Vec<ImportGroup>,
 }

--- a/crates/biome_js_analyze/src/control_flow/visitor.rs
+++ b/crates/biome_js_analyze/src/control_flow/visitor.rs
@@ -158,7 +158,7 @@ pub(super) struct FunctionVisitor {
 }
 
 declare_node_union! {
-    pub(crate) AnyJsControlFlowRoot = JsModule
+    pub AnyJsControlFlowRoot = JsModule
         | JsScript
         | AnyJsFunction
         | JsGetterObjectMember

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::{borrow::Cow, error::Error};
 
-mod analyzers;
-mod aria_analyzers;
+pub mod analyzers;
+pub mod aria_analyzers;
 mod aria_services;
 mod assists;
 mod ast_utils;

--- a/crates/biome_js_analyze/src/manifest_services.rs
+++ b/crates/biome_js_analyze/src/manifest_services.rs
@@ -8,7 +8,7 @@ use biome_rowan::AstNode;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
-pub(crate) struct ManifestServices {
+pub struct ManifestServices {
     pub(crate) manifest: Arc<PackageJson>,
 }
 
@@ -50,7 +50,7 @@ impl Phase for ManifestServices {
 
 /// Query type usable by lint rules **that uses the semantic model** to match on specific [AstNode] types
 #[derive(Clone)]
-pub(crate) struct Manifest<N>(pub N);
+pub struct Manifest<N>(pub N);
 
 impl<N> Queryable for Manifest<N>
 where

--- a/crates/biome_js_analyze/src/options.rs
+++ b/crates/biome_js_analyze/src/options.rs
@@ -1,175 +1,292 @@
-//! This module contains the rules that have options
+//! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::analyzers::nursery::no_restricted_imports::RestrictedImportsOptions;
-use crate::analyzers::nursery::use_consistent_array_type::ConsistentArrayTypeOptions;
-use crate::analyzers::nursery::use_filenaming_convention::FilenamingConventionOptions;
-use crate::semantic_analyzers::correctness::use_exhaustive_dependencies::HooksOptions;
-use crate::semantic_analyzers::correctness::use_hook_at_top_level::DeprecatedHooksOptions;
-use crate::semantic_analyzers::nursery::use_sorted_classes::UtilityClassSortingOptions;
-use crate::semantic_analyzers::style::no_restricted_globals::RestrictedGlobalsOptions;
-use crate::semantic_analyzers::style::use_naming_convention::NamingConventionOptions;
-use crate::{
-    analyzers::complexity::no_excessive_cognitive_complexity::ComplexityOptions,
-    aria_analyzers::a11y::use_valid_aria_role::ValidAriaRoleOptions,
-};
-use biome_analyze::options::RuleOptions;
-use biome_analyze::RuleKey;
-use biome_console::markup;
-use biome_deserialize::{Deserializable, DeserializableValue, DeserializationDiagnostic};
-#[cfg(feature = "schemars")]
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use crate::analyzers;
+use crate::aria_analyzers;
+use crate::semantic_analyzers;
 
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[serde(rename_all = "camelCase", deny_unknown_fields, untagged)]
-pub enum PossibleOptions {
-    /// Options for `noExcessiveComplexity` rule
-    Complexity(ComplexityOptions),
-    /// Options for `useConsistentArrayType` rule
-    ConsistentArrayType(ConsistentArrayTypeOptions),
-    /// Options for `useFilenamingConvention` rule
-    FilenamingConvention(FilenamingConventionOptions),
-    /// Options for `useExhaustiveDependencies` rule
-    Hooks(HooksOptions),
-    /// Deprecated options for `useHookAtTopLevel` rule
-    DeprecatedHooks(DeprecatedHooksOptions),
-    /// Options for `useNamingConvention` rule
-    NamingConvention(NamingConventionOptions),
-    /// Options for `noRestrictedGlobals` rule
-    RestrictedGlobals(RestrictedGlobalsOptions),
-    /// Options for `noRestrictedImports` rule
-    RestrictedImports(RestrictedImportsOptions),
-    /// Options for `useValidAriaRole` rule
-    ValidAriaRole(ValidAriaRoleOptions),
-    /// Options for `useSortedClasses` rule
-    UtilityClassSorting(UtilityClassSortingOptions),
-}
-
-impl Default for PossibleOptions {
-    fn default() -> Self {
-        Self::Complexity(ComplexityOptions::default())
-    }
-}
-
-impl PossibleOptions {
-    pub fn extract_option(&self, rule_key: &RuleKey) -> RuleOptions {
-        match rule_key.rule_name() {
-            "noExcessiveCognitiveComplexity" => {
-                let options = match self {
-                    PossibleOptions::Complexity(options) => options.clone(),
-                    _ => ComplexityOptions::default(),
-                };
-                RuleOptions::new(options)
-            }
-            "useConsistentArrayType" => {
-                let options = match self {
-                    PossibleOptions::ConsistentArrayType(options) => options.clone(),
-                    _ => ConsistentArrayTypeOptions::default(),
-                };
-                RuleOptions::new(options)
-            }
-            "useExhaustiveDependencies" => {
-                let options = match self {
-                    PossibleOptions::Hooks(options) => options.clone(),
-                    _ => HooksOptions::default(),
-                };
-                RuleOptions::new(options)
-            }
-            "useFilenamingConvention" => {
-                let options = match self {
-                    PossibleOptions::FilenamingConvention(options) => options.clone(),
-                    _ => FilenamingConventionOptions::default(),
-                };
-                RuleOptions::new(options)
-            }
-            "useHookAtTopLevel" => {
-                let options = match self {
-                    PossibleOptions::DeprecatedHooks(options) => options.clone(),
-                    _ => DeprecatedHooksOptions::default(),
-                };
-                RuleOptions::new(options)
-            }
-            "useNamingConvention" => {
-                let options = match self {
-                    PossibleOptions::NamingConvention(options) => options.clone(),
-                    _ => NamingConventionOptions::default(),
-                };
-                RuleOptions::new(options)
-            }
-            "noRestrictedGlobals" => {
-                let options = match self {
-                    PossibleOptions::RestrictedGlobals(options) => options.clone(),
-                    _ => RestrictedGlobalsOptions::default(),
-                };
-                RuleOptions::new(options)
-            }
-            "noRestrictedImports" => {
-                let options = match self {
-                    PossibleOptions::RestrictedImports(options) => options.clone(),
-                    _ => RestrictedImportsOptions::default(),
-                };
-                RuleOptions::new(options)
-            }
-            "useValidAriaRole" => {
-                let options = match self {
-                    PossibleOptions::ValidAriaRole(options) => options.clone(),
-                    _ => ValidAriaRoleOptions::default(),
-                };
-                RuleOptions::new(options)
-            }
-            "useSortedClasses" => {
-                let options = match self {
-                    PossibleOptions::UtilityClassSorting(options) => options.clone(),
-                    _ => UtilityClassSortingOptions::default(),
-                };
-                RuleOptions::new(options)
-            }
-            // TODO: review error
-            _ => panic!("This rule {:?} doesn't have options", rule_key),
-        }
-    }
-}
-
-impl Deserializable for PossibleOptions {
-    fn deserialize(
-        value: &impl DeserializableValue,
-        rule_name: &str,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<Self> {
-        match rule_name {
-            "noExcessiveCognitiveComplexity" => {
-                Deserializable::deserialize(value, "options", diagnostics).map(Self::Complexity)
-            }
-            "noRestrictedGlobals" => Deserializable::deserialize(value, "options", diagnostics)
-                .map(Self::RestrictedGlobals),
-            "noRestrictedImports" => Deserializable::deserialize(value, "options", diagnostics)
-                .map(Self::RestrictedImports),
-            "useConsistentArrayType" => Deserializable::deserialize(value, "options", diagnostics)
-                .map(Self::ConsistentArrayType),
-            "useExhaustiveDependencies" => {
-                Deserializable::deserialize(value, "options", diagnostics).map(Self::Hooks)
-            }
-            "useHookAtTopLevel" => Deserializable::deserialize(value, "options", diagnostics)
-                .map(Self::DeprecatedHooks),
-            "useFilenamingConvention" => Deserializable::deserialize(value, "options", diagnostics)
-                .map(Self::FilenamingConvention),
-            "useNamingConvention" => Deserializable::deserialize(value, "options", diagnostics)
-                .map(Self::NamingConvention),
-            "useValidAriaRole" => {
-                Deserializable::deserialize(value, "options", diagnostics).map(Self::ValidAriaRole)
-            }
-            "useSortedClasses" => Deserializable::deserialize(value, "options", diagnostics)
-                .map(Self::UtilityClassSorting),
-            _ => {
-                diagnostics.push(
-                    DeserializationDiagnostic::new(markup! {
-                        "The rule "<Emphasis>{rule_name}</Emphasis>" doesn't accept any options."
-                    })
-                    .with_range(value.range()),
-                );
-                None
-            }
-        }
-    }
-}
+pub type NoAccessKey =
+    <analyzers::a11y::no_access_key::NoAccessKey as biome_analyze::Rule>::Options;
+pub type NoAccumulatingSpread = < semantic_analyzers :: performance :: no_accumulating_spread :: NoAccumulatingSpread as biome_analyze :: Rule > :: Options ;
+pub type NoApproximativeNumericConstant = < analyzers :: suspicious :: no_approximative_numeric_constant :: NoApproximativeNumericConstant as biome_analyze :: Rule > :: Options ;
+pub type NoArguments =
+    <semantic_analyzers::style::no_arguments::NoArguments as biome_analyze::Rule>::Options;
+pub type NoAriaHiddenOnFocusable = < aria_analyzers :: a11y :: no_aria_hidden_on_focusable :: NoAriaHiddenOnFocusable as biome_analyze :: Rule > :: Options ;
+pub type NoAriaUnsupportedElements = < aria_analyzers :: a11y :: no_aria_unsupported_elements :: NoAriaUnsupportedElements as biome_analyze :: Rule > :: Options ;
+pub type NoArrayIndexKey = < semantic_analyzers :: suspicious :: no_array_index_key :: NoArrayIndexKey as biome_analyze :: Rule > :: Options ;
+pub type NoAssignInExpressions = < analyzers :: suspicious :: no_assign_in_expressions :: NoAssignInExpressions as biome_analyze :: Rule > :: Options ;
+pub type NoAsyncPromiseExecutor = < analyzers :: suspicious :: no_async_promise_executor :: NoAsyncPromiseExecutor as biome_analyze :: Rule > :: Options ;
+pub type NoAutofocus = <analyzers::a11y::no_autofocus::NoAutofocus as biome_analyze::Rule>::Options;
+pub type NoBannedTypes = < semantic_analyzers :: complexity :: no_banned_types :: NoBannedTypes as biome_analyze :: Rule > :: Options ;
+pub type NoBlankTarget =
+    <analyzers::a11y::no_blank_target::NoBlankTarget as biome_analyze::Rule>::Options;
+pub type NoCatchAssign = < semantic_analyzers :: suspicious :: no_catch_assign :: NoCatchAssign as biome_analyze :: Rule > :: Options ;
+pub type NoChildrenProp = < semantic_analyzers :: correctness :: no_children_prop :: NoChildrenProp as biome_analyze :: Rule > :: Options ;
+pub type NoClassAssign = < semantic_analyzers :: suspicious :: no_class_assign :: NoClassAssign as biome_analyze :: Rule > :: Options ;
+pub type NoCommaOperator =
+    <analyzers::style::no_comma_operator::NoCommaOperator as biome_analyze::Rule>::Options;
+pub type NoCommentText =
+    <analyzers::suspicious::no_comment_text::NoCommentText as biome_analyze::Rule>::Options;
+pub type NoCompareNegZero =
+    <analyzers::suspicious::no_compare_neg_zero::NoCompareNegZero as biome_analyze::Rule>::Options;
+pub type NoConfusingLabels =
+    <analyzers::suspicious::no_confusing_labels::NoConfusingLabels as biome_analyze::Rule>::Options;
+pub type NoConfusingVoidType = < analyzers :: suspicious :: no_confusing_void_type :: NoConfusingVoidType as biome_analyze :: Rule > :: Options ;
+pub type NoConsole =
+    <semantic_analyzers::nursery::no_console::NoConsole as biome_analyze::Rule>::Options;
+pub type NoConsoleLog =
+    <semantic_analyzers::suspicious::no_console_log::NoConsoleLog as biome_analyze::Rule>::Options;
+pub type NoConstAssign = < semantic_analyzers :: correctness :: no_const_assign :: NoConstAssign as biome_analyze :: Rule > :: Options ;
+pub type NoConstEnum =
+    <analyzers::suspicious::no_const_enum::NoConstEnum as biome_analyze::Rule>::Options;
+pub type NoConstantCondition = < semantic_analyzers :: correctness :: no_constant_condition :: NoConstantCondition as biome_analyze :: Rule > :: Options ;
+pub type NoConstructorReturn = < analyzers :: correctness :: no_constructor_return :: NoConstructorReturn as biome_analyze :: Rule > :: Options ;
+pub type NoControlCharactersInRegex = < analyzers :: suspicious :: no_control_characters_in_regex :: NoControlCharactersInRegex as biome_analyze :: Rule > :: Options ;
+pub type NoDangerouslySetInnerHtml = < semantic_analyzers :: security :: no_dangerously_set_inner_html :: NoDangerouslySetInnerHtml as biome_analyze :: Rule > :: Options ;
+pub type NoDangerouslySetInnerHtmlWithChildren = < semantic_analyzers :: security :: no_dangerously_set_inner_html_with_children :: NoDangerouslySetInnerHtmlWithChildren as biome_analyze :: Rule > :: Options ;
+pub type NoDebugger =
+    <analyzers::suspicious::no_debugger::NoDebugger as biome_analyze::Rule>::Options;
+pub type NoDefaultExport =
+    <analyzers::style::no_default_export::NoDefaultExport as biome_analyze::Rule>::Options;
+pub type NoDelete = <analyzers::performance::no_delete::NoDelete as biome_analyze::Rule>::Options;
+pub type NoDistractingElements = < analyzers :: a11y :: no_distracting_elements :: NoDistractingElements as biome_analyze :: Rule > :: Options ;
+pub type NoDoubleEquals =
+    <analyzers::suspicious::no_double_equals::NoDoubleEquals as biome_analyze::Rule>::Options;
+pub type NoDuplicateCase =
+    <analyzers::suspicious::no_duplicate_case::NoDuplicateCase as biome_analyze::Rule>::Options;
+pub type NoDuplicateClassMembers = < analyzers :: suspicious :: no_duplicate_class_members :: NoDuplicateClassMembers as biome_analyze :: Rule > :: Options ;
+pub type NoDuplicateJsxProps = < analyzers :: suspicious :: no_duplicate_jsx_props :: NoDuplicateJsxProps as biome_analyze :: Rule > :: Options ;
+pub type NoDuplicateObjectKeys = < analyzers :: suspicious :: no_duplicate_object_keys :: NoDuplicateObjectKeys as biome_analyze :: Rule > :: Options ;
+pub type NoDuplicateParameters = < semantic_analyzers :: suspicious :: no_duplicate_parameters :: NoDuplicateParameters as biome_analyze :: Rule > :: Options ;
+pub type NoEmptyBlockStatements = < analyzers :: nursery :: no_empty_block_statements :: NoEmptyBlockStatements as biome_analyze :: Rule > :: Options ;
+pub type NoEmptyCharacterClassInRegex = < analyzers :: correctness :: no_empty_character_class_in_regex :: NoEmptyCharacterClassInRegex as biome_analyze :: Rule > :: Options ;
+pub type NoEmptyInterface =
+    <analyzers::suspicious::no_empty_interface::NoEmptyInterface as biome_analyze::Rule>::Options;
+pub type NoEmptyPattern =
+    <analyzers::correctness::no_empty_pattern::NoEmptyPattern as biome_analyze::Rule>::Options;
+pub type NoEmptyTypeParameters = < analyzers :: nursery :: no_empty_type_parameters :: NoEmptyTypeParameters as biome_analyze :: Rule > :: Options ;
+pub type NoExcessiveCognitiveComplexity = < analyzers :: complexity :: no_excessive_cognitive_complexity :: NoExcessiveCognitiveComplexity as biome_analyze :: Rule > :: Options ;
+pub type NoExplicitAny =
+    <analyzers::suspicious::no_explicit_any::NoExplicitAny as biome_analyze::Rule>::Options;
+pub type NoExtraBooleanCast = < analyzers :: complexity :: no_extra_boolean_cast :: NoExtraBooleanCast as biome_analyze :: Rule > :: Options ;
+pub type NoExtraNonNullAssertion = < analyzers :: suspicious :: no_extra_non_null_assertion :: NoExtraNonNullAssertion as biome_analyze :: Rule > :: Options ;
+pub type NoFallthroughSwitchClause = < analyzers :: suspicious :: no_fallthrough_switch_clause :: NoFallthroughSwitchClause as biome_analyze :: Rule > :: Options ;
+pub type NoFocusedTests =
+    <analyzers::nursery::no_focused_tests::NoFocusedTests as biome_analyze::Rule>::Options;
+pub type NoForEach =
+    <analyzers::complexity::no_for_each::NoForEach as biome_analyze::Rule>::Options;
+pub type NoFunctionAssign = < semantic_analyzers :: suspicious :: no_function_assign :: NoFunctionAssign as biome_analyze :: Rule > :: Options ;
+pub type NoGlobalAssign =
+    <semantic_analyzers::nursery::no_global_assign::NoGlobalAssign as biome_analyze::Rule>::Options;
+pub type NoGlobalEval =
+    <semantic_analyzers::nursery::no_global_eval::NoGlobalEval as biome_analyze::Rule>::Options;
+pub type NoGlobalIsFinite = < semantic_analyzers :: suspicious :: no_global_is_finite :: NoGlobalIsFinite as biome_analyze :: Rule > :: Options ;
+pub type NoGlobalIsNan = < semantic_analyzers :: suspicious :: no_global_is_nan :: NoGlobalIsNan as biome_analyze :: Rule > :: Options ;
+pub type NoGlobalObjectCalls = < semantic_analyzers :: correctness :: no_global_object_calls :: NoGlobalObjectCalls as biome_analyze :: Rule > :: Options ;
+pub type NoHeaderScope =
+    <analyzers::a11y::no_header_scope::NoHeaderScope as biome_analyze::Rule>::Options;
+pub type NoImplicitAnyLet =
+    <analyzers::suspicious::no_implicit_any_let::NoImplicitAnyLet as biome_analyze::Rule>::Options;
+pub type NoImplicitBoolean =
+    <analyzers::style::no_implicit_boolean::NoImplicitBoolean as biome_analyze::Rule>::Options;
+pub type NoImportAssign = < semantic_analyzers :: suspicious :: no_import_assign :: NoImportAssign as biome_analyze :: Rule > :: Options ;
+pub type NoInferrableTypes =
+    <analyzers::style::no_inferrable_types::NoInferrableTypes as biome_analyze::Rule>::Options;
+pub type NoInnerDeclarations = < analyzers :: correctness :: no_inner_declarations :: NoInnerDeclarations as biome_analyze :: Rule > :: Options ;
+pub type NoInteractiveElementToNoninteractiveRole = < aria_analyzers :: a11y :: no_interactive_element_to_noninteractive_role :: NoInteractiveElementToNoninteractiveRole as biome_analyze :: Rule > :: Options ;
+pub type NoInvalidConstructorSuper = < analyzers :: correctness :: no_invalid_constructor_super :: NoInvalidConstructorSuper as biome_analyze :: Rule > :: Options ;
+pub type NoInvalidNewBuiltin = < semantic_analyzers :: correctness :: no_invalid_new_builtin :: NoInvalidNewBuiltin as biome_analyze :: Rule > :: Options ;
+pub type NoInvalidUseBeforeDeclaration = < semantic_analyzers :: nursery :: no_invalid_use_before_declaration :: NoInvalidUseBeforeDeclaration as biome_analyze :: Rule > :: Options ;
+pub type NoLabelVar =
+    <semantic_analyzers::suspicious::no_label_var::NoLabelVar as biome_analyze::Rule>::Options;
+pub type NoMisleadingCharacterClass = < semantic_analyzers :: nursery :: no_misleading_character_class :: NoMisleadingCharacterClass as biome_analyze :: Rule > :: Options ;
+pub type NoMisleadingInstantiator = < analyzers :: suspicious :: no_misleading_instantiator :: NoMisleadingInstantiator as biome_analyze :: Rule > :: Options ;
+pub type NoMisrefactoredShorthandAssign = < analyzers :: suspicious :: no_misrefactored_shorthand_assign :: NoMisrefactoredShorthandAssign as biome_analyze :: Rule > :: Options ;
+pub type NoMultipleSpacesInRegularExpressionLiterals = < analyzers :: complexity :: no_multiple_spaces_in_regular_expression_literals :: NoMultipleSpacesInRegularExpressionLiterals as biome_analyze :: Rule > :: Options ;
+pub type NoNamespace =
+    <analyzers::style::no_namespace::NoNamespace as biome_analyze::Rule>::Options;
+pub type NoNamespaceImport =
+    <analyzers::nursery::no_namespace_import::NoNamespaceImport as biome_analyze::Rule>::Options;
+pub type NoNegationElse =
+    <analyzers::style::no_negation_else::NoNegationElse as biome_analyze::Rule>::Options;
+pub type NoNewSymbol =
+    <semantic_analyzers::correctness::no_new_symbol::NoNewSymbol as biome_analyze::Rule>::Options;
+pub type NoNodejsModules =
+    <analyzers::nursery::no_nodejs_modules::NoNodejsModules as biome_analyze::Rule>::Options;
+pub type NoNonNullAssertion =
+    <analyzers::style::no_non_null_assertion::NoNonNullAssertion as biome_analyze::Rule>::Options;
+pub type NoNoninteractiveElementToInteractiveRole = < aria_analyzers :: a11y :: no_noninteractive_element_to_interactive_role :: NoNoninteractiveElementToInteractiveRole as biome_analyze :: Rule > :: Options ;
+pub type NoNoninteractiveTabindex = < aria_analyzers :: a11y :: no_noninteractive_tabindex :: NoNoninteractiveTabindex as biome_analyze :: Rule > :: Options ;
+pub type NoNonoctalDecimalEscape = < analyzers :: correctness :: no_nonoctal_decimal_escape :: NoNonoctalDecimalEscape as biome_analyze :: Rule > :: Options ;
+pub type NoParameterAssign = < semantic_analyzers :: style :: no_parameter_assign :: NoParameterAssign as biome_analyze :: Rule > :: Options ;
+pub type NoParameterProperties = < analyzers :: style :: no_parameter_properties :: NoParameterProperties as biome_analyze :: Rule > :: Options ;
+pub type NoPositiveTabindex = < semantic_analyzers :: a11y :: no_positive_tabindex :: NoPositiveTabindex as biome_analyze :: Rule > :: Options ;
+pub type NoPrecisionLoss =
+    <analyzers::correctness::no_precision_loss::NoPrecisionLoss as biome_analyze::Rule>::Options;
+pub type NoPrototypeBuiltins = < analyzers :: suspicious :: no_prototype_builtins :: NoPrototypeBuiltins as biome_analyze :: Rule > :: Options ;
+pub type NoReExportAll =
+    <semantic_analyzers::nursery::no_re_export_all::NoReExportAll as biome_analyze::Rule>::Options;
+pub type NoRedeclare =
+    <semantic_analyzers::suspicious::no_redeclare::NoRedeclare as biome_analyze::Rule>::Options;
+pub type NoRedundantAlt =
+    <analyzers::a11y::no_redundant_alt::NoRedundantAlt as biome_analyze::Rule>::Options;
+pub type NoRedundantRoles =
+    <aria_analyzers::a11y::no_redundant_roles::NoRedundantRoles as biome_analyze::Rule>::Options;
+pub type NoRedundantUseStrict = < analyzers :: suspicious :: no_redundant_use_strict :: NoRedundantUseStrict as biome_analyze :: Rule > :: Options ;
+pub type NoRenderReturnValue = < semantic_analyzers :: correctness :: no_render_return_value :: NoRenderReturnValue as biome_analyze :: Rule > :: Options ;
+pub type NoRestrictedGlobals = < semantic_analyzers :: style :: no_restricted_globals :: NoRestrictedGlobals as biome_analyze :: Rule > :: Options ;
+pub type NoRestrictedImports = < analyzers :: nursery :: no_restricted_imports :: NoRestrictedImports as biome_analyze :: Rule > :: Options ;
+pub type NoSelfAssign =
+    <analyzers::correctness::no_self_assign::NoSelfAssign as biome_analyze::Rule>::Options;
+pub type NoSelfCompare =
+    <analyzers::suspicious::no_self_compare::NoSelfCompare as biome_analyze::Rule>::Options;
+pub type NoSetterReturn =
+    <analyzers::correctness::no_setter_return::NoSetterReturn as biome_analyze::Rule>::Options;
+pub type NoShadowRestrictedNames = < analyzers :: suspicious :: no_shadow_restricted_names :: NoShadowRestrictedNames as biome_analyze :: Rule > :: Options ;
+pub type NoShoutyConstants = < semantic_analyzers :: style :: no_shouty_constants :: NoShoutyConstants as biome_analyze :: Rule > :: Options ;
+pub type NoSkippedTests =
+    <analyzers::nursery::no_skipped_tests::NoSkippedTests as biome_analyze::Rule>::Options;
+pub type NoSparseArray =
+    <analyzers::suspicious::no_sparse_array::NoSparseArray as biome_analyze::Rule>::Options;
+pub type NoStaticOnlyClass = < analyzers :: complexity :: no_static_only_class :: NoStaticOnlyClass as biome_analyze :: Rule > :: Options ;
+pub type NoStringCaseMismatch = < analyzers :: correctness :: no_string_case_mismatch :: NoStringCaseMismatch as biome_analyze :: Rule > :: Options ;
+pub type NoSvgWithoutTitle =
+    <analyzers::a11y::no_svg_without_title::NoSvgWithoutTitle as biome_analyze::Rule>::Options;
+pub type NoSwitchDeclarations = < analyzers :: correctness :: no_switch_declarations :: NoSwitchDeclarations as biome_analyze :: Rule > :: Options ;
+pub type NoThenProperty =
+    <semantic_analyzers::nursery::no_then_property::NoThenProperty as biome_analyze::Rule>::Options;
+pub type NoThisInStatic = < semantic_analyzers :: complexity :: no_this_in_static :: NoThisInStatic as biome_analyze :: Rule > :: Options ;
+pub type NoUndeclaredDependencies = < analyzers :: nursery :: no_undeclared_dependencies :: NoUndeclaredDependencies as biome_analyze :: Rule > :: Options ;
+pub type NoUndeclaredVariables = < semantic_analyzers :: correctness :: no_undeclared_variables :: NoUndeclaredVariables as biome_analyze :: Rule > :: Options ;
+pub type NoUnnecessaryContinue = < analyzers :: correctness :: no_unnecessary_continue :: NoUnnecessaryContinue as biome_analyze :: Rule > :: Options ;
+pub type NoUnreachable =
+    <analyzers::correctness::no_unreachable::NoUnreachable as biome_analyze::Rule>::Options;
+pub type NoUnreachableSuper = < analyzers :: correctness :: no_unreachable_super :: NoUnreachableSuper as biome_analyze :: Rule > :: Options ;
+pub type NoUnsafeDeclarationMerging = < semantic_analyzers :: suspicious :: no_unsafe_declaration_merging :: NoUnsafeDeclarationMerging as biome_analyze :: Rule > :: Options ;
+pub type NoUnsafeFinally =
+    <analyzers::correctness::no_unsafe_finally::NoUnsafeFinally as biome_analyze::Rule>::Options;
+pub type NoUnsafeNegation =
+    <analyzers::suspicious::no_unsafe_negation::NoUnsafeNegation as biome_analyze::Rule>::Options;
+pub type NoUnsafeOptionalChaining = < analyzers :: correctness :: no_unsafe_optional_chaining :: NoUnsafeOptionalChaining as biome_analyze :: Rule > :: Options ;
+pub type NoUnusedImports = < semantic_analyzers :: nursery :: no_unused_imports :: NoUnusedImports as biome_analyze :: Rule > :: Options ;
+pub type NoUnusedLabels =
+    <analyzers::correctness::no_unused_labels::NoUnusedLabels as biome_analyze::Rule>::Options;
+pub type NoUnusedPrivateClassMembers = < analyzers :: nursery :: no_unused_private_class_members :: NoUnusedPrivateClassMembers as biome_analyze :: Rule > :: Options ;
+pub type NoUnusedTemplateLiteral = < analyzers :: style :: no_unused_template_literal :: NoUnusedTemplateLiteral as biome_analyze :: Rule > :: Options ;
+pub type NoUnusedVariables = < semantic_analyzers :: correctness :: no_unused_variables :: NoUnusedVariables as biome_analyze :: Rule > :: Options ;
+pub type NoUselessCatch =
+    <analyzers::complexity::no_useless_catch::NoUselessCatch as biome_analyze::Rule>::Options;
+pub type NoUselessConstructor = < analyzers :: complexity :: no_useless_constructor :: NoUselessConstructor as biome_analyze :: Rule > :: Options ;
+pub type NoUselessElse =
+    <analyzers::style::no_useless_else::NoUselessElse as biome_analyze::Rule>::Options;
+pub type NoUselessEmptyExport = < analyzers :: complexity :: no_useless_empty_export :: NoUselessEmptyExport as biome_analyze :: Rule > :: Options ;
+pub type NoUselessFragments = < semantic_analyzers :: complexity :: no_useless_fragments :: NoUselessFragments as biome_analyze :: Rule > :: Options ;
+pub type NoUselessLabel =
+    <analyzers::complexity::no_useless_label::NoUselessLabel as biome_analyze::Rule>::Options;
+pub type NoUselessLoneBlockStatements = < analyzers :: nursery :: no_useless_lone_block_statements :: NoUselessLoneBlockStatements as biome_analyze :: Rule > :: Options ;
+pub type NoUselessRename =
+    <analyzers::complexity::no_useless_rename::NoUselessRename as biome_analyze::Rule>::Options;
+pub type NoUselessSwitchCase = < analyzers :: complexity :: no_useless_switch_case :: NoUselessSwitchCase as biome_analyze :: Rule > :: Options ;
+pub type NoUselessTernary =
+    <analyzers::nursery::no_useless_ternary::NoUselessTernary as biome_analyze::Rule>::Options;
+pub type NoUselessThisAlias = < semantic_analyzers :: complexity :: no_useless_this_alias :: NoUselessThisAlias as biome_analyze :: Rule > :: Options ;
+pub type NoUselessTypeConstraint = < analyzers :: complexity :: no_useless_type_constraint :: NoUselessTypeConstraint as biome_analyze :: Rule > :: Options ;
+pub type NoVar = <semantic_analyzers::style::no_var::NoVar as biome_analyze::Rule>::Options;
+pub type NoVoid = <analyzers::complexity::no_void::NoVoid as biome_analyze::Rule>::Options;
+pub type NoVoidElementsWithChildren = < semantic_analyzers :: correctness :: no_void_elements_with_children :: NoVoidElementsWithChildren as biome_analyze :: Rule > :: Options ;
+pub type NoVoidTypeReturn =
+    <analyzers::correctness::no_void_type_return::NoVoidTypeReturn as biome_analyze::Rule>::Options;
+pub type NoWith = <analyzers::complexity::no_with::NoWith as biome_analyze::Rule>::Options;
+pub type UseAltText = <analyzers::a11y::use_alt_text::UseAltText as biome_analyze::Rule>::Options;
+pub type UseAnchorContent =
+    <analyzers::a11y::use_anchor_content::UseAnchorContent as biome_analyze::Rule>::Options;
+pub type UseAriaActivedescendantWithTabindex = < aria_analyzers :: a11y :: use_aria_activedescendant_with_tabindex :: UseAriaActivedescendantWithTabindex as biome_analyze :: Rule > :: Options ;
+pub type UseAriaPropsForRole = < aria_analyzers :: a11y :: use_aria_props_for_role :: UseAriaPropsForRole as biome_analyze :: Rule > :: Options ;
+pub type UseArrowFunction =
+    <analyzers::complexity::use_arrow_function::UseArrowFunction as biome_analyze::Rule>::Options;
+pub type UseAsConstAssertion =
+    <analyzers::style::use_as_const_assertion::UseAsConstAssertion as biome_analyze::Rule>::Options;
+pub type UseAwait = <analyzers::nursery::use_await::UseAwait as biome_analyze::Rule>::Options;
+pub type UseBlockStatements =
+    <analyzers::style::use_block_statements::UseBlockStatements as biome_analyze::Rule>::Options;
+pub type UseButtonType =
+    <semantic_analyzers::a11y::use_button_type::UseButtonType as biome_analyze::Rule>::Options;
+pub type UseCollapsedElseIf =
+    <analyzers::style::use_collapsed_else_if::UseCollapsedElseIf as biome_analyze::Rule>::Options;
+pub type UseConsistentArrayType = < analyzers :: nursery :: use_consistent_array_type :: UseConsistentArrayType as biome_analyze :: Rule > :: Options ;
+pub type UseConst =
+    <semantic_analyzers::style::use_const::UseConst as biome_analyze::Rule>::Options;
+pub type UseDefaultParameterLast = < analyzers :: style :: use_default_parameter_last :: UseDefaultParameterLast as biome_analyze :: Rule > :: Options ;
+pub type UseDefaultSwitchClauseLast = < analyzers :: suspicious :: use_default_switch_clause_last :: UseDefaultSwitchClauseLast as biome_analyze :: Rule > :: Options ;
+pub type UseEnumInitializers =
+    <analyzers::style::use_enum_initializers::UseEnumInitializers as biome_analyze::Rule>::Options;
+pub type UseExhaustiveDependencies = < semantic_analyzers :: correctness :: use_exhaustive_dependencies :: UseExhaustiveDependencies as biome_analyze :: Rule > :: Options ;
+pub type UseExponentiationOperator = < analyzers :: style :: use_exponentiation_operator :: UseExponentiationOperator as biome_analyze :: Rule > :: Options ;
+pub type UseExportType =
+    <semantic_analyzers::nursery::use_export_type::UseExportType as biome_analyze::Rule>::Options;
+pub type UseFilenamingConvention = < analyzers :: nursery :: use_filenaming_convention :: UseFilenamingConvention as biome_analyze :: Rule > :: Options ;
+pub type UseFlatMap =
+    <analyzers::complexity::use_flat_map::UseFlatMap as biome_analyze::Rule>::Options;
+pub type UseForOf =
+    <semantic_analyzers::nursery::use_for_of::UseForOf as biome_analyze::Rule>::Options;
+pub type UseFragmentSyntax = < semantic_analyzers :: style :: use_fragment_syntax :: UseFragmentSyntax as biome_analyze :: Rule > :: Options ;
+pub type UseGetterReturn =
+    <analyzers::suspicious::use_getter_return::UseGetterReturn as biome_analyze::Rule>::Options;
+pub type UseGroupedTypeImport = < analyzers :: nursery :: use_grouped_type_import :: UseGroupedTypeImport as biome_analyze :: Rule > :: Options ;
+pub type UseHeadingContent =
+    <analyzers::a11y::use_heading_content::UseHeadingContent as biome_analyze::Rule>::Options;
+pub type UseHookAtTopLevel = < semantic_analyzers :: correctness :: use_hook_at_top_level :: UseHookAtTopLevel as biome_analyze :: Rule > :: Options ;
+pub type UseHtmlLang =
+    <analyzers::a11y::use_html_lang::UseHtmlLang as biome_analyze::Rule>::Options;
+pub type UseIframeTitle =
+    <analyzers::a11y::use_iframe_title::UseIframeTitle as biome_analyze::Rule>::Options;
+pub type UseImportRestrictions = < analyzers :: nursery :: use_import_restrictions :: UseImportRestrictions as biome_analyze :: Rule > :: Options ;
+pub type UseImportType =
+    <semantic_analyzers::nursery::use_import_type::UseImportType as biome_analyze::Rule>::Options;
+pub type UseIsArray =
+    <semantic_analyzers::suspicious::use_is_array::UseIsArray as biome_analyze::Rule>::Options;
+pub type UseIsNan =
+    <semantic_analyzers::correctness::use_is_nan::UseIsNan as biome_analyze::Rule>::Options;
+pub type UseKeyWithClickEvents = < analyzers :: a11y :: use_key_with_click_events :: UseKeyWithClickEvents as biome_analyze :: Rule > :: Options ;
+pub type UseKeyWithMouseEvents = < analyzers :: a11y :: use_key_with_mouse_events :: UseKeyWithMouseEvents as biome_analyze :: Rule > :: Options ;
+pub type UseLiteralEnumMembers = < analyzers :: style :: use_literal_enum_members :: UseLiteralEnumMembers as biome_analyze :: Rule > :: Options ;
+pub type UseLiteralKeys =
+    <analyzers::complexity::use_literal_keys::UseLiteralKeys as biome_analyze::Rule>::Options;
+pub type UseMediaCaption =
+    <analyzers::a11y::use_media_caption::UseMediaCaption as biome_analyze::Rule>::Options;
+pub type UseNamespaceKeyword = < analyzers :: suspicious :: use_namespace_keyword :: UseNamespaceKeyword as biome_analyze :: Rule > :: Options ;
+pub type UseNamingConvention = < semantic_analyzers :: style :: use_naming_convention :: UseNamingConvention as biome_analyze :: Rule > :: Options ;
+pub type UseNodeAssertStrict = < analyzers :: nursery :: use_node_assert_strict :: UseNodeAssertStrict as biome_analyze :: Rule > :: Options ;
+pub type UseNodejsImportProtocol = < analyzers :: nursery :: use_nodejs_import_protocol :: UseNodejsImportProtocol as biome_analyze :: Rule > :: Options ;
+pub type UseNumberNamespace = < semantic_analyzers :: nursery :: use_number_namespace :: UseNumberNamespace as biome_analyze :: Rule > :: Options ;
+pub type UseNumericLiterals =
+    <analyzers::style::use_numeric_literals::UseNumericLiterals as biome_analyze::Rule>::Options;
+pub type UseOptionalChain =
+    <analyzers::complexity::use_optional_chain::UseOptionalChain as biome_analyze::Rule>::Options;
+pub type UseRegexLiterals =
+    <analyzers::complexity::use_regex_literals::UseRegexLiterals as biome_analyze::Rule>::Options;
+pub type UseSelfClosingElements = < analyzers :: style :: use_self_closing_elements :: UseSelfClosingElements as biome_analyze :: Rule > :: Options ;
+pub type UseShorthandArrayType = < analyzers :: style :: use_shorthand_array_type :: UseShorthandArrayType as biome_analyze :: Rule > :: Options ;
+pub type UseShorthandAssign =
+    <analyzers::style::use_shorthand_assign::UseShorthandAssign as biome_analyze::Rule>::Options;
+pub type UseShorthandFunctionType = < analyzers :: nursery :: use_shorthand_function_type :: UseShorthandFunctionType as biome_analyze :: Rule > :: Options ;
+pub type UseSimpleNumberKeys = < analyzers :: complexity :: use_simple_number_keys :: UseSimpleNumberKeys as biome_analyze :: Rule > :: Options ;
+pub type UseSimplifiedLogicExpression = < analyzers :: complexity :: use_simplified_logic_expression :: UseSimplifiedLogicExpression as biome_analyze :: Rule > :: Options ;
+pub type UseSingleCaseStatement = < analyzers :: style :: use_single_case_statement :: UseSingleCaseStatement as biome_analyze :: Rule > :: Options ;
+pub type UseSingleVarDeclarator = < analyzers :: style :: use_single_var_declarator :: UseSingleVarDeclarator as biome_analyze :: Rule > :: Options ;
+pub type UseSortedClasses = < semantic_analyzers :: nursery :: use_sorted_classes :: UseSortedClasses as biome_analyze :: Rule > :: Options ;
+pub type UseTemplate =
+    <analyzers::style::use_template::UseTemplate as biome_analyze::Rule>::Options;
+pub type UseValidAnchor =
+    <analyzers::a11y::use_valid_anchor::UseValidAnchor as biome_analyze::Rule>::Options;
+pub type UseValidAriaProps =
+    <aria_analyzers::a11y::use_valid_aria_props::UseValidAriaProps as biome_analyze::Rule>::Options;
+pub type UseValidAriaRole =
+    <aria_analyzers::a11y::use_valid_aria_role::UseValidAriaRole as biome_analyze::Rule>::Options;
+pub type UseValidAriaValues = < aria_analyzers :: a11y :: use_valid_aria_values :: UseValidAriaValues as biome_analyze :: Rule > :: Options ;
+pub type UseValidForDirection = < analyzers :: correctness :: use_valid_for_direction :: UseValidForDirection as biome_analyze :: Rule > :: Options ;
+pub type UseValidLang =
+    <aria_analyzers::a11y::use_valid_lang::UseValidLang as biome_analyze::Rule>::Options;
+pub type UseValidTypeof =
+    <analyzers::suspicious::use_valid_typeof::UseValidTypeof as biome_analyze::Rule>::Options;
+pub type UseWhile = <analyzers::style::use_while::UseWhile as biome_analyze::Rule>::Options;
+pub type UseYield = <analyzers::correctness::use_yield::UseYield as biome_analyze::Rule>::Options;

--- a/crates/biome_js_analyze/src/react.rs
+++ b/crates/biome_js_analyze/src/react.rs
@@ -19,7 +19,7 @@ pub(crate) trait ReactApiCall {
 /// A convenient data structure that returns the three arguments of the [React.createElement] call
 ///
 ///[React.createElement]: https://reactjs.org/docs/react-api.html#createelement
-pub(crate) struct ReactCreateElementCall {
+pub struct ReactCreateElementCall {
     /// The type of the react element
     pub(crate) element_type: AnyJsCallArgument,
     /// Optional props
@@ -118,7 +118,7 @@ impl ReactApiCall for ReactCreateElementCall {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum ReactLibrary {
+pub enum ReactLibrary {
     React,
     ReactDOM,
 }

--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 /// Return result of [react_hook_with_dependency].
 #[derive(Debug)]
-pub(crate) struct ReactCallWithDependencyResult {
+pub struct ReactCallWithDependencyResult {
     pub(crate) function_name_range: TextRange,
     pub(crate) closure_node: Option<AnyJsExpression>,
     pub(crate) dependencies_node: Option<AnyJsExpression>,

--- a/crates/biome_js_analyze/src/semantic_analyzers.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers.rs
@@ -1,11 +1,11 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-pub(crate) mod a11y;
-pub(crate) mod complexity;
-pub(crate) mod correctness;
-pub(crate) mod nursery;
-pub(crate) mod performance;
-pub(crate) mod security;
-pub(crate) mod style;
-pub(crate) mod suspicious;
-::biome_analyze::declare_category! { pub (crate) SemanticAnalyzers { kind : Lint , groups : [self :: a11y :: A11y , self :: complexity :: Complexity , self :: correctness :: Correctness , self :: nursery :: Nursery , self :: performance :: Performance , self :: security :: Security , self :: style :: Style , self :: suspicious :: Suspicious ,] } }
+pub mod a11y;
+pub mod complexity;
+pub mod correctness;
+pub mod nursery;
+pub mod performance;
+pub mod security;
+pub mod style;
+pub mod suspicious;
+::biome_analyze::declare_category! { pub SemanticAnalyzers { kind : Lint , groups : [self :: a11y :: A11y , self :: complexity :: Complexity , self :: correctness :: Correctness , self :: nursery :: Nursery , self :: performance :: Performance , self :: security :: Security , self :: style :: Style , self :: suspicious :: Suspicious ,] } }

--- a/crates/biome_js_analyze/src/semantic_analyzers/a11y.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/a11y.rs
@@ -2,11 +2,11 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_positive_tabindex;
-pub(crate) mod use_button_type;
+pub mod no_positive_tabindex;
+pub mod use_button_type;
 
 declare_group! {
-    pub (crate) A11y {
+    pub A11y {
         name : "a11y" ,
         rules : [
             self :: no_positive_tabindex :: NoPositiveTabindex ,

--- a/crates/biome_js_analyze/src/semantic_analyzers/a11y/no_positive_tabindex.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/a11y/no_positive_tabindex.rs
@@ -48,7 +48,7 @@ declare_rule! {
     /// ```js
     /// React.createElement("div", { tabIndex: -1 })
     /// ```
-    pub(crate) NoPositiveTabindex {
+    pub NoPositiveTabindex {
         version: "1.0.0",
         name: "noPositiveTabindex",
         source: RuleSource::EslintJsxA11y("tabindex-no-positive"),
@@ -58,11 +58,11 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) TabindexProp = JsxAttribute | JsPropertyObjectMember
+    pub TabindexProp = JsxAttribute | JsPropertyObjectMember
 }
 
 declare_node_union! {
-    pub(crate) NoPositiveTabindexQuery = AnyJsxElement | JsCallExpression
+    pub NoPositiveTabindexQuery = AnyJsxElement | JsCallExpression
 }
 
 declare_node_union! {
@@ -74,7 +74,7 @@ declare_node_union! {
     /// - `JsNumberLiteralExpression` &mdash; `5`
     /// - `JsUnaryExpression` &mdash; `+5` | `-5`
     ///
-    pub(crate) AnyNumberLikeExpression = JsStringLiteralExpression | JsNumberLiteralExpression | JsUnaryExpression
+    pub AnyNumberLikeExpression = JsStringLiteralExpression | JsNumberLiteralExpression | JsUnaryExpression
 }
 
 impl NoPositiveTabindexQuery {

--- a/crates/biome_js_analyze/src/semantic_analyzers/a11y/use_button_type.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/a11y/use_button_type.rs
@@ -36,7 +36,7 @@ declare_rule! {
     ///     <button type={buttonType}>Do something</button>
     /// </>
     /// ```
-    pub(crate) UseButtonType {
+    pub UseButtonType {
         version: "1.0.0",
         name: "useButtonType",
         source: RuleSource::EslintReact("button-has-type"),
@@ -47,10 +47,10 @@ declare_rule! {
 const ALLOWED_BUTTON_TYPES: [&str; 3] = ["submit", "button", "reset"];
 
 declare_node_union! {
-    pub(crate) UseButtonTypeQuery = JsxSelfClosingElement | JsxOpeningElement | JsCallExpression
+    pub UseButtonTypeQuery = JsxSelfClosingElement | JsxOpeningElement | JsCallExpression
 }
 
-pub(crate) struct UseButtonTypeState {
+pub struct UseButtonTypeState {
     range: TextRange,
     missing_prop: bool,
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/complexity.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/complexity.rs
@@ -2,13 +2,13 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_banned_types;
-pub(crate) mod no_this_in_static;
-pub(crate) mod no_useless_fragments;
-pub(crate) mod no_useless_this_alias;
+pub mod no_banned_types;
+pub mod no_this_in_static;
+pub mod no_useless_fragments;
+pub mod no_useless_this_alias;
 
 declare_group! {
-    pub (crate) Complexity {
+    pub Complexity {
         name : "complexity" ,
         rules : [
             self :: no_banned_types :: NoBannedTypes ,

--- a/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_banned_types.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_banned_types.rs
@@ -88,7 +88,7 @@ declare_rule! {
     /// let tuple: [boolean, string] = [false, "foo"];
     /// ```
     ///
-    pub(crate) NoBannedTypes {
+    pub NoBannedTypes {
         version: "1.0.0",
         name: "noBannedTypes",
         source: RuleSource::EslintTypeScript("ban-types"),
@@ -185,7 +185,7 @@ impl Rule for NoBannedTypes {
 }
 
 declare_node_union! {
-    pub(crate) TsBannedType = TsReferenceType | TsObjectType
+    pub TsBannedType = TsReferenceType | TsObjectType
 }
 
 pub struct State {

--- a/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_this_in_static.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_this_in_static.rs
@@ -78,7 +78,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoThisInStatic {
+    pub NoThisInStatic {
         version: "1.3.1",
         name: "noThisInStatic",
         source: RuleSource::EslintMysticatea("no-this-in-static"),
@@ -180,7 +180,7 @@ impl Rule for NoThisInStatic {
 }
 
 declare_node_union! {
-    pub(crate) JsThisSuperExpression = JsSuperExpression | JsThisExpression
+    pub JsThisSuperExpression = JsSuperExpression | JsThisExpression
 }
 
 impl JsThisSuperExpression {

--- a/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_useless_fragments.rs
@@ -57,7 +57,7 @@ declare_rule! {
     /// <>foo {bar}</>
     /// ```
     ///
-    pub(crate) NoUselessFragments {
+    pub NoUselessFragments {
         version: "1.0.0",
         name: "noUselessFragments",
         source: RuleSource::EslintReact("jsx-no-useless-fragment"),
@@ -67,13 +67,13 @@ declare_rule! {
 }
 
 #[derive(Debug)]
-pub(crate) enum NoUselessFragmentsState {
+pub enum NoUselessFragmentsState {
     Empty,
     Child(AnyJsxChild),
 }
 
 declare_node_union! {
-    pub(crate) NoUselessFragmentsQuery = JsxFragment | JsxElement
+    pub NoUselessFragmentsQuery = JsxFragment | JsxElement
 }
 
 impl NoUselessFragmentsQuery {

--- a/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_useless_this_alias.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/complexity/no_useless_this_alias.rs
@@ -49,7 +49,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoUselessThisAlias {
+    pub NoUselessThisAlias {
         version: "1.0.0",
         name: "noUselessThisAlias",
         source: RuleSource::EslintTypeScript("no-this-alias"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness.rs
@@ -2,22 +2,22 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_children_prop;
-pub(crate) mod no_const_assign;
-pub(crate) mod no_constant_condition;
-pub(crate) mod no_global_object_calls;
-pub(crate) mod no_invalid_new_builtin;
-pub(crate) mod no_new_symbol;
-pub(crate) mod no_render_return_value;
-pub(crate) mod no_undeclared_variables;
-pub(crate) mod no_unused_variables;
-pub(crate) mod no_void_elements_with_children;
-pub(crate) mod use_exhaustive_dependencies;
-pub(crate) mod use_hook_at_top_level;
-pub(crate) mod use_is_nan;
+pub mod no_children_prop;
+pub mod no_const_assign;
+pub mod no_constant_condition;
+pub mod no_global_object_calls;
+pub mod no_invalid_new_builtin;
+pub mod no_new_symbol;
+pub mod no_render_return_value;
+pub mod no_undeclared_variables;
+pub mod no_unused_variables;
+pub mod no_void_elements_with_children;
+pub mod use_exhaustive_dependencies;
+pub mod use_hook_at_top_level;
+pub mod use_is_nan;
 
 declare_group! {
-    pub (crate) Correctness {
+    pub Correctness {
         name : "correctness" ,
         rules : [
             self :: no_children_prop :: NoChildrenProp ,

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_children_prop.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_children_prop.rs
@@ -22,7 +22,7 @@ declare_rule! {
     /// ```js,expect_diagnostic
     /// React.createElement('div', { children: 'foo' });
     /// ```
-    pub(crate) NoChildrenProp {
+    pub NoChildrenProp {
         version: "1.0.0",
         name: "noChildrenProp",
         source: RuleSource::EslintReact("no-children-prop"),
@@ -31,10 +31,10 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) NoChildrenPropQuery = JsxAttribute | JsCallExpression
+    pub NoChildrenPropQuery = JsxAttribute | JsCallExpression
 }
 
-pub(crate) enum NoChildrenPropState {
+pub enum NoChildrenPropState {
     JsxProp(TextRange),
     MemberProp(TextRange),
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_const_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_const_assign.rs
@@ -47,7 +47,7 @@ declare_rule! {
     /// b = 20;
     /// ```
     ///
-    pub(crate) NoConstAssign {
+    pub NoConstAssign {
         version: "1.0.0",
         name: "noConstAssign",
         source: RuleSource::Eslint("no-const-assign"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_constant_condition.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_constant_condition.rs
@@ -79,7 +79,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoConstantCondition    {
+    pub NoConstantCondition    {
         version: "1.0.0",
         name: "noConstantCondition",
         source: RuleSource::Eslint("no-constant-condition"),
@@ -88,7 +88,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) ConditionalStatement = JsConditionalExpression | JsWhileStatement | JsDoWhileStatement | JsIfStatement | JsForStatement
+    pub ConditionalStatement = JsConditionalExpression | JsWhileStatement | JsDoWhileStatement | JsIfStatement | JsForStatement
 }
 
 impl Rule for NoConstantCondition {

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_global_object_calls.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_global_object_calls.rs
@@ -83,7 +83,7 @@ declare_rule! {
     /// var segmenterFr = new Intl.Segmenter("fr", { granularity: "word" });
     /// ```
     ///
-    pub(crate) NoGlobalObjectCalls {
+    pub NoGlobalObjectCalls {
         version: "1.0.0",
         name: "noGlobalObjectCalls",
         source: RuleSource::Eslint("no-obj-calls"),
@@ -125,7 +125,7 @@ impl Rule for NoGlobalObjectCalls {
 
 declare_node_union! {
     /// Enum for [JsCallExpression] and [JsNewExpression]
-    pub(crate) QueryNode  = JsNewExpression  | JsCallExpression
+    pub QueryNode  = JsNewExpression  | JsCallExpression
 }
 
 impl QueryNode {
@@ -138,7 +138,7 @@ impl QueryNode {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub(crate) enum NonCallableGlobals {
+pub enum NonCallableGlobals {
     Atomics,
     Json,
     Math,

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_invalid_new_builtin.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_invalid_new_builtin.rs
@@ -49,7 +49,7 @@ declare_rule! {
     ///     const corge = new BigInt(9007199254740991);
     /// }
     /// ```
-    pub(crate) NoInvalidNewBuiltin {
+    pub NoInvalidNewBuiltin {
         version: "1.3.0",
         name: "noInvalidNewBuiltin",
         source: RuleSource::Eslint("no-new-native-nonconstructor"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_new_symbol.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_new_symbol.rs
@@ -30,7 +30,7 @@ declare_rule! {
     ///     new Symbol();
     /// }
     /// ```
-    pub(crate) NoNewSymbol {
+    pub NoNewSymbol {
         version: "1.0.0",
         name: "noNewSymbol",
         recommended: false,

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_render_return_value.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_render_return_value.rs
@@ -29,7 +29,7 @@ declare_rule! {
     /// ```jsx
     /// ReactDOM.render(<div />, document.body);
     /// ```
-    pub(crate) NoRenderReturnValue {
+    pub NoRenderReturnValue {
         version: "1.0.0",
         name: "noRenderReturnValue",
         recommended: true,

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
@@ -31,7 +31,7 @@ declare_rule! {
     /// ```ts
     /// type B<T> = PromiseLike<T>
     /// ```
-    pub(crate) NoUndeclaredVariables {
+    pub NoUndeclaredVariables {
         version: "1.0.0",
         name: "noUndeclaredVariables",
         source: RuleSource::Eslint("no-undef"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_unused_variables.rs
@@ -96,7 +96,7 @@ declare_rule! {
     /// }
     /// used_overloaded();
     /// ```
-    pub(crate) NoUnusedVariables {
+    pub NoUnusedVariables {
         version: "1.0.0",
         name: "noUnusedVariables",
         source: RuleSource::Eslint("no-unused-vars"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_void_elements_with_children.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/no_void_elements_with_children.rs
@@ -30,7 +30,7 @@ declare_rule! {
     /// ```js,expect_diagnostic
     /// React.createElement('img', {}, 'child')
     /// ```
-    pub(crate) NoVoidElementsWithChildren {
+    pub NoVoidElementsWithChildren {
         version: "1.0.0",
         name: "noVoidElementsWithChildren",
         source: RuleSource::EslintReact("void-dom-elements-no-children"),
@@ -40,7 +40,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) NoVoidElementsWithChildrenQuery = JsxElement | JsCallExpression | JsxSelfClosingElement
+    pub NoVoidElementsWithChildrenQuery = JsxElement | JsCallExpression | JsxSelfClosingElement
 }
 
 /// Returns true if the name of the element belong to a self-closing element
@@ -66,7 +66,7 @@ fn is_void_dom_element(element_name: &str) -> bool {
     )
 }
 
-pub(crate) enum NoVoidElementsWithChildrenCause {
+pub enum NoVoidElementsWithChildrenCause {
     /// The cause affects React using JSX code
     Jsx {
         /// If the current element has children props in style
@@ -99,7 +99,7 @@ pub(crate) enum NoVoidElementsWithChildrenCause {
     },
 }
 
-pub(crate) struct NoVoidElementsWithChildrenState {
+pub struct NoVoidElementsWithChildrenState {
     /// The name of the element that triggered the rule
     element_name: String,
     /// It tracks the causes that triggers the rule

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
@@ -165,7 +165,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) UseExhaustiveDependencies {
+    pub UseExhaustiveDependencies {
         version: "1.0.0",
         name: "useExhaustiveDependencies",
         source: RuleSource::EslintReactHooks("exhaustive-deps"),
@@ -474,11 +474,11 @@ impl Rule for UseExhaustiveDependencies {
     type Query = Semantic<JsCallExpression>;
     type State = Fix;
     type Signals = Vec<Self::State>;
-    type Options = HooksOptions;
+    type Options = Box<HooksOptions>;
 
     fn run(ctx: &RuleContext<Self>) -> Vec<Self::State> {
         let options = ctx.options();
-        let options = ReactExtensiveDependenciesOptions::new(options.clone());
+        let options = ReactExtensiveDependenciesOptions::new(options.as_ref().clone());
 
         let mut signals = vec![];
 

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_hook_at_top_level.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_hook_at_top_level.rs
@@ -62,7 +62,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) UseHookAtTopLevel {
+    pub UseHookAtTopLevel {
         version: "1.0.0",
         name: "useHookAtTopLevel",
         source: RuleSource::EslintReactHooks("rules-of-hooks"),
@@ -364,7 +364,7 @@ impl Phase for FunctionCallServices {
 }
 
 #[derive(Clone)]
-pub(crate) struct FunctionCall(JsCallExpression);
+pub struct FunctionCall(JsCallExpression);
 
 impl QueryMatch for FunctionCall {
     fn text_range(&self) -> TextRange {

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_is_nan.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_is_nan.rs
@@ -59,7 +59,7 @@ declare_rule! {
     /// switch(foo) {}
     /// ```
     ///
-    pub(crate) UseIsNan {
+    pub UseIsNan {
         version: "1.0.0",
         name: "useIsNan",
         source: RuleSource::Eslint("use-isnan"),
@@ -69,7 +69,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) UseIsNanQuery = JsBinaryExpression | JsCaseClause | JsSwitchStatement
+    pub UseIsNanQuery = JsBinaryExpression | JsCaseClause | JsSwitchStatement
 }
 
 enum Message {

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery.rs
@@ -2,22 +2,22 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_console;
-pub(crate) mod no_global_assign;
-pub(crate) mod no_global_eval;
-pub(crate) mod no_invalid_use_before_declaration;
-pub(crate) mod no_misleading_character_class;
-pub(crate) mod no_re_export_all;
-pub(crate) mod no_then_property;
-pub(crate) mod no_unused_imports;
-pub(crate) mod use_export_type;
-pub(crate) mod use_for_of;
-pub(crate) mod use_import_type;
-pub(crate) mod use_number_namespace;
-pub(crate) mod use_sorted_classes;
+pub mod no_console;
+pub mod no_global_assign;
+pub mod no_global_eval;
+pub mod no_invalid_use_before_declaration;
+pub mod no_misleading_character_class;
+pub mod no_re_export_all;
+pub mod no_then_property;
+pub mod no_unused_imports;
+pub mod use_export_type;
+pub mod use_for_of;
+pub mod use_import_type;
+pub mod use_number_namespace;
+pub mod use_sorted_classes;
 
 declare_group! {
-    pub (crate) Nursery {
+    pub Nursery {
         name : "nursery" ,
         rules : [
             self :: no_console :: NoConsole ,

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_console.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_console.rs
@@ -20,7 +20,7 @@ declare_rule! {
     /// console.error('hello world')
     /// ```
     ///
-    pub(crate) NoConsole {
+    pub NoConsole {
         version: "next",
         name: "noConsole",
         source: RuleSource::Eslint("no-console"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_global_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_global_assign.rs
@@ -40,7 +40,7 @@ declare_rule! {
     /// let window;
     /// window = {};
     /// ```
-    pub(crate) NoGlobalAssign {
+    pub NoGlobalAssign {
         version: "1.5.0",
         name: "noGlobalAssign",
         source: RuleSource::Eslint("no-global-assign"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_global_eval.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_global_eval.rs
@@ -49,7 +49,7 @@ declare_rule! {
     /// let foo = globalThis;
     /// foo.eval("let a = 0;");
     /// ```
-    pub(crate) NoGlobalEval {
+    pub NoGlobalEval {
         version: "1.5.0",
         name: "noGlobalEval",
         source: RuleSource::Eslint("no-eval"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_invalid_use_before_declaration.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_invalid_use_before_declaration.rs
@@ -57,7 +57,7 @@ declare_rule! {
     /// function f() { return CONSTANT; }
     /// const CONSTANT = 0;
     /// ```
-    pub(crate) NoInvalidUseBeforeDeclaration {
+    pub NoInvalidUseBeforeDeclaration {
         version: "1.5.0",
         name: "noInvalidUseBeforeDeclaration",
         source: RuleSource::EslintTypeScript("no-use-before-define"),
@@ -176,14 +176,14 @@ impl Rule for NoInvalidUseBeforeDeclaration {
 }
 
 #[derive(Debug)]
-pub(crate) struct InvalidUseBeforeDeclaration {
+pub struct InvalidUseBeforeDeclaration {
     declaration_kind: DeclarationKind,
     reference_range: TextRange,
     binding_range: TextRange,
 }
 
 #[derive(Debug, Copy, Clone)]
-pub(crate) enum DeclarationKind {
+pub enum DeclarationKind {
     Parameter,
     Variable,
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_misleading_character_class.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_misleading_character_class.rs
@@ -58,9 +58,7 @@ declare_rule! {
     /// /^[👍]$/u;
     /// /^[\q{👶🏻}]$/v;
     /// ```
-    ///
-
-    pub(crate) NoMisleadingCharacterClass {
+    pub NoMisleadingCharacterClass {
         version: "1.5.0",
         name: "noMisleadingCharacterClass",
         source: RuleSource::Eslint("no-misleading-character-class"),
@@ -70,7 +68,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-  pub(crate) AnyRegexExpression = JsNewExpression | JsCallExpression | JsRegexLiteralExpression
+  pub AnyRegexExpression = JsNewExpression | JsCallExpression | JsRegexLiteralExpression
 }
 
 pub enum Message {

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_re_export_all.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_re_export_all.rs
@@ -30,7 +30,7 @@ declare_rule! {
     /// export { foo } from "foo";
     /// ```
     ///
-    pub(crate) NoReExportAll {
+    pub NoReExportAll {
         version: "next",
         name: "noReExportAll",
         recommended: false,

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_then_property.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_then_property.rs
@@ -83,7 +83,7 @@ declare_rule! {
     /// const foo = bar.then;
     /// ```
     ///
-    pub(crate) NoThenProperty {
+    pub NoThenProperty {
         version: "1.5.0",
         name: "noThenProperty",
         source: RuleSource::EslintUnicorn("no-thenable"),
@@ -92,7 +92,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) NoThenPropertyQuery =
+    pub NoThenPropertyQuery =
         AnyJsObjectMember |
         JsComputedMemberName |
         AnyJsClassMember |

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_unused_imports.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/no_unused_imports.rs
@@ -61,7 +61,7 @@ declare_rule! {
     ///     return new A(arg);
     /// }
     /// ```
-    pub(crate) NoUnusedImports {
+    pub NoUnusedImports {
         version: "1.3.0",
         name: "noUnusedImports",
         recommended: false,

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_export_type.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_export_type.rs
@@ -57,7 +57,7 @@ declare_rule! {
     /// ```ts,ignore
     /// export { TypeA } from "./mod.ts"
     /// ```
-    pub(crate) UseExportType {
+    pub UseExportType {
         version: "1.5.0",
         name: "useExportType",
         source: RuleSource::EslintTypeScript("consistent-type-exports"),
@@ -213,7 +213,7 @@ impl Rule for UseExportType {
 }
 
 #[derive(Debug)]
-pub(crate) enum ExportTypeFix {
+pub enum ExportTypeFix {
     /**
      * Group inline type exports such as `export { type A, type B }` into `export type { A, B }`.
      */

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_for_of.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_for_of.rs
@@ -40,7 +40,7 @@ declare_rule! {
     ///  }
     /// ```
     ///
-    pub(crate) UseForOf {
+    pub UseForOf {
         version: "1.5.0",
         name: "useForOf",
         source: RuleSource::EslintTypeScript("prefer-for-of"),
@@ -49,11 +49,11 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) AnyIncrementableLike = JsPostUpdateExpression | JsPreUpdateExpression | JsAssignmentExpression
+    pub AnyIncrementableLike = JsPostUpdateExpression | JsPreUpdateExpression | JsAssignmentExpression
 }
 
 declare_node_union! {
-    pub(crate) AnyBindingExpression = JsPostUpdateExpression | JsPreUpdateExpression | JsIdentifierExpression | JsShorthandPropertyObjectMember
+    pub AnyBindingExpression = JsPostUpdateExpression | JsPreUpdateExpression | JsIdentifierExpression | JsShorthandPropertyObjectMember
 }
 
 impl Rule for UseForOf {

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_import_type.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_import_type.rs
@@ -64,7 +64,7 @@ declare_rule! {
     /// import { B } from "./mod.js" with {};
     /// export type { B };
     /// ```
-    pub(crate) UseImportType {
+    pub UseImportType {
         version: "1.5.0",
         name: "useImportType",
         source: RuleSource::EslintTypeScript("consistent-type-imports"),
@@ -462,7 +462,7 @@ impl Rule for UseImportType {
 }
 
 #[derive(Debug)]
-pub(crate) enum ImportTypeFix {
+pub enum ImportTypeFix {
     UseImportType,
     ExtractDefaultImportType(Vec<AnyJsNamedImportSpecifier>),
     ExtractCombinedImportType,
@@ -485,7 +485,7 @@ fn is_only_used_as_type(model: &SemanticModel, binding: &JsIdentifierBinding) ->
 }
 
 #[derive(Debug)]
-pub(crate) enum NamedImportTypeFix {
+pub enum NamedImportTypeFix {
     UseImportType(Vec<AnyJsNamedImportSpecifier>),
     AddInlineTypeQualifiers(Vec<AnyJsNamedImportSpecifier>),
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_number_namespace.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_number_namespace.rs
@@ -65,7 +65,7 @@ declare_rule! {
     /// Number.NEGATIVE_INFINITY; // false
     /// ```
     ///
-    pub(crate) UseNumberNamespace {
+    pub UseNumberNamespace {
         version: "1.5.0",
         name: "useNumberNamespace",
         source: RuleSource::EslintUnicorn("prefer-number-properties"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_sorted_classes.rs
@@ -137,7 +137,7 @@ declare_rule! {
     ///
     /// This is a deliberate decision. We're unsure about this behavior, and would appreciate feedback on it. If this is a problem for you, please share a detailed explanation of your use case in [the GitHub issue](https://github.com/biomejs/biome/issues/1274).
     ///
-    pub(crate) UseSortedClasses {
+    pub UseSortedClasses {
         version: "next",
         name: "useSortedClasses",
         recommended: false,
@@ -156,7 +156,7 @@ impl Rule for UseSortedClasses {
     type Query = Ast<AnyClassStringLike>;
     type State = String;
     type Signals = Option<Self::State>;
-    type Options = UtilityClassSortingOptions;
+    type Options = Box<UtilityClassSortingOptions>;
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let options = ctx.options();

--- a/crates/biome_js_analyze/src/semantic_analyzers/performance.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/performance.rs
@@ -2,10 +2,10 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_accumulating_spread;
+pub mod no_accumulating_spread;
 
 declare_group! {
-    pub (crate) Performance {
+    pub Performance {
         name : "performance" ,
         rules : [
             self :: no_accumulating_spread :: NoAccumulatingSpread ,

--- a/crates/biome_js_analyze/src/semantic_analyzers/performance/no_accumulating_spread.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/performance/no_accumulating_spread.rs
@@ -45,7 +45,7 @@ declare_rule! {
     /// a.reduce((acc, val) => {acc.push(val); return acc}, []);
     /// ```
     ///
-    pub(crate) NoAccumulatingSpread {
+    pub NoAccumulatingSpread {
         version: "1.0.0",
         name: "noAccumulatingSpread",
         recommended: true,

--- a/crates/biome_js_analyze/src/semantic_analyzers/security.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/security.rs
@@ -2,11 +2,11 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_dangerously_set_inner_html;
-pub(crate) mod no_dangerously_set_inner_html_with_children;
+pub mod no_dangerously_set_inner_html;
+pub mod no_dangerously_set_inner_html_with_children;
 
 declare_group! {
-    pub (crate) Security {
+    pub Security {
         name : "security" ,
         rules : [
             self :: no_dangerously_set_inner_html :: NoDangerouslySetInnerHtml ,

--- a/crates/biome_js_analyze/src/semantic_analyzers/security/no_dangerously_set_inner_html.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/security/no_dangerously_set_inner_html.rs
@@ -25,7 +25,7 @@ declare_rule! {
     ///     dangerouslySetInnerHTML: { __html: 'child' }
     /// });
     /// ```
-    pub(crate) NoDangerouslySetInnerHtml {
+    pub NoDangerouslySetInnerHtml {
         version: "1.0.0",
         name: "noDangerouslySetInnerHtml",
         source: RuleSource::EslintReact("no-danger-with-children"),
@@ -34,10 +34,10 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) AnyJsCreateElement = JsxAttribute | JsCallExpression
+    pub AnyJsCreateElement = JsxAttribute | JsCallExpression
 }
 
-pub(crate) enum NoDangerState {
+pub enum NoDangerState {
     Attribute(TextRange),
     Property(TextRange),
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/security/no_dangerously_set_inner_html_with_children.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/security/no_dangerously_set_inner_html_with_children.rs
@@ -34,7 +34,7 @@ declare_rule! {
     /// ```js,expect_diagnostic
     /// React.createElement('div', { dangerouslySetInnerHTML: { __html: 'HTML' } }, 'children')
     /// ```
-    pub(crate) NoDangerouslySetInnerHtmlWithChildren {
+    pub NoDangerouslySetInnerHtmlWithChildren {
         version: "1.0.0",
         name: "noDangerouslySetInnerHtmlWithChildren",
         source: RuleSource::EslintReact("no-danger"),
@@ -43,7 +43,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) DangerousProp = JsxAttribute | JsPropertyObjectMember
+    pub DangerousProp = JsxAttribute | JsPropertyObjectMember
 }
 /// The kind of children
 enum ChildrenKind {
@@ -67,7 +67,7 @@ impl ChildrenKind {
     }
 }
 
-pub(crate) struct RuleState {
+pub struct RuleState {
     /// The `dangerouslySetInnerHTML` prop range
     dangerous_prop: TextRange,
 
@@ -76,7 +76,7 @@ pub(crate) struct RuleState {
 }
 
 declare_node_union! {
-    pub(crate) AnyJsCreateElement = JsxElement | JsxSelfClosingElement | JsCallExpression
+    pub AnyJsCreateElement = JsxElement | JsxSelfClosingElement | JsCallExpression
 }
 
 impl AnyJsCreateElement {

--- a/crates/biome_js_analyze/src/semantic_analyzers/style.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style.rs
@@ -2,17 +2,17 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_arguments;
-pub(crate) mod no_parameter_assign;
-pub(crate) mod no_restricted_globals;
-pub(crate) mod no_shouty_constants;
-pub(crate) mod no_var;
-pub(crate) mod use_const;
-pub(crate) mod use_fragment_syntax;
-pub(crate) mod use_naming_convention;
+pub mod no_arguments;
+pub mod no_parameter_assign;
+pub mod no_restricted_globals;
+pub mod no_shouty_constants;
+pub mod no_var;
+pub mod use_const;
+pub mod use_fragment_syntax;
+pub mod use_naming_convention;
 
 declare_group! {
-    pub (crate) Style {
+    pub Style {
         name : "style" ,
         rules : [
             self :: no_arguments :: NoArguments ,

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/no_arguments.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/no_arguments.rs
@@ -24,7 +24,7 @@ declare_rule! {
     ///     console.log(arguments);
     /// }
     /// ```
-    pub(crate) NoArguments {
+    pub NoArguments {
         version: "1.0.0",
         name: "noArguments",
         source: RuleSource::Eslint("prefer-rest-params"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/no_parameter_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/no_parameter_assign.rs
@@ -53,7 +53,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoParameterAssign {
+    pub NoParameterAssign {
         version: "1.0.0",
         name: "noParameterAssign",
         source: RuleSource::Eslint("no-param-reassign"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/no_restricted_globals.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/no_restricted_globals.rs
@@ -45,7 +45,7 @@ declare_rule! {
     /// In the example above, the rule will emit a diagnostics if tried to use `$` or `MooTools` without
     /// creating a local variable.
     ///
-    pub(crate) NoRestrictedGlobals {
+    pub NoRestrictedGlobals {
         version: "1.0.0",
         name: "noRestrictedGlobals",
         source: RuleSource::Eslint("no-restricted-globals"),
@@ -69,7 +69,7 @@ impl Rule for NoRestrictedGlobals {
     type Query = SemanticServices;
     type State = (TextRange, String);
     type Signals = Vec<Self::State>;
-    type Options = RestrictedGlobalsOptions;
+    type Options = Box<RestrictedGlobalsOptions>;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let model = ctx.model();

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
@@ -44,7 +44,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoShoutyConstants {
+    pub NoShoutyConstants {
         version: "1.0.0",
         name: "noShoutyConstants",
         recommended: false,

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/no_var.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/no_var.rs
@@ -34,7 +34,7 @@ declare_rule! {
     /// const foo = 1;
     /// let bar = 1;
     ///```
-    pub(crate) NoVar {
+    pub NoVar {
         version: "1.0.0",
         name: "noVar",
         source: RuleSource::Eslint("no-var"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/use_const.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/use_const.rs
@@ -56,7 +56,7 @@ declare_rule! {
     /// let a = 1, b = 2;
     /// b = 3;
     /// ```
-    pub(crate) UseConst {
+    pub UseConst {
         version: "1.0.0",
         name: "useConst",
         source: RuleSource::Eslint("prefer-const"),
@@ -132,7 +132,7 @@ impl Rule for UseConst {
     }
 }
 
-pub(crate) struct ConstBindings {
+pub struct ConstBindings {
     pub can_be_const: Vec<JsIdentifierBinding>,
     pub can_fix: bool,
 }
@@ -302,7 +302,7 @@ fn with_binding_identifier(
 }
 
 declare_node_union! {
-    pub(crate) DestructuringHost = JsVariableDeclarator | JsAssignmentExpression
+    pub DestructuringHost = JsVariableDeclarator | JsAssignmentExpression
 }
 
 impl DestructuringHost {

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/use_fragment_syntax.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/use_fragment_syntax.rs
@@ -27,7 +27,7 @@ declare_rule! {
     /// ```js,expect_diagnostic
     /// <React.Fragment>child</React.Fragment>
     /// ```
-    pub(crate) UseFragmentSyntax {
+    pub UseFragmentSyntax {
         version: "1.0.0",
         name: "useFragmentSyntax",
         source: RuleSource::EslintReact("jsx-fragments"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
@@ -281,7 +281,7 @@ declare_rule! {
     /// [`camelCase`]: https://en.wikipedia.org/wiki/Camel_case
     /// [`PascalCase`]: https://en.wikipedia.org/wiki/Camel_case
     /// [`CONSTANT_CASE`]: https://en.wikipedia.org/wiki/Snake_case
-    pub(crate)  UseNamingConvention {
+    pub UseNamingConvention {
         version: "1.0.0",
         name: "useNamingConvention",
         source: RuleSource::EslintTypeScript("naming-convention"),
@@ -459,7 +459,7 @@ impl Rule for UseNamingConvention {
 
 declare_node_union! {
     /// Ast nodes that defines a name.
-    pub(crate) AnyIdentifierBindingLike =
+    pub AnyIdentifierBindingLike =
         JsIdentifierBinding |
         JsLiteralMemberName |
         JsPrivateClassMemberName |
@@ -490,13 +490,13 @@ impl AnyIdentifierBindingLike {
 }
 
 #[derive(Debug)]
-pub(crate) struct State {
+pub struct State {
     element: Named,
     suggestion: Suggestion,
 }
 
 #[derive(Debug)]
-pub(crate) enum Suggestion {
+pub enum Suggestion {
     /// No suggestion
     None,
     /// Suggest aa new name

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious.rs
@@ -2,22 +2,22 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_array_index_key;
-pub(crate) mod no_catch_assign;
-pub(crate) mod no_class_assign;
-pub(crate) mod no_console_log;
-pub(crate) mod no_duplicate_parameters;
-pub(crate) mod no_function_assign;
-pub(crate) mod no_global_is_finite;
-pub(crate) mod no_global_is_nan;
-pub(crate) mod no_import_assign;
-pub(crate) mod no_label_var;
-pub(crate) mod no_redeclare;
-pub(crate) mod no_unsafe_declaration_merging;
-pub(crate) mod use_is_array;
+pub mod no_array_index_key;
+pub mod no_catch_assign;
+pub mod no_class_assign;
+pub mod no_console_log;
+pub mod no_duplicate_parameters;
+pub mod no_function_assign;
+pub mod no_global_is_finite;
+pub mod no_global_is_nan;
+pub mod no_import_assign;
+pub mod no_label_var;
+pub mod no_redeclare;
+pub mod no_unsafe_declaration_merging;
+pub mod use_is_array;
 
 declare_group! {
-    pub (crate) Suspicious {
+    pub Suspicious {
         name : "suspicious" ,
         rules : [
             self :: no_array_index_key :: NoArrayIndexKey ,

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_array_index_key.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_array_index_key.rs
@@ -63,7 +63,7 @@ declare_rule! {
     /// });
     /// ```
     ///
-    pub(crate) NoArrayIndexKey {
+    pub NoArrayIndexKey {
         version: "1.0.0",
         name: "noArrayIndexKey",
         source: RuleSource::EslintReact("no-array-index-key"),
@@ -72,7 +72,7 @@ declare_rule! {
 }
 
 declare_node_union! {
-    pub(crate) NoArrayIndexKeyQuery = JsxAttribute | JsPropertyObjectMember
+    pub NoArrayIndexKeyQuery = JsxAttribute | JsPropertyObjectMember
 }
 
 impl NoArrayIndexKeyQuery {
@@ -114,7 +114,7 @@ impl NoArrayIndexKeyQuery {
     }
 }
 
-pub(crate) struct NoArrayIndexKeyState {
+pub struct NoArrayIndexKeyState {
     /// The incorrect prop
     incorrect_prop: TextRange,
     /// Where the incorrect prop was defined

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_catch_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_catch_assign.rs
@@ -34,7 +34,7 @@ declare_rule! {
     ///   e = 100;
     /// }
     /// ```
-    pub(crate) NoCatchAssign {
+    pub NoCatchAssign {
         version: "1.0.0",
         name: "noCatchAssign",
         source: RuleSource::Eslint("no-ex-assign"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_class_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_class_assign.rs
@@ -65,7 +65,7 @@ declare_rule! {
     /// }
     /// ```
     ///
-    pub(crate) NoClassAssign {
+    pub NoClassAssign {
         version: "1.0.0",
         name: "noClassAssign",
         source: RuleSource::Eslint("no-class-assign"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_console_log.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_console_log.rs
@@ -33,7 +33,7 @@ declare_rule! {
     /// console.log();
     /// ```
     ///
-    pub(crate) NoConsoleLog {
+    pub NoConsoleLog {
         version: "1.0.0",
         name: "noConsoleLog",
         source: RuleSource::Eslint("no-console"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_duplicate_parameters.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_duplicate_parameters.rs
@@ -37,7 +37,7 @@ declare_rule! {
     /// function l([, l]) {}
     /// function foo([[a, b], [c, d]]) {}
     /// ```
-    pub(crate) NoDuplicateParameters {
+    pub NoDuplicateParameters {
         version: "1.0.0",
         name: "noDuplicateParameters",
         source: RuleSource::Eslint("no-dupe-args"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_function_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_function_assign.rs
@@ -93,7 +93,7 @@ declare_rule! {
     ///     var foo = bar;
     /// }
     /// ```
-    pub(crate) NoFunctionAssign {
+    pub NoFunctionAssign {
         version: "1.0.0",
         name: "noFunctionAssign",
         source: RuleSource::Eslint("no-func-assign"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_global_is_finite.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_global_is_finite.rs
@@ -29,7 +29,7 @@ declare_rule! {
     /// ```js
     /// Number.isFinite(false); // false
     /// ```
-    pub(crate) NoGlobalIsFinite {
+    pub NoGlobalIsFinite {
         version: "1.0.0",
         name: "noGlobalIsFinite",
         recommended: true,

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_global_is_nan.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_global_is_nan.rs
@@ -30,7 +30,7 @@ declare_rule! {
     /// Number.isNaN({}); // false
     /// ```
     ///
-    pub(crate) NoGlobalIsNan {
+    pub NoGlobalIsNan {
         version: "1.0.0",
         name: "noGlobalIsNan",
         recommended: true,

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_import_assign.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_import_assign.rs
@@ -49,7 +49,7 @@ declare_rule! {
     /// import * as e from "y";
     /// e = 1;
     /// ```
-    pub(crate) NoImportAssign {
+    pub NoImportAssign {
         version: "1.0.0",
         name: "noImportAssign",
         source: RuleSource::Eslint("no-import-assign"),
@@ -126,5 +126,5 @@ impl Rule for NoImportAssign {
 }
 
 declare_node_union! {
-    pub(crate) AnyJsImportLike = JsNamedImportSpecifier | JsShorthandNamedImportSpecifier | JsNamespaceImportSpecifier | JsDefaultImportSpecifier
+    pub AnyJsImportLike = JsNamedImportSpecifier | JsShorthandNamedImportSpecifier | JsNamespaceImportSpecifier | JsDefaultImportSpecifier
 }

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_label_var.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_label_var.rs
@@ -22,7 +22,7 @@ declare_rule! {
     /// const x = "test";
     /// z: expr;
     /// ```
-    pub(crate) NoLabelVar {
+    pub NoLabelVar {
         version: "1.0.0",
         name: "noLabelVar",
         source: RuleSource::Eslint("no-label-var"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_redeclare.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_redeclare.rs
@@ -58,7 +58,7 @@ declare_rule! {
     ///     bar(a: A, b: B) {}
     /// }
     /// ```
-    pub(crate) NoRedeclare {
+    pub NoRedeclare {
         version: "1.0.0",
         name: "noRedeclare",
         source: RuleSource::EslintTypeScript("no-redeclare"),
@@ -67,7 +67,7 @@ declare_rule! {
 }
 
 #[derive(Debug)]
-pub(crate) struct Redeclaration {
+pub struct Redeclaration {
     name: String,
     declaration: TextRange,
     redeclaration: TextRange,

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_unsafe_declaration_merging.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_unsafe_declaration_merging.rs
@@ -40,7 +40,7 @@ declare_rule! {
     /// namespace Baz {}
     /// enum Baz {}
     /// ```
-    pub(crate) NoUnsafeDeclarationMerging {
+    pub NoUnsafeDeclarationMerging {
         version: "1.0.0",
         name: "noUnsafeDeclarationMerging",
         source: RuleSource::EslintTypeScript("no-unsafe-declaration-merging"),

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/use_is_array.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/use_is_array.rs
@@ -36,7 +36,7 @@ declare_rule! {
     /// if (Array.isArray(xs)) {}
     /// ```
     ///
-    pub(crate) UseIsArray {
+    pub UseIsArray {
         version: "1.0.0",
         name: "useIsArray",
         source: RuleSource::EslintUnicorn("no-instanceof-array"),

--- a/crates/biome_js_analyze/src/semantic_services.rs
+++ b/crates/biome_js_analyze/src/semantic_services.rs
@@ -86,7 +86,7 @@ where
     }
 }
 
-pub(crate) struct SemanticModelBuilderVisitor {
+pub struct SemanticModelBuilderVisitor {
     extractor: SemanticEventExtractor,
     builder: SemanticModelBuilder,
 }

--- a/crates/biome_js_analyze/src/syntax.rs
+++ b/crates/biome_js_analyze/src/syntax.rs
@@ -1,5 +1,5 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-pub(crate) mod correctness;
-pub(crate) mod nursery;
-::biome_analyze::declare_category! { pub (crate) Syntax { kind : Syntax , groups : [self :: correctness :: Correctness , self :: nursery :: Nursery ,] } }
+pub mod correctness;
+pub mod nursery;
+::biome_analyze::declare_category! { pub Syntax { kind : Syntax , groups : [self :: correctness :: Correctness , self :: nursery :: Nursery ,] } }

--- a/crates/biome_js_analyze/src/syntax/correctness.rs
+++ b/crates/biome_js_analyze/src/syntax/correctness.rs
@@ -2,12 +2,12 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_duplicate_private_class_members;
-pub(crate) mod no_initializer_with_definite;
-pub(crate) mod no_super_without_extends;
+pub mod no_duplicate_private_class_members;
+pub mod no_initializer_with_definite;
+pub mod no_super_without_extends;
 
 declare_group! {
-    pub (crate) Correctness {
+    pub Correctness {
         name : "correctness" ,
         rules : [
             self :: no_duplicate_private_class_members :: NoDuplicatePrivateClassMembers ,

--- a/crates/biome_js_analyze/src/syntax/correctness/no_duplicate_private_class_members.rs
+++ b/crates/biome_js_analyze/src/syntax/correctness/no_duplicate_private_class_members.rs
@@ -16,7 +16,7 @@ declare_rule! {
     ///   #foo;
     //  }
     /// ```
-    pub(crate) NoDuplicatePrivateClassMembers {
+    pub NoDuplicatePrivateClassMembers {
         version: "1.0.0",
         name: "noDuplicatePrivateClassMembers",
     }

--- a/crates/biome_js_analyze/src/syntax/correctness/no_initializer_with_definite.rs
+++ b/crates/biome_js_analyze/src/syntax/correctness/no_initializer_with_definite.rs
@@ -12,7 +12,7 @@ declare_rule! {
     /// ```js
     /// let foo!: string = "bar";
     /// ```
-    pub(crate) NoInitializerWithDefinite {
+    pub NoInitializerWithDefinite {
         version: "1.4.0",
         name: "noInitializerWithDefinite",
     }

--- a/crates/biome_js_analyze/src/syntax/correctness/no_super_without_extends.rs
+++ b/crates/biome_js_analyze/src/syntax/correctness/no_super_without_extends.rs
@@ -17,7 +17,7 @@ declare_rule! {
     //     }
     // }
     /// ```
-    pub(crate) NoSuperWithoutExtends {
+    pub NoSuperWithoutExtends {
         version: "1.0.0",
         name: "noSuperWithoutExtends",
     }

--- a/crates/biome_js_analyze/src/syntax/nursery.rs
+++ b/crates/biome_js_analyze/src/syntax/nursery.rs
@@ -2,10 +2,10 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_type_only_import_attributes;
+pub mod no_type_only_import_attributes;
 
 declare_group! {
-    pub (crate) Nursery {
+    pub Nursery {
         name : "nursery" ,
         rules : [
             self :: no_type_only_import_attributes :: NoTypeOnlyImportAttributes ,

--- a/crates/biome_js_analyze/src/syntax/nursery/no_type_only_import_attributes.rs
+++ b/crates/biome_js_analyze/src/syntax/nursery/no_type_only_import_attributes.rs
@@ -13,7 +13,7 @@ declare_rule! {
     /// ```js
     /// import type { A } from "./a.json" with { type: "json" };
     /// ```
-    pub(crate) NoTypeOnlyImportAttributes {
+    pub NoTypeOnlyImportAttributes {
         version: "1.5.0",
         name: "noTypeOnlyImportAttributes",
     }
@@ -114,7 +114,7 @@ impl Rule for NoTypeOnlyImportAttributes {
 }
 
 #[derive(Debug)]
-pub(crate) struct RuleState {
+pub struct RuleState {
     /// Range of the first found type token
     type_token_range: TextRange,
     /// Range of import attributes

--- a/crates/biome_js_analyze/src/utils.rs
+++ b/crates/biome_js_analyze/src/utils.rs
@@ -9,7 +9,7 @@ pub mod rename;
 pub mod tests;
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum EscapeError {
+pub enum EscapeError {
     EscapeAtEndOfString,
     InvalidEscapedChar(char),
 }
@@ -72,7 +72,7 @@ pub(crate) fn is_node_equal(a_node: &JsSyntaxNode, b_node: &JsSyntaxNode) -> boo
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum VariablePosition {
+pub enum VariablePosition {
     Right,
     Left,
 }

--- a/crates/biome_json_analyze/src/analyzers.rs
+++ b/crates/biome_json_analyze/src/analyzers.rs
@@ -1,4 +1,4 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-pub(crate) mod nursery;
-::biome_analyze::declare_category! { pub (crate) Analyzers { kind : Lint , groups : [self :: nursery :: Nursery ,] } }
+pub mod nursery;
+::biome_analyze::declare_category! { pub Analyzers { kind : Lint , groups : [self :: nursery :: Nursery ,] } }

--- a/crates/biome_json_analyze/src/analyzers/nursery.rs
+++ b/crates/biome_json_analyze/src/analyzers/nursery.rs
@@ -2,10 +2,10 @@
 
 use biome_analyze::declare_group;
 
-pub(crate) mod no_duplicate_json_keys;
+pub mod no_duplicate_json_keys;
 
 declare_group! {
-    pub (crate) Nursery {
+    pub Nursery {
         name : "nursery" ,
         rules : [
             self :: no_duplicate_json_keys :: NoDuplicateJsonKeys ,

--- a/crates/biome_json_analyze/src/analyzers/nursery/no_duplicate_json_keys.rs
+++ b/crates/biome_json_analyze/src/analyzers/nursery/no_duplicate_json_keys.rs
@@ -26,14 +26,14 @@ declare_rule! {
     ///   "secondTitle": "Second title"
     /// }
     /// ```
-    pub(crate) NoDuplicateJsonKeys {
+    pub NoDuplicateJsonKeys {
         version: "1.0.0",
         name: "noDuplicateJsonKeys",
         recommended: true,
     }
 }
 
-pub(crate) struct DuplicatedKeys {
+pub struct DuplicatedKeys {
     /// The fist key, which should be the correct one
     original_key: JsonMemberName,
     /// The ranges where the duplicated keys are found

--- a/crates/biome_json_analyze/src/lib.rs
+++ b/crates/biome_json_analyze/src/lib.rs
@@ -1,4 +1,5 @@
 mod analyzers;
+pub mod options;
 mod registry;
 
 pub use crate::registry::visit_registry;

--- a/crates/biome_json_analyze/src/options.rs
+++ b/crates/biome_json_analyze/src/options.rs
@@ -1,0 +1,5 @@
+//! Generated file, do not edit by hand, see `xtask/codegen`
+
+use crate::analyzers;
+
+pub type NoDuplicateJsonKeys = < analyzers :: nursery :: no_duplicate_json_keys :: NoDuplicateJsonKeys as biome_analyze :: Rule > :: Options ;

--- a/crates/biome_service/src/configuration/generated.rs
+++ b/crates/biome_service/src/configuration/generated.rs
@@ -1,7 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 use crate::configuration::linter::*;
-use crate::{RuleConfiguration, Rules};
+use crate::Rules;
 use biome_analyze::{AnalyzerRules, MetadataRegistry};
 pub(crate) fn push_to_analyzer_rules(
     rules: &Rules,
@@ -10,112 +10,72 @@ pub(crate) fn push_to_analyzer_rules(
 ) {
     if let Some(rules) = rules.a11y.as_ref() {
         for rule_name in &A11y::GROUP_RULES {
-            if let Some(RuleConfiguration::WithOptions(rule_options)) =
-                rules.get_rule_configuration(rule_name)
-            {
-                if let Some(possible_options) = &rule_options.options {
-                    if let Some(rule_key) = metadata.find_rule("a11y", rule_name) {
-                        let rule_options = possible_options.extract_option(&rule_key);
-                        analyzer_rules.push_rule(rule_key, rule_options);
-                    }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
+                if let Some(rule_key) = metadata.find_rule("a11y", rule_name) {
+                    analyzer_rules.push_rule(rule_key, rule_options);
                 }
             }
         }
     }
     if let Some(rules) = rules.complexity.as_ref() {
         for rule_name in &Complexity::GROUP_RULES {
-            if let Some(RuleConfiguration::WithOptions(rule_options)) =
-                rules.get_rule_configuration(rule_name)
-            {
-                if let Some(possible_options) = &rule_options.options {
-                    if let Some(rule_key) = metadata.find_rule("complexity", rule_name) {
-                        let rule_options = possible_options.extract_option(&rule_key);
-                        analyzer_rules.push_rule(rule_key, rule_options);
-                    }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
+                if let Some(rule_key) = metadata.find_rule("complexity", rule_name) {
+                    analyzer_rules.push_rule(rule_key, rule_options);
                 }
             }
         }
     }
     if let Some(rules) = rules.correctness.as_ref() {
         for rule_name in &Correctness::GROUP_RULES {
-            if let Some(RuleConfiguration::WithOptions(rule_options)) =
-                rules.get_rule_configuration(rule_name)
-            {
-                if let Some(possible_options) = &rule_options.options {
-                    if let Some(rule_key) = metadata.find_rule("correctness", rule_name) {
-                        let rule_options = possible_options.extract_option(&rule_key);
-                        analyzer_rules.push_rule(rule_key, rule_options);
-                    }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
+                if let Some(rule_key) = metadata.find_rule("correctness", rule_name) {
+                    analyzer_rules.push_rule(rule_key, rule_options);
                 }
             }
         }
     }
     if let Some(rules) = rules.nursery.as_ref() {
         for rule_name in &Nursery::GROUP_RULES {
-            if let Some(RuleConfiguration::WithOptions(rule_options)) =
-                rules.get_rule_configuration(rule_name)
-            {
-                if let Some(possible_options) = &rule_options.options {
-                    if let Some(rule_key) = metadata.find_rule("nursery", rule_name) {
-                        let rule_options = possible_options.extract_option(&rule_key);
-                        analyzer_rules.push_rule(rule_key, rule_options);
-                    }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
+                if let Some(rule_key) = metadata.find_rule("nursery", rule_name) {
+                    analyzer_rules.push_rule(rule_key, rule_options);
                 }
             }
         }
     }
     if let Some(rules) = rules.performance.as_ref() {
         for rule_name in &Performance::GROUP_RULES {
-            if let Some(RuleConfiguration::WithOptions(rule_options)) =
-                rules.get_rule_configuration(rule_name)
-            {
-                if let Some(possible_options) = &rule_options.options {
-                    if let Some(rule_key) = metadata.find_rule("performance", rule_name) {
-                        let rule_options = possible_options.extract_option(&rule_key);
-                        analyzer_rules.push_rule(rule_key, rule_options);
-                    }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
+                if let Some(rule_key) = metadata.find_rule("performance", rule_name) {
+                    analyzer_rules.push_rule(rule_key, rule_options);
                 }
             }
         }
     }
     if let Some(rules) = rules.security.as_ref() {
         for rule_name in &Security::GROUP_RULES {
-            if let Some(RuleConfiguration::WithOptions(rule_options)) =
-                rules.get_rule_configuration(rule_name)
-            {
-                if let Some(possible_options) = &rule_options.options {
-                    if let Some(rule_key) = metadata.find_rule("security", rule_name) {
-                        let rule_options = possible_options.extract_option(&rule_key);
-                        analyzer_rules.push_rule(rule_key, rule_options);
-                    }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
+                if let Some(rule_key) = metadata.find_rule("security", rule_name) {
+                    analyzer_rules.push_rule(rule_key, rule_options);
                 }
             }
         }
     }
     if let Some(rules) = rules.style.as_ref() {
         for rule_name in &Style::GROUP_RULES {
-            if let Some(RuleConfiguration::WithOptions(rule_options)) =
-                rules.get_rule_configuration(rule_name)
-            {
-                if let Some(possible_options) = &rule_options.options {
-                    if let Some(rule_key) = metadata.find_rule("style", rule_name) {
-                        let rule_options = possible_options.extract_option(&rule_key);
-                        analyzer_rules.push_rule(rule_key, rule_options);
-                    }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
+                if let Some(rule_key) = metadata.find_rule("style", rule_name) {
+                    analyzer_rules.push_rule(rule_key, rule_options);
                 }
             }
         }
     }
     if let Some(rules) = rules.suspicious.as_ref() {
         for rule_name in &Suspicious::GROUP_RULES {
-            if let Some(RuleConfiguration::WithOptions(rule_options)) =
-                rules.get_rule_configuration(rule_name)
-            {
-                if let Some(possible_options) = &rule_options.options {
-                    if let Some(rule_key) = metadata.find_rule("suspicious", rule_name) {
-                        let rule_options = possible_options.extract_option(&rule_key);
-                        analyzer_rules.push_rule(rule_key, rule_options);
-                    }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
+                if let Some(rule_key) = metadata.find_rule("suspicious", rule_name) {
+                    analyzer_rules.push_rule(rule_key, rule_options);
                 }
             }
         }

--- a/crates/biome_service/src/configuration/linter/mod.rs
+++ b/crates/biome_service/src/configuration/linter/mod.rs
@@ -5,12 +5,11 @@ pub use crate::configuration::linter::rules::Rules;
 use crate::configuration::overrides::OverrideLinterConfiguration;
 use crate::settings::{to_matcher, LinterSettings};
 use crate::{Matcher, WorkspaceError};
-use biome_deserialize::{
-    DeserializableValue, DeserializationDiagnostic, Merge, StringSet, VisitableType,
-};
+use biome_analyze::options::RuleOptions;
+use biome_deserialize::{Deserializable, StringSet};
+use biome_deserialize::{DeserializableValue, DeserializationDiagnostic, Merge, VisitableType};
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use biome_diagnostics::Severity;
-use biome_js_analyze::options::PossibleOptions;
 use bpaf::Bpaf;
 pub use rules::*;
 #[cfg(feature = "schema")]
@@ -98,28 +97,27 @@ impl TryFrom<OverrideLinterConfiguration> for LinterSettings {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, untagged)]
-pub enum RuleConfiguration {
+pub enum RuleConfiguration<T: Default> {
     Plain(RulePlainConfiguration),
-    WithOptions(Box<RuleWithOptions>),
+    WithOptions(RuleWithOptions<T>),
 }
 
-impl biome_deserialize::Deserializable for RuleConfiguration {
+impl<T: Default + Deserializable> Deserializable for RuleConfiguration<T> {
     fn deserialize(
         value: &impl DeserializableValue,
         rule_name: &str,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<Self> {
         if value.is_type(VisitableType::STR) {
-            biome_deserialize::Deserializable::deserialize(value, rule_name, diagnostics)
-                .map(Self::Plain)
+            Deserializable::deserialize(value, rule_name, diagnostics).map(Self::Plain)
         } else {
-            biome_deserialize::Deserializable::deserialize(value, rule_name, diagnostics)
-                .map(|rule| Self::WithOptions(Box::new(rule)))
+            Deserializable::deserialize(value, rule_name, diagnostics)
+                .map(|rule| Self::WithOptions(rule))
         }
     }
 }
 
-impl FromStr for RuleConfiguration {
+impl<T: Default> FromStr for RuleConfiguration<T> {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -128,7 +126,7 @@ impl FromStr for RuleConfiguration {
     }
 }
 
-impl RuleConfiguration {
+impl<T: Default> RuleConfiguration<T> {
     pub fn is_err(&self) -> bool {
         if let Self::WithOptions(rule) = self {
             rule.level == RulePlainConfiguration::Error
@@ -148,25 +146,24 @@ impl RuleConfiguration {
     pub fn is_enabled(&self) -> bool {
         !self.is_disabled()
     }
-}
 
-impl Default for RuleConfiguration {
-    fn default() -> Self {
-        Self::Plain(RulePlainConfiguration::Error)
+    pub fn level(&self) -> RulePlainConfiguration {
+        match self {
+            RuleConfiguration::Plain(plain) => *plain,
+            RuleConfiguration::WithOptions(options) => options.level,
+        }
     }
 }
 
 // Rule configuration has a custom [Merge] implementation so that overriding the
 // severity doesn't override the options.
-impl Merge for RuleConfiguration {
+impl<T: Clone + Default> Merge for RuleConfiguration<T> {
     fn merge_with(&mut self, other: Self) {
         *self = match (&self, other) {
-            (Self::WithOptions(this), Self::Plain(other)) => {
-                Self::WithOptions(Box::new(RuleWithOptions {
-                    level: other,
-                    options: this.options.clone(),
-                }))
-            }
+            (Self::WithOptions(this), Self::Plain(other)) => Self::WithOptions(RuleWithOptions {
+                level: other,
+                options: this.options.clone(),
+            }),
             // FIXME: Rule options don't have a `NoneState`, so we can't deep
             //        merge them yet. For now, if an override specifies options,
             //        it will still override *all* options.
@@ -175,20 +172,37 @@ impl Merge for RuleConfiguration {
     }
 }
 
-impl From<&RuleConfiguration> for Severity {
-    fn from(conf: &RuleConfiguration) -> Self {
-        match conf {
-            RuleConfiguration::Plain(p) => p.into(),
-            RuleConfiguration::WithOptions(conf) => {
-                let level = &conf.level;
-                level.into()
+impl<T: Clone + Default + 'static> RuleConfiguration<T> {
+    pub fn get_options(&self) -> Option<RuleOptions> {
+        match self {
+            RuleConfiguration::Plain(_) => None,
+            RuleConfiguration::WithOptions(options) => {
+                Some(RuleOptions::new(options.options.clone()))
             }
         }
     }
 }
 
-impl From<&RulePlainConfiguration> for Severity {
-    fn from(conf: &RulePlainConfiguration) -> Self {
+impl<T: Default> Default for RuleConfiguration<T> {
+    fn default() -> Self {
+        Self::Plain(RulePlainConfiguration::Error)
+    }
+}
+
+impl<T: Default> From<&RuleConfiguration<T>> for Severity {
+    fn from(conf: &RuleConfiguration<T>) -> Self {
+        match conf {
+            RuleConfiguration::Plain(p) => (*p).into(),
+            RuleConfiguration::WithOptions(conf) => {
+                let level = &conf.level;
+                (*level).into()
+            }
+        }
+    }
+}
+
+impl From<RulePlainConfiguration> for Severity {
+    fn from(conf: RulePlainConfiguration) -> Self {
         match conf {
             RulePlainConfiguration::Warn => Severity::Warning,
             RulePlainConfiguration::Error => Severity::Error,
@@ -197,7 +211,7 @@ impl From<&RulePlainConfiguration> for Severity {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Deserializable, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub enum RulePlainConfiguration {
@@ -223,20 +237,7 @@ impl FromStr for RulePlainConfiguration {
 #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct RuleWithOptions {
+pub struct RuleWithOptions<T: Default> {
     pub level: RulePlainConfiguration,
-
-    #[deserializable(passthrough_name)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub options: Option<PossibleOptions>,
-}
-
-impl FromStr for RuleWithOptions {
-    type Err = String;
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        Ok(Self {
-            level: RulePlainConfiguration::default(),
-            options: None,
-        })
-    }
+    pub options: T,
 }

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -1,11 +1,14 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
+use super::RulePlainConfiguration;
 use crate::RuleConfiguration;
-use biome_analyze::RuleFilter;
+use biome_analyze::{options::RuleOptions, RuleFilter};
 use biome_console::markup;
 use biome_deserialize::{DeserializableValidator, DeserializationDiagnostic};
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_diagnostics::{Category, Severity};
+use biome_js_analyze::options::*;
+use biome_json_analyze::options::*;
 use biome_rowan::TextRange;
 use indexmap::IndexSet;
 #[cfg(feature = "schema")]
@@ -100,7 +103,7 @@ impl Rules {
                     .a11y
                     .as_ref()
                     .and_then(|a11y| a11y.get_rule_configuration(rule_name))
-                    .map(|rule_setting| rule_setting.into())
+                    .map(|(level, _)| level.into())
                     .unwrap_or_else(|| {
                         if A11y::is_recommended_rule(rule_name) {
                             Severity::Error
@@ -112,7 +115,7 @@ impl Rules {
                     .complexity
                     .as_ref()
                     .and_then(|complexity| complexity.get_rule_configuration(rule_name))
-                    .map(|rule_setting| rule_setting.into())
+                    .map(|(level, _)| level.into())
                     .unwrap_or_else(|| {
                         if Complexity::is_recommended_rule(rule_name) {
                             Severity::Error
@@ -124,7 +127,7 @@ impl Rules {
                     .correctness
                     .as_ref()
                     .and_then(|correctness| correctness.get_rule_configuration(rule_name))
-                    .map(|rule_setting| rule_setting.into())
+                    .map(|(level, _)| level.into())
                     .unwrap_or_else(|| {
                         if Correctness::is_recommended_rule(rule_name) {
                             Severity::Error
@@ -136,7 +139,7 @@ impl Rules {
                     .nursery
                     .as_ref()
                     .and_then(|nursery| nursery.get_rule_configuration(rule_name))
-                    .map(|rule_setting| rule_setting.into())
+                    .map(|(level, _)| level.into())
                     .unwrap_or_else(|| {
                         if Nursery::is_recommended_rule(rule_name) {
                             Severity::Error
@@ -148,7 +151,7 @@ impl Rules {
                     .performance
                     .as_ref()
                     .and_then(|performance| performance.get_rule_configuration(rule_name))
-                    .map(|rule_setting| rule_setting.into())
+                    .map(|(level, _)| level.into())
                     .unwrap_or_else(|| {
                         if Performance::is_recommended_rule(rule_name) {
                             Severity::Error
@@ -160,7 +163,7 @@ impl Rules {
                     .security
                     .as_ref()
                     .and_then(|security| security.get_rule_configuration(rule_name))
-                    .map(|rule_setting| rule_setting.into())
+                    .map(|(level, _)| level.into())
                     .unwrap_or_else(|| {
                         if Security::is_recommended_rule(rule_name) {
                             Severity::Error
@@ -172,7 +175,7 @@ impl Rules {
                     .style
                     .as_ref()
                     .and_then(|style| style.get_rule_configuration(rule_name))
-                    .map(|rule_setting| rule_setting.into())
+                    .map(|(level, _)| level.into())
                     .unwrap_or_else(|| {
                         if Style::is_recommended_rule(rule_name) {
                             Severity::Error
@@ -184,7 +187,7 @@ impl Rules {
                     .suspicious
                     .as_ref()
                     .and_then(|suspicious| suspicious.get_rule_configuration(rule_name))
-                    .map(|rule_setting| rule_setting.into())
+                    .map(|(level, _)| level.into())
                     .unwrap_or_else(|| {
                         if Suspicious::is_recommended_rule(rule_name) {
                             Severity::Error
@@ -351,94 +354,97 @@ pub struct A11y {
     pub all: Option<bool>,
     #[doc = "Enforce that the accessKey attribute is not used on any HTML element."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_access_key: Option<RuleConfiguration>,
+    pub no_access_key: Option<RuleConfiguration<NoAccessKey>>,
     #[doc = "Enforce that aria-hidden=\"true\" is not set on focusable elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_aria_hidden_on_focusable: Option<RuleConfiguration>,
+    pub no_aria_hidden_on_focusable: Option<RuleConfiguration<NoAriaHiddenOnFocusable>>,
     #[doc = "Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_aria_unsupported_elements: Option<RuleConfiguration>,
+    pub no_aria_unsupported_elements: Option<RuleConfiguration<NoAriaUnsupportedElements>>,
     #[doc = "Enforce that autoFocus prop is not used on elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_autofocus: Option<RuleConfiguration>,
+    pub no_autofocus: Option<RuleConfiguration<NoAutofocus>>,
     #[doc = "Disallow target=\"_blank\" attribute without rel=\"noreferrer\""]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_blank_target: Option<RuleConfiguration>,
+    pub no_blank_target: Option<RuleConfiguration<NoBlankTarget>>,
     #[doc = "Enforces that no distracting elements are used."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_distracting_elements: Option<RuleConfiguration>,
+    pub no_distracting_elements: Option<RuleConfiguration<NoDistractingElements>>,
     #[doc = "The scope prop should be used only on <th> elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_header_scope: Option<RuleConfiguration>,
+    pub no_header_scope: Option<RuleConfiguration<NoHeaderScope>>,
     #[doc = "Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_interactive_element_to_noninteractive_role: Option<RuleConfiguration>,
+    pub no_interactive_element_to_noninteractive_role:
+        Option<RuleConfiguration<NoInteractiveElementToNoninteractiveRole>>,
     #[doc = "Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_noninteractive_element_to_interactive_role: Option<RuleConfiguration>,
+    pub no_noninteractive_element_to_interactive_role:
+        Option<RuleConfiguration<NoNoninteractiveElementToInteractiveRole>>,
     #[doc = "Enforce that tabIndex is not assigned to non-interactive HTML elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_noninteractive_tabindex: Option<RuleConfiguration>,
+    pub no_noninteractive_tabindex: Option<RuleConfiguration<NoNoninteractiveTabindex>>,
     #[doc = "Prevent the usage of positive integers on tabIndex property"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_positive_tabindex: Option<RuleConfiguration>,
+    pub no_positive_tabindex: Option<RuleConfiguration<NoPositiveTabindex>>,
     #[doc = "Enforce img alt prop does not contain the word \"image\", \"picture\", or \"photo\"."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_redundant_alt: Option<RuleConfiguration>,
+    pub no_redundant_alt: Option<RuleConfiguration<NoRedundantAlt>>,
     #[doc = "Enforce explicit role property is not the same as implicit/default role property on an element."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_redundant_roles: Option<RuleConfiguration>,
+    pub no_redundant_roles: Option<RuleConfiguration<NoRedundantRoles>>,
     #[doc = "Enforces the usage of the title element for the svg element."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_svg_without_title: Option<RuleConfiguration>,
+    pub no_svg_without_title: Option<RuleConfiguration<NoSvgWithoutTitle>>,
     #[doc = "Enforce that all elements that require alternative text have meaningful information to relay back to the end user."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_alt_text: Option<RuleConfiguration>,
+    pub use_alt_text: Option<RuleConfiguration<UseAltText>>,
     #[doc = "Enforce that anchors have content and that the content is accessible to screen readers."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_anchor_content: Option<RuleConfiguration>,
+    pub use_anchor_content: Option<RuleConfiguration<UseAnchorContent>>,
     #[doc = "Enforce that tabIndex is assigned to non-interactive HTML elements with aria-activedescendant."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_aria_activedescendant_with_tabindex: Option<RuleConfiguration>,
+    pub use_aria_activedescendant_with_tabindex:
+        Option<RuleConfiguration<UseAriaActivedescendantWithTabindex>>,
     #[doc = "Enforce that elements with ARIA roles must have all required ARIA attributes for that role."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_aria_props_for_role: Option<RuleConfiguration>,
+    pub use_aria_props_for_role: Option<RuleConfiguration<UseAriaPropsForRole>>,
     #[doc = "Enforces the usage of the attribute type for the element button"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_button_type: Option<RuleConfiguration>,
+    pub use_button_type: Option<RuleConfiguration<UseButtonType>>,
     #[doc = "Enforce that heading elements (h1, h2, etc.) have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the aria-hidden prop."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_heading_content: Option<RuleConfiguration>,
+    pub use_heading_content: Option<RuleConfiguration<UseHeadingContent>>,
     #[doc = "Enforce that html element has lang attribute."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_html_lang: Option<RuleConfiguration>,
+    pub use_html_lang: Option<RuleConfiguration<UseHtmlLang>>,
     #[doc = "Enforces the usage of the attribute title for the element iframe."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_iframe_title: Option<RuleConfiguration>,
+    pub use_iframe_title: Option<RuleConfiguration<UseIframeTitle>>,
     #[doc = "Enforce onClick is accompanied by at least one of the following: onKeyUp, onKeyDown, onKeyPress."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_key_with_click_events: Option<RuleConfiguration>,
+    pub use_key_with_click_events: Option<RuleConfiguration<UseKeyWithClickEvents>>,
     #[doc = "Enforce onMouseOver / onMouseOut are accompanied by onFocus / onBlur."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_key_with_mouse_events: Option<RuleConfiguration>,
+    pub use_key_with_mouse_events: Option<RuleConfiguration<UseKeyWithMouseEvents>>,
     #[doc = "Enforces that audio and video elements must have a track for captions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_media_caption: Option<RuleConfiguration>,
+    pub use_media_caption: Option<RuleConfiguration<UseMediaCaption>>,
     #[doc = "Enforce that all anchors are valid, and they are navigable elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_valid_anchor: Option<RuleConfiguration>,
+    pub use_valid_anchor: Option<RuleConfiguration<UseValidAnchor>>,
     #[doc = "Ensures that ARIA properties aria-* are all valid."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_valid_aria_props: Option<RuleConfiguration>,
+    pub use_valid_aria_props: Option<RuleConfiguration<UseValidAriaProps>>,
     #[doc = "Elements with ARIA roles must use a valid, non-abstract ARIA role."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_valid_aria_role: Option<RuleConfiguration>,
+    pub use_valid_aria_role: Option<RuleConfiguration<UseValidAriaRole>>,
     #[doc = "Enforce that ARIA state and property values are valid."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_valid_aria_values: Option<RuleConfiguration>,
+    pub use_valid_aria_values: Option<RuleConfiguration<UseValidAriaValues>>,
     #[doc = "Ensure that the attribute passed to the lang attribute is a correct ISO language and/or country."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_valid_lang: Option<RuleConfiguration>,
+    pub use_valid_lang: Option<RuleConfiguration<UseValidLang>>,
 }
 impl DeserializableValidator for A11y {
     fn validate(
@@ -937,44 +943,131 @@ impl A11y {
             disabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(&self, rule_name: &str) -> Option<&RuleConfiguration> {
+    pub(crate) fn get_rule_configuration(
+        &self,
+        rule_name: &str,
+    ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
         match rule_name {
-            "noAccessKey" => self.no_access_key.as_ref(),
-            "noAriaHiddenOnFocusable" => self.no_aria_hidden_on_focusable.as_ref(),
-            "noAriaUnsupportedElements" => self.no_aria_unsupported_elements.as_ref(),
-            "noAutofocus" => self.no_autofocus.as_ref(),
-            "noBlankTarget" => self.no_blank_target.as_ref(),
-            "noDistractingElements" => self.no_distracting_elements.as_ref(),
-            "noHeaderScope" => self.no_header_scope.as_ref(),
-            "noInteractiveElementToNoninteractiveRole" => {
-                self.no_interactive_element_to_noninteractive_role.as_ref()
-            }
-            "noNoninteractiveElementToInteractiveRole" => {
-                self.no_noninteractive_element_to_interactive_role.as_ref()
-            }
-            "noNoninteractiveTabindex" => self.no_noninteractive_tabindex.as_ref(),
-            "noPositiveTabindex" => self.no_positive_tabindex.as_ref(),
-            "noRedundantAlt" => self.no_redundant_alt.as_ref(),
-            "noRedundantRoles" => self.no_redundant_roles.as_ref(),
-            "noSvgWithoutTitle" => self.no_svg_without_title.as_ref(),
-            "useAltText" => self.use_alt_text.as_ref(),
-            "useAnchorContent" => self.use_anchor_content.as_ref(),
-            "useAriaActivedescendantWithTabindex" => {
-                self.use_aria_activedescendant_with_tabindex.as_ref()
-            }
-            "useAriaPropsForRole" => self.use_aria_props_for_role.as_ref(),
-            "useButtonType" => self.use_button_type.as_ref(),
-            "useHeadingContent" => self.use_heading_content.as_ref(),
-            "useHtmlLang" => self.use_html_lang.as_ref(),
-            "useIframeTitle" => self.use_iframe_title.as_ref(),
-            "useKeyWithClickEvents" => self.use_key_with_click_events.as_ref(),
-            "useKeyWithMouseEvents" => self.use_key_with_mouse_events.as_ref(),
-            "useMediaCaption" => self.use_media_caption.as_ref(),
-            "useValidAnchor" => self.use_valid_anchor.as_ref(),
-            "useValidAriaProps" => self.use_valid_aria_props.as_ref(),
-            "useValidAriaRole" => self.use_valid_aria_role.as_ref(),
-            "useValidAriaValues" => self.use_valid_aria_values.as_ref(),
-            "useValidLang" => self.use_valid_lang.as_ref(),
+            "noAccessKey" => self
+                .no_access_key
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noAriaHiddenOnFocusable" => self
+                .no_aria_hidden_on_focusable
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noAriaUnsupportedElements" => self
+                .no_aria_unsupported_elements
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noAutofocus" => self
+                .no_autofocus
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noBlankTarget" => self
+                .no_blank_target
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDistractingElements" => self
+                .no_distracting_elements
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noHeaderScope" => self
+                .no_header_scope
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noInteractiveElementToNoninteractiveRole" => self
+                .no_interactive_element_to_noninteractive_role
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noNoninteractiveElementToInteractiveRole" => self
+                .no_noninteractive_element_to_interactive_role
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noNoninteractiveTabindex" => self
+                .no_noninteractive_tabindex
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noPositiveTabindex" => self
+                .no_positive_tabindex
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noRedundantAlt" => self
+                .no_redundant_alt
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noRedundantRoles" => self
+                .no_redundant_roles
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noSvgWithoutTitle" => self
+                .no_svg_without_title
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useAltText" => self
+                .use_alt_text
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useAnchorContent" => self
+                .use_anchor_content
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useAriaActivedescendantWithTabindex" => self
+                .use_aria_activedescendant_with_tabindex
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useAriaPropsForRole" => self
+                .use_aria_props_for_role
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useButtonType" => self
+                .use_button_type
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useHeadingContent" => self
+                .use_heading_content
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useHtmlLang" => self
+                .use_html_lang
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useIframeTitle" => self
+                .use_iframe_title
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useKeyWithClickEvents" => self
+                .use_key_with_click_events
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useKeyWithMouseEvents" => self
+                .use_key_with_mouse_events
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useMediaCaption" => self
+                .use_media_caption
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useValidAnchor" => self
+                .use_valid_anchor
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useValidAriaProps" => self
+                .use_valid_aria_props
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useValidAriaRole" => self
+                .use_valid_aria_role
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useValidAriaValues" => self
+                .use_valid_aria_values
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useValidLang" => self
+                .use_valid_lang
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
             _ => None,
         }
     }
@@ -993,79 +1086,81 @@ pub struct Complexity {
     pub all: Option<bool>,
     #[doc = "Disallow primitive type aliases and misleading types."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_banned_types: Option<RuleConfiguration>,
+    pub no_banned_types: Option<RuleConfiguration<NoBannedTypes>>,
     #[doc = "Disallow functions that exceed a given Cognitive Complexity score."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_excessive_cognitive_complexity: Option<RuleConfiguration>,
+    pub no_excessive_cognitive_complexity:
+        Option<RuleConfiguration<NoExcessiveCognitiveComplexity>>,
     #[doc = "Disallow unnecessary boolean casts"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_extra_boolean_cast: Option<RuleConfiguration>,
+    pub no_extra_boolean_cast: Option<RuleConfiguration<NoExtraBooleanCast>>,
     #[doc = "Prefer for...of statement instead of Array.forEach."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_for_each: Option<RuleConfiguration>,
+    pub no_for_each: Option<RuleConfiguration<NoForEach>>,
     #[doc = "Disallow unclear usage of consecutive space characters in regular expression literals"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_multiple_spaces_in_regular_expression_literals: Option<RuleConfiguration>,
+    pub no_multiple_spaces_in_regular_expression_literals:
+        Option<RuleConfiguration<NoMultipleSpacesInRegularExpressionLiterals>>,
     #[doc = "This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_static_only_class: Option<RuleConfiguration>,
+    pub no_static_only_class: Option<RuleConfiguration<NoStaticOnlyClass>>,
     #[doc = "Disallow this and super in static contexts."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_this_in_static: Option<RuleConfiguration>,
+    pub no_this_in_static: Option<RuleConfiguration<NoThisInStatic>>,
     #[doc = "Disallow unnecessary catch clauses."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_catch: Option<RuleConfiguration>,
+    pub no_useless_catch: Option<RuleConfiguration<NoUselessCatch>>,
     #[doc = "Disallow unnecessary constructors."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_constructor: Option<RuleConfiguration>,
+    pub no_useless_constructor: Option<RuleConfiguration<NoUselessConstructor>>,
     #[doc = "Disallow empty exports that don't change anything in a module file."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_empty_export: Option<RuleConfiguration>,
+    pub no_useless_empty_export: Option<RuleConfiguration<NoUselessEmptyExport>>,
     #[doc = "Disallow unnecessary fragments"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_fragments: Option<RuleConfiguration>,
+    pub no_useless_fragments: Option<RuleConfiguration<NoUselessFragments>>,
     #[doc = "Disallow unnecessary labels."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_label: Option<RuleConfiguration>,
+    pub no_useless_label: Option<RuleConfiguration<NoUselessLabel>>,
     #[doc = "Disallow renaming import, export, and destructured assignments to the same name."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_rename: Option<RuleConfiguration>,
+    pub no_useless_rename: Option<RuleConfiguration<NoUselessRename>>,
     #[doc = "Disallow useless case in switch statements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_switch_case: Option<RuleConfiguration>,
+    pub no_useless_switch_case: Option<RuleConfiguration<NoUselessSwitchCase>>,
     #[doc = "Disallow useless this aliasing."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_this_alias: Option<RuleConfiguration>,
+    pub no_useless_this_alias: Option<RuleConfiguration<NoUselessThisAlias>>,
     #[doc = "Disallow using any or unknown as type constraint."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_type_constraint: Option<RuleConfiguration>,
+    pub no_useless_type_constraint: Option<RuleConfiguration<NoUselessTypeConstraint>>,
     #[doc = "Disallow the use of void operators, which is not a familiar operator."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_void: Option<RuleConfiguration>,
+    pub no_void: Option<RuleConfiguration<NoVoid>>,
     #[doc = "Disallow with statements in non-strict contexts."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_with: Option<RuleConfiguration>,
+    pub no_with: Option<RuleConfiguration<NoWith>>,
     #[doc = "Use arrow functions over function expressions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_arrow_function: Option<RuleConfiguration>,
+    pub use_arrow_function: Option<RuleConfiguration<UseArrowFunction>>,
     #[doc = "Promotes the use of .flatMap() when map().flat() are used together."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_flat_map: Option<RuleConfiguration>,
+    pub use_flat_map: Option<RuleConfiguration<UseFlatMap>>,
     #[doc = "Enforce the usage of a literal access to properties over computed property access."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_literal_keys: Option<RuleConfiguration>,
+    pub use_literal_keys: Option<RuleConfiguration<UseLiteralKeys>>,
     #[doc = "Enforce using concise optional chain instead of chained logical expressions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_optional_chain: Option<RuleConfiguration>,
+    pub use_optional_chain: Option<RuleConfiguration<UseOptionalChain>>,
     #[doc = "Enforce the use of the regular expression literals instead of the RegExp constructor if possible."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_regex_literals: Option<RuleConfiguration>,
+    pub use_regex_literals: Option<RuleConfiguration<UseRegexLiterals>>,
     #[doc = "Disallow number literal object member names which are not base10 or uses underscore as separator"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_simple_number_keys: Option<RuleConfiguration>,
+    pub use_simple_number_keys: Option<RuleConfiguration<UseSimpleNumberKeys>>,
     #[doc = "Discard redundant terms from logical expressions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_simplified_logic_expression: Option<RuleConfiguration>,
+    pub use_simplified_logic_expression: Option<RuleConfiguration<UseSimplifiedLogicExpression>>,
 }
 impl DeserializableValidator for Complexity {
     fn validate(
@@ -1494,35 +1589,111 @@ impl Complexity {
             disabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(&self, rule_name: &str) -> Option<&RuleConfiguration> {
+    pub(crate) fn get_rule_configuration(
+        &self,
+        rule_name: &str,
+    ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
         match rule_name {
-            "noBannedTypes" => self.no_banned_types.as_ref(),
-            "noExcessiveCognitiveComplexity" => self.no_excessive_cognitive_complexity.as_ref(),
-            "noExtraBooleanCast" => self.no_extra_boolean_cast.as_ref(),
-            "noForEach" => self.no_for_each.as_ref(),
+            "noBannedTypes" => self
+                .no_banned_types
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noExcessiveCognitiveComplexity" => self
+                .no_excessive_cognitive_complexity
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noExtraBooleanCast" => self
+                .no_extra_boolean_cast
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noForEach" => self
+                .no_for_each
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
             "noMultipleSpacesInRegularExpressionLiterals" => self
                 .no_multiple_spaces_in_regular_expression_literals
-                .as_ref(),
-            "noStaticOnlyClass" => self.no_static_only_class.as_ref(),
-            "noThisInStatic" => self.no_this_in_static.as_ref(),
-            "noUselessCatch" => self.no_useless_catch.as_ref(),
-            "noUselessConstructor" => self.no_useless_constructor.as_ref(),
-            "noUselessEmptyExport" => self.no_useless_empty_export.as_ref(),
-            "noUselessFragments" => self.no_useless_fragments.as_ref(),
-            "noUselessLabel" => self.no_useless_label.as_ref(),
-            "noUselessRename" => self.no_useless_rename.as_ref(),
-            "noUselessSwitchCase" => self.no_useless_switch_case.as_ref(),
-            "noUselessThisAlias" => self.no_useless_this_alias.as_ref(),
-            "noUselessTypeConstraint" => self.no_useless_type_constraint.as_ref(),
-            "noVoid" => self.no_void.as_ref(),
-            "noWith" => self.no_with.as_ref(),
-            "useArrowFunction" => self.use_arrow_function.as_ref(),
-            "useFlatMap" => self.use_flat_map.as_ref(),
-            "useLiteralKeys" => self.use_literal_keys.as_ref(),
-            "useOptionalChain" => self.use_optional_chain.as_ref(),
-            "useRegexLiterals" => self.use_regex_literals.as_ref(),
-            "useSimpleNumberKeys" => self.use_simple_number_keys.as_ref(),
-            "useSimplifiedLogicExpression" => self.use_simplified_logic_expression.as_ref(),
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noStaticOnlyClass" => self
+                .no_static_only_class
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noThisInStatic" => self
+                .no_this_in_static
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUselessCatch" => self
+                .no_useless_catch
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUselessConstructor" => self
+                .no_useless_constructor
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUselessEmptyExport" => self
+                .no_useless_empty_export
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUselessFragments" => self
+                .no_useless_fragments
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUselessLabel" => self
+                .no_useless_label
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUselessRename" => self
+                .no_useless_rename
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUselessSwitchCase" => self
+                .no_useless_switch_case
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUselessThisAlias" => self
+                .no_useless_this_alias
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUselessTypeConstraint" => self
+                .no_useless_type_constraint
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noVoid" => self
+                .no_void
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noWith" => self
+                .no_with
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useArrowFunction" => self
+                .use_arrow_function
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useFlatMap" => self
+                .use_flat_map
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useLiteralKeys" => self
+                .use_literal_keys
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useOptionalChain" => self
+                .use_optional_chain
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useRegexLiterals" => self
+                .use_regex_literals
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useSimpleNumberKeys" => self
+                .use_simple_number_keys
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useSimplifiedLogicExpression" => self
+                .use_simplified_logic_expression
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
             _ => None,
         }
     }
@@ -1541,103 +1712,103 @@ pub struct Correctness {
     pub all: Option<bool>,
     #[doc = "Prevent passing of children as props."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_children_prop: Option<RuleConfiguration>,
+    pub no_children_prop: Option<RuleConfiguration<NoChildrenProp>>,
     #[doc = "Prevents from having const variables being re-assigned."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_const_assign: Option<RuleConfiguration>,
+    pub no_const_assign: Option<RuleConfiguration<NoConstAssign>>,
     #[doc = "Disallow constant expressions in conditions"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_constant_condition: Option<RuleConfiguration>,
+    pub no_constant_condition: Option<RuleConfiguration<NoConstantCondition>>,
     #[doc = "Disallow returning a value from a constructor."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_constructor_return: Option<RuleConfiguration>,
+    pub no_constructor_return: Option<RuleConfiguration<NoConstructorReturn>>,
     #[doc = "Disallow empty character classes in regular expression literals."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_empty_character_class_in_regex: Option<RuleConfiguration>,
+    pub no_empty_character_class_in_regex: Option<RuleConfiguration<NoEmptyCharacterClassInRegex>>,
     #[doc = "Disallows empty destructuring patterns."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_empty_pattern: Option<RuleConfiguration>,
+    pub no_empty_pattern: Option<RuleConfiguration<NoEmptyPattern>>,
     #[doc = "Disallow calling global object properties as functions"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_global_object_calls: Option<RuleConfiguration>,
+    pub no_global_object_calls: Option<RuleConfiguration<NoGlobalObjectCalls>>,
     #[doc = "Disallow function and var declarations that are accessible outside their block."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_inner_declarations: Option<RuleConfiguration>,
+    pub no_inner_declarations: Option<RuleConfiguration<NoInnerDeclarations>>,
     #[doc = "Prevents the incorrect use of super() inside classes. It also checks whether a call super() is missing from classes that extends other constructors."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_invalid_constructor_super: Option<RuleConfiguration>,
+    pub no_invalid_constructor_super: Option<RuleConfiguration<NoInvalidConstructorSuper>>,
     #[doc = "Disallow new operators with global non-constructor functions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_invalid_new_builtin: Option<RuleConfiguration>,
+    pub no_invalid_new_builtin: Option<RuleConfiguration<NoInvalidNewBuiltin>>,
     #[doc = "Disallow new operators with the Symbol object."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_new_symbol: Option<RuleConfiguration>,
+    pub no_new_symbol: Option<RuleConfiguration<NoNewSymbol>>,
     #[doc = "Disallow \\8 and \\9 escape sequences in string literals."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_nonoctal_decimal_escape: Option<RuleConfiguration>,
+    pub no_nonoctal_decimal_escape: Option<RuleConfiguration<NoNonoctalDecimalEscape>>,
     #[doc = "Disallow literal numbers that lose precision"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_precision_loss: Option<RuleConfiguration>,
+    pub no_precision_loss: Option<RuleConfiguration<NoPrecisionLoss>>,
     #[doc = "Prevent the usage of the return value of React.render."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_render_return_value: Option<RuleConfiguration>,
+    pub no_render_return_value: Option<RuleConfiguration<NoRenderReturnValue>>,
     #[doc = "Disallow assignments where both sides are exactly the same."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_self_assign: Option<RuleConfiguration>,
+    pub no_self_assign: Option<RuleConfiguration<NoSelfAssign>>,
     #[doc = "Disallow returning a value from a setter"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_setter_return: Option<RuleConfiguration>,
+    pub no_setter_return: Option<RuleConfiguration<NoSetterReturn>>,
     #[doc = "Disallow comparison of expressions modifying the string case with non-compliant value."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_string_case_mismatch: Option<RuleConfiguration>,
+    pub no_string_case_mismatch: Option<RuleConfiguration<NoStringCaseMismatch>>,
     #[doc = "Disallow lexical declarations in switch clauses."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_switch_declarations: Option<RuleConfiguration>,
+    pub no_switch_declarations: Option<RuleConfiguration<NoSwitchDeclarations>>,
     #[doc = "Prevents the usage of variables that haven't been declared inside the document."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_undeclared_variables: Option<RuleConfiguration>,
+    pub no_undeclared_variables: Option<RuleConfiguration<NoUndeclaredVariables>>,
     #[doc = "Avoid using unnecessary continue."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unnecessary_continue: Option<RuleConfiguration>,
+    pub no_unnecessary_continue: Option<RuleConfiguration<NoUnnecessaryContinue>>,
     #[doc = "Disallow unreachable code"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unreachable: Option<RuleConfiguration>,
+    pub no_unreachable: Option<RuleConfiguration<NoUnreachable>>,
     #[doc = "Ensures the super() constructor is called exactly once on every code  path in a class constructor before this is accessed if the class has a superclass"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unreachable_super: Option<RuleConfiguration>,
+    pub no_unreachable_super: Option<RuleConfiguration<NoUnreachableSuper>>,
     #[doc = "Disallow control flow statements in finally blocks."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unsafe_finally: Option<RuleConfiguration>,
+    pub no_unsafe_finally: Option<RuleConfiguration<NoUnsafeFinally>>,
     #[doc = "Disallow the use of optional chaining in contexts where the undefined value is not allowed."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unsafe_optional_chaining: Option<RuleConfiguration>,
+    pub no_unsafe_optional_chaining: Option<RuleConfiguration<NoUnsafeOptionalChaining>>,
     #[doc = "Disallow unused labels."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unused_labels: Option<RuleConfiguration>,
+    pub no_unused_labels: Option<RuleConfiguration<NoUnusedLabels>>,
     #[doc = "Disallow unused variables."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unused_variables: Option<RuleConfiguration>,
+    pub no_unused_variables: Option<RuleConfiguration<NoUnusedVariables>>,
     #[doc = "This rules prevents void elements (AKA self-closing elements) from having children."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_void_elements_with_children: Option<RuleConfiguration>,
+    pub no_void_elements_with_children: Option<RuleConfiguration<NoVoidElementsWithChildren>>,
     #[doc = "Disallow returning a value from a function with the return type 'void'"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_void_type_return: Option<RuleConfiguration>,
+    pub no_void_type_return: Option<RuleConfiguration<NoVoidTypeReturn>>,
     #[doc = "Enforce all dependencies are correctly specified in a React hook."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_exhaustive_dependencies: Option<RuleConfiguration>,
+    pub use_exhaustive_dependencies: Option<RuleConfiguration<UseExhaustiveDependencies>>,
     #[doc = "Enforce that all React hooks are being called from the Top Level component functions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_hook_at_top_level: Option<RuleConfiguration>,
+    pub use_hook_at_top_level: Option<RuleConfiguration<UseHookAtTopLevel>>,
     #[doc = "Require calls to isNaN() when checking for NaN."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_is_nan: Option<RuleConfiguration>,
+    pub use_is_nan: Option<RuleConfiguration<UseIsNan>>,
     #[doc = "Enforce \"for\" loop update clause moving the counter in the right direction."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_valid_for_direction: Option<RuleConfiguration>,
+    pub use_valid_for_direction: Option<RuleConfiguration<UseValidForDirection>>,
     #[doc = "Require generator functions to contain yield."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_yield: Option<RuleConfiguration>,
+    pub use_yield: Option<RuleConfiguration<UseYield>>,
 }
 impl DeserializableValidator for Correctness {
     fn validate(
@@ -2170,41 +2341,143 @@ impl Correctness {
             disabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(&self, rule_name: &str) -> Option<&RuleConfiguration> {
+    pub(crate) fn get_rule_configuration(
+        &self,
+        rule_name: &str,
+    ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
         match rule_name {
-            "noChildrenProp" => self.no_children_prop.as_ref(),
-            "noConstAssign" => self.no_const_assign.as_ref(),
-            "noConstantCondition" => self.no_constant_condition.as_ref(),
-            "noConstructorReturn" => self.no_constructor_return.as_ref(),
-            "noEmptyCharacterClassInRegex" => self.no_empty_character_class_in_regex.as_ref(),
-            "noEmptyPattern" => self.no_empty_pattern.as_ref(),
-            "noGlobalObjectCalls" => self.no_global_object_calls.as_ref(),
-            "noInnerDeclarations" => self.no_inner_declarations.as_ref(),
-            "noInvalidConstructorSuper" => self.no_invalid_constructor_super.as_ref(),
-            "noInvalidNewBuiltin" => self.no_invalid_new_builtin.as_ref(),
-            "noNewSymbol" => self.no_new_symbol.as_ref(),
-            "noNonoctalDecimalEscape" => self.no_nonoctal_decimal_escape.as_ref(),
-            "noPrecisionLoss" => self.no_precision_loss.as_ref(),
-            "noRenderReturnValue" => self.no_render_return_value.as_ref(),
-            "noSelfAssign" => self.no_self_assign.as_ref(),
-            "noSetterReturn" => self.no_setter_return.as_ref(),
-            "noStringCaseMismatch" => self.no_string_case_mismatch.as_ref(),
-            "noSwitchDeclarations" => self.no_switch_declarations.as_ref(),
-            "noUndeclaredVariables" => self.no_undeclared_variables.as_ref(),
-            "noUnnecessaryContinue" => self.no_unnecessary_continue.as_ref(),
-            "noUnreachable" => self.no_unreachable.as_ref(),
-            "noUnreachableSuper" => self.no_unreachable_super.as_ref(),
-            "noUnsafeFinally" => self.no_unsafe_finally.as_ref(),
-            "noUnsafeOptionalChaining" => self.no_unsafe_optional_chaining.as_ref(),
-            "noUnusedLabels" => self.no_unused_labels.as_ref(),
-            "noUnusedVariables" => self.no_unused_variables.as_ref(),
-            "noVoidElementsWithChildren" => self.no_void_elements_with_children.as_ref(),
-            "noVoidTypeReturn" => self.no_void_type_return.as_ref(),
-            "useExhaustiveDependencies" => self.use_exhaustive_dependencies.as_ref(),
-            "useHookAtTopLevel" => self.use_hook_at_top_level.as_ref(),
-            "useIsNan" => self.use_is_nan.as_ref(),
-            "useValidForDirection" => self.use_valid_for_direction.as_ref(),
-            "useYield" => self.use_yield.as_ref(),
+            "noChildrenProp" => self
+                .no_children_prop
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noConstAssign" => self
+                .no_const_assign
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noConstantCondition" => self
+                .no_constant_condition
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noConstructorReturn" => self
+                .no_constructor_return
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noEmptyCharacterClassInRegex" => self
+                .no_empty_character_class_in_regex
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noEmptyPattern" => self
+                .no_empty_pattern
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noGlobalObjectCalls" => self
+                .no_global_object_calls
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noInnerDeclarations" => self
+                .no_inner_declarations
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noInvalidConstructorSuper" => self
+                .no_invalid_constructor_super
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noInvalidNewBuiltin" => self
+                .no_invalid_new_builtin
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noNewSymbol" => self
+                .no_new_symbol
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noNonoctalDecimalEscape" => self
+                .no_nonoctal_decimal_escape
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noPrecisionLoss" => self
+                .no_precision_loss
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noRenderReturnValue" => self
+                .no_render_return_value
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noSelfAssign" => self
+                .no_self_assign
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noSetterReturn" => self
+                .no_setter_return
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noStringCaseMismatch" => self
+                .no_string_case_mismatch
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noSwitchDeclarations" => self
+                .no_switch_declarations
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUndeclaredVariables" => self
+                .no_undeclared_variables
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUnnecessaryContinue" => self
+                .no_unnecessary_continue
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUnreachable" => self
+                .no_unreachable
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUnreachableSuper" => self
+                .no_unreachable_super
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUnsafeFinally" => self
+                .no_unsafe_finally
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUnsafeOptionalChaining" => self
+                .no_unsafe_optional_chaining
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUnusedLabels" => self
+                .no_unused_labels
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUnusedVariables" => self
+                .no_unused_variables
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noVoidElementsWithChildren" => self
+                .no_void_elements_with_children
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noVoidTypeReturn" => self
+                .no_void_type_return
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useExhaustiveDependencies" => self
+                .use_exhaustive_dependencies
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useHookAtTopLevel" => self
+                .use_hook_at_top_level
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useIsNan" => self
+                .use_is_nan
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useValidForDirection" => self
+                .use_valid_for_direction
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useYield" => self
+                .use_yield
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
             _ => None,
         }
     }
@@ -2223,103 +2496,103 @@ pub struct Nursery {
     pub all: Option<bool>,
     #[doc = "Disallow the use of console."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_console: Option<RuleConfiguration>,
+    pub no_console: Option<RuleConfiguration<NoConsole>>,
     #[doc = "Disallow two keys with the same name inside a JSON object."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_duplicate_json_keys: Option<RuleConfiguration>,
+    pub no_duplicate_json_keys: Option<RuleConfiguration<NoDuplicateJsonKeys>>,
     #[doc = "Disallow empty block statements and static blocks."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_empty_block_statements: Option<RuleConfiguration>,
+    pub no_empty_block_statements: Option<RuleConfiguration<NoEmptyBlockStatements>>,
     #[doc = "Disallow empty type parameters in type aliases and interfaces."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_empty_type_parameters: Option<RuleConfiguration>,
+    pub no_empty_type_parameters: Option<RuleConfiguration<NoEmptyTypeParameters>>,
     #[doc = "Disallow focused tests."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_focused_tests: Option<RuleConfiguration>,
+    pub no_focused_tests: Option<RuleConfiguration<NoFocusedTests>>,
     #[doc = "Disallow assignments to native objects and read-only global variables."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_global_assign: Option<RuleConfiguration>,
+    pub no_global_assign: Option<RuleConfiguration<NoGlobalAssign>>,
     #[doc = "Disallow the use of global eval()."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_global_eval: Option<RuleConfiguration>,
+    pub no_global_eval: Option<RuleConfiguration<NoGlobalEval>>,
     #[doc = "Disallow the use of variables and function parameters before their declaration"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_invalid_use_before_declaration: Option<RuleConfiguration>,
+    pub no_invalid_use_before_declaration: Option<RuleConfiguration<NoInvalidUseBeforeDeclaration>>,
     #[doc = "Disallow characters made with multiple code points in character class syntax."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_misleading_character_class: Option<RuleConfiguration>,
+    pub no_misleading_character_class: Option<RuleConfiguration<NoMisleadingCharacterClass>>,
     #[doc = "Disallow the use of namespace imports."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_namespace_import: Option<RuleConfiguration>,
+    pub no_namespace_import: Option<RuleConfiguration<NoNamespaceImport>>,
     #[doc = "Forbid the use of Node.js builtin modules."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_nodejs_modules: Option<RuleConfiguration>,
+    pub no_nodejs_modules: Option<RuleConfiguration<NoNodejsModules>>,
     #[doc = "Avoid re-export all."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_re_export_all: Option<RuleConfiguration>,
+    pub no_re_export_all: Option<RuleConfiguration<NoReExportAll>>,
     #[doc = "Disallow specified modules when loaded by import or require."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_restricted_imports: Option<RuleConfiguration>,
+    pub no_restricted_imports: Option<RuleConfiguration<NoRestrictedImports>>,
     #[doc = "Disallow disabled tests."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_skipped_tests: Option<RuleConfiguration>,
+    pub no_skipped_tests: Option<RuleConfiguration<NoSkippedTests>>,
     #[doc = "Disallow then property."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_then_property: Option<RuleConfiguration>,
+    pub no_then_property: Option<RuleConfiguration<NoThenProperty>>,
     #[doc = "Disallow the use of dependencies that aren't specified in the package.json."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_undeclared_dependencies: Option<RuleConfiguration>,
+    pub no_undeclared_dependencies: Option<RuleConfiguration<NoUndeclaredDependencies>>,
     #[doc = "Disallow unused imports."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unused_imports: Option<RuleConfiguration>,
+    pub no_unused_imports: Option<RuleConfiguration<NoUnusedImports>>,
     #[doc = "Disallow unused private class members"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unused_private_class_members: Option<RuleConfiguration>,
+    pub no_unused_private_class_members: Option<RuleConfiguration<NoUnusedPrivateClassMembers>>,
     #[doc = "Disallow unnecessary nested block statements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_lone_block_statements: Option<RuleConfiguration>,
+    pub no_useless_lone_block_statements: Option<RuleConfiguration<NoUselessLoneBlockStatements>>,
     #[doc = "Disallow ternary operators when simpler alternatives exist."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_ternary: Option<RuleConfiguration>,
+    pub no_useless_ternary: Option<RuleConfiguration<NoUselessTernary>>,
     #[doc = "Ensure async functions utilize await."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_await: Option<RuleConfiguration>,
+    pub use_await: Option<RuleConfiguration<UseAwait>>,
     #[doc = "Require consistently using either T[] or Array<T>"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_consistent_array_type: Option<RuleConfiguration>,
+    pub use_consistent_array_type: Option<RuleConfiguration<UseConsistentArrayType>>,
     #[doc = "Promotes the use of export type for types."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_export_type: Option<RuleConfiguration>,
+    pub use_export_type: Option<RuleConfiguration<UseExportType>>,
     #[doc = "Enforce naming conventions for JavaScript and TypeScript filenames."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_filenaming_convention: Option<RuleConfiguration>,
+    pub use_filenaming_convention: Option<RuleConfiguration<UseFilenamingConvention>>,
     #[doc = "This rule recommends a for-of loop when in a for loop, the index used to extract an item from the iterated array."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_for_of: Option<RuleConfiguration>,
+    pub use_for_of: Option<RuleConfiguration<UseForOf>>,
     #[doc = "Enforce the use of import type when an import only has specifiers with type qualifier."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_grouped_type_import: Option<RuleConfiguration>,
+    pub use_grouped_type_import: Option<RuleConfiguration<UseGroupedTypeImport>>,
     #[doc = "Disallows package private imports."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_import_restrictions: Option<RuleConfiguration>,
+    pub use_import_restrictions: Option<RuleConfiguration<UseImportRestrictions>>,
     #[doc = "Promotes the use of import type for types."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_import_type: Option<RuleConfiguration>,
+    pub use_import_type: Option<RuleConfiguration<UseImportType>>,
     #[doc = "Promotes the usage of node:assert/strict over node:assert."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_node_assert_strict: Option<RuleConfiguration>,
+    pub use_node_assert_strict: Option<RuleConfiguration<UseNodeAssertStrict>>,
     #[doc = "Enforces using the node: protocol for Node.js builtin modules."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_nodejs_import_protocol: Option<RuleConfiguration>,
+    pub use_nodejs_import_protocol: Option<RuleConfiguration<UseNodejsImportProtocol>>,
     #[doc = "Use the Number properties instead of global ones."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_number_namespace: Option<RuleConfiguration>,
+    pub use_number_namespace: Option<RuleConfiguration<UseNumberNamespace>>,
     #[doc = "Enforce using function types instead of object type with call signatures."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_shorthand_function_type: Option<RuleConfiguration>,
+    pub use_shorthand_function_type: Option<RuleConfiguration<UseShorthandFunctionType>>,
     #[doc = "Enforce the sorting of CSS utility classes."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_sorted_classes: Option<RuleConfiguration>,
+    pub use_sorted_classes: Option<RuleConfiguration<UseSortedClasses>>,
 }
 impl DeserializableValidator for Nursery {
     fn validate(
@@ -2818,41 +3091,143 @@ impl Nursery {
             disabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(&self, rule_name: &str) -> Option<&RuleConfiguration> {
+    pub(crate) fn get_rule_configuration(
+        &self,
+        rule_name: &str,
+    ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
         match rule_name {
-            "noConsole" => self.no_console.as_ref(),
-            "noDuplicateJsonKeys" => self.no_duplicate_json_keys.as_ref(),
-            "noEmptyBlockStatements" => self.no_empty_block_statements.as_ref(),
-            "noEmptyTypeParameters" => self.no_empty_type_parameters.as_ref(),
-            "noFocusedTests" => self.no_focused_tests.as_ref(),
-            "noGlobalAssign" => self.no_global_assign.as_ref(),
-            "noGlobalEval" => self.no_global_eval.as_ref(),
-            "noInvalidUseBeforeDeclaration" => self.no_invalid_use_before_declaration.as_ref(),
-            "noMisleadingCharacterClass" => self.no_misleading_character_class.as_ref(),
-            "noNamespaceImport" => self.no_namespace_import.as_ref(),
-            "noNodejsModules" => self.no_nodejs_modules.as_ref(),
-            "noReExportAll" => self.no_re_export_all.as_ref(),
-            "noRestrictedImports" => self.no_restricted_imports.as_ref(),
-            "noSkippedTests" => self.no_skipped_tests.as_ref(),
-            "noThenProperty" => self.no_then_property.as_ref(),
-            "noUndeclaredDependencies" => self.no_undeclared_dependencies.as_ref(),
-            "noUnusedImports" => self.no_unused_imports.as_ref(),
-            "noUnusedPrivateClassMembers" => self.no_unused_private_class_members.as_ref(),
-            "noUselessLoneBlockStatements" => self.no_useless_lone_block_statements.as_ref(),
-            "noUselessTernary" => self.no_useless_ternary.as_ref(),
-            "useAwait" => self.use_await.as_ref(),
-            "useConsistentArrayType" => self.use_consistent_array_type.as_ref(),
-            "useExportType" => self.use_export_type.as_ref(),
-            "useFilenamingConvention" => self.use_filenaming_convention.as_ref(),
-            "useForOf" => self.use_for_of.as_ref(),
-            "useGroupedTypeImport" => self.use_grouped_type_import.as_ref(),
-            "useImportRestrictions" => self.use_import_restrictions.as_ref(),
-            "useImportType" => self.use_import_type.as_ref(),
-            "useNodeAssertStrict" => self.use_node_assert_strict.as_ref(),
-            "useNodejsImportProtocol" => self.use_nodejs_import_protocol.as_ref(),
-            "useNumberNamespace" => self.use_number_namespace.as_ref(),
-            "useShorthandFunctionType" => self.use_shorthand_function_type.as_ref(),
-            "useSortedClasses" => self.use_sorted_classes.as_ref(),
+            "noConsole" => self
+                .no_console
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDuplicateJsonKeys" => self
+                .no_duplicate_json_keys
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noEmptyBlockStatements" => self
+                .no_empty_block_statements
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noEmptyTypeParameters" => self
+                .no_empty_type_parameters
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noFocusedTests" => self
+                .no_focused_tests
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noGlobalAssign" => self
+                .no_global_assign
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noGlobalEval" => self
+                .no_global_eval
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noInvalidUseBeforeDeclaration" => self
+                .no_invalid_use_before_declaration
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noMisleadingCharacterClass" => self
+                .no_misleading_character_class
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noNamespaceImport" => self
+                .no_namespace_import
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noNodejsModules" => self
+                .no_nodejs_modules
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noReExportAll" => self
+                .no_re_export_all
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noRestrictedImports" => self
+                .no_restricted_imports
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noSkippedTests" => self
+                .no_skipped_tests
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noThenProperty" => self
+                .no_then_property
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUndeclaredDependencies" => self
+                .no_undeclared_dependencies
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUnusedImports" => self
+                .no_unused_imports
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUnusedPrivateClassMembers" => self
+                .no_unused_private_class_members
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUselessLoneBlockStatements" => self
+                .no_useless_lone_block_statements
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUselessTernary" => self
+                .no_useless_ternary
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useAwait" => self
+                .use_await
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useConsistentArrayType" => self
+                .use_consistent_array_type
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useExportType" => self
+                .use_export_type
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useFilenamingConvention" => self
+                .use_filenaming_convention
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useForOf" => self
+                .use_for_of
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useGroupedTypeImport" => self
+                .use_grouped_type_import
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useImportRestrictions" => self
+                .use_import_restrictions
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useImportType" => self
+                .use_import_type
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useNodeAssertStrict" => self
+                .use_node_assert_strict
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useNodejsImportProtocol" => self
+                .use_nodejs_import_protocol
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useNumberNamespace" => self
+                .use_number_namespace
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useShorthandFunctionType" => self
+                .use_shorthand_function_type
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useSortedClasses" => self
+                .use_sorted_classes
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
             _ => None,
         }
     }
@@ -2871,10 +3246,10 @@ pub struct Performance {
     pub all: Option<bool>,
     #[doc = "Disallow the use of spread (...) syntax on accumulators."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_accumulating_spread: Option<RuleConfiguration>,
+    pub no_accumulating_spread: Option<RuleConfiguration<NoAccumulatingSpread>>,
     #[doc = "Disallow the use of the delete operator."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_delete: Option<RuleConfiguration>,
+    pub no_delete: Option<RuleConfiguration<NoDelete>>,
 }
 impl DeserializableValidator for Performance {
     fn validate(
@@ -2975,10 +3350,19 @@ impl Performance {
             disabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(&self, rule_name: &str) -> Option<&RuleConfiguration> {
+    pub(crate) fn get_rule_configuration(
+        &self,
+        rule_name: &str,
+    ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
         match rule_name {
-            "noAccumulatingSpread" => self.no_accumulating_spread.as_ref(),
-            "noDelete" => self.no_delete.as_ref(),
+            "noAccumulatingSpread" => self
+                .no_accumulating_spread
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDelete" => self
+                .no_delete
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
             _ => None,
         }
     }
@@ -2997,10 +3381,11 @@ pub struct Security {
     pub all: Option<bool>,
     #[doc = "Prevent the usage of dangerous JSX props"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_dangerously_set_inner_html: Option<RuleConfiguration>,
+    pub no_dangerously_set_inner_html: Option<RuleConfiguration<NoDangerouslySetInnerHtml>>,
     #[doc = "Report when a DOM element or a component uses both children and dangerouslySetInnerHTML prop."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_dangerously_set_inner_html_with_children: Option<RuleConfiguration>,
+    pub no_dangerously_set_inner_html_with_children:
+        Option<RuleConfiguration<NoDangerouslySetInnerHtmlWithChildren>>,
 }
 impl DeserializableValidator for Security {
     fn validate(
@@ -3107,12 +3492,19 @@ impl Security {
             disabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(&self, rule_name: &str) -> Option<&RuleConfiguration> {
+    pub(crate) fn get_rule_configuration(
+        &self,
+        rule_name: &str,
+    ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
         match rule_name {
-            "noDangerouslySetInnerHtml" => self.no_dangerously_set_inner_html.as_ref(),
-            "noDangerouslySetInnerHtmlWithChildren" => {
-                self.no_dangerously_set_inner_html_with_children.as_ref()
-            }
+            "noDangerouslySetInnerHtml" => self
+                .no_dangerously_set_inner_html
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDangerouslySetInnerHtmlWithChildren" => self
+                .no_dangerously_set_inner_html_with_children
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
             _ => None,
         }
     }
@@ -3131,103 +3523,103 @@ pub struct Style {
     pub all: Option<bool>,
     #[doc = "Disallow the use of arguments."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_arguments: Option<RuleConfiguration>,
+    pub no_arguments: Option<RuleConfiguration<NoArguments>>,
     #[doc = "Disallow comma operator."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_comma_operator: Option<RuleConfiguration>,
+    pub no_comma_operator: Option<RuleConfiguration<NoCommaOperator>>,
     #[doc = "Disallow default exports."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_default_export: Option<RuleConfiguration>,
+    pub no_default_export: Option<RuleConfiguration<NoDefaultExport>>,
     #[doc = "Disallow implicit true values on JSX boolean attributes"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_implicit_boolean: Option<RuleConfiguration>,
+    pub no_implicit_boolean: Option<RuleConfiguration<NoImplicitBoolean>>,
     #[doc = "Disallow type annotations for variables, parameters, and class properties initialized with a literal expression."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_inferrable_types: Option<RuleConfiguration>,
+    pub no_inferrable_types: Option<RuleConfiguration<NoInferrableTypes>>,
     #[doc = "Disallow the use of TypeScript's namespaces."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_namespace: Option<RuleConfiguration>,
+    pub no_namespace: Option<RuleConfiguration<NoNamespace>>,
     #[doc = "Disallow negation in the condition of an if statement if it has an else clause."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_negation_else: Option<RuleConfiguration>,
+    pub no_negation_else: Option<RuleConfiguration<NoNegationElse>>,
     #[doc = "Disallow non-null assertions using the ! postfix operator."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_non_null_assertion: Option<RuleConfiguration>,
+    pub no_non_null_assertion: Option<RuleConfiguration<NoNonNullAssertion>>,
     #[doc = "Disallow reassigning function parameters."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_parameter_assign: Option<RuleConfiguration>,
+    pub no_parameter_assign: Option<RuleConfiguration<NoParameterAssign>>,
     #[doc = "Disallow the use of parameter properties in class constructors."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_parameter_properties: Option<RuleConfiguration>,
+    pub no_parameter_properties: Option<RuleConfiguration<NoParameterProperties>>,
     #[doc = "This rule allows you to specify global variable names that you don’t want to use in your application."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_restricted_globals: Option<RuleConfiguration>,
+    pub no_restricted_globals: Option<RuleConfiguration<NoRestrictedGlobals>>,
     #[doc = "Disallow the use of constants which its value is the upper-case version of its name."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_shouty_constants: Option<RuleConfiguration>,
+    pub no_shouty_constants: Option<RuleConfiguration<NoShoutyConstants>>,
     #[doc = "Disallow template literals if interpolation and special-character handling are not needed"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unused_template_literal: Option<RuleConfiguration>,
+    pub no_unused_template_literal: Option<RuleConfiguration<NoUnusedTemplateLiteral>>,
     #[doc = "Disallow else block when the if block breaks early."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_else: Option<RuleConfiguration>,
+    pub no_useless_else: Option<RuleConfiguration<NoUselessElse>>,
     #[doc = "Disallow the use of var"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_var: Option<RuleConfiguration>,
+    pub no_var: Option<RuleConfiguration<NoVar>>,
     #[doc = "Enforce the use of as const over literal type and type annotation."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_as_const_assertion: Option<RuleConfiguration>,
+    pub use_as_const_assertion: Option<RuleConfiguration<UseAsConstAssertion>>,
     #[doc = "Requires following curly brace conventions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_block_statements: Option<RuleConfiguration>,
+    pub use_block_statements: Option<RuleConfiguration<UseBlockStatements>>,
     #[doc = "Enforce using else if instead of nested if in else clauses."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_collapsed_else_if: Option<RuleConfiguration>,
+    pub use_collapsed_else_if: Option<RuleConfiguration<UseCollapsedElseIf>>,
     #[doc = "Require const declarations for variables that are never reassigned after declared."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_const: Option<RuleConfiguration>,
+    pub use_const: Option<RuleConfiguration<UseConst>>,
     #[doc = "Enforce default function parameters and optional function parameters to be last."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_default_parameter_last: Option<RuleConfiguration>,
+    pub use_default_parameter_last: Option<RuleConfiguration<UseDefaultParameterLast>>,
     #[doc = "Require that each enum member value be explicitly initialized."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_enum_initializers: Option<RuleConfiguration>,
+    pub use_enum_initializers: Option<RuleConfiguration<UseEnumInitializers>>,
     #[doc = "Disallow the use of Math.pow in favor of the ** operator."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_exponentiation_operator: Option<RuleConfiguration>,
+    pub use_exponentiation_operator: Option<RuleConfiguration<UseExponentiationOperator>>,
     #[doc = "This rule enforces the use of <>...</> over <Fragment>...</Fragment>."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_fragment_syntax: Option<RuleConfiguration>,
+    pub use_fragment_syntax: Option<RuleConfiguration<UseFragmentSyntax>>,
     #[doc = "Require all enum members to be literal values."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_literal_enum_members: Option<RuleConfiguration>,
+    pub use_literal_enum_members: Option<RuleConfiguration<UseLiteralEnumMembers>>,
     #[doc = "Enforce naming conventions for everything across a codebase."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_naming_convention: Option<RuleConfiguration>,
+    pub use_naming_convention: Option<RuleConfiguration<UseNamingConvention>>,
     #[doc = "Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_numeric_literals: Option<RuleConfiguration>,
+    pub use_numeric_literals: Option<RuleConfiguration<UseNumericLiterals>>,
     #[doc = "Prevent extra closing tags for components without children"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_self_closing_elements: Option<RuleConfiguration>,
+    pub use_self_closing_elements: Option<RuleConfiguration<UseSelfClosingElements>>,
     #[doc = "When expressing array types, this rule promotes the usage of T[] shorthand instead of Array<T>."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_shorthand_array_type: Option<RuleConfiguration>,
+    pub use_shorthand_array_type: Option<RuleConfiguration<UseShorthandArrayType>>,
     #[doc = "Require assignment operator shorthand where possible."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_shorthand_assign: Option<RuleConfiguration>,
+    pub use_shorthand_assign: Option<RuleConfiguration<UseShorthandAssign>>,
     #[doc = "Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_single_case_statement: Option<RuleConfiguration>,
+    pub use_single_case_statement: Option<RuleConfiguration<UseSingleCaseStatement>>,
     #[doc = "Disallow multiple variable declarations in the same variable statement"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_single_var_declarator: Option<RuleConfiguration>,
+    pub use_single_var_declarator: Option<RuleConfiguration<UseSingleVarDeclarator>>,
     #[doc = "Prefer template literals over string concatenation."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_template: Option<RuleConfiguration>,
+    pub use_template: Option<RuleConfiguration<UseTemplate>>,
     #[doc = "Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_while: Option<RuleConfiguration>,
+    pub use_while: Option<RuleConfiguration<UseWhile>>,
 }
 impl DeserializableValidator for Style {
     fn validate(
@@ -3740,41 +4132,143 @@ impl Style {
             disabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(&self, rule_name: &str) -> Option<&RuleConfiguration> {
+    pub(crate) fn get_rule_configuration(
+        &self,
+        rule_name: &str,
+    ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
         match rule_name {
-            "noArguments" => self.no_arguments.as_ref(),
-            "noCommaOperator" => self.no_comma_operator.as_ref(),
-            "noDefaultExport" => self.no_default_export.as_ref(),
-            "noImplicitBoolean" => self.no_implicit_boolean.as_ref(),
-            "noInferrableTypes" => self.no_inferrable_types.as_ref(),
-            "noNamespace" => self.no_namespace.as_ref(),
-            "noNegationElse" => self.no_negation_else.as_ref(),
-            "noNonNullAssertion" => self.no_non_null_assertion.as_ref(),
-            "noParameterAssign" => self.no_parameter_assign.as_ref(),
-            "noParameterProperties" => self.no_parameter_properties.as_ref(),
-            "noRestrictedGlobals" => self.no_restricted_globals.as_ref(),
-            "noShoutyConstants" => self.no_shouty_constants.as_ref(),
-            "noUnusedTemplateLiteral" => self.no_unused_template_literal.as_ref(),
-            "noUselessElse" => self.no_useless_else.as_ref(),
-            "noVar" => self.no_var.as_ref(),
-            "useAsConstAssertion" => self.use_as_const_assertion.as_ref(),
-            "useBlockStatements" => self.use_block_statements.as_ref(),
-            "useCollapsedElseIf" => self.use_collapsed_else_if.as_ref(),
-            "useConst" => self.use_const.as_ref(),
-            "useDefaultParameterLast" => self.use_default_parameter_last.as_ref(),
-            "useEnumInitializers" => self.use_enum_initializers.as_ref(),
-            "useExponentiationOperator" => self.use_exponentiation_operator.as_ref(),
-            "useFragmentSyntax" => self.use_fragment_syntax.as_ref(),
-            "useLiteralEnumMembers" => self.use_literal_enum_members.as_ref(),
-            "useNamingConvention" => self.use_naming_convention.as_ref(),
-            "useNumericLiterals" => self.use_numeric_literals.as_ref(),
-            "useSelfClosingElements" => self.use_self_closing_elements.as_ref(),
-            "useShorthandArrayType" => self.use_shorthand_array_type.as_ref(),
-            "useShorthandAssign" => self.use_shorthand_assign.as_ref(),
-            "useSingleCaseStatement" => self.use_single_case_statement.as_ref(),
-            "useSingleVarDeclarator" => self.use_single_var_declarator.as_ref(),
-            "useTemplate" => self.use_template.as_ref(),
-            "useWhile" => self.use_while.as_ref(),
+            "noArguments" => self
+                .no_arguments
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noCommaOperator" => self
+                .no_comma_operator
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDefaultExport" => self
+                .no_default_export
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noImplicitBoolean" => self
+                .no_implicit_boolean
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noInferrableTypes" => self
+                .no_inferrable_types
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noNamespace" => self
+                .no_namespace
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noNegationElse" => self
+                .no_negation_else
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noNonNullAssertion" => self
+                .no_non_null_assertion
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noParameterAssign" => self
+                .no_parameter_assign
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noParameterProperties" => self
+                .no_parameter_properties
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noRestrictedGlobals" => self
+                .no_restricted_globals
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noShoutyConstants" => self
+                .no_shouty_constants
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUnusedTemplateLiteral" => self
+                .no_unused_template_literal
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUselessElse" => self
+                .no_useless_else
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noVar" => self
+                .no_var
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useAsConstAssertion" => self
+                .use_as_const_assertion
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useBlockStatements" => self
+                .use_block_statements
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useCollapsedElseIf" => self
+                .use_collapsed_else_if
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useConst" => self
+                .use_const
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useDefaultParameterLast" => self
+                .use_default_parameter_last
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useEnumInitializers" => self
+                .use_enum_initializers
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useExponentiationOperator" => self
+                .use_exponentiation_operator
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useFragmentSyntax" => self
+                .use_fragment_syntax
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useLiteralEnumMembers" => self
+                .use_literal_enum_members
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useNamingConvention" => self
+                .use_naming_convention
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useNumericLiterals" => self
+                .use_numeric_literals
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useSelfClosingElements" => self
+                .use_self_closing_elements
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useShorthandArrayType" => self
+                .use_shorthand_array_type
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useShorthandAssign" => self
+                .use_shorthand_assign
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useSingleCaseStatement" => self
+                .use_single_case_statement
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useSingleVarDeclarator" => self
+                .use_single_var_declarator
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useTemplate" => self
+                .use_template
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useWhile" => self
+                .use_while
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
             _ => None,
         }
     }
@@ -3793,139 +4287,141 @@ pub struct Suspicious {
     pub all: Option<bool>,
     #[doc = "Use standard constants instead of approximated literals."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_approximative_numeric_constant: Option<RuleConfiguration>,
+    pub no_approximative_numeric_constant:
+        Option<RuleConfiguration<NoApproximativeNumericConstant>>,
     #[doc = "Discourage the usage of Array index in keys."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_array_index_key: Option<RuleConfiguration>,
+    pub no_array_index_key: Option<RuleConfiguration<NoArrayIndexKey>>,
     #[doc = "Disallow assignments in expressions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_assign_in_expressions: Option<RuleConfiguration>,
+    pub no_assign_in_expressions: Option<RuleConfiguration<NoAssignInExpressions>>,
     #[doc = "Disallows using an async function as a Promise executor."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_async_promise_executor: Option<RuleConfiguration>,
+    pub no_async_promise_executor: Option<RuleConfiguration<NoAsyncPromiseExecutor>>,
     #[doc = "Disallow reassigning exceptions in catch clauses."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_catch_assign: Option<RuleConfiguration>,
+    pub no_catch_assign: Option<RuleConfiguration<NoCatchAssign>>,
     #[doc = "Disallow reassigning class members."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_class_assign: Option<RuleConfiguration>,
+    pub no_class_assign: Option<RuleConfiguration<NoClassAssign>>,
     #[doc = "Prevent comments from being inserted as text nodes"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_comment_text: Option<RuleConfiguration>,
+    pub no_comment_text: Option<RuleConfiguration<NoCommentText>>,
     #[doc = "Disallow comparing against -0"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_compare_neg_zero: Option<RuleConfiguration>,
+    pub no_compare_neg_zero: Option<RuleConfiguration<NoCompareNegZero>>,
     #[doc = "Disallow labeled statements that are not loops."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_confusing_labels: Option<RuleConfiguration>,
+    pub no_confusing_labels: Option<RuleConfiguration<NoConfusingLabels>>,
     #[doc = "Disallow void type outside of generic or return types."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_confusing_void_type: Option<RuleConfiguration>,
+    pub no_confusing_void_type: Option<RuleConfiguration<NoConfusingVoidType>>,
     #[doc = "Disallow the use of console.log"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_console_log: Option<RuleConfiguration>,
+    pub no_console_log: Option<RuleConfiguration<NoConsoleLog>>,
     #[doc = "Disallow TypeScript const enum"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_const_enum: Option<RuleConfiguration>,
+    pub no_const_enum: Option<RuleConfiguration<NoConstEnum>>,
     #[doc = "Prevents from having control characters and some escape sequences that match control characters in regular expressions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_control_characters_in_regex: Option<RuleConfiguration>,
+    pub no_control_characters_in_regex: Option<RuleConfiguration<NoControlCharactersInRegex>>,
     #[doc = "Disallow the use of debugger"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_debugger: Option<RuleConfiguration>,
+    pub no_debugger: Option<RuleConfiguration<NoDebugger>>,
     #[doc = "Require the use of === and !=="]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_double_equals: Option<RuleConfiguration>,
+    pub no_double_equals: Option<RuleConfiguration<NoDoubleEquals>>,
     #[doc = "Disallow duplicate case labels."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_duplicate_case: Option<RuleConfiguration>,
+    pub no_duplicate_case: Option<RuleConfiguration<NoDuplicateCase>>,
     #[doc = "Disallow duplicate class members."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_duplicate_class_members: Option<RuleConfiguration>,
+    pub no_duplicate_class_members: Option<RuleConfiguration<NoDuplicateClassMembers>>,
     #[doc = "Prevents JSX properties to be assigned multiple times."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_duplicate_jsx_props: Option<RuleConfiguration>,
+    pub no_duplicate_jsx_props: Option<RuleConfiguration<NoDuplicateJsxProps>>,
     #[doc = "Prevents object literals having more than one property declaration for the same name."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_duplicate_object_keys: Option<RuleConfiguration>,
+    pub no_duplicate_object_keys: Option<RuleConfiguration<NoDuplicateObjectKeys>>,
     #[doc = "Disallow duplicate function parameter name."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_duplicate_parameters: Option<RuleConfiguration>,
+    pub no_duplicate_parameters: Option<RuleConfiguration<NoDuplicateParameters>>,
     #[doc = "Disallow the declaration of empty interfaces."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_empty_interface: Option<RuleConfiguration>,
+    pub no_empty_interface: Option<RuleConfiguration<NoEmptyInterface>>,
     #[doc = "Disallow the any type usage."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_explicit_any: Option<RuleConfiguration>,
+    pub no_explicit_any: Option<RuleConfiguration<NoExplicitAny>>,
     #[doc = "Prevents the wrong usage of the non-null assertion operator (!) in TypeScript files."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_extra_non_null_assertion: Option<RuleConfiguration>,
+    pub no_extra_non_null_assertion: Option<RuleConfiguration<NoExtraNonNullAssertion>>,
     #[doc = "Disallow fallthrough of switch clauses."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_fallthrough_switch_clause: Option<RuleConfiguration>,
+    pub no_fallthrough_switch_clause: Option<RuleConfiguration<NoFallthroughSwitchClause>>,
     #[doc = "Disallow reassigning function declarations."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_function_assign: Option<RuleConfiguration>,
+    pub no_function_assign: Option<RuleConfiguration<NoFunctionAssign>>,
     #[doc = "Use Number.isFinite instead of global isFinite."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_global_is_finite: Option<RuleConfiguration>,
+    pub no_global_is_finite: Option<RuleConfiguration<NoGlobalIsFinite>>,
     #[doc = "Use Number.isNaN instead of global isNaN."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_global_is_nan: Option<RuleConfiguration>,
+    pub no_global_is_nan: Option<RuleConfiguration<NoGlobalIsNan>>,
     #[doc = "Disallow use of implicit any type on variable declarations."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_implicit_any_let: Option<RuleConfiguration>,
+    pub no_implicit_any_let: Option<RuleConfiguration<NoImplicitAnyLet>>,
     #[doc = "Disallow assigning to imported bindings"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_import_assign: Option<RuleConfiguration>,
+    pub no_import_assign: Option<RuleConfiguration<NoImportAssign>>,
     #[doc = "Disallow labels that share a name with a variable"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_label_var: Option<RuleConfiguration>,
+    pub no_label_var: Option<RuleConfiguration<NoLabelVar>>,
     #[doc = "Enforce proper usage of new and constructor."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_misleading_instantiator: Option<RuleConfiguration>,
+    pub no_misleading_instantiator: Option<RuleConfiguration<NoMisleadingInstantiator>>,
     #[doc = "Disallow shorthand assign when variable appears on both sides."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_misrefactored_shorthand_assign: Option<RuleConfiguration>,
+    pub no_misrefactored_shorthand_assign:
+        Option<RuleConfiguration<NoMisrefactoredShorthandAssign>>,
     #[doc = "Disallow direct use of Object.prototype builtins."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_prototype_builtins: Option<RuleConfiguration>,
+    pub no_prototype_builtins: Option<RuleConfiguration<NoPrototypeBuiltins>>,
     #[doc = "Disallow variable, function, class, and type redeclarations in the same scope."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_redeclare: Option<RuleConfiguration>,
+    pub no_redeclare: Option<RuleConfiguration<NoRedeclare>>,
     #[doc = "Prevents from having redundant \"use strict\"."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_redundant_use_strict: Option<RuleConfiguration>,
+    pub no_redundant_use_strict: Option<RuleConfiguration<NoRedundantUseStrict>>,
     #[doc = "Disallow comparisons where both sides are exactly the same."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_self_compare: Option<RuleConfiguration>,
+    pub no_self_compare: Option<RuleConfiguration<NoSelfCompare>>,
     #[doc = "Disallow identifiers from shadowing restricted names."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_shadow_restricted_names: Option<RuleConfiguration>,
+    pub no_shadow_restricted_names: Option<RuleConfiguration<NoShadowRestrictedNames>>,
     #[doc = "Disallow sparse arrays"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_sparse_array: Option<RuleConfiguration>,
+    pub no_sparse_array: Option<RuleConfiguration<NoSparseArray>>,
     #[doc = "Disallow unsafe declaration merging between interfaces and classes."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unsafe_declaration_merging: Option<RuleConfiguration>,
+    pub no_unsafe_declaration_merging: Option<RuleConfiguration<NoUnsafeDeclarationMerging>>,
     #[doc = "Disallow using unsafe negation."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unsafe_negation: Option<RuleConfiguration>,
+    pub no_unsafe_negation: Option<RuleConfiguration<NoUnsafeNegation>>,
     #[doc = "Enforce default clauses in switch statements to be last"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_default_switch_clause_last: Option<RuleConfiguration>,
+    pub use_default_switch_clause_last: Option<RuleConfiguration<UseDefaultSwitchClauseLast>>,
     #[doc = "Enforce get methods to always return a value."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_getter_return: Option<RuleConfiguration>,
+    pub use_getter_return: Option<RuleConfiguration<UseGetterReturn>>,
     #[doc = "Use Array.isArray() instead of instanceof Array."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_is_array: Option<RuleConfiguration>,
+    pub use_is_array: Option<RuleConfiguration<UseIsArray>>,
     #[doc = "Require using the namespace keyword over the module keyword to declare TypeScript namespaces."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_namespace_keyword: Option<RuleConfiguration>,
+    pub use_namespace_keyword: Option<RuleConfiguration<UseNamespaceKeyword>>,
     #[doc = "This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_valid_typeof: Option<RuleConfiguration>,
+    pub use_valid_typeof: Option<RuleConfiguration<UseValidTypeof>>,
 }
 impl DeserializableValidator for Suspicious {
     fn validate(
@@ -4628,53 +5124,191 @@ impl Suspicious {
             disabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(&self, rule_name: &str) -> Option<&RuleConfiguration> {
+    pub(crate) fn get_rule_configuration(
+        &self,
+        rule_name: &str,
+    ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
         match rule_name {
-            "noApproximativeNumericConstant" => self.no_approximative_numeric_constant.as_ref(),
-            "noArrayIndexKey" => self.no_array_index_key.as_ref(),
-            "noAssignInExpressions" => self.no_assign_in_expressions.as_ref(),
-            "noAsyncPromiseExecutor" => self.no_async_promise_executor.as_ref(),
-            "noCatchAssign" => self.no_catch_assign.as_ref(),
-            "noClassAssign" => self.no_class_assign.as_ref(),
-            "noCommentText" => self.no_comment_text.as_ref(),
-            "noCompareNegZero" => self.no_compare_neg_zero.as_ref(),
-            "noConfusingLabels" => self.no_confusing_labels.as_ref(),
-            "noConfusingVoidType" => self.no_confusing_void_type.as_ref(),
-            "noConsoleLog" => self.no_console_log.as_ref(),
-            "noConstEnum" => self.no_const_enum.as_ref(),
-            "noControlCharactersInRegex" => self.no_control_characters_in_regex.as_ref(),
-            "noDebugger" => self.no_debugger.as_ref(),
-            "noDoubleEquals" => self.no_double_equals.as_ref(),
-            "noDuplicateCase" => self.no_duplicate_case.as_ref(),
-            "noDuplicateClassMembers" => self.no_duplicate_class_members.as_ref(),
-            "noDuplicateJsxProps" => self.no_duplicate_jsx_props.as_ref(),
-            "noDuplicateObjectKeys" => self.no_duplicate_object_keys.as_ref(),
-            "noDuplicateParameters" => self.no_duplicate_parameters.as_ref(),
-            "noEmptyInterface" => self.no_empty_interface.as_ref(),
-            "noExplicitAny" => self.no_explicit_any.as_ref(),
-            "noExtraNonNullAssertion" => self.no_extra_non_null_assertion.as_ref(),
-            "noFallthroughSwitchClause" => self.no_fallthrough_switch_clause.as_ref(),
-            "noFunctionAssign" => self.no_function_assign.as_ref(),
-            "noGlobalIsFinite" => self.no_global_is_finite.as_ref(),
-            "noGlobalIsNan" => self.no_global_is_nan.as_ref(),
-            "noImplicitAnyLet" => self.no_implicit_any_let.as_ref(),
-            "noImportAssign" => self.no_import_assign.as_ref(),
-            "noLabelVar" => self.no_label_var.as_ref(),
-            "noMisleadingInstantiator" => self.no_misleading_instantiator.as_ref(),
-            "noMisrefactoredShorthandAssign" => self.no_misrefactored_shorthand_assign.as_ref(),
-            "noPrototypeBuiltins" => self.no_prototype_builtins.as_ref(),
-            "noRedeclare" => self.no_redeclare.as_ref(),
-            "noRedundantUseStrict" => self.no_redundant_use_strict.as_ref(),
-            "noSelfCompare" => self.no_self_compare.as_ref(),
-            "noShadowRestrictedNames" => self.no_shadow_restricted_names.as_ref(),
-            "noSparseArray" => self.no_sparse_array.as_ref(),
-            "noUnsafeDeclarationMerging" => self.no_unsafe_declaration_merging.as_ref(),
-            "noUnsafeNegation" => self.no_unsafe_negation.as_ref(),
-            "useDefaultSwitchClauseLast" => self.use_default_switch_clause_last.as_ref(),
-            "useGetterReturn" => self.use_getter_return.as_ref(),
-            "useIsArray" => self.use_is_array.as_ref(),
-            "useNamespaceKeyword" => self.use_namespace_keyword.as_ref(),
-            "useValidTypeof" => self.use_valid_typeof.as_ref(),
+            "noApproximativeNumericConstant" => self
+                .no_approximative_numeric_constant
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noArrayIndexKey" => self
+                .no_array_index_key
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noAssignInExpressions" => self
+                .no_assign_in_expressions
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noAsyncPromiseExecutor" => self
+                .no_async_promise_executor
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noCatchAssign" => self
+                .no_catch_assign
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noClassAssign" => self
+                .no_class_assign
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noCommentText" => self
+                .no_comment_text
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noCompareNegZero" => self
+                .no_compare_neg_zero
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noConfusingLabels" => self
+                .no_confusing_labels
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noConfusingVoidType" => self
+                .no_confusing_void_type
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noConsoleLog" => self
+                .no_console_log
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noConstEnum" => self
+                .no_const_enum
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noControlCharactersInRegex" => self
+                .no_control_characters_in_regex
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDebugger" => self
+                .no_debugger
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDoubleEquals" => self
+                .no_double_equals
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDuplicateCase" => self
+                .no_duplicate_case
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDuplicateClassMembers" => self
+                .no_duplicate_class_members
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDuplicateJsxProps" => self
+                .no_duplicate_jsx_props
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDuplicateObjectKeys" => self
+                .no_duplicate_object_keys
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDuplicateParameters" => self
+                .no_duplicate_parameters
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noEmptyInterface" => self
+                .no_empty_interface
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noExplicitAny" => self
+                .no_explicit_any
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noExtraNonNullAssertion" => self
+                .no_extra_non_null_assertion
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noFallthroughSwitchClause" => self
+                .no_fallthrough_switch_clause
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noFunctionAssign" => self
+                .no_function_assign
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noGlobalIsFinite" => self
+                .no_global_is_finite
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noGlobalIsNan" => self
+                .no_global_is_nan
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noImplicitAnyLet" => self
+                .no_implicit_any_let
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noImportAssign" => self
+                .no_import_assign
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noLabelVar" => self
+                .no_label_var
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noMisleadingInstantiator" => self
+                .no_misleading_instantiator
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noMisrefactoredShorthandAssign" => self
+                .no_misrefactored_shorthand_assign
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noPrototypeBuiltins" => self
+                .no_prototype_builtins
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noRedeclare" => self
+                .no_redeclare
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noRedundantUseStrict" => self
+                .no_redundant_use_strict
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noSelfCompare" => self
+                .no_self_compare
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noShadowRestrictedNames" => self
+                .no_shadow_restricted_names
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noSparseArray" => self
+                .no_sparse_array
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUnsafeDeclarationMerging" => self
+                .no_unsafe_declaration_merging
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noUnsafeNegation" => self
+                .no_unsafe_negation
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useDefaultSwitchClauseLast" => self
+                .use_default_switch_clause_last
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useGetterReturn" => self
+                .use_getter_return
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useIsArray" => self
+                .use_is_array
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useNamespaceKeyword" => self
+                .use_namespace_keyword
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useValidTypeof" => self
+                .use_valid_typeof
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
             _ => None,
         }
     }

--- a/crates/biome_service/src/configuration/parse/json/linter.rs
+++ b/crates/biome_service/src/configuration/parse/json/linter.rs
@@ -1,0 +1,160 @@
+use std::marker::PhantomData;
+
+use crate::configuration::linter::{RulePlainConfiguration, RuleWithOptions};
+use crate::configuration::LinterConfiguration;
+use crate::RuleConfiguration;
+use biome_deserialize::{
+    Deserializable, DeserializableValue, DeserializationDiagnostic, DeserializationVisitor, Text,
+    VisitableType,
+};
+use biome_rowan::TextRange;
+
+impl Deserializable for LinterConfiguration {
+    fn deserialize(
+        value: &impl DeserializableValue,
+        name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self> {
+        value.deserialize(LinterConfigurationVisitor, name, diagnostics)
+    }
+}
+
+struct LinterConfigurationVisitor;
+impl DeserializationVisitor for LinterConfigurationVisitor {
+    type Output = LinterConfiguration;
+
+    const EXPECTED_TYPE: VisitableType = VisitableType::MAP;
+
+    fn visit_map(
+        self,
+        members: impl Iterator<Item = Option<(impl DeserializableValue, impl DeserializableValue)>>,
+        _range: biome_rowan::TextRange,
+        _name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self::Output> {
+        const ALLOWED_KEYS: &[&str] = &["enabled", "rules", "include", "ignore"];
+        let mut result = Self::Output::default();
+        for (key, value) in members.flatten() {
+            let Some(key_text) = Text::deserialize(&key, "", diagnostics) else {
+                continue;
+            };
+            match key_text.text() {
+                "ignore" => {
+                    result.ignore = Deserializable::deserialize(&value, &key_text, diagnostics);
+                }
+                "include" => {
+                    result.include = Deserializable::deserialize(&value, &key_text, diagnostics);
+                }
+                "enabled" => {
+                    result.enabled = Deserializable::deserialize(&value, &key_text, diagnostics);
+                }
+                "rules" => {
+                    result.rules = Deserializable::deserialize(&value, &key_text, diagnostics);
+                }
+                unknown_key => diagnostics.push(DeserializationDiagnostic::new_unknown_key(
+                    unknown_key,
+                    key.range(),
+                    ALLOWED_KEYS,
+                )),
+            }
+        }
+        Some(result)
+    }
+}
+
+impl<T: Deserializable + Default> Deserializable for RuleConfiguration<T> {
+    fn deserialize(
+        value: &impl DeserializableValue,
+        rule_name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self> {
+        value.deserialize(
+            RuleConfigurationVisitor(PhantomData),
+            rule_name,
+            diagnostics,
+        )
+    }
+}
+
+struct RuleConfigurationVisitor<T>(PhantomData<T>);
+impl<T: Deserializable + Default> DeserializationVisitor for RuleConfigurationVisitor<T> {
+    type Output = RuleConfiguration<T>;
+
+    const EXPECTED_TYPE: VisitableType = VisitableType::STR.union(VisitableType::MAP);
+
+    fn visit_str(
+        self,
+        value: Text,
+        range: TextRange,
+        _rule_name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self::Output> {
+        RulePlainConfiguration::deserialize_from_str(value, range, diagnostics)
+            .map(RuleConfiguration::Plain)
+    }
+
+    fn visit_map(
+        self,
+        members: impl Iterator<Item = Option<(impl DeserializableValue, impl DeserializableValue)>>,
+        _range: biome_rowan::TextRange,
+        rule_name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self::Output> {
+        const ALLOWED_KEYS: &[&str] = &["level", "options"];
+        let mut result = RuleWithOptions::default();
+        for (key, value) in members.flatten() {
+            let Some(key_text) = Text::deserialize(&key, "", diagnostics) else {
+                continue;
+            };
+            match key_text.text() {
+                "level" => {
+                    result.level = Deserializable::deserialize(&value, &key_text, diagnostics)?;
+                }
+                "options" => {
+                    if let Some(options) =
+                        Deserializable::deserialize(&value, rule_name, diagnostics)
+                    {
+                        result.options = options;
+                    }
+                }
+                unknown_key => diagnostics.push(DeserializationDiagnostic::new_unknown_key(
+                    unknown_key,
+                    key.range(),
+                    ALLOWED_KEYS,
+                )),
+            }
+        }
+        Some(RuleConfiguration::WithOptions(result))
+    }
+}
+
+impl RulePlainConfiguration {
+    fn deserialize_from_str(
+        value: Text,
+        range: TextRange,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self> {
+        const ALLOWED_VARIANTS: &[&str] = &["error", "warn", "off"];
+        if let Ok(value) = value.text().parse::<Self>() {
+            Some(value)
+        } else {
+            diagnostics.push(DeserializationDiagnostic::new_unknown_value(
+                value.text(),
+                range,
+                ALLOWED_VARIANTS,
+            ));
+            None
+        }
+    }
+}
+
+impl Deserializable for RulePlainConfiguration {
+    fn deserialize(
+        value: &impl DeserializableValue,
+        name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self> {
+        let value_text = Text::deserialize(value, name, diagnostics)?;
+        Self::deserialize_from_str(value_text, value.range(), diagnostics)
+    }
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -475,59 +475,59 @@ export interface A11y {
 	/**
 	 * Enforce that the accessKey attribute is not used on any HTML element.
 	 */
-	noAccessKey?: RuleConfiguration;
+	noAccessKey?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce that aria-hidden="true" is not set on focusable elements.
 	 */
-	noAriaHiddenOnFocusable?: RuleConfiguration;
+	noAriaHiddenOnFocusable?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.
 	 */
-	noAriaUnsupportedElements?: RuleConfiguration;
+	noAriaUnsupportedElements?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce that autoFocus prop is not used on elements.
 	 */
-	noAutofocus?: RuleConfiguration;
+	noAutofocus?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow target="_blank" attribute without rel="noreferrer"
 	 */
-	noBlankTarget?: RuleConfiguration;
+	noBlankTarget?: RuleConfiguration_for_Null;
 	/**
 	 * Enforces that no distracting elements are used.
 	 */
-	noDistractingElements?: RuleConfiguration;
+	noDistractingElements?: RuleConfiguration_for_Null;
 	/**
 	 * The scope prop should be used only on <th> elements.
 	 */
-	noHeaderScope?: RuleConfiguration;
+	noHeaderScope?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements.
 	 */
-	noInteractiveElementToNoninteractiveRole?: RuleConfiguration;
+	noInteractiveElementToNoninteractiveRole?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.
 	 */
-	noNoninteractiveElementToInteractiveRole?: RuleConfiguration;
+	noNoninteractiveElementToInteractiveRole?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce that tabIndex is not assigned to non-interactive HTML elements.
 	 */
-	noNoninteractiveTabindex?: RuleConfiguration;
+	noNoninteractiveTabindex?: RuleConfiguration_for_Null;
 	/**
 	 * Prevent the usage of positive integers on tabIndex property
 	 */
-	noPositiveTabindex?: RuleConfiguration;
+	noPositiveTabindex?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce img alt prop does not contain the word "image", "picture", or "photo".
 	 */
-	noRedundantAlt?: RuleConfiguration;
+	noRedundantAlt?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce explicit role property is not the same as implicit/default role property on an element.
 	 */
-	noRedundantRoles?: RuleConfiguration;
+	noRedundantRoles?: RuleConfiguration_for_Null;
 	/**
 	 * Enforces the usage of the title element for the svg element.
 	 */
-	noSvgWithoutTitle?: RuleConfiguration;
+	noSvgWithoutTitle?: RuleConfiguration_for_Null;
 	/**
 	 * It enables the recommended rules for this group
 	 */
@@ -535,67 +535,67 @@ export interface A11y {
 	/**
 	 * Enforce that all elements that require alternative text have meaningful information to relay back to the end user.
 	 */
-	useAltText?: RuleConfiguration;
+	useAltText?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce that anchors have content and that the content is accessible to screen readers.
 	 */
-	useAnchorContent?: RuleConfiguration;
+	useAnchorContent?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce that tabIndex is assigned to non-interactive HTML elements with aria-activedescendant.
 	 */
-	useAriaActivedescendantWithTabindex?: RuleConfiguration;
+	useAriaActivedescendantWithTabindex?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce that elements with ARIA roles must have all required ARIA attributes for that role.
 	 */
-	useAriaPropsForRole?: RuleConfiguration;
+	useAriaPropsForRole?: RuleConfiguration_for_Null;
 	/**
 	 * Enforces the usage of the attribute type for the element button
 	 */
-	useButtonType?: RuleConfiguration;
+	useButtonType?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce that heading elements (h1, h2, etc.) have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the aria-hidden prop.
 	 */
-	useHeadingContent?: RuleConfiguration;
+	useHeadingContent?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce that html element has lang attribute.
 	 */
-	useHtmlLang?: RuleConfiguration;
+	useHtmlLang?: RuleConfiguration_for_Null;
 	/**
 	 * Enforces the usage of the attribute title for the element iframe.
 	 */
-	useIframeTitle?: RuleConfiguration;
+	useIframeTitle?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce onClick is accompanied by at least one of the following: onKeyUp, onKeyDown, onKeyPress.
 	 */
-	useKeyWithClickEvents?: RuleConfiguration;
+	useKeyWithClickEvents?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce onMouseOver / onMouseOut are accompanied by onFocus / onBlur.
 	 */
-	useKeyWithMouseEvents?: RuleConfiguration;
+	useKeyWithMouseEvents?: RuleConfiguration_for_Null;
 	/**
 	 * Enforces that audio and video elements must have a track for captions.
 	 */
-	useMediaCaption?: RuleConfiguration;
+	useMediaCaption?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce that all anchors are valid, and they are navigable elements.
 	 */
-	useValidAnchor?: RuleConfiguration;
+	useValidAnchor?: RuleConfiguration_for_Null;
 	/**
 	 * Ensures that ARIA properties aria-* are all valid.
 	 */
-	useValidAriaProps?: RuleConfiguration;
+	useValidAriaProps?: RuleConfiguration_for_Null;
 	/**
 	 * Elements with ARIA roles must use a valid, non-abstract ARIA role.
 	 */
-	useValidAriaRole?: RuleConfiguration;
+	useValidAriaRole?: RuleConfiguration_for_ValidAriaRoleOptions;
 	/**
 	 * Enforce that ARIA state and property values are valid.
 	 */
-	useValidAriaValues?: RuleConfiguration;
+	useValidAriaValues?: RuleConfiguration_for_Null;
 	/**
 	 * Ensure that the attribute passed to the lang attribute is a correct ISO language and/or country.
 	 */
-	useValidLang?: RuleConfiguration;
+	useValidLang?: RuleConfiguration_for_Null;
 }
 /**
  * A list of rules that belong to this group
@@ -608,75 +608,75 @@ export interface Complexity {
 	/**
 	 * Disallow primitive type aliases and misleading types.
 	 */
-	noBannedTypes?: RuleConfiguration;
+	noBannedTypes?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow functions that exceed a given Cognitive Complexity score.
 	 */
-	noExcessiveCognitiveComplexity?: RuleConfiguration;
+	noExcessiveCognitiveComplexity?: RuleConfiguration_for_ComplexityOptions;
 	/**
 	 * Disallow unnecessary boolean casts
 	 */
-	noExtraBooleanCast?: RuleConfiguration;
+	noExtraBooleanCast?: RuleConfiguration_for_Null;
 	/**
 	 * Prefer for...of statement instead of Array.forEach.
 	 */
-	noForEach?: RuleConfiguration;
+	noForEach?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow unclear usage of consecutive space characters in regular expression literals
 	 */
-	noMultipleSpacesInRegularExpressionLiterals?: RuleConfiguration;
+	noMultipleSpacesInRegularExpressionLiterals?: RuleConfiguration_for_Null;
 	/**
 	 * This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace.
 	 */
-	noStaticOnlyClass?: RuleConfiguration;
+	noStaticOnlyClass?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow this and super in static contexts.
 	 */
-	noThisInStatic?: RuleConfiguration;
+	noThisInStatic?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow unnecessary catch clauses.
 	 */
-	noUselessCatch?: RuleConfiguration;
+	noUselessCatch?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow unnecessary constructors.
 	 */
-	noUselessConstructor?: RuleConfiguration;
+	noUselessConstructor?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow empty exports that don't change anything in a module file.
 	 */
-	noUselessEmptyExport?: RuleConfiguration;
+	noUselessEmptyExport?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow unnecessary fragments
 	 */
-	noUselessFragments?: RuleConfiguration;
+	noUselessFragments?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow unnecessary labels.
 	 */
-	noUselessLabel?: RuleConfiguration;
+	noUselessLabel?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow renaming import, export, and destructured assignments to the same name.
 	 */
-	noUselessRename?: RuleConfiguration;
+	noUselessRename?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow useless case in switch statements.
 	 */
-	noUselessSwitchCase?: RuleConfiguration;
+	noUselessSwitchCase?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow useless this aliasing.
 	 */
-	noUselessThisAlias?: RuleConfiguration;
+	noUselessThisAlias?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow using any or unknown as type constraint.
 	 */
-	noUselessTypeConstraint?: RuleConfiguration;
+	noUselessTypeConstraint?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of void operators, which is not a familiar operator.
 	 */
-	noVoid?: RuleConfiguration;
+	noVoid?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow with statements in non-strict contexts.
 	 */
-	noWith?: RuleConfiguration;
+	noWith?: RuleConfiguration_for_Null;
 	/**
 	 * It enables the recommended rules for this group
 	 */
@@ -684,31 +684,31 @@ export interface Complexity {
 	/**
 	 * Use arrow functions over function expressions.
 	 */
-	useArrowFunction?: RuleConfiguration;
+	useArrowFunction?: RuleConfiguration_for_Null;
 	/**
 	 * Promotes the use of .flatMap() when map().flat() are used together.
 	 */
-	useFlatMap?: RuleConfiguration;
+	useFlatMap?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce the usage of a literal access to properties over computed property access.
 	 */
-	useLiteralKeys?: RuleConfiguration;
+	useLiteralKeys?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce using concise optional chain instead of chained logical expressions.
 	 */
-	useOptionalChain?: RuleConfiguration;
+	useOptionalChain?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce the use of the regular expression literals instead of the RegExp constructor if possible.
 	 */
-	useRegexLiterals?: RuleConfiguration;
+	useRegexLiterals?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow number literal object member names which are not base10 or uses underscore as separator
 	 */
-	useSimpleNumberKeys?: RuleConfiguration;
+	useSimpleNumberKeys?: RuleConfiguration_for_Null;
 	/**
 	 * Discard redundant terms from logical expressions.
 	 */
-	useSimplifiedLogicExpression?: RuleConfiguration;
+	useSimplifiedLogicExpression?: RuleConfiguration_for_Null;
 }
 /**
  * A list of rules that belong to this group
@@ -721,115 +721,115 @@ export interface Correctness {
 	/**
 	 * Prevent passing of children as props.
 	 */
-	noChildrenProp?: RuleConfiguration;
+	noChildrenProp?: RuleConfiguration_for_Null;
 	/**
 	 * Prevents from having const variables being re-assigned.
 	 */
-	noConstAssign?: RuleConfiguration;
+	noConstAssign?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow constant expressions in conditions
 	 */
-	noConstantCondition?: RuleConfiguration;
+	noConstantCondition?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow returning a value from a constructor.
 	 */
-	noConstructorReturn?: RuleConfiguration;
+	noConstructorReturn?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow empty character classes in regular expression literals.
 	 */
-	noEmptyCharacterClassInRegex?: RuleConfiguration;
+	noEmptyCharacterClassInRegex?: RuleConfiguration_for_Null;
 	/**
 	 * Disallows empty destructuring patterns.
 	 */
-	noEmptyPattern?: RuleConfiguration;
+	noEmptyPattern?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow calling global object properties as functions
 	 */
-	noGlobalObjectCalls?: RuleConfiguration;
+	noGlobalObjectCalls?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow function and var declarations that are accessible outside their block.
 	 */
-	noInnerDeclarations?: RuleConfiguration;
+	noInnerDeclarations?: RuleConfiguration_for_Null;
 	/**
 	 * Prevents the incorrect use of super() inside classes. It also checks whether a call super() is missing from classes that extends other constructors.
 	 */
-	noInvalidConstructorSuper?: RuleConfiguration;
+	noInvalidConstructorSuper?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow new operators with global non-constructor functions.
 	 */
-	noInvalidNewBuiltin?: RuleConfiguration;
+	noInvalidNewBuiltin?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow new operators with the Symbol object.
 	 */
-	noNewSymbol?: RuleConfiguration;
+	noNewSymbol?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow \8 and \9 escape sequences in string literals.
 	 */
-	noNonoctalDecimalEscape?: RuleConfiguration;
+	noNonoctalDecimalEscape?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow literal numbers that lose precision
 	 */
-	noPrecisionLoss?: RuleConfiguration;
+	noPrecisionLoss?: RuleConfiguration_for_Null;
 	/**
 	 * Prevent the usage of the return value of React.render.
 	 */
-	noRenderReturnValue?: RuleConfiguration;
+	noRenderReturnValue?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow assignments where both sides are exactly the same.
 	 */
-	noSelfAssign?: RuleConfiguration;
+	noSelfAssign?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow returning a value from a setter
 	 */
-	noSetterReturn?: RuleConfiguration;
+	noSetterReturn?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow comparison of expressions modifying the string case with non-compliant value.
 	 */
-	noStringCaseMismatch?: RuleConfiguration;
+	noStringCaseMismatch?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow lexical declarations in switch clauses.
 	 */
-	noSwitchDeclarations?: RuleConfiguration;
+	noSwitchDeclarations?: RuleConfiguration_for_Null;
 	/**
 	 * Prevents the usage of variables that haven't been declared inside the document.
 	 */
-	noUndeclaredVariables?: RuleConfiguration;
+	noUndeclaredVariables?: RuleConfiguration_for_Null;
 	/**
 	 * Avoid using unnecessary continue.
 	 */
-	noUnnecessaryContinue?: RuleConfiguration;
+	noUnnecessaryContinue?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow unreachable code
 	 */
-	noUnreachable?: RuleConfiguration;
+	noUnreachable?: RuleConfiguration_for_Null;
 	/**
 	 * Ensures the super() constructor is called exactly once on every code  path in a class constructor before this is accessed if the class has a superclass
 	 */
-	noUnreachableSuper?: RuleConfiguration;
+	noUnreachableSuper?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow control flow statements in finally blocks.
 	 */
-	noUnsafeFinally?: RuleConfiguration;
+	noUnsafeFinally?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of optional chaining in contexts where the undefined value is not allowed.
 	 */
-	noUnsafeOptionalChaining?: RuleConfiguration;
+	noUnsafeOptionalChaining?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow unused labels.
 	 */
-	noUnusedLabels?: RuleConfiguration;
+	noUnusedLabels?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow unused variables.
 	 */
-	noUnusedVariables?: RuleConfiguration;
+	noUnusedVariables?: RuleConfiguration_for_Null;
 	/**
 	 * This rules prevents void elements (AKA self-closing elements) from having children.
 	 */
-	noVoidElementsWithChildren?: RuleConfiguration;
+	noVoidElementsWithChildren?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow returning a value from a function with the return type 'void'
 	 */
-	noVoidTypeReturn?: RuleConfiguration;
+	noVoidTypeReturn?: RuleConfiguration_for_Null;
 	/**
 	 * It enables the recommended rules for this group
 	 */
@@ -837,23 +837,23 @@ export interface Correctness {
 	/**
 	 * Enforce all dependencies are correctly specified in a React hook.
 	 */
-	useExhaustiveDependencies?: RuleConfiguration;
+	useExhaustiveDependencies?: RuleConfiguration_for_HooksOptions;
 	/**
 	 * Enforce that all React hooks are being called from the Top Level component functions.
 	 */
-	useHookAtTopLevel?: RuleConfiguration;
+	useHookAtTopLevel?: RuleConfiguration_for_DeprecatedHooksOptions;
 	/**
 	 * Require calls to isNaN() when checking for NaN.
 	 */
-	useIsNan?: RuleConfiguration;
+	useIsNan?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce "for" loop update clause moving the counter in the right direction.
 	 */
-	useValidForDirection?: RuleConfiguration;
+	useValidForDirection?: RuleConfiguration_for_Null;
 	/**
 	 * Require generator functions to contain yield.
 	 */
-	useYield?: RuleConfiguration;
+	useYield?: RuleConfiguration_for_Null;
 }
 /**
  * A list of rules that belong to this group
@@ -866,83 +866,83 @@ export interface Nursery {
 	/**
 	 * Disallow the use of console.
 	 */
-	noConsole?: RuleConfiguration;
+	noConsole?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow two keys with the same name inside a JSON object.
 	 */
-	noDuplicateJsonKeys?: RuleConfiguration;
+	noDuplicateJsonKeys?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow empty block statements and static blocks.
 	 */
-	noEmptyBlockStatements?: RuleConfiguration;
+	noEmptyBlockStatements?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow empty type parameters in type aliases and interfaces.
 	 */
-	noEmptyTypeParameters?: RuleConfiguration;
+	noEmptyTypeParameters?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow focused tests.
 	 */
-	noFocusedTests?: RuleConfiguration;
+	noFocusedTests?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow assignments to native objects and read-only global variables.
 	 */
-	noGlobalAssign?: RuleConfiguration;
+	noGlobalAssign?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of global eval().
 	 */
-	noGlobalEval?: RuleConfiguration;
+	noGlobalEval?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of variables and function parameters before their declaration
 	 */
-	noInvalidUseBeforeDeclaration?: RuleConfiguration;
+	noInvalidUseBeforeDeclaration?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow characters made with multiple code points in character class syntax.
 	 */
-	noMisleadingCharacterClass?: RuleConfiguration;
+	noMisleadingCharacterClass?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of namespace imports.
 	 */
-	noNamespaceImport?: RuleConfiguration;
+	noNamespaceImport?: RuleConfiguration_for_Null;
 	/**
 	 * Forbid the use of Node.js builtin modules.
 	 */
-	noNodejsModules?: RuleConfiguration;
+	noNodejsModules?: RuleConfiguration_for_Null;
 	/**
 	 * Avoid re-export all.
 	 */
-	noReExportAll?: RuleConfiguration;
+	noReExportAll?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow specified modules when loaded by import or require.
 	 */
-	noRestrictedImports?: RuleConfiguration;
+	noRestrictedImports?: RuleConfiguration_for_RestrictedImportsOptions;
 	/**
 	 * Disallow disabled tests.
 	 */
-	noSkippedTests?: RuleConfiguration;
+	noSkippedTests?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow then property.
 	 */
-	noThenProperty?: RuleConfiguration;
+	noThenProperty?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of dependencies that aren't specified in the package.json.
 	 */
-	noUndeclaredDependencies?: RuleConfiguration;
+	noUndeclaredDependencies?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow unused imports.
 	 */
-	noUnusedImports?: RuleConfiguration;
+	noUnusedImports?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow unused private class members
 	 */
-	noUnusedPrivateClassMembers?: RuleConfiguration;
+	noUnusedPrivateClassMembers?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow unnecessary nested block statements.
 	 */
-	noUselessLoneBlockStatements?: RuleConfiguration;
+	noUselessLoneBlockStatements?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow ternary operators when simpler alternatives exist.
 	 */
-	noUselessTernary?: RuleConfiguration;
+	noUselessTernary?: RuleConfiguration_for_Null;
 	/**
 	 * It enables the recommended rules for this group
 	 */
@@ -950,55 +950,55 @@ export interface Nursery {
 	/**
 	 * Ensure async functions utilize await.
 	 */
-	useAwait?: RuleConfiguration;
+	useAwait?: RuleConfiguration_for_Null;
 	/**
 	 * Require consistently using either T[] or Array<T>
 	 */
-	useConsistentArrayType?: RuleConfiguration;
+	useConsistentArrayType?: RuleConfiguration_for_ConsistentArrayTypeOptions;
 	/**
 	 * Promotes the use of export type for types.
 	 */
-	useExportType?: RuleConfiguration;
+	useExportType?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce naming conventions for JavaScript and TypeScript filenames.
 	 */
-	useFilenamingConvention?: RuleConfiguration;
+	useFilenamingConvention?: RuleConfiguration_for_FilenamingConventionOptions;
 	/**
 	 * This rule recommends a for-of loop when in a for loop, the index used to extract an item from the iterated array.
 	 */
-	useForOf?: RuleConfiguration;
+	useForOf?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce the use of import type when an import only has specifiers with type qualifier.
 	 */
-	useGroupedTypeImport?: RuleConfiguration;
+	useGroupedTypeImport?: RuleConfiguration_for_Null;
 	/**
 	 * Disallows package private imports.
 	 */
-	useImportRestrictions?: RuleConfiguration;
+	useImportRestrictions?: RuleConfiguration_for_Null;
 	/**
 	 * Promotes the use of import type for types.
 	 */
-	useImportType?: RuleConfiguration;
+	useImportType?: RuleConfiguration_for_Null;
 	/**
 	 * Promotes the usage of node:assert/strict over node:assert.
 	 */
-	useNodeAssertStrict?: RuleConfiguration;
+	useNodeAssertStrict?: RuleConfiguration_for_Null;
 	/**
 	 * Enforces using the node: protocol for Node.js builtin modules.
 	 */
-	useNodejsImportProtocol?: RuleConfiguration;
+	useNodejsImportProtocol?: RuleConfiguration_for_Null;
 	/**
 	 * Use the Number properties instead of global ones.
 	 */
-	useNumberNamespace?: RuleConfiguration;
+	useNumberNamespace?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce using function types instead of object type with call signatures.
 	 */
-	useShorthandFunctionType?: RuleConfiguration;
+	useShorthandFunctionType?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce the sorting of CSS utility classes.
 	 */
-	useSortedClasses?: RuleConfiguration;
+	useSortedClasses?: RuleConfiguration_for_UtilityClassSortingOptions;
 }
 /**
  * A list of rules that belong to this group
@@ -1011,11 +1011,11 @@ export interface Performance {
 	/**
 	 * Disallow the use of spread (...) syntax on accumulators.
 	 */
-	noAccumulatingSpread?: RuleConfiguration;
+	noAccumulatingSpread?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of the delete operator.
 	 */
-	noDelete?: RuleConfiguration;
+	noDelete?: RuleConfiguration_for_Null;
 	/**
 	 * It enables the recommended rules for this group
 	 */
@@ -1032,11 +1032,11 @@ export interface Security {
 	/**
 	 * Prevent the usage of dangerous JSX props
 	 */
-	noDangerouslySetInnerHtml?: RuleConfiguration;
+	noDangerouslySetInnerHtml?: RuleConfiguration_for_Null;
 	/**
 	 * Report when a DOM element or a component uses both children and dangerouslySetInnerHTML prop.
 	 */
-	noDangerouslySetInnerHtmlWithChildren?: RuleConfiguration;
+	noDangerouslySetInnerHtmlWithChildren?: RuleConfiguration_for_Null;
 	/**
 	 * It enables the recommended rules for this group
 	 */
@@ -1053,63 +1053,63 @@ export interface Style {
 	/**
 	 * Disallow the use of arguments.
 	 */
-	noArguments?: RuleConfiguration;
+	noArguments?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow comma operator.
 	 */
-	noCommaOperator?: RuleConfiguration;
+	noCommaOperator?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow default exports.
 	 */
-	noDefaultExport?: RuleConfiguration;
+	noDefaultExport?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow implicit true values on JSX boolean attributes
 	 */
-	noImplicitBoolean?: RuleConfiguration;
+	noImplicitBoolean?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow type annotations for variables, parameters, and class properties initialized with a literal expression.
 	 */
-	noInferrableTypes?: RuleConfiguration;
+	noInferrableTypes?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of TypeScript's namespaces.
 	 */
-	noNamespace?: RuleConfiguration;
+	noNamespace?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow negation in the condition of an if statement if it has an else clause.
 	 */
-	noNegationElse?: RuleConfiguration;
+	noNegationElse?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow non-null assertions using the ! postfix operator.
 	 */
-	noNonNullAssertion?: RuleConfiguration;
+	noNonNullAssertion?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow reassigning function parameters.
 	 */
-	noParameterAssign?: RuleConfiguration;
+	noParameterAssign?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of parameter properties in class constructors.
 	 */
-	noParameterProperties?: RuleConfiguration;
+	noParameterProperties?: RuleConfiguration_for_Null;
 	/**
 	 * This rule allows you to specify global variable names that you don’t want to use in your application.
 	 */
-	noRestrictedGlobals?: RuleConfiguration;
+	noRestrictedGlobals?: RuleConfiguration_for_RestrictedGlobalsOptions;
 	/**
 	 * Disallow the use of constants which its value is the upper-case version of its name.
 	 */
-	noShoutyConstants?: RuleConfiguration;
+	noShoutyConstants?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow template literals if interpolation and special-character handling are not needed
 	 */
-	noUnusedTemplateLiteral?: RuleConfiguration;
+	noUnusedTemplateLiteral?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow else block when the if block breaks early.
 	 */
-	noUselessElse?: RuleConfiguration;
+	noUselessElse?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of var
 	 */
-	noVar?: RuleConfiguration;
+	noVar?: RuleConfiguration_for_Null;
 	/**
 	 * It enables the recommended rules for this group
 	 */
@@ -1117,75 +1117,75 @@ export interface Style {
 	/**
 	 * Enforce the use of as const over literal type and type annotation.
 	 */
-	useAsConstAssertion?: RuleConfiguration;
+	useAsConstAssertion?: RuleConfiguration_for_Null;
 	/**
 	 * Requires following curly brace conventions.
 	 */
-	useBlockStatements?: RuleConfiguration;
+	useBlockStatements?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce using else if instead of nested if in else clauses.
 	 */
-	useCollapsedElseIf?: RuleConfiguration;
+	useCollapsedElseIf?: RuleConfiguration_for_Null;
 	/**
 	 * Require const declarations for variables that are never reassigned after declared.
 	 */
-	useConst?: RuleConfiguration;
+	useConst?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce default function parameters and optional function parameters to be last.
 	 */
-	useDefaultParameterLast?: RuleConfiguration;
+	useDefaultParameterLast?: RuleConfiguration_for_Null;
 	/**
 	 * Require that each enum member value be explicitly initialized.
 	 */
-	useEnumInitializers?: RuleConfiguration;
+	useEnumInitializers?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of Math.pow in favor of the ** operator.
 	 */
-	useExponentiationOperator?: RuleConfiguration;
+	useExponentiationOperator?: RuleConfiguration_for_Null;
 	/**
 	 * This rule enforces the use of <>...</> over <Fragment>...</Fragment>.
 	 */
-	useFragmentSyntax?: RuleConfiguration;
+	useFragmentSyntax?: RuleConfiguration_for_Null;
 	/**
 	 * Require all enum members to be literal values.
 	 */
-	useLiteralEnumMembers?: RuleConfiguration;
+	useLiteralEnumMembers?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce naming conventions for everything across a codebase.
 	 */
-	useNamingConvention?: RuleConfiguration;
+	useNamingConvention?: RuleConfiguration_for_NamingConventionOptions;
 	/**
 	 * Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals
 	 */
-	useNumericLiterals?: RuleConfiguration;
+	useNumericLiterals?: RuleConfiguration_for_Null;
 	/**
 	 * Prevent extra closing tags for components without children
 	 */
-	useSelfClosingElements?: RuleConfiguration;
+	useSelfClosingElements?: RuleConfiguration_for_Null;
 	/**
 	 * When expressing array types, this rule promotes the usage of T[] shorthand instead of Array<T>.
 	 */
-	useShorthandArrayType?: RuleConfiguration;
+	useShorthandArrayType?: RuleConfiguration_for_Null;
 	/**
 	 * Require assignment operator shorthand where possible.
 	 */
-	useShorthandAssign?: RuleConfiguration;
+	useShorthandAssign?: RuleConfiguration_for_Null;
 	/**
 	 * Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block.
 	 */
-	useSingleCaseStatement?: RuleConfiguration;
+	useSingleCaseStatement?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow multiple variable declarations in the same variable statement
 	 */
-	useSingleVarDeclarator?: RuleConfiguration;
+	useSingleVarDeclarator?: RuleConfiguration_for_Null;
 	/**
 	 * Prefer template literals over string concatenation.
 	 */
-	useTemplate?: RuleConfiguration;
+	useTemplate?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed.
 	 */
-	useWhile?: RuleConfiguration;
+	useWhile?: RuleConfiguration_for_Null;
 }
 /**
  * A list of rules that belong to this group
@@ -1198,163 +1198,163 @@ export interface Suspicious {
 	/**
 	 * Use standard constants instead of approximated literals.
 	 */
-	noApproximativeNumericConstant?: RuleConfiguration;
+	noApproximativeNumericConstant?: RuleConfiguration_for_Null;
 	/**
 	 * Discourage the usage of Array index in keys.
 	 */
-	noArrayIndexKey?: RuleConfiguration;
+	noArrayIndexKey?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow assignments in expressions.
 	 */
-	noAssignInExpressions?: RuleConfiguration;
+	noAssignInExpressions?: RuleConfiguration_for_Null;
 	/**
 	 * Disallows using an async function as a Promise executor.
 	 */
-	noAsyncPromiseExecutor?: RuleConfiguration;
+	noAsyncPromiseExecutor?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow reassigning exceptions in catch clauses.
 	 */
-	noCatchAssign?: RuleConfiguration;
+	noCatchAssign?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow reassigning class members.
 	 */
-	noClassAssign?: RuleConfiguration;
+	noClassAssign?: RuleConfiguration_for_Null;
 	/**
 	 * Prevent comments from being inserted as text nodes
 	 */
-	noCommentText?: RuleConfiguration;
+	noCommentText?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow comparing against -0
 	 */
-	noCompareNegZero?: RuleConfiguration;
+	noCompareNegZero?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow labeled statements that are not loops.
 	 */
-	noConfusingLabels?: RuleConfiguration;
+	noConfusingLabels?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow void type outside of generic or return types.
 	 */
-	noConfusingVoidType?: RuleConfiguration;
+	noConfusingVoidType?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of console.log
 	 */
-	noConsoleLog?: RuleConfiguration;
+	noConsoleLog?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow TypeScript const enum
 	 */
-	noConstEnum?: RuleConfiguration;
+	noConstEnum?: RuleConfiguration_for_Null;
 	/**
 	 * Prevents from having control characters and some escape sequences that match control characters in regular expressions.
 	 */
-	noControlCharactersInRegex?: RuleConfiguration;
+	noControlCharactersInRegex?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of debugger
 	 */
-	noDebugger?: RuleConfiguration;
+	noDebugger?: RuleConfiguration_for_Null;
 	/**
 	 * Require the use of === and !==
 	 */
-	noDoubleEquals?: RuleConfiguration;
+	noDoubleEquals?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow duplicate case labels.
 	 */
-	noDuplicateCase?: RuleConfiguration;
+	noDuplicateCase?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow duplicate class members.
 	 */
-	noDuplicateClassMembers?: RuleConfiguration;
+	noDuplicateClassMembers?: RuleConfiguration_for_Null;
 	/**
 	 * Prevents JSX properties to be assigned multiple times.
 	 */
-	noDuplicateJsxProps?: RuleConfiguration;
+	noDuplicateJsxProps?: RuleConfiguration_for_Null;
 	/**
 	 * Prevents object literals having more than one property declaration for the same name.
 	 */
-	noDuplicateObjectKeys?: RuleConfiguration;
+	noDuplicateObjectKeys?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow duplicate function parameter name.
 	 */
-	noDuplicateParameters?: RuleConfiguration;
+	noDuplicateParameters?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the declaration of empty interfaces.
 	 */
-	noEmptyInterface?: RuleConfiguration;
+	noEmptyInterface?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the any type usage.
 	 */
-	noExplicitAny?: RuleConfiguration;
+	noExplicitAny?: RuleConfiguration_for_Null;
 	/**
 	 * Prevents the wrong usage of the non-null assertion operator (!) in TypeScript files.
 	 */
-	noExtraNonNullAssertion?: RuleConfiguration;
+	noExtraNonNullAssertion?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow fallthrough of switch clauses.
 	 */
-	noFallthroughSwitchClause?: RuleConfiguration;
+	noFallthroughSwitchClause?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow reassigning function declarations.
 	 */
-	noFunctionAssign?: RuleConfiguration;
+	noFunctionAssign?: RuleConfiguration_for_Null;
 	/**
 	 * Use Number.isFinite instead of global isFinite.
 	 */
-	noGlobalIsFinite?: RuleConfiguration;
+	noGlobalIsFinite?: RuleConfiguration_for_Null;
 	/**
 	 * Use Number.isNaN instead of global isNaN.
 	 */
-	noGlobalIsNan?: RuleConfiguration;
+	noGlobalIsNan?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow use of implicit any type on variable declarations.
 	 */
-	noImplicitAnyLet?: RuleConfiguration;
+	noImplicitAnyLet?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow assigning to imported bindings
 	 */
-	noImportAssign?: RuleConfiguration;
+	noImportAssign?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow labels that share a name with a variable
 	 */
-	noLabelVar?: RuleConfiguration;
+	noLabelVar?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce proper usage of new and constructor.
 	 */
-	noMisleadingInstantiator?: RuleConfiguration;
+	noMisleadingInstantiator?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow shorthand assign when variable appears on both sides.
 	 */
-	noMisrefactoredShorthandAssign?: RuleConfiguration;
+	noMisrefactoredShorthandAssign?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow direct use of Object.prototype builtins.
 	 */
-	noPrototypeBuiltins?: RuleConfiguration;
+	noPrototypeBuiltins?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow variable, function, class, and type redeclarations in the same scope.
 	 */
-	noRedeclare?: RuleConfiguration;
+	noRedeclare?: RuleConfiguration_for_Null;
 	/**
 	 * Prevents from having redundant "use strict".
 	 */
-	noRedundantUseStrict?: RuleConfiguration;
+	noRedundantUseStrict?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow comparisons where both sides are exactly the same.
 	 */
-	noSelfCompare?: RuleConfiguration;
+	noSelfCompare?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow identifiers from shadowing restricted names.
 	 */
-	noShadowRestrictedNames?: RuleConfiguration;
+	noShadowRestrictedNames?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow sparse arrays
 	 */
-	noSparseArray?: RuleConfiguration;
+	noSparseArray?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow unsafe declaration merging between interfaces and classes.
 	 */
-	noUnsafeDeclarationMerging?: RuleConfiguration;
+	noUnsafeDeclarationMerging?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow using unsafe negation.
 	 */
-	noUnsafeNegation?: RuleConfiguration;
+	noUnsafeNegation?: RuleConfiguration_for_Null;
 	/**
 	 * It enables the recommended rules for this group
 	 */
@@ -1362,23 +1362,23 @@ export interface Suspicious {
 	/**
 	 * Enforce default clauses in switch statements to be last
 	 */
-	useDefaultSwitchClauseLast?: RuleConfiguration;
+	useDefaultSwitchClauseLast?: RuleConfiguration_for_Null;
 	/**
 	 * Enforce get methods to always return a value.
 	 */
-	useGetterReturn?: RuleConfiguration;
+	useGetterReturn?: RuleConfiguration_for_Null;
 	/**
 	 * Use Array.isArray() instead of instanceof Array.
 	 */
-	useIsArray?: RuleConfiguration;
+	useIsArray?: RuleConfiguration_for_Null;
 	/**
 	 * Require using the namespace keyword over the module keyword to declare TypeScript namespaces.
 	 */
-	useNamespaceKeyword?: RuleConfiguration;
+	useNamespaceKeyword?: RuleConfiguration_for_Null;
 	/**
 	 * This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions
 	 */
-	useValidTypeof?: RuleConfiguration;
+	useValidTypeof?: RuleConfiguration_for_Null;
 }
 export interface OverrideFormatterConfiguration {
 	/**
@@ -1427,23 +1427,88 @@ export interface OverrideOrganizeImportsConfiguration {
 	 */
 	enabled?: boolean;
 }
-export type RuleConfiguration = RulePlainConfiguration | RuleWithOptions;
+export type RuleConfiguration_for_Null =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_Null;
+export type RuleConfiguration_for_ValidAriaRoleOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_ValidAriaRoleOptions;
+export type RuleConfiguration_for_ComplexityOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_ComplexityOptions;
+export type RuleConfiguration_for_HooksOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_HooksOptions;
+export type RuleConfiguration_for_DeprecatedHooksOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_DeprecatedHooksOptions;
+export type RuleConfiguration_for_RestrictedImportsOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_RestrictedImportsOptions;
+export type RuleConfiguration_for_ConsistentArrayTypeOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_ConsistentArrayTypeOptions;
+export type RuleConfiguration_for_FilenamingConventionOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_FilenamingConventionOptions;
+export type RuleConfiguration_for_UtilityClassSortingOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_UtilityClassSortingOptions;
+export type RuleConfiguration_for_RestrictedGlobalsOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_RestrictedGlobalsOptions;
+export type RuleConfiguration_for_NamingConventionOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_NamingConventionOptions;
 export type RulePlainConfiguration = "warn" | "error" | "off";
-export interface RuleWithOptions {
+export interface RuleWithOptions_for_Null {
 	level: RulePlainConfiguration;
-	options?: PossibleOptions;
+	options: null;
 }
-export type PossibleOptions =
-	| ComplexityOptions
-	| ConsistentArrayTypeOptions
-	| FilenamingConventionOptions
-	| HooksOptions
-	| DeprecatedHooksOptions
-	| NamingConventionOptions
-	| RestrictedGlobalsOptions
-	| RestrictedImportsOptions
-	| ValidAriaRoleOptions
-	| UtilityClassSortingOptions;
+export interface RuleWithOptions_for_ValidAriaRoleOptions {
+	level: RulePlainConfiguration;
+	options: ValidAriaRoleOptions;
+}
+export interface RuleWithOptions_for_ComplexityOptions {
+	level: RulePlainConfiguration;
+	options: ComplexityOptions;
+}
+export interface RuleWithOptions_for_HooksOptions {
+	level: RulePlainConfiguration;
+	options: HooksOptions;
+}
+export interface RuleWithOptions_for_DeprecatedHooksOptions {
+	level: RulePlainConfiguration;
+	options: DeprecatedHooksOptions;
+}
+export interface RuleWithOptions_for_RestrictedImportsOptions {
+	level: RulePlainConfiguration;
+	options: RestrictedImportsOptions;
+}
+export interface RuleWithOptions_for_ConsistentArrayTypeOptions {
+	level: RulePlainConfiguration;
+	options: ConsistentArrayTypeOptions;
+}
+export interface RuleWithOptions_for_FilenamingConventionOptions {
+	level: RulePlainConfiguration;
+	options: FilenamingConventionOptions;
+}
+export interface RuleWithOptions_for_UtilityClassSortingOptions {
+	level: RulePlainConfiguration;
+	options: UtilityClassSortingOptions;
+}
+export interface RuleWithOptions_for_RestrictedGlobalsOptions {
+	level: RulePlainConfiguration;
+	options: RestrictedGlobalsOptions;
+}
+export interface RuleWithOptions_for_NamingConventionOptions {
+	level: RulePlainConfiguration;
+	options: NamingConventionOptions;
+}
+export interface ValidAriaRoleOptions {
+	allowInvalidRoles: string[];
+	ignoreNonDom: boolean;
+}
 /**
  * Options for the rule `noExcessiveCognitiveComplexity`.
  */
@@ -1452,6 +1517,28 @@ export interface ComplexityOptions {
 	 * The maximum complexity score that we allow. Anything higher is considered excessive.
 	 */
 	maxAllowedComplexity: number;
+}
+/**
+ * Options for the rule `useExhaustiveDependencies`
+ */
+export interface HooksOptions {
+	/**
+	 * List of safe hooks
+	 */
+	hooks: Hooks[];
+}
+/**
+ * Options for the `useHookAtTopLevel` rule have been deprecated, since we now use the React hook naming convention to determine whether a function is a hook.
+ */
+export interface DeprecatedHooksOptions {}
+/**
+ * Options for the rule `noRestrictedImports`.
+ */
+export interface RestrictedImportsOptions {
+	/**
+	 * A list of names that should trigger the rule
+	 */
+	paths: {};
 }
 export interface ConsistentArrayTypeOptions {
 	syntax: ConsistentArrayType;
@@ -1473,19 +1560,25 @@ export interface FilenamingConventionOptions {
 	 */
 	strictCase: boolean;
 }
-/**
- * Options for the rule `useExhaustiveDependencies`
- */
-export interface HooksOptions {
+export interface UtilityClassSortingOptions {
 	/**
-	 * List of safe hooks
+	 * Additional attributes that will be sorted.
 	 */
-	hooks: Hooks[];
+	attributes?: string[];
+	/**
+	 * Names of the functions or tagged templates that will be sorted.
+	 */
+	functions?: string[];
 }
 /**
- * Options for the `useHookAtTopLevel` rule have been deprecated, since we now use the React hook naming convention to determine whether a function is a hook.
+ * Options for the rule `noRestrictedGlobals`.
  */
-export interface DeprecatedHooksOptions {}
+export interface RestrictedGlobalsOptions {
+	/**
+	 * A list of names that should trigger the rule
+	 */
+	deniedGlobals: string[];
+}
 /**
  * Rule's options.
  */
@@ -1503,40 +1596,6 @@ export interface NamingConventionOptions {
 	 */
 	strictCase: boolean;
 }
-/**
- * Options for the rule `noRestrictedGlobals`.
- */
-export interface RestrictedGlobalsOptions {
-	/**
-	 * A list of names that should trigger the rule
-	 */
-	deniedGlobals: string[];
-}
-/**
- * Options for the rule `noRestrictedImports`.
- */
-export interface RestrictedImportsOptions {
-	/**
-	 * A list of names that should trigger the rule
-	 */
-	paths: {};
-}
-export interface ValidAriaRoleOptions {
-	allowInvalidRoles: string[];
-	ignoreNonDom: boolean;
-}
-export interface UtilityClassSortingOptions {
-	/**
-	 * Additional attributes that will be sorted.
-	 */
-	attributes?: string[];
-	/**
-	 * Names of the functions or tagged templates that will be sorted.
-	 */
-	functions?: string[];
-}
-export type ConsistentArrayType = "shorthand" | "generic";
-export type FilenameCases = FilenameCase[];
 export interface Hooks {
 	/**
 	* The "position" of the closure function, starting from zero.
@@ -1553,6 +1612,8 @@ export interface Hooks {
 	 */
 	name: string;
 }
+export type ConsistentArrayType = "shorthand" | "generic";
+export type FilenameCases = FilenameCase[];
 /**
  * Supported cases for TypeScript `enum` member names.
  */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -83,98 +83,98 @@
 				"noAccessKey": {
 					"description": "Enforce that the accessKey attribute is not used on any HTML element.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noAriaHiddenOnFocusable": {
 					"description": "Enforce that aria-hidden=\"true\" is not set on focusable elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noAriaUnsupportedElements": {
 					"description": "Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noAutofocus": {
 					"description": "Enforce that autoFocus prop is not used on elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noBlankTarget": {
 					"description": "Disallow target=\"_blank\" attribute without rel=\"noreferrer\"",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDistractingElements": {
 					"description": "Enforces that no distracting elements are used.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noHeaderScope": {
 					"description": "The scope prop should be used only on <th> elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noInteractiveElementToNoninteractiveRole": {
 					"description": "Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noNoninteractiveElementToInteractiveRole": {
 					"description": "Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noNoninteractiveTabindex": {
 					"description": "Enforce that tabIndex is not assigned to non-interactive HTML elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noPositiveTabindex": {
 					"description": "Prevent the usage of positive integers on tabIndex property",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noRedundantAlt": {
 					"description": "Enforce img alt prop does not contain the word \"image\", \"picture\", or \"photo\".",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noRedundantRoles": {
 					"description": "Enforce explicit role property is not the same as implicit/default role property on an element.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noSvgWithoutTitle": {
 					"description": "Enforces the usage of the title element for the svg element.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -185,114 +185,112 @@
 				"useAltText": {
 					"description": "Enforce that all elements that require alternative text have meaningful information to relay back to the end user.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useAnchorContent": {
 					"description": "Enforce that anchors have content and that the content is accessible to screen readers.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useAriaActivedescendantWithTabindex": {
 					"description": "Enforce that tabIndex is assigned to non-interactive HTML elements with aria-activedescendant.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useAriaPropsForRole": {
 					"description": "Enforce that elements with ARIA roles must have all required ARIA attributes for that role.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useButtonType": {
 					"description": "Enforces the usage of the attribute type for the element button",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useHeadingContent": {
 					"description": "Enforce that heading elements (h1, h2, etc.) have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the aria-hidden prop.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useHtmlLang": {
 					"description": "Enforce that html element has lang attribute.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useIframeTitle": {
 					"description": "Enforces the usage of the attribute title for the element iframe.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useKeyWithClickEvents": {
 					"description": "Enforce onClick is accompanied by at least one of the following: onKeyUp, onKeyDown, onKeyPress.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useKeyWithMouseEvents": {
 					"description": "Enforce onMouseOver / onMouseOut are accompanied by onFocus / onBlur.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useMediaCaption": {
 					"description": "Enforces that audio and video elements must have a track for captions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useValidAnchor": {
 					"description": "Enforce that all anchors are valid, and they are navigable elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useValidAriaProps": {
 					"description": "Ensures that ARIA properties aria-* are all valid.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useValidAriaRole": {
 					"description": "Elements with ARIA roles must use a valid, non-abstract ARIA role.",
 					"anyOf": [
-						{
-							"$ref": "#/definitions/RuleConfiguration_for_ValidAriaRoleOptions"
-						},
+						{ "$ref": "#/definitions/ValidAriaRoleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useValidAriaValues": {
 					"description": "Enforce that ARIA state and property values are valid.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useValidLang": {
 					"description": "Ensure that the attribute passed to the lang attribute is a correct ISO language and/or country.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				}
@@ -311,126 +309,126 @@
 				"noBannedTypes": {
 					"description": "Disallow primitive type aliases and misleading types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noExcessiveCognitiveComplexity": {
 					"description": "Disallow functions that exceed a given Cognitive Complexity score.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_ComplexityOptions" },
+						{ "$ref": "#/definitions/ComplexityConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noExtraBooleanCast": {
 					"description": "Disallow unnecessary boolean casts",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noForEach": {
 					"description": "Prefer for...of statement instead of Array.forEach.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noMultipleSpacesInRegularExpressionLiterals": {
 					"description": "Disallow unclear usage of consecutive space characters in regular expression literals",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noStaticOnlyClass": {
 					"description": "This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noThisInStatic": {
 					"description": "Disallow this and super in static contexts.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessCatch": {
 					"description": "Disallow unnecessary catch clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessConstructor": {
 					"description": "Disallow unnecessary constructors.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessEmptyExport": {
 					"description": "Disallow empty exports that don't change anything in a module file.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessFragments": {
 					"description": "Disallow unnecessary fragments",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessLabel": {
 					"description": "Disallow unnecessary labels.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessRename": {
 					"description": "Disallow renaming import, export, and destructured assignments to the same name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessSwitchCase": {
 					"description": "Disallow useless case in switch statements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessThisAlias": {
 					"description": "Disallow useless this aliasing.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessTypeConstraint": {
 					"description": "Disallow using any or unknown as type constraint.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noVoid": {
 					"description": "Disallow the use of void operators, which is not a familiar operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noWith": {
 					"description": "Disallow with statements in non-strict contexts.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -441,53 +439,59 @@
 				"useArrowFunction": {
 					"description": "Use arrow functions over function expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useFlatMap": {
 					"description": "Promotes the use of .flatMap() when map().flat() are used together.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useLiteralKeys": {
 					"description": "Enforce the usage of a literal access to properties over computed property access.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useOptionalChain": {
 					"description": "Enforce using concise optional chain instead of chained logical expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useRegexLiterals": {
 					"description": "Enforce the use of the regular expression literals instead of the RegExp constructor if possible.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useSimpleNumberKeys": {
 					"description": "Disallow number literal object member names which are not base10 or uses underscore as separator",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useSimplifiedLogicExpression": {
 					"description": "Discard redundant terms from logical expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				}
 			}
+		},
+		"ComplexityConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "RuleWithComplexityOptions" }
+			]
 		},
 		"ComplexityOptions": {
 			"description": "Options for the rule `noExcessiveCognitiveComplexity`.",
@@ -517,6 +521,12 @@
 				}
 			]
 		},
+		"ConsistentArrayTypeConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "RuleWithConsistentArrayTypeOptions" }
+			]
+		},
 		"ConsistentArrayTypeOptions": {
 			"type": "object",
 			"required": ["syntax"],
@@ -536,196 +546,196 @@
 				"noChildrenProp": {
 					"description": "Prevent passing of children as props.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noConstAssign": {
 					"description": "Prevents from having const variables being re-assigned.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noConstantCondition": {
 					"description": "Disallow constant expressions in conditions",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noConstructorReturn": {
 					"description": "Disallow returning a value from a constructor.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noEmptyCharacterClassInRegex": {
 					"description": "Disallow empty character classes in regular expression literals.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noEmptyPattern": {
 					"description": "Disallows empty destructuring patterns.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noGlobalObjectCalls": {
 					"description": "Disallow calling global object properties as functions",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noInnerDeclarations": {
 					"description": "Disallow function and var declarations that are accessible outside their block.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noInvalidConstructorSuper": {
 					"description": "Prevents the incorrect use of super() inside classes. It also checks whether a call super() is missing from classes that extends other constructors.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noInvalidNewBuiltin": {
 					"description": "Disallow new operators with global non-constructor functions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noNewSymbol": {
 					"description": "Disallow new operators with the Symbol object.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noNonoctalDecimalEscape": {
 					"description": "Disallow \\8 and \\9 escape sequences in string literals.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noPrecisionLoss": {
 					"description": "Disallow literal numbers that lose precision",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noRenderReturnValue": {
 					"description": "Prevent the usage of the return value of React.render.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noSelfAssign": {
 					"description": "Disallow assignments where both sides are exactly the same.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noSetterReturn": {
 					"description": "Disallow returning a value from a setter",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noStringCaseMismatch": {
 					"description": "Disallow comparison of expressions modifying the string case with non-compliant value.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noSwitchDeclarations": {
 					"description": "Disallow lexical declarations in switch clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUndeclaredVariables": {
 					"description": "Prevents the usage of variables that haven't been declared inside the document.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnnecessaryContinue": {
 					"description": "Avoid using unnecessary continue.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnreachable": {
 					"description": "Disallow unreachable code",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnreachableSuper": {
 					"description": "Ensures the super() constructor is called exactly once on every code  path in a class constructor before this is accessed if the class has a superclass",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnsafeFinally": {
 					"description": "Disallow control flow statements in finally blocks.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnsafeOptionalChaining": {
 					"description": "Disallow the use of optional chaining in contexts where the undefined value is not allowed.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedLabels": {
 					"description": "Disallow unused labels.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedVariables": {
 					"description": "Disallow unused variables.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noVoidElementsWithChildren": {
 					"description": "This rules prevents void elements (AKA self-closing elements) from having children.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noVoidTypeReturn": {
 					"description": "Disallow returning a value from a function with the return type 'void'",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -736,37 +746,35 @@
 				"useExhaustiveDependencies": {
 					"description": "Enforce all dependencies are correctly specified in a React hook.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_HooksOptions" },
+						{ "$ref": "#/definitions/HooksConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useHookAtTopLevel": {
 					"description": "Enforce that all React hooks are being called from the Top Level component functions.",
 					"anyOf": [
-						{
-							"$ref": "#/definitions/RuleConfiguration_for_DeprecatedHooksOptions"
-						},
+						{ "$ref": "#/definitions/DeprecatedHooksConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useIsNan": {
 					"description": "Require calls to isNaN() when checking for NaN.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useValidForDirection": {
 					"description": "Enforce \"for\" loop update clause moving the counter in the right direction.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useYield": {
 					"description": "Require generator functions to contain yield.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				}
@@ -841,6 +849,12 @@
 			},
 			"additionalProperties": false
 		},
+		"DeprecatedHooksConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "RuleWithDeprecatedHooksOptions" }
+			]
+		},
 		"DeprecatedHooksOptions": {
 			"description": "Options for the `useHookAtTopLevel` rule have been deprecated, since we now use the React hook naming convention to determine whether a function is a hook.",
 			"type": "object",
@@ -892,6 +906,12 @@
 			"type": "array",
 			"items": { "$ref": "#/definitions/FilenameCase" },
 			"uniqueItems": true
+		},
+		"FilenamingConventionConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "RuleWithFilenamingConventionOptions" }
+			]
 		},
 		"FilenamingConventionOptions": {
 			"description": "Rule's options.",
@@ -1010,6 +1030,12 @@
 				"name": { "description": "The name of the hook", "type": "string" }
 			},
 			"additionalProperties": false
+		},
+		"HooksConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "RuleWithHooksOptions" }
+			]
 		},
 		"HooksOptions": {
 			"description": "Options for the rule `useExhaustiveDependencies`",
@@ -1273,6 +1299,12 @@
 			},
 			"additionalProperties": false
 		},
+		"NamingConventionConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "RuleWithNamingConventionOptions" }
+			]
+		},
 		"NamingConventionOptions": {
 			"description": "Rule's options.",
 			"type": "object",
@@ -1303,142 +1335,140 @@
 				"noConsole": {
 					"description": "Disallow the use of console.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDuplicateJsonKeys": {
 					"description": "Disallow two keys with the same name inside a JSON object.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noEmptyBlockStatements": {
 					"description": "Disallow empty block statements and static blocks.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noEmptyTypeParameters": {
 					"description": "Disallow empty type parameters in type aliases and interfaces.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noFocusedTests": {
 					"description": "Disallow focused tests.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noGlobalAssign": {
 					"description": "Disallow assignments to native objects and read-only global variables.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noGlobalEval": {
 					"description": "Disallow the use of global eval().",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noInvalidUseBeforeDeclaration": {
 					"description": "Disallow the use of variables and function parameters before their declaration",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noMisleadingCharacterClass": {
 					"description": "Disallow characters made with multiple code points in character class syntax.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noNamespaceImport": {
 					"description": "Disallow the use of namespace imports.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noNodejsModules": {
 					"description": "Forbid the use of Node.js builtin modules.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noReExportAll": {
 					"description": "Avoid re-export all.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noRestrictedImports": {
 					"description": "Disallow specified modules when loaded by import or require.",
 					"anyOf": [
-						{
-							"$ref": "#/definitions/RuleConfiguration_for_RestrictedImportsOptions"
-						},
+						{ "$ref": "#/definitions/RestrictedImportsConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noSkippedTests": {
 					"description": "Disallow disabled tests.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noThenProperty": {
 					"description": "Disallow then property.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUndeclaredDependencies": {
 					"description": "Disallow the use of dependencies that aren't specified in the package.json.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedImports": {
 					"description": "Disallow unused imports.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedPrivateClassMembers": {
 					"description": "Disallow unused private class members",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessLoneBlockStatements": {
 					"description": "Disallow unnecessary nested block statements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessTernary": {
 					"description": "Disallow ternary operators when simpler alternatives exist.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1449,97 +1479,91 @@
 				"useAwait": {
 					"description": "Ensure async functions utilize await.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useConsistentArrayType": {
 					"description": "Require consistently using either T[] or Array<T>",
 					"anyOf": [
-						{
-							"$ref": "#/definitions/RuleConfiguration_for_ConsistentArrayTypeOptions"
-						},
+						{ "$ref": "#/definitions/ConsistentArrayTypeConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useExportType": {
 					"description": "Promotes the use of export type for types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useFilenamingConvention": {
 					"description": "Enforce naming conventions for JavaScript and TypeScript filenames.",
 					"anyOf": [
-						{
-							"$ref": "#/definitions/RuleConfiguration_for_FilenamingConventionOptions"
-						},
+						{ "$ref": "#/definitions/FilenamingConventionConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useForOf": {
 					"description": "This rule recommends a for-of loop when in a for loop, the index used to extract an item from the iterated array.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useGroupedTypeImport": {
 					"description": "Enforce the use of import type when an import only has specifiers with type qualifier.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useImportRestrictions": {
 					"description": "Disallows package private imports.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useImportType": {
 					"description": "Promotes the use of import type for types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useNodeAssertStrict": {
 					"description": "Promotes the usage of node:assert/strict over node:assert.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useNodejsImportProtocol": {
 					"description": "Enforces using the node: protocol for Node.js builtin modules.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useNumberNamespace": {
 					"description": "Use the Number properties instead of global ones.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useShorthandFunctionType": {
 					"description": "Enforce using function types instead of object type with call signatures.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useSortedClasses": {
 					"description": "Enforce the sorting of CSS utility classes.",
 					"anyOf": [
-						{
-							"$ref": "#/definitions/RuleConfiguration_for_UtilityClassSortingOptions"
-						},
+						{ "$ref": "#/definitions/UtilityClassSortingConfiguration" },
 						{ "type": "null" }
 					]
 				}
@@ -1706,14 +1730,14 @@
 				"noAccumulatingSpread": {
 					"description": "Disallow the use of spread (...) syntax on accumulators.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDelete": {
 					"description": "Disallow the use of the delete operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1731,6 +1755,12 @@
 		},
 		"QuoteProperties": { "type": "string", "enum": ["asNeeded", "preserve"] },
 		"QuoteStyle": { "type": "string", "enum": ["double", "single"] },
+		"RestrictedGlobalsConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "RuleWithRestrictedGlobalsOptions" }
+			]
+		},
 		"RestrictedGlobalsOptions": {
 			"description": "Options for the rule `noRestrictedGlobals`.",
 			"type": "object",
@@ -1743,6 +1773,12 @@
 				}
 			},
 			"additionalProperties": false
+		},
+		"RestrictedImportsConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "RuleWithRestrictedImportsOptions" }
+			]
 		},
 		"RestrictedImportsOptions": {
 			"description": "Options for the rule `noRestrictedImports`.",
@@ -1757,83 +1793,17 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleConfiguration_for_ComplexityOptions": {
+		"RuleConfiguration": {
 			"anyOf": [
 				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithOptions_for_ComplexityOptions" }
-			]
-		},
-		"RuleConfiguration_for_ConsistentArrayTypeOptions": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{
-					"$ref": "#/definitions/RuleWithOptions_for_ConsistentArrayTypeOptions"
-				}
-			]
-		},
-		"RuleConfiguration_for_DeprecatedHooksOptions": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithOptions_for_DeprecatedHooksOptions" }
-			]
-		},
-		"RuleConfiguration_for_FilenamingConventionOptions": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{
-					"$ref": "#/definitions/RuleWithOptions_for_FilenamingConventionOptions"
-				}
-			]
-		},
-		"RuleConfiguration_for_HooksOptions": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithOptions_for_HooksOptions" }
-			]
-		},
-		"RuleConfiguration_for_NamingConventionOptions": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithOptions_for_NamingConventionOptions" }
-			]
-		},
-		"RuleConfiguration_for_Null": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithOptions_for_Null" }
-			]
-		},
-		"RuleConfiguration_for_RestrictedGlobalsOptions": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithOptions_for_RestrictedGlobalsOptions" }
-			]
-		},
-		"RuleConfiguration_for_RestrictedImportsOptions": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithOptions_for_RestrictedImportsOptions" }
-			]
-		},
-		"RuleConfiguration_for_UtilityClassSortingOptions": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{
-					"$ref": "#/definitions/RuleWithOptions_for_UtilityClassSortingOptions"
-				}
-			]
-		},
-		"RuleConfiguration_for_ValidAriaRoleOptions": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithOptions_for_ValidAriaRoleOptions" }
+				{ "$ref": "#/definitions/RuleWithNoOptions" }
 			]
 		},
 		"RulePlainConfiguration": {
 			"type": "string",
 			"enum": ["warn", "error", "off"]
 		},
-		"RuleWithOptions_for_ComplexityOptions": {
+		"RuleWithComplexityOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -1842,7 +1812,7 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithOptions_for_ConsistentArrayTypeOptions": {
+		"RuleWithConsistentArrayTypeOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -1851,7 +1821,7 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithOptions_for_DeprecatedHooksOptions": {
+		"RuleWithDeprecatedHooksOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -1860,7 +1830,7 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithOptions_for_FilenamingConventionOptions": {
+		"RuleWithFilenamingConventionOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -1869,7 +1839,7 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithOptions_for_HooksOptions": {
+		"RuleWithHooksOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -1878,7 +1848,7 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithOptions_for_NamingConventionOptions": {
+		"RuleWithNamingConventionOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -1887,7 +1857,7 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithOptions_for_Null": {
+		"RuleWithNoOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -1896,7 +1866,7 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithOptions_for_RestrictedGlobalsOptions": {
+		"RuleWithRestrictedGlobalsOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -1905,7 +1875,7 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithOptions_for_RestrictedImportsOptions": {
+		"RuleWithRestrictedImportsOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -1914,7 +1884,7 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithOptions_for_UtilityClassSortingOptions": {
+		"RuleWithUtilityClassSortingOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -1923,7 +1893,7 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithOptions_for_ValidAriaRoleOptions": {
+		"RuleWithValidAriaRoleOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -1981,14 +1951,14 @@
 				"noDangerouslySetInnerHtml": {
 					"description": "Prevent the usage of dangerous JSX props",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDangerouslySetInnerHtmlWithChildren": {
 					"description": "Report when a DOM element or a component uses both children and dangerouslySetInnerHTML prop.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2015,107 +1985,105 @@
 				"noArguments": {
 					"description": "Disallow the use of arguments.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noCommaOperator": {
 					"description": "Disallow comma operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDefaultExport": {
 					"description": "Disallow default exports.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noImplicitBoolean": {
 					"description": "Disallow implicit true values on JSX boolean attributes",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noInferrableTypes": {
 					"description": "Disallow type annotations for variables, parameters, and class properties initialized with a literal expression.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noNamespace": {
 					"description": "Disallow the use of TypeScript's namespaces.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noNegationElse": {
 					"description": "Disallow negation in the condition of an if statement if it has an else clause.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noNonNullAssertion": {
 					"description": "Disallow non-null assertions using the ! postfix operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noParameterAssign": {
 					"description": "Disallow reassigning function parameters.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noParameterProperties": {
 					"description": "Disallow the use of parameter properties in class constructors.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noRestrictedGlobals": {
 					"description": "This rule allows you to specify global variable names that you don’t want to use in your application.",
 					"anyOf": [
-						{
-							"$ref": "#/definitions/RuleConfiguration_for_RestrictedGlobalsOptions"
-						},
+						{ "$ref": "#/definitions/RestrictedGlobalsConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noShoutyConstants": {
 					"description": "Disallow the use of constants which its value is the upper-case version of its name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedTemplateLiteral": {
 					"description": "Disallow template literals if interpolation and special-character handling are not needed",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessElse": {
 					"description": "Disallow else block when the if block breaks early.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noVar": {
 					"description": "Disallow the use of var",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2126,128 +2094,126 @@
 				"useAsConstAssertion": {
 					"description": "Enforce the use of as const over literal type and type annotation.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useBlockStatements": {
 					"description": "Requires following curly brace conventions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useCollapsedElseIf": {
 					"description": "Enforce using else if instead of nested if in else clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useConst": {
 					"description": "Require const declarations for variables that are never reassigned after declared.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useDefaultParameterLast": {
 					"description": "Enforce default function parameters and optional function parameters to be last.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useEnumInitializers": {
 					"description": "Require that each enum member value be explicitly initialized.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useExponentiationOperator": {
 					"description": "Disallow the use of Math.pow in favor of the ** operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useFragmentSyntax": {
 					"description": "This rule enforces the use of <>...</> over <Fragment>...</Fragment>.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useLiteralEnumMembers": {
 					"description": "Require all enum members to be literal values.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useNamingConvention": {
 					"description": "Enforce naming conventions for everything across a codebase.",
 					"anyOf": [
-						{
-							"$ref": "#/definitions/RuleConfiguration_for_NamingConventionOptions"
-						},
+						{ "$ref": "#/definitions/NamingConventionConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useNumericLiterals": {
 					"description": "Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useSelfClosingElements": {
 					"description": "Prevent extra closing tags for components without children",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useShorthandArrayType": {
 					"description": "When expressing array types, this rule promotes the usage of T[] shorthand instead of Array<T>.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useShorthandAssign": {
 					"description": "Require assignment operator shorthand where possible.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useSingleCaseStatement": {
 					"description": "Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useSingleVarDeclarator": {
 					"description": "Disallow multiple variable declarations in the same variable statement",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useTemplate": {
 					"description": "Prefer template literals over string concatenation.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useWhile": {
 					"description": "Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				}
@@ -2264,280 +2230,280 @@
 				"noApproximativeNumericConstant": {
 					"description": "Use standard constants instead of approximated literals.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noArrayIndexKey": {
 					"description": "Discourage the usage of Array index in keys.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noAssignInExpressions": {
 					"description": "Disallow assignments in expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noAsyncPromiseExecutor": {
 					"description": "Disallows using an async function as a Promise executor.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noCatchAssign": {
 					"description": "Disallow reassigning exceptions in catch clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noClassAssign": {
 					"description": "Disallow reassigning class members.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noCommentText": {
 					"description": "Prevent comments from being inserted as text nodes",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noCompareNegZero": {
 					"description": "Disallow comparing against -0",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noConfusingLabels": {
 					"description": "Disallow labeled statements that are not loops.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noConfusingVoidType": {
 					"description": "Disallow void type outside of generic or return types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noConsoleLog": {
 					"description": "Disallow the use of console.log",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noConstEnum": {
 					"description": "Disallow TypeScript const enum",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noControlCharactersInRegex": {
 					"description": "Prevents from having control characters and some escape sequences that match control characters in regular expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDebugger": {
 					"description": "Disallow the use of debugger",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDoubleEquals": {
 					"description": "Require the use of === and !==",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDuplicateCase": {
 					"description": "Disallow duplicate case labels.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDuplicateClassMembers": {
 					"description": "Disallow duplicate class members.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDuplicateJsxProps": {
 					"description": "Prevents JSX properties to be assigned multiple times.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDuplicateObjectKeys": {
 					"description": "Prevents object literals having more than one property declaration for the same name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDuplicateParameters": {
 					"description": "Disallow duplicate function parameter name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noEmptyInterface": {
 					"description": "Disallow the declaration of empty interfaces.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noExplicitAny": {
 					"description": "Disallow the any type usage.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noExtraNonNullAssertion": {
 					"description": "Prevents the wrong usage of the non-null assertion operator (!) in TypeScript files.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noFallthroughSwitchClause": {
 					"description": "Disallow fallthrough of switch clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noFunctionAssign": {
 					"description": "Disallow reassigning function declarations.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noGlobalIsFinite": {
 					"description": "Use Number.isFinite instead of global isFinite.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noGlobalIsNan": {
 					"description": "Use Number.isNaN instead of global isNaN.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noImplicitAnyLet": {
 					"description": "Disallow use of implicit any type on variable declarations.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noImportAssign": {
 					"description": "Disallow assigning to imported bindings",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noLabelVar": {
 					"description": "Disallow labels that share a name with a variable",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noMisleadingInstantiator": {
 					"description": "Enforce proper usage of new and constructor.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noMisrefactoredShorthandAssign": {
 					"description": "Disallow shorthand assign when variable appears on both sides.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noPrototypeBuiltins": {
 					"description": "Disallow direct use of Object.prototype builtins.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noRedeclare": {
 					"description": "Disallow variable, function, class, and type redeclarations in the same scope.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noRedundantUseStrict": {
 					"description": "Prevents from having redundant \"use strict\".",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noSelfCompare": {
 					"description": "Disallow comparisons where both sides are exactly the same.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noShadowRestrictedNames": {
 					"description": "Disallow identifiers from shadowing restricted names.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noSparseArray": {
 					"description": "Disallow sparse arrays",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnsafeDeclarationMerging": {
 					"description": "Disallow unsafe declaration merging between interfaces and classes.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnsafeNegation": {
 					"description": "Disallow using unsafe negation.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2548,35 +2514,35 @@
 				"useDefaultSwitchClauseLast": {
 					"description": "Enforce default clauses in switch statements to be last",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useGetterReturn": {
 					"description": "Enforce get methods to always return a value.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useIsArray": {
 					"description": "Use Array.isArray() instead of instanceof Array.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useNamespaceKeyword": {
 					"description": "Require using the namespace keyword over the module keyword to declare TypeScript namespaces.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useValidTypeof": {
 					"description": "This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				}
@@ -2602,6 +2568,12 @@
 				}
 			]
 		},
+		"UtilityClassSortingConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "RuleWithUtilityClassSortingOptions" }
+			]
+		},
 		"UtilityClassSortingOptions": {
 			"type": "object",
 			"properties": {
@@ -2617,6 +2589,12 @@
 				}
 			},
 			"additionalProperties": false
+		},
+		"ValidAriaRoleConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "RuleWithValidAriaRoleOptions" }
+			]
 		},
 		"ValidAriaRoleOptions": {
 			"type": "object",

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -83,98 +83,98 @@
 				"noAccessKey": {
 					"description": "Enforce that the accessKey attribute is not used on any HTML element.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noAriaHiddenOnFocusable": {
 					"description": "Enforce that aria-hidden=\"true\" is not set on focusable elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noAriaUnsupportedElements": {
 					"description": "Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noAutofocus": {
 					"description": "Enforce that autoFocus prop is not used on elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noBlankTarget": {
 					"description": "Disallow target=\"_blank\" attribute without rel=\"noreferrer\"",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDistractingElements": {
 					"description": "Enforces that no distracting elements are used.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noHeaderScope": {
 					"description": "The scope prop should be used only on <th> elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noInteractiveElementToNoninteractiveRole": {
 					"description": "Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noNoninteractiveElementToInteractiveRole": {
 					"description": "Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noNoninteractiveTabindex": {
 					"description": "Enforce that tabIndex is not assigned to non-interactive HTML elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noPositiveTabindex": {
 					"description": "Prevent the usage of positive integers on tabIndex property",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noRedundantAlt": {
 					"description": "Enforce img alt prop does not contain the word \"image\", \"picture\", or \"photo\".",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noRedundantRoles": {
 					"description": "Enforce explicit role property is not the same as implicit/default role property on an element.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noSvgWithoutTitle": {
 					"description": "Enforces the usage of the title element for the svg element.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -185,112 +185,114 @@
 				"useAltText": {
 					"description": "Enforce that all elements that require alternative text have meaningful information to relay back to the end user.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useAnchorContent": {
 					"description": "Enforce that anchors have content and that the content is accessible to screen readers.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useAriaActivedescendantWithTabindex": {
 					"description": "Enforce that tabIndex is assigned to non-interactive HTML elements with aria-activedescendant.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useAriaPropsForRole": {
 					"description": "Enforce that elements with ARIA roles must have all required ARIA attributes for that role.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useButtonType": {
 					"description": "Enforces the usage of the attribute type for the element button",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useHeadingContent": {
 					"description": "Enforce that heading elements (h1, h2, etc.) have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the aria-hidden prop.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useHtmlLang": {
 					"description": "Enforce that html element has lang attribute.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useIframeTitle": {
 					"description": "Enforces the usage of the attribute title for the element iframe.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useKeyWithClickEvents": {
 					"description": "Enforce onClick is accompanied by at least one of the following: onKeyUp, onKeyDown, onKeyPress.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useKeyWithMouseEvents": {
 					"description": "Enforce onMouseOver / onMouseOut are accompanied by onFocus / onBlur.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useMediaCaption": {
 					"description": "Enforces that audio and video elements must have a track for captions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useValidAnchor": {
 					"description": "Enforce that all anchors are valid, and they are navigable elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useValidAriaProps": {
 					"description": "Ensures that ARIA properties aria-* are all valid.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useValidAriaRole": {
 					"description": "Elements with ARIA roles must use a valid, non-abstract ARIA role.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{
+							"$ref": "#/definitions/RuleConfiguration_for_ValidAriaRoleOptions"
+						},
 						{ "type": "null" }
 					]
 				},
 				"useValidAriaValues": {
 					"description": "Enforce that ARIA state and property values are valid.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useValidLang": {
 					"description": "Ensure that the attribute passed to the lang attribute is a correct ISO language and/or country.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				}
@@ -309,126 +311,126 @@
 				"noBannedTypes": {
 					"description": "Disallow primitive type aliases and misleading types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noExcessiveCognitiveComplexity": {
 					"description": "Disallow functions that exceed a given Cognitive Complexity score.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_ComplexityOptions" },
 						{ "type": "null" }
 					]
 				},
 				"noExtraBooleanCast": {
 					"description": "Disallow unnecessary boolean casts",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noForEach": {
 					"description": "Prefer for...of statement instead of Array.forEach.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noMultipleSpacesInRegularExpressionLiterals": {
 					"description": "Disallow unclear usage of consecutive space characters in regular expression literals",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noStaticOnlyClass": {
 					"description": "This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noThisInStatic": {
 					"description": "Disallow this and super in static contexts.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessCatch": {
 					"description": "Disallow unnecessary catch clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessConstructor": {
 					"description": "Disallow unnecessary constructors.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessEmptyExport": {
 					"description": "Disallow empty exports that don't change anything in a module file.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessFragments": {
 					"description": "Disallow unnecessary fragments",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessLabel": {
 					"description": "Disallow unnecessary labels.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessRename": {
 					"description": "Disallow renaming import, export, and destructured assignments to the same name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessSwitchCase": {
 					"description": "Disallow useless case in switch statements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessThisAlias": {
 					"description": "Disallow useless this aliasing.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessTypeConstraint": {
 					"description": "Disallow using any or unknown as type constraint.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noVoid": {
 					"description": "Disallow the use of void operators, which is not a familiar operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noWith": {
 					"description": "Disallow with statements in non-strict contexts.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -439,49 +441,49 @@
 				"useArrowFunction": {
 					"description": "Use arrow functions over function expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useFlatMap": {
 					"description": "Promotes the use of .flatMap() when map().flat() are used together.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useLiteralKeys": {
 					"description": "Enforce the usage of a literal access to properties over computed property access.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useOptionalChain": {
 					"description": "Enforce using concise optional chain instead of chained logical expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useRegexLiterals": {
 					"description": "Enforce the use of the regular expression literals instead of the RegExp constructor if possible.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useSimpleNumberKeys": {
 					"description": "Disallow number literal object member names which are not base10 or uses underscore as separator",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useSimplifiedLogicExpression": {
 					"description": "Discard redundant terms from logical expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				}
@@ -534,196 +536,196 @@
 				"noChildrenProp": {
 					"description": "Prevent passing of children as props.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noConstAssign": {
 					"description": "Prevents from having const variables being re-assigned.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noConstantCondition": {
 					"description": "Disallow constant expressions in conditions",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noConstructorReturn": {
 					"description": "Disallow returning a value from a constructor.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noEmptyCharacterClassInRegex": {
 					"description": "Disallow empty character classes in regular expression literals.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noEmptyPattern": {
 					"description": "Disallows empty destructuring patterns.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noGlobalObjectCalls": {
 					"description": "Disallow calling global object properties as functions",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noInnerDeclarations": {
 					"description": "Disallow function and var declarations that are accessible outside their block.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noInvalidConstructorSuper": {
 					"description": "Prevents the incorrect use of super() inside classes. It also checks whether a call super() is missing from classes that extends other constructors.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noInvalidNewBuiltin": {
 					"description": "Disallow new operators with global non-constructor functions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noNewSymbol": {
 					"description": "Disallow new operators with the Symbol object.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noNonoctalDecimalEscape": {
 					"description": "Disallow \\8 and \\9 escape sequences in string literals.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noPrecisionLoss": {
 					"description": "Disallow literal numbers that lose precision",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noRenderReturnValue": {
 					"description": "Prevent the usage of the return value of React.render.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noSelfAssign": {
 					"description": "Disallow assignments where both sides are exactly the same.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noSetterReturn": {
 					"description": "Disallow returning a value from a setter",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noStringCaseMismatch": {
 					"description": "Disallow comparison of expressions modifying the string case with non-compliant value.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noSwitchDeclarations": {
 					"description": "Disallow lexical declarations in switch clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUndeclaredVariables": {
 					"description": "Prevents the usage of variables that haven't been declared inside the document.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnnecessaryContinue": {
 					"description": "Avoid using unnecessary continue.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnreachable": {
 					"description": "Disallow unreachable code",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnreachableSuper": {
 					"description": "Ensures the super() constructor is called exactly once on every code  path in a class constructor before this is accessed if the class has a superclass",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnsafeFinally": {
 					"description": "Disallow control flow statements in finally blocks.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnsafeOptionalChaining": {
 					"description": "Disallow the use of optional chaining in contexts where the undefined value is not allowed.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedLabels": {
 					"description": "Disallow unused labels.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedVariables": {
 					"description": "Disallow unused variables.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noVoidElementsWithChildren": {
 					"description": "This rules prevents void elements (AKA self-closing elements) from having children.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noVoidTypeReturn": {
 					"description": "Disallow returning a value from a function with the return type 'void'",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -734,35 +736,37 @@
 				"useExhaustiveDependencies": {
 					"description": "Enforce all dependencies are correctly specified in a React hook.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_HooksOptions" },
 						{ "type": "null" }
 					]
 				},
 				"useHookAtTopLevel": {
 					"description": "Enforce that all React hooks are being called from the Top Level component functions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{
+							"$ref": "#/definitions/RuleConfiguration_for_DeprecatedHooksOptions"
+						},
 						{ "type": "null" }
 					]
 				},
 				"useIsNan": {
 					"description": "Require calls to isNaN() when checking for NaN.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useValidForDirection": {
 					"description": "Enforce \"for\" loop update clause moving the counter in the right direction.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useYield": {
 					"description": "Require generator functions to contain yield.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				}
@@ -1299,140 +1303,142 @@
 				"noConsole": {
 					"description": "Disallow the use of console.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDuplicateJsonKeys": {
 					"description": "Disallow two keys with the same name inside a JSON object.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noEmptyBlockStatements": {
 					"description": "Disallow empty block statements and static blocks.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noEmptyTypeParameters": {
 					"description": "Disallow empty type parameters in type aliases and interfaces.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noFocusedTests": {
 					"description": "Disallow focused tests.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noGlobalAssign": {
 					"description": "Disallow assignments to native objects and read-only global variables.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noGlobalEval": {
 					"description": "Disallow the use of global eval().",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noInvalidUseBeforeDeclaration": {
 					"description": "Disallow the use of variables and function parameters before their declaration",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noMisleadingCharacterClass": {
 					"description": "Disallow characters made with multiple code points in character class syntax.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noNamespaceImport": {
 					"description": "Disallow the use of namespace imports.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noNodejsModules": {
 					"description": "Forbid the use of Node.js builtin modules.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noReExportAll": {
 					"description": "Avoid re-export all.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noRestrictedImports": {
 					"description": "Disallow specified modules when loaded by import or require.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{
+							"$ref": "#/definitions/RuleConfiguration_for_RestrictedImportsOptions"
+						},
 						{ "type": "null" }
 					]
 				},
 				"noSkippedTests": {
 					"description": "Disallow disabled tests.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noThenProperty": {
 					"description": "Disallow then property.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUndeclaredDependencies": {
 					"description": "Disallow the use of dependencies that aren't specified in the package.json.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedImports": {
 					"description": "Disallow unused imports.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedPrivateClassMembers": {
 					"description": "Disallow unused private class members",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessLoneBlockStatements": {
 					"description": "Disallow unnecessary nested block statements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessTernary": {
 					"description": "Disallow ternary operators when simpler alternatives exist.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -1443,91 +1449,97 @@
 				"useAwait": {
 					"description": "Ensure async functions utilize await.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useConsistentArrayType": {
 					"description": "Require consistently using either T[] or Array<T>",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{
+							"$ref": "#/definitions/RuleConfiguration_for_ConsistentArrayTypeOptions"
+						},
 						{ "type": "null" }
 					]
 				},
 				"useExportType": {
 					"description": "Promotes the use of export type for types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useFilenamingConvention": {
 					"description": "Enforce naming conventions for JavaScript and TypeScript filenames.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{
+							"$ref": "#/definitions/RuleConfiguration_for_FilenamingConventionOptions"
+						},
 						{ "type": "null" }
 					]
 				},
 				"useForOf": {
 					"description": "This rule recommends a for-of loop when in a for loop, the index used to extract an item from the iterated array.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useGroupedTypeImport": {
 					"description": "Enforce the use of import type when an import only has specifiers with type qualifier.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useImportRestrictions": {
 					"description": "Disallows package private imports.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useImportType": {
 					"description": "Promotes the use of import type for types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useNodeAssertStrict": {
 					"description": "Promotes the usage of node:assert/strict over node:assert.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useNodejsImportProtocol": {
 					"description": "Enforces using the node: protocol for Node.js builtin modules.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useNumberNamespace": {
 					"description": "Use the Number properties instead of global ones.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useShorthandFunctionType": {
 					"description": "Enforce using function types instead of object type with call signatures.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useSortedClasses": {
 					"description": "Enforce the sorting of CSS utility classes.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{
+							"$ref": "#/definitions/RuleConfiguration_for_UtilityClassSortingOptions"
+						},
 						{ "type": "null" }
 					]
 				}
@@ -1694,14 +1706,14 @@
 				"noAccumulatingSpread": {
 					"description": "Disallow the use of spread (...) syntax on accumulators.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDelete": {
 					"description": "Disallow the use of the delete operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -1715,50 +1727,6 @@
 			"oneOf": [
 				{ "description": "Tab", "type": "string", "enum": ["tab"] },
 				{ "description": "Space", "type": "string", "enum": ["space"] }
-			]
-		},
-		"PossibleOptions": {
-			"anyOf": [
-				{
-					"description": "Options for `noExcessiveComplexity` rule",
-					"allOf": [{ "$ref": "#/definitions/ComplexityOptions" }]
-				},
-				{
-					"description": "Options for `useConsistentArrayType` rule",
-					"allOf": [{ "$ref": "#/definitions/ConsistentArrayTypeOptions" }]
-				},
-				{
-					"description": "Options for `useFilenamingConvention` rule",
-					"allOf": [{ "$ref": "#/definitions/FilenamingConventionOptions" }]
-				},
-				{
-					"description": "Options for `useExhaustiveDependencies` rule",
-					"allOf": [{ "$ref": "#/definitions/HooksOptions" }]
-				},
-				{
-					"description": "Deprecated options for `useHookAtTopLevel` rule",
-					"allOf": [{ "$ref": "#/definitions/DeprecatedHooksOptions" }]
-				},
-				{
-					"description": "Options for `useNamingConvention` rule",
-					"allOf": [{ "$ref": "#/definitions/NamingConventionOptions" }]
-				},
-				{
-					"description": "Options for `noRestrictedGlobals` rule",
-					"allOf": [{ "$ref": "#/definitions/RestrictedGlobalsOptions" }]
-				},
-				{
-					"description": "Options for `noRestrictedImports` rule",
-					"allOf": [{ "$ref": "#/definitions/RestrictedImportsOptions" }]
-				},
-				{
-					"description": "Options for `useValidAriaRole` rule",
-					"allOf": [{ "$ref": "#/definitions/ValidAriaRoleOptions" }]
-				},
-				{
-					"description": "Options for `useSortedClasses` rule",
-					"allOf": [{ "$ref": "#/definitions/UtilityClassSortingOptions" }]
-				}
 			]
 		},
 		"QuoteProperties": { "type": "string", "enum": ["asNeeded", "preserve"] },
@@ -1789,27 +1757,178 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleConfiguration": {
+		"RuleConfiguration_for_ComplexityOptions": {
 			"anyOf": [
 				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithOptions" }
+				{ "$ref": "#/definitions/RuleWithOptions_for_ComplexityOptions" }
+			]
+		},
+		"RuleConfiguration_for_ConsistentArrayTypeOptions": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{
+					"$ref": "#/definitions/RuleWithOptions_for_ConsistentArrayTypeOptions"
+				}
+			]
+		},
+		"RuleConfiguration_for_DeprecatedHooksOptions": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithOptions_for_DeprecatedHooksOptions" }
+			]
+		},
+		"RuleConfiguration_for_FilenamingConventionOptions": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{
+					"$ref": "#/definitions/RuleWithOptions_for_FilenamingConventionOptions"
+				}
+			]
+		},
+		"RuleConfiguration_for_HooksOptions": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithOptions_for_HooksOptions" }
+			]
+		},
+		"RuleConfiguration_for_NamingConventionOptions": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithOptions_for_NamingConventionOptions" }
+			]
+		},
+		"RuleConfiguration_for_Null": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithOptions_for_Null" }
+			]
+		},
+		"RuleConfiguration_for_RestrictedGlobalsOptions": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithOptions_for_RestrictedGlobalsOptions" }
+			]
+		},
+		"RuleConfiguration_for_RestrictedImportsOptions": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithOptions_for_RestrictedImportsOptions" }
+			]
+		},
+		"RuleConfiguration_for_UtilityClassSortingOptions": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{
+					"$ref": "#/definitions/RuleWithOptions_for_UtilityClassSortingOptions"
+				}
+			]
+		},
+		"RuleConfiguration_for_ValidAriaRoleOptions": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithOptions_for_ValidAriaRoleOptions" }
 			]
 		},
 		"RulePlainConfiguration": {
 			"type": "string",
 			"enum": ["warn", "error", "off"]
 		},
-		"RuleWithOptions": {
+		"RuleWithOptions_for_ComplexityOptions": {
 			"type": "object",
-			"required": ["level"],
+			"required": ["level", "options"],
 			"properties": {
 				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
-				"options": {
-					"anyOf": [
-						{ "$ref": "#/definitions/PossibleOptions" },
-						{ "type": "null" }
-					]
-				}
+				"options": { "$ref": "#/definitions/ComplexityOptions" }
+			},
+			"additionalProperties": false
+		},
+		"RuleWithOptions_for_ConsistentArrayTypeOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
+				"options": { "$ref": "#/definitions/ConsistentArrayTypeOptions" }
+			},
+			"additionalProperties": false
+		},
+		"RuleWithOptions_for_DeprecatedHooksOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
+				"options": { "$ref": "#/definitions/DeprecatedHooksOptions" }
+			},
+			"additionalProperties": false
+		},
+		"RuleWithOptions_for_FilenamingConventionOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
+				"options": { "$ref": "#/definitions/FilenamingConventionOptions" }
+			},
+			"additionalProperties": false
+		},
+		"RuleWithOptions_for_HooksOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
+				"options": { "$ref": "#/definitions/HooksOptions" }
+			},
+			"additionalProperties": false
+		},
+		"RuleWithOptions_for_NamingConventionOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
+				"options": { "$ref": "#/definitions/NamingConventionOptions" }
+			},
+			"additionalProperties": false
+		},
+		"RuleWithOptions_for_Null": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
+				"options": { "type": "null" }
+			},
+			"additionalProperties": false
+		},
+		"RuleWithOptions_for_RestrictedGlobalsOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
+				"options": { "$ref": "#/definitions/RestrictedGlobalsOptions" }
+			},
+			"additionalProperties": false
+		},
+		"RuleWithOptions_for_RestrictedImportsOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
+				"options": { "$ref": "#/definitions/RestrictedImportsOptions" }
+			},
+			"additionalProperties": false
+		},
+		"RuleWithOptions_for_UtilityClassSortingOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
+				"options": { "$ref": "#/definitions/UtilityClassSortingOptions" }
+			},
+			"additionalProperties": false
+		},
+		"RuleWithOptions_for_ValidAriaRoleOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
+				"options": { "$ref": "#/definitions/ValidAriaRoleOptions" }
 			},
 			"additionalProperties": false
 		},
@@ -1862,14 +1981,14 @@
 				"noDangerouslySetInnerHtml": {
 					"description": "Prevent the usage of dangerous JSX props",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDangerouslySetInnerHtmlWithChildren": {
 					"description": "Report when a DOM element or a component uses both children and dangerouslySetInnerHTML prop.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -1896,105 +2015,107 @@
 				"noArguments": {
 					"description": "Disallow the use of arguments.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noCommaOperator": {
 					"description": "Disallow comma operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDefaultExport": {
 					"description": "Disallow default exports.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noImplicitBoolean": {
 					"description": "Disallow implicit true values on JSX boolean attributes",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noInferrableTypes": {
 					"description": "Disallow type annotations for variables, parameters, and class properties initialized with a literal expression.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noNamespace": {
 					"description": "Disallow the use of TypeScript's namespaces.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noNegationElse": {
 					"description": "Disallow negation in the condition of an if statement if it has an else clause.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noNonNullAssertion": {
 					"description": "Disallow non-null assertions using the ! postfix operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noParameterAssign": {
 					"description": "Disallow reassigning function parameters.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noParameterProperties": {
 					"description": "Disallow the use of parameter properties in class constructors.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noRestrictedGlobals": {
 					"description": "This rule allows you to specify global variable names that you don’t want to use in your application.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{
+							"$ref": "#/definitions/RuleConfiguration_for_RestrictedGlobalsOptions"
+						},
 						{ "type": "null" }
 					]
 				},
 				"noShoutyConstants": {
 					"description": "Disallow the use of constants which its value is the upper-case version of its name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedTemplateLiteral": {
 					"description": "Disallow template literals if interpolation and special-character handling are not needed",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessElse": {
 					"description": "Disallow else block when the if block breaks early.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noVar": {
 					"description": "Disallow the use of var",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2005,126 +2126,128 @@
 				"useAsConstAssertion": {
 					"description": "Enforce the use of as const over literal type and type annotation.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useBlockStatements": {
 					"description": "Requires following curly brace conventions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useCollapsedElseIf": {
 					"description": "Enforce using else if instead of nested if in else clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useConst": {
 					"description": "Require const declarations for variables that are never reassigned after declared.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useDefaultParameterLast": {
 					"description": "Enforce default function parameters and optional function parameters to be last.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useEnumInitializers": {
 					"description": "Require that each enum member value be explicitly initialized.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useExponentiationOperator": {
 					"description": "Disallow the use of Math.pow in favor of the ** operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useFragmentSyntax": {
 					"description": "This rule enforces the use of <>...</> over <Fragment>...</Fragment>.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useLiteralEnumMembers": {
 					"description": "Require all enum members to be literal values.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useNamingConvention": {
 					"description": "Enforce naming conventions for everything across a codebase.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{
+							"$ref": "#/definitions/RuleConfiguration_for_NamingConventionOptions"
+						},
 						{ "type": "null" }
 					]
 				},
 				"useNumericLiterals": {
 					"description": "Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useSelfClosingElements": {
 					"description": "Prevent extra closing tags for components without children",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useShorthandArrayType": {
 					"description": "When expressing array types, this rule promotes the usage of T[] shorthand instead of Array<T>.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useShorthandAssign": {
 					"description": "Require assignment operator shorthand where possible.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useSingleCaseStatement": {
 					"description": "Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useSingleVarDeclarator": {
 					"description": "Disallow multiple variable declarations in the same variable statement",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useTemplate": {
 					"description": "Prefer template literals over string concatenation.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useWhile": {
 					"description": "Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				}
@@ -2141,280 +2264,280 @@
 				"noApproximativeNumericConstant": {
 					"description": "Use standard constants instead of approximated literals.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noArrayIndexKey": {
 					"description": "Discourage the usage of Array index in keys.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noAssignInExpressions": {
 					"description": "Disallow assignments in expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noAsyncPromiseExecutor": {
 					"description": "Disallows using an async function as a Promise executor.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noCatchAssign": {
 					"description": "Disallow reassigning exceptions in catch clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noClassAssign": {
 					"description": "Disallow reassigning class members.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noCommentText": {
 					"description": "Prevent comments from being inserted as text nodes",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noCompareNegZero": {
 					"description": "Disallow comparing against -0",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noConfusingLabels": {
 					"description": "Disallow labeled statements that are not loops.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noConfusingVoidType": {
 					"description": "Disallow void type outside of generic or return types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noConsoleLog": {
 					"description": "Disallow the use of console.log",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noConstEnum": {
 					"description": "Disallow TypeScript const enum",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noControlCharactersInRegex": {
 					"description": "Prevents from having control characters and some escape sequences that match control characters in regular expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDebugger": {
 					"description": "Disallow the use of debugger",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDoubleEquals": {
 					"description": "Require the use of === and !==",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDuplicateCase": {
 					"description": "Disallow duplicate case labels.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDuplicateClassMembers": {
 					"description": "Disallow duplicate class members.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDuplicateJsxProps": {
 					"description": "Prevents JSX properties to be assigned multiple times.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDuplicateObjectKeys": {
 					"description": "Prevents object literals having more than one property declaration for the same name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDuplicateParameters": {
 					"description": "Disallow duplicate function parameter name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noEmptyInterface": {
 					"description": "Disallow the declaration of empty interfaces.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noExplicitAny": {
 					"description": "Disallow the any type usage.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noExtraNonNullAssertion": {
 					"description": "Prevents the wrong usage of the non-null assertion operator (!) in TypeScript files.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noFallthroughSwitchClause": {
 					"description": "Disallow fallthrough of switch clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noFunctionAssign": {
 					"description": "Disallow reassigning function declarations.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noGlobalIsFinite": {
 					"description": "Use Number.isFinite instead of global isFinite.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noGlobalIsNan": {
 					"description": "Use Number.isNaN instead of global isNaN.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noImplicitAnyLet": {
 					"description": "Disallow use of implicit any type on variable declarations.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noImportAssign": {
 					"description": "Disallow assigning to imported bindings",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noLabelVar": {
 					"description": "Disallow labels that share a name with a variable",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noMisleadingInstantiator": {
 					"description": "Enforce proper usage of new and constructor.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noMisrefactoredShorthandAssign": {
 					"description": "Disallow shorthand assign when variable appears on both sides.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noPrototypeBuiltins": {
 					"description": "Disallow direct use of Object.prototype builtins.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noRedeclare": {
 					"description": "Disallow variable, function, class, and type redeclarations in the same scope.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noRedundantUseStrict": {
 					"description": "Prevents from having redundant \"use strict\".",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noSelfCompare": {
 					"description": "Disallow comparisons where both sides are exactly the same.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noShadowRestrictedNames": {
 					"description": "Disallow identifiers from shadowing restricted names.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noSparseArray": {
 					"description": "Disallow sparse arrays",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnsafeDeclarationMerging": {
 					"description": "Disallow unsafe declaration merging between interfaces and classes.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnsafeNegation": {
 					"description": "Disallow using unsafe negation.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2425,35 +2548,35 @@
 				"useDefaultSwitchClauseLast": {
 					"description": "Enforce default clauses in switch statements to be last",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useGetterReturn": {
 					"description": "Enforce get methods to always return a value.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useIsArray": {
 					"description": "Use Array.isArray() instead of instanceof Array.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useNamespaceKeyword": {
 					"description": "Require using the namespace keyword over the module keyword to declare TypeScript namespaces.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useValidTypeof": {
 					"description": "This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				}

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -491,7 +491,7 @@ fn handle_comma_list<'a>(grammar: &'a Grammar, rules: &[Rule]) -> Option<CommaLi
         _ => return None,
     };
 
-    // Does the repeat match (token node))
+    // Does the repeat match (token)
     let comma = match repeat.as_slice() {
         [comma, Rule::Node(n)] => {
             let separator_matches_trailing = if let Some(trailing) = trailing_separator {

--- a/xtask/codegen/src/generate_bindings.rs
+++ b/xtask/codegen/src/generate_bindings.rs
@@ -10,7 +10,7 @@ use biome_js_syntax::{
 use biome_rowan::AstNode;
 use biome_service::workspace_types::{generate_type, methods, ModuleQueue};
 use xtask::{project_root, Mode, Result};
-use xtask_codegen::{to_camel_case, update};
+use xtask_codegen::{to_lower_camel_case, update};
 
 pub(crate) fn generate_workspace_bindings(mode: Mode) -> Result<()> {
     let bindings_path = project_root().join("packages/@biomejs/backend-jsonrpc/src/workspace.ts");
@@ -25,7 +25,7 @@ pub(crate) fn generate_workspace_bindings(mode: Mode) -> Result<()> {
         let params = generate_type(&mut declarations, &mut queue, &method.params);
         let result = generate_type(&mut declarations, &mut queue, &method.result);
 
-        let camel_case = to_camel_case(method.name);
+        let camel_case = to_lower_camel_case(method.name);
 
         member_definitions.push(AnyTsTypeMember::TsMethodSignatureTypeMember(
             make::ts_method_signature_type_member(

--- a/xtask/codegen/src/generate_new_lintrule.rs
+++ b/xtask/codegen/src/generate_new_lintrule.rs
@@ -51,7 +51,7 @@ declare_rule! {{
     /// var a = 1;
     /// ```
     ///
-    pub(crate) {rule_name_upper_camel} {{
+    pub {rule_name_upper_camel} {{
         version: "next",
         name: "{rule_name_lower_camel}",
         recommended: false,

--- a/xtask/codegen/src/generate_node_factory.rs
+++ b/xtask/codegen/src/generate_node_factory.rs
@@ -1,6 +1,5 @@
 use super::js_kinds_src::AstSrc;
-use crate::to_lower_snake_case;
-use crate::{js_kinds_src::Field, to_upper_snake_case, LanguageKind};
+use crate::{js_kinds_src::Field, to_lower_snake_case, to_upper_snake_case, LanguageKind};
 use quote::{format_ident, quote};
 use xtask::Result;
 

--- a/xtask/codegen/src/generate_nodes.rs
+++ b/xtask/codegen/src/generate_nodes.rs
@@ -347,7 +347,7 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
                 .iter()
                 .map(|variant| {
                     let variant_name = format_ident!("{}", variant);
-                    let fn_name = format_ident!("as_{}", to_lower_snake_case(variant));
+                    let fn_name = format_ident!("as_{}", (to_lower_snake_case(variant)));
                     quote! {
                         pub fn #fn_name(&self) -> Option<&#variant_name> {
                            match &self {

--- a/xtask/codegen/src/lib.rs
+++ b/xtask/codegen/src/lib.rs
@@ -197,9 +197,25 @@ pub fn update(path: &Path, contents: &str, mode: &Mode) -> Result<UpdateResult> 
     Ok(UpdateResult::Updated)
 }
 
-pub fn to_camel_case(s: &str) -> String {
+pub fn to_capitalized(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+    }
+}
+
+pub fn to_lower_camel_case(s: &str) -> String {
+    to_pascal_camel_case(s, false)
+}
+
+pub fn to_pascal_case(s: &str) -> String {
+    to_pascal_camel_case(s, true)
+}
+
+fn to_pascal_camel_case(s: &str, is_ascal: bool) -> String {
     let mut buf = String::with_capacity(s.len());
-    let mut prev = false;
+    let mut prev = is_ascal;
     for c in s.chars() {
         if c == '_' {
             prev = true;


### PR DESCRIPTION
## Summary

Part of #1263.
This should also help for #1795.

This PR reduces by 352% (from 4016 bytes to 1140 bytes) the memory usage of `biome.json`.
Most of the memory usage comes from the `RuleConfiguration` type (16 bytes) that is present for every rule.
`RuleConfiguration` is an enum with two variants, thus it took the size of its biggest variant: `RuleWithOptions`.
Most of the rules have no options, so this is just a waste of memory.

I managed to reduce the size of `RuleWithOptions` to only 1 byte for a rule without options.
This reduces the size of `RuleConfiguration` to 2 bytes :)
To do that, I added a type parameter to `RuleConfiguration` and `RuleWithOptions`.
This type parameter is set to the Options type of the rule. Most of the rule has `Rule::Options` set to `()`.
Rules with options took a variable amount of memory depending on the memory layout of their options.
I used the same trick as my previous PR (#1283) to ensure a maximum usage of 16 bytes: I wrapped the `Options` type in a `Box` when its size is larger than 16 (this is the case for 3 rules).

A nice side effect is that we get exact JSON schema.

We now generate an `options.rs` file in `biome_js_analyze` and `biome_json_analyze` that exports the options for the rules.
I had to make the rules public to satisfy the Rust compiler: it reported the use of a crate-scoped type in the public interface. Unfortunately disabling the Clippy check is not enough: the compiler still complained.

I also had to fix a bug in our deserializable derive macro that handled wrongly constrained generics.

## Test Plan

CI should pass.
