### PR TITLE
feat(analyzer): infer quote from formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   ```
 
 - Add lint rule useJsxKeyInIterable from Eslint rule [`react/jsx-key`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md). Contributed by @vohoanglong0107
+- The analyzer now **infers** the correct quote from `javascript.formatter.quoteStyle`, if set. This means that code fixes suggested by the analyzer will use the same quote of the formatter. Contributed by @ematipico
 
 #### Enhancements
 

--- a/crates/biome_analyze/src/context.rs
+++ b/crates/biome_analyze/src/context.rs
@@ -1,3 +1,4 @@
+use crate::options::PreferredQuote;
 use crate::{registry::RuleRoot, FromServices, Queryable, Rule, RuleKey, ServiceBag};
 use biome_diagnostics::{Error, Result};
 use std::ops::Deref;
@@ -17,6 +18,7 @@ where
     globals: &'a [&'a str],
     file_path: &'a Path,
     options: &'a R::Options,
+    preferred_quote: &'a PreferredQuote,
 }
 
 impl<'a, R> RuleContext<'a, R>
@@ -30,6 +32,7 @@ where
         globals: &'a [&'a str],
         file_path: &'a Path,
         options: &'a R::Options,
+        preferred_quote: &'a PreferredQuote,
     ) -> Result<Self, Error> {
         let rule_key = RuleKey::rule::<R>();
         Ok(Self {
@@ -40,6 +43,7 @@ where
             globals,
             file_path,
             options,
+            preferred_quote,
         })
     }
 
@@ -108,6 +112,11 @@ where
     /// The file path of the current file
     pub fn file_path(&self) -> &Path {
         self.file_path
+    }
+
+    /// Returns the preferred quote that should be used when providing code actions
+    pub fn as_preferred_quote(&self) -> &PreferredQuote {
+        self.preferred_quote
     }
 }
 

--- a/crates/biome_analyze/src/options.rs
+++ b/crates/biome_analyze/src/options.rs
@@ -53,6 +53,9 @@ pub struct AnalyzerConfiguration {
     ///
     /// For example, lint rules should ignore them.
     pub globals: Vec<String>,
+
+    /// Allows to choose a different quote when applying fixes inside the lint rules
+    pub preferred_quote: PreferredQuote,
 }
 
 /// A set of information useful to the analyzer infrastructure
@@ -82,5 +85,28 @@ impl AnalyzerOptions {
             .rules
             .get_rule_options::<R::Options>(&RuleKey::rule::<R>())
             .map(R::Options::clone)
+    }
+
+    pub fn preferred_quote(&self) -> &PreferredQuote {
+        &self.configuration.preferred_quote
+    }
+}
+
+#[derive(Debug, Default)]
+pub enum PreferredQuote {
+    /// Double quotes
+    #[default]
+    Double,
+    /// Single quotes
+    Single,
+}
+
+impl PreferredQuote {
+    pub const fn is_double(&self) -> bool {
+        matches!(self, Self::Double)
+    }
+
+    pub const fn is_single(&self) -> bool {
+        matches!(self, Self::Single)
     }
 }

--- a/crates/biome_analyze/src/registry.rs
+++ b/crates/biome_analyze/src/registry.rs
@@ -411,6 +411,7 @@ impl<L: Language + Default> RegistryRule<L> {
             let query_result = params.query.downcast_ref().unwrap();
             let query_result = <R::Query as Queryable>::unwrap_match(params.services, query_result);
             let globals = params.options.globals();
+            let preferred_quote = params.options.preferred_quote();
             let options = params.options.rule_options::<R>().unwrap_or_default();
             let ctx = match RuleContext::new(
                 &query_result,
@@ -419,6 +420,7 @@ impl<L: Language + Default> RegistryRule<L> {
                 &globals,
                 &params.options.file_path,
                 &options,
+                preferred_quote,
             ) {
                 Ok(ctx) => ctx,
                 Err(error) => return Err(error),

--- a/crates/biome_analyze/src/signals.rs
+++ b/crates/biome_analyze/src/signals.rs
@@ -347,6 +347,7 @@ where
 {
     fn diagnostic(&self) -> Option<AnalyzerDiagnostic> {
         let globals = self.options.globals();
+        let preferred_quote = self.options.preferred_quote();
         let options = self.options.rule_options::<R>().unwrap_or_default();
         let ctx = RuleContext::new(
             &self.query_result,
@@ -355,6 +356,7 @@ where
             &globals,
             &self.options.file_path,
             &options,
+            preferred_quote,
         )
         .ok()?;
 
@@ -372,6 +374,7 @@ where
             &globals,
             &self.options.file_path,
             &options,
+            &self.options.configuration.preferred_quote,
         )
         .ok();
         if let Some(ctx) = ctx {
@@ -416,6 +419,7 @@ where
             &globals,
             &self.options.file_path,
             &options,
+            &self.options.configuration.preferred_quote,
         )
         .ok();
         if let Some(ctx) = ctx {

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -391,6 +391,10 @@ impl QuoteStyle {
             QuoteStyle::Single => QuoteStyle::Double,
         }
     }
+
+    pub const fn is_double(&self) -> bool {
+        matches!(self, Self::Double)
+    }
 }
 
 impl FromStr for QuoteStyle {

--- a/crates/biome_js_analyze/src/analyzers/complexity/use_literal_keys.rs
+++ b/crates/biome_js_analyze/src/analyzers/complexity/use_literal_keys.rs
@@ -155,8 +155,10 @@ impl Rule for UseLiteralKeys {
             AnyJsMember::JsComputedMemberName(member) => {
                 let name_token = if is_js_ident(identifier) {
                     make::ident(identifier)
-                } else {
+                } else if ctx.as_preferred_quote().is_double() {
                     make::js_string_literal(identifier)
+                } else {
+                    make::js_string_literal_single_quotes(identifier)
                 };
                 let literal_member_name = js_literal_member_name(name_token);
                 mutation.replace_node(

--- a/crates/biome_js_analyze/src/analyzers/correctness/no_string_case_mismatch.rs
+++ b/crates/biome_js_analyze/src/analyzers/correctness/no_string_case_mismatch.rs
@@ -93,9 +93,11 @@ impl Rule for NoStringCaseMismatch {
             state.literal.clone(),
             AnyJsExpression::AnyJsLiteralExpression(
                 AnyJsLiteralExpression::JsStringLiteralExpression(
-                    make::js_string_literal_expression(make::js_string_literal(
-                        &state.expected_value,
-                    )),
+                    make::js_string_literal_expression(if ctx.as_preferred_quote().is_double() {
+                        make::js_string_literal(&state.expected_value)
+                    } else {
+                        make::js_string_literal_single_quotes(&state.expected_value)
+                    }),
                 ),
             ),
         );

--- a/crates/biome_js_analyze/src/analyzers/style/no_unused_template_literal.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/no_unused_template_literal.rs
@@ -96,7 +96,11 @@ impl Rule for NoUnusedTemplateLiteral {
             AnyJsExpression::JsTemplateExpression(node.clone()),
             AnyJsExpression::AnyJsLiteralExpression(
                 AnyJsLiteralExpression::JsStringLiteralExpression(
-                    make::js_string_literal_expression(make::js_string_literal(&inner_content)),
+                    make::js_string_literal_expression(if ctx.as_preferred_quote().is_double() {
+                        make::js_string_literal(&inner_content)
+                    } else {
+                        make::js_string_literal_single_quotes(&inner_content)
+                    }),
                 ),
             ),
         );

--- a/crates/biome_js_analyze/src/analyzers/style/use_enum_initializers.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_enum_initializers.rs
@@ -159,7 +159,13 @@ impl Rule for UseEnumInitializers {
                         let enum_name = enum_member.name().ok()?.name()?;
                         let enum_name = enum_name.text();
                         Some(AnyJsLiteralExpression::JsStringLiteralExpression(
-                            make::js_string_literal_expression(make::js_string_literal(enum_name)),
+                            make::js_string_literal_expression(
+                                if ctx.as_preferred_quote().is_double() {
+                                    make::js_string_literal(enum_name)
+                                } else {
+                                    make::js_string_literal_single_quotes(enum_name)
+                                },
+                            ),
                         ))
                     }
                     EnumInitializer::Other => None,

--- a/crates/biome_js_analyze/src/analyzers/suspicious/use_valid_typeof.rs
+++ b/crates/biome_js_analyze/src/analyzers/suspicious/use_valid_typeof.rs
@@ -229,7 +229,11 @@ impl Rule for UseValidTypeof {
         mutation.replace_node(
             expr.clone(),
             AnyJsExpression::AnyJsLiteralExpression(AnyJsLiteralExpression::from(
-                make::js_string_literal_expression(make::js_string_literal(type_name.as_str())),
+                make::js_string_literal_expression(if ctx.as_preferred_quote().is_double() {
+                    make::js_string_literal(type_name.as_str())
+                } else {
+                    make::js_string_literal_single_quotes(type_name.as_str())
+                }),
             )),
         );
 

--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_sorted_classes.rs
@@ -13,8 +13,8 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make::{
-    js_string_literal, js_string_literal_expression, js_template_chunk, js_template_chunk_element,
-    jsx_string,
+    js_string_literal, js_string_literal_expression, js_string_literal_single_quotes,
+    js_template_chunk, js_template_chunk_element, jsx_string,
 };
 use biome_rowan::{AstNode, BatchMutationExt};
 use lazy_static::lazy_static;
@@ -186,11 +186,20 @@ impl Rule for UseSortedClasses {
         let mut mutation = ctx.root().begin();
         match ctx.query() {
             AnyClassStringLike::JsStringLiteralExpression(string_literal) => {
-                let replacement = js_string_literal_expression(js_string_literal(state));
+                let replacement =
+                    js_string_literal_expression(if ctx.as_preferred_quote().is_double() {
+                        js_string_literal(state)
+                    } else {
+                        js_string_literal_single_quotes(state)
+                    });
                 mutation.replace_node(string_literal.clone(), replacement);
             }
             AnyClassStringLike::JsxString(jsx_string_node) => {
-                let replacement = jsx_string(js_string_literal(state));
+                let replacement = jsx_string(if ctx.as_preferred_quote().is_double() {
+                    js_string_literal(state)
+                } else {
+                    js_string_literal_single_quotes(state)
+                });
                 mutation.replace_node(jsx_string_node.clone(), replacement);
             }
             AnyClassStringLike::JsTemplateChunkElement(chunk) => {

--- a/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid2.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid2.options.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid2.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid2.ts
@@ -1,0 +1,5 @@
+export enum Color {
+    Red = "Red",
+    Green = "Green",
+    Blue,
+}

--- a/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid2.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useEnumInitializers/invalid2.ts.snap
@@ -1,0 +1,44 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid2.ts
+---
+# Input
+```ts
+export enum Color {
+    Red = "Red",
+    Green = "Green",
+    Blue,
+}
+
+```
+
+# Diagnostics
+```
+invalid2.ts:1:13 lint/style/useEnumInitializers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This enum declaration contains members that are implicitly initialized.
+  
+  > 1 │ export enum Color {
+      │             ^^^^^
+    2 │     Red = "Red",
+    3 │     Green = "Green",
+  
+  i This enum member should be explicitly initialized.
+  
+    2 │     Red = "Red",
+    3 │     Green = "Green",
+  > 4 │     Blue,
+      │     ^^^^
+    5 │ }
+    6 │ 
+  
+  i Allowing implicit initializations for enum members can cause bugs if enum declarations are modified over time.
+  
+  i Safe fix: Initialize all enum members.
+  
+    4 │ ····Blue·=·'Blue',
+      │         +++++++++ 
+
+```
+
+

--- a/crates/biome_js_factory/src/make.rs
+++ b/crates/biome_js_factory/src/make.rs
@@ -29,11 +29,31 @@ pub fn js_string_literal(text: &str) -> JsSyntaxToken {
     )
 }
 
+/// Create a new string literal token with no attached trivia, using single quotes
+pub fn js_string_literal_single_quotes(text: &str) -> JsSyntaxToken {
+    JsSyntaxToken::new_detached(
+        JsSyntaxKind::JS_STRING_LITERAL,
+        &format!("'{text}'"),
+        [],
+        [],
+    )
+}
+
 /// Create a new string literal token with no attached trivia
 pub fn jsx_string_literal(text: &str) -> JsSyntaxToken {
     JsSyntaxToken::new_detached(
         JsSyntaxKind::JSX_STRING_LITERAL,
         &format!("\"{text}\""),
+        [],
+        [],
+    )
+}
+
+/// Create a new string literal token with no attached trivia, using single quotes
+pub fn jsx_string_literal_single_quotes(text: &str) -> JsSyntaxToken {
+    JsSyntaxToken::new_detached(
+        JsSyntaxKind::JSX_STRING_LITERAL,
+        &format!("'{text}'"),
         [],
         [],
     )

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     WorkspaceError,
 };
+use biome_analyze::options::PreferredQuote;
 use biome_analyze::{
     AnalysisFilter, AnalyzerConfiguration, AnalyzerOptions, ControlFlow, GroupCategory, Never,
     QueryMatch, RegistryVisitor, RuleCategories, RuleCategory, RuleFilter, RuleGroup,
@@ -800,6 +801,19 @@ pub(crate) fn organize_imports(parse: AnyParse) -> Result<OrganizeImportsResult,
 
 fn compute_analyzer_options(settings: &SettingsHandle, file_path: PathBuf) -> AnalyzerOptions {
     let settings = settings.as_ref();
+    let preferred_quote = settings
+        .languages
+        .javascript
+        .formatter
+        .quote_style
+        .map(|quote_style: QuoteStyle| {
+            if quote_style == QuoteStyle::Single {
+                PreferredQuote::Single
+            } else {
+                PreferredQuote::Double
+            }
+        })
+        .unwrap_or_default();
     let configuration = AnalyzerConfiguration {
         rules: to_analyzer_rules(settings, file_path.as_path()),
         globals: settings
@@ -810,6 +824,7 @@ fn compute_analyzer_options(settings: &SettingsHandle, file_path: PathBuf) -> An
             )
             .into_iter()
             .collect(),
+        preferred_quote,
     };
 
     AnalyzerOptions {

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -13,6 +13,7 @@ use crate::workspace::{
     FixFileResult, GetSyntaxTreeResult, OrganizeImportsResult, PullActionsResult,
 };
 use crate::WorkspaceError;
+use biome_analyze::options::PreferredQuote;
 use biome_analyze::{
     AnalysisFilter, AnalyzerConfiguration, AnalyzerOptions, ControlFlow, Never, RuleCategories,
 };
@@ -406,6 +407,7 @@ fn compute_analyzer_options(settings: &SettingsHandle, file_path: PathBuf) -> An
     let configuration = AnalyzerConfiguration {
         rules: to_analyzer_rules(settings.as_ref(), file_path.as_path()),
         globals: vec![],
+        preferred_quote: PreferredQuote::Double,
     };
     AnalyzerOptions {
         configuration,

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -63,6 +63,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   ```
 
 - Add lint rule useJsxKeyInIterable from Eslint rule [`react/jsx-key`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md). Contributed by @vohoanglong0107
+- The analyzer now **infers** the correct quote from `javascript.formatter.quoteStyle`, if set. This means that code fixes suggested by the analyzer will use the same quote of the formatter. Contributed by @ematipico
 
 #### Enhancements
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/1102
Closes https://github.com/biomejs/biome/issues/1903

This PR adds a `preferred_quote` to the analyzer. It is currently used only inside the JavaScript analyzer.

This quote is then computed using the configuration, provide `PreferredQuote::Single` when the formatter is set to use the single quote inside the formatter.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I updated the test suite to compute this new configuration, and added a new test case in one of the rules that use this new logic.

<!-- What demonstrates that your implementation is correct? -->
