### PR TITLE
docs: remove outdated `requireConfiguration` docs

### DIFF
--- a/website/src/content/docs/ja/reference/vscode.mdx
+++ b/website/src/content/docs/ja/reference/vscode.mdx
@@ -108,11 +108,6 @@ BiomeのVS Code拡張機能は、Organize Imports コードアクションを通
 
 Biomeがワークスペース内の名前変更を処理することを有効にします（実験的機能）。
 
-### `biome.requireConfiguration`
-
-`biome.json`ファイルのないプロジェクトに対して、format、lint、構文エラーを無効にします。
-デフォルトでは有効化されています。
-
 ## バージョン管理
 
 [公式ドキュメント](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions)で提案された仕様に従っています：

--- a/website/src/content/docs/pt-br/reference/vscode.mdx
+++ b/website/src/content/docs/pt-br/reference/vscode.mdx
@@ -110,11 +110,6 @@ A pasta do workspace é usada como caminho base se o caminho for relativo.
 
 Habilita o Biome para lidar com renomeações no workspace (experimental).
 
-### `biome.requireConfiguration`
-
-Desabilita a formatação, linting e erros de sintaxe para projetos sem um arquivo `biome.json`.
-Habilitado por padrão.
-
 ## Versionamento
 
 Seguimos as especificações sugeridas pela [documentação oficial](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions):

--- a/website/src/content/docs/reference/vscode.mdx
+++ b/website/src/content/docs/reference/vscode.mdx
@@ -108,11 +108,6 @@ The workspace folder is used as the base path if the path is relative.
 
 Enables Biome to handle renames in the workspace (experimental).
 
-### `biome.requireConfiguration`
-
-Disables formatting, linting, and syntax errors for projects without a `biome.json` file.
-Enabled by default.
-
 ## Versioning
 
 We follow the specs suggested by [the official documentation](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions):

--- a/website/src/content/docs/zh-cn/reference/vscode.mdx
+++ b/website/src/content/docs/zh-cn/reference/vscode.mdx
@@ -108,11 +108,6 @@ Biome 的 VS Code 扩展通过 "Organize Imports" 代码操作支持导入排序
 
 启用 Biome 在工作空间中处理重命名（实验性）。
 
-### `biome.requireConfiguration`
-
-禁用没有 `biome.json` 文件的项目的格式化、lint 和语法错误。
-默认启用。
-
 ## 版本控制
 
 我们遵循 [官方文档](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions) 建议的规范：


### PR DESCRIPTION
## Summary

This PR removes the outdated requireConfiguration option from the VS Code extension's documentation.

Fix https://github.com/biomejs/biome/issues/1943
