### PR TITLE
Fix/arrowfunction with conditional expression body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Fix [#1827](https://github.com/biomejs/biome/issues/1827) by properly analyzing nested `try-finally` statements. Contributed by @ah-yu
 
 - Fix [#1924](https://github.com/biomejs/biome/issues/1924) Use the correct export name to sort in the import clause. Contributed by @ah-yu
+- Fix [#1805](https://github.com/biomejs/biome/issues/1805) fix formatting arrow function which has conditional expression body  Contributed by @mdm317
 
 ### CLI
 

--- a/crates/biome_formatter/src/format_element.rs
+++ b/crates/biome_formatter/src/format_element.rs
@@ -19,7 +19,7 @@ use std::rc::Rc;
 pub enum FormatElement {
     /// A space token, see [crate::builders::space] for documentation.
     Space,
-
+    HardSpace,
     /// A new line, see [crate::builders::soft_line_break], [crate::builders::hard_line_break], and [crate::builders::soft_line_break_or_space] for documentation.
     Line(LineMode),
 
@@ -27,7 +27,9 @@ pub enum FormatElement {
     ExpandParent,
 
     /// Token constructed by the formatter from a static string
-    StaticText { text: &'static str },
+    StaticText {
+        text: &'static str,
+    },
 
     /// Token constructed from the input source as a dynamic
     /// string with its start position in the input document.
@@ -66,7 +68,7 @@ pub enum FormatElement {
 impl std::fmt::Debug for FormatElement {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            FormatElement::Space => write!(fmt, "Space"),
+            FormatElement::Space | FormatElement::HardSpace => write!(fmt, "Space"),
             FormatElement::Line(mode) => fmt.debug_tuple("Line").field(mode).finish(),
             FormatElement::ExpandParent => write!(fmt, "ExpandParent"),
             FormatElement::StaticText { text } => {
@@ -251,9 +253,10 @@ impl FormatElements for FormatElement {
             // Traverse into the most flat version because the content is guaranteed to expand when even
             // the most flat version contains some content that forces a break.
             FormatElement::BestFitting(best_fitting) => best_fitting.most_flat().will_break(),
-            FormatElement::LineSuffixBoundary | FormatElement::Space | FormatElement::Tag(_) => {
-                false
-            }
+            FormatElement::LineSuffixBoundary
+            | FormatElement::Space
+            | FormatElement::Tag(_)
+            | FormatElement::HardSpace => false,
         }
     }
 

--- a/crates/biome_formatter/src/format_element/document.rs
+++ b/crates/biome_formatter/src/format_element/document.rs
@@ -236,6 +236,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
 
             match element {
                 element @ (FormatElement::Space
+                | FormatElement::HardSpace
                 | FormatElement::StaticText { .. }
                 | FormatElement::DynamicText { .. }
                 | FormatElement::LocatedTokenText { .. }) => {
@@ -246,7 +247,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
                     in_text = true;
 
                     match element {
-                        FormatElement::Space => {
+                        FormatElement::Space | FormatElement::HardSpace => {
                             write!(f, [text(" ")])?;
                         }
                         element if element.is_text() => f.write_element(element.clone())?,

--- a/crates/biome_formatter/src/printer/mod.rs
+++ b/crates/biome_formatter/src/printer/mod.rs
@@ -88,7 +88,7 @@ impl<'a> Printer<'a> {
         let args = stack.top();
 
         match element {
-            FormatElement::Space => {
+            FormatElement::Space | FormatElement::HardSpace => {
                 if self.state.line_width > 0 {
                     self.state.pending_space = true;
                 }
@@ -985,7 +985,12 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                     self.state.pending_space = true;
                 }
             }
-
+            FormatElement::HardSpace => {
+                self.state.line_width += 1;
+                if self.state.line_width > self.options().print_width.into() {
+                    return Ok(Fits::No);
+                }
+            }
             FormatElement::Line(line_mode) => {
                 if args.mode().is_flat() {
                     match line_mode {
@@ -1628,7 +1633,6 @@ two lines`,
 
         assert_eq!(printed.as_code(), "[1, 2, 3]; // trailing")
     }
-
     #[test]
     fn conditional_with_group_id_in_fits() {
         let content = format_with(|f| {

--- a/crates/biome_js_formatter/tests/specs/prettier/js/arrows/issue-1805-with-body-conditional-expression.js
+++ b/crates/biome_js_formatter/tests/specs/prettier/js/arrows/issue-1805-with-body-conditional-expression.js
@@ -1,0 +1,5 @@
+(seventeenfourcharacterssssssssssssssssssssssssssssssssssssssssssssssssssss)=>a?b:c;
+
+(seventeenfivecharactersssssssssssssssssssssssssssssssssssssssssssssssssssss)=>a?b:c;
+
+(seventeensixcharactersssssssssssssssssssssssssssssssssssssssssssssssssssssss)=>a?b:c;

--- a/crates/biome_js_formatter/tests/specs/prettier/js/arrows/issue-1805-with-body-conditional-expression.js.prettier-snap
+++ b/crates/biome_js_formatter/tests/specs/prettier/js/arrows/issue-1805-with-body-conditional-expression.js.prettier-snap
@@ -1,0 +1,10 @@
+(seventeenfourcharacterssssssssssssssssssssssssssssssssssssssssssssssssssss) =>
+  a ? b : c;
+
+(
+  seventeenfivecharactersssssssssssssssssssssssssssssssssssssssssssssssssssss,
+) => (a ? b : c);
+
+(
+  seventeensixcharactersssssssssssssssssssssssssssssssssssssssssssssssssssssss,
+) => (a ? b : c);

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -105,6 +105,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Fix [#1827](https://github.com/biomejs/biome/issues/1827) by properly analyzing nested `try-finally` statements. Contributed by @ah-yu
 
 - Fix [#1924](https://github.com/biomejs/biome/issues/1924) Use the correct export name to sort in the import clause. Contributed by @ah-yu
+- Fix [#1805](https://github.com/biomejs/biome/issues/1805) fix formatting arrow function which has conditional expression body  Contributed by @mdm317
 
 ### CLI
 


### PR DESCRIPTION
## Summary
Closes #1805 
I found an incompatibility issue with Prettier when using arrow functions which body is conditional expression

I found this issue occurs when formatting arrow functions whose body is conditional expression 
see below example code when linewidth 17
```
(someProperty)=>someProperty?'one':'two'
```
[playground](https://biomejs.dev/playground/?lineWidth=17&indentStyle=space&quoteStyle=single&trailingComma=none&code=KABzAG8AbQBlAFAAcgBvAHAAZQByAHQAeQApAD0APgBzAG8AbQBlAFAAcgBvAHAAZQByAHQAeQA%2FACcAbwBuAGUAJwA6ACcAdAB3AG8AJwA%3D&typescript=false)

I found prettier enforce space after `=>` this token in this case.
And I tried to implement this without changing to FormatElement but failed. So, I added a `HardSpace` to `FormatElement` to implement this.

I am not sure if this approach is acceptable. 
Also Documenting can be quite challenging.

Please review my code

## Test Plan

add test case 
