### PR TITLE
refactor(noUndeclaredDependencies): ignore imports with a protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,7 +335,11 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Contributed by @DaniGuardiola
 
 - Add rule [noUndeclaredependencies](https://biomejs.dev/linter/rules/no-undeclared-dependencies), to detect the use of
-  dependencies that aren't present in the `package.json`
+  dependencies that aren't present in the `package.json`.
+
+  The rule ignores imports using a protocol such as `node:`, `bun:`, `jsr:`, `https:`.
+
+  Contributed by @ematipico and @Conaclos
 
 - Add rule [noNamespaceImport](https://biomejs.dev/linter/rules/no-namespace-import), to report namespace imports:
 

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_undeclared_dependencies.rs
@@ -10,6 +10,8 @@ declare_rule! {
     /// Indirect dependencies will trigger the rule because they aren't declared in the `package.json`. This means that if package `@org/foo` has a dependency on `lodash`, and then you use
     /// `import "lodash"` somewhere in your project, the rule will trigger a diagnostic for this import.
     ///
+    /// The rule ignores imports using a protocol such as `node:`, `bun:`, `jsr:`, `https:`.
+    ///
     /// ## Examples
     ///
     /// ### Invalid
@@ -18,6 +20,15 @@ declare_rule! {
     /// import "vite";
     /// ```
     ///
+    /// ### Valid
+    ///
+    /// ```js,ignore
+    /// import { A } from "./local.js";
+    /// ```
+    ///
+    /// ```js,ignore
+    /// import assert from "node:assert";
+    /// ```
     pub NoUndeclaredDependencies {
         version: "next",
         name: "noUndeclaredDependencies",
@@ -35,6 +46,8 @@ impl Rule for NoUndeclaredDependencies {
         let node = ctx.query();
         let text = node.inner_string_text()?;
         if !text.text().starts_with('.')
+            // Ignore imports using a protocol such as `node:`, `bun:`, `jsr:`, `https:`, and so on.
+            && !text.text().contains(':')
             && !ctx.is_dependency(text.text())
             && !ctx.is_dev_dependency(text.text())
         {

--- a/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.js
@@ -7,3 +7,8 @@ import("@testing-library/react");
 require("./valid");
 require("react");
 require("@testing-library/react");
+
+import "node:assert";
+require("node:assert");
+
+import "bun:test";

--- a/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.js.snap
@@ -14,6 +14,11 @@ require("./valid");
 require("react");
 require("@testing-library/react");
 
+import "node:assert";
+require("node:assert");
+
+import "bun:test";
+
 ```
 
 

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -341,7 +341,11 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Contributed by @DaniGuardiola
 
 - Add rule [noUndeclaredependencies](https://biomejs.dev/linter/rules/no-undeclared-dependencies), to detect the use of
-  dependencies that aren't present in the `package.json`
+  dependencies that aren't present in the `package.json`.
+
+  The rule ignores imports using a protocol such as `node:`, `bun:`, `jsr:`, `https:`.
+
+  Contributed by @ematipico and @Conaclos
 
 - Add rule [noNamespaceImport](https://biomejs.dev/linter/rules/no-namespace-import), to report namespace imports:
 

--- a/website/src/content/docs/linter/rules/no-undeclared-dependencies.md
+++ b/website/src/content/docs/linter/rules/no-undeclared-dependencies.md
@@ -17,12 +17,24 @@ Disallow the use of dependencies that aren't specified in the `package.json`.
 Indirect dependencies will trigger the rule because they aren't declared in the `package.json`. This means that if package `@org/foo` has a dependency on `lodash`, and then you use
 `import "lodash"` somewhere in your project, the rule will trigger a diagnostic for this import.
 
+The rule ignores imports using a protocol such as `node:`, `bun:`, `jsr:`, `https:`.
+
 ## Examples
 
 ### Invalid
 
 ```jsx
 import "vite";
+```
+
+### Valid
+
+```jsx
+import { A } from "./local.js";
+```
+
+```jsx
+import assert from "node:assert";
 ```
 
 ## Related links


### PR DESCRIPTION
## Summary

`noUndeclaredDependencies` currently reports runtime dependencies such as `node:assert` or `bun:test`.
With this PR, `noUndeclaredDependencies` ignores all dependencies that use a protocol.

## Test Plan

I added some tests.
