### PR TITLE
fix: concurrency deadlock

### DIFF
--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -110,9 +110,7 @@ impl WorkspaceServer {
             .get(path)
             .map(|doc| doc.file_source_index)
             .and_then(|index| self.get_source(index))
-            .unwrap_or(
-                DocumentFileSource::from_path(path)
-            )
+            .unwrap_or(DocumentFileSource::from_path(path))
     }
 
     /// Return an error factory function for unsupported features at a given path
@@ -387,9 +385,11 @@ impl Workspace for WorkspaceServer {
 
     /// Add a new file to the workspace
     fn open_file(&self, params: OpenFileParams) -> Result<(), WorkspaceError> {
-        let index = self.set_source(params
-            .document_file_source
-            .unwrap_or(DocumentFileSource::from_path(&params.path)));
+        let index = self.set_source(
+            params
+                .document_file_source
+                .unwrap_or(DocumentFileSource::from_path(&params.path)),
+        );
         self.syntax.remove(&params.path);
         self.documents.insert(
             params.path,


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

To fix the deadlock, I created two functions get/set to manage the `IndexSet<DocumentFileSource>` list. By doing so, we reduce the "window" of when the lock is actually owned by a thread. In the function `get_parse`, we were actually trying to lock the same resource multiple times without releasing them.

By using two small functions, the lock is released when the scope of the function ends, making it safer.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I run our internal `pnpm check` multiple time and now there's not deadlock

<!-- What demonstrates that your implementation is correct? -->
