### PR TITLE
Implement stable hook configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,34 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @arendjr
 
+- Implemented [#1128](https://github.com/biomejs/biome/issues/1128). User-provided React hooks can
+  now be configured to return stable results. For example:
+
+  ```json
+  "useExhaustiveDependencies": {
+      "level": "error",
+      "options": {
+          "hooks": [{
+              "name": "useMyState",
+              "stableResult": [
+                  1
+              ]
+          }]
+      }
+  }
+  ```
+
+  This will allow the following to be validated:
+
+  ```js
+  const [myState, setMyState] = useMyState();
+  const toggleMyState = useCallback(() => {
+    setMyState(!myState);
+  }, [myState]); // Only `myState` needs to be specified here.
+  ```
+
+  Contributed by @arendjr
+
 #### Bug fixes
 
 - Fix [#1748](https://github.com/biomejs/biome/issues/1748). Now for the following case we won't provide an unsafe fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Contributed by @arendjr
 
 - Implemented [#1128](https://github.com/biomejs/biome/issues/1128). User-provided React hooks can
-  now be configured to return stable results. For example:
+  now be configured to track stable results. For example:
 
   ```json
   "useExhaustiveDependencies": {

--- a/crates/biome_deserialize/src/validator.rs
+++ b/crates/biome_deserialize/src/validator.rs
@@ -13,7 +13,7 @@ pub trait DeserializableValidator {
     /// Returns `true` if the instance passes validation and `false` when it
     /// should be rejected.
     fn validate(
-        &self,
+        &mut self,
         name: &str,
         range: TextRange,
         diagnostics: &mut Vec<DeserializationDiagnostic>,

--- a/crates/biome_deserialize_macros/src/deserializable_derive.rs
+++ b/crates/biome_deserialize_macros/src/deserializable_derive.rs
@@ -231,7 +231,7 @@ fn generate_deserializable_enum(
 
     let validator = if data.with_validator {
         quote! {
-            if !biome_deserialize::DeserializableValidator::validate(&result, name, range, diagnostics) {
+            if !biome_deserialize::DeserializableValidator::validate(&mut result, name, range, diagnostics) {
                 return None;
             }
         }
@@ -274,7 +274,7 @@ fn generate_deserializable_newtype(
 ) -> TokenStream {
     let validator = if data.with_validator {
         quote! {
-            if !biome_deserialize::DeserializableValidator::validate(&result, name, value.range(), diagnostics) {
+            if !biome_deserialize::DeserializableValidator::validate(&mut result, name, value.range(), diagnostics) {
                 return None;
             }
         }
@@ -436,7 +436,7 @@ fn generate_deserializable_struct(
     let validator = if data.with_validator {
         quote! {
             #validator
-            if !biome_deserialize::DeserializableValidator::validate(&result, name, range, diagnostics) {
+            if !biome_deserialize::DeserializableValidator::validate(&mut result, name, range, diagnostics) {
                 return None;
             }
         }

--- a/crates/biome_deserialize_macros/src/lib.rs
+++ b/crates/biome_deserialize_macros/src/lib.rs
@@ -90,7 +90,7 @@ use syn::{parse_macro_input, DeriveInput};
 /// }
 ///
 /// impl DeserializableValidator for ValidatedStruct {
-///     fn fn validate(
+///     fn validate(
 ///         &self,
 ///         name: &str,
 ///         range: biome_rowan::TextRange,

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -241,9 +241,8 @@ mod tests {
     use biome_js_syntax::{JsFileSource, TextRange, TextSize};
     use std::slice;
 
-    use crate::semantic_analyzers::correctness::use_exhaustive_dependencies::{
-        Hooks, HooksOptions,
-    };
+    use crate::react::hooks::StableHookResult;
+    use crate::semantic_analyzers::correctness::use_exhaustive_dependencies::{Hook, HooksOptions};
     use crate::{analyze, AnalysisFilter, ControlFlow};
 
     // #[ignore]
@@ -260,18 +259,16 @@ mod tests {
 
         const SOURCE: &str = r#"<a href="class/html-css1/navigation/links#" onclick="window.location.href=index.html"> Home </a>
         "#;
-        // const SOURCE: &str = r#"document.querySelector("foo").value = document.querySelector("foo").value
-        //
-        // "#;
 
         let parsed = parse(SOURCE, JsFileSource::tsx(), JsParserOptions::default());
 
         let mut error_ranges: Vec<TextRange> = Vec::new();
         let mut options = AnalyzerOptions::default();
-        let hook = Hooks {
+        let hook = Hook {
             name: "myEffect".to_string(),
             closure_index: Some(0),
             dependencies_index: Some(1),
+            stable_result: StableHookResult::None,
         };
         let rule_filter = RuleFilter::Rule("a11y", "useValidAnchor");
 

--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -1,5 +1,8 @@
 use crate::react::{is_react_call_api, ReactLibrary};
 
+use biome_console::markup;
+use biome_deserialize::{DeserializationDiagnostic, DeserializationVisitor, VisitableType};
+use biome_diagnostics::Severity;
 use biome_js_semantic::{Capture, Closure, ClosureExtensions, SemanticModel};
 use biome_js_syntax::binding_ext::AnyJsBindingDeclaration;
 use biome_js_syntax::{
@@ -11,6 +14,9 @@ use biome_js_syntax::{JsArrayBindingPatternElement, JsLanguage};
 use biome_rowan::{AstNode, SyntaxToken};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 
 /// Return result of [react_hook_with_dependency].
 #[derive(Debug)]
@@ -83,8 +89,8 @@ impl ReactCallWithDependencyResult {
 
 #[derive(Default, Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct ReactHookConfiguration {
-    pub closure_index: Option<usize>,
-    pub dependencies_index: Option<usize>,
+    pub closure_index: u8,
+    pub dependencies_index: u8,
 
     /// `true` if it's a built-in React hook. For built-in hooks, we verify
     /// whether they are imported from the React library. For user-defined
@@ -92,11 +98,11 @@ pub struct ReactHookConfiguration {
     pub builtin: bool,
 }
 
-impl From<(usize, usize, bool)> for ReactHookConfiguration {
-    fn from((closure, dependencies, builtin): (usize, usize, bool)) -> Self {
+impl From<(u8, u8, bool)> for ReactHookConfiguration {
+    fn from((closure_index, dependencies_index, builtin): (u8, u8, bool)) -> Self {
         Self {
-            closure_index: Some(closure),
-            dependencies_index: Some(dependencies),
+            closure_index,
+            dependencies_index,
             builtin,
         }
     }
@@ -182,8 +188,8 @@ pub(crate) fn react_hook_with_dependency(
         return None;
     }
 
-    let closure_index = hook.closure_index?;
-    let dependencies_index = hook.dependencies_index?;
+    let closure_index = hook.closure_index as usize;
+    let dependencies_index = hook.dependencies_index as usize;
 
     let mut indices = [closure_index, dependencies_index];
     indices.sort_unstable();
@@ -201,17 +207,120 @@ pub(crate) fn react_hook_with_dependency(
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StableReactHookConfiguration {
     /// Name of the React hook
-    hook_name: String,
-    /// Index of the position of the stable return, [None] if
-    /// none returns are stable
-    index: Option<usize>,
+    pub(crate) hook_name: String,
+
+    /// The kind of (stable) result returned by the hook.
+    pub(crate) result: StableHookResult,
+
+    /// `true` if it's a built-in React hook. For built-in hooks, we verify
+    /// whether they are imported from the React library. For user-defined
+    /// hooks, we don't.
+    pub(crate) builtin: bool,
 }
 
 impl StableReactHookConfiguration {
-    pub fn new(hook_name: &str, index: Option<usize>) -> Self {
+    pub fn new(hook_name: &str, result: StableHookResult, builtin: bool) -> Self {
         Self {
             hook_name: hook_name.into(),
-            index,
+            result,
+            builtin,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub enum StableHookResult {
+    /// Used to indicate the hook does not have a stable result.
+    #[default]
+    None,
+
+    /// Used to indicate the identity of the result value is stable.
+    ///
+    /// Note this does not imply internal stability. For instance, the ref
+    /// objects returned by React's `useRef()` always have a stable identity,
+    /// but their internal value may be mutable.
+    Identity,
+
+    /// Used to indicate the hook returns an array and some of its indices have
+    /// stable identities.
+    ///
+    /// For example, React's `useState()` hook returns a stable function at
+    /// index 1.
+    Indices(Vec<u8>),
+}
+
+impl biome_deserialize::Deserializable for StableHookResult {
+    fn deserialize(
+        value: &impl biome_deserialize::DeserializableValue,
+        name: &str,
+        diagnostics: &mut Vec<biome_deserialize::DeserializationDiagnostic>,
+    ) -> Option<Self> {
+        value.deserialize(StableResultVisitor, name, diagnostics)
+    }
+}
+
+struct StableResultVisitor;
+impl DeserializationVisitor for StableResultVisitor {
+    type Output = StableHookResult;
+
+    const EXPECTED_TYPE: VisitableType = VisitableType::ARRAY
+        .union(VisitableType::BOOL)
+        .union(VisitableType::NUMBER);
+
+    fn visit_array(
+        self,
+        items: impl Iterator<Item = Option<impl biome_deserialize::DeserializableValue>>,
+        _range: TextRange,
+        _name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self::Output> {
+        let indices = items
+            .filter_map(|value| {
+                biome_deserialize::Deserializable::deserialize(&value?, "", diagnostics)
+            })
+            .collect();
+
+        Some(StableHookResult::Indices(indices))
+    }
+
+    fn visit_bool(
+        self,
+        value: bool,
+        range: TextRange,
+        _name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self::Output> {
+        match value {
+            true => Some(StableHookResult::Identity),
+            false => {
+                diagnostics.push(
+                    DeserializationDiagnostic::new(
+                        markup! { "This hook is configured to not have a stable result" },
+                    )
+                    .with_custom_severity(Severity::Warning)
+                    .with_range(range),
+                );
+                Some(StableHookResult::None)
+            }
+        }
+    }
+
+    fn visit_number(
+        self,
+        value: biome_deserialize::TextNumber,
+        range: TextRange,
+        _name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self::Output> {
+        match value.parse::<u8>() {
+            Ok(index) => Some(StableHookResult::Indices(vec![index])),
+            Err(_) => {
+                diagnostics.push(DeserializationDiagnostic::new_out_of_bound_integer(
+                    0, 255, range,
+                ));
+                None
+            }
         }
     }
 }
@@ -243,7 +352,8 @@ pub fn is_binding_react_stable(
     };
     let index = binding
         .parent::<JsArrayBindingPatternElement>()
-        .map(|parent| parent.syntax().index() / 2);
+        .map(|parent| parent.syntax().index() / 2)
+        .and_then(|index| index.try_into().ok());
     let Some(callee) = declarator
         .initializer()
         .and_then(|initializer| initializer.expression().ok())
@@ -252,8 +362,17 @@ pub fn is_binding_react_stable(
         return false;
     };
     stable_config.iter().any(|config| {
-        is_react_call_api(&callee, model, ReactLibrary::React, &config.hook_name)
-            && index == config.index
+        if config.builtin
+            && !is_react_call_api(&callee, model, ReactLibrary::React, &config.hook_name)
+        {
+            return false;
+        }
+
+        match (&config.result, index) {
+            (StableHookResult::Identity, index) => index.is_none(),
+            (StableHookResult::Indices(indices), Some(index)) => indices.contains(&index),
+            (_, _) => false,
+        }
     })
 }
 
@@ -319,8 +438,8 @@ mod test {
         let set_name = AnyJsIdentifierBinding::cast(node).unwrap();
 
         let config = FxHashSet::from_iter([
-            StableReactHookConfiguration::new("useRef", None),
-            StableReactHookConfiguration::new("useState", Some(1)),
+            StableReactHookConfiguration::new("useRef", StableHookResult::Identity, true),
+            StableReactHookConfiguration::new("useState", StableHookResult::Indices(vec![1]), true),
         ]);
 
         assert!(is_binding_react_stable(
@@ -349,8 +468,8 @@ mod test {
         let set_name = AnyJsIdentifierBinding::cast(node).unwrap();
 
         let config = FxHashSet::from_iter([
-            StableReactHookConfiguration::new("useRef", None),
-            StableReactHookConfiguration::new("useState", Some(1)),
+            StableReactHookConfiguration::new("useRef", StableHookResult::Identity, true),
+            StableReactHookConfiguration::new("useState", StableHookResult::Indices(vec![1]), true),
         ]);
 
         assert!(is_binding_react_stable(

--- a/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/correctness/use_exhaustive_dependencies.rs
@@ -143,11 +143,16 @@ declare_rule! {
     /// ## Options
     ///
     /// Allows to specify custom hooks - from libraries or internal projects -
-    /// for which dependencies should be checked.
+    /// for which dependencies should be checked and/or which are known to have
+    /// stable return values.
     ///
-    /// For every hook, you should specify the index of the closure (whose
-    /// dependencies should be checked) and the index of the dependencies array
-    /// to validate against.
+    /// ### Validating dependencies
+    ///
+    /// For every hook for which you want the dependencies to be validated, you
+    /// should specify the index of the closure and the index of the
+    /// dependencies array to validate against.
+    ///
+    /// #### Example
     ///
     /// ```json
     /// {
@@ -168,6 +173,44 @@ declare_rule! {
     ///     const location = useLocation(() => {}, []);
     ///     const query = useQuery([], () => {});
     /// }
+    /// ```
+    ///
+    /// ### Stable results
+    ///
+    /// When a hook is known to have a stable return value (its identity doesn't
+    /// change across invocations), that value doesn't need to be specified in
+    /// dependency arrays. For example, setters returned by React's `useState`
+    /// hook always have the same identity and should be omitted as such.
+    ///
+    /// You can configure custom hooks that return stable results in one of
+    /// three ways:
+    ///
+    /// * `"stableResult": true` -- marks the return value as stable. An example
+    ///   of a React hook that would be configured like this is `useRef()`.
+    /// * `"stableResult": [1]` -- expects the return value to be an array and
+    ///   marks the given index or indices to be stable. An example of a React
+    ///   hook that would be configured like this is `useState()`.
+    /// * `"stableResult": 1` -- shorthand for `"stableResult": [1]`.
+    ///
+    /// #### Example
+    ///
+    /// ```json
+    /// {
+    ///     "//": "...",
+    ///     "options": {
+    ///         "hooks": [
+    ///             { "name": "useDispatch", "stableResult": true }
+    ///         ]
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// With this configuration, the following is valid:
+    ///
+    /// ```js
+    /// const dispatch = useDispatch();
+    /// // No need to list `dispatch` as dependency:
+    /// const doAction = useCallback(() => dispatch(someAction()), []);
     /// ```
     ///
     pub UseExhaustiveDependencies {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/invalidIndices.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/invalidIndices.js.snap
@@ -1,0 +1,44 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidIndices.js
+---
+# Input
+```jsx
+
+```
+
+# Diagnostics
+```
+invalidIndices.options:15:37 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The number should be an integer between 0 and 255.
+  
+    13 │                                 "dependenciesIndex": 0,
+    14 │                                 "stableResult": [
+  > 15 │                                     -1
+       │                                     ^^
+    16 │                                 ]
+    17 │                             }
+  
+
+```
+
+```
+invalidIndices.options:10:29 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × closureIndex and dependenciesIndex may not be the same
+  
+     8 │                     "options": {
+     9 │                         "hooks": [
+  > 10 │                             {
+       │                             ^
+  > 11 │                                 "name": "useMyEffect",
+        ...
+  > 16 │                                 ]
+  > 17 │                             }
+       │                             ^
+    18 │                         ]
+    19 │                     }
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/invalidIndices.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/invalidIndices.options.json
@@ -8,14 +8,11 @@
                     "options": {
                         "hooks": [
                             {
-                                "name": "useEffect",
+                                "name": "useMyEffect",
                                 "closureIndex": 0,
-                                "dependenciesIndex": 1
-                            },
-                            {
-                                "name": "useState",
+                                "dependenciesIndex": 0,
                                 "stableResult": [
-                                    1
+                                    -1
                                 ]
                             }
                         ]

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'library-reexporting-react';
+import * as ReactReexport from 'library-reexporting-react';
 
 function MyComponent25() {
     const [calc, setCalc] = useState(0);
@@ -6,6 +7,18 @@ function MyComponent25() {
     // they're imported from the "react" library. Explicitly configuring them
     // in the hooks array (as if they are user-provided hooks) overrides this.
     useEffect(() => {
+        if (calc === 0) {
+            setCalc(1);
+        }
+    }, []);
+}
+
+function MyComponent26() {
+    const [calc, setCalc] = ReactReexport.useState(0);
+    // Built-in hooks such as `useEffect()` normally only get validated when
+    // they're imported from the "react" library. Explicitly configuring them
+    // in the hooks array (as if they are user-provided hooks) overrides this.
+    ReactReexport.useEffect(() => {
         if (calc === 0) {
             setCalc(1);
         }

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js.snap
@@ -5,6 +5,7 @@ expression: issue1931.js
 # Input
 ```jsx
 import { useEffect, useState } from 'library-reexporting-react';
+import * as ReactReexport from 'library-reexporting-react';
 
 function MyComponent25() {
     const [calc, setCalc] = useState(0);
@@ -18,29 +19,41 @@ function MyComponent25() {
     }, []);
 }
 
+function MyComponent26() {
+    const [calc, setCalc] = ReactReexport.useState(0);
+    // Built-in hooks such as `useEffect()` normally only get validated when
+    // they're imported from the "react" library. Explicitly configuring them
+    // in the hooks array (as if they are user-provided hooks) overrides this.
+    ReactReexport.useEffect(() => {
+        if (calc === 0) {
+            setCalc(1);
+        }
+    }, []);
+}
+
 ```
 
 # Diagnostics
 ```
-issue1931.js:8:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+issue1931.js:9:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This hook does not specify all of its dependencies: calc
   
-     6 │     // they're imported from the "react" library. Explicitly configuring them
-     7 │     // in the hooks array (as if they are user-provided hooks) overrides this.
-   > 8 │     useEffect(() => {
+     7 │     // they're imported from the "react" library. Explicitly configuring them
+     8 │     // in the hooks array (as if they are user-provided hooks) overrides this.
+   > 9 │     useEffect(() => {
        │     ^^^^^^^^^
-     9 │         if (calc === 0) {
-    10 │             setCalc(1);
+    10 │         if (calc === 0) {
+    11 │             setCalc(1);
   
   i This dependency is not specified in the hook dependency list.
   
-     7 │     // in the hooks array (as if they are user-provided hooks) overrides this.
-     8 │     useEffect(() => {
-   > 9 │         if (calc === 0) {
+     8 │     // in the hooks array (as if they are user-provided hooks) overrides this.
+     9 │     useEffect(() => {
+  > 10 │         if (calc === 0) {
        │             ^^^^
-    10 │             setCalc(1);
-    11 │         }
+    11 │             setCalc(1);
+    12 │         }
   
   i Either include it or remove the dependency array
   
@@ -48,25 +61,25 @@ issue1931.js:8:5 lint/correctness/useExhaustiveDependencies ━━━━━━�
 ```
 
 ```
-issue1931.js:8:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+issue1931.js:21:19 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This hook does not specify all of its dependencies: setCalc
+  ! This hook does not specify all of its dependencies: calc
   
-     6 │     // they're imported from the "react" library. Explicitly configuring them
-     7 │     // in the hooks array (as if they are user-provided hooks) overrides this.
-   > 8 │     useEffect(() => {
-       │     ^^^^^^^^^
-     9 │         if (calc === 0) {
-    10 │             setCalc(1);
+    19 │     // they're imported from the "react" library. Explicitly configuring them
+    20 │     // in the hooks array (as if they are user-provided hooks) overrides this.
+  > 21 │     ReactReexport.useEffect(() => {
+       │                   ^^^^^^^^^
+    22 │         if (calc === 0) {
+    23 │             setCalc(1);
   
   i This dependency is not specified in the hook dependency list.
   
-     8 │     useEffect(() => {
-     9 │         if (calc === 0) {
-  > 10 │             setCalc(1);
-       │             ^^^^^^^
-    11 │         }
-    12 │     }, []);
+    20 │     // in the hooks array (as if they are user-provided hooks) overrides this.
+    21 │     ReactReexport.useEffect(() => {
+  > 22 │         if (calc === 0) {
+       │             ^^^^
+    23 │             setCalc(1);
+    24 │         }
   
   i Either include it or remove the dependency array
   

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResult.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResult.js
@@ -1,0 +1,7 @@
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+
+function MyComponent25() {
+    const dispatch = useDispatch();
+    const doAction = useCallback(() => dispatch(someAction()), []);
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResult.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResult.js.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: stableResult.js
+---
+# Input
+```jsx
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+
+function MyComponent25() {
+    const dispatch = useDispatch();
+    const doAction = useCallback(() => dispatch(someAction()), []);
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResult.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResult.options.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+    "linter": {
+        "rules": {
+            "correctness": {
+                "useExhaustiveDependencies": {
+                    "level": "error",
+                    "options": {
+                        "hooks": [
+                            {
+                                "name": "useDispatch",
+                                "stableResult": true
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -52,7 +52,7 @@ pub struct Rules {
 }
 impl DeserializableValidator for Rules {
     fn validate(
-        &self,
+        &mut self,
         _name: &str,
         range: TextRange,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
@@ -448,7 +448,7 @@ pub struct A11y {
 }
 impl DeserializableValidator for A11y {
     fn validate(
-        &self,
+        &mut self,
         _name: &str,
         range: TextRange,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
@@ -1164,7 +1164,7 @@ pub struct Complexity {
 }
 impl DeserializableValidator for Complexity {
     fn validate(
-        &self,
+        &mut self,
         _name: &str,
         range: TextRange,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
@@ -1812,7 +1812,7 @@ pub struct Correctness {
 }
 impl DeserializableValidator for Correctness {
     fn validate(
-        &self,
+        &mut self,
         _name: &str,
         range: TextRange,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
@@ -2614,7 +2614,7 @@ pub struct Nursery {
 }
 impl DeserializableValidator for Nursery {
     fn validate(
-        &self,
+        &mut self,
         _name: &str,
         range: TextRange,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
@@ -3375,7 +3375,7 @@ pub struct Performance {
 }
 impl DeserializableValidator for Performance {
     fn validate(
-        &self,
+        &mut self,
         _name: &str,
         range: TextRange,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
@@ -3511,7 +3511,7 @@ pub struct Security {
 }
 impl DeserializableValidator for Security {
     fn validate(
-        &self,
+        &mut self,
         _name: &str,
         range: TextRange,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
@@ -3745,7 +3745,7 @@ pub struct Style {
 }
 impl DeserializableValidator for Style {
     fn validate(
-        &self,
+        &mut self,
         _name: &str,
         range: TextRange,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
@@ -4547,7 +4547,7 @@ pub struct Suspicious {
 }
 impl DeserializableValidator for Suspicious {
     fn validate(
-        &self,
+        &mut self,
         _name: &str,
         range: TextRange,
         diagnostics: &mut Vec<DeserializationDiagnostic>,

--- a/crates/biome_service/src/configuration/vcs.rs
+++ b/crates/biome_service/src/configuration/vcs.rs
@@ -67,7 +67,7 @@ impl PartialVcsConfiguration {
 
 impl DeserializableValidator for PartialVcsConfiguration {
     fn validate(
-        &self,
+        &mut self,
         _name: &str,
         range: biome_rowan::TextRange,
         diagnostics: &mut Vec<DeserializationDiagnostic>,

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1552,9 +1552,9 @@ export interface ComplexityOptions {
  */
 export interface HooksOptions {
 	/**
-	 * List of safe hooks
+	 * List of hooks of which the dependencies should be validated.
 	 */
-	hooks: Hooks[];
+	hooks: Hook[];
 }
 /**
  * Options for the `useHookAtTopLevel` rule have been deprecated, since we now use the React hook naming convention to determine whether a function is a hook.
@@ -1625,21 +1625,31 @@ export interface NamingConventionOptions {
 	 */
 	strictCase: boolean;
 }
-export interface Hooks {
+export interface Hook {
 	/**
 	* The "position" of the closure function, starting from zero.
 
-### Example 
+For example, for React's `useEffect()` hook, the closure index is 0. 
 	 */
 	closureIndex?: number;
 	/**
-	 * The "position" of the array of dependencies, starting from zero.
+	* The "position" of the array of dependencies, starting from zero.
+
+For example, for React's `useEffect()` hook, the dependencies index is 1. 
 	 */
 	dependenciesIndex?: number;
 	/**
-	 * The name of the hook
+	 * The name of the hook.
 	 */
 	name: string;
+	/**
+	* Whether the result of the hook is stable.
+
+Set to `true` to mark the identity of the hook's return value as stable, or use a number/an array of numbers to mark the "positions" in the return array as stable.
+
+For example, for React's `useRef()` hook the value would be `true`, while for `useState()` it would be `[1]`. 
+	 */
+	stableResult: StableHookResult;
 }
 export type ConsistentArrayType = "shorthand" | "generic";
 export type FilenameCases = FilenameCase[];
@@ -1647,6 +1657,7 @@ export type FilenameCases = FilenameCase[];
  * Supported cases for TypeScript `enum` member names.
  */
 export type EnumMemberCase = "PascalCase" | "CONSTANT_CASE" | "camelCase";
+export type StableHookResult = "None" | "Identity" | { Indices: number[] };
 /**
  * Supported cases for TypeScript `enum` member names.
  */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1014,23 +1014,27 @@
 			},
 			"additionalProperties": false
 		},
-		"Hooks": {
+		"Hook": {
 			"type": "object",
-			"required": ["name"],
+			"required": ["name", "stableResult"],
 			"properties": {
 				"closureIndex": {
-					"description": "The \"position\" of the closure function, starting from zero.\n\n### Example",
+					"description": "The \"position\" of the closure function, starting from zero.\n\nFor example, for React's `useEffect()` hook, the closure index is 0.",
 					"type": ["integer", "null"],
-					"format": "uint",
+					"format": "uint8",
 					"minimum": 0.0
 				},
 				"dependenciesIndex": {
-					"description": "The \"position\" of the array of dependencies, starting from zero.",
+					"description": "The \"position\" of the array of dependencies, starting from zero.\n\nFor example, for React's `useEffect()` hook, the dependencies index is 1.",
 					"type": ["integer", "null"],
-					"format": "uint",
+					"format": "uint8",
 					"minimum": 0.0
 				},
-				"name": { "description": "The name of the hook", "type": "string" }
+				"name": { "description": "The name of the hook.", "type": "string" },
+				"stableResult": {
+					"description": "Whether the result of the hook is stable.\n\nSet to `true` to mark the identity of the hook's return value as stable, or use a number/an array of numbers to mark the \"positions\" in the return array as stable.\n\nFor example, for React's `useRef()` hook the value would be `true`, while for `useState()` it would be `[1]`.",
+					"allOf": [{ "$ref": "#/definitions/StableHookResult" }]
+				}
 			},
 			"additionalProperties": false
 		},
@@ -1046,9 +1050,9 @@
 			"required": ["hooks"],
 			"properties": {
 				"hooks": {
-					"description": "List of safe hooks",
+					"description": "List of hooks of which the dependencies should be validated.",
 					"type": "array",
-					"items": { "$ref": "#/definitions/Hooks" }
+					"items": { "$ref": "#/definitions/Hook" }
 				}
 			},
 			"additionalProperties": false
@@ -2024,6 +2028,32 @@
 			"additionalProperties": false
 		},
 		"Semicolons": { "type": "string", "enum": ["always", "asNeeded"] },
+		"StableHookResult": {
+			"oneOf": [
+				{
+					"description": "Used to indicate the hook does not have a stable result.",
+					"type": "string",
+					"enum": ["None"]
+				},
+				{
+					"description": "Used to indicate the identity of the result value is stable.\n\nNote this does not imply internal stability. For instance, the ref objects returned by React's `useRef()` always have a stable identity, but their internal value may be mutable.",
+					"type": "string",
+					"enum": ["Identity"]
+				},
+				{
+					"description": "Used to indicate the hook returns an array and some of its indices have stable identities.\n\nFor example, React's `useState()` hook returns a stable function at index 1.",
+					"type": "object",
+					"required": ["Indices"],
+					"properties": {
+						"Indices": {
+							"type": "array",
+							"items": { "type": "integer", "format": "uint8", "minimum": 0.0 }
+						}
+					},
+					"additionalProperties": false
+				}
+			]
+		},
 		"StringSet": {
 			"type": "array",
 			"items": { "type": "string" },

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -85,6 +85,34 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @arendjr
 
+- Implemented [#1128](https://github.com/biomejs/biome/issues/1128). User-provided React hooks can
+  now be configured to return stable results. For example:
+
+  ```json
+  "useExhaustiveDependencies": {
+      "level": "error",
+      "options": {
+          "hooks": [{
+              "name": "useMyState",
+              "stableResult": [
+                  1
+              ]
+          }]
+      }
+  }
+  ```
+
+  This will allow the following to be validated:
+
+  ```js
+  const [myState, setMyState] = useMyState();
+  const toggleMyState = useCallback(() => {
+    setMyState(!myState);
+  }, [myState]); // Only `myState` needs to be specified here.
+  ```
+
+  Contributed by @arendjr
+
 #### Bug fixes
 
 - Fix [#1748](https://github.com/biomejs/biome/issues/1748). Now for the following case we won't provide an unsafe fix

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -86,7 +86,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Contributed by @arendjr
 
 - Implemented [#1128](https://github.com/biomejs/biome/issues/1128). User-provided React hooks can
-  now be configured to return stable results. For example:
+  now be configured to track stable results. For example:
 
   ```json
   "useExhaustiveDependencies": {

--- a/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
+++ b/website/src/content/docs/linter/rules/use-exhaustive-dependencies.md
@@ -223,11 +223,16 @@ function component() {
 ## Options
 
 Allows to specify custom hooks - from libraries or internal projects -
-for which dependencies should be checked.
+for which dependencies should be checked and/or which are known to have
+stable return values.
 
-For every hook, you should specify the index of the closure (whose
-dependencies should be checked) and the index of the dependencies array
-to validate against.
+### Validating dependencies
+
+For every hook for which you want the dependencies to be validated, you
+should specify the index of the closure and the index of the
+dependencies array to validate against.
+
+#### Example
 
 ```json
 {
@@ -248,6 +253,44 @@ function Foo() {
     const location = useLocation(() => {}, []);
     const query = useQuery([], () => {});
 }
+```
+
+### Stable results
+
+When a hook is known to have a stable return value (its identity doesn't
+change across invocations), that value doesn't need to be specified in
+dependency arrays. For example, setters returned by React's `useState`
+hook always have the same identity and should be omitted as such.
+
+You can configure custom hooks that return stable results in one of
+three ways:
+
+- `"stableResult": true` -- marks the return value as stable. An example
+of a React hook that would be configured like this is `useRef()`.
+- `"stableResult": [1]` -- expects the return value to be an array and
+marks the given index or indices to be stable. An example of a React
+hook that would be configured like this is `useState()`.
+- `"stableResult": 1` -- shorthand for `"stableResult": [1]`.
+
+#### Example
+
+```json
+{
+    "//": "...",
+    "options": {
+        "hooks": [
+            { "name": "useDispatch", "stableResult": true }
+        ]
+    }
+}
+```
+
+With this configuration, the following is valid:
+
+```jsx
+const dispatch = useDispatch();
+// No need to list `dispatch` as dependency:
+const doAction = useCallback(() => dispatch(someAction()), []);
 ```
 
 ## Related links

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -164,7 +164,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
 
         impl DeserializableValidator for Rules {
             fn validate(
-                &self,
+                &mut self,
                 _name: &str,
                 range: TextRange,
                 diagnostics: &mut Vec<DeserializationDiagnostic>,
@@ -429,7 +429,7 @@ fn generate_struct(group: &str, rules: &BTreeMap<&'static str, RuleMetadata>) ->
 
         impl DeserializableValidator for #group_struct_name {
             fn validate(
-                &self,
+                &mut self,
                 _name: &str,
                 range: TextRange,
                 diagnostics: &mut Vec<DeserializationDiagnostic>,


### PR DESCRIPTION
## Summary

User-provided React hooks can now be configured to return stable results.

Implements #1128.

I went for a slightly different configuration syntax than suggested in #1128 to avoid repetition of hooks that have both stable results and a dependencies array to be validated.

## Test Plan

Added and updated test cases.
