### PR TITLE
refactor(lint/namimg-convention): turn off `requireAscii` to avoid breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,40 +246,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Linter
 
-#### BREAKING CHANGES
-
-- [useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention)
-  and [useFilenamingConvention](https://biomejs.dev/linter/rules/use-filenaming-convention) now require identifiers to
-  be in ASCII and without consecutive delimiters.
-
-  Set the `requireAscii` rule option to `false` to allow non-ASCII identifiers.
-
-  ```json
-  {
-    "linter": {
-      "rules": {
-        "style": {
-          "useNamingConvention": { "options": { "requireAscii": false } }
-        },
-        "nursery": {
-          "useFilenamingConvention": { "options": { "requireAscii": false } }
-        }
-      }
-    }
-  }
-
-  ```
-
-  The following name is now invalid because it includes two underscores:
-
-  ```js
-  export const MY__CONSTANT = 0;
-  ```
-
-  Note that we still allow consecutive leading and consecutive trailing underscores.
-
-  Contributed by @Conaclos
-
 #### New features
 
 - Add the rule [noSkippedTests](https://biomejs.dev/linter/rules/no-skipped-tests), to disallow skipped tests:
@@ -396,6 +362,32 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention)
+  and [useFilenamingConvention](https://biomejs.dev/linter/rules/use-filenaming-convention) now provides a new option `requireAscii` to require identifiers to
+  be in ASCII.
+
+  To avoid any breaking change, this option is turned off by default.
+  We intend to turn it on in the next major release of Biome (Biome 2.0).
+
+  Set the `requireAscii` rule option to `true` to require identifiers to be in ASCII.
+
+  ```json
+  {
+    "linter": {
+      "rules": {
+        "style": {
+          "useNamingConvention": { "options": { "requireAscii": false } }
+        },
+        "nursery": {
+          "useFilenamingConvention": { "options": { "requireAscii": false } }
+        }
+      }
+    }
+  }
+  ```
+
+  Contributed by @Conaclos
+
 #### Bug fixes
 
 - Fix missing link in [noStaticOnlyClass](https://biomejs.dev/linter/rules/no-static-only-class) documentation.
@@ -438,22 +430,18 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Fix [#1651](https://github.com/biomejs/biome/issues/1651). [noVar](https://biomejs.dev/linter/rules/no-var/) now
   ignores TsGlobalDeclaration. Contributed by @vasucp1207
 
--
-Fix [#1640](https://github.com/biomejs/biome/issues/1640). [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
-code action now generates valid code when last member has a comment but no comma. Contributed by @kalleep
+- Fix [#1640](https://github.com/biomejs/biome/issues/1640). [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers) code action now generates valid code when last member has a comment but no comma. Contributed by @kalleep
 
-- Fix [#1653](https://github.com/biomejs/biome/issues/1653). Handle a shorthand value in `useForOf` to avoid the
-  false-positive case. Contributed by @togami2864
+- Fix [#1653](https://github.com/biomejs/biome/issues/1653). Handle a shorthand value in `useForOf` to avoid the false-positive case. Contributed by @togami2864
 
--
-Fix [#1656](https://github.com/biomejs/biome/issues/1656). [useOptionalChain](https://biomejs.dev/linter/rules/use-optional-chain/)
-code action now correctly handles logical and chains where methods with the same name are invoked with different
-arguments:
-```diff
-- tags·&&·tags.includes('a')·&&·tags.includes('b')
-+ tags?.includes('a') && tags.includes('b')
-```
-Contributed by @lucasweng
+- Fix [#1656](https://github.com/biomejs/biome/issues/1656). [useOptionalChain](https://biomejs.dev/linter/rules/use-optional-chain/) code action now correctly handles logical and chains where methods with the same name are invoked with different arguments:
+
+  ```diff
+  - tags·&&·tags.includes('a')·&&·tags.includes('b')
+  + tags?.includes('a') && tags.includes('b')
+  ```
+
+  Contributed by @lucasweng
 
 - Fix [#1704](https://github.com/biomejs/biome/issues/1704). Convert `/` to escaped slash `\/` to avoid parsing error in
   the result of autofix. Contributed by @togami2864
@@ -470,6 +458,19 @@ Contributed by @lucasweng
   delete element.dataset.prop;
   ```
   Contributed by @ematipico
+
+- [useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention)
+  and [useFilenamingConvention](https://biomejs.dev/linter/rules/use-filenaming-convention) now reject identifiers with consecutive delimiters.
+
+  The following name is now invalid because it includes two underscores:
+
+  ```js
+  export const MY__CONSTANT = 0;
+  ```
+
+  Note that we still allow consecutive leading and consecutive trailing underscores.
+
+  Contributed by @Conaclos
 
 ### Parser
 

--- a/crates/biome_js_analyze/src/analyzers/nursery/use_filenaming_convention.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/use_filenaming_convention.rs
@@ -61,7 +61,9 @@ declare_rule! {
     /// When the option is set to `false`, anames may include non-ASCII characters.
     /// `café` and `안녕하세요` are so valid.
     ///
-    /// Default: `true`
+    /// Default: `false`
+    ///
+    /// **This option will be turned on by default in Biome 2.0.**
     ///
     /// ### filenameCases
     ///
@@ -246,7 +248,7 @@ pub struct FilenamingConventionOptions {
     pub strict_case: bool,
 
     /// If `false`, then non-ASCII characters are allowed.
-    #[serde(default = "enabled", skip_serializing_if = "is_enabled")]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub require_ascii: bool,
 
     /// Allowed cases for _TypeScript_ `enum` member names.
@@ -262,6 +264,10 @@ const fn is_enabled(value: &bool) -> bool {
     *value
 }
 
+fn is_default<T: Default + Eq>(value: &T) -> bool {
+    value == &T::default()
+}
+
 fn is_default_filename_cases(value: &FilenameCases) -> bool {
     value.0.len() == 4 && !value.0.contains(&FilenameCase::Pascal)
 }
@@ -269,8 +275,8 @@ fn is_default_filename_cases(value: &FilenameCases) -> bool {
 impl Default for FilenamingConventionOptions {
     fn default() -> Self {
         Self {
-            strict_case: enabled(),
-            require_ascii: enabled(),
+            strict_case: true,
+            require_ascii: false,
             filename_cases: FilenameCases::default(),
         }
     }

--- a/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/style/use_naming_convention.rs
@@ -267,7 +267,9 @@ declare_rule! {
     /// When the option is set to `false`, anames may include non-ASCII characters.
     /// `café` and `안녕하세요` are so valid.
     ///
-    /// Default: `true`
+    /// Default: `false`
+    ///
+    /// **This option will be turned on by default in Biome 2.0.**
     ///
     /// ### enumMemberCase
     ///
@@ -516,7 +518,7 @@ pub struct NamingConventionOptions {
     pub strict_case: bool,
 
     /// If `false`, then non-ASCII characters are allowed.
-    #[serde(default = "enabled", skip_serializing_if = "is_enabled")]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub require_ascii: bool,
 
     /// Allowed cases for _TypeScript_ `enum` member names.
@@ -539,8 +541,8 @@ fn is_default<T: Default + Eq>(value: &T) -> bool {
 impl Default for NamingConventionOptions {
     fn default() -> Self {
         Self {
-            strict_case: enabled(),
-            require_ascii: enabled(),
+            strict_case: true,
+            require_ascii: false,
             enum_member_case: EnumMemberCase::default(),
         }
     }

--- a/crates/biome_js_analyze/tests/specs/nursery/useFilenamingConvention/invalid-non-ascii-café.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useFilenamingConvention/invalid-non-ascii-café.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useFilenamingConvention": {
+					"level": "error",
+					"options": {
+						"requireAscii": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidNonAscii.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidNonAscii.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"style": {
+				"useNamingConvention": {
+					"level": "error",
+					"options": {
+						"requireAscii": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -252,40 +252,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Linter
 
-#### BREAKING CHANGES
-
-- [useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention)
-  and [useFilenamingConvention](https://biomejs.dev/linter/rules/use-filenaming-convention) now require identifiers to
-  be in ASCII and without consecutive delimiters.
-
-  Set the `requireAscii` rule option to `false` to allow non-ASCII identifiers.
-
-  ```json
-  {
-    "linter": {
-      "rules": {
-        "style": {
-          "useNamingConvention": { "options": { "requireAscii": false } }
-        },
-        "nursery": {
-          "useFilenamingConvention": { "options": { "requireAscii": false } }
-        }
-      }
-    }
-  }
-
-  ```
-
-  The following name is now invalid because it includes two underscores:
-
-  ```js
-  export const MY__CONSTANT = 0;
-  ```
-
-  Note that we still allow consecutive leading and consecutive trailing underscores.
-
-  Contributed by @Conaclos
-
 #### New features
 
 - Add the rule [noSkippedTests](https://biomejs.dev/linter/rules/no-skipped-tests), to disallow skipped tests:
@@ -402,6 +368,32 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention)
+  and [useFilenamingConvention](https://biomejs.dev/linter/rules/use-filenaming-convention) now provides a new option `requireAscii` to require identifiers to
+  be in ASCII.
+
+  To avoid any breaking change, this option is turned off by default.
+  We intend to turn it on in the next major release of Biome (Biome 2.0).
+
+  Set the `requireAscii` rule option to `true` to require identifiers to be in ASCII.
+
+  ```json
+  {
+    "linter": {
+      "rules": {
+        "style": {
+          "useNamingConvention": { "options": { "requireAscii": false } }
+        },
+        "nursery": {
+          "useFilenamingConvention": { "options": { "requireAscii": false } }
+        }
+      }
+    }
+  }
+  ```
+
+  Contributed by @Conaclos
+
 #### Bug fixes
 
 - Fix missing link in [noStaticOnlyClass](https://biomejs.dev/linter/rules/no-static-only-class) documentation.
@@ -444,22 +436,18 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Fix [#1651](https://github.com/biomejs/biome/issues/1651). [noVar](https://biomejs.dev/linter/rules/no-var/) now
   ignores TsGlobalDeclaration. Contributed by @vasucp1207
 
--
-Fix [#1640](https://github.com/biomejs/biome/issues/1640). [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
-code action now generates valid code when last member has a comment but no comma. Contributed by @kalleep
+- Fix [#1640](https://github.com/biomejs/biome/issues/1640). [useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers) code action now generates valid code when last member has a comment but no comma. Contributed by @kalleep
 
-- Fix [#1653](https://github.com/biomejs/biome/issues/1653). Handle a shorthand value in `useForOf` to avoid the
-  false-positive case. Contributed by @togami2864
+- Fix [#1653](https://github.com/biomejs/biome/issues/1653). Handle a shorthand value in `useForOf` to avoid the false-positive case. Contributed by @togami2864
 
--
-Fix [#1656](https://github.com/biomejs/biome/issues/1656). [useOptionalChain](https://biomejs.dev/linter/rules/use-optional-chain/)
-code action now correctly handles logical and chains where methods with the same name are invoked with different
-arguments:
-```diff
-- tags·&&·tags.includes('a')·&&·tags.includes('b')
-+ tags?.includes('a') && tags.includes('b')
-```
-Contributed by @lucasweng
+- Fix [#1656](https://github.com/biomejs/biome/issues/1656). [useOptionalChain](https://biomejs.dev/linter/rules/use-optional-chain/) code action now correctly handles logical and chains where methods with the same name are invoked with different arguments:
+
+  ```diff
+  - tags·&&·tags.includes('a')·&&·tags.includes('b')
+  + tags?.includes('a') && tags.includes('b')
+  ```
+
+  Contributed by @lucasweng
 
 - Fix [#1704](https://github.com/biomejs/biome/issues/1704). Convert `/` to escaped slash `\/` to avoid parsing error in
   the result of autofix. Contributed by @togami2864
@@ -476,6 +464,19 @@ Contributed by @lucasweng
   delete element.dataset.prop;
   ```
   Contributed by @ematipico
+
+- [useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention)
+  and [useFilenamingConvention](https://biomejs.dev/linter/rules/use-filenaming-convention) now reject identifiers with consecutive delimiters.
+
+  The following name is now invalid because it includes two underscores:
+
+  ```js
+  export const MY__CONSTANT = 0;
+  ```
+
+  Note that we still allow consecutive leading and consecutive trailing underscores.
+
+  Contributed by @Conaclos
 
 ### Parser
 

--- a/website/src/content/docs/linter/rules/use-filenaming-convention.md
+++ b/website/src/content/docs/linter/rules/use-filenaming-convention.md
@@ -56,7 +56,9 @@ For instance,  when the option is set to `true`, `café` or `안녕하세요` wi
 When the option is set to `false`, anames may include non-ASCII characters.
 `café` and `안녕하세요` are so valid.
 
-Default: `true`
+Default: `false`
+
+**This option will be turned on by default in Biome 2.0.**
 
 ### filenameCases
 

--- a/website/src/content/docs/linter/rules/use-naming-convention.md
+++ b/website/src/content/docs/linter/rules/use-naming-convention.md
@@ -348,7 +348,9 @@ For instance,  when the option is set to `true`, `café` or `안녕하세요` wi
 When the option is set to `false`, anames may include non-ASCII characters.
 `café` and `안녕하세요` are so valid.
 
-Default: `true`
+Default: `false`
+
+**This option will be turned on by default in Biome 2.0.**
 
 ### enumMemberCase
 


### PR DESCRIPTION
## Summary

I recently added a new option to the naming convention rules: `requireAscii`. Enabling it by default is a good thing, but this is a breaking change. According to our [versioning philosophy](https://biomejs.dev/internals/versioning/), we should release a major release. This seems overkill for such a small change.

So I have decided to disable this option by default and postpone the change to a future major release. I will create an issue to track this.

## Test Plan

All tests passed.
