### PR TITLE
fix(playground): recognize typescript definition files by their file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -604,6 +604,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @printfn
 
+### Website
+
+#### Bug fixes
+
+- Fix [#1981](https://github.com/biomejs/biome/issues/1981). Identify TypeScript definition files by their file path within the playground. Contributed by @ah-yu
+
 ## 1.5.3 (2024-01-22)
 
 ### LSP

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -110,6 +110,7 @@ impl DocumentFileSource {
             "cts" => JsFileSource::ts()
                 .with_module_kind(ModuleKind::Script)
                 .into(),
+            "d.ts" | "d.mts" | "d.cts" => JsFileSource::d_ts().into(),
             "tsx" => JsFileSource::tsx().into(),
             "json" => JsonFileSource::json().into(),
             "jsonc" => JsonFileSource::jsonc().into(),
@@ -154,8 +155,14 @@ impl DocumentFileSource {
 
     /// Returns the language corresponding to the file path
     pub fn from_path(path: &Path) -> Self {
-        path.extension()
-            .and_then(|path| path.to_str())
+        let extension = match path {
+            _ if path.to_str().is_some_and(|p| p.ends_with(".d.ts")) => Some("d.ts"),
+            _ if path.to_str().is_some_and(|p| p.ends_with(".d.mts")) => Some("d.mts"),
+            _ if path.to_str().is_some_and(|p| p.ends_with(".d.cts")) => Some("d.cts"),
+            path => path.extension().and_then(|path| path.to_str()),
+        };
+
+        extension
             .map(DocumentFileSource::from_extension)
             .unwrap_or(DocumentFileSource::Unknown)
     }
@@ -163,8 +170,14 @@ impl DocumentFileSource {
     /// Returns the language corresponding to the file path
     /// relying on the file extension and the known files.
     pub fn from_path_and_known_filename(path: &Path) -> Self {
-        path.extension()
-            .and_then(OsStr::to_str)
+        let extension = match path {
+            _ if path.to_str().is_some_and(|p| p.ends_with(".d.ts")) => Some("d.ts"),
+            _ if path.to_str().is_some_and(|p| p.ends_with(".d.mts")) => Some("d.mts"),
+            _ if path.to_str().is_some_and(|p| p.ends_with(".d.cts")) => Some("d.cts"),
+            path => path.extension().and_then(|path| path.to_str()),
+        };
+
+        extension
             .map(DocumentFileSource::from_extension)
             .or(path
                 .file_name()

--- a/crates/biome_service/tests/workspace.rs
+++ b/crates/biome_service/tests/workspace.rs
@@ -28,3 +28,22 @@ fn debug_control_flow() {
 
     assert_eq!(cfg, GRAPH);
 }
+
+#[test]
+fn recognize_typescript_definition_file() {
+    let workspace = server();
+
+    let file = FileGuard::open(
+        workspace.as_ref(),
+        OpenFileParams {
+            path: BiomePath::new("file.d.ts"),
+            // the following code snippet can be correctly parsed in .d.ts file but not in .ts file
+            content: "export const foo: number".into(),
+            version: 0,
+            document_file_source: None,
+        },
+    )
+    .unwrap();
+
+    assert!(file.format_file().is_ok());
+}

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -610,6 +610,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @printfn
 
+### Website
+
+#### Bug fixes
+
+- Fix [#1981](https://github.com/biomejs/biome/issues/1981). Identify TypeScript definition files by their file path within the playground. Contributed by @ah-yu
+
 ## 1.5.3 (2024-01-22)
 
 ### LSP


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/1981

It seems the playground treats typescript definition files as normal typescript files before

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

Add a new test case
