### PR TITLE
fix(lint/origanizeImports): use the correct export name to sort in the import clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Fix [#1827](https://github.com/biomejs/biome/issues/1827) by properly analyzing nested `try-finally` statements. Contributed by @ah-yu
 
+- Fix [#1924](https://github.com/biomejs/biome/issues/1924) Use the correct export name to sort in the import clause. Contributed by @ah-yu
+
 ### CLI
 
 #### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Fix [#1748](https://github.com/biomejs/biome/issues/1748). Now for the following case we won't provide an unsafe fix
   for the `noNonNullAssertion` rule:
 
+  ```ts
+  x[y.z!];
+  ```
+
+  Contributed by @ah-yu
+
 - Imports that contain the protocol `:` are now sorted after the `npm:` modules, and before the `URL` modules.
   Contributed by @ematipico
 
@@ -84,12 +90,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   + import { sortBy } from "virtual:utils";
   + import Component from "./component.js"
   ```
-
-  ```ts
-  x[y.z!];
-  ```
-
-  Contributed by @ah-yu
 
 - Fix [#1081](https://github.com/biomejs/biome/issues/1081). The `useAwait` rule does not report `for await...of`.
   Contributed by @unvalley

--- a/crates/biome_js_analyze/tests/specs/correctness/organizeImports/issue-1924.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/organizeImports/issue-1924.js
@@ -1,0 +1,2 @@
+import { path } from './foo';
+import { relative as relativePath, relative } from 'node:path';

--- a/crates/biome_js_analyze/tests/specs/correctness/organizeImports/issue-1924.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/organizeImports/issue-1924.js.snap
@@ -1,0 +1,19 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue-1924.js
+---
+# Input
+```jsx
+import { path } from './foo';
+import { relative as relativePath, relative } from 'node:path';
+
+```
+
+# Actions
+```diff
+@@ -1,2 +1,2 @@
++import { relative, relative as relativePath } from 'node:path';
+ import { path } from './foo';
+-import { relative as relativePath, relative } from 'node:path';
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/organizeImports/namedSpecifiers.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/organizeImports/namedSpecifiers.js
@@ -52,3 +52,5 @@ import {
     k1, /* comment 1 */
     k3, // comment 3
     k2, /* comment 2 */ } from 'k';
+
+import { m1 as m3, m2 } from 'm'

--- a/crates/biome_js_analyze/tests/specs/correctness/organizeImports/namedSpecifiers.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/organizeImports/namedSpecifiers.js.snap
@@ -59,11 +59,13 @@ import {
     k3, // comment 3
     k2, /* comment 2 */ } from 'k';
 
+import { m1 as m3, m2 } from 'm'
+
 ```
 
 # Actions
 ```diff
-@@ -1,54 +1,57 @@
+@@ -1,56 +1,59 @@
 -import { a1, a3, a5, a2, a4 } from 'a';
 +import { a1, a2, a3, a4, a5 } from 'a';
  
@@ -78,12 +80,12 @@ import {
  
  import {
      e1,
--    e3,
--    e5,
-     e2,
-+    e3,
-     e4,
-+    e5,
++    e2,
+     e3,
++    e4,
+     e5,
+-    e2,
+-    e4,
  } from 'e';
  
  import {
@@ -140,7 +142,8 @@ import {
      k3, // comment 3
 -    k2, /* comment 2 */ } from 'k';
 +} from 'k';
+ 
+-import { m1 as m3, m2 } from 'm'
++import { m2, m1 as m3 } from 'm'
 
 ```
-
-

--- a/crates/biome_js_syntax/src/import_ext.rs
+++ b/crates/biome_js_syntax/src/import_ext.rs
@@ -130,10 +130,9 @@ impl AnyJsNamedImportSpecifier {
     /// ```
     pub fn imported_name(&self) -> Option<JsSyntaxToken> {
         match self {
-            Self::JsNamedImportSpecifier(specifier) => specifier.name().ok()?.value().ok(),
-            Self::JsShorthandNamedImportSpecifier(specifier) => specifier
-                .local_name()
-                .ok()?
+            specifier @ (Self::JsNamedImportSpecifier(_)
+            | Self::JsShorthandNamedImportSpecifier(_)) => specifier
+                .local_name()?
                 .as_js_identifier_binding()?
                 .name_token()
                 .ok(),

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -80,6 +80,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Fix [#1748](https://github.com/biomejs/biome/issues/1748). Now for the following case we won't provide an unsafe fix
   for the `noNonNullAssertion` rule:
 
+  ```ts
+  x[y.z!];
+  ```
+
+  Contributed by @ah-yu
+
 - Imports that contain the protocol `:` are now sorted after the `npm:` modules, and before the `URL` modules.
   Contributed by @ematipico
 
@@ -91,16 +97,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   + import Component from "./component.js"
   ```
 
-  ```ts
-  x[y.z!];
-  ```
-
-  Contributed by @ah-yu
-
 - Fix [#1081](https://github.com/biomejs/biome/issues/1081). The `useAwait` rule does not report `for await...of`.
   Contributed by @unvalley
 
 - Fix [#1827](https://github.com/biomejs/biome/issues/1827) by properly analyzing nested `try-finally` statements. Contributed by @ah-yu
+
+- Fix [#1924](https://github.com/biomejs/biome/issues/1924) Use the correct export name to sort in the import clause. Contributed by @ah-yu
 
 ### CLI
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

- Closes https://github.com/biomejs/biome/issues/1924

For the following case
```js
import { a1 as a3, a2 } from 'a'
```
We used to use `a1` and `a2` for sorting. The reported bug occurs when `a1` is the same as `a2`. Now we use `a3` and `a2` for sorting.

This fix may alter the original behavior. The above code snippet was formatted as `import { a1 as a3, a2 } from 'a'` before, but now it's formatted as `import { a2, a1 as a3 } from 'a'`.

`Eslint` uses `a3` and `a2` for sorting: [link](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgc29ydC1pbXBvcnRzOiBcImVycm9yXCIqL1xuaW1wb3J0IHttMiwgbTEgYXMgbTN9IGZyb20gJ20nOyIsIm9wdGlvbnMiOnsiZW52Ijp7fSwicnVsZXMiOnt9LCJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e30sImVjbWFWZXJzaW9uIjoibGF0ZXN0Iiwic291cmNlVHlwZSI6Im1vZHVsZSJ9fX0=)

## Test Plan

Add new test cases
