### PR TITLE
feat(service): implement format_range and format_on_type for vue, astro and svelte files

### DIFF
--- a/crates/biome_service/src/file_handlers/astro.rs
+++ b/crates/biome_service/src/file_handlers/astro.rs
@@ -9,7 +9,7 @@ use crate::WorkspaceError;
 use biome_formatter::Printed;
 use biome_fs::RomePath;
 use biome_js_parser::{parse_js_with_cache, JsParserOptions};
-use biome_js_syntax::JsFileSource;
+use biome_js_syntax::{JsFileSource, TextRange, TextSize};
 use biome_parser::AnyParse;
 use biome_rowan::NodeCache;
 use lazy_static::lazy_static;
@@ -89,8 +89,8 @@ impl ExtensionHandler for AstroFileHandler {
             },
             formatter: FormatterCapabilities {
                 format: Some(format),
-                format_range: None,
-                format_on_type: None,
+                format_range: Some(format_range),
+                format_on_type: Some(format_on_type),
             },
         }
     }
@@ -130,6 +130,24 @@ fn format(
     settings: SettingsHandle,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format(rome_path, parse, settings)
+}
+
+pub(crate) fn format_range(
+    rome_path: &RomePath,
+    parse: AnyParse,
+    settings: SettingsHandle,
+    range: TextRange,
+) -> Result<Printed, WorkspaceError> {
+    javascript::format_range(rome_path, parse, settings, range)
+}
+
+pub(crate) fn format_on_type(
+    rome_path: &RomePath,
+    parse: AnyParse,
+    settings: SettingsHandle,
+    offset: TextSize,
+) -> Result<Printed, WorkspaceError> {
+    javascript::format_on_type(rome_path, parse, settings, offset)
 }
 
 pub(crate) fn lint(params: LintParams) -> LintResults {

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -656,7 +656,7 @@ pub(crate) fn format(
 }
 
 #[tracing::instrument(level = "trace", skip(parse, settings))]
-fn format_range(
+pub(crate) fn format_range(
     rome_path: &RomePath,
     parse: AnyParse,
     settings: SettingsHandle,
@@ -670,7 +670,7 @@ fn format_range(
 }
 
 #[tracing::instrument(level = "trace", skip(parse, settings))]
-fn format_on_type(
+pub(crate) fn format_on_type(
     rome_path: &RomePath,
     parse: AnyParse,
     settings: SettingsHandle,

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -9,7 +9,7 @@ use crate::WorkspaceError;
 use biome_formatter::Printed;
 use biome_fs::RomePath;
 use biome_js_parser::{parse_js_with_cache, JsParserOptions};
-use biome_js_syntax::JsFileSource;
+use biome_js_syntax::{JsFileSource, TextRange, TextSize};
 use biome_parser::AnyParse;
 use biome_rowan::NodeCache;
 use lazy_static::lazy_static;
@@ -108,8 +108,8 @@ impl ExtensionHandler for SvelteFileHandler {
             },
             formatter: FormatterCapabilities {
                 format: Some(format),
-                format_range: None,
-                format_on_type: None,
+                format_range: Some(format_range),
+                format_on_type: Some(format_on_type),
             },
         }
     }
@@ -163,6 +163,24 @@ fn format(
     settings: SettingsHandle,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format(rome_path, parse, settings)
+}
+
+pub(crate) fn format_range(
+    rome_path: &RomePath,
+    parse: AnyParse,
+    settings: SettingsHandle,
+    range: TextRange,
+) -> Result<Printed, WorkspaceError> {
+    javascript::format_range(rome_path, parse, settings, range)
+}
+
+pub(crate) fn format_on_type(
+    rome_path: &RomePath,
+    parse: AnyParse,
+    settings: SettingsHandle,
+    offset: TextSize,
+) -> Result<Printed, WorkspaceError> {
+    javascript::format_on_type(rome_path, parse, settings, offset)
 }
 
 pub(crate) fn lint(params: LintParams) -> LintResults {

--- a/crates/biome_service/src/file_handlers/vue.rs
+++ b/crates/biome_service/src/file_handlers/vue.rs
@@ -9,7 +9,7 @@ use crate::WorkspaceError;
 use biome_formatter::Printed;
 use biome_fs::RomePath;
 use biome_js_parser::{parse_js_with_cache, JsParserOptions};
-use biome_js_syntax::JsFileSource;
+use biome_js_syntax::{JsFileSource, TextRange, TextSize};
 use biome_parser::AnyParse;
 use biome_rowan::NodeCache;
 use lazy_static::lazy_static;
@@ -108,8 +108,8 @@ impl ExtensionHandler for VueFileHandler {
             },
             formatter: FormatterCapabilities {
                 format: Some(format),
-                format_range: None,
-                format_on_type: None,
+                format_range: Some(format_range),
+                format_on_type: Some(format_on_type),
             },
         }
     }
@@ -152,6 +152,24 @@ fn format(
     settings: SettingsHandle,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format(rome_path, parse, settings)
+}
+
+pub(crate) fn format_range(
+    rome_path: &RomePath,
+    parse: AnyParse,
+    settings: SettingsHandle,
+    range: TextRange,
+) -> Result<Printed, WorkspaceError> {
+    javascript::format_range(rome_path, parse, settings, range)
+}
+
+pub(crate) fn format_on_type(
+    rome_path: &RomePath,
+    parse: AnyParse,
+    settings: SettingsHandle,
+    offset: TextSize,
+) -> Result<Printed, WorkspaceError> {
+    javascript::format_on_type(rome_path, parse, settings, offset)
 }
 
 pub(crate) fn lint(params: LintParams) -> LintResults {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR adds `format_range` and `format_on_type` support for Vue, Astro and Svelte files. I followed the instructions here: https://github.com/biomejs/biome/issues/1719#issuecomment-1959219699

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
