### PR TITLE
fix(`useShorthandFunctionType`): generic interface type parameters

### DIFF
--- a/crates/biome_js_analyze/src/analyzers/style/use_shorthand_function_type.rs
+++ b/crates/biome_js_analyze/src/analyzers/style/use_shorthand_function_type.rs
@@ -145,7 +145,8 @@ impl Rule for UseShorthandFunctionType {
                     node,
                 )?),
             )
-            .build();
+            .build()
+            .with_type_parameters(interface_decl.type_parameters());
 
             mutation.replace_node(
                 AnyJsDeclarationClause::from(interface_decl),

--- a/crates/biome_js_analyze/tests/specs/style/useShorthandFunctionType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useShorthandFunctionType/invalid.ts
@@ -31,3 +31,8 @@ type GenericCallSignature<T> = { (arg: T): T };
 
 // Object type with optional call signature
 let optionalCall: { (): number | undefined };
+
+// Generic interface with a call signature
+interface GenericInterface<T> {
+	(value: T): boolean;
+}

--- a/crates/biome_js_analyze/tests/specs/style/useShorthandFunctionType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useShorthandFunctionType/invalid.ts.snap
@@ -38,6 +38,11 @@ type GenericCallSignature<T> = { (arg: T): T };
 // Object type with optional call signature
 let optionalCall: { (): number | undefined };
 
+// Generic interface with a call signature
+interface GenericInterface<T> {
+	(value: T): boolean;
+}
+
 ```
 
 # Diagnostics
@@ -229,6 +234,7 @@ invalid.ts:33:21 lint/style/useShorthandFunctionType  FIXABLE  ━━━━━�
   > 33 │ let optionalCall: { (): number | undefined };
        │                     ^^^^^^^^^^^^^^^^^^^^^^
     34 │ 
+    35 │ // Generic interface with a call signature
   
   i Types containing only a call signature can be shortened to a function type.
   
@@ -239,8 +245,34 @@ invalid.ts:33:21 lint/style/useShorthandFunctionType  FIXABLE  ━━━━━�
     33    │ - let·optionalCall:·{·():·number·|·undefined·};
        33 │ + let·optionalCall:·()·=>·number·|·undefined;
     34 34 │   
+    35 35 │   // Generic interface with a call signature
   
 
 ```
 
+```
+invalid.ts:37:2 lint/style/useShorthandFunctionType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Use a function type instead of a call signature.
+  
+    35 │ // Generic interface with a call signature
+    36 │ interface GenericInterface<T> {
+  > 37 │ 	(value: T): boolean;
+       │ 	^^^^^^^^^^^^^^^^^^^^
+    38 │ }
+    39 │ 
+  
+  i Types containing only a call signature can be shortened to a function type.
+  
+  i Safe fix: Alias a function type instead of using an interface with a call signature.
+  
+    34 34 │   
+    35 35 │   // Generic interface with a call signature
+    36    │ - interface·GenericInterface<T>·{
+    37    │ - → (value:·T):·boolean;
+    38    │ - }
+       36 │ + type·GenericInterface<T>·=·(value:·T)·=>·boolean
+    39 37 │   
+  
+
+```


### PR DESCRIPTION
## Summary

Preserve type parameters of generic interfaces when applying fixes.

Fixes #2015.

## Test Plan

Add an invalid case where a generic interface has a single call signature, and the fix action preserves the type parameters of the generic interface.
