### PR TITLE
feat(cli): add `--stdio` argument to `lsp-proxy` command

### DIFF
--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -259,6 +259,9 @@ pub enum BiomeCommand {
         /// Allows to set a custom path when discovering the configuration file `biome.json`
         #[bpaf(env("BIOME_CONFIG_PATH"), long("config-path"), argument("PATH"))]
         Option<PathBuf>,
+        /// Bogus argument to make the command work with vscode-languageclient
+        #[bpaf(long("stdio"), hide, hide_usage, switch)]
+        bool,
     ),
     /// It updates the configuration when there are breaking changes
     #[bpaf(command)]
@@ -327,7 +330,7 @@ impl BiomeCommand {
             | BiomeCommand::Ci { cli_options, .. }
             | BiomeCommand::Format { cli_options, .. }
             | BiomeCommand::Migrate { cli_options, .. } => cli_options.colors.as_ref(),
-            BiomeCommand::LspProxy(_)
+            BiomeCommand::LspProxy(_, _)
             | BiomeCommand::Start(_)
             | BiomeCommand::Stop
             | BiomeCommand::Init(_)
@@ -350,7 +353,7 @@ impl BiomeCommand {
             | BiomeCommand::Start(_)
             | BiomeCommand::Stop
             | BiomeCommand::Explain { .. }
-            | BiomeCommand::LspProxy(_)
+            | BiomeCommand::LspProxy(_, _)
             | BiomeCommand::RunServer { .. }
             | BiomeCommand::PrintSocket => false,
         }
@@ -373,7 +376,7 @@ impl BiomeCommand {
             | BiomeCommand::Stop
             | BiomeCommand::Init(_)
             | BiomeCommand::Explain { .. }
-            | BiomeCommand::LspProxy(_)
+            | BiomeCommand::LspProxy(_, _)
             | BiomeCommand::RunServer { .. }
             | BiomeCommand::PrintSocket => false,
         }
@@ -387,7 +390,7 @@ impl BiomeCommand {
             | BiomeCommand::Ci { cli_options, .. }
             | BiomeCommand::Migrate { cli_options, .. } => cli_options.log_level.clone(),
             BiomeCommand::Version(_)
-            | BiomeCommand::LspProxy(_)
+            | BiomeCommand::LspProxy(_, _)
             | BiomeCommand::Rage(..)
             | BiomeCommand::Start(_)
             | BiomeCommand::Stop
@@ -406,7 +409,7 @@ impl BiomeCommand {
             | BiomeCommand::Migrate { cli_options, .. } => cli_options.log_kind.clone(),
             BiomeCommand::Version(_)
             | BiomeCommand::Rage(..)
-            | BiomeCommand::LspProxy(_)
+            | BiomeCommand::LspProxy(_, _)
             | BiomeCommand::Start(_)
             | BiomeCommand::Stop
             | BiomeCommand::Init(_)

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -188,7 +188,7 @@ impl<'app> CliSession<'app> {
             ),
             BiomeCommand::Explain { doc } => commands::explain::explain(self, doc),
             BiomeCommand::Init(emit_jsonc) => commands::init::init(self, emit_jsonc),
-            BiomeCommand::LspProxy(config_path) => commands::daemon::lsp_proxy(config_path),
+            BiomeCommand::LspProxy(config_path, _) => commands::daemon::lsp_proxy(config_path),
             BiomeCommand::Migrate {
                 cli_options,
                 write,


### PR DESCRIPTION
## Summary

This PR introduces a bogus `--stdio` argument for the `lsp-proxy` command.

According to the [Implementation Considerations](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#implementationConsiderations) section of the LSP specification, it is recommended that language servers support the `--stdio` argument if the server communicates over stdio.

The absence of this argument actually makes it harder to spawn Biome's LSP when using `vscode-languageclient`, because it appends an `--stdio` argument to the command, and since the `lsp-proxy` command does not support it, the binary exits with an error.

By introducing this bogus (and hidden) argument, we make it easier to interface with Biome's LSP.

## Test Plan

Try spawning Biome's LSP using vscode-languageclient:

```ts
new LanguageClient(
	"biome",
	{
		command: bin.fsPath,
		transport: TransportKind.stdio,
		args: ["lsp-proxy"],
	},
	{
		outputChannel: logger,
		traceOutputChannel: window.createOutputChannel(`Biome LSP`, {
			log: true,
		}),
		documentSelector: this.generateDocumentSelector(),
	},
);
```
