### PR TITLE
fix: website favicon

### DIFF
--- a/website/public/img/favicon.svg
+++ b/website/public/img/favicon.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg width="64" height="55.425" version="1.0" xmlns="http://www.w3.org/2000/svg">
+<svg width="64" height="64" version="1.0" xmlns="http://www.w3.org/2000/svg">
  <rect id="background" width="100%" height="100%" fill="none" />
- <path id="emblem" d="m32 0-14.255 24.69c5.409-1.6676 11.228-1.9148 16.869-0.58434l4.8177 1.1372-4.5328 19.22-4.8247-1.1372c-5.9293-1.3987-11.628 1.716-14.036 6.6851l-4.4595-2.1575c3.4034-7.0291 11.424-11.285 19.636-9.3476l2.2595-9.579c-8.0938-1.9081-16.624-9e-3 -23.145 5.153-6.5204 5.1607-10.329 13.028-10.329 21.344l64 7.9e-4z" fill="#60a5fa" stroke-linecap="square" stroke-width="4.8768" style="paint-order:markers fill stroke" />
+ <path id="emblem" d="m32 4.2875-14.255 24.69c5.409-1.6676 11.228-1.9148 16.869-0.58434l4.8177 1.1372-4.5328 19.22-4.8247-1.1372c-5.9293-1.3987-11.628 1.716-14.036 6.6851l-4.4595-2.1575c3.4034-7.0291 11.424-11.285 19.636-9.3476l2.2595-9.579c-8.0938-1.9081-16.624-9e-3 -23.145 5.153-6.5204 5.1607-10.329 13.028-10.329 21.344l64 7.9e-4z" fill="#60a5fa" stroke-linecap="square" stroke-width="4.8768" style="paint-order:markers fill stroke" />
 </svg>


### PR DESCRIPTION
## Summary

Favicon should be a square so it won't get stretched when displayed on browser tabs.

Fixes #1987.

## Test Plan

Serve the website locally and visually confirm the icon is not stretched anymore.
