### PR TITLE
feat(ci): build linux-arm64 with 16K page size

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -114,6 +114,11 @@ jobs:
         if: matrix.code-target == 'linux-x64'
         run: cargo audit
 
+      - name: Set jemalloc page size for linux-arm64
+        if: matrix.code-target == 'linux-arm64'
+        run: |
+          echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
+
       # Build the CLI binary
       - name: Build binaries
         run: cargo build -p biome_cli --release --target ${{ matrix.target }}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Build for linux-arm64 with a page size of 16K, to fix following error:
```
<jemalloc>: Unsupported system page size
<jemalloc>: Unsupported system page size
memory allocation of 5 bytes failed
```

Related issue:
 * #1692 

## Test Plan

Run the build binary on an linux-arm64 with 16K page size.
