### PR TITLE
feat(lint): rule `noMisplacedAssertion`

### DIFF
--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -119,6 +119,7 @@ define_categories! {
     "lint/nursery/noExcessiveNestedTestSuites": "https://biomejs.dev/linter/rules/no-excessive-nested-test-suites",
     "lint/nursery/noExportsInTest": "https://biomejs.dev/linter/rules/no-exports-in-test",
     "lint/nursery/noFocusedTests": "https://biomejs.dev/linter/rules/no-focused-tests",
+    "lint/nursery/noMisplacedAssertion": "https://biomejs.dev/linter/rules/no-misplaced-assertion",
     "lint/nursery/noNamespaceImport": "https://biomejs.dev/linter/rules/no-namespace-import",
     "lint/nursery/noNodejsModules": "https://biomejs.dev/linter/rules/no-nodejs-modules",
     "lint/nursery/noReExportAll": "https://biomejs.dev/linter/rules/no-re-export-all",

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -252,11 +252,8 @@ mod tests {
             String::from_utf8(buffer).unwrap()
         }
 
-        const SOURCE: &str = r#"import assert from "node:assert";
-import { describe } from "node:test";
-
-describe(() => {
-	assert.equal("something", "something")
+        const SOURCE: &str = r#"describe(() => {
+	expect("something").toBeTrue()
 })
         "#;
 

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -252,8 +252,11 @@ mod tests {
             String::from_utf8(buffer).unwrap()
         }
 
-        const SOURCE: &str = r#"describe(() => {
-	expect("something").toBeTrue()
+        const SOURCE: &str = r#"import assert from "node:assert";
+import { describe } from "node:test";
+
+describe(() => {
+	assert.equal("something", "something")
 })
         "#;
 

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -252,7 +252,12 @@ mod tests {
             String::from_utf8(buffer).unwrap()
         }
 
-        const SOURCE: &str = r#"<>{provider}</>
+        const SOURCE: &str = r#"import assert from "node:assert";
+import { describe } from "node:test";
+
+describe(() => {
+	assert.equal("something", "something")
+})
         "#;
 
         let parsed = parse(SOURCE, JsFileSource::tsx(), JsParserOptions::default());
@@ -265,7 +270,7 @@ mod tests {
             dependencies_index: Some(1),
             stable_result: StableHookResult::None,
         };
-        let rule_filter = RuleFilter::Rule("complexity", "noUselessFragments");
+        let rule_filter = RuleFilter::Rule("nursery", "noMisplacedAssertion");
 
         options.configuration.rules.push_rule(
             RuleKey::new("nursery", "useHookAtTopLevel"),

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
@@ -42,7 +42,7 @@ declare_rule! {
     /// </>
     /// ```
     ///
-    /// ### Options
+    /// ## Options
     ///
     /// ```json
     /// {

--- a/crates/biome_js_analyze/src/lint/nursery.rs
+++ b/crates/biome_js_analyze/src/lint/nursery.rs
@@ -11,6 +11,7 @@ pub mod no_evolving_any;
 pub mod no_excessive_nested_test_suites;
 pub mod no_exports_in_test;
 pub mod no_focused_tests;
+pub mod no_misplaced_assertion;
 pub mod no_namespace_import;
 pub mod no_nodejs_modules;
 pub mod no_re_export_all;
@@ -37,6 +38,7 @@ declare_group! {
             self :: no_excessive_nested_test_suites :: NoExcessiveNestedTestSuites ,
             self :: no_exports_in_test :: NoExportsInTest ,
             self :: no_focused_tests :: NoFocusedTests ,
+            self :: no_misplaced_assertion :: NoMisplacedAssertion ,
             self :: no_namespace_import :: NoNamespaceImport ,
             self :: no_nodejs_modules :: NoNodejsModules ,
             self :: no_re_export_all :: NoReExportAll ,

--- a/crates/biome_js_analyze/src/lint/nursery/no_excessive_nested_test_suites.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_excessive_nested_test_suites.rs
@@ -80,10 +80,10 @@ impl Rule for NoExcessiveNestedTestSuites {
                     "Excessive `describe()` nesting detected."
                 },
             )
-            .note(markup! {
+                .note(markup! {
                 "Excessive nesting of "<Emphasis>"describe()"</Emphasis>" calls can hinder test readability."
             })
-            .note(markup! {
+                .note(markup! {
                 "Consider refactoring and "<Emphasis>"reduce the level of nested describe"</Emphasis>" to improve code clarity."
             }),
         )
@@ -116,14 +116,10 @@ impl Visitor for NestedTestVisitor {
             WalkEvent::Enter(node) => {
                 if let Some(node) = JsCallExpression::cast_ref(node) {
                     if let Ok(callee) = node.callee() {
-                        if callee.contains_a_test_pattern() == Ok(true) {
-                            if let Some(function_name) = callee.get_callee_object_name() {
-                                if function_name.text_trimmed() == "describe" {
-                                    self.curr_count += 1;
-                                    if self.curr_count == self.max_count + 1 {
-                                        ctx.match_query(NestedTest(node.clone()));
-                                    }
-                                }
+                        if callee.is_test_describe_call() {
+                            self.curr_count += 1;
+                            if self.curr_count == self.max_count + 1 {
+                                ctx.match_query(NestedTest(node.clone()));
                             }
                         }
                     }
@@ -132,12 +128,8 @@ impl Visitor for NestedTestVisitor {
             WalkEvent::Leave(node) => {
                 if let Some(node) = JsCallExpression::cast_ref(node) {
                     if let Ok(callee) = node.callee() {
-                        if callee.contains_a_test_pattern() == Ok(true) {
-                            if let Some(function_name) = callee.get_callee_object_name() {
-                                if function_name.text_trimmed() == "describe" {
-                                    self.curr_count -= 1;
-                                }
-                            }
+                        if callee.is_test_describe_call() {
+                            self.curr_count -= 1;
                         }
                     }
                 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_excessive_nested_test_suites.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_excessive_nested_test_suites.rs
@@ -116,7 +116,7 @@ impl Visitor for NestedTestVisitor {
             WalkEvent::Enter(node) => {
                 if let Some(node) = JsCallExpression::cast_ref(node) {
                     if let Ok(callee) = node.callee() {
-                        if callee.is_test_describe_call() {
+                        if callee.contains_describe_call() {
                             self.curr_count += 1;
                             if self.curr_count == self.max_count + 1 {
                                 ctx.match_query(NestedTest(node.clone()));
@@ -128,7 +128,7 @@ impl Visitor for NestedTestVisitor {
             WalkEvent::Leave(node) => {
                 if let Some(node) = JsCallExpression::cast_ref(node) {
                     if let Ok(callee) = node.callee() {
-                        if callee.is_test_describe_call() {
+                        if callee.contains_describe_call() {
                             self.curr_count -= 1;
                         }
                     }

--- a/crates/biome_js_analyze/src/lint/nursery/no_misplaced_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misplaced_assertion.rs
@@ -1,0 +1,116 @@
+use crate::semantic_services::Semantic;
+use biome_analyze::{
+    context::RuleContext, declare_rule, Rule, RuleDiagnostic, RuleSource, RuleSourceKind,
+};
+use biome_console::markup;
+use biome_deserialize::TextRange;
+use biome_js_syntax::{
+    AnyJsNamedImportSpecifier, JsCallExpression, JsIdentifierBinding, JsImport, JsModule,
+};
+use biome_rowan::{AstNode, WalkEvent};
+
+declare_rule! {
+    /// Succinct description of the rule.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// ```
+    ///
+    pub NoMisplacedAssertion {
+        version: "next",
+        name: "noMisplacedAssertion",
+        recommended: false,
+        source: RuleSource::EslintJest("no-standalone-expect"),
+        source_kind: RuleSourceKind::Inspired,
+    }
+}
+
+impl Rule for NoMisplacedAssertion {
+    type Query = Semantic<JsModule>;
+    type State = TextRange;
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+        let model = ctx.model();
+        let preorder = node.syntax().preorder();
+        let mut inside_describe_call = false;
+        let mut inside_it_call = false;
+        let mut assertion_call = None;
+        for event in preorder {
+            match event {
+                WalkEvent::Enter(node) => {
+                    if let Some(node) = JsCallExpression::cast(node) {
+                        if let Ok(callee) = node.callee() {
+                            if callee.is_test_describe_call() {
+                                inside_describe_call = true
+                            }
+                            if callee.is_test_it_call() {
+                                inside_it_call = true
+                            }
+                        }
+                    }
+                }
+                WalkEvent::Leave(node) => {
+                    if let Some(node) = JsCallExpression::cast(node) {
+                        if let Ok(callee) = node.callee() {
+                            if callee.is_test_describe_call() {
+                                inside_describe_call = false
+                            }
+                            if callee.is_test_it_call() {
+                                inside_it_call = false
+                            }
+                            if callee.is_assertion_call() {
+                                if inside_describe_call && !inside_it_call {
+                                    assertion_call =
+                                        Some(node.callee().ok()?.as_js_reference_identifier()?);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(assertion_call) = assertion_call {
+            let call_text = assertion_call.value_token().ok()?;
+            let binding = model.binding(&assertion_call);
+            if let Some(binding) = binding {
+                let ident = JsIdentifierBinding::cast_ref(binding.syntax())?;
+                let import_specifier = ident.parent::<AnyJsNamedImportSpecifier>()?;
+                let import = import_specifier.import_clause()?.parent::<JsImport>()?;
+                let source_text = import.source_text().ok()?;
+                if (matches!(source_text.text(), "chai") && call_text.text_trimmed() == "expect")
+                    || (matches!(call_text.text_trimmed(), "assert")
+                        && matches!(source_text.text(), "node:assert" | "node:assert/strict"))
+                {
+                    return Some(assertion_call.range());
+                }
+            } else {
+                return Some(assertion_call.range());
+            }
+        }
+
+        None
+    }
+
+    fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        Some(RuleDiagnostic::new(
+            rule_category!(),
+            state,
+            markup! {
+                "The assertion isn't inside an it call."
+            },
+        ))
+    }
+}

--- a/crates/biome_js_analyze/src/lint/nursery/no_misplaced_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misplaced_assertion.rs
@@ -4,24 +4,32 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_deserialize::TextRange;
+use biome_deserialize_macros::Deserializable;
 use biome_js_syntax::{
-    AnyJsNamedImportSpecifier, JsCallExpression, JsIdentifierBinding, JsImport, JsModule,
+     JsCallExpression, JsIdentifierBinding, JsImport, JsModule,
 };
 use biome_rowan::{AstNode, WalkEvent};
+use serde::{Deserialize, Serialize};
 
 declare_rule! {
-    /// Succinct description of the rule.
+    /// Checks that the assertion function, for example `expect`, is placed inside an `it()` function call.
+    ///
+    /// Placing (and using) the `expect` assertion function can result in unexpected behavoiurs when executing your testing suite.
     ///
     /// ## Examples
     ///
     /// ### Invalid
     ///
     /// ```js,expect_diagnostic
+    /// describe(() => {
+    ///     expect()
+    /// })
     /// ```
     ///
     /// ### Valid
     ///
     /// ```js
+    ///
     /// ```
     ///
     pub NoMisplacedAssertion {
@@ -33,15 +41,43 @@ declare_rule! {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Deserializable, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct NoMisplacedOptions {
+    /// The name of the function that will run the assertion. By default, its name is `expect`.
+    assertion_function_names: Vec<String>,
+    /// A list of specifiers that export the `assertionFunctionName` function.
+    ///
+    /// If your assertion function name is a global, provide an empty array.
+    ///
+    /// Defaults to: `"chai"`, `"node:assert"` and `node:assert/strict`.
+    specifiers: Vec<String>,
+}
+
+impl Default for NoMisplacedOptions {
+    fn default() -> Self {
+        Self {
+            assertion_function_names: vec!["expect".to_string(), "assert".to_string()],
+            specifiers: vec![
+                "chai".to_string(),
+                "node:assert".to_string(),
+                "node:assert/strict".to_string(),
+            ],
+        }
+    }
+}
+
 impl Rule for NoMisplacedAssertion {
     type Query = Semantic<JsModule>;
     type State = TextRange;
     type Signals = Option<Self::State>;
-    type Options = ();
+    type Options = NoMisplacedOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let model = ctx.model();
+        let options = ctx.options();
         let preorder = node.syntax().preorder();
         let mut inside_describe_call = false;
         let mut inside_it_call = false;
@@ -61,6 +97,7 @@ impl Rule for NoMisplacedAssertion {
                     }
                 }
                 WalkEvent::Leave(node) => {
+
                     if let Some(node) = JsCallExpression::cast(node) {
                         if let Ok(callee) = node.callee() {
                             if callee.is_test_describe_call() {
@@ -69,10 +106,10 @@ impl Rule for NoMisplacedAssertion {
                             if callee.is_test_it_call() {
                                 inside_it_call = false
                             }
-                            if callee.is_assertion_call() {
+                            if let Some(identifier) = callee.get_callee_object_identifier() {
                                 if inside_describe_call && !inside_it_call {
                                     assertion_call =
-                                        Some(node.callee().ok()?.as_js_reference_identifier()?);
+                                        Some(identifier);
                                     break;
                                 }
                             }
@@ -81,23 +118,37 @@ impl Rule for NoMisplacedAssertion {
                 }
             }
         }
-
         if let Some(assertion_call) = assertion_call {
             let call_text = assertion_call.value_token().ok()?;
             let binding = model.binding(&assertion_call);
-            if let Some(binding) = binding {
-                let ident = JsIdentifierBinding::cast_ref(binding.syntax())?;
-                let import_specifier = ident.parent::<AnyJsNamedImportSpecifier>()?;
-                let import = import_specifier.import_clause()?.parent::<JsImport>()?;
-                let source_text = import.source_text().ok()?;
-                if (matches!(source_text.text(), "chai") && call_text.text_trimmed() == "expect")
-                    || (matches!(call_text.text_trimmed(), "assert")
-                        && matches!(source_text.text(), "node:assert" | "node:assert/strict"))
+            dbg!(&binding);
+            if !options.specifiers.is_empty() {
+                if let Some(binding) = binding {
+                    let ident = JsIdentifierBinding::cast_ref(binding.syntax())?;
+                    let import = ident.syntax().ancestors().find_map(JsImport::cast)?;
+                    let source_text = import.source_text().ok()?;
+                    if options.assertion_function_names.iter()
+                        .find(|function_name| function_name.as_str() == call_text.text_trimmed())
+                        .is_some()
+
+                        && options
+                        .specifiers
+                        .iter()
+                        .find(|specifier| specifier.as_str() == source_text.text())
+                        .is_some()
+
+                    {
+                        return Some(assertion_call.range());
+                    }
+                }
+            } else {
+                if options.assertion_function_names.iter()
+                    .find(|function_name| function_name.as_str() == call_text.text_trimmed())
+                    .is_some()
+
                 {
                     return Some(assertion_call.range());
                 }
-            } else {
-                return Some(assertion_call.range());
             }
         }
 
@@ -105,12 +156,20 @@ impl Rule for NoMisplacedAssertion {
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
-        Some(RuleDiagnostic::new(
-            rule_category!(),
-            state,
-            markup! {
-                "The assertion isn't inside an it call."
-            },
-        ))
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                state,
+                markup! {
+                    "The assertion isn't inside a "<Emphasis>"it()"</Emphasis>" function call."
+                },
+            )
+            .note(markup! {
+                "This will result in unexpected behaviours from your test suite."
+            })
+            .note(markup! {
+                "Move the assertion inside a "<Emphasis>"it()"</Emphasis>" function call."
+            }),
+        )
     }
 }

--- a/crates/biome_js_analyze/src/options.rs
+++ b/crates/biome_js_analyze/src/options.rs
@@ -1,338 +1,300 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::lint;
+use crate::analyzers;
+use crate::aria_analyzers;
+use crate::semantic_analyzers;
 
-pub type NoAccessKey = <lint::a11y::no_access_key::NoAccessKey as biome_analyze::Rule>::Options;
-pub type NoAccumulatingSpread = < lint :: performance :: no_accumulating_spread :: NoAccumulatingSpread as biome_analyze :: Rule > :: Options ;
-pub type NoApproximativeNumericConstant = < lint :: suspicious :: no_approximative_numeric_constant :: NoApproximativeNumericConstant as biome_analyze :: Rule > :: Options ;
-pub type NoArguments = <lint::style::no_arguments::NoArguments as biome_analyze::Rule>::Options;
-pub type NoAriaHiddenOnFocusable = < lint :: a11y :: no_aria_hidden_on_focusable :: NoAriaHiddenOnFocusable as biome_analyze :: Rule > :: Options ;
-pub type NoAriaUnsupportedElements = < lint :: a11y :: no_aria_unsupported_elements :: NoAriaUnsupportedElements as biome_analyze :: Rule > :: Options ;
-pub type NoArrayIndexKey =
-    <lint::suspicious::no_array_index_key::NoArrayIndexKey as biome_analyze::Rule>::Options;
-pub type NoAssignInExpressions = < lint :: suspicious :: no_assign_in_expressions :: NoAssignInExpressions as biome_analyze :: Rule > :: Options ;
-pub type NoAsyncPromiseExecutor = < lint :: suspicious :: no_async_promise_executor :: NoAsyncPromiseExecutor as biome_analyze :: Rule > :: Options ;
-pub type NoAutofocus = <lint::a11y::no_autofocus::NoAutofocus as biome_analyze::Rule>::Options;
-pub type NoBannedTypes =
-    <lint::complexity::no_banned_types::NoBannedTypes as biome_analyze::Rule>::Options;
+pub type NoAccessKey =
+    <analyzers::a11y::no_access_key::NoAccessKey as biome_analyze::Rule>::Options;
+pub type NoAccumulatingSpread = < semantic_analyzers :: performance :: no_accumulating_spread :: NoAccumulatingSpread as biome_analyze :: Rule > :: Options ;
+pub type NoApproximativeNumericConstant = < analyzers :: suspicious :: no_approximative_numeric_constant :: NoApproximativeNumericConstant as biome_analyze :: Rule > :: Options ;
+pub type NoArguments =
+    <semantic_analyzers::style::no_arguments::NoArguments as biome_analyze::Rule>::Options;
+pub type NoAriaHiddenOnFocusable = < aria_analyzers :: a11y :: no_aria_hidden_on_focusable :: NoAriaHiddenOnFocusable as biome_analyze :: Rule > :: Options ;
+pub type NoAriaUnsupportedElements = < aria_analyzers :: a11y :: no_aria_unsupported_elements :: NoAriaUnsupportedElements as biome_analyze :: Rule > :: Options ;
+pub type NoArrayIndexKey = < semantic_analyzers :: suspicious :: no_array_index_key :: NoArrayIndexKey as biome_analyze :: Rule > :: Options ;
+pub type NoAssignInExpressions = < analyzers :: suspicious :: no_assign_in_expressions :: NoAssignInExpressions as biome_analyze :: Rule > :: Options ;
+pub type NoAsyncPromiseExecutor = < analyzers :: suspicious :: no_async_promise_executor :: NoAsyncPromiseExecutor as biome_analyze :: Rule > :: Options ;
+pub type NoAutofocus = <analyzers::a11y::no_autofocus::NoAutofocus as biome_analyze::Rule>::Options;
+pub type NoBannedTypes = < semantic_analyzers :: complexity :: no_banned_types :: NoBannedTypes as biome_analyze :: Rule > :: Options ;
 pub type NoBarrelFile =
-    <lint::nursery::no_barrel_file::NoBarrelFile as biome_analyze::Rule>::Options;
+    <analyzers::nursery::no_barrel_file::NoBarrelFile as biome_analyze::Rule>::Options;
 pub type NoBlankTarget =
-    <lint::a11y::no_blank_target::NoBlankTarget as biome_analyze::Rule>::Options;
-pub type NoCatchAssign =
-    <lint::suspicious::no_catch_assign::NoCatchAssign as biome_analyze::Rule>::Options;
-pub type NoChildrenProp =
-    <lint::correctness::no_children_prop::NoChildrenProp as biome_analyze::Rule>::Options;
-pub type NoClassAssign =
-    <lint::suspicious::no_class_assign::NoClassAssign as biome_analyze::Rule>::Options;
+    <analyzers::a11y::no_blank_target::NoBlankTarget as biome_analyze::Rule>::Options;
+pub type NoCatchAssign = < semantic_analyzers :: suspicious :: no_catch_assign :: NoCatchAssign as biome_analyze :: Rule > :: Options ;
+pub type NoChildrenProp = < semantic_analyzers :: correctness :: no_children_prop :: NoChildrenProp as biome_analyze :: Rule > :: Options ;
+pub type NoClassAssign = < semantic_analyzers :: suspicious :: no_class_assign :: NoClassAssign as biome_analyze :: Rule > :: Options ;
 pub type NoCommaOperator =
-    <lint::style::no_comma_operator::NoCommaOperator as biome_analyze::Rule>::Options;
+    <analyzers::style::no_comma_operator::NoCommaOperator as biome_analyze::Rule>::Options;
 pub type NoCommentText =
-    <lint::suspicious::no_comment_text::NoCommentText as biome_analyze::Rule>::Options;
+    <analyzers::suspicious::no_comment_text::NoCommentText as biome_analyze::Rule>::Options;
 pub type NoCompareNegZero =
-    <lint::suspicious::no_compare_neg_zero::NoCompareNegZero as biome_analyze::Rule>::Options;
+    <analyzers::suspicious::no_compare_neg_zero::NoCompareNegZero as biome_analyze::Rule>::Options;
 pub type NoConfusingLabels =
-    <lint::suspicious::no_confusing_labels::NoConfusingLabels as biome_analyze::Rule>::Options;
-pub type NoConfusingVoidType =
-    <lint::suspicious::no_confusing_void_type::NoConfusingVoidType as biome_analyze::Rule>::Options;
-pub type NoConsole = <lint::nursery::no_console::NoConsole as biome_analyze::Rule>::Options;
+    <analyzers::suspicious::no_confusing_labels::NoConfusingLabels as biome_analyze::Rule>::Options;
+pub type NoConfusingVoidType = < analyzers :: suspicious :: no_confusing_void_type :: NoConfusingVoidType as biome_analyze :: Rule > :: Options ;
+pub type NoConsole =
+    <semantic_analyzers::nursery::no_console::NoConsole as biome_analyze::Rule>::Options;
 pub type NoConsoleLog =
-    <lint::suspicious::no_console_log::NoConsoleLog as biome_analyze::Rule>::Options;
-pub type NoConstAssign =
-    <lint::correctness::no_const_assign::NoConstAssign as biome_analyze::Rule>::Options;
+    <semantic_analyzers::suspicious::no_console_log::NoConsoleLog as biome_analyze::Rule>::Options;
+pub type NoConstAssign = < semantic_analyzers :: correctness :: no_const_assign :: NoConstAssign as biome_analyze :: Rule > :: Options ;
 pub type NoConstEnum =
-    <lint::suspicious::no_const_enum::NoConstEnum as biome_analyze::Rule>::Options;
-pub type NoConstantCondition =
-    <lint::correctness::no_constant_condition::NoConstantCondition as biome_analyze::Rule>::Options;
-pub type NoConstructorReturn =
-    <lint::correctness::no_constructor_return::NoConstructorReturn as biome_analyze::Rule>::Options;
-pub type NoControlCharactersInRegex = < lint :: suspicious :: no_control_characters_in_regex :: NoControlCharactersInRegex as biome_analyze :: Rule > :: Options ;
-pub type NoDangerouslySetInnerHtml = < lint :: security :: no_dangerously_set_inner_html :: NoDangerouslySetInnerHtml as biome_analyze :: Rule > :: Options ;
-pub type NoDangerouslySetInnerHtmlWithChildren = < lint :: security :: no_dangerously_set_inner_html_with_children :: NoDangerouslySetInnerHtmlWithChildren as biome_analyze :: Rule > :: Options ;
-pub type NoDebugger = <lint::suspicious::no_debugger::NoDebugger as biome_analyze::Rule>::Options;
+    <analyzers::suspicious::no_const_enum::NoConstEnum as biome_analyze::Rule>::Options;
+pub type NoConstantCondition = < semantic_analyzers :: correctness :: no_constant_condition :: NoConstantCondition as biome_analyze :: Rule > :: Options ;
+pub type NoConstructorReturn = < analyzers :: correctness :: no_constructor_return :: NoConstructorReturn as biome_analyze :: Rule > :: Options ;
+pub type NoControlCharactersInRegex = < analyzers :: suspicious :: no_control_characters_in_regex :: NoControlCharactersInRegex as biome_analyze :: Rule > :: Options ;
+pub type NoDangerouslySetInnerHtml = < semantic_analyzers :: security :: no_dangerously_set_inner_html :: NoDangerouslySetInnerHtml as biome_analyze :: Rule > :: Options ;
+pub type NoDangerouslySetInnerHtmlWithChildren = < semantic_analyzers :: security :: no_dangerously_set_inner_html_with_children :: NoDangerouslySetInnerHtmlWithChildren as biome_analyze :: Rule > :: Options ;
+pub type NoDebugger =
+    <analyzers::suspicious::no_debugger::NoDebugger as biome_analyze::Rule>::Options;
 pub type NoDefaultExport =
-    <lint::style::no_default_export::NoDefaultExport as biome_analyze::Rule>::Options;
-pub type NoDelete = <lint::performance::no_delete::NoDelete as biome_analyze::Rule>::Options;
-pub type NoDistractingElements =
-    <lint::a11y::no_distracting_elements::NoDistractingElements as biome_analyze::Rule>::Options;
+    <analyzers::style::no_default_export::NoDefaultExport as biome_analyze::Rule>::Options;
+pub type NoDelete = <analyzers::performance::no_delete::NoDelete as biome_analyze::Rule>::Options;
+pub type NoDistractingElements = < analyzers :: a11y :: no_distracting_elements :: NoDistractingElements as biome_analyze :: Rule > :: Options ;
 pub type NoDoneCallback =
-    <lint::nursery::no_done_callback::NoDoneCallback as biome_analyze::Rule>::Options;
+    <analyzers::nursery::no_done_callback::NoDoneCallback as biome_analyze::Rule>::Options;
 pub type NoDoubleEquals =
-    <lint::suspicious::no_double_equals::NoDoubleEquals as biome_analyze::Rule>::Options;
+    <analyzers::suspicious::no_double_equals::NoDoubleEquals as biome_analyze::Rule>::Options;
 pub type NoDuplicateCase =
-    <lint::suspicious::no_duplicate_case::NoDuplicateCase as biome_analyze::Rule>::Options;
-pub type NoDuplicateClassMembers = < lint :: suspicious :: no_duplicate_class_members :: NoDuplicateClassMembers as biome_analyze :: Rule > :: Options ;
-pub type NoDuplicateElseIf =
-    <lint::nursery::no_duplicate_else_if::NoDuplicateElseIf as biome_analyze::Rule>::Options;
-pub type NoDuplicateJsxProps =
-    <lint::suspicious::no_duplicate_jsx_props::NoDuplicateJsxProps as biome_analyze::Rule>::Options;
-pub type NoDuplicateObjectKeys = < lint :: suspicious :: no_duplicate_object_keys :: NoDuplicateObjectKeys as biome_analyze :: Rule > :: Options ;
-pub type NoDuplicateParameters = < lint :: suspicious :: no_duplicate_parameters :: NoDuplicateParameters as biome_analyze :: Rule > :: Options ;
-pub type NoDuplicateTestHooks =
-    <lint::nursery::no_duplicate_test_hooks::NoDuplicateTestHooks as biome_analyze::Rule>::Options;
-pub type NoEmptyBlockStatements = < lint :: suspicious :: no_empty_block_statements :: NoEmptyBlockStatements as biome_analyze :: Rule > :: Options ;
-pub type NoEmptyCharacterClassInRegex = < lint :: correctness :: no_empty_character_class_in_regex :: NoEmptyCharacterClassInRegex as biome_analyze :: Rule > :: Options ;
+    <analyzers::suspicious::no_duplicate_case::NoDuplicateCase as biome_analyze::Rule>::Options;
+pub type NoDuplicateClassMembers = < analyzers :: suspicious :: no_duplicate_class_members :: NoDuplicateClassMembers as biome_analyze :: Rule > :: Options ;
+pub type NoDuplicateJsxProps = < analyzers :: suspicious :: no_duplicate_jsx_props :: NoDuplicateJsxProps as biome_analyze :: Rule > :: Options ;
+pub type NoDuplicateObjectKeys = < analyzers :: suspicious :: no_duplicate_object_keys :: NoDuplicateObjectKeys as biome_analyze :: Rule > :: Options ;
+pub type NoDuplicateParameters = < semantic_analyzers :: suspicious :: no_duplicate_parameters :: NoDuplicateParameters as biome_analyze :: Rule > :: Options ;
+pub type NoDuplicateTestHooks = < analyzers :: nursery :: no_duplicate_test_hooks :: NoDuplicateTestHooks as biome_analyze :: Rule > :: Options ;
+pub type NoEmptyBlockStatements = < analyzers :: suspicious :: no_empty_block_statements :: NoEmptyBlockStatements as biome_analyze :: Rule > :: Options ;
+pub type NoEmptyCharacterClassInRegex = < analyzers :: correctness :: no_empty_character_class_in_regex :: NoEmptyCharacterClassInRegex as biome_analyze :: Rule > :: Options ;
 pub type NoEmptyInterface =
-    <lint::suspicious::no_empty_interface::NoEmptyInterface as biome_analyze::Rule>::Options;
+    <analyzers::suspicious::no_empty_interface::NoEmptyInterface as biome_analyze::Rule>::Options;
 pub type NoEmptyPattern =
-    <lint::correctness::no_empty_pattern::NoEmptyPattern as biome_analyze::Rule>::Options;
-pub type NoEmptyTypeParameters = < lint :: complexity :: no_empty_type_parameters :: NoEmptyTypeParameters as biome_analyze :: Rule > :: Options ;
-pub type NoEvolvingAny =
-    <lint::nursery::no_evolving_any::NoEvolvingAny as biome_analyze::Rule>::Options;
-pub type NoExcessiveCognitiveComplexity = < lint :: complexity :: no_excessive_cognitive_complexity :: NoExcessiveCognitiveComplexity as biome_analyze :: Rule > :: Options ;
-pub type NoExcessiveNestedTestSuites = < lint :: nursery :: no_excessive_nested_test_suites :: NoExcessiveNestedTestSuites as biome_analyze :: Rule > :: Options ;
+    <analyzers::correctness::no_empty_pattern::NoEmptyPattern as biome_analyze::Rule>::Options;
+pub type NoEmptyTypeParameters = < analyzers :: complexity :: no_empty_type_parameters :: NoEmptyTypeParameters as biome_analyze :: Rule > :: Options ;
+pub type NoExcessiveCognitiveComplexity = < analyzers :: complexity :: no_excessive_cognitive_complexity :: NoExcessiveCognitiveComplexity as biome_analyze :: Rule > :: Options ;
+pub type NoExcessiveNestedTestSuites = < analyzers :: nursery :: no_excessive_nested_test_suites :: NoExcessiveNestedTestSuites as biome_analyze :: Rule > :: Options ;
 pub type NoExplicitAny =
-    <lint::suspicious::no_explicit_any::NoExplicitAny as biome_analyze::Rule>::Options;
+    <analyzers::suspicious::no_explicit_any::NoExplicitAny as biome_analyze::Rule>::Options;
 pub type NoExportsInTest =
-    <lint::nursery::no_exports_in_test::NoExportsInTest as biome_analyze::Rule>::Options;
-pub type NoExtraBooleanCast =
-    <lint::complexity::no_extra_boolean_cast::NoExtraBooleanCast as biome_analyze::Rule>::Options;
-pub type NoExtraNonNullAssertion = < lint :: suspicious :: no_extra_non_null_assertion :: NoExtraNonNullAssertion as biome_analyze :: Rule > :: Options ;
-pub type NoFallthroughSwitchClause = < lint :: suspicious :: no_fallthrough_switch_clause :: NoFallthroughSwitchClause as biome_analyze :: Rule > :: Options ;
+    <analyzers::nursery::no_exports_in_test::NoExportsInTest as biome_analyze::Rule>::Options;
+pub type NoExtraBooleanCast = < analyzers :: complexity :: no_extra_boolean_cast :: NoExtraBooleanCast as biome_analyze :: Rule > :: Options ;
+pub type NoExtraNonNullAssertion = < analyzers :: suspicious :: no_extra_non_null_assertion :: NoExtraNonNullAssertion as biome_analyze :: Rule > :: Options ;
+pub type NoFallthroughSwitchClause = < analyzers :: suspicious :: no_fallthrough_switch_clause :: NoFallthroughSwitchClause as biome_analyze :: Rule > :: Options ;
 pub type NoFocusedTests =
-    <lint::nursery::no_focused_tests::NoFocusedTests as biome_analyze::Rule>::Options;
-pub type NoForEach = <lint::complexity::no_for_each::NoForEach as biome_analyze::Rule>::Options;
-pub type NoFunctionAssign =
-    <lint::suspicious::no_function_assign::NoFunctionAssign as biome_analyze::Rule>::Options;
-pub type NoGlobalAssign =
-    <lint::suspicious::no_global_assign::NoGlobalAssign as biome_analyze::Rule>::Options;
+    <analyzers::nursery::no_focused_tests::NoFocusedTests as biome_analyze::Rule>::Options;
+pub type NoForEach =
+    <analyzers::complexity::no_for_each::NoForEach as biome_analyze::Rule>::Options;
+pub type NoFunctionAssign = < semantic_analyzers :: suspicious :: no_function_assign :: NoFunctionAssign as biome_analyze :: Rule > :: Options ;
+pub type NoGlobalAssign = < semantic_analyzers :: suspicious :: no_global_assign :: NoGlobalAssign as biome_analyze :: Rule > :: Options ;
 pub type NoGlobalEval =
-    <lint::security::no_global_eval::NoGlobalEval as biome_analyze::Rule>::Options;
-pub type NoGlobalIsFinite =
-    <lint::suspicious::no_global_is_finite::NoGlobalIsFinite as biome_analyze::Rule>::Options;
-pub type NoGlobalIsNan =
-    <lint::suspicious::no_global_is_nan::NoGlobalIsNan as biome_analyze::Rule>::Options;
-pub type NoGlobalObjectCalls = < lint :: correctness :: no_global_object_calls :: NoGlobalObjectCalls as biome_analyze :: Rule > :: Options ;
+    <semantic_analyzers::security::no_global_eval::NoGlobalEval as biome_analyze::Rule>::Options;
+pub type NoGlobalIsFinite = < semantic_analyzers :: suspicious :: no_global_is_finite :: NoGlobalIsFinite as biome_analyze :: Rule > :: Options ;
+pub type NoGlobalIsNan = < semantic_analyzers :: suspicious :: no_global_is_nan :: NoGlobalIsNan as biome_analyze :: Rule > :: Options ;
+pub type NoGlobalObjectCalls = < semantic_analyzers :: correctness :: no_global_object_calls :: NoGlobalObjectCalls as biome_analyze :: Rule > :: Options ;
 pub type NoHeaderScope =
-    <lint::a11y::no_header_scope::NoHeaderScope as biome_analyze::Rule>::Options;
+    <analyzers::a11y::no_header_scope::NoHeaderScope as biome_analyze::Rule>::Options;
 pub type NoImplicitAnyLet =
-    <lint::suspicious::no_implicit_any_let::NoImplicitAnyLet as biome_analyze::Rule>::Options;
+    <analyzers::suspicious::no_implicit_any_let::NoImplicitAnyLet as biome_analyze::Rule>::Options;
 pub type NoImplicitBoolean =
-    <lint::style::no_implicit_boolean::NoImplicitBoolean as biome_analyze::Rule>::Options;
-pub type NoImportAssign =
-    <lint::suspicious::no_import_assign::NoImportAssign as biome_analyze::Rule>::Options;
+    <analyzers::style::no_implicit_boolean::NoImplicitBoolean as biome_analyze::Rule>::Options;
+pub type NoImportAssign = < semantic_analyzers :: suspicious :: no_import_assign :: NoImportAssign as biome_analyze :: Rule > :: Options ;
 pub type NoInferrableTypes =
-    <lint::style::no_inferrable_types::NoInferrableTypes as biome_analyze::Rule>::Options;
-pub type NoInnerDeclarations =
-    <lint::correctness::no_inner_declarations::NoInnerDeclarations as biome_analyze::Rule>::Options;
-pub type NoInteractiveElementToNoninteractiveRole = < lint :: a11y :: no_interactive_element_to_noninteractive_role :: NoInteractiveElementToNoninteractiveRole as biome_analyze :: Rule > :: Options ;
-pub type NoInvalidConstructorSuper = < lint :: correctness :: no_invalid_constructor_super :: NoInvalidConstructorSuper as biome_analyze :: Rule > :: Options ;
-pub type NoInvalidNewBuiltin = < lint :: correctness :: no_invalid_new_builtin :: NoInvalidNewBuiltin as biome_analyze :: Rule > :: Options ;
-pub type NoInvalidUseBeforeDeclaration = < lint :: correctness :: no_invalid_use_before_declaration :: NoInvalidUseBeforeDeclaration as biome_analyze :: Rule > :: Options ;
-pub type NoLabelVar = <lint::suspicious::no_label_var::NoLabelVar as biome_analyze::Rule>::Options;
-pub type NoMisleadingCharacterClass = < lint :: suspicious :: no_misleading_character_class :: NoMisleadingCharacterClass as biome_analyze :: Rule > :: Options ;
-pub type NoMisleadingInstantiator = < lint :: suspicious :: no_misleading_instantiator :: NoMisleadingInstantiator as biome_analyze :: Rule > :: Options ;
-pub type NoMisrefactoredShorthandAssign = < lint :: suspicious :: no_misrefactored_shorthand_assign :: NoMisrefactoredShorthandAssign as biome_analyze :: Rule > :: Options ;
-pub type NoMultipleSpacesInRegularExpressionLiterals = < lint :: complexity :: no_multiple_spaces_in_regular_expression_literals :: NoMultipleSpacesInRegularExpressionLiterals as biome_analyze :: Rule > :: Options ;
-pub type NoNamespace = <lint::style::no_namespace::NoNamespace as biome_analyze::Rule>::Options;
+    <analyzers::style::no_inferrable_types::NoInferrableTypes as biome_analyze::Rule>::Options;
+pub type NoInnerDeclarations = < analyzers :: correctness :: no_inner_declarations :: NoInnerDeclarations as biome_analyze :: Rule > :: Options ;
+pub type NoInteractiveElementToNoninteractiveRole = < aria_analyzers :: a11y :: no_interactive_element_to_noninteractive_role :: NoInteractiveElementToNoninteractiveRole as biome_analyze :: Rule > :: Options ;
+pub type NoInvalidConstructorSuper = < analyzers :: correctness :: no_invalid_constructor_super :: NoInvalidConstructorSuper as biome_analyze :: Rule > :: Options ;
+pub type NoInvalidNewBuiltin = < semantic_analyzers :: correctness :: no_invalid_new_builtin :: NoInvalidNewBuiltin as biome_analyze :: Rule > :: Options ;
+pub type NoInvalidUseBeforeDeclaration = < semantic_analyzers :: correctness :: no_invalid_use_before_declaration :: NoInvalidUseBeforeDeclaration as biome_analyze :: Rule > :: Options ;
+pub type NoLabelVar =
+    <semantic_analyzers::suspicious::no_label_var::NoLabelVar as biome_analyze::Rule>::Options;
+pub type NoMisleadingCharacterClass = < semantic_analyzers :: suspicious :: no_misleading_character_class :: NoMisleadingCharacterClass as biome_analyze :: Rule > :: Options ;
+pub type NoMisleadingInstantiator = < analyzers :: suspicious :: no_misleading_instantiator :: NoMisleadingInstantiator as biome_analyze :: Rule > :: Options ;
+pub type NoMisplacedAssertion = < analyzers :: nursery :: no_misplaced_assertion :: NoMisplacedAssertion as biome_analyze :: Rule > :: Options ;
+pub type NoMisrefactoredShorthandAssign = < analyzers :: suspicious :: no_misrefactored_shorthand_assign :: NoMisrefactoredShorthandAssign as biome_analyze :: Rule > :: Options ;
+pub type NoMultipleSpacesInRegularExpressionLiterals = < analyzers :: complexity :: no_multiple_spaces_in_regular_expression_literals :: NoMultipleSpacesInRegularExpressionLiterals as biome_analyze :: Rule > :: Options ;
+pub type NoNamespace =
+    <analyzers::style::no_namespace::NoNamespace as biome_analyze::Rule>::Options;
 pub type NoNamespaceImport =
-    <lint::nursery::no_namespace_import::NoNamespaceImport as biome_analyze::Rule>::Options;
+    <analyzers::nursery::no_namespace_import::NoNamespaceImport as biome_analyze::Rule>::Options;
 pub type NoNegationElse =
-    <lint::style::no_negation_else::NoNegationElse as biome_analyze::Rule>::Options;
+    <analyzers::style::no_negation_else::NoNegationElse as biome_analyze::Rule>::Options;
 pub type NoNewSymbol =
-    <lint::correctness::no_new_symbol::NoNewSymbol as biome_analyze::Rule>::Options;
+    <semantic_analyzers::correctness::no_new_symbol::NoNewSymbol as biome_analyze::Rule>::Options;
 pub type NoNodejsModules =
-    <lint::nursery::no_nodejs_modules::NoNodejsModules as biome_analyze::Rule>::Options;
+    <analyzers::nursery::no_nodejs_modules::NoNodejsModules as biome_analyze::Rule>::Options;
 pub type NoNonNullAssertion =
-    <lint::style::no_non_null_assertion::NoNonNullAssertion as biome_analyze::Rule>::Options;
-pub type NoNoninteractiveElementToInteractiveRole = < lint :: a11y :: no_noninteractive_element_to_interactive_role :: NoNoninteractiveElementToInteractiveRole as biome_analyze :: Rule > :: Options ;
-pub type NoNoninteractiveTabindex = < lint :: a11y :: no_noninteractive_tabindex :: NoNoninteractiveTabindex as biome_analyze :: Rule > :: Options ;
-pub type NoNonoctalDecimalEscape = < lint :: correctness :: no_nonoctal_decimal_escape :: NoNonoctalDecimalEscape as biome_analyze :: Rule > :: Options ;
-pub type NoParameterAssign =
-    <lint::style::no_parameter_assign::NoParameterAssign as biome_analyze::Rule>::Options;
-pub type NoParameterProperties =
-    <lint::style::no_parameter_properties::NoParameterProperties as biome_analyze::Rule>::Options;
-pub type NoPositiveTabindex =
-    <lint::a11y::no_positive_tabindex::NoPositiveTabindex as biome_analyze::Rule>::Options;
+    <analyzers::style::no_non_null_assertion::NoNonNullAssertion as biome_analyze::Rule>::Options;
+pub type NoNoninteractiveElementToInteractiveRole = < aria_analyzers :: a11y :: no_noninteractive_element_to_interactive_role :: NoNoninteractiveElementToInteractiveRole as biome_analyze :: Rule > :: Options ;
+pub type NoNoninteractiveTabindex = < aria_analyzers :: a11y :: no_noninteractive_tabindex :: NoNoninteractiveTabindex as biome_analyze :: Rule > :: Options ;
+pub type NoNonoctalDecimalEscape = < analyzers :: correctness :: no_nonoctal_decimal_escape :: NoNonoctalDecimalEscape as biome_analyze :: Rule > :: Options ;
+pub type NoParameterAssign = < semantic_analyzers :: style :: no_parameter_assign :: NoParameterAssign as biome_analyze :: Rule > :: Options ;
+pub type NoParameterProperties = < analyzers :: style :: no_parameter_properties :: NoParameterProperties as biome_analyze :: Rule > :: Options ;
+pub type NoPositiveTabindex = < semantic_analyzers :: a11y :: no_positive_tabindex :: NoPositiveTabindex as biome_analyze :: Rule > :: Options ;
 pub type NoPrecisionLoss =
-    <lint::correctness::no_precision_loss::NoPrecisionLoss as biome_analyze::Rule>::Options;
-pub type NoPrototypeBuiltins =
-    <lint::suspicious::no_prototype_builtins::NoPrototypeBuiltins as biome_analyze::Rule>::Options;
+    <analyzers::correctness::no_precision_loss::NoPrecisionLoss as biome_analyze::Rule>::Options;
+pub type NoPrototypeBuiltins = < analyzers :: suspicious :: no_prototype_builtins :: NoPrototypeBuiltins as biome_analyze :: Rule > :: Options ;
 pub type NoReExportAll =
-    <lint::nursery::no_re_export_all::NoReExportAll as biome_analyze::Rule>::Options;
+    <semantic_analyzers::nursery::no_re_export_all::NoReExportAll as biome_analyze::Rule>::Options;
 pub type NoRedeclare =
-    <lint::suspicious::no_redeclare::NoRedeclare as biome_analyze::Rule>::Options;
+    <semantic_analyzers::suspicious::no_redeclare::NoRedeclare as biome_analyze::Rule>::Options;
 pub type NoRedundantAlt =
-    <lint::a11y::no_redundant_alt::NoRedundantAlt as biome_analyze::Rule>::Options;
+    <analyzers::a11y::no_redundant_alt::NoRedundantAlt as biome_analyze::Rule>::Options;
 pub type NoRedundantRoles =
-    <lint::a11y::no_redundant_roles::NoRedundantRoles as biome_analyze::Rule>::Options;
-pub type NoRedundantUseStrict = < lint :: suspicious :: no_redundant_use_strict :: NoRedundantUseStrict as biome_analyze :: Rule > :: Options ;
-pub type NoRenderReturnValue = < lint :: correctness :: no_render_return_value :: NoRenderReturnValue as biome_analyze :: Rule > :: Options ;
-pub type NoRestrictedGlobals =
-    <lint::style::no_restricted_globals::NoRestrictedGlobals as biome_analyze::Rule>::Options;
-pub type NoRestrictedImports =
-    <lint::nursery::no_restricted_imports::NoRestrictedImports as biome_analyze::Rule>::Options;
+    <aria_analyzers::a11y::no_redundant_roles::NoRedundantRoles as biome_analyze::Rule>::Options;
+pub type NoRedundantUseStrict = < analyzers :: suspicious :: no_redundant_use_strict :: NoRedundantUseStrict as biome_analyze :: Rule > :: Options ;
+pub type NoRenderReturnValue = < semantic_analyzers :: correctness :: no_render_return_value :: NoRenderReturnValue as biome_analyze :: Rule > :: Options ;
+pub type NoRestrictedGlobals = < semantic_analyzers :: style :: no_restricted_globals :: NoRestrictedGlobals as biome_analyze :: Rule > :: Options ;
+pub type NoRestrictedImports = < analyzers :: nursery :: no_restricted_imports :: NoRestrictedImports as biome_analyze :: Rule > :: Options ;
 pub type NoSelfAssign =
-    <lint::correctness::no_self_assign::NoSelfAssign as biome_analyze::Rule>::Options;
+    <analyzers::correctness::no_self_assign::NoSelfAssign as biome_analyze::Rule>::Options;
 pub type NoSelfCompare =
-    <lint::suspicious::no_self_compare::NoSelfCompare as biome_analyze::Rule>::Options;
-pub type NoSemicolonInJsx =
-    <lint::nursery::no_semicolon_in_jsx::NoSemicolonInJsx as biome_analyze::Rule>::Options;
+    <analyzers::suspicious::no_self_compare::NoSelfCompare as biome_analyze::Rule>::Options;
+pub type NoSemicolonInJsx = < semantic_analyzers :: nursery :: no_semicolon_in_jsx :: NoSemicolonInJsx as biome_analyze :: Rule > :: Options ;
 pub type NoSetterReturn =
-    <lint::correctness::no_setter_return::NoSetterReturn as biome_analyze::Rule>::Options;
-pub type NoShadowRestrictedNames = < lint :: suspicious :: no_shadow_restricted_names :: NoShadowRestrictedNames as biome_analyze :: Rule > :: Options ;
-pub type NoShoutyConstants =
-    <lint::style::no_shouty_constants::NoShoutyConstants as biome_analyze::Rule>::Options;
+    <analyzers::correctness::no_setter_return::NoSetterReturn as biome_analyze::Rule>::Options;
+pub type NoShadowRestrictedNames = < analyzers :: suspicious :: no_shadow_restricted_names :: NoShadowRestrictedNames as biome_analyze :: Rule > :: Options ;
+pub type NoShoutyConstants = < semantic_analyzers :: style :: no_shouty_constants :: NoShoutyConstants as biome_analyze :: Rule > :: Options ;
 pub type NoSkippedTests =
-    <lint::nursery::no_skipped_tests::NoSkippedTests as biome_analyze::Rule>::Options;
+    <analyzers::nursery::no_skipped_tests::NoSkippedTests as biome_analyze::Rule>::Options;
 pub type NoSparseArray =
-    <lint::suspicious::no_sparse_array::NoSparseArray as biome_analyze::Rule>::Options;
-pub type NoStaticOnlyClass =
-    <lint::complexity::no_static_only_class::NoStaticOnlyClass as biome_analyze::Rule>::Options;
-pub type NoStringCaseMismatch = < lint :: correctness :: no_string_case_mismatch :: NoStringCaseMismatch as biome_analyze :: Rule > :: Options ;
+    <analyzers::suspicious::no_sparse_array::NoSparseArray as biome_analyze::Rule>::Options;
+pub type NoStaticOnlyClass = < analyzers :: complexity :: no_static_only_class :: NoStaticOnlyClass as biome_analyze :: Rule > :: Options ;
+pub type NoStringCaseMismatch = < analyzers :: correctness :: no_string_case_mismatch :: NoStringCaseMismatch as biome_analyze :: Rule > :: Options ;
 pub type NoSvgWithoutTitle =
-    <lint::a11y::no_svg_without_title::NoSvgWithoutTitle as biome_analyze::Rule>::Options;
-pub type NoSwitchDeclarations = < lint :: correctness :: no_switch_declarations :: NoSwitchDeclarations as biome_analyze :: Rule > :: Options ;
-pub type NoThenProperty =
-    <lint::suspicious::no_then_property::NoThenProperty as biome_analyze::Rule>::Options;
-pub type NoThisInStatic =
-    <lint::complexity::no_this_in_static::NoThisInStatic as biome_analyze::Rule>::Options;
-pub type NoUndeclaredDependencies = < lint :: nursery :: no_undeclared_dependencies :: NoUndeclaredDependencies as biome_analyze :: Rule > :: Options ;
-pub type NoUndeclaredVariables = < lint :: correctness :: no_undeclared_variables :: NoUndeclaredVariables as biome_analyze :: Rule > :: Options ;
-pub type NoUnnecessaryContinue = < lint :: correctness :: no_unnecessary_continue :: NoUnnecessaryContinue as biome_analyze :: Rule > :: Options ;
+    <analyzers::a11y::no_svg_without_title::NoSvgWithoutTitle as biome_analyze::Rule>::Options;
+pub type NoSwitchDeclarations = < analyzers :: correctness :: no_switch_declarations :: NoSwitchDeclarations as biome_analyze :: Rule > :: Options ;
+pub type NoThenProperty = < semantic_analyzers :: suspicious :: no_then_property :: NoThenProperty as biome_analyze :: Rule > :: Options ;
+pub type NoThisInStatic = < semantic_analyzers :: complexity :: no_this_in_static :: NoThisInStatic as biome_analyze :: Rule > :: Options ;
+pub type NoUndeclaredDependencies = < analyzers :: nursery :: no_undeclared_dependencies :: NoUndeclaredDependencies as biome_analyze :: Rule > :: Options ;
+pub type NoUndeclaredVariables = < semantic_analyzers :: correctness :: no_undeclared_variables :: NoUndeclaredVariables as biome_analyze :: Rule > :: Options ;
+pub type NoUnnecessaryContinue = < analyzers :: correctness :: no_unnecessary_continue :: NoUnnecessaryContinue as biome_analyze :: Rule > :: Options ;
 pub type NoUnreachable =
-    <lint::correctness::no_unreachable::NoUnreachable as biome_analyze::Rule>::Options;
-pub type NoUnreachableSuper =
-    <lint::correctness::no_unreachable_super::NoUnreachableSuper as biome_analyze::Rule>::Options;
-pub type NoUnsafeDeclarationMerging = < lint :: suspicious :: no_unsafe_declaration_merging :: NoUnsafeDeclarationMerging as biome_analyze :: Rule > :: Options ;
+    <analyzers::correctness::no_unreachable::NoUnreachable as biome_analyze::Rule>::Options;
+pub type NoUnreachableSuper = < analyzers :: correctness :: no_unreachable_super :: NoUnreachableSuper as biome_analyze :: Rule > :: Options ;
+pub type NoUnsafeDeclarationMerging = < semantic_analyzers :: suspicious :: no_unsafe_declaration_merging :: NoUnsafeDeclarationMerging as biome_analyze :: Rule > :: Options ;
 pub type NoUnsafeFinally =
-    <lint::correctness::no_unsafe_finally::NoUnsafeFinally as biome_analyze::Rule>::Options;
+    <analyzers::correctness::no_unsafe_finally::NoUnsafeFinally as biome_analyze::Rule>::Options;
 pub type NoUnsafeNegation =
-    <lint::suspicious::no_unsafe_negation::NoUnsafeNegation as biome_analyze::Rule>::Options;
-pub type NoUnsafeOptionalChaining = < lint :: correctness :: no_unsafe_optional_chaining :: NoUnsafeOptionalChaining as biome_analyze :: Rule > :: Options ;
-pub type NoUnusedImports =
-    <lint::correctness::no_unused_imports::NoUnusedImports as biome_analyze::Rule>::Options;
+    <analyzers::suspicious::no_unsafe_negation::NoUnsafeNegation as biome_analyze::Rule>::Options;
+pub type NoUnsafeOptionalChaining = < analyzers :: correctness :: no_unsafe_optional_chaining :: NoUnsafeOptionalChaining as biome_analyze :: Rule > :: Options ;
+pub type NoUnusedImports = < semantic_analyzers :: correctness :: no_unused_imports :: NoUnusedImports as biome_analyze :: Rule > :: Options ;
 pub type NoUnusedLabels =
-    <lint::correctness::no_unused_labels::NoUnusedLabels as biome_analyze::Rule>::Options;
-pub type NoUnusedPrivateClassMembers = < lint :: correctness :: no_unused_private_class_members :: NoUnusedPrivateClassMembers as biome_analyze :: Rule > :: Options ;
-pub type NoUnusedTemplateLiteral = < lint :: style :: no_unused_template_literal :: NoUnusedTemplateLiteral as biome_analyze :: Rule > :: Options ;
-pub type NoUnusedVariables =
-    <lint::correctness::no_unused_variables::NoUnusedVariables as biome_analyze::Rule>::Options;
+    <analyzers::correctness::no_unused_labels::NoUnusedLabels as biome_analyze::Rule>::Options;
+pub type NoUnusedPrivateClassMembers = < analyzers :: correctness :: no_unused_private_class_members :: NoUnusedPrivateClassMembers as biome_analyze :: Rule > :: Options ;
+pub type NoUnusedTemplateLiteral = < analyzers :: style :: no_unused_template_literal :: NoUnusedTemplateLiteral as biome_analyze :: Rule > :: Options ;
+pub type NoUnusedVariables = < semantic_analyzers :: correctness :: no_unused_variables :: NoUnusedVariables as biome_analyze :: Rule > :: Options ;
 pub type NoUselessCatch =
-    <lint::complexity::no_useless_catch::NoUselessCatch as biome_analyze::Rule>::Options;
-pub type NoUselessConstructor = < lint :: complexity :: no_useless_constructor :: NoUselessConstructor as biome_analyze :: Rule > :: Options ;
+    <analyzers::complexity::no_useless_catch::NoUselessCatch as biome_analyze::Rule>::Options;
+pub type NoUselessConstructor = < analyzers :: complexity :: no_useless_constructor :: NoUselessConstructor as biome_analyze :: Rule > :: Options ;
 pub type NoUselessElse =
-    <lint::style::no_useless_else::NoUselessElse as biome_analyze::Rule>::Options;
-pub type NoUselessEmptyExport = < lint :: complexity :: no_useless_empty_export :: NoUselessEmptyExport as biome_analyze :: Rule > :: Options ;
-pub type NoUselessFragments =
-    <lint::complexity::no_useless_fragments::NoUselessFragments as biome_analyze::Rule>::Options;
+    <analyzers::style::no_useless_else::NoUselessElse as biome_analyze::Rule>::Options;
+pub type NoUselessEmptyExport = < analyzers :: complexity :: no_useless_empty_export :: NoUselessEmptyExport as biome_analyze :: Rule > :: Options ;
+pub type NoUselessFragments = < semantic_analyzers :: complexity :: no_useless_fragments :: NoUselessFragments as biome_analyze :: Rule > :: Options ;
 pub type NoUselessLabel =
-    <lint::complexity::no_useless_label::NoUselessLabel as biome_analyze::Rule>::Options;
-pub type NoUselessLoneBlockStatements = < lint :: complexity :: no_useless_lone_block_statements :: NoUselessLoneBlockStatements as biome_analyze :: Rule > :: Options ;
+    <analyzers::complexity::no_useless_label::NoUselessLabel as biome_analyze::Rule>::Options;
+pub type NoUselessLoneBlockStatements = < analyzers :: complexity :: no_useless_lone_block_statements :: NoUselessLoneBlockStatements as biome_analyze :: Rule > :: Options ;
 pub type NoUselessRename =
-    <lint::complexity::no_useless_rename::NoUselessRename as biome_analyze::Rule>::Options;
-pub type NoUselessSwitchCase =
-    <lint::complexity::no_useless_switch_case::NoUselessSwitchCase as biome_analyze::Rule>::Options;
+    <analyzers::complexity::no_useless_rename::NoUselessRename as biome_analyze::Rule>::Options;
+pub type NoUselessSwitchCase = < analyzers :: complexity :: no_useless_switch_case :: NoUselessSwitchCase as biome_analyze :: Rule > :: Options ;
 pub type NoUselessTernary =
-    <lint::nursery::no_useless_ternary::NoUselessTernary as biome_analyze::Rule>::Options;
-pub type NoUselessThisAlias =
-    <lint::complexity::no_useless_this_alias::NoUselessThisAlias as biome_analyze::Rule>::Options;
-pub type NoUselessTypeConstraint = < lint :: complexity :: no_useless_type_constraint :: NoUselessTypeConstraint as biome_analyze :: Rule > :: Options ;
-pub type NoVar = <lint::style::no_var::NoVar as biome_analyze::Rule>::Options;
-pub type NoVoid = <lint::complexity::no_void::NoVoid as biome_analyze::Rule>::Options;
-pub type NoVoidElementsWithChildren = < lint :: correctness :: no_void_elements_with_children :: NoVoidElementsWithChildren as biome_analyze :: Rule > :: Options ;
+    <analyzers::nursery::no_useless_ternary::NoUselessTernary as biome_analyze::Rule>::Options;
+pub type NoUselessThisAlias = < semantic_analyzers :: complexity :: no_useless_this_alias :: NoUselessThisAlias as biome_analyze :: Rule > :: Options ;
+pub type NoUselessTypeConstraint = < analyzers :: complexity :: no_useless_type_constraint :: NoUselessTypeConstraint as biome_analyze :: Rule > :: Options ;
+pub type NoVar = <semantic_analyzers::style::no_var::NoVar as biome_analyze::Rule>::Options;
+pub type NoVoid = <analyzers::complexity::no_void::NoVoid as biome_analyze::Rule>::Options;
+pub type NoVoidElementsWithChildren = < semantic_analyzers :: correctness :: no_void_elements_with_children :: NoVoidElementsWithChildren as biome_analyze :: Rule > :: Options ;
 pub type NoVoidTypeReturn =
-    <lint::correctness::no_void_type_return::NoVoidTypeReturn as biome_analyze::Rule>::Options;
-pub type NoWith = <lint::complexity::no_with::NoWith as biome_analyze::Rule>::Options;
-pub type UseAltText = <lint::a11y::use_alt_text::UseAltText as biome_analyze::Rule>::Options;
+    <analyzers::correctness::no_void_type_return::NoVoidTypeReturn as biome_analyze::Rule>::Options;
+pub type NoWith = <analyzers::complexity::no_with::NoWith as biome_analyze::Rule>::Options;
+pub type UseAltText = <analyzers::a11y::use_alt_text::UseAltText as biome_analyze::Rule>::Options;
 pub type UseAnchorContent =
-    <lint::a11y::use_anchor_content::UseAnchorContent as biome_analyze::Rule>::Options;
-pub type UseAriaActivedescendantWithTabindex = < lint :: a11y :: use_aria_activedescendant_with_tabindex :: UseAriaActivedescendantWithTabindex as biome_analyze :: Rule > :: Options ;
-pub type UseAriaPropsForRole =
-    <lint::a11y::use_aria_props_for_role::UseAriaPropsForRole as biome_analyze::Rule>::Options;
+    <analyzers::a11y::use_anchor_content::UseAnchorContent as biome_analyze::Rule>::Options;
+pub type UseAriaActivedescendantWithTabindex = < aria_analyzers :: a11y :: use_aria_activedescendant_with_tabindex :: UseAriaActivedescendantWithTabindex as biome_analyze :: Rule > :: Options ;
+pub type UseAriaPropsForRole = < aria_analyzers :: a11y :: use_aria_props_for_role :: UseAriaPropsForRole as biome_analyze :: Rule > :: Options ;
 pub type UseArrowFunction =
-    <lint::complexity::use_arrow_function::UseArrowFunction as biome_analyze::Rule>::Options;
+    <analyzers::complexity::use_arrow_function::UseArrowFunction as biome_analyze::Rule>::Options;
 pub type UseAsConstAssertion =
-    <lint::style::use_as_const_assertion::UseAsConstAssertion as biome_analyze::Rule>::Options;
-pub type UseAwait = <lint::suspicious::use_await::UseAwait as biome_analyze::Rule>::Options;
+    <analyzers::style::use_as_const_assertion::UseAsConstAssertion as biome_analyze::Rule>::Options;
+pub type UseAwait = <analyzers::suspicious::use_await::UseAwait as biome_analyze::Rule>::Options;
 pub type UseBlockStatements =
-    <lint::style::use_block_statements::UseBlockStatements as biome_analyze::Rule>::Options;
+    <analyzers::style::use_block_statements::UseBlockStatements as biome_analyze::Rule>::Options;
 pub type UseButtonType =
-    <lint::a11y::use_button_type::UseButtonType as biome_analyze::Rule>::Options;
+    <semantic_analyzers::a11y::use_button_type::UseButtonType as biome_analyze::Rule>::Options;
 pub type UseCollapsedElseIf =
-    <lint::style::use_collapsed_else_if::UseCollapsedElseIf as biome_analyze::Rule>::Options;
-pub type UseConsistentArrayType = < lint :: style :: use_consistent_array_type :: UseConsistentArrayType as biome_analyze :: Rule > :: Options ;
-pub type UseConst = <lint::style::use_const::UseConst as biome_analyze::Rule>::Options;
-pub type UseDefaultParameterLast = < lint :: style :: use_default_parameter_last :: UseDefaultParameterLast as biome_analyze :: Rule > :: Options ;
-pub type UseDefaultSwitchClauseLast = < lint :: suspicious :: use_default_switch_clause_last :: UseDefaultSwitchClauseLast as biome_analyze :: Rule > :: Options ;
+    <analyzers::style::use_collapsed_else_if::UseCollapsedElseIf as biome_analyze::Rule>::Options;
+pub type UseConsistentArrayType = < analyzers :: style :: use_consistent_array_type :: UseConsistentArrayType as biome_analyze :: Rule > :: Options ;
+pub type UseConst =
+    <semantic_analyzers::style::use_const::UseConst as biome_analyze::Rule>::Options;
+pub type UseDefaultParameterLast = < analyzers :: style :: use_default_parameter_last :: UseDefaultParameterLast as biome_analyze :: Rule > :: Options ;
+pub type UseDefaultSwitchClauseLast = < analyzers :: suspicious :: use_default_switch_clause_last :: UseDefaultSwitchClauseLast as biome_analyze :: Rule > :: Options ;
 pub type UseEnumInitializers =
-    <lint::style::use_enum_initializers::UseEnumInitializers as biome_analyze::Rule>::Options;
-pub type UseExhaustiveDependencies = < lint :: correctness :: use_exhaustive_dependencies :: UseExhaustiveDependencies as biome_analyze :: Rule > :: Options ;
-pub type UseExponentiationOperator = < lint :: style :: use_exponentiation_operator :: UseExponentiationOperator as biome_analyze :: Rule > :: Options ;
+    <analyzers::style::use_enum_initializers::UseEnumInitializers as biome_analyze::Rule>::Options;
+pub type UseExhaustiveDependencies = < semantic_analyzers :: correctness :: use_exhaustive_dependencies :: UseExhaustiveDependencies as biome_analyze :: Rule > :: Options ;
+pub type UseExponentiationOperator = < analyzers :: style :: use_exponentiation_operator :: UseExponentiationOperator as biome_analyze :: Rule > :: Options ;
 pub type UseExportType =
-    <lint::style::use_export_type::UseExportType as biome_analyze::Rule>::Options;
-pub type UseFilenamingConvention = < lint :: style :: use_filenaming_convention :: UseFilenamingConvention as biome_analyze :: Rule > :: Options ;
-pub type UseFlatMap = <lint::complexity::use_flat_map::UseFlatMap as biome_analyze::Rule>::Options;
-pub type UseForOf = <lint::style::use_for_of::UseForOf as biome_analyze::Rule>::Options;
-pub type UseFragmentSyntax =
-    <lint::style::use_fragment_syntax::UseFragmentSyntax as biome_analyze::Rule>::Options;
+    <semantic_analyzers::style::use_export_type::UseExportType as biome_analyze::Rule>::Options;
+pub type UseFilenamingConvention = < analyzers :: style :: use_filenaming_convention :: UseFilenamingConvention as biome_analyze :: Rule > :: Options ;
+pub type UseFlatMap =
+    <analyzers::complexity::use_flat_map::UseFlatMap as biome_analyze::Rule>::Options;
+pub type UseForOf =
+    <semantic_analyzers::style::use_for_of::UseForOf as biome_analyze::Rule>::Options;
+pub type UseFragmentSyntax = < semantic_analyzers :: style :: use_fragment_syntax :: UseFragmentSyntax as biome_analyze :: Rule > :: Options ;
 pub type UseGetterReturn =
-    <lint::suspicious::use_getter_return::UseGetterReturn as biome_analyze::Rule>::Options;
+    <analyzers::suspicious::use_getter_return::UseGetterReturn as biome_analyze::Rule>::Options;
 pub type UseHeadingContent =
-    <lint::a11y::use_heading_content::UseHeadingContent as biome_analyze::Rule>::Options;
-pub type UseHookAtTopLevel =
-    <lint::correctness::use_hook_at_top_level::UseHookAtTopLevel as biome_analyze::Rule>::Options;
-pub type UseHtmlLang = <lint::a11y::use_html_lang::UseHtmlLang as biome_analyze::Rule>::Options;
+    <analyzers::a11y::use_heading_content::UseHeadingContent as biome_analyze::Rule>::Options;
+pub type UseHookAtTopLevel = < semantic_analyzers :: correctness :: use_hook_at_top_level :: UseHookAtTopLevel as biome_analyze :: Rule > :: Options ;
+pub type UseHtmlLang =
+    <analyzers::a11y::use_html_lang::UseHtmlLang as biome_analyze::Rule>::Options;
 pub type UseIframeTitle =
-    <lint::a11y::use_iframe_title::UseIframeTitle as biome_analyze::Rule>::Options;
-pub type UseImportRestrictions =
-    <lint::nursery::use_import_restrictions::UseImportRestrictions as biome_analyze::Rule>::Options;
+    <analyzers::a11y::use_iframe_title::UseIframeTitle as biome_analyze::Rule>::Options;
+pub type UseImportRestrictions = < analyzers :: nursery :: use_import_restrictions :: UseImportRestrictions as biome_analyze :: Rule > :: Options ;
 pub type UseImportType =
-    <lint::style::use_import_type::UseImportType as biome_analyze::Rule>::Options;
-pub type UseIsArray = <lint::suspicious::use_is_array::UseIsArray as biome_analyze::Rule>::Options;
-pub type UseIsNan = <lint::correctness::use_is_nan::UseIsNan as biome_analyze::Rule>::Options;
-pub type UseJsxKeyInIterable =
-    <lint::nursery::use_jsx_key_in_iterable::UseJsxKeyInIterable as biome_analyze::Rule>::Options;
-pub type UseKeyWithClickEvents =
-    <lint::a11y::use_key_with_click_events::UseKeyWithClickEvents as biome_analyze::Rule>::Options;
-pub type UseKeyWithMouseEvents =
-    <lint::a11y::use_key_with_mouse_events::UseKeyWithMouseEvents as biome_analyze::Rule>::Options;
-pub type UseLiteralEnumMembers =
-    <lint::style::use_literal_enum_members::UseLiteralEnumMembers as biome_analyze::Rule>::Options;
+    <semantic_analyzers::style::use_import_type::UseImportType as biome_analyze::Rule>::Options;
+pub type UseIsArray =
+    <semantic_analyzers::suspicious::use_is_array::UseIsArray as biome_analyze::Rule>::Options;
+pub type UseIsNan =
+    <semantic_analyzers::correctness::use_is_nan::UseIsNan as biome_analyze::Rule>::Options;
+pub type UseJsxKeyInIterable = < semantic_analyzers :: nursery :: use_jsx_key_in_iterable :: UseJsxKeyInIterable as biome_analyze :: Rule > :: Options ;
+pub type UseKeyWithClickEvents = < analyzers :: a11y :: use_key_with_click_events :: UseKeyWithClickEvents as biome_analyze :: Rule > :: Options ;
+pub type UseKeyWithMouseEvents = < analyzers :: a11y :: use_key_with_mouse_events :: UseKeyWithMouseEvents as biome_analyze :: Rule > :: Options ;
+pub type UseLiteralEnumMembers = < analyzers :: style :: use_literal_enum_members :: UseLiteralEnumMembers as biome_analyze :: Rule > :: Options ;
 pub type UseLiteralKeys =
-    <lint::complexity::use_literal_keys::UseLiteralKeys as biome_analyze::Rule>::Options;
+    <analyzers::complexity::use_literal_keys::UseLiteralKeys as biome_analyze::Rule>::Options;
 pub type UseMediaCaption =
-    <lint::a11y::use_media_caption::UseMediaCaption as biome_analyze::Rule>::Options;
-pub type UseNamespaceKeyword =
-    <lint::suspicious::use_namespace_keyword::UseNamespaceKeyword as biome_analyze::Rule>::Options;
-pub type UseNamingConvention =
-    <lint::style::use_naming_convention::UseNamingConvention as biome_analyze::Rule>::Options;
-pub type UseNodeAssertStrict =
-    <lint::nursery::use_node_assert_strict::UseNodeAssertStrict as biome_analyze::Rule>::Options;
-pub type UseNodejsImportProtocol = < lint :: style :: use_nodejs_import_protocol :: UseNodejsImportProtocol as biome_analyze :: Rule > :: Options ;
-pub type UseNumberNamespace =
-    <lint::style::use_number_namespace::UseNumberNamespace as biome_analyze::Rule>::Options;
+    <analyzers::a11y::use_media_caption::UseMediaCaption as biome_analyze::Rule>::Options;
+pub type UseNamespaceKeyword = < analyzers :: suspicious :: use_namespace_keyword :: UseNamespaceKeyword as biome_analyze :: Rule > :: Options ;
+pub type UseNamingConvention = < semantic_analyzers :: style :: use_naming_convention :: UseNamingConvention as biome_analyze :: Rule > :: Options ;
+pub type UseNodeAssertStrict = < analyzers :: nursery :: use_node_assert_strict :: UseNodeAssertStrict as biome_analyze :: Rule > :: Options ;
+pub type UseNodejsImportProtocol = < analyzers :: style :: use_nodejs_import_protocol :: UseNodejsImportProtocol as biome_analyze :: Rule > :: Options ;
+pub type UseNumberNamespace = < semantic_analyzers :: style :: use_number_namespace :: UseNumberNamespace as biome_analyze :: Rule > :: Options ;
 pub type UseNumericLiterals =
-    <lint::style::use_numeric_literals::UseNumericLiterals as biome_analyze::Rule>::Options;
+    <analyzers::style::use_numeric_literals::UseNumericLiterals as biome_analyze::Rule>::Options;
 pub type UseOptionalChain =
-    <lint::complexity::use_optional_chain::UseOptionalChain as biome_analyze::Rule>::Options;
+    <analyzers::complexity::use_optional_chain::UseOptionalChain as biome_analyze::Rule>::Options;
 pub type UseRegexLiterals =
-    <lint::complexity::use_regex_literals::UseRegexLiterals as biome_analyze::Rule>::Options;
-pub type UseSelfClosingElements = < lint :: style :: use_self_closing_elements :: UseSelfClosingElements as biome_analyze :: Rule > :: Options ;
-pub type UseShorthandArrayType =
-    <lint::style::use_shorthand_array_type::UseShorthandArrayType as biome_analyze::Rule>::Options;
+    <analyzers::complexity::use_regex_literals::UseRegexLiterals as biome_analyze::Rule>::Options;
+pub type UseSelfClosingElements = < analyzers :: style :: use_self_closing_elements :: UseSelfClosingElements as biome_analyze :: Rule > :: Options ;
+pub type UseShorthandArrayType = < analyzers :: style :: use_shorthand_array_type :: UseShorthandArrayType as biome_analyze :: Rule > :: Options ;
 pub type UseShorthandAssign =
-    <lint::style::use_shorthand_assign::UseShorthandAssign as biome_analyze::Rule>::Options;
-pub type UseShorthandFunctionType = < lint :: style :: use_shorthand_function_type :: UseShorthandFunctionType as biome_analyze :: Rule > :: Options ;
-pub type UseSimpleNumberKeys =
-    <lint::complexity::use_simple_number_keys::UseSimpleNumberKeys as biome_analyze::Rule>::Options;
-pub type UseSimplifiedLogicExpression = < lint :: complexity :: use_simplified_logic_expression :: UseSimplifiedLogicExpression as biome_analyze :: Rule > :: Options ;
-pub type UseSingleCaseStatement = < lint :: style :: use_single_case_statement :: UseSingleCaseStatement as biome_analyze :: Rule > :: Options ;
-pub type UseSingleVarDeclarator = < lint :: style :: use_single_var_declarator :: UseSingleVarDeclarator as biome_analyze :: Rule > :: Options ;
-pub type UseSortedClasses =
-    <lint::nursery::use_sorted_classes::UseSortedClasses as biome_analyze::Rule>::Options;
-pub type UseTemplate = <lint::style::use_template::UseTemplate as biome_analyze::Rule>::Options;
+    <analyzers::style::use_shorthand_assign::UseShorthandAssign as biome_analyze::Rule>::Options;
+pub type UseShorthandFunctionType = < analyzers :: style :: use_shorthand_function_type :: UseShorthandFunctionType as biome_analyze :: Rule > :: Options ;
+pub type UseSimpleNumberKeys = < analyzers :: complexity :: use_simple_number_keys :: UseSimpleNumberKeys as biome_analyze :: Rule > :: Options ;
+pub type UseSimplifiedLogicExpression = < analyzers :: complexity :: use_simplified_logic_expression :: UseSimplifiedLogicExpression as biome_analyze :: Rule > :: Options ;
+pub type UseSingleCaseStatement = < analyzers :: style :: use_single_case_statement :: UseSingleCaseStatement as biome_analyze :: Rule > :: Options ;
+pub type UseSingleVarDeclarator = < analyzers :: style :: use_single_var_declarator :: UseSingleVarDeclarator as biome_analyze :: Rule > :: Options ;
+pub type UseSortedClasses = < semantic_analyzers :: nursery :: use_sorted_classes :: UseSortedClasses as biome_analyze :: Rule > :: Options ;
+pub type UseTemplate =
+    <analyzers::style::use_template::UseTemplate as biome_analyze::Rule>::Options;
 pub type UseValidAnchor =
-    <lint::a11y::use_valid_anchor::UseValidAnchor as biome_analyze::Rule>::Options;
+    <analyzers::a11y::use_valid_anchor::UseValidAnchor as biome_analyze::Rule>::Options;
 pub type UseValidAriaProps =
-    <lint::a11y::use_valid_aria_props::UseValidAriaProps as biome_analyze::Rule>::Options;
+    <aria_analyzers::a11y::use_valid_aria_props::UseValidAriaProps as biome_analyze::Rule>::Options;
 pub type UseValidAriaRole =
-    <lint::a11y::use_valid_aria_role::UseValidAriaRole as biome_analyze::Rule>::Options;
-pub type UseValidAriaValues =
-    <lint::a11y::use_valid_aria_values::UseValidAriaValues as biome_analyze::Rule>::Options;
-pub type UseValidForDirection = < lint :: correctness :: use_valid_for_direction :: UseValidForDirection as biome_analyze :: Rule > :: Options ;
-pub type UseValidLang = <lint::a11y::use_valid_lang::UseValidLang as biome_analyze::Rule>::Options;
+    <aria_analyzers::a11y::use_valid_aria_role::UseValidAriaRole as biome_analyze::Rule>::Options;
+pub type UseValidAriaValues = < aria_analyzers :: a11y :: use_valid_aria_values :: UseValidAriaValues as biome_analyze :: Rule > :: Options ;
+pub type UseValidForDirection = < analyzers :: correctness :: use_valid_for_direction :: UseValidForDirection as biome_analyze :: Rule > :: Options ;
+pub type UseValidLang =
+    <aria_analyzers::a11y::use_valid_lang::UseValidLang as biome_analyze::Rule>::Options;
 pub type UseValidTypeof =
-    <lint::suspicious::use_valid_typeof::UseValidTypeof as biome_analyze::Rule>::Options;
-pub type UseWhile = <lint::style::use_while::UseWhile as biome_analyze::Rule>::Options;
-pub type UseYield = <lint::correctness::use_yield::UseYield as biome_analyze::Rule>::Options;
+    <analyzers::suspicious::use_valid_typeof::UseValidTypeof as biome_analyze::Rule>::Options;
+pub type UseWhile = <analyzers::style::use_while::UseWhile as biome_analyze::Rule>::Options;
+pub type UseYield = <analyzers::correctness::use_yield::UseYield as biome_analyze::Rule>::Options;

--- a/crates/biome_js_analyze/src/options.rs
+++ b/crates/biome_js_analyze/src/options.rs
@@ -1,300 +1,340 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::analyzers;
-use crate::aria_analyzers;
-use crate::semantic_analyzers;
+use crate::lint;
 
-pub type NoAccessKey =
-    <analyzers::a11y::no_access_key::NoAccessKey as biome_analyze::Rule>::Options;
-pub type NoAccumulatingSpread = < semantic_analyzers :: performance :: no_accumulating_spread :: NoAccumulatingSpread as biome_analyze :: Rule > :: Options ;
-pub type NoApproximativeNumericConstant = < analyzers :: suspicious :: no_approximative_numeric_constant :: NoApproximativeNumericConstant as biome_analyze :: Rule > :: Options ;
-pub type NoArguments =
-    <semantic_analyzers::style::no_arguments::NoArguments as biome_analyze::Rule>::Options;
-pub type NoAriaHiddenOnFocusable = < aria_analyzers :: a11y :: no_aria_hidden_on_focusable :: NoAriaHiddenOnFocusable as biome_analyze :: Rule > :: Options ;
-pub type NoAriaUnsupportedElements = < aria_analyzers :: a11y :: no_aria_unsupported_elements :: NoAriaUnsupportedElements as biome_analyze :: Rule > :: Options ;
-pub type NoArrayIndexKey = < semantic_analyzers :: suspicious :: no_array_index_key :: NoArrayIndexKey as biome_analyze :: Rule > :: Options ;
-pub type NoAssignInExpressions = < analyzers :: suspicious :: no_assign_in_expressions :: NoAssignInExpressions as biome_analyze :: Rule > :: Options ;
-pub type NoAsyncPromiseExecutor = < analyzers :: suspicious :: no_async_promise_executor :: NoAsyncPromiseExecutor as biome_analyze :: Rule > :: Options ;
-pub type NoAutofocus = <analyzers::a11y::no_autofocus::NoAutofocus as biome_analyze::Rule>::Options;
-pub type NoBannedTypes = < semantic_analyzers :: complexity :: no_banned_types :: NoBannedTypes as biome_analyze :: Rule > :: Options ;
+pub type NoAccessKey = <lint::a11y::no_access_key::NoAccessKey as biome_analyze::Rule>::Options;
+pub type NoAccumulatingSpread = < lint :: performance :: no_accumulating_spread :: NoAccumulatingSpread as biome_analyze :: Rule > :: Options ;
+pub type NoApproximativeNumericConstant = < lint :: suspicious :: no_approximative_numeric_constant :: NoApproximativeNumericConstant as biome_analyze :: Rule > :: Options ;
+pub type NoArguments = <lint::style::no_arguments::NoArguments as biome_analyze::Rule>::Options;
+pub type NoAriaHiddenOnFocusable = < lint :: a11y :: no_aria_hidden_on_focusable :: NoAriaHiddenOnFocusable as biome_analyze :: Rule > :: Options ;
+pub type NoAriaUnsupportedElements = < lint :: a11y :: no_aria_unsupported_elements :: NoAriaUnsupportedElements as biome_analyze :: Rule > :: Options ;
+pub type NoArrayIndexKey =
+    <lint::suspicious::no_array_index_key::NoArrayIndexKey as biome_analyze::Rule>::Options;
+pub type NoAssignInExpressions = < lint :: suspicious :: no_assign_in_expressions :: NoAssignInExpressions as biome_analyze :: Rule > :: Options ;
+pub type NoAsyncPromiseExecutor = < lint :: suspicious :: no_async_promise_executor :: NoAsyncPromiseExecutor as biome_analyze :: Rule > :: Options ;
+pub type NoAutofocus = <lint::a11y::no_autofocus::NoAutofocus as biome_analyze::Rule>::Options;
+pub type NoBannedTypes =
+    <lint::complexity::no_banned_types::NoBannedTypes as biome_analyze::Rule>::Options;
 pub type NoBarrelFile =
-    <analyzers::nursery::no_barrel_file::NoBarrelFile as biome_analyze::Rule>::Options;
+    <lint::nursery::no_barrel_file::NoBarrelFile as biome_analyze::Rule>::Options;
 pub type NoBlankTarget =
-    <analyzers::a11y::no_blank_target::NoBlankTarget as biome_analyze::Rule>::Options;
-pub type NoCatchAssign = < semantic_analyzers :: suspicious :: no_catch_assign :: NoCatchAssign as biome_analyze :: Rule > :: Options ;
-pub type NoChildrenProp = < semantic_analyzers :: correctness :: no_children_prop :: NoChildrenProp as biome_analyze :: Rule > :: Options ;
-pub type NoClassAssign = < semantic_analyzers :: suspicious :: no_class_assign :: NoClassAssign as biome_analyze :: Rule > :: Options ;
+    <lint::a11y::no_blank_target::NoBlankTarget as biome_analyze::Rule>::Options;
+pub type NoCatchAssign =
+    <lint::suspicious::no_catch_assign::NoCatchAssign as biome_analyze::Rule>::Options;
+pub type NoChildrenProp =
+    <lint::correctness::no_children_prop::NoChildrenProp as biome_analyze::Rule>::Options;
+pub type NoClassAssign =
+    <lint::suspicious::no_class_assign::NoClassAssign as biome_analyze::Rule>::Options;
 pub type NoCommaOperator =
-    <analyzers::style::no_comma_operator::NoCommaOperator as biome_analyze::Rule>::Options;
+    <lint::style::no_comma_operator::NoCommaOperator as biome_analyze::Rule>::Options;
 pub type NoCommentText =
-    <analyzers::suspicious::no_comment_text::NoCommentText as biome_analyze::Rule>::Options;
+    <lint::suspicious::no_comment_text::NoCommentText as biome_analyze::Rule>::Options;
 pub type NoCompareNegZero =
-    <analyzers::suspicious::no_compare_neg_zero::NoCompareNegZero as biome_analyze::Rule>::Options;
+    <lint::suspicious::no_compare_neg_zero::NoCompareNegZero as biome_analyze::Rule>::Options;
 pub type NoConfusingLabels =
-    <analyzers::suspicious::no_confusing_labels::NoConfusingLabels as biome_analyze::Rule>::Options;
-pub type NoConfusingVoidType = < analyzers :: suspicious :: no_confusing_void_type :: NoConfusingVoidType as biome_analyze :: Rule > :: Options ;
-pub type NoConsole =
-    <semantic_analyzers::nursery::no_console::NoConsole as biome_analyze::Rule>::Options;
+    <lint::suspicious::no_confusing_labels::NoConfusingLabels as biome_analyze::Rule>::Options;
+pub type NoConfusingVoidType =
+    <lint::suspicious::no_confusing_void_type::NoConfusingVoidType as biome_analyze::Rule>::Options;
+pub type NoConsole = <lint::nursery::no_console::NoConsole as biome_analyze::Rule>::Options;
 pub type NoConsoleLog =
-    <semantic_analyzers::suspicious::no_console_log::NoConsoleLog as biome_analyze::Rule>::Options;
-pub type NoConstAssign = < semantic_analyzers :: correctness :: no_const_assign :: NoConstAssign as biome_analyze :: Rule > :: Options ;
+    <lint::suspicious::no_console_log::NoConsoleLog as biome_analyze::Rule>::Options;
+pub type NoConstAssign =
+    <lint::correctness::no_const_assign::NoConstAssign as biome_analyze::Rule>::Options;
 pub type NoConstEnum =
-    <analyzers::suspicious::no_const_enum::NoConstEnum as biome_analyze::Rule>::Options;
-pub type NoConstantCondition = < semantic_analyzers :: correctness :: no_constant_condition :: NoConstantCondition as biome_analyze :: Rule > :: Options ;
-pub type NoConstructorReturn = < analyzers :: correctness :: no_constructor_return :: NoConstructorReturn as biome_analyze :: Rule > :: Options ;
-pub type NoControlCharactersInRegex = < analyzers :: suspicious :: no_control_characters_in_regex :: NoControlCharactersInRegex as biome_analyze :: Rule > :: Options ;
-pub type NoDangerouslySetInnerHtml = < semantic_analyzers :: security :: no_dangerously_set_inner_html :: NoDangerouslySetInnerHtml as biome_analyze :: Rule > :: Options ;
-pub type NoDangerouslySetInnerHtmlWithChildren = < semantic_analyzers :: security :: no_dangerously_set_inner_html_with_children :: NoDangerouslySetInnerHtmlWithChildren as biome_analyze :: Rule > :: Options ;
-pub type NoDebugger =
-    <analyzers::suspicious::no_debugger::NoDebugger as biome_analyze::Rule>::Options;
+    <lint::suspicious::no_const_enum::NoConstEnum as biome_analyze::Rule>::Options;
+pub type NoConstantCondition =
+    <lint::correctness::no_constant_condition::NoConstantCondition as biome_analyze::Rule>::Options;
+pub type NoConstructorReturn =
+    <lint::correctness::no_constructor_return::NoConstructorReturn as biome_analyze::Rule>::Options;
+pub type NoControlCharactersInRegex = < lint :: suspicious :: no_control_characters_in_regex :: NoControlCharactersInRegex as biome_analyze :: Rule > :: Options ;
+pub type NoDangerouslySetInnerHtml = < lint :: security :: no_dangerously_set_inner_html :: NoDangerouslySetInnerHtml as biome_analyze :: Rule > :: Options ;
+pub type NoDangerouslySetInnerHtmlWithChildren = < lint :: security :: no_dangerously_set_inner_html_with_children :: NoDangerouslySetInnerHtmlWithChildren as biome_analyze :: Rule > :: Options ;
+pub type NoDebugger = <lint::suspicious::no_debugger::NoDebugger as biome_analyze::Rule>::Options;
 pub type NoDefaultExport =
-    <analyzers::style::no_default_export::NoDefaultExport as biome_analyze::Rule>::Options;
-pub type NoDelete = <analyzers::performance::no_delete::NoDelete as biome_analyze::Rule>::Options;
-pub type NoDistractingElements = < analyzers :: a11y :: no_distracting_elements :: NoDistractingElements as biome_analyze :: Rule > :: Options ;
+    <lint::style::no_default_export::NoDefaultExport as biome_analyze::Rule>::Options;
+pub type NoDelete = <lint::performance::no_delete::NoDelete as biome_analyze::Rule>::Options;
+pub type NoDistractingElements =
+    <lint::a11y::no_distracting_elements::NoDistractingElements as biome_analyze::Rule>::Options;
 pub type NoDoneCallback =
-    <analyzers::nursery::no_done_callback::NoDoneCallback as biome_analyze::Rule>::Options;
+    <lint::nursery::no_done_callback::NoDoneCallback as biome_analyze::Rule>::Options;
 pub type NoDoubleEquals =
-    <analyzers::suspicious::no_double_equals::NoDoubleEquals as biome_analyze::Rule>::Options;
+    <lint::suspicious::no_double_equals::NoDoubleEquals as biome_analyze::Rule>::Options;
 pub type NoDuplicateCase =
-    <analyzers::suspicious::no_duplicate_case::NoDuplicateCase as biome_analyze::Rule>::Options;
-pub type NoDuplicateClassMembers = < analyzers :: suspicious :: no_duplicate_class_members :: NoDuplicateClassMembers as biome_analyze :: Rule > :: Options ;
-pub type NoDuplicateJsxProps = < analyzers :: suspicious :: no_duplicate_jsx_props :: NoDuplicateJsxProps as biome_analyze :: Rule > :: Options ;
-pub type NoDuplicateObjectKeys = < analyzers :: suspicious :: no_duplicate_object_keys :: NoDuplicateObjectKeys as biome_analyze :: Rule > :: Options ;
-pub type NoDuplicateParameters = < semantic_analyzers :: suspicious :: no_duplicate_parameters :: NoDuplicateParameters as biome_analyze :: Rule > :: Options ;
-pub type NoDuplicateTestHooks = < analyzers :: nursery :: no_duplicate_test_hooks :: NoDuplicateTestHooks as biome_analyze :: Rule > :: Options ;
-pub type NoEmptyBlockStatements = < analyzers :: suspicious :: no_empty_block_statements :: NoEmptyBlockStatements as biome_analyze :: Rule > :: Options ;
-pub type NoEmptyCharacterClassInRegex = < analyzers :: correctness :: no_empty_character_class_in_regex :: NoEmptyCharacterClassInRegex as biome_analyze :: Rule > :: Options ;
+    <lint::suspicious::no_duplicate_case::NoDuplicateCase as biome_analyze::Rule>::Options;
+pub type NoDuplicateClassMembers = < lint :: suspicious :: no_duplicate_class_members :: NoDuplicateClassMembers as biome_analyze :: Rule > :: Options ;
+pub type NoDuplicateElseIf =
+    <lint::nursery::no_duplicate_else_if::NoDuplicateElseIf as biome_analyze::Rule>::Options;
+pub type NoDuplicateJsxProps =
+    <lint::suspicious::no_duplicate_jsx_props::NoDuplicateJsxProps as biome_analyze::Rule>::Options;
+pub type NoDuplicateObjectKeys = < lint :: suspicious :: no_duplicate_object_keys :: NoDuplicateObjectKeys as biome_analyze :: Rule > :: Options ;
+pub type NoDuplicateParameters = < lint :: suspicious :: no_duplicate_parameters :: NoDuplicateParameters as biome_analyze :: Rule > :: Options ;
+pub type NoDuplicateTestHooks =
+    <lint::nursery::no_duplicate_test_hooks::NoDuplicateTestHooks as biome_analyze::Rule>::Options;
+pub type NoEmptyBlockStatements = < lint :: suspicious :: no_empty_block_statements :: NoEmptyBlockStatements as biome_analyze :: Rule > :: Options ;
+pub type NoEmptyCharacterClassInRegex = < lint :: correctness :: no_empty_character_class_in_regex :: NoEmptyCharacterClassInRegex as biome_analyze :: Rule > :: Options ;
 pub type NoEmptyInterface =
-    <analyzers::suspicious::no_empty_interface::NoEmptyInterface as biome_analyze::Rule>::Options;
+    <lint::suspicious::no_empty_interface::NoEmptyInterface as biome_analyze::Rule>::Options;
 pub type NoEmptyPattern =
-    <analyzers::correctness::no_empty_pattern::NoEmptyPattern as biome_analyze::Rule>::Options;
-pub type NoEmptyTypeParameters = < analyzers :: complexity :: no_empty_type_parameters :: NoEmptyTypeParameters as biome_analyze :: Rule > :: Options ;
-pub type NoExcessiveCognitiveComplexity = < analyzers :: complexity :: no_excessive_cognitive_complexity :: NoExcessiveCognitiveComplexity as biome_analyze :: Rule > :: Options ;
-pub type NoExcessiveNestedTestSuites = < analyzers :: nursery :: no_excessive_nested_test_suites :: NoExcessiveNestedTestSuites as biome_analyze :: Rule > :: Options ;
+    <lint::correctness::no_empty_pattern::NoEmptyPattern as biome_analyze::Rule>::Options;
+pub type NoEmptyTypeParameters = < lint :: complexity :: no_empty_type_parameters :: NoEmptyTypeParameters as biome_analyze :: Rule > :: Options ;
+pub type NoEvolvingAny =
+    <lint::nursery::no_evolving_any::NoEvolvingAny as biome_analyze::Rule>::Options;
+pub type NoExcessiveCognitiveComplexity = < lint :: complexity :: no_excessive_cognitive_complexity :: NoExcessiveCognitiveComplexity as biome_analyze :: Rule > :: Options ;
+pub type NoExcessiveNestedTestSuites = < lint :: nursery :: no_excessive_nested_test_suites :: NoExcessiveNestedTestSuites as biome_analyze :: Rule > :: Options ;
 pub type NoExplicitAny =
-    <analyzers::suspicious::no_explicit_any::NoExplicitAny as biome_analyze::Rule>::Options;
+    <lint::suspicious::no_explicit_any::NoExplicitAny as biome_analyze::Rule>::Options;
 pub type NoExportsInTest =
-    <analyzers::nursery::no_exports_in_test::NoExportsInTest as biome_analyze::Rule>::Options;
-pub type NoExtraBooleanCast = < analyzers :: complexity :: no_extra_boolean_cast :: NoExtraBooleanCast as biome_analyze :: Rule > :: Options ;
-pub type NoExtraNonNullAssertion = < analyzers :: suspicious :: no_extra_non_null_assertion :: NoExtraNonNullAssertion as biome_analyze :: Rule > :: Options ;
-pub type NoFallthroughSwitchClause = < analyzers :: suspicious :: no_fallthrough_switch_clause :: NoFallthroughSwitchClause as biome_analyze :: Rule > :: Options ;
+    <lint::nursery::no_exports_in_test::NoExportsInTest as biome_analyze::Rule>::Options;
+pub type NoExtraBooleanCast =
+    <lint::complexity::no_extra_boolean_cast::NoExtraBooleanCast as biome_analyze::Rule>::Options;
+pub type NoExtraNonNullAssertion = < lint :: suspicious :: no_extra_non_null_assertion :: NoExtraNonNullAssertion as biome_analyze :: Rule > :: Options ;
+pub type NoFallthroughSwitchClause = < lint :: suspicious :: no_fallthrough_switch_clause :: NoFallthroughSwitchClause as biome_analyze :: Rule > :: Options ;
 pub type NoFocusedTests =
-    <analyzers::nursery::no_focused_tests::NoFocusedTests as biome_analyze::Rule>::Options;
-pub type NoForEach =
-    <analyzers::complexity::no_for_each::NoForEach as biome_analyze::Rule>::Options;
-pub type NoFunctionAssign = < semantic_analyzers :: suspicious :: no_function_assign :: NoFunctionAssign as biome_analyze :: Rule > :: Options ;
-pub type NoGlobalAssign = < semantic_analyzers :: suspicious :: no_global_assign :: NoGlobalAssign as biome_analyze :: Rule > :: Options ;
+    <lint::nursery::no_focused_tests::NoFocusedTests as biome_analyze::Rule>::Options;
+pub type NoForEach = <lint::complexity::no_for_each::NoForEach as biome_analyze::Rule>::Options;
+pub type NoFunctionAssign =
+    <lint::suspicious::no_function_assign::NoFunctionAssign as biome_analyze::Rule>::Options;
+pub type NoGlobalAssign =
+    <lint::suspicious::no_global_assign::NoGlobalAssign as biome_analyze::Rule>::Options;
 pub type NoGlobalEval =
-    <semantic_analyzers::security::no_global_eval::NoGlobalEval as biome_analyze::Rule>::Options;
-pub type NoGlobalIsFinite = < semantic_analyzers :: suspicious :: no_global_is_finite :: NoGlobalIsFinite as biome_analyze :: Rule > :: Options ;
-pub type NoGlobalIsNan = < semantic_analyzers :: suspicious :: no_global_is_nan :: NoGlobalIsNan as biome_analyze :: Rule > :: Options ;
-pub type NoGlobalObjectCalls = < semantic_analyzers :: correctness :: no_global_object_calls :: NoGlobalObjectCalls as biome_analyze :: Rule > :: Options ;
+    <lint::security::no_global_eval::NoGlobalEval as biome_analyze::Rule>::Options;
+pub type NoGlobalIsFinite =
+    <lint::suspicious::no_global_is_finite::NoGlobalIsFinite as biome_analyze::Rule>::Options;
+pub type NoGlobalIsNan =
+    <lint::suspicious::no_global_is_nan::NoGlobalIsNan as biome_analyze::Rule>::Options;
+pub type NoGlobalObjectCalls = < lint :: correctness :: no_global_object_calls :: NoGlobalObjectCalls as biome_analyze :: Rule > :: Options ;
 pub type NoHeaderScope =
-    <analyzers::a11y::no_header_scope::NoHeaderScope as biome_analyze::Rule>::Options;
+    <lint::a11y::no_header_scope::NoHeaderScope as biome_analyze::Rule>::Options;
 pub type NoImplicitAnyLet =
-    <analyzers::suspicious::no_implicit_any_let::NoImplicitAnyLet as biome_analyze::Rule>::Options;
+    <lint::suspicious::no_implicit_any_let::NoImplicitAnyLet as biome_analyze::Rule>::Options;
 pub type NoImplicitBoolean =
-    <analyzers::style::no_implicit_boolean::NoImplicitBoolean as biome_analyze::Rule>::Options;
-pub type NoImportAssign = < semantic_analyzers :: suspicious :: no_import_assign :: NoImportAssign as biome_analyze :: Rule > :: Options ;
+    <lint::style::no_implicit_boolean::NoImplicitBoolean as biome_analyze::Rule>::Options;
+pub type NoImportAssign =
+    <lint::suspicious::no_import_assign::NoImportAssign as biome_analyze::Rule>::Options;
 pub type NoInferrableTypes =
-    <analyzers::style::no_inferrable_types::NoInferrableTypes as biome_analyze::Rule>::Options;
-pub type NoInnerDeclarations = < analyzers :: correctness :: no_inner_declarations :: NoInnerDeclarations as biome_analyze :: Rule > :: Options ;
-pub type NoInteractiveElementToNoninteractiveRole = < aria_analyzers :: a11y :: no_interactive_element_to_noninteractive_role :: NoInteractiveElementToNoninteractiveRole as biome_analyze :: Rule > :: Options ;
-pub type NoInvalidConstructorSuper = < analyzers :: correctness :: no_invalid_constructor_super :: NoInvalidConstructorSuper as biome_analyze :: Rule > :: Options ;
-pub type NoInvalidNewBuiltin = < semantic_analyzers :: correctness :: no_invalid_new_builtin :: NoInvalidNewBuiltin as biome_analyze :: Rule > :: Options ;
-pub type NoInvalidUseBeforeDeclaration = < semantic_analyzers :: correctness :: no_invalid_use_before_declaration :: NoInvalidUseBeforeDeclaration as biome_analyze :: Rule > :: Options ;
-pub type NoLabelVar =
-    <semantic_analyzers::suspicious::no_label_var::NoLabelVar as biome_analyze::Rule>::Options;
-pub type NoMisleadingCharacterClass = < semantic_analyzers :: suspicious :: no_misleading_character_class :: NoMisleadingCharacterClass as biome_analyze :: Rule > :: Options ;
-pub type NoMisleadingInstantiator = < analyzers :: suspicious :: no_misleading_instantiator :: NoMisleadingInstantiator as biome_analyze :: Rule > :: Options ;
-pub type NoMisplacedAssertion = < analyzers :: nursery :: no_misplaced_assertion :: NoMisplacedAssertion as biome_analyze :: Rule > :: Options ;
-pub type NoMisrefactoredShorthandAssign = < analyzers :: suspicious :: no_misrefactored_shorthand_assign :: NoMisrefactoredShorthandAssign as biome_analyze :: Rule > :: Options ;
-pub type NoMultipleSpacesInRegularExpressionLiterals = < analyzers :: complexity :: no_multiple_spaces_in_regular_expression_literals :: NoMultipleSpacesInRegularExpressionLiterals as biome_analyze :: Rule > :: Options ;
-pub type NoNamespace =
-    <analyzers::style::no_namespace::NoNamespace as biome_analyze::Rule>::Options;
+    <lint::style::no_inferrable_types::NoInferrableTypes as biome_analyze::Rule>::Options;
+pub type NoInnerDeclarations =
+    <lint::correctness::no_inner_declarations::NoInnerDeclarations as biome_analyze::Rule>::Options;
+pub type NoInteractiveElementToNoninteractiveRole = < lint :: a11y :: no_interactive_element_to_noninteractive_role :: NoInteractiveElementToNoninteractiveRole as biome_analyze :: Rule > :: Options ;
+pub type NoInvalidConstructorSuper = < lint :: correctness :: no_invalid_constructor_super :: NoInvalidConstructorSuper as biome_analyze :: Rule > :: Options ;
+pub type NoInvalidNewBuiltin = < lint :: correctness :: no_invalid_new_builtin :: NoInvalidNewBuiltin as biome_analyze :: Rule > :: Options ;
+pub type NoInvalidUseBeforeDeclaration = < lint :: correctness :: no_invalid_use_before_declaration :: NoInvalidUseBeforeDeclaration as biome_analyze :: Rule > :: Options ;
+pub type NoLabelVar = <lint::suspicious::no_label_var::NoLabelVar as biome_analyze::Rule>::Options;
+pub type NoMisleadingCharacterClass = < lint :: suspicious :: no_misleading_character_class :: NoMisleadingCharacterClass as biome_analyze :: Rule > :: Options ;
+pub type NoMisleadingInstantiator = < lint :: suspicious :: no_misleading_instantiator :: NoMisleadingInstantiator as biome_analyze :: Rule > :: Options ;
+pub type NoMisplacedAssertion =
+    <lint::nursery::no_misplaced_assertion::NoMisplacedAssertion as biome_analyze::Rule>::Options;
+pub type NoMisrefactoredShorthandAssign = < lint :: suspicious :: no_misrefactored_shorthand_assign :: NoMisrefactoredShorthandAssign as biome_analyze :: Rule > :: Options ;
+pub type NoMultipleSpacesInRegularExpressionLiterals = < lint :: complexity :: no_multiple_spaces_in_regular_expression_literals :: NoMultipleSpacesInRegularExpressionLiterals as biome_analyze :: Rule > :: Options ;
+pub type NoNamespace = <lint::style::no_namespace::NoNamespace as biome_analyze::Rule>::Options;
 pub type NoNamespaceImport =
-    <analyzers::nursery::no_namespace_import::NoNamespaceImport as biome_analyze::Rule>::Options;
+    <lint::nursery::no_namespace_import::NoNamespaceImport as biome_analyze::Rule>::Options;
 pub type NoNegationElse =
-    <analyzers::style::no_negation_else::NoNegationElse as biome_analyze::Rule>::Options;
+    <lint::style::no_negation_else::NoNegationElse as biome_analyze::Rule>::Options;
 pub type NoNewSymbol =
-    <semantic_analyzers::correctness::no_new_symbol::NoNewSymbol as biome_analyze::Rule>::Options;
+    <lint::correctness::no_new_symbol::NoNewSymbol as biome_analyze::Rule>::Options;
 pub type NoNodejsModules =
-    <analyzers::nursery::no_nodejs_modules::NoNodejsModules as biome_analyze::Rule>::Options;
+    <lint::nursery::no_nodejs_modules::NoNodejsModules as biome_analyze::Rule>::Options;
 pub type NoNonNullAssertion =
-    <analyzers::style::no_non_null_assertion::NoNonNullAssertion as biome_analyze::Rule>::Options;
-pub type NoNoninteractiveElementToInteractiveRole = < aria_analyzers :: a11y :: no_noninteractive_element_to_interactive_role :: NoNoninteractiveElementToInteractiveRole as biome_analyze :: Rule > :: Options ;
-pub type NoNoninteractiveTabindex = < aria_analyzers :: a11y :: no_noninteractive_tabindex :: NoNoninteractiveTabindex as biome_analyze :: Rule > :: Options ;
-pub type NoNonoctalDecimalEscape = < analyzers :: correctness :: no_nonoctal_decimal_escape :: NoNonoctalDecimalEscape as biome_analyze :: Rule > :: Options ;
-pub type NoParameterAssign = < semantic_analyzers :: style :: no_parameter_assign :: NoParameterAssign as biome_analyze :: Rule > :: Options ;
-pub type NoParameterProperties = < analyzers :: style :: no_parameter_properties :: NoParameterProperties as biome_analyze :: Rule > :: Options ;
-pub type NoPositiveTabindex = < semantic_analyzers :: a11y :: no_positive_tabindex :: NoPositiveTabindex as biome_analyze :: Rule > :: Options ;
+    <lint::style::no_non_null_assertion::NoNonNullAssertion as biome_analyze::Rule>::Options;
+pub type NoNoninteractiveElementToInteractiveRole = < lint :: a11y :: no_noninteractive_element_to_interactive_role :: NoNoninteractiveElementToInteractiveRole as biome_analyze :: Rule > :: Options ;
+pub type NoNoninteractiveTabindex = < lint :: a11y :: no_noninteractive_tabindex :: NoNoninteractiveTabindex as biome_analyze :: Rule > :: Options ;
+pub type NoNonoctalDecimalEscape = < lint :: correctness :: no_nonoctal_decimal_escape :: NoNonoctalDecimalEscape as biome_analyze :: Rule > :: Options ;
+pub type NoParameterAssign =
+    <lint::style::no_parameter_assign::NoParameterAssign as biome_analyze::Rule>::Options;
+pub type NoParameterProperties =
+    <lint::style::no_parameter_properties::NoParameterProperties as biome_analyze::Rule>::Options;
+pub type NoPositiveTabindex =
+    <lint::a11y::no_positive_tabindex::NoPositiveTabindex as biome_analyze::Rule>::Options;
 pub type NoPrecisionLoss =
-    <analyzers::correctness::no_precision_loss::NoPrecisionLoss as biome_analyze::Rule>::Options;
-pub type NoPrototypeBuiltins = < analyzers :: suspicious :: no_prototype_builtins :: NoPrototypeBuiltins as biome_analyze :: Rule > :: Options ;
+    <lint::correctness::no_precision_loss::NoPrecisionLoss as biome_analyze::Rule>::Options;
+pub type NoPrototypeBuiltins =
+    <lint::suspicious::no_prototype_builtins::NoPrototypeBuiltins as biome_analyze::Rule>::Options;
 pub type NoReExportAll =
-    <semantic_analyzers::nursery::no_re_export_all::NoReExportAll as biome_analyze::Rule>::Options;
+    <lint::nursery::no_re_export_all::NoReExportAll as biome_analyze::Rule>::Options;
 pub type NoRedeclare =
-    <semantic_analyzers::suspicious::no_redeclare::NoRedeclare as biome_analyze::Rule>::Options;
+    <lint::suspicious::no_redeclare::NoRedeclare as biome_analyze::Rule>::Options;
 pub type NoRedundantAlt =
-    <analyzers::a11y::no_redundant_alt::NoRedundantAlt as biome_analyze::Rule>::Options;
+    <lint::a11y::no_redundant_alt::NoRedundantAlt as biome_analyze::Rule>::Options;
 pub type NoRedundantRoles =
-    <aria_analyzers::a11y::no_redundant_roles::NoRedundantRoles as biome_analyze::Rule>::Options;
-pub type NoRedundantUseStrict = < analyzers :: suspicious :: no_redundant_use_strict :: NoRedundantUseStrict as biome_analyze :: Rule > :: Options ;
-pub type NoRenderReturnValue = < semantic_analyzers :: correctness :: no_render_return_value :: NoRenderReturnValue as biome_analyze :: Rule > :: Options ;
-pub type NoRestrictedGlobals = < semantic_analyzers :: style :: no_restricted_globals :: NoRestrictedGlobals as biome_analyze :: Rule > :: Options ;
-pub type NoRestrictedImports = < analyzers :: nursery :: no_restricted_imports :: NoRestrictedImports as biome_analyze :: Rule > :: Options ;
+    <lint::a11y::no_redundant_roles::NoRedundantRoles as biome_analyze::Rule>::Options;
+pub type NoRedundantUseStrict = < lint :: suspicious :: no_redundant_use_strict :: NoRedundantUseStrict as biome_analyze :: Rule > :: Options ;
+pub type NoRenderReturnValue = < lint :: correctness :: no_render_return_value :: NoRenderReturnValue as biome_analyze :: Rule > :: Options ;
+pub type NoRestrictedGlobals =
+    <lint::style::no_restricted_globals::NoRestrictedGlobals as biome_analyze::Rule>::Options;
+pub type NoRestrictedImports =
+    <lint::nursery::no_restricted_imports::NoRestrictedImports as biome_analyze::Rule>::Options;
 pub type NoSelfAssign =
-    <analyzers::correctness::no_self_assign::NoSelfAssign as biome_analyze::Rule>::Options;
+    <lint::correctness::no_self_assign::NoSelfAssign as biome_analyze::Rule>::Options;
 pub type NoSelfCompare =
-    <analyzers::suspicious::no_self_compare::NoSelfCompare as biome_analyze::Rule>::Options;
-pub type NoSemicolonInJsx = < semantic_analyzers :: nursery :: no_semicolon_in_jsx :: NoSemicolonInJsx as biome_analyze :: Rule > :: Options ;
+    <lint::suspicious::no_self_compare::NoSelfCompare as biome_analyze::Rule>::Options;
+pub type NoSemicolonInJsx =
+    <lint::nursery::no_semicolon_in_jsx::NoSemicolonInJsx as biome_analyze::Rule>::Options;
 pub type NoSetterReturn =
-    <analyzers::correctness::no_setter_return::NoSetterReturn as biome_analyze::Rule>::Options;
-pub type NoShadowRestrictedNames = < analyzers :: suspicious :: no_shadow_restricted_names :: NoShadowRestrictedNames as biome_analyze :: Rule > :: Options ;
-pub type NoShoutyConstants = < semantic_analyzers :: style :: no_shouty_constants :: NoShoutyConstants as biome_analyze :: Rule > :: Options ;
+    <lint::correctness::no_setter_return::NoSetterReturn as biome_analyze::Rule>::Options;
+pub type NoShadowRestrictedNames = < lint :: suspicious :: no_shadow_restricted_names :: NoShadowRestrictedNames as biome_analyze :: Rule > :: Options ;
+pub type NoShoutyConstants =
+    <lint::style::no_shouty_constants::NoShoutyConstants as biome_analyze::Rule>::Options;
 pub type NoSkippedTests =
-    <analyzers::nursery::no_skipped_tests::NoSkippedTests as biome_analyze::Rule>::Options;
+    <lint::nursery::no_skipped_tests::NoSkippedTests as biome_analyze::Rule>::Options;
 pub type NoSparseArray =
-    <analyzers::suspicious::no_sparse_array::NoSparseArray as biome_analyze::Rule>::Options;
-pub type NoStaticOnlyClass = < analyzers :: complexity :: no_static_only_class :: NoStaticOnlyClass as biome_analyze :: Rule > :: Options ;
-pub type NoStringCaseMismatch = < analyzers :: correctness :: no_string_case_mismatch :: NoStringCaseMismatch as biome_analyze :: Rule > :: Options ;
+    <lint::suspicious::no_sparse_array::NoSparseArray as biome_analyze::Rule>::Options;
+pub type NoStaticOnlyClass =
+    <lint::complexity::no_static_only_class::NoStaticOnlyClass as biome_analyze::Rule>::Options;
+pub type NoStringCaseMismatch = < lint :: correctness :: no_string_case_mismatch :: NoStringCaseMismatch as biome_analyze :: Rule > :: Options ;
 pub type NoSvgWithoutTitle =
-    <analyzers::a11y::no_svg_without_title::NoSvgWithoutTitle as biome_analyze::Rule>::Options;
-pub type NoSwitchDeclarations = < analyzers :: correctness :: no_switch_declarations :: NoSwitchDeclarations as biome_analyze :: Rule > :: Options ;
-pub type NoThenProperty = < semantic_analyzers :: suspicious :: no_then_property :: NoThenProperty as biome_analyze :: Rule > :: Options ;
-pub type NoThisInStatic = < semantic_analyzers :: complexity :: no_this_in_static :: NoThisInStatic as biome_analyze :: Rule > :: Options ;
-pub type NoUndeclaredDependencies = < analyzers :: nursery :: no_undeclared_dependencies :: NoUndeclaredDependencies as biome_analyze :: Rule > :: Options ;
-pub type NoUndeclaredVariables = < semantic_analyzers :: correctness :: no_undeclared_variables :: NoUndeclaredVariables as biome_analyze :: Rule > :: Options ;
-pub type NoUnnecessaryContinue = < analyzers :: correctness :: no_unnecessary_continue :: NoUnnecessaryContinue as biome_analyze :: Rule > :: Options ;
+    <lint::a11y::no_svg_without_title::NoSvgWithoutTitle as biome_analyze::Rule>::Options;
+pub type NoSwitchDeclarations = < lint :: correctness :: no_switch_declarations :: NoSwitchDeclarations as biome_analyze :: Rule > :: Options ;
+pub type NoThenProperty =
+    <lint::suspicious::no_then_property::NoThenProperty as biome_analyze::Rule>::Options;
+pub type NoThisInStatic =
+    <lint::complexity::no_this_in_static::NoThisInStatic as biome_analyze::Rule>::Options;
+pub type NoUndeclaredDependencies = < lint :: nursery :: no_undeclared_dependencies :: NoUndeclaredDependencies as biome_analyze :: Rule > :: Options ;
+pub type NoUndeclaredVariables = < lint :: correctness :: no_undeclared_variables :: NoUndeclaredVariables as biome_analyze :: Rule > :: Options ;
+pub type NoUnnecessaryContinue = < lint :: correctness :: no_unnecessary_continue :: NoUnnecessaryContinue as biome_analyze :: Rule > :: Options ;
 pub type NoUnreachable =
-    <analyzers::correctness::no_unreachable::NoUnreachable as biome_analyze::Rule>::Options;
-pub type NoUnreachableSuper = < analyzers :: correctness :: no_unreachable_super :: NoUnreachableSuper as biome_analyze :: Rule > :: Options ;
-pub type NoUnsafeDeclarationMerging = < semantic_analyzers :: suspicious :: no_unsafe_declaration_merging :: NoUnsafeDeclarationMerging as biome_analyze :: Rule > :: Options ;
+    <lint::correctness::no_unreachable::NoUnreachable as biome_analyze::Rule>::Options;
+pub type NoUnreachableSuper =
+    <lint::correctness::no_unreachable_super::NoUnreachableSuper as biome_analyze::Rule>::Options;
+pub type NoUnsafeDeclarationMerging = < lint :: suspicious :: no_unsafe_declaration_merging :: NoUnsafeDeclarationMerging as biome_analyze :: Rule > :: Options ;
 pub type NoUnsafeFinally =
-    <analyzers::correctness::no_unsafe_finally::NoUnsafeFinally as biome_analyze::Rule>::Options;
+    <lint::correctness::no_unsafe_finally::NoUnsafeFinally as biome_analyze::Rule>::Options;
 pub type NoUnsafeNegation =
-    <analyzers::suspicious::no_unsafe_negation::NoUnsafeNegation as biome_analyze::Rule>::Options;
-pub type NoUnsafeOptionalChaining = < analyzers :: correctness :: no_unsafe_optional_chaining :: NoUnsafeOptionalChaining as biome_analyze :: Rule > :: Options ;
-pub type NoUnusedImports = < semantic_analyzers :: correctness :: no_unused_imports :: NoUnusedImports as biome_analyze :: Rule > :: Options ;
+    <lint::suspicious::no_unsafe_negation::NoUnsafeNegation as biome_analyze::Rule>::Options;
+pub type NoUnsafeOptionalChaining = < lint :: correctness :: no_unsafe_optional_chaining :: NoUnsafeOptionalChaining as biome_analyze :: Rule > :: Options ;
+pub type NoUnusedImports =
+    <lint::correctness::no_unused_imports::NoUnusedImports as biome_analyze::Rule>::Options;
 pub type NoUnusedLabels =
-    <analyzers::correctness::no_unused_labels::NoUnusedLabels as biome_analyze::Rule>::Options;
-pub type NoUnusedPrivateClassMembers = < analyzers :: correctness :: no_unused_private_class_members :: NoUnusedPrivateClassMembers as biome_analyze :: Rule > :: Options ;
-pub type NoUnusedTemplateLiteral = < analyzers :: style :: no_unused_template_literal :: NoUnusedTemplateLiteral as biome_analyze :: Rule > :: Options ;
-pub type NoUnusedVariables = < semantic_analyzers :: correctness :: no_unused_variables :: NoUnusedVariables as biome_analyze :: Rule > :: Options ;
+    <lint::correctness::no_unused_labels::NoUnusedLabels as biome_analyze::Rule>::Options;
+pub type NoUnusedPrivateClassMembers = < lint :: correctness :: no_unused_private_class_members :: NoUnusedPrivateClassMembers as biome_analyze :: Rule > :: Options ;
+pub type NoUnusedTemplateLiteral = < lint :: style :: no_unused_template_literal :: NoUnusedTemplateLiteral as biome_analyze :: Rule > :: Options ;
+pub type NoUnusedVariables =
+    <lint::correctness::no_unused_variables::NoUnusedVariables as biome_analyze::Rule>::Options;
 pub type NoUselessCatch =
-    <analyzers::complexity::no_useless_catch::NoUselessCatch as biome_analyze::Rule>::Options;
-pub type NoUselessConstructor = < analyzers :: complexity :: no_useless_constructor :: NoUselessConstructor as biome_analyze :: Rule > :: Options ;
+    <lint::complexity::no_useless_catch::NoUselessCatch as biome_analyze::Rule>::Options;
+pub type NoUselessConstructor = < lint :: complexity :: no_useless_constructor :: NoUselessConstructor as biome_analyze :: Rule > :: Options ;
 pub type NoUselessElse =
-    <analyzers::style::no_useless_else::NoUselessElse as biome_analyze::Rule>::Options;
-pub type NoUselessEmptyExport = < analyzers :: complexity :: no_useless_empty_export :: NoUselessEmptyExport as biome_analyze :: Rule > :: Options ;
-pub type NoUselessFragments = < semantic_analyzers :: complexity :: no_useless_fragments :: NoUselessFragments as biome_analyze :: Rule > :: Options ;
+    <lint::style::no_useless_else::NoUselessElse as biome_analyze::Rule>::Options;
+pub type NoUselessEmptyExport = < lint :: complexity :: no_useless_empty_export :: NoUselessEmptyExport as biome_analyze :: Rule > :: Options ;
+pub type NoUselessFragments =
+    <lint::complexity::no_useless_fragments::NoUselessFragments as biome_analyze::Rule>::Options;
 pub type NoUselessLabel =
-    <analyzers::complexity::no_useless_label::NoUselessLabel as biome_analyze::Rule>::Options;
-pub type NoUselessLoneBlockStatements = < analyzers :: complexity :: no_useless_lone_block_statements :: NoUselessLoneBlockStatements as biome_analyze :: Rule > :: Options ;
+    <lint::complexity::no_useless_label::NoUselessLabel as biome_analyze::Rule>::Options;
+pub type NoUselessLoneBlockStatements = < lint :: complexity :: no_useless_lone_block_statements :: NoUselessLoneBlockStatements as biome_analyze :: Rule > :: Options ;
 pub type NoUselessRename =
-    <analyzers::complexity::no_useless_rename::NoUselessRename as biome_analyze::Rule>::Options;
-pub type NoUselessSwitchCase = < analyzers :: complexity :: no_useless_switch_case :: NoUselessSwitchCase as biome_analyze :: Rule > :: Options ;
+    <lint::complexity::no_useless_rename::NoUselessRename as biome_analyze::Rule>::Options;
+pub type NoUselessSwitchCase =
+    <lint::complexity::no_useless_switch_case::NoUselessSwitchCase as biome_analyze::Rule>::Options;
 pub type NoUselessTernary =
-    <analyzers::nursery::no_useless_ternary::NoUselessTernary as biome_analyze::Rule>::Options;
-pub type NoUselessThisAlias = < semantic_analyzers :: complexity :: no_useless_this_alias :: NoUselessThisAlias as biome_analyze :: Rule > :: Options ;
-pub type NoUselessTypeConstraint = < analyzers :: complexity :: no_useless_type_constraint :: NoUselessTypeConstraint as biome_analyze :: Rule > :: Options ;
-pub type NoVar = <semantic_analyzers::style::no_var::NoVar as biome_analyze::Rule>::Options;
-pub type NoVoid = <analyzers::complexity::no_void::NoVoid as biome_analyze::Rule>::Options;
-pub type NoVoidElementsWithChildren = < semantic_analyzers :: correctness :: no_void_elements_with_children :: NoVoidElementsWithChildren as biome_analyze :: Rule > :: Options ;
+    <lint::nursery::no_useless_ternary::NoUselessTernary as biome_analyze::Rule>::Options;
+pub type NoUselessThisAlias =
+    <lint::complexity::no_useless_this_alias::NoUselessThisAlias as biome_analyze::Rule>::Options;
+pub type NoUselessTypeConstraint = < lint :: complexity :: no_useless_type_constraint :: NoUselessTypeConstraint as biome_analyze :: Rule > :: Options ;
+pub type NoVar = <lint::style::no_var::NoVar as biome_analyze::Rule>::Options;
+pub type NoVoid = <lint::complexity::no_void::NoVoid as biome_analyze::Rule>::Options;
+pub type NoVoidElementsWithChildren = < lint :: correctness :: no_void_elements_with_children :: NoVoidElementsWithChildren as biome_analyze :: Rule > :: Options ;
 pub type NoVoidTypeReturn =
-    <analyzers::correctness::no_void_type_return::NoVoidTypeReturn as biome_analyze::Rule>::Options;
-pub type NoWith = <analyzers::complexity::no_with::NoWith as biome_analyze::Rule>::Options;
-pub type UseAltText = <analyzers::a11y::use_alt_text::UseAltText as biome_analyze::Rule>::Options;
+    <lint::correctness::no_void_type_return::NoVoidTypeReturn as biome_analyze::Rule>::Options;
+pub type NoWith = <lint::complexity::no_with::NoWith as biome_analyze::Rule>::Options;
+pub type UseAltText = <lint::a11y::use_alt_text::UseAltText as biome_analyze::Rule>::Options;
 pub type UseAnchorContent =
-    <analyzers::a11y::use_anchor_content::UseAnchorContent as biome_analyze::Rule>::Options;
-pub type UseAriaActivedescendantWithTabindex = < aria_analyzers :: a11y :: use_aria_activedescendant_with_tabindex :: UseAriaActivedescendantWithTabindex as biome_analyze :: Rule > :: Options ;
-pub type UseAriaPropsForRole = < aria_analyzers :: a11y :: use_aria_props_for_role :: UseAriaPropsForRole as biome_analyze :: Rule > :: Options ;
+    <lint::a11y::use_anchor_content::UseAnchorContent as biome_analyze::Rule>::Options;
+pub type UseAriaActivedescendantWithTabindex = < lint :: a11y :: use_aria_activedescendant_with_tabindex :: UseAriaActivedescendantWithTabindex as biome_analyze :: Rule > :: Options ;
+pub type UseAriaPropsForRole =
+    <lint::a11y::use_aria_props_for_role::UseAriaPropsForRole as biome_analyze::Rule>::Options;
 pub type UseArrowFunction =
-    <analyzers::complexity::use_arrow_function::UseArrowFunction as biome_analyze::Rule>::Options;
+    <lint::complexity::use_arrow_function::UseArrowFunction as biome_analyze::Rule>::Options;
 pub type UseAsConstAssertion =
-    <analyzers::style::use_as_const_assertion::UseAsConstAssertion as biome_analyze::Rule>::Options;
-pub type UseAwait = <analyzers::suspicious::use_await::UseAwait as biome_analyze::Rule>::Options;
+    <lint::style::use_as_const_assertion::UseAsConstAssertion as biome_analyze::Rule>::Options;
+pub type UseAwait = <lint::suspicious::use_await::UseAwait as biome_analyze::Rule>::Options;
 pub type UseBlockStatements =
-    <analyzers::style::use_block_statements::UseBlockStatements as biome_analyze::Rule>::Options;
+    <lint::style::use_block_statements::UseBlockStatements as biome_analyze::Rule>::Options;
 pub type UseButtonType =
-    <semantic_analyzers::a11y::use_button_type::UseButtonType as biome_analyze::Rule>::Options;
+    <lint::a11y::use_button_type::UseButtonType as biome_analyze::Rule>::Options;
 pub type UseCollapsedElseIf =
-    <analyzers::style::use_collapsed_else_if::UseCollapsedElseIf as biome_analyze::Rule>::Options;
-pub type UseConsistentArrayType = < analyzers :: style :: use_consistent_array_type :: UseConsistentArrayType as biome_analyze :: Rule > :: Options ;
-pub type UseConst =
-    <semantic_analyzers::style::use_const::UseConst as biome_analyze::Rule>::Options;
-pub type UseDefaultParameterLast = < analyzers :: style :: use_default_parameter_last :: UseDefaultParameterLast as biome_analyze :: Rule > :: Options ;
-pub type UseDefaultSwitchClauseLast = < analyzers :: suspicious :: use_default_switch_clause_last :: UseDefaultSwitchClauseLast as biome_analyze :: Rule > :: Options ;
+    <lint::style::use_collapsed_else_if::UseCollapsedElseIf as biome_analyze::Rule>::Options;
+pub type UseConsistentArrayType = < lint :: style :: use_consistent_array_type :: UseConsistentArrayType as biome_analyze :: Rule > :: Options ;
+pub type UseConst = <lint::style::use_const::UseConst as biome_analyze::Rule>::Options;
+pub type UseDefaultParameterLast = < lint :: style :: use_default_parameter_last :: UseDefaultParameterLast as biome_analyze :: Rule > :: Options ;
+pub type UseDefaultSwitchClauseLast = < lint :: suspicious :: use_default_switch_clause_last :: UseDefaultSwitchClauseLast as biome_analyze :: Rule > :: Options ;
 pub type UseEnumInitializers =
-    <analyzers::style::use_enum_initializers::UseEnumInitializers as biome_analyze::Rule>::Options;
-pub type UseExhaustiveDependencies = < semantic_analyzers :: correctness :: use_exhaustive_dependencies :: UseExhaustiveDependencies as biome_analyze :: Rule > :: Options ;
-pub type UseExponentiationOperator = < analyzers :: style :: use_exponentiation_operator :: UseExponentiationOperator as biome_analyze :: Rule > :: Options ;
+    <lint::style::use_enum_initializers::UseEnumInitializers as biome_analyze::Rule>::Options;
+pub type UseExhaustiveDependencies = < lint :: correctness :: use_exhaustive_dependencies :: UseExhaustiveDependencies as biome_analyze :: Rule > :: Options ;
+pub type UseExponentiationOperator = < lint :: style :: use_exponentiation_operator :: UseExponentiationOperator as biome_analyze :: Rule > :: Options ;
 pub type UseExportType =
-    <semantic_analyzers::style::use_export_type::UseExportType as biome_analyze::Rule>::Options;
-pub type UseFilenamingConvention = < analyzers :: style :: use_filenaming_convention :: UseFilenamingConvention as biome_analyze :: Rule > :: Options ;
-pub type UseFlatMap =
-    <analyzers::complexity::use_flat_map::UseFlatMap as biome_analyze::Rule>::Options;
-pub type UseForOf =
-    <semantic_analyzers::style::use_for_of::UseForOf as biome_analyze::Rule>::Options;
-pub type UseFragmentSyntax = < semantic_analyzers :: style :: use_fragment_syntax :: UseFragmentSyntax as biome_analyze :: Rule > :: Options ;
+    <lint::style::use_export_type::UseExportType as biome_analyze::Rule>::Options;
+pub type UseFilenamingConvention = < lint :: style :: use_filenaming_convention :: UseFilenamingConvention as biome_analyze :: Rule > :: Options ;
+pub type UseFlatMap = <lint::complexity::use_flat_map::UseFlatMap as biome_analyze::Rule>::Options;
+pub type UseForOf = <lint::style::use_for_of::UseForOf as biome_analyze::Rule>::Options;
+pub type UseFragmentSyntax =
+    <lint::style::use_fragment_syntax::UseFragmentSyntax as biome_analyze::Rule>::Options;
 pub type UseGetterReturn =
-    <analyzers::suspicious::use_getter_return::UseGetterReturn as biome_analyze::Rule>::Options;
+    <lint::suspicious::use_getter_return::UseGetterReturn as biome_analyze::Rule>::Options;
 pub type UseHeadingContent =
-    <analyzers::a11y::use_heading_content::UseHeadingContent as biome_analyze::Rule>::Options;
-pub type UseHookAtTopLevel = < semantic_analyzers :: correctness :: use_hook_at_top_level :: UseHookAtTopLevel as biome_analyze :: Rule > :: Options ;
-pub type UseHtmlLang =
-    <analyzers::a11y::use_html_lang::UseHtmlLang as biome_analyze::Rule>::Options;
+    <lint::a11y::use_heading_content::UseHeadingContent as biome_analyze::Rule>::Options;
+pub type UseHookAtTopLevel =
+    <lint::correctness::use_hook_at_top_level::UseHookAtTopLevel as biome_analyze::Rule>::Options;
+pub type UseHtmlLang = <lint::a11y::use_html_lang::UseHtmlLang as biome_analyze::Rule>::Options;
 pub type UseIframeTitle =
-    <analyzers::a11y::use_iframe_title::UseIframeTitle as biome_analyze::Rule>::Options;
-pub type UseImportRestrictions = < analyzers :: nursery :: use_import_restrictions :: UseImportRestrictions as biome_analyze :: Rule > :: Options ;
+    <lint::a11y::use_iframe_title::UseIframeTitle as biome_analyze::Rule>::Options;
+pub type UseImportRestrictions =
+    <lint::nursery::use_import_restrictions::UseImportRestrictions as biome_analyze::Rule>::Options;
 pub type UseImportType =
-    <semantic_analyzers::style::use_import_type::UseImportType as biome_analyze::Rule>::Options;
-pub type UseIsArray =
-    <semantic_analyzers::suspicious::use_is_array::UseIsArray as biome_analyze::Rule>::Options;
-pub type UseIsNan =
-    <semantic_analyzers::correctness::use_is_nan::UseIsNan as biome_analyze::Rule>::Options;
-pub type UseJsxKeyInIterable = < semantic_analyzers :: nursery :: use_jsx_key_in_iterable :: UseJsxKeyInIterable as biome_analyze :: Rule > :: Options ;
-pub type UseKeyWithClickEvents = < analyzers :: a11y :: use_key_with_click_events :: UseKeyWithClickEvents as biome_analyze :: Rule > :: Options ;
-pub type UseKeyWithMouseEvents = < analyzers :: a11y :: use_key_with_mouse_events :: UseKeyWithMouseEvents as biome_analyze :: Rule > :: Options ;
-pub type UseLiteralEnumMembers = < analyzers :: style :: use_literal_enum_members :: UseLiteralEnumMembers as biome_analyze :: Rule > :: Options ;
+    <lint::style::use_import_type::UseImportType as biome_analyze::Rule>::Options;
+pub type UseIsArray = <lint::suspicious::use_is_array::UseIsArray as biome_analyze::Rule>::Options;
+pub type UseIsNan = <lint::correctness::use_is_nan::UseIsNan as biome_analyze::Rule>::Options;
+pub type UseJsxKeyInIterable =
+    <lint::nursery::use_jsx_key_in_iterable::UseJsxKeyInIterable as biome_analyze::Rule>::Options;
+pub type UseKeyWithClickEvents =
+    <lint::a11y::use_key_with_click_events::UseKeyWithClickEvents as biome_analyze::Rule>::Options;
+pub type UseKeyWithMouseEvents =
+    <lint::a11y::use_key_with_mouse_events::UseKeyWithMouseEvents as biome_analyze::Rule>::Options;
+pub type UseLiteralEnumMembers =
+    <lint::style::use_literal_enum_members::UseLiteralEnumMembers as biome_analyze::Rule>::Options;
 pub type UseLiteralKeys =
-    <analyzers::complexity::use_literal_keys::UseLiteralKeys as biome_analyze::Rule>::Options;
+    <lint::complexity::use_literal_keys::UseLiteralKeys as biome_analyze::Rule>::Options;
 pub type UseMediaCaption =
-    <analyzers::a11y::use_media_caption::UseMediaCaption as biome_analyze::Rule>::Options;
-pub type UseNamespaceKeyword = < analyzers :: suspicious :: use_namespace_keyword :: UseNamespaceKeyword as biome_analyze :: Rule > :: Options ;
-pub type UseNamingConvention = < semantic_analyzers :: style :: use_naming_convention :: UseNamingConvention as biome_analyze :: Rule > :: Options ;
-pub type UseNodeAssertStrict = < analyzers :: nursery :: use_node_assert_strict :: UseNodeAssertStrict as biome_analyze :: Rule > :: Options ;
-pub type UseNodejsImportProtocol = < analyzers :: style :: use_nodejs_import_protocol :: UseNodejsImportProtocol as biome_analyze :: Rule > :: Options ;
-pub type UseNumberNamespace = < semantic_analyzers :: style :: use_number_namespace :: UseNumberNamespace as biome_analyze :: Rule > :: Options ;
+    <lint::a11y::use_media_caption::UseMediaCaption as biome_analyze::Rule>::Options;
+pub type UseNamespaceKeyword =
+    <lint::suspicious::use_namespace_keyword::UseNamespaceKeyword as biome_analyze::Rule>::Options;
+pub type UseNamingConvention =
+    <lint::style::use_naming_convention::UseNamingConvention as biome_analyze::Rule>::Options;
+pub type UseNodeAssertStrict =
+    <lint::nursery::use_node_assert_strict::UseNodeAssertStrict as biome_analyze::Rule>::Options;
+pub type UseNodejsImportProtocol = < lint :: style :: use_nodejs_import_protocol :: UseNodejsImportProtocol as biome_analyze :: Rule > :: Options ;
+pub type UseNumberNamespace =
+    <lint::style::use_number_namespace::UseNumberNamespace as biome_analyze::Rule>::Options;
 pub type UseNumericLiterals =
-    <analyzers::style::use_numeric_literals::UseNumericLiterals as biome_analyze::Rule>::Options;
+    <lint::style::use_numeric_literals::UseNumericLiterals as biome_analyze::Rule>::Options;
 pub type UseOptionalChain =
-    <analyzers::complexity::use_optional_chain::UseOptionalChain as biome_analyze::Rule>::Options;
+    <lint::complexity::use_optional_chain::UseOptionalChain as biome_analyze::Rule>::Options;
 pub type UseRegexLiterals =
-    <analyzers::complexity::use_regex_literals::UseRegexLiterals as biome_analyze::Rule>::Options;
-pub type UseSelfClosingElements = < analyzers :: style :: use_self_closing_elements :: UseSelfClosingElements as biome_analyze :: Rule > :: Options ;
-pub type UseShorthandArrayType = < analyzers :: style :: use_shorthand_array_type :: UseShorthandArrayType as biome_analyze :: Rule > :: Options ;
+    <lint::complexity::use_regex_literals::UseRegexLiterals as biome_analyze::Rule>::Options;
+pub type UseSelfClosingElements = < lint :: style :: use_self_closing_elements :: UseSelfClosingElements as biome_analyze :: Rule > :: Options ;
+pub type UseShorthandArrayType =
+    <lint::style::use_shorthand_array_type::UseShorthandArrayType as biome_analyze::Rule>::Options;
 pub type UseShorthandAssign =
-    <analyzers::style::use_shorthand_assign::UseShorthandAssign as biome_analyze::Rule>::Options;
-pub type UseShorthandFunctionType = < analyzers :: style :: use_shorthand_function_type :: UseShorthandFunctionType as biome_analyze :: Rule > :: Options ;
-pub type UseSimpleNumberKeys = < analyzers :: complexity :: use_simple_number_keys :: UseSimpleNumberKeys as biome_analyze :: Rule > :: Options ;
-pub type UseSimplifiedLogicExpression = < analyzers :: complexity :: use_simplified_logic_expression :: UseSimplifiedLogicExpression as biome_analyze :: Rule > :: Options ;
-pub type UseSingleCaseStatement = < analyzers :: style :: use_single_case_statement :: UseSingleCaseStatement as biome_analyze :: Rule > :: Options ;
-pub type UseSingleVarDeclarator = < analyzers :: style :: use_single_var_declarator :: UseSingleVarDeclarator as biome_analyze :: Rule > :: Options ;
-pub type UseSortedClasses = < semantic_analyzers :: nursery :: use_sorted_classes :: UseSortedClasses as biome_analyze :: Rule > :: Options ;
-pub type UseTemplate =
-    <analyzers::style::use_template::UseTemplate as biome_analyze::Rule>::Options;
+    <lint::style::use_shorthand_assign::UseShorthandAssign as biome_analyze::Rule>::Options;
+pub type UseShorthandFunctionType = < lint :: style :: use_shorthand_function_type :: UseShorthandFunctionType as biome_analyze :: Rule > :: Options ;
+pub type UseSimpleNumberKeys =
+    <lint::complexity::use_simple_number_keys::UseSimpleNumberKeys as biome_analyze::Rule>::Options;
+pub type UseSimplifiedLogicExpression = < lint :: complexity :: use_simplified_logic_expression :: UseSimplifiedLogicExpression as biome_analyze :: Rule > :: Options ;
+pub type UseSingleCaseStatement = < lint :: style :: use_single_case_statement :: UseSingleCaseStatement as biome_analyze :: Rule > :: Options ;
+pub type UseSingleVarDeclarator = < lint :: style :: use_single_var_declarator :: UseSingleVarDeclarator as biome_analyze :: Rule > :: Options ;
+pub type UseSortedClasses =
+    <lint::nursery::use_sorted_classes::UseSortedClasses as biome_analyze::Rule>::Options;
+pub type UseTemplate = <lint::style::use_template::UseTemplate as biome_analyze::Rule>::Options;
 pub type UseValidAnchor =
-    <analyzers::a11y::use_valid_anchor::UseValidAnchor as biome_analyze::Rule>::Options;
+    <lint::a11y::use_valid_anchor::UseValidAnchor as biome_analyze::Rule>::Options;
 pub type UseValidAriaProps =
-    <aria_analyzers::a11y::use_valid_aria_props::UseValidAriaProps as biome_analyze::Rule>::Options;
+    <lint::a11y::use_valid_aria_props::UseValidAriaProps as biome_analyze::Rule>::Options;
 pub type UseValidAriaRole =
-    <aria_analyzers::a11y::use_valid_aria_role::UseValidAriaRole as biome_analyze::Rule>::Options;
-pub type UseValidAriaValues = < aria_analyzers :: a11y :: use_valid_aria_values :: UseValidAriaValues as biome_analyze :: Rule > :: Options ;
-pub type UseValidForDirection = < analyzers :: correctness :: use_valid_for_direction :: UseValidForDirection as biome_analyze :: Rule > :: Options ;
-pub type UseValidLang =
-    <aria_analyzers::a11y::use_valid_lang::UseValidLang as biome_analyze::Rule>::Options;
+    <lint::a11y::use_valid_aria_role::UseValidAriaRole as biome_analyze::Rule>::Options;
+pub type UseValidAriaValues =
+    <lint::a11y::use_valid_aria_values::UseValidAriaValues as biome_analyze::Rule>::Options;
+pub type UseValidForDirection = < lint :: correctness :: use_valid_for_direction :: UseValidForDirection as biome_analyze :: Rule > :: Options ;
+pub type UseValidLang = <lint::a11y::use_valid_lang::UseValidLang as biome_analyze::Rule>::Options;
 pub type UseValidTypeof =
-    <analyzers::suspicious::use_valid_typeof::UseValidTypeof as biome_analyze::Rule>::Options;
-pub type UseWhile = <analyzers::style::use_while::UseWhile as biome_analyze::Rule>::Options;
-pub type UseYield = <analyzers::correctness::use_yield::UseYield as biome_analyze::Rule>::Options;
+    <lint::suspicious::use_valid_typeof::UseValidTypeof as biome_analyze::Rule>::Options;
+pub type UseWhile = <lint::style::use_while::UseWhile as biome_analyze::Rule>::Options;
+pub type UseYield = <lint::correctness::use_yield::UseYield as biome_analyze::Rule>::Options;

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalid.js
@@ -1,0 +1,3 @@
+describe(() => {
+	expect("something").toBeTrue()
+})

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalid.js
@@ -1,3 +1,6 @@
 describe(() => {
-	expect("something").toBeTrue()
+    expect("something").toBeTrue()
 })
+
+expect("")
+assertEquals(1, 1)

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalid.js.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.js
+---
+# Input
+```jsx
+describe(() => {
+	expect("something").toBeTrue()
+})
+```
+
+# Diagnostics
+```
+invalid.js:2:2 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The assertion isn't inside an it call.
+  
+    1 │ describe(() => {
+  > 2 │ 	expect("something").toBeTrue()
+      │ 	^^^^^^^^^^^^^^^^^^^
+    3 │ })
+  
+
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalid.js.snap
@@ -8,19 +8,3 @@ describe(() => {
 	expect("something").toBeTrue()
 })
 ```
-
-# Diagnostics
-```
-invalid.js:2:2 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The assertion isn't inside an it call.
-  
-    1 │ describe(() => {
-  > 2 │ 	expect("something").toBeTrue()
-      │ 	^^^^^^^^^^^^^^^^^^^
-    3 │ })
-  
-
-```
-
-

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalid.js.snap
@@ -8,3 +8,21 @@ describe(() => {
 	expect("something").toBeTrue()
 })
 ```
+
+# Diagnostics
+```
+invalid.js:2:2 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The assertion isn't inside a it() function call.
+  
+    1 │ describe(() => {
+  > 2 │ 	expect("something").toBeTrue()
+      │ 	^^^^^^
+    3 │ })
+  
+  i This will result in unexpected behaviours from your test suite.
+  
+  i Move the assertion inside a it() function call.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalid.js.snap
@@ -5,24 +5,62 @@ expression: invalid.js
 # Input
 ```jsx
 describe(() => {
-	expect("something").toBeTrue()
+    expect("something").toBeTrue()
 })
+
+expect("")
+assertEquals(1, 1)
 ```
 
 # Diagnostics
 ```
-invalid.js:2:2 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:2:5 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The assertion isn't inside a it() function call.
+  ! The assertion isn't inside a it(), test() or Deno.test() function call.
   
     1 │ describe(() => {
-  > 2 │ 	expect("something").toBeTrue()
-      │ 	^^^^^^
+  > 2 │     expect("something").toBeTrue()
+      │     ^^^^^^
     3 │ })
+    4 │ 
   
   i This will result in unexpected behaviours from your test suite.
   
-  i Move the assertion inside a it() function call.
+  i Move the assertion inside a it(), test() or Deno.test() function call.
+  
+
+```
+
+```
+invalid.js:5:1 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The assertion isn't inside a it(), test() or Deno.test() function call.
+  
+    3 │ })
+    4 │ 
+  > 5 │ expect("")
+      │ ^^^^^^
+    6 │ assertEquals(1, 1)
+  
+  i This will result in unexpected behaviours from your test suite.
+  
+  i Move the assertion inside a it(), test() or Deno.test() function call.
+  
+
+```
+
+```
+invalid.js:6:1 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The assertion isn't inside a it(), test() or Deno.test() function call.
+  
+    5 │ expect("")
+  > 6 │ assertEquals(1, 1)
+      │ ^^^^^^^^^^^^
+  
+  i This will result in unexpected behaviours from your test suite.
+  
+  i Move the assertion inside a it(), test() or Deno.test() function call.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedBun.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedBun.js
@@ -1,0 +1,3 @@
+import {test, expect} from "bun:test";
+
+expect("something").toBeTrue()

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedBun.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedBun.js.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidImportedBun.js
+---
+# Input
+```jsx
+import {test, expect} from "bun:test";
+
+expect("something").toBeTrue()
+```
+
+# Diagnostics
+```
+invalidImportedBun.js:3:1 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The assertion isn't inside a it(), test() or Deno.test() function call.
+  
+    1 │ import {test, expect} from "bun:test";
+    2 │ 
+  > 3 │ expect("something").toBeTrue()
+      │ ^^^^^^
+  
+  i This will result in unexpected behaviours from your test suite.
+  
+  i Move the assertion inside a it(), test() or Deno.test() function call.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedChai.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedChai.js
@@ -1,0 +1,4 @@
+import { expect } from "chai";
+describe(() => {
+	expect("something").toBeTrue()
+})

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedChai.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedChai.js.snap
@@ -14,15 +14,17 @@ describe(() => {
 ```
 invalidImportedChai.js:3:2 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The assertion isn't inside an it call.
+  ! The assertion isn't inside a it() function call.
   
     1 │ import { expect } from "chai";
     2 │ describe(() => {
   > 3 │ 	expect("something").toBeTrue()
-      │ 	^^^^^^^^^^^^^^^^^^^
+      │ 	^^^^^^
     4 │ })
+  
+  i This will result in unexpected behaviours from your test suite.
+  
+  i Move the assertion inside a it() function call.
   
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedChai.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedChai.js.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidImportedChai.js
+---
+# Input
+```jsx
+import { expect } from "chai";
+describe(() => {
+	expect("something").toBeTrue()
+})
+```
+
+# Diagnostics
+```
+invalidImportedChai.js:3:2 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The assertion isn't inside an it call.
+  
+    1 │ import { expect } from "chai";
+    2 │ describe(() => {
+  > 3 │ 	expect("something").toBeTrue()
+      │ 	^^^^^^^^^^^^^^^^^^^
+    4 │ })
+  
+
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedChai.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedChai.js.snap
@@ -14,7 +14,7 @@ describe(() => {
 ```
 invalidImportedChai.js:3:2 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The assertion isn't inside a it() function call.
+  ! The assertion isn't inside a it(), test() or Deno.test() function call.
   
     1 │ import { expect } from "chai";
     2 │ describe(() => {
@@ -24,7 +24,7 @@ invalidImportedChai.js:3:2 lint/nursery/noMisplacedAssertion ━━━━━━�
   
   i This will result in unexpected behaviours from your test suite.
   
-  i Move the assertion inside a it() function call.
+  i Move the assertion inside a it(), test() or Deno.test() function call.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedDeno.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedDeno.js
@@ -1,0 +1,6 @@
+import {assertEquals} from "https://deno.land/std@0.220.0/assert/mod.ts";
+
+assertEquals(url.href, "https://deno.land/foo.js");
+Deno.test("url test", () => {
+    const url = new URL("./foo.js", "https://deno.land/");
+});

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedDeno.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedDeno.js.snap
@@ -1,0 +1,33 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidImportedDeno.js
+---
+# Input
+```jsx
+import {assertEquals} from "https://deno.land/std@0.220.0/assert/mod.ts";
+
+assertEquals(url.href, "https://deno.land/foo.js");
+Deno.test("url test", () => {
+    const url = new URL("./foo.js", "https://deno.land/");
+});
+```
+
+# Diagnostics
+```
+invalidImportedDeno.js:3:1 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The assertion isn't inside a it(), test() or Deno.test() function call.
+  
+    1 │ import {assertEquals} from "https://deno.land/std@0.220.0/assert/mod.ts";
+    2 │ 
+  > 3 │ assertEquals(url.href, "https://deno.land/foo.js");
+      │ ^^^^^^^^^^^^
+    4 │ Deno.test("url test", () => {
+    5 │     const url = new URL("./foo.js", "https://deno.land/");
+  
+  i This will result in unexpected behaviours from your test suite.
+  
+  i Move the assertion inside a it(), test() or Deno.test() function call.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedNode.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedNode.js
@@ -1,0 +1,6 @@
+import assert from "node:assert";
+import { describe } from "node:test";
+
+describe(() => {
+	assert.equal("something", "something")
+})

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedNode.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedNode.js.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidImportedNode.js
+---
+# Input
+```jsx
+import assert from "node:assert";
+import { describe } from "node:test";
+
+describe(() => {
+	assert.equal("something", "something")
+})
+```
+
+# Diagnostics
+```
+invalidImportedNode.js:5:2 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The assertion isn't inside a it() function call.
+  
+    4 │ describe(() => {
+  > 5 │ 	assert.equal("something", "something")
+      │ 	^^^^^^
+    6 │ })
+  
+  i This will result in unexpected behaviours from your test suite.
+  
+  i Move the assertion inside a it() function call.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedNode.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/invalidImportedNode.js.snap
@@ -16,7 +16,7 @@ describe(() => {
 ```
 invalidImportedNode.js:5:2 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The assertion isn't inside a it() function call.
+  ! The assertion isn't inside a it(), test() or Deno.test() function call.
   
     4 │ describe(() => {
   > 5 │ 	assert.equal("something", "something")
@@ -25,7 +25,7 @@ invalidImportedNode.js:5:2 lint/nursery/noMisplacedAssertion ━━━━━━�
   
   i This will result in unexpected behaviours from your test suite.
   
-  i Move the assertion inside a it() function call.
+  i Move the assertion inside a it(), test() or Deno.test() function call.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js
@@ -1,0 +1,5 @@
+describe("msg", () => {
+	it("msg", () => {
+		expect("something").toBeTrue()
+	})
+})

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js
@@ -1,5 +1,13 @@
 describe("msg", () => {
-	it("msg", () => {
-		expect("something").toBeTrue()
-	})
+    it("msg", () => {
+        expect("something").toBeTrue()
+    })
+})
+
+test("something", () => {
+    expect("something").toBeTrue()
+})
+
+Deno.test("something", () => {
+    expect("something").toBeTrue()
 })

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```jsx
+describe("msg", () => {
+	it("msg", () => {
+		expect("something").toBeTrue()
+	})
+})
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js.snap
@@ -5,10 +5,16 @@ expression: valid.js
 # Input
 ```jsx
 describe("msg", () => {
-	it("msg", () => {
-		expect("something").toBeTrue()
-	})
+    it("msg", () => {
+        expect("something").toBeTrue()
+    })
+})
+
+test("something", () => {
+    expect("something").toBeTrue()
+})
+
+Deno.test("something", () => {
+    expect("something").toBeTrue()
 })
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/validBun.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/validBun.js
@@ -1,0 +1,5 @@
+import {test, expect} from "bun:test";
+
+test("something", () => {
+    expect("something").toBeTrue()
+})

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/validBun.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/validBun.js.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validBun.js
+---
+# Input
+```jsx
+import {test, expect} from "bun:test";
+
+test("something", () => {
+    expect("something").toBeTrue()
+})
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/validDeno.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/validDeno.js
@@ -1,0 +1,6 @@
+import {assertEquals} from "https://deno.land/std@0.220.0/assert/mod.ts";
+
+Deno.test("url test", () => {
+    const url = new URL("./foo.js", "https://deno.land/");
+    assertEquals(url.href, "https://deno.land/foo.js");
+});

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/validDeno.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/validDeno.js.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validDeno.js
+---
+# Input
+```jsx
+import {assertEquals} from "https://deno.land/std@0.220.0/assert/mod.ts";
+
+Deno.test("url test", () => {
+    const url = new URL("./foo.js", "https://deno.land/");
+    assertEquals(url.href, "https://deno.land/foo.js");
+});
+```

--- a/crates/biome_js_syntax/src/expr_ext.rs
+++ b/crates/biome_js_syntax/src/expr_ext.rs
@@ -960,20 +960,26 @@ impl AnyJsExpression {
     }
 
     pub fn get_callee_object_name(&self) -> Option<JsSyntaxToken> {
+        let identifier = self.get_callee_object_identifier()?;
+        identifier.value_token().ok()
+
+
+    }
+
+    pub fn get_callee_object_identifier(&self) -> Option<JsReferenceIdentifier> {
         match self {
             AnyJsExpression::JsStaticMemberExpression(node) => {
                 let member = node.object().ok()?;
-                let member = member.as_js_identifier_expression()?.name().ok()?;
-                member.value_token().ok()
+                member.as_js_identifier_expression()?.name().ok()
             }
             AnyJsExpression::JsTemplateExpression(node) => {
                 let tag = node.tag()?;
                 let tag = tag.as_js_static_member_expression()?;
                 let member = tag.object().ok()?;
-                let member = member.as_js_identifier_expression()?.name().ok()?;
-                member.value_token().ok()
+                member.as_js_identifier_expression()?.name().ok()
+
             }
-            AnyJsExpression::JsIdentifierExpression(node) => node.name().ok()?.value_token().ok(),
+            AnyJsExpression::JsIdentifierExpression(node) => node.name().ok(),
             _ => None,
         }
     }
@@ -1092,15 +1098,15 @@ impl AnyJsExpression {
         false
     }
 
-    pub fn is_assertion_call(&self) -> bool {
+    pub fn to_assertion_call(&self) -> Option<JsSyntaxToken> {
         let name = self.get_callee_object_name();
         if let Some(name) = name {
             if matches!(name.text_trimmed(), "expect" | "assert") {
-                return true;
+                return Some(name);
             }
         }
 
-        false
+        None
     }
 }
 

--- a/crates/biome_js_syntax/src/expr_ext.rs
+++ b/crates/biome_js_syntax/src/expr_ext.rs
@@ -1069,6 +1069,39 @@ impl AnyJsExpression {
             _ => false,
         })
     }
+
+    pub fn is_test_describe_call(&self) -> bool {
+        if self.contains_a_test_pattern() == Ok(true) {
+            if let Some(function_name) = self.get_callee_object_name() {
+                if matches!(function_name.text_trimmed(), "describe") {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    pub fn is_test_it_call(&self) -> bool {
+        if self.contains_a_test_pattern() == Ok(true) {
+            if let Some(function_name) = self.get_callee_object_name() {
+                if matches!(function_name.text_trimmed(), "it") {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    pub fn is_assertion_call(&self) -> bool {
+        let name = self.get_callee_object_name();
+        if let Some(name) = name {
+            if matches!(name.text_trimmed(), "expect" | "assert") {
+                return true;
+            }
+        }
+
+        false
+    }
 }
 
 /// Iterator that returns the callee names in "top down order".

--- a/crates/biome_js_syntax/src/expr_ext.rs
+++ b/crates/biome_js_syntax/src/expr_ext.rs
@@ -962,8 +962,6 @@ impl AnyJsExpression {
     pub fn get_callee_object_name(&self) -> Option<JsSyntaxToken> {
         let identifier = self.get_callee_object_identifier()?;
         identifier.value_token().ok()
-
-
     }
 
     pub fn get_callee_object_identifier(&self) -> Option<JsReferenceIdentifier> {
@@ -977,7 +975,6 @@ impl AnyJsExpression {
                 let tag = tag.as_js_static_member_expression()?;
                 let member = tag.object().ok()?;
                 member.as_js_identifier_expression()?.name().ok()
-
             }
             AnyJsExpression::JsIdentifierExpression(node) => node.name().ok(),
             _ => None,

--- a/crates/biome_js_syntax/src/expr_ext.rs
+++ b/crates/biome_js_syntax/src/expr_ext.rs
@@ -1101,10 +1101,7 @@ impl AnyJsExpression {
 
         match first {
             Some("test" | "it") => true,
-            Some("Deno") => match second {
-                Some("test") => true,
-                _ => false,
-            },
+            Some("Deno") => matches!(second, Some("test")),
             _ => false,
         }
     }
@@ -1127,12 +1124,12 @@ impl AnyJsExpression {
             Some(first) => {
                 if first.text() == "assert" {
                     if second.is_some() {
-                        return Some(first.clone());
+                        Some(first.clone())
                     } else {
                         None
                     }
                 } else if matches!(first.text(), "expect" | "assertEquals") {
-                    return Some(first.clone());
+                    Some(first.clone())
                 } else {
                     None
                 }

--- a/crates/biome_js_syntax/src/expr_ext.rs
+++ b/crates/biome_js_syntax/src/expr_ext.rs
@@ -1073,6 +1073,7 @@ impl AnyJsExpression {
         })
     }
 
+    /// Checks whether the current called is named `"describe"`
     pub fn is_test_describe_call(&self) -> bool {
         if self.contains_a_test_pattern() == Ok(true) {
             if let Some(function_name) = self.get_callee_object_name() {
@@ -1084,6 +1085,7 @@ impl AnyJsExpression {
         false
     }
 
+    /// Checks whether the current called is named `"it"`
     pub fn is_test_it_call(&self) -> bool {
         if self.contains_a_test_pattern() == Ok(true) {
             if let Some(function_name) = self.get_callee_object_name() {
@@ -1095,6 +1097,7 @@ impl AnyJsExpression {
         false
     }
 
+    /// Checks whether the current called is named `"expect"` or `"assert"`
     pub fn to_assertion_call(&self) -> Option<JsSyntaxToken> {
         let name = self.get_callee_object_name();
         if let Some(name) = name {

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -2589,6 +2589,9 @@ pub struct Nursery {
     #[doc = "Disallow focused tests."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_focused_tests: Option<RuleConfiguration<NoFocusedTests>>,
+    #[doc = "Checks that the assertion function, for example expect, is placed inside an it() function call."]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_misplaced_assertion: Option<RuleConfiguration<NoMisplacedAssertion>>,
     #[doc = "Disallow the use of namespace imports."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_namespace_import: Option<RuleConfiguration<NoNamespaceImport>>,
@@ -2642,7 +2645,7 @@ impl DeserializableValidator for Nursery {
 }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
-    pub(crate) const GROUP_RULES: [&'static str; 23] = [
+    pub(crate) const GROUP_RULES: [&'static str; 24] = [
         "noBarrelFile",
         "noColorInvalidHex",
         "noConsole",
@@ -2654,6 +2657,7 @@ impl Nursery {
         "noExcessiveNestedTestSuites",
         "noExportsInTest",
         "noFocusedTests",
+        "noMisplacedAssertion",
         "noNamespaceImport",
         "noNodejsModules",
         "noReExportAll",
@@ -2688,10 +2692,10 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
     ];
-    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 23] = [
+    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 24] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
@@ -2715,6 +2719,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended(&self) -> bool {
@@ -2786,64 +2791,69 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.no_namespace_import.as_ref() {
+        if let Some(rule) = self.no_misplaced_assertion.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.no_nodejs_modules.as_ref() {
+        if let Some(rule) = self.no_namespace_import.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.no_re_export_all.as_ref() {
+        if let Some(rule) = self.no_nodejs_modules.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.no_restricted_imports.as_ref() {
+        if let Some(rule) = self.no_re_export_all.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.no_semicolon_in_jsx.as_ref() {
+        if let Some(rule) = self.no_restricted_imports.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.no_skipped_tests.as_ref() {
+        if let Some(rule) = self.no_semicolon_in_jsx.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.no_undeclared_dependencies.as_ref() {
+        if let Some(rule) = self.no_skipped_tests.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_useless_ternary.as_ref() {
+        if let Some(rule) = self.no_undeclared_dependencies.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.no_useless_ternary.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.use_jsx_key_in_iterable.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.use_node_assert_strict.as_ref() {
+        if let Some(rule) = self.use_jsx_key_in_iterable.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_node_assert_strict.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
+            }
+        }
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
         index_set
@@ -2905,64 +2915,69 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.no_namespace_import.as_ref() {
+        if let Some(rule) = self.no_misplaced_assertion.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.no_nodejs_modules.as_ref() {
+        if let Some(rule) = self.no_namespace_import.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.no_re_export_all.as_ref() {
+        if let Some(rule) = self.no_nodejs_modules.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.no_restricted_imports.as_ref() {
+        if let Some(rule) = self.no_re_export_all.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.no_semicolon_in_jsx.as_ref() {
+        if let Some(rule) = self.no_restricted_imports.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.no_skipped_tests.as_ref() {
+        if let Some(rule) = self.no_semicolon_in_jsx.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.no_undeclared_dependencies.as_ref() {
+        if let Some(rule) = self.no_skipped_tests.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_useless_ternary.as_ref() {
+        if let Some(rule) = self.no_undeclared_dependencies.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.no_useless_ternary.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.use_jsx_key_in_iterable.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.use_node_assert_strict.as_ref() {
+        if let Some(rule) = self.use_jsx_key_in_iterable.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_node_assert_strict.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
+            }
+        }
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
         index_set
@@ -2978,7 +2993,7 @@ impl Nursery {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 10] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 23] {
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 24] {
         Self::ALL_RULES_AS_FILTERS
     }
     #[doc = r" Select preset rules"]
@@ -3043,6 +3058,10 @@ impl Nursery {
                 .map(|conf| (conf.level(), conf.get_options())),
             "noFocusedTests" => self
                 .no_focused_tests
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noMisplacedAssertion" => self
+                .no_misplaced_assertion
                 .as_ref()
                 .map(|conf| (conf.level(), conf.get_options())),
             "noNamespaceImport" => self

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -935,7 +935,7 @@ export interface Nursery {
 	/**
 	 * Checks that the assertion function, for example expect, is placed inside an it() function call.
 	 */
-	noMisplacedAssertion?: RuleConfiguration_for_NoMisplacedOptions;
+	noMisplacedAssertion?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow the use of namespace imports.
 	 */
@@ -1487,9 +1487,6 @@ export type RuleConfiguration_for_HooksOptions =
 export type RuleConfiguration_for_DeprecatedHooksOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_DeprecatedHooksOptions;
-export type RuleConfiguration_for_NoMisplacedOptions =
-	| RulePlainConfiguration
-	| RuleWithOptions_for_NoMisplacedOptions;
 export type RuleConfiguration_for_RestrictedImportsOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_RestrictedImportsOptions;
@@ -1528,10 +1525,6 @@ export interface RuleWithOptions_for_HooksOptions {
 export interface RuleWithOptions_for_DeprecatedHooksOptions {
 	level: RulePlainConfiguration;
 	options: DeprecatedHooksOptions;
-}
-export interface RuleWithOptions_for_NoMisplacedOptions {
-	level: RulePlainConfiguration;
-	options: NoMisplacedOptions;
 }
 export interface RuleWithOptions_for_RestrictedImportsOptions {
 	level: RulePlainConfiguration;
@@ -1583,20 +1576,6 @@ export interface HooksOptions {
  * Options for the `useHookAtTopLevel` rule have been deprecated, since we now use the React hook naming convention to determine whether a function is a hook.
  */
 export interface DeprecatedHooksOptions {}
-export interface NoMisplacedOptions {
-	/**
-	 * The name of the function that will run the assertion. By default, its name is `expect`.
-	 */
-	assertionFunctionNames: string[];
-	/**
-	* A list of specifiers that export the `assertionFunctionName` function.
-
-If your assertion function name is a global, provide an empty array.
-
-Defaults to: `"chai"`, `"node:assert"` and `node:assert/strict`. 
-	 */
-	specifiers: string[];
-}
 /**
  * Options for the rule `noRestrictedImports`.
  */

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -933,6 +933,10 @@ export interface Nursery {
 	 */
 	noFocusedTests?: RuleConfiguration_for_Null;
 	/**
+	 * Checks that the assertion function, for example expect, is placed inside an it() function call.
+	 */
+	noMisplacedAssertion?: RuleConfiguration_for_NoMisplacedOptions;
+	/**
 	 * Disallow the use of namespace imports.
 	 */
 	noNamespaceImport?: RuleConfiguration_for_Null;
@@ -1483,6 +1487,9 @@ export type RuleConfiguration_for_HooksOptions =
 export type RuleConfiguration_for_DeprecatedHooksOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_DeprecatedHooksOptions;
+export type RuleConfiguration_for_NoMisplacedOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_NoMisplacedOptions;
 export type RuleConfiguration_for_RestrictedImportsOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_RestrictedImportsOptions;
@@ -1521,6 +1528,10 @@ export interface RuleWithOptions_for_HooksOptions {
 export interface RuleWithOptions_for_DeprecatedHooksOptions {
 	level: RulePlainConfiguration;
 	options: DeprecatedHooksOptions;
+}
+export interface RuleWithOptions_for_NoMisplacedOptions {
+	level: RulePlainConfiguration;
+	options: NoMisplacedOptions;
 }
 export interface RuleWithOptions_for_RestrictedImportsOptions {
 	level: RulePlainConfiguration;
@@ -1572,6 +1583,20 @@ export interface HooksOptions {
  * Options for the `useHookAtTopLevel` rule have been deprecated, since we now use the React hook naming convention to determine whether a function is a hook.
  */
 export interface DeprecatedHooksOptions {}
+export interface NoMisplacedOptions {
+	/**
+	 * The name of the function that will run the assertion. By default, its name is `expect`.
+	 */
+	assertionFunctionNames: string[];
+	/**
+	* A list of specifiers that export the `assertionFunctionName` function.
+
+If your assertion function name is a global, provide an empty array.
+
+Defaults to: `"chai"`, `"node:assert"` and `node:assert/strict`. 
+	 */
+	specifiers: string[];
+}
 /**
  * Options for the rule `noRestrictedImports`.
  */
@@ -1907,6 +1932,7 @@ export type Category =
 	| "lint/nursery/noExcessiveNestedTestSuites"
 	| "lint/nursery/noExportsInTest"
 	| "lint/nursery/noFocusedTests"
+	| "lint/nursery/noMisplacedAssertion"
 	| "lint/nursery/noNamespaceImport"
 	| "lint/nursery/noNodejsModules"
 	| "lint/nursery/noReExportAll"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1373,29 +1373,6 @@
 			},
 			"additionalProperties": false
 		},
-		"NoMisplacedConfiguration": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithNoMisplacedOptions" }
-			]
-		},
-		"NoMisplacedOptions": {
-			"type": "object",
-			"required": ["assertionFunctionNames", "specifiers"],
-			"properties": {
-				"assertionFunctionNames": {
-					"description": "The name of the function that will run the assertion. By default, its name is `expect`.",
-					"type": "array",
-					"items": { "type": "string" }
-				},
-				"specifiers": {
-					"description": "A list of specifiers that export the `assertionFunctionName` function.\n\nIf your assertion function name is a global, provide an empty array.\n\nDefaults to: `\"chai\"`, `\"node:assert\"` and `node:assert/strict`.",
-					"type": "array",
-					"items": { "type": "string" }
-				}
-			},
-			"additionalProperties": false
-		},
 		"Nursery": {
 			"description": "A list of rules that belong to this group",
 			"type": "object",
@@ -1484,7 +1461,7 @@
 				"noMisplacedAssertion": {
 					"description": "Checks that the assertion function, for example expect, is placed inside an it() function call.",
 					"anyOf": [
-						{ "$ref": "#/definitions/NoMisplacedConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1865,15 +1842,6 @@
 			"properties": {
 				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
 				"options": { "$ref": "#/definitions/NamingConventionOptions" }
-			},
-			"additionalProperties": false
-		},
-		"RuleWithNoMisplacedOptions": {
-			"type": "object",
-			"required": ["level", "options"],
-			"properties": {
-				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
-				"options": { "$ref": "#/definitions/NoMisplacedOptions" }
 			},
 			"additionalProperties": false
 		},

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1373,6 +1373,29 @@
 			},
 			"additionalProperties": false
 		},
+		"NoMisplacedConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithNoMisplacedOptions" }
+			]
+		},
+		"NoMisplacedOptions": {
+			"type": "object",
+			"required": ["assertionFunctionNames", "specifiers"],
+			"properties": {
+				"assertionFunctionNames": {
+					"description": "The name of the function that will run the assertion. By default, its name is `expect`.",
+					"type": "array",
+					"items": { "type": "string" }
+				},
+				"specifiers": {
+					"description": "A list of specifiers that export the `assertionFunctionName` function.\n\nIf your assertion function name is a global, provide an empty array.\n\nDefaults to: `\"chai\"`, `\"node:assert\"` and `node:assert/strict`.",
+					"type": "array",
+					"items": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
 		"Nursery": {
 			"description": "A list of rules that belong to this group",
 			"type": "object",
@@ -1455,6 +1478,13 @@
 					"description": "Disallow focused tests.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noMisplacedAssertion": {
+					"description": "Checks that the assertion function, for example expect, is placed inside an it() function call.",
+					"anyOf": [
+						{ "$ref": "#/definitions/NoMisplacedConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1835,6 +1865,15 @@
 			"properties": {
 				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
 				"options": { "$ref": "#/definitions/NamingConventionOptions" }
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNoMisplacedOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
+				"options": { "$ref": "#/definitions/NoMisplacedOptions" }
 			},
 			"additionalProperties": false
 		},

--- a/website/src/components/generated/NumberOfRules.astro
+++ b/website/src/components/generated/NumberOfRules.astro
@@ -1,2 +1,2 @@
 <!-- this file is auto generated, use `cargo lintdoc` to update it -->
- <p>Biome's linter has a total of <strong><a href='/linter/rules'>211 rules</a></strong><p>
+ <p>Biome's linter has a total of <strong><a href='/linter/rules'>212 rules</a></strong><p>

--- a/website/src/content/docs/linter/rules/index.mdx
+++ b/website/src/content/docs/linter/rules/index.mdx
@@ -261,6 +261,7 @@ Rules that belong to this group <strong>are not subject to semantic version</str
 | [noExcessiveNestedTestSuites](/linter/rules/no-excessive-nested-test-suites) | This rule enforces a maximum depth to nested <code>describe()</code> in test files. |  |
 | [noExportsInTest](/linter/rules/no-exports-in-test) | Disallow using <code>export</code> or <code>module.exports</code> in files containing tests |  |
 | [noFocusedTests](/linter/rules/no-focused-tests) | Disallow focused tests. | <span aria-label="The rule has an unsafe fix" role="img" title="The rule has an unsafe fix">⚠️ </span> |
+| [noMisplacedAssertion](/linter/rules/no-misplaced-assertion) | Checks that the assertion function, for example <code>expect</code>, is placed inside an <code>it()</code> function call. |  |
 | [noNamespaceImport](/linter/rules/no-namespace-import) | Disallow the use of namespace imports. |  |
 | [noNodejsModules](/linter/rules/no-nodejs-modules) | Forbid the use of Node.js builtin modules. |  |
 | [noReExportAll](/linter/rules/no-re-export-all) | Avoid re-export all. |  |

--- a/website/src/content/docs/linter/rules/no-misplaced-assertion.md
+++ b/website/src/content/docs/linter/rules/no-misplaced-assertion.md
@@ -1,0 +1,56 @@
+---
+title: noMisplacedAssertion (not released)
+---
+
+**Diagnostic Category: `lint/nursery/noMisplacedAssertion`**
+
+:::danger
+This rule hasn't been released yet.
+:::
+
+:::caution
+This rule is part of the [nursery](/linter/rules/#nursery) group.
+:::
+
+Succinct description of the rule.
+
+Put context and details about the rule.
+As a starting point, you can take the description of the corresponding _ESLint_ rule (if any).
+
+Try to stay consistent with the descriptions of implemented rules.
+
+Add a link to the corresponding ESLint rule (if any):
+
+## Examples
+
+### Invalid
+
+```jsx
+var a = 1;
+a = 2;
+```
+
+<pre class="language-text"><code class="language-text">nursery/noMisplacedAssertion.js:1:11 <a href="https://biomejs.dev/linter/rules/no-misplaced-assertion">lint/nursery/noMisplacedAssertion</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Variable is read here.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>var a = 1;
+   <strong>   │ </strong>          
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>a = 2;
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">This note will give you more information.</span>
+  
+</code></pre>
+
+### Valid
+
+```jsx
+var a = 1;
+```
+
+## Related links
+
+- [Disable a rule](/linter/#disable-a-lint-rule)
+- [Rule options](/linter/#rule-options)

--- a/website/src/content/docs/linter/rules/no-misplaced-assertion.md
+++ b/website/src/content/docs/linter/rules/no-misplaced-assertion.md
@@ -18,9 +18,22 @@ Checks that the assertion function, for example `expect`, is placed inside an `i
 
 Placing (and using) the `expect` assertion function can result in unexpected behaviors when executing your testing suite.
 
-By default, the rule will the following assertion functions: `expect` and `assert`.
+The rule will check for the following assertion calls:
 
-If `expect` or `assert` are imported, the rule will check if they are imported from `"chai"`, `"node:assert"` and `"node:assert/strict"`. Check the [options](#options) if you need to change the defaults.
+- `expect`
+- `assert`
+- `assertEquals`
+
+If the assertion function is imported, the rule will check if they are imported from:
+
+- `"chai"`
+- `"node:assert"`
+- `"node:assert/strict"`
+- `"bun:test"`
+- `"vitest"`
+- Deno assertion module URL
+
+Check the [options](#options) if you need to change the defaults.
 
 ## Examples
 
@@ -34,7 +47,7 @@ describe("describe", () => {
 
 <pre class="language-text"><code class="language-text">nursery/noMisplacedAssertion.js:2:5 <a href="https://biomejs.dev/linter/rules/no-misplaced-assertion">lint/nursery/noMisplacedAssertion</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The assertion isn't inside a </span><span style="color: Orange;"><strong>it()</strong></span><span style="color: Orange;"> function call.</span>
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The assertion isn't inside a </span><span style="color: Orange;"><strong>it()</strong></span><span style="color: Orange;">, </span><span style="color: Orange;"><strong>test()</strong></span><span style="color: Orange;"> or </span><span style="color: Orange;"><strong>Deno.test()</strong></span><span style="color: Orange;"> function call.</span>
   
     <strong>1 │ </strong>describe(&quot;describe&quot;, () =&gt; {
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>    expect()
@@ -44,7 +57,7 @@ describe("describe", () => {
   
 <strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">This will result in unexpected behaviours from your test suite.</span>
   
-<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Move the assertion inside a </span><span style="color: lightgreen;"><strong>it()</strong></span><span style="color: lightgreen;"> function call.</span>
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Move the assertion inside a </span><span style="color: lightgreen;"><strong>it()</strong></span><span style="color: lightgreen;">, </span><span style="color: lightgreen;"><strong>test()</strong></span><span style="color: lightgreen;"> or </span><span style="color: lightgreen;"><strong>Deno.test()</strong></span><span style="color: lightgreen;"> function call.</span>
   
 </code></pre>
 
@@ -57,7 +70,7 @@ describe("describe", () => {
 
 <pre class="language-text"><code class="language-text">nursery/noMisplacedAssertion.js:3:5 <a href="https://biomejs.dev/linter/rules/no-misplaced-assertion">lint/nursery/noMisplacedAssertion</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The assertion isn't inside a </span><span style="color: Orange;"><strong>it()</strong></span><span style="color: Orange;"> function call.</span>
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The assertion isn't inside a </span><span style="color: Orange;"><strong>it()</strong></span><span style="color: Orange;">, </span><span style="color: Orange;"><strong>test()</strong></span><span style="color: Orange;"> or </span><span style="color: Orange;"><strong>Deno.test()</strong></span><span style="color: Orange;"> function call.</span>
   
     <strong>1 │ </strong>import assert from &quot;node:assert&quot;;
     <strong>2 │ </strong>describe(&quot;describe&quot;, () =&gt; {
@@ -68,7 +81,53 @@ describe("describe", () => {
   
 <strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">This will result in unexpected behaviours from your test suite.</span>
   
-<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Move the assertion inside a </span><span style="color: lightgreen;"><strong>it()</strong></span><span style="color: lightgreen;"> function call.</span>
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Move the assertion inside a </span><span style="color: lightgreen;"><strong>it()</strong></span><span style="color: lightgreen;">, </span><span style="color: lightgreen;"><strong>test()</strong></span><span style="color: lightgreen;"> or </span><span style="color: lightgreen;"><strong>Deno.test()</strong></span><span style="color: lightgreen;"> function call.</span>
+  
+</code></pre>
+
+```jsx
+import {test, expect} from "bun:test";
+expect(1, 2)
+```
+
+<pre class="language-text"><code class="language-text">nursery/noMisplacedAssertion.js:2:1 <a href="https://biomejs.dev/linter/rules/no-misplaced-assertion">lint/nursery/noMisplacedAssertion</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The assertion isn't inside a </span><span style="color: Orange;"><strong>it()</strong></span><span style="color: Orange;">, </span><span style="color: Orange;"><strong>test()</strong></span><span style="color: Orange;"> or </span><span style="color: Orange;"><strong>Deno.test()</strong></span><span style="color: Orange;"> function call.</span>
+  
+    <strong>1 │ </strong>import {test, expect} from &quot;bun:test&quot;;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>expect(1, 2)
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">This will result in unexpected behaviours from your test suite.</span>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Move the assertion inside a </span><span style="color: lightgreen;"><strong>it()</strong></span><span style="color: lightgreen;">, </span><span style="color: lightgreen;"><strong>test()</strong></span><span style="color: lightgreen;"> or </span><span style="color: lightgreen;"><strong>Deno.test()</strong></span><span style="color: lightgreen;"> function call.</span>
+  
+</code></pre>
+
+```jsx
+import {assertEquals} from "https://deno.land/std@0.220.0/assert/mod.ts";
+
+assertEquals(url.href, "https://deno.land/foo.js");
+Deno.test("url test", () => {
+    const url = new URL("./foo.js", "https://deno.land/");
+});
+```
+
+<pre class="language-text"><code class="language-text">nursery/noMisplacedAssertion.js:3:1 <a href="https://biomejs.dev/linter/rules/no-misplaced-assertion">lint/nursery/noMisplacedAssertion</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The assertion isn't inside a </span><span style="color: Orange;"><strong>it()</strong></span><span style="color: Orange;">, </span><span style="color: Orange;"><strong>test()</strong></span><span style="color: Orange;"> or </span><span style="color: Orange;"><strong>Deno.test()</strong></span><span style="color: Orange;"> function call.</span>
+  
+    <strong>1 │ </strong>import {assertEquals} from &quot;https://deno.land/std@0.220.0/assert/mod.ts&quot;;
+    <strong>2 │ </strong>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>assertEquals(url.href, &quot;https://deno.land/foo.js&quot;);
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>4 │ </strong>Deno.test(&quot;url test&quot;, () =&gt; {
+    <strong>5 │ </strong>    const url = new URL(&quot;./foo.js&quot;, &quot;https://deno.land/&quot;);
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">This will result in unexpected behaviours from your test suite.</span>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Move the assertion inside a </span><span style="color: lightgreen;"><strong>it()</strong></span><span style="color: lightgreen;">, </span><span style="color: lightgreen;"><strong>test()</strong></span><span style="color: lightgreen;"> or </span><span style="color: lightgreen;"><strong>Deno.test()</strong></span><span style="color: lightgreen;"> function call.</span>
   
 </code></pre>
 
@@ -88,28 +147,6 @@ describe("describe", () => {
     it("it", () => {
         expect()
     })
-})
-```
-
-## Options
-
-The rule allows to change the name of the assertion function to check, and the modules to inspect in case the function is imported.
-
-```json
-{
-    "options": {
-        "assertionFunctionNames": ["expect"],
-        "specifiers": ["somePackage"]
-    }
-}
-```
-
-With the previous configuration, the rule will be triggered if the function `expect` is used _and_ it is imported from the package `"somePackage"`.
-
-```jsx
-import {expect} from "somePackage";
-describe("describe", () => {
-    assert.equal()
 })
 ```
 

--- a/website/src/content/docs/linter/rules/no-misplaced-assertion.md
+++ b/website/src/content/docs/linter/rules/no-misplaced-assertion.md
@@ -12,42 +12,105 @@ This rule hasn't been released yet.
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
-Succinct description of the rule.
+Inspired from: <a href="https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md" target="_blank"><code>no-standalone-expect</code></a>
 
-Put context and details about the rule.
-As a starting point, you can take the description of the corresponding _ESLint_ rule (if any).
+Checks that the assertion function, for example `expect`, is placed inside an `it()` function call.
 
-Try to stay consistent with the descriptions of implemented rules.
+Placing (and using) the `expect` assertion function can result in unexpected behaviors when executing your testing suite.
 
-Add a link to the corresponding ESLint rule (if any):
+By default, the rule will the following assertion functions: `expect` and `assert`.
+
+If `expect` or `assert` are imported, the rule will check if they are imported from `"chai"`, `"node:assert"` and `"node:assert/strict"`. Check the [options](#options) if you need to change the defaults.
 
 ## Examples
 
 ### Invalid
 
 ```jsx
-var a = 1;
-a = 2;
+describe("describe", () => {
+    expect()
+})
 ```
 
-<pre class="language-text"><code class="language-text">nursery/noMisplacedAssertion.js:1:11 <a href="https://biomejs.dev/linter/rules/no-misplaced-assertion">lint/nursery/noMisplacedAssertion</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+<pre class="language-text"><code class="language-text">nursery/noMisplacedAssertion.js:2:5 <a href="https://biomejs.dev/linter/rules/no-misplaced-assertion">lint/nursery/noMisplacedAssertion</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Variable is read here.</span>
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The assertion isn't inside a </span><span style="color: Orange;"><strong>it()</strong></span><span style="color: Orange;"> function call.</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>var a = 1;
-   <strong>   │ </strong>          
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>a = 2;
-   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>3 │ </strong>
+    <strong>1 │ </strong>describe(&quot;describe&quot;, () =&gt; {
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>    expect()
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>})
+    <strong>4 │ </strong>
   
-<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">This note will give you more information.</span>
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">This will result in unexpected behaviours from your test suite.</span>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Move the assertion inside a </span><span style="color: lightgreen;"><strong>it()</strong></span><span style="color: lightgreen;"> function call.</span>
+  
+</code></pre>
+
+```jsx
+import assert from "node:assert";
+describe("describe", () => {
+    assert.equal()
+})
+```
+
+<pre class="language-text"><code class="language-text">nursery/noMisplacedAssertion.js:3:5 <a href="https://biomejs.dev/linter/rules/no-misplaced-assertion">lint/nursery/noMisplacedAssertion</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The assertion isn't inside a </span><span style="color: Orange;"><strong>it()</strong></span><span style="color: Orange;"> function call.</span>
+  
+    <strong>1 │ </strong>import assert from &quot;node:assert&quot;;
+    <strong>2 │ </strong>describe(&quot;describe&quot;, () =&gt; {
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>    assert.equal()
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>4 │ </strong>})
+    <strong>5 │ </strong>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">This will result in unexpected behaviours from your test suite.</span>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Move the assertion inside a </span><span style="color: lightgreen;"><strong>it()</strong></span><span style="color: lightgreen;"> function call.</span>
   
 </code></pre>
 
 ### Valid
 
 ```jsx
-var a = 1;
+import assert from "node:assert";
+describe("describe", () => {
+    it("it", () => {
+        assert.equal()
+    })
+})
+```
+
+```jsx
+describe("describe", () => {
+    it("it", () => {
+        expect()
+    })
+})
+```
+
+## Options
+
+The rule allows to change the name of the assertion function to check, and the modules to inspect in case the function is imported.
+
+```json
+{
+    "options": {
+        "assertionFunctionNames": ["expect"],
+        "specifiers": ["somePackage"]
+    }
+}
+```
+
+With the previous configuration, the rule will be triggered if the function `expect` is used _and_ it is imported from the package `"somePackage"`.
+
+```jsx
+import {expect} from "somePackage";
+describe("describe", () => {
+    assert.equal()
+})
 ```
 
 ## Related links

--- a/website/src/content/docs/linter/rules/use-valid-aria-role.md
+++ b/website/src/content/docs/linter/rules/use-valid-aria-role.md
@@ -110,7 +110,7 @@ Elements with ARIA roles must use a valid, non-abstract ARIA role.
 </>
 ```
 
-### Options
+## Options
 
 ```json
 {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR closes #1848 (last rule)

It implements the rule `noMisplacedAssertion`, which checks if `expect` or `assert` are called inside the `it` function.

This rule has options: users can define the name of the assertion functions and the specifiers from which these functions are imported.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added test cases 

<!-- What demonstrates that your implementation is correct? -->
