### PR TITLE
fix(js_formatter): fix invalid formatting of long arrow function for AsNeeded arrow parens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Contributed by @ah-yu
 - Fix [#1659](https://github.com/biomejs/biome/issues/1659) and [#1662](https://github.com/biomejs/biome/issues/1662), by correctly taking into account the leading comma inside the formatter options. Contributed by @ematipico
 
+- Fix [#1934](https://github.com/biomejs/biome/pull/1934). Fix invalid formatting of long arrow function for AsNeeded arrow parens Contributed by @fireairforce
+
 ### JavaScript APIs
 
 ### Linter

--- a/crates/biome_js_formatter/src/js/bindings/formal_parameter.rs
+++ b/crates/biome_js_formatter/src/js/bindings/formal_parameter.rs
@@ -36,7 +36,7 @@ impl FormatNodeRule<JsFormalParameter> for FormatJsFormalParameter {
             .grand_parent()
             .and_then(FormatAnyJsParameters::cast)
             .map_or(false, |parameters| {
-                should_hug_function_parameters(&parameters, f.comments()).unwrap_or(false)
+                should_hug_function_parameters(&parameters, f.comments(), false).unwrap_or(false)
             });
 
         if is_hug_parameter && decorators.is_empty() {

--- a/crates/biome_js_formatter/src/utils/object_pattern_like.rs
+++ b/crates/biome_js_formatter/src/utils/object_pattern_like.rs
@@ -130,7 +130,7 @@ impl JsObjectPatternLike {
                 .and_then(|parameter| parameter.syntax().grand_parent())
                 .and_then(FormatAnyJsParameters::cast)
                 .map_or(false, |parameters| {
-                    should_hug_function_parameters(&parameters, comments).unwrap_or(false)
+                    should_hug_function_parameters(&parameters, comments, false).unwrap_or(false)
                 }),
         }
     }

--- a/crates/biome_js_formatter/tests/quick_test.rs
+++ b/crates/biome_js_formatter/tests/quick_test.rs
@@ -14,33 +14,15 @@ mod language {
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
     let src = r#"
-   import React from "react";
-
-const Component = () => (
-  <div>
-    <div data-a="1">
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </div>
-
-    <div data-a="1" data-b="2" data-c="3">
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </div>
-
-    <div data-a="Lorem ipsum dolor sit amet" data-b="Lorem ipsum dolor sit amet" data-c="Lorem ipsum dolor sit amet">
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </div>
-
-    <div data-long-attribute-a="1" data-long-attribute-b="2" data-long-attribute-c="3">
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </div>
-
-    <img src="/images/foo.png" />
-
-    <img src="/images/foo.png" alt="bar" />
-
-    <img src="/images/foo.png" alt="Lorem ipsum dolor sit amet, consectetur adipiscing elit." />
-  </div>
-);
+type InstanceID = string;
+type MaybeCardWithAttachment = string;
+function outerFunctionToForceIndent() {
+    const cardWithAttachment: (id: InstanceID) => MaybeCardWithAttachment = (
+        id
+    ) => {
+        return `${id}test`;
+    };
+}
 
     "#;
     let source_type = JsFileSource::tsx();
@@ -51,11 +33,11 @@ const Component = () => (
     );
     let options = JsFormatOptions::new(source_type)
         .with_indent_style(IndentStyle::Space)
-        .with_line_width(LineWidth::try_from(120).unwrap())
+        .with_line_width(LineWidth::try_from(80).unwrap())
         .with_semicolons(Semicolons::Always)
         .with_quote_style(QuoteStyle::Double)
         .with_jsx_quote_style(QuoteStyle::Single)
-        .with_arrow_parentheses(ArrowParentheses::Always)
+        .with_arrow_parentheses(ArrowParentheses::AsNeeded)
         .with_attribute_position(AttributePosition::Multiline);
 
     let doc = format_node(options.clone(), &tree.syntax()).unwrap();

--- a/crates/biome_js_formatter/tests/specs/ts/arrow/long_arrow_parentheses_with_line_break.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow/long_arrow_parentheses_with_line_break.ts
@@ -1,0 +1,15 @@
+const this_is_a_very_long_function_name_so_need_to_break_a_new_line_here = (
+  id
+) => {
+  return id;
+};
+
+type InstanceID = string;
+type MaybeCardWithAttachment = string;
+function outerFunctionToForceIndent() {
+    const cardWithAttachment: (id: InstanceID) => MaybeCardWithAttachment = (
+        id
+    ) => {
+        return `${id}test`;
+    };
+}

--- a/crates/biome_js_formatter/tests/specs/ts/arrow/long_arrow_parentheses_with_line_break.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow/long_arrow_parentheses_with_line_break.ts.snap
@@ -1,0 +1,102 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: ts/arrow/long_arrow_parentheses_with_line_break.ts
+---
+
+# Input
+
+```ts
+const this_is_a_very_long_function_name_so_need_to_break_a_new_line_here = (
+  id
+) => {
+  return id;
+};
+
+type InstanceID = string;
+type MaybeCardWithAttachment = string;
+function outerFunctionToForceIndent() {
+    const cardWithAttachment: (id: InstanceID) => MaybeCardWithAttachment = (
+        id
+    ) => {
+        return `${id}test`;
+    };
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+-----
+
+```ts
+const this_is_a_very_long_function_name_so_need_to_break_a_new_line_here = (
+	id,
+) => {
+	return id;
+};
+
+type InstanceID = string;
+type MaybeCardWithAttachment = string;
+function outerFunctionToForceIndent() {
+	const cardWithAttachment: (id: InstanceID) => MaybeCardWithAttachment = (
+		id,
+	) => {
+		return `${id}test`;
+	};
+}
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: As needed
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+-----
+
+```ts
+const this_is_a_very_long_function_name_so_need_to_break_a_new_line_here =
+	id => {
+		return id;
+	};
+
+type InstanceID = string;
+type MaybeCardWithAttachment = string;
+function outerFunctionToForceIndent() {
+	const cardWithAttachment: (id: InstanceID) => MaybeCardWithAttachment =
+		id => {
+			return `${id}test`;
+		};
+}
+```
+
+

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -304,6 +304,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Contributed by @ah-yu
 - Fix [#1659](https://github.com/biomejs/biome/issues/1659) and [#1662](https://github.com/biomejs/biome/issues/1662), by correctly taking into account the leading comma inside the formatter options. Contributed by @ematipico
 
+- Fix [#1934](https://github.com/biomejs/biome/pull/1934). Fix invalid formatting of long arrow function for AsNeeded arrow parens Contributed by @fireairforce
+
 ### JavaScript APIs
 
 ### Linter


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes: #1905 

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
