### PR TITLE
feat(deserializable): add `unknown_fields` struct attribute

### DIFF
--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -18,6 +18,7 @@ use indexmap::IndexSet;
 use std::path::{Path, PathBuf};
 
 #[derive(Clone, Debug, Deserializable, Eq, PartialEq)]
+#[deserializable(unknown_fields = "allow")]
 pub(crate) struct PrettierConfiguration {
     /// https://prettier.io/docs/en/options#print-width
     print_width: u16,

--- a/crates/biome_cli/tests/snapshots/main_configuration/incorrect_rule_name.snap
+++ b/crates/biome_cli/tests/snapshots/main_configuration/incorrect_rule_name.snap
@@ -45,7 +45,7 @@ biome.json:6:13 deserialize ━━━━━━━━━━━━━━━━━�
     7 │         },
     8 │         "style": {
   
-  i Accepted keys
+  i Known keys:
   
   - recommended
   - all
@@ -98,7 +98,7 @@ biome.json:9:13 deserialize ━━━━━━━━━━━━━━━━━�
     10 │         }
     11 │     }
   
-  i Accepted keys
+  i Known keys:
   
   - recommended
   - all

--- a/crates/biome_deserialize/src/diagnostics.rs
+++ b/crates/biome_deserialize/src/diagnostics.rs
@@ -129,7 +129,7 @@ impl DeserializationDiagnostic {
     pub fn new_unknown_key(key_name: &str, range: impl AsSpan, allowed_keys: &[&str]) -> Self {
         Self::new(markup!("Found an unknown key `"<Emphasis>{key_name}</Emphasis>"`." ))
             .with_range(range)
-            .note_with_list("Accepted keys", allowed_keys)
+            .note_with_list("Known keys:", allowed_keys)
     }
 
     /// Emitted when there's an unknown value, against a set of known ones

--- a/crates/biome_deserialize_macros/src/lib.rs
+++ b/crates/biome_deserialize_macros/src/lib.rs
@@ -42,6 +42,38 @@ use syn::{parse_macro_input, DeriveInput};
 /// When [Deserializable] is derived on a struct or  an enum,
 /// its behavior may be adjusted through attributes.
 ///
+/// ### `unknown_fields`
+///
+/// This attribute allows controling how to handle unknown fields in structs.
+/// It takes one of the following values:
+///
+/// - `"deny"`: emit an error when an unknown struct field is found.
+/// - `"warn"`: emit a warning when an unknown struct field is found.
+/// - `"allow"`: ignore unknown struct fields.
+///
+/// The default behavior is `"warn"`, when the attribute is not specified.
+///
+/// For structs that also implement Serde's [serde::Deserialize],
+/// it automatically picks up on Serde's
+/// [`deny_unknown_fields` attribute](https://serde.rs/container-attrs.html#from).
+/// `serde(deny_unknown_fields)` is mapped to `unknown_fields = "error"`.
+/// `deserializable(unknown_fields = _)` takes precdence over `serde(deny_unknown_fields = _)`.
+///
+/// ```no_test
+/// #[derive(Default, Deserializable)]
+/// #[deserializable(unknown_fields = "deny")]
+/// struct Contact {
+///     fullname: String,
+/// }
+///
+/// #[derive(Default, Deserializable)]
+/// #[deserializable(unknown_fields = "allow")]
+/// struct Person {
+///     firstnames: String,
+///     lastname: String,
+/// }
+/// ```
+///
 /// ### `with_validator`
 ///
 /// When the `with_validator` attribute is present, the deserializable type is

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/malformedOptions.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/malformedOptions.js.snap
@@ -20,7 +20,7 @@ malformedOptions.options:9:7 deserialize ━━━━━━━━━━━━━
     10 │ 							{
     11 │ 								"name": "useMyEffect",
   
-  i Accepted keys
+  i Known keys:
   
   - hooks
   

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -343,7 +343,7 @@ impl Rules {
 #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
 #[deserializable(with_validator)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct A11y {
     #[doc = r" It enables the recommended rules for this group"]
@@ -1075,7 +1075,7 @@ impl A11y {
 #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
 #[deserializable(with_validator)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Complexity {
     #[doc = r" It enables the recommended rules for this group"]
@@ -1701,7 +1701,7 @@ impl Complexity {
 #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
 #[deserializable(with_validator)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Correctness {
     #[doc = r" It enables the recommended rules for this group"]
@@ -2485,7 +2485,7 @@ impl Correctness {
 #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
 #[deserializable(with_validator)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Nursery {
     #[doc = r" It enables the recommended rules for this group"]
@@ -3298,7 +3298,7 @@ impl Nursery {
 #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
 #[deserializable(with_validator)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Performance {
     #[doc = r" It enables the recommended rules for this group"]
@@ -3433,7 +3433,7 @@ impl Performance {
 #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
 #[deserializable(with_validator)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Security {
     #[doc = r" It enables the recommended rules for this group"]
@@ -3575,7 +3575,7 @@ impl Security {
 #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
 #[deserializable(with_validator)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Style {
     #[doc = r" It enables the recommended rules for this group"]
@@ -4339,7 +4339,7 @@ impl Style {
 #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
 #[deserializable(with_validator)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[doc = r" A list of rules that belong to this group"]
 pub struct Suspicious {
     #[doc = r" It enables the recommended rules for this group"]

--- a/crates/biome_service/tests/invalid/files_extraneous_field.json.snap
+++ b/crates/biome_service/tests/invalid/files_extraneous_field.json.snap
@@ -13,7 +13,7 @@ files_extraneous_field.json:3:3 deserialize ━━━━━━━━━━━━
     4 │ 	}
     5 │ }
   
-  i Accepted keys
+  i Known keys:
   
   - maxSize
   - ignore

--- a/crates/biome_service/tests/invalid/formatter_extraneous_field.json.snap
+++ b/crates/biome_service/tests/invalid/formatter_extraneous_field.json.snap
@@ -13,7 +13,7 @@ formatter_extraneous_field.json:3:3 deserialize ━━━━━━━━━━�
     4 │ 	}
     5 │ }
   
-  i Accepted keys
+  i Known keys:
   
   - enabled
   - formatWithErrors

--- a/crates/biome_service/tests/invalid/formatter_quote_style.json.snap
+++ b/crates/biome_service/tests/invalid/formatter_quote_style.json.snap
@@ -13,7 +13,7 @@ formatter_quote_style.json:3:9 deserialize ━━━━━━━━━━━━�
     4 │     }
     5 │ }
   
-  i Accepted keys
+  i Known keys:
   
   - enabled
   - formatWithErrors

--- a/crates/biome_service/tests/invalid/hooks_incorrect_options.json.snap
+++ b/crates/biome_service/tests/invalid/hooks_incorrect_options.json.snap
@@ -13,7 +13,7 @@ hooks_incorrect_options.json:9:7 deserialize ━━━━━━━━━━━�
     10 │ 					}
     11 │ 				}
   
-  i Accepted keys
+  i Known keys:
   
   - hooks
   

--- a/crates/biome_service/tests/invalid/naming_convention_incorrect_options.json.snap
+++ b/crates/biome_service/tests/invalid/naming_convention_incorrect_options.json.snap
@@ -13,7 +13,7 @@ naming_convention_incorrect_options.json:9:7 deserialize ━━━━━━━�
     10 │ 					}
     11 │ 				}
   
-  i Accepted keys
+  i Known keys:
   
   - strictCase
   - requireAscii

--- a/crates/biome_service/tests/invalid/overrides/incorrect_key.json.snap
+++ b/crates/biome_service/tests/invalid/overrides/incorrect_key.json.snap
@@ -13,7 +13,7 @@ incorrect_key.json:4:4 deserialize ━━━━━━━━━━━━━━━
     5 │ 		}
     6 │ 	]
   
