### PR TITLE
chore: replace TypeScript ESLint with typescript-eslint

### DIFF
--- a/packages/@biomejs/biome/README.ja.md
+++ b/packages/@biomejs/biome/README.ja.md
@@ -37,7 +37,7 @@
 
 **Biome は _JavaScript_, _TypeScript_, _JSX_ そして _JSON_ 向けの[高速なFormatter](./benchmark#formatting)**であり、**[_Prettier_ との互換性は97%](https://console.algora.io/challenges/prettier)** を達成しています。
 
-**Biome は _JavaScript_, _TypeScript_, _JSX_ のための[高性能なLinter](https://github.com/biomejs/biome/tree/main/benchmark#linting)** であり、ESLint, TypeScript ESLint, [その他のソース](https://github.com/biomejs/biome/discussions/3)から **[170以上のルール](https://biomejs.dev/linter/rules/)**を提供しています。Biome は**詳細で文脈に沿った結果を出力**するため、コードを改善し、より良いプログラマになるための手助けをします！
+**Biome は _JavaScript_, _TypeScript_, _JSX_ のための[高性能なLinter](https://github.com/biomejs/biome/tree/main/benchmark#linting)** であり、ESLint, typescript-eslint, [その他のソース](https://github.com/biomejs/biome/discussions/3)から **[170以上のルール](https://biomejs.dev/linter/rules/)**を提供しています。Biome は**詳細で文脈に沿った結果を出力**するため、コードを改善し、より良いプログラマになるための手助けをします！
 
 **Biome** は最初から[**エディタ内で対話的に**](https://biomejs.dev/ja/guides/integrate-in-editor/)使用できるように設計されています。
 あなたがコードを書いているときに、形の崩れたコードを format と lint することができます。

--- a/packages/@biomejs/biome/README.md
+++ b/packages/@biomejs/biome/README.md
@@ -38,7 +38,7 @@ English | [简体中文](https://github.com/biomejs/biome/blob/main/packages/%40
 
 **Biome is a [fast formatter](./benchmark#formatting)** for _JavaScript_, _TypeScript_, _JSX_, and _JSON_ that scores **[97% compatibility with _Prettier_](https://console.algora.io/challenges/prettier)**.
 
-**Biome is a [performant linter](https://github.com/biomejs/biome/tree/main/benchmark#linting)** for _JavaScript_, _TypeScript_, and _JSX_ that features **[more than 190 rules](https://biomejs.dev/linter/rules/)** from ESLint, TypeScript ESLint, and [other sources](https://github.com/biomejs/biome/discussions/3).
+**Biome is a [performant linter](https://github.com/biomejs/biome/tree/main/benchmark#linting)** for _JavaScript_, _TypeScript_, and _JSX_ that features **[more than 190 rules](https://biomejs.dev/linter/rules/)** from ESLint, typescript-eslint, and [other sources](https://github.com/biomejs/biome/discussions/3).
 It **outputs detailed and contextualized diagnostics** that help you to improve your code and become a better programmer!
 
 **Biome** is designed from the start to be used [interactively within an editor](https://biomejs.dev/guides/integrate-in-editor/).

--- a/packages/@biomejs/biome/README.pt-br.md
+++ b/packages/@biomejs/biome/README.pt-br.md
@@ -37,7 +37,7 @@
 
 **Biome é um [formatador rápido](./benchmark#formatting)** para _JavaScript_, _TypeScript_, _JSX_, e _JSON_ que atinge **[97% de compatibilidade com o _Prettier_](https://console.algora.io/challenges/prettier)**.
 
-**Biome é um [linter eficiente](https://github.com/biomejs/biome/tree/main/benchmark#linting)** para _JavaScript_, _TypeScript_, e _JSX_ que possui **[mais de 190 regras](https://biomejs.dev/linter/rules/)** do ESLint, TypeScript ESLint, e de [outras fontes](https://github.com/biomejs/biome/discussions/3).
+**Biome é um [linter eficiente](https://github.com/biomejs/biome/tree/main/benchmark#linting)** para _JavaScript_, _TypeScript_, e _JSX_ que possui **[mais de 190 regras](https://biomejs.dev/linter/rules/)** do ESLint, typescript-eslint, e de [outras fontes](https://github.com/biomejs/biome/discussions/3).
 Ele **fornece diagnósticos detalhados e contextualizados** que ajudam você a melhorar seu código e se tornar um programador melhor!
 
 **Biome** é projetado desde o início para ser usado [interativamente dentro de um editor](https://biomejs.dev/guides/integrate-in-editor/).

--- a/packages/@biomejs/biome/README.zh-CN.md
+++ b/packages/@biomejs/biome/README.zh-CN.md
@@ -37,7 +37,7 @@
 
 **Biome 是一个[快速的格式化工具](./benchmark#formatting)**，适用于 _JavaScript_、_TypeScript_、_JSX_、_JSON_ 等，与 _Prettier_ 的兼容性达到了 **[97%](https://console.algora.io/challenges/prettier)**。
 
-**Biome 是一个[高性能的 Linter](https://github.com/biomejs/biome/tree/main/benchmark#linting)**，适用于 _JavaScript_、_TypeScript_、_JSX_ 等，包含了来自 ESLint、TypeScript ESLint 和[其他来源](https://github.com/biomejs/biome/discussions/3)的 **[190 余项规则](https://biomejs.dev/zh-cn/linter/rules/)**。它**输出详细且有上下文诊断信息**，能帮助你优化代码，成为一名更好的程序员！
+**Biome 是一个[高性能的 Linter](https://github.com/biomejs/biome/tree/main/benchmark#linting)**，适用于 _JavaScript_、_TypeScript_、_JSX_ 等，包含了来自 ESLint、typescript-eslint 和[其他来源](https://github.com/biomejs/biome/discussions/3)的 **[190 余项规则](https://biomejs.dev/zh-cn/linter/rules/)**。它**输出详细且有上下文诊断信息**，能帮助你优化代码，成为一名更好的程序员！
 
 **Biome** 从一开始就设计为[在编辑器中交互式使用](https://biomejs.dev/zh-cn/guides/integrate-in-editor/)。它可以在你编写代码时格式化并检查出不规范的代码。
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -101,7 +101,7 @@ import LinterExample from "@/components/linter/example.md";
 <div class="hero-code">
     <h2 class="head">Fix problems, learn best practice</h2>
 
-    **Biome is a [performant linter](https://github.com/biomejs/biome/tree/main/benchmark#linting)** for _JavaScript_, _TypeScript_, and _JSX_ that features **[more than 190 rules](https://biomejs.dev/linter/rules/)** from ESLint, TypeScript ESLint, and [other sources](https://github.com/biomejs/biome/discussions/3).
+    **Biome is a [performant linter](https://github.com/biomejs/biome/tree/main/benchmark#linting)** for _JavaScript_, _TypeScript_, and _JSX_ that features **[more than 190 rules](https://biomejs.dev/linter/rules/)** from ESLint, typescript-eslint, and [other sources](https://github.com/biomejs/biome/discussions/3).
 
     **Biome outputs detailed and contextualized diagnostics** that help you to improve your code and become a better programmer!
 

--- a/website/src/content/docs/ja/index.mdx
+++ b/website/src/content/docs/ja/index.mdx
@@ -102,7 +102,7 @@ import LinterExample from "@/components/linter/example.md";
 <div class="hero-code">
     <h2 class="head">Fix problems, learn best practice</h2>
 
-    **Biome は _JavaScript_, _TypeScript_ そして _JSX_ のための [高性能な linter](https://github.com/biomejs/biome/tree/main/benchmark#linting)** であり、ESLint, TypeScript ESLint 及び[その他のソース](https://github.com/biomejs/biome/discussions/3)から **[190 以上のルール](https://biomejs.dev/linter/rules/)** を備えています。
+    **Biome は _JavaScript_, _TypeScript_ そして _JSX_ のための [高性能な linter](https://github.com/biomejs/biome/tree/main/benchmark#linting)** であり、ESLint, typescript-eslint 及び[その他のソース](https://github.com/biomejs/biome/discussions/3)から **[190 以上のルール](https://biomejs.dev/linter/rules/)** を備えています。
 
     **Biomeは、詳細で文脈を考慮した診断を出力し**、あなたのコードを改善し、より優れたプログラマーになるのに役立ちます！
 

--- a/website/src/content/docs/pt-br/index.mdx
+++ b/website/src/content/docs/pt-br/index.mdx
@@ -98,7 +98,7 @@ import LinterExample from "@/components/linter/example.md";
 <div class="hero-code">
     <h2 class="head">Corrija problemas e aprenda boas práticas</h2>
 
-    **O Biome é um [linter performático](https://github.com/biomejs/biome/tree/main/benchmark#linting)** para _JavaScript_, _TypeScript_, e _JSX_ que possui **[mais de 190 regras](https://biomejs.dev/pt-br/linter/rules/)** do ESLint, TypeScript ESLint, e [de outras fontes](https://github.com/biomejs/biome/discussions/3).
+    **O Biome é um [linter performático](https://github.com/biomejs/biome/tree/main/benchmark#linting)** para _JavaScript_, _TypeScript_, e _JSX_ que possui **[mais de 190 regras](https://biomejs.dev/pt-br/linter/rules/)** do ESLint, typescript-eslint, e [de outras fontes](https://github.com/biomejs/biome/discussions/3).
 
     **O Biome retorna diagnósticos detalhados e contextualizados** que ajuda a melhorar seu código e ajuda você a se tornar um programador melhor!
 

--- a/website/src/content/docs/zh-cn/index.mdx
+++ b/website/src/content/docs/zh-cn/index.mdx
@@ -99,7 +99,7 @@ import LinterExample from "@/components/linter/example.md";
 <div class="hero-code">
     <h2 class="head">修复错误，学习最佳实践</h2>
 
-    Biome 是一个适用于 _JavaScript_、_TypeScript_ 和 _JSX_ 的[**高性能 linter**](https://github.com/biomejs/biome/tree/main/benchmark#linting)，拥有来自 ESLint、TypeScript ESLint 以及[其它规则源](https://github.com/biomejs/biome/discussions/3)的[超过 190 条规则](/zh-cn/linter/rules/)。
+    Biome 是一个适用于 _JavaScript_、_TypeScript_ 和 _JSX_ 的[**高性能 linter**](https://github.com/biomejs/biome/tree/main/benchmark#linting)，拥有来自 ESLint、typescript-eslint 以及[其它规则源](https://github.com/biomejs/biome/discussions/3)的[超过 190 条规则](/zh-cn/linter/rules/)。
 
     **Biome 可以输出详细且上下文相结合的诊断信息**来帮助你改进你的代码，成为更优秀的程序员！
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR replaces `TypeScript ESLint` with `typescript-eslint`
https://typescript-eslint.io/maintenance/branding

> Our project name is "typescript-eslint". We sometimes refer to it as "ts-eslint" for short.
> "typescript-eslint" is preferred over "TypeScript ESLint" or "TypeScript-ESLint" because ESLint and TypeScript are written in abbreviated Pascal Case. Combining lowercase with a dash helps differentiate us.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
