### PR TITLE
Address dirname suggestion in internal codegen script

### DIFF
--- a/packages/tailwindcss-config-analyzer/src/generate-tailwind-preset.ts
+++ b/packages/tailwindcss-config-analyzer/src/generate-tailwind-preset.ts
@@ -2,6 +2,7 @@
 // requires Bun installed globally: bun.sh
 
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { readPackageUp } from "read-package-up";
 import { introspectTailwindConfig } from "./introspect.js";
 import { type SortConfig, sortConfigFromSpec } from "./sort-config.js";
@@ -58,7 +59,7 @@ function generateFile(sortConfig: SortConfig) {
 }
 
 async function findRoot() {
-	let nextPath = import.meta.dir;
+	let nextPath = path.dirname(fileURLToPath(import.meta.url));
 	let rootPath: string | false = false;
 	while (!rootPath) {
 		const pkg = await readPackageUp({ cwd: nextPath });


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

Changes `import.meta.dir` to

```ts
import path from "node:path";
import { fileURLToPath } from "node:url";

path.dirname(fileURLToPath(import.meta.url))
```

In case we want to switch in the future from Bun to something like `tsx` or `ts-node` (which are Node.js based and do not support Bun APIs) to run the internal codegen script for tailwind class sorting.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

Run `just gen-tw`.