-  i Accepted keys
+  i Known keys:
   
   - ignore
   - include

--- a/crates/biome_service/tests/invalid/top_level_extraneous_field.json.snap
+++ b/crates/biome_service/tests/invalid/top_level_extraneous_field.json.snap
@@ -12,7 +12,7 @@ top_level_extraneous_field.json:2:2 deserialize ━━━━━━━━━━�
     3 │ 		"maxSize": 45000
     4 │ 	}
   
-  i Accepted keys
+  i Known keys:
   
   - $schema
   - vcs

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -294,7 +294,8 @@
 						{ "type": "null" }
 					]
 				}
-			}
+			},
+			"additionalProperties": false
 		},
 		"ArrowParentheses": { "type": "string", "enum": ["always", "asNeeded"] },
 		"AttributePosition": { "type": "string", "enum": ["auto", "multiline"] },
@@ -485,7 +486,8 @@
 						{ "type": "null" }
 					]
 				}
-			}
+			},
+			"additionalProperties": false
 		},
 		"ComplexityConfiguration": {
 			"anyOf": [
@@ -778,7 +780,8 @@
 						{ "type": "null" }
 					]
 				}
-			}
+			},
+			"additionalProperties": false
 		},
 		"CssConfiguration": {
 			"description": "Options applied to CSS files",
@@ -1588,7 +1591,8 @@
 						{ "type": "null" }
 					]
 				}
-			}
+			},
+			"additionalProperties": false
 		},
 		"OrganizeImports": {
 			"type": "object",
@@ -1766,7 +1770,8 @@
 					"description": "It enables the recommended rules for this group",
 					"type": ["boolean", "null"]
 				}
-			}
+			},
+			"additionalProperties": false
 		},
 		"PlainIndentStyle": {
 			"oneOf": [
@@ -1987,7 +1992,8 @@
 					"description": "It enables the recommended rules for this group",
 					"type": ["boolean", "null"]
 				}
-			}
+			},
+			"additionalProperties": false
 		},
 		"Semicolons": { "type": "string", "enum": ["always", "asNeeded"] },
 		"StringSet": {
@@ -2238,7 +2244,8 @@
 						{ "type": "null" }
 					]
 				}
-			}
+			},
+			"additionalProperties": false
 		},
 		"Suspicious": {
 			"description": "A list of rules that belong to this group",
@@ -2567,7 +2574,8 @@
 						{ "type": "null" }
 					]
 				}
-			}
+			},
+			"additionalProperties": false
 		},
 		"TrailingComma": {
 			"description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.",

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -413,7 +413,7 @@ fn generate_struct(group: &str, rules: &BTreeMap<&'static str, RuleMetadata>) ->
         #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
         #[deserializable(with_validator)]
         #[cfg_attr(feature = "schema", derive(JsonSchema))]
-        #[serde(rename_all = "camelCase", default)]
+        #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
         /// A list of rules that belong to this group
         pub struct #group_struct_name {
             /// It enables the recommended rules for this group


### PR DESCRIPTION
## Summary

Fix #1901
Partially fix #1898

This PR adds the `allow_unknown_fields` struct attribute.

## Test Plan

I updated the snapshots
