### PR TITLE
fix(lint/noExhaustiveDependencies): avoid getting the whole static member expression for the reference if the expression does not start with the reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Fix [#1924](https://github.com/biomejs/biome/issues/1924) Use the correct export name to sort in the import clause. Contributed by @ah-yu
 - Fix [#1805](https://github.com/biomejs/biome/issues/1805) fix formatting arrow function which has conditional expression body  Contributed by @mdm317
 
+- Fix [#1781](https://github.com/biomejs/biome/issues/1781) by avoiding the retrieval of the entire static member expression for the reference if the static member expression does not start with the reference. Contributed by @ah-yu
+
 ### CLI
 
 #### New features

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
@@ -287,9 +287,17 @@ pub enum Fix {
 fn get_whole_static_member_expression(reference: &JsSyntaxNode) -> Option<AnyJsMemberExpression> {
     let root = reference
         .ancestors()
-        .skip(2) //IDENT and JS_REFERENCE_IDENTIFIER
-        .take_while(|x| AnyJsMemberExpression::can_cast(x.kind()))
-        .last()?;
+        .skip(1) // JS_REFERENCE_IDENTIFIER
+        .take_while(|x| {
+            x.parent().is_some_and(|parent| {
+                parent.cast::<AnyJsMemberExpression>().is_some_and(|member_expr| {
+                    member_expr.object().is_ok_and(|object| object.syntax() == x)
+                })
+            })
+        })
+        .last()?
+        .parent()?;
+
     root.cast()
 }
 

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
@@ -290,9 +290,13 @@ fn get_whole_static_member_expression(reference: &JsSyntaxNode) -> Option<AnyJsM
         .skip(1) // JS_REFERENCE_IDENTIFIER
         .take_while(|x| {
             x.parent().is_some_and(|parent| {
-                parent.cast::<AnyJsMemberExpression>().is_some_and(|member_expr| {
-                    member_expr.object().is_ok_and(|object| object.syntax() == x)
-                })
+                parent
+                    .cast::<AnyJsMemberExpression>()
+                    .is_some_and(|member_expr| {
+                        member_expr
+                            .object()
+                            .is_ok_and(|object| object.syntax() == x)
+                    })
             })
         })
         .last()?

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1781.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1781.js
@@ -1,0 +1,8 @@
+import { useMemo } from 'react';
+
+const data = {}
+function MyComponent24({ idx }) {
+    useMemo(() => {
+        data[idx]
+    }, [idx])
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1781.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1781.js.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue1781.js
+---
+# Input
+```jsx
+import { useMemo } from 'react';
+
+const data = {}
+function MyComponent24({ idx }) {
+    useMemo(() => {
+        data[idx]
+    }, [idx])
+}
+```

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -107,6 +107,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Fix [#1924](https://github.com/biomejs/biome/issues/1924) Use the correct export name to sort in the import clause. Contributed by @ah-yu
 - Fix [#1805](https://github.com/biomejs/biome/issues/1805) fix formatting arrow function which has conditional expression body  Contributed by @mdm317
 
+- Fix [#1781](https://github.com/biomejs/biome/issues/1781) by avoiding the retrieval of the entire static member expression for the reference if the static member expression does not start with the reference. Contributed by @ah-yu
+
 ### CLI
 
 #### New features


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

- Closes https://github.com/biomejs/biome/issues/1781

```js
function Component({a, e}) {
  const foo = React.useMemo(() => {
    a.b.c  // find a.b.c for a because the static member expression starts with a
    ~~~~~
    d[e]  // no need to find d[e] for e
      ~
  }, [])
}
````

## Test Plan

Add a new test case
