### PR TITLE
fix(playground): fix `bracketSameLine` default

### DIFF
--- a/website/src/playground/PlaygroundLoader.tsx
+++ b/website/src/playground/PlaygroundLoader.tsx
@@ -343,7 +343,7 @@ function initState(
 				searchParams.get("bracketSpacing") === "true" ||
 				defaultPlaygroundState.settings.bracketSpacing,
 			bracketSameLine:
-				searchParams.get("bracketSameLine") === "true" ??
+				searchParams.get("bracketSameLine") === "true" ||
 				defaultPlaygroundState.settings.bracketSameLine,
 			lintRules:
 				(searchParams.get("lintRules") as LintRules) ??


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fix a vite warning around a useless `??` operator

We should probably rethink PlaygroundLoader around the loading of boolean config values, it looks like (haven't tested) the current code will make a `false` value load the default as if it was `null`
![image](https://github.com/biomejs/biome/assets/53496941/a67a50f3-11f4-465f-9984-b455191e7390)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
