### PR TITLE
fix(lint/useExhaustiveDependencies): lint React hooks from other sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @ah-yu
 
+- Fix [#1931](https://github.com/biomejs/biome/issues/1931). Built-in React hooks such as
+  `useEffect()` can now be validated by the
+  [`useExhaustiveDependendies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/), even
+  when they're not being imported from the React library. To do so, simply configure them like
+  any other user-provided hooks.
+
+  Contributed by @arendjr
+
 #### Bug fixes
 
 - Fix [#1748](https://github.com/biomejs/biome/issues/1748). Now for the following case we won't provide an unsafe fix

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
@@ -142,7 +142,12 @@ declare_rule! {
     ///
     /// ## Options
     ///
-    /// Allows to specify custom hooks - from libraries or internal projects - that can be considered stable.
+    /// Allows to specify custom hooks - from libraries or internal projects -
+    /// for which dependencies should be checked.
+    ///
+    /// For every hook, you should specify the index of the closure (whose
+    /// dependencies should be checked) and the index of the dependencies array
+    /// to validate against.
     ///
     /// ```json
     /// {
@@ -182,12 +187,12 @@ pub struct ReactExtensiveDependenciesOptions {
 impl Default for ReactExtensiveDependenciesOptions {
     fn default() -> Self {
         let hooks_config = FxHashMap::from_iter([
-            ("useEffect".to_string(), (0, 1).into()),
-            ("useLayoutEffect".to_string(), (0, 1).into()),
-            ("useInsertionEffect".to_string(), (0, 1).into()),
-            ("useCallback".to_string(), (0, 1).into()),
-            ("useMemo".to_string(), (0, 1).into()),
-            ("useImperativeHandle".to_string(), (1, 2).into()),
+            ("useEffect".to_string(), (0, 1, true).into()),
+            ("useLayoutEffect".to_string(), (0, 1, true).into()),
+            ("useInsertionEffect".to_string(), (0, 1, true).into()),
+            ("useCallback".to_string(), (0, 1, true).into()),
+            ("useMemo".to_string(), (0, 1, true).into()),
+            ("useImperativeHandle".to_string(), (1, 2, true).into()),
             ("useState".to_string(), ReactHookConfiguration::default()),
             ("useReducer".to_string(), ReactHookConfiguration::default()),
             ("useRef".to_string(), ReactHookConfiguration::default()),
@@ -253,6 +258,7 @@ impl ReactExtensiveDependenciesOptions {
                 ReactHookConfiguration {
                     closure_index: hook.closure_index,
                     dependencies_index: hook.dependencies_index,
+                    builtin: false,
                 },
             );
         }

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'library-reexporting-react';
+
+function MyComponent25() {
+    const [calc, setCalc] = useState(0);
+    // Built-in hooks such as `useEffect()` normally only get validated when
+    // they're imported from the "react" library. Explicitly configuring them
+    // in the hooks array (as if they are user-provided hooks) overrides this.
+    useEffect(() => {
+        if (calc === 0) {
+            setCalc(1);
+        }
+    }, []);
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
-assertion_line: 83
 expression: issue1931.js
 ---
 # Input
@@ -73,5 +72,3 @@ issue1931.js:8:5 lint/correctness/useExhaustiveDependencies ━━━━━━�
   
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js.snap.new
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js.snap.new
@@ -1,0 +1,77 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 83
+expression: issue1931.js
+---
+# Input
+```jsx
+import { useEffect, useState } from 'library-reexporting-react';
+
+function MyComponent25() {
+    const [calc, setCalc] = useState(0);
+    // Built-in hooks such as `useEffect()` normally only get validated when
+    // they're imported from the "react" library. Explicitly configuring them
+    // in the hooks array (as if they are user-provided hooks) overrides this.
+    useEffect(() => {
+        if (calc === 0) {
+            setCalc(1);
+        }
+    }, []);
+}
+
+```
+
+# Diagnostics
+```
+issue1931.js:8:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook does not specify all of its dependencies: calc
+  
+     6 │     // they're imported from the "react" library. Explicitly configuring them
+     7 │     // in the hooks array (as if they are user-provided hooks) overrides this.
+   > 8 │     useEffect(() => {
+       │     ^^^^^^^^^
+     9 │         if (calc === 0) {
+    10 │             setCalc(1);
+  
+  i This dependency is not specified in the hook dependency list.
+  
+     7 │     // in the hooks array (as if they are user-provided hooks) overrides this.
+     8 │     useEffect(() => {
+   > 9 │         if (calc === 0) {
+       │             ^^^^
+    10 │             setCalc(1);
+    11 │         }
+  
+  i Either include it or remove the dependency array
+  
+
+```
+
+```
+issue1931.js:8:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook does not specify all of its dependencies: setCalc
+  
+     6 │     // they're imported from the "react" library. Explicitly configuring them
+     7 │     // in the hooks array (as if they are user-provided hooks) overrides this.
+   > 8 │     useEffect(() => {
+       │     ^^^^^^^^^
+     9 │         if (calc === 0) {
+    10 │             setCalc(1);
+  
+  i This dependency is not specified in the hook dependency list.
+  
+     8 │     useEffect(() => {
+     9 │         if (calc === 0) {
+  > 10 │             setCalc(1);
+       │             ^^^^^^^
+    11 │         }
+    12 │     }, []);
+  
+  i Either include it or remove the dependency array
+  
+
+```
+
+

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.options.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+    "linter": {
+        "rules": {
+            "correctness": {
+                "useExhaustiveDependencies": {
+                    "level": "error",
+                    "options": {
+                        "hooks": [
+                            {
+                                "name": "useEffect",
+                                "closureIndex": 0,
+                                "dependenciesIndex": 1
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -77,6 +77,14 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @ah-yu
 
+- Fix [#1931](https://github.com/biomejs/biome/issues/1931). Built-in React hooks such as
+  `useEffect()` can now be validated by the
+  [`useExhaustiveDependendies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/), even
+  when they're not being imported from the React library. To do so, simply configure them like
+  any other user-provided hooks.
+
+  Contributed by @arendjr
+
 #### Bug fixes
 
 - Fix [#1748](https://github.com/biomejs/biome/issues/1748). Now for the following case we won't provide an unsafe fix

--- a/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
+++ b/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
@@ -222,7 +222,12 @@ function component() {
 
 ## Options
 
-Allows to specify custom hooks - from libraries or internal projects - that can be considered stable.
+Allows to specify custom hooks - from libraries or internal projects -
+for which dependencies should be checked.
+
+For every hook, you should specify the index of the closure (whose
+dependencies should be checked) and the index of the dependencies array
+to validate against.
 
 ```json
 {


### PR DESCRIPTION
## Summary

React hooks are only validated by `useExhaustiveDependencies` if they are being imported from the React library. Sometimes, this is undesirable, for instance when a library re-exports the React hooks. This change allows users to configure built-in hooks as if they were user-provided hooks to get the desired result.

Fixes #1931. 

## Test Plan

Added a test case.
