### PR TITLE
fix(`overrides`): `json.formatter.trailingCommas` should work

### DIFF
--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -263,7 +263,7 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("Indent size", markup!({DebugDisplayOption(json_formatter_configuration.indent_size)}))}
                             {KeyValuePair("Line ending", markup!({DebugDisplayOption(json_formatter_configuration.line_ending)}))}
                             {KeyValuePair("Line width", markup!({DebugDisplayOption(json_formatter_configuration.line_width.map(|lw| lw.get()))}))}
-                            {KeyValuePair("Trailing Commas", markup!({DebugDisplay(json_formatter_configuration.trailing_commas)}))}
+                            {KeyValuePair("Trailing Commas", markup!({DebugDisplayOption(json_formatter_configuration.trailing_commas)}))}
                         ).fmt(fmt)?;
                     }
 

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -263,7 +263,7 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("Indent size", markup!({DebugDisplayOption(json_formatter_configuration.indent_size)}))}
                             {KeyValuePair("Line ending", markup!({DebugDisplayOption(json_formatter_configuration.line_ending)}))}
                             {KeyValuePair("Line width", markup!({DebugDisplayOption(json_formatter_configuration.line_width.map(|lw| lw.get()))}))}
-                            {KeyValuePair("Trailing Commas", markup!({DebugDisplayOption(json_formatter_configuration.trailing_commas)}))}
+                            {KeyValuePair("Trailing Commas", markup!({DebugDisplay(json_formatter_configuration.trailing_commas)}))}
                         ).fmt(fmt)?;
                     }
 

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -2302,7 +2302,7 @@ fn format_json_when_allow_trailing_commas_write() {
 }
 
 #[test]
-fn format_omits_json_trailing_comma() {
+fn format_json_trailing_commas_none() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
@@ -2338,7 +2338,7 @@ fn format_omits_json_trailing_comma() {
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
-        "format_omits_json_trailing_comma",
+        "format_json_trailing_commas_none",
         fs,
         console,
         result,
@@ -2346,7 +2346,7 @@ fn format_omits_json_trailing_comma() {
 }
 
 #[test]
-fn format_omits_json_trailing_comma_omit() {
+fn format_json_trailing_commas_all() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
@@ -2382,7 +2382,107 @@ fn format_omits_json_trailing_comma_omit() {
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
-        "format_omits_json_trailing_comma_omit",
+        "format_json_trailing_commas_all",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_json_trailing_commas_overrides_all() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let config_json = r#"{
+    "json": {
+        "parser": { "allowTrailingCommas": true },
+        "formatter": { "trailingCommas": "none" }
+    },
+    "overrides": [{
+        "include": ["file.json"],
+        "json": {
+            "formatter": { "trailingCommas": "all" }
+        }
+    }]
+}"#;
+    let biome_config = "biome.json";
+    let code = r#"{   "loreum_ipsum_lorem_ipsum":   "bar", "loreum_ipsum_lorem_ipsum":   "bar", "loreum_ipsum_lorem_ipsum":   "bar", "loreum_ipsum_lorem_ipsum":   "bar", "loreum_ipsum_lorem_ipsum":   "bar",
+}"#;
+    let file_path = Path::new("file.json");
+    fs.insert(file_path.into(), code.as_bytes());
+    fs.insert(biome_config.into(), config_json);
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                "--write",
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, Path::new(file_path), "{\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n}\n");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_json_trailing_commas_overrides_all",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_json_trailing_commas_overrides_none() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let config_json = r#"{
+    "json": {
+        "parser": { "allowTrailingCommas": true },
+        "formatter": { "trailingCommas": "all" }
+    },
+    "overrides": [{
+        "include": ["file.json"],
+        "json": {
+            "formatter": { "trailingCommas": "none" }
+        }
+    }]
+}"#;
+    let biome_config = "biome.json";
+    let code = r#"{   "loreum_ipsum_lorem_ipsum":   "bar", "loreum_ipsum_lorem_ipsum":   "bar", "loreum_ipsum_lorem_ipsum":   "bar", "loreum_ipsum_lorem_ipsum":   "bar", "loreum_ipsum_lorem_ipsum":   "bar",
+}"#;
+    let file_path = Path::new("file.json");
+    fs.insert(file_path.into(), code.as_bytes());
+    fs.insert(biome_config.into(), config_json);
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                "--write",
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, Path::new(file_path), "{\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\"\n}\n");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_json_trailing_commas_overrides_none",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_json_trailing_commas_all.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_json_trailing_commas_all.snap
@@ -31,5 +31,3 @@ expression: content
 ```block
 Formatted 1 file in <TIME>. Fixed 1 file.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_json_trailing_commas_none.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_json_trailing_commas_none.snap
@@ -31,5 +31,3 @@ expression: content
 ```block
 Formatted 1 file in <TIME>. Fixed 1 file.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_json_trailing_commas_overrides_all.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_json_trailing_commas_overrides_all.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "json": {
+    "parser": { "allowTrailingCommas": true },
+    "formatter": { "trailingCommas": "none" }
+  },
+  "overrides": [
+    {
+      "include": ["file.json"],
+      "json": {
+        "formatter": { "trailingCommas": "all" }
+      }
+    }
+  ]
+}
+```
+
+## `file.json`
+
+```json
+{
+	"loreum_ipsum_lorem_ipsum": "bar",
+	"loreum_ipsum_lorem_ipsum": "bar",
+	"loreum_ipsum_lorem_ipsum": "bar",
+	"loreum_ipsum_lorem_ipsum": "bar",
+	"loreum_ipsum_lorem_ipsum": "bar",
+}
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_json_trailing_commas_overrides_none.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_json_trailing_commas_overrides_none.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "json": {
+    "parser": { "allowTrailingCommas": true },
+    "formatter": { "trailingCommas": "all" }
+  },
+  "overrides": [
+    {
+      "include": ["file.json"],
+      "json": {
+        "formatter": { "trailingCommas": "none" }
+      }
+    }
+  ]
+}
+```
+
+## `file.json`
+
+```json
+{
+	"loreum_ipsum_lorem_ipsum": "bar",
+	"loreum_ipsum_lorem_ipsum": "bar",
+	"loreum_ipsum_lorem_ipsum": "bar",
+	"loreum_ipsum_lorem_ipsum": "bar",
+	"loreum_ipsum_lorem_ipsum": "bar"
+}
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
@@ -110,7 +110,7 @@ JSON Formatter:
   Indent size:                  unset
   Line ending:                  Lf
   Line width:                   100
-  Trailing Commas:              unset
+  Trailing Commas:              None
 
 Server:
   Version:                      0.0.0
@@ -121,5 +121,3 @@ Server:
 Workspace:
   Open Documents:               0
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
@@ -110,7 +110,7 @@ JSON Formatter:
   Indent size:                  unset
   Line ending:                  Lf
   Line width:                   100
-  Trailing Commas:              None
+  Trailing Commas:              unset
 
 Server:
   Version:                      0.0.0

--- a/crates/biome_json_formatter/src/context.rs
+++ b/crates/biome_json_formatter/src/context.rs
@@ -77,9 +77,9 @@ pub struct JsonFormatOptions {
 )]
 pub enum TrailingCommas {
     #[default]
-    /// The formatter will remove the trailing comma
+    /// The formatter will remove the trailing commas
     None,
-    /// The trailing comma is allowed and advised
+    /// The trailing commas are allowed and advised
     All,
 }
 
@@ -131,8 +131,8 @@ impl JsonFormatOptions {
         self
     }
 
-    pub fn with_trailing_comma(mut self, trailing_comma: TrailingCommas) -> Self {
-        self.trailing_commas = trailing_comma;
+    pub fn with_trailing_commas(mut self, trailing_commas: TrailingCommas) -> Self {
+        self.trailing_commas = trailing_commas;
         self
     }
 
@@ -150,6 +150,10 @@ impl JsonFormatOptions {
 
     pub fn set_line_width(&mut self, line_width: LineWidth) {
         self.line_width = line_width;
+    }
+
+    pub fn set_trailing_commas(&mut self, trailing_commas: TrailingCommas) {
+        self.trailing_commas = trailing_commas;
     }
 
     pub(crate) fn to_trailing_separator(&self) -> TrailingSeparator {
@@ -192,6 +196,6 @@ impl fmt::Display for JsonFormatOptions {
         writeln!(f, "Indent width: {}", self.indent_width.value())?;
         writeln!(f, "Line ending: {}", self.line_ending)?;
         writeln!(f, "Line width: {}", self.line_width.get())?;
-        writeln!(f, "Trailing comma: {}", self.trailing_commas)
+        writeln!(f, "Trailing commas: {}", self.trailing_commas)
     }
 }

--- a/crates/biome_json_formatter/tests/specs/json/array/empty_line.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/empty_line.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/empty_line.json
 ---
-
 # Input
 
 ```json
@@ -28,7 +27,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -40,5 +39,3 @@ Trailing comma: None
 	]
 }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/array/empty_line.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/empty_line.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/empty_line.json
 ---
+
 # Input
 
 ```json
@@ -39,3 +40,4 @@ Trailing commas: None
 	]
 }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/array/fill_layout.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/fill_layout.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/fill_layout.json
 ---
-
 # Input
 
 ```json
@@ -24,7 +23,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -33,5 +32,3 @@ Trailing comma: None
 	1232132112321321123213211232132112321321
 ]
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/array/fill_layout.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/fill_layout.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/fill_layout.json
 ---
+
 # Input
 
 ```json
@@ -32,3 +33,4 @@ Trailing commas: None
 	1232132112321321123213211232132112321321
 ]
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/array/layout.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/layout.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/layout.json
 ---
-
 # Input
 
 ```json
@@ -32,7 +31,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -63,5 +62,3 @@ Trailing comma: None
 	]
 }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/array/layout.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/layout.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/layout.json
 ---
+
 # Input
 
 ```json
@@ -62,3 +63,4 @@ Trailing commas: None
 	]
 }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/array/multi_line.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/multi_line.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/multi_line.json
 ---
+
 # Input
 
 ```json
@@ -45,3 +46,4 @@ Trailing commas: None
 	]
 }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/array/multi_line.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/multi_line.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/multi_line.json
 ---
-
 # Input
 
 ```json
@@ -28,7 +27,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -46,5 +45,3 @@ Trailing comma: None
 	]
 }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/array/nested.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/nested.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/nested.json
 ---
+
 # Input
 
 ```json
@@ -48,3 +49,4 @@ Trailing commas: None
 	]
 }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/array/nested.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/nested.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/nested.json
 ---
-
 # Input
 
 ```json
@@ -24,7 +23,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -49,5 +48,3 @@ Trailing comma: None
 	]
 }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/array/one_per_line_layout.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/one_per_line_layout.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/one_per_line_layout.json
 ---
-
 # Input
 
 ```json
@@ -32,7 +31,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -80,5 +79,3 @@ Trailing comma: None
 	]
 }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/array/one_per_line_layout.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/one_per_line_layout.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/one_per_line_layout.json
 ---
+
 # Input
 
 ```json
@@ -79,3 +80,4 @@ Trailing commas: None
 	]
 }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/array/single_line.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/single_line.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/single_line.json
 ---
-
 # Input
 
 ```json
@@ -29,7 +28,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -38,5 +37,3 @@ Trailing comma: None
 	"indented": [1111, 2222, true]
 }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/array/single_line.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/array/single_line.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/array/single_line.json
 ---
+
 # Input
 
 ```json
@@ -37,3 +38,4 @@ Trailing commas: None
 	"indented": [1111, 2222, true]
 }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/comments/empty_with_comments.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/comments/empty_with_comments.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/comments/empty_with_comments.json
 ---
+
 # Input
 
 ```json
@@ -62,3 +63,4 @@ Trailing commas: None
 	]
 }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/comments/empty_with_comments.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/comments/empty_with_comments.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/comments/empty_with_comments.json
 ---
-
 # Input
 
 ```json
@@ -36,7 +35,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -63,5 +62,3 @@ Trailing comma: None
 	]
 }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/comments/multiline.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/comments/multiline.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/comments/multiline.json
 ---
+
 # Input
 
 ```json
@@ -63,3 +64,4 @@ Trailing commas: None
  * Trailing
  **/
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/comments/multiline.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/comments/multiline.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/comments/multiline.json
 ---
-
 # Input
 
 ```json
@@ -37,7 +36,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -64,5 +63,3 @@ Trailing comma: None
  * Trailing
  **/
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/empty.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/empty.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/empty.json
 ---
+
 # Input
 
 ```json
@@ -31,3 +32,4 @@ Trailing commas: None
 ## Unimplemented nodes/tokens
 
 "" => 0..0
+

--- a/crates/biome_json_formatter/tests/specs/json/empty.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/empty.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/empty.json
 ---
-
 # Input
 
 ```json
@@ -21,7 +20,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -32,4 +31,3 @@ Trailing comma: None
 ## Unimplemented nodes/tokens
 
 "" => 0..0
-

--- a/crates/biome_json_formatter/tests/specs/json/number.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/number.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/number.json
 ---
+
 # Input
 
 ```json
@@ -79,3 +80,4 @@ Trailing commas: None
 	2.0
 ]
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/number.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/number.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/number.json
 ---
-
 # Input
 
 ```json
@@ -48,7 +47,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -80,5 +79,3 @@ Trailing comma: None
 	2.0
 ]
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/object/complex.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/complex.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/complex.json
 ---
+
 # Input
 
 ```json
@@ -45,3 +46,4 @@ Trailing commas: None
 	"null": null
 }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/object/complex.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/complex.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/complex.json
 ---
-
 # Input
 
 ```json
@@ -28,7 +27,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -46,5 +45,3 @@ Trailing comma: None
 	"null": null
 }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/object/missing_value.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/missing_value.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/missing_value.json
 ---
-
 # Input
 
 ```json
@@ -30,7 +29,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -45,5 +44,3 @@ Trailing comma: None
 	"d": 3
 }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/object/missing_value.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/missing_value.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/missing_value.json
 ---
+
 # Input
 
 ```json
@@ -44,3 +45,4 @@ Trailing commas: None
 	"d": 3
 }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/object/multi_line.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/multi_line.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/multi_line.json
 ---
-
 # Input
 
 ```json
@@ -25,7 +24,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -34,5 +33,3 @@ Trailing comma: None
 	"string": "some-string"
 }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/object/multi_line.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/multi_line.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/multi_line.json
 ---
+
 # Input
 
 ```json
@@ -33,3 +34,4 @@ Trailing commas: None
 	"string": "some-string"
 }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/object/multi_line_long.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/multi_line_long.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/multi_line_long.json
 ---
-
 # Input
 
 ```json
@@ -25,7 +24,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -34,5 +33,3 @@ Trailing comma: None
 	"string": "some-long-long-long-long-long-long-long-string"
 }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/object/multi_line_long.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/multi_line_long.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/multi_line_long.json
 ---
+
 # Input
 
 ```json
@@ -33,3 +34,4 @@ Trailing commas: None
 	"string": "some-long-long-long-long-long-long-long-string"
 }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/object/one_line.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/one_line.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/one_line.json
 ---
-
 # Input
 
 ```json
@@ -22,11 +21,9 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
 { "number": 123, "string": "some-string" }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/object/one_line.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/one_line.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/one_line.json
 ---
+
 # Input
 
 ```json
@@ -27,3 +28,4 @@ Trailing commas: None
 ```json
 { "number": 123, "string": "some-string" }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/object/one_line_long.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/one_line_long.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/one_line_long.json
 ---
-
 # Input
 
 ```json
@@ -22,7 +21,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -31,5 +30,3 @@ Trailing comma: None
 	"string": "some-long-long-long-long-long-long-long-string"
 }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/object/one_line_long.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/one_line_long.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/one_line_long.json
 ---
+
 # Input
 
 ```json
@@ -30,3 +31,4 @@ Trailing commas: None
 	"string": "some-long-long-long-long-long-long-long-string"
 }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/object/string.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/string.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/string.json
 ---
+
 # Input
 
 ```json
@@ -42,3 +43,4 @@ Trailing commas: None
     2: 	"/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string",
     3: 	"/ & /": "/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?",
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/object/string.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/string.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/object/string.json
 ---
-
 # Input
 
 ```json
@@ -27,7 +26,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -43,5 +42,3 @@ Trailing comma: None
     2: 	"/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string",
     3: 	"/ & /": "/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?",
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/smoke.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/smoke.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/smoke.json
 ---
-
 # Input
 
 ```json
@@ -28,7 +27,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
@@ -40,5 +39,3 @@ Trailing comma: None
 	"e": false
 }
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/smoke.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/smoke.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/smoke.json
 ---
+
 # Input
 
 ```json
@@ -39,3 +40,4 @@ Trailing commas: None
 	"e": false
 }
 ```
+

--- a/crates/biome_json_formatter/tests/specs/json/undefined/utf8_bom_empty_object.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/undefined/utf8_bom_empty_object.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/undefined/utf8_bom_empty_object.json
 ---
-
 # Input
 
 ```json
@@ -21,11 +20,9 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
-Trailing comma: None
+Trailing commas: None
 -----
 
 ```json
 ﻿{}
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/json/undefined/utf8_bom_empty_object.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/undefined/utf8_bom_empty_object.json.snap
@@ -2,6 +2,7 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/undefined/utf8_bom_empty_object.json
 ---
+
 # Input
 
 ```json
@@ -26,3 +27,4 @@ Trailing commas: None
 ```json
 ﻿{}
 ```
+

--- a/crates/biome_service/src/configuration/json.rs
+++ b/crates/biome_service/src/configuration/json.rs
@@ -71,7 +71,7 @@ pub struct JsonFormatter {
 
     /// Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "none".
     #[partial(bpaf(long("json-formatter-trailing-commas"), argument("none|all"), optional))]
-    pub trailing_commas: TrailingCommas,
+    pub trailing_commas: Option<TrailingCommas>,
 }
 
 impl PartialJsonFormatter {
@@ -83,7 +83,7 @@ impl PartialJsonFormatter {
             indent_size: self.indent_size,
             line_ending: self.line_ending,
             line_width: self.line_width,
-            trailing_commas: self.trailing_commas.unwrap_or_default(),
+            trailing_commas: self.trailing_commas,
         }
     }
 }

--- a/crates/biome_service/src/configuration/json.rs
+++ b/crates/biome_service/src/configuration/json.rs
@@ -71,7 +71,7 @@ pub struct JsonFormatter {
 
     /// Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "none".
     #[partial(bpaf(long("json-formatter-trailing-commas"), argument("none|all"), optional))]
-    pub trailing_commas: Option<TrailingCommas>,
+    pub trailing_commas: TrailingCommas,
 }
 
 impl PartialJsonFormatter {
@@ -83,7 +83,7 @@ impl PartialJsonFormatter {
             indent_size: self.indent_size,
             line_ending: self.line_ending,
             line_width: self.line_width,
-            trailing_commas: self.trailing_commas,
+            trailing_commas: self.trailing_commas.unwrap_or_default(),
         }
     }
 }

--- a/crates/biome_service/src/configuration/overrides.rs
+++ b/crates/biome_service/src/configuration/overrides.rs
@@ -324,6 +324,8 @@ fn to_json_language_settings(
         .indent_style
         .map(Into::into)
         .or(parent_formatter.indent_style);
+    language_setting.formatter.trailing_commas =
+        formatter.trailing_commas.or(parent_formatter.trailing_commas);
 
     let parser = conf.parser.take().unwrap_or_default();
     let parent_parser = &parent_settings.parser;

--- a/crates/biome_service/src/configuration/overrides.rs
+++ b/crates/biome_service/src/configuration/overrides.rs
@@ -324,8 +324,9 @@ fn to_json_language_settings(
         .indent_style
         .map(Into::into)
         .or(parent_formatter.indent_style);
-    language_setting.formatter.trailing_commas =
-        formatter.trailing_commas.or(parent_formatter.trailing_commas);
+    language_setting.formatter.trailing_commas = formatter
+        .trailing_commas
+        .or(parent_formatter.trailing_commas);
 
     let parser = conf.parser.take().unwrap_or_default();
     let parent_parser = &parent_settings.parser;

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -38,7 +38,7 @@ pub struct JsonFormatterSettings {
     pub line_width: Option<LineWidth>,
     pub indent_width: Option<IndentWidth>,
     pub indent_style: Option<IndentStyle>,
-    pub trailing_comma: Option<TrailingCommas>,
+    pub trailing_commas: Option<TrailingCommas>,
     pub enabled: Option<bool>,
 }
 
@@ -95,7 +95,7 @@ impl Language for JsonLanguage {
                 .with_indent_style(indent_style)
                 .with_indent_width(indent_width)
                 .with_line_width(line_width)
-                .with_trailing_comma(language.trailing_comma.unwrap_or_default()),
+                .with_trailing_commas(language.trailing_commas.unwrap_or_default()),
         )
     }
 }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -342,7 +342,7 @@ impl From<JsonConfiguration> for LanguageSettings<JsonLanguage> {
 
         language_setting.parser.allow_comments = json.parser.allow_comments;
         language_setting.parser.allow_trailing_commas = json.parser.allow_trailing_commas;
-        language_setting.formatter.trailing_comma = json.formatter.trailing_commas;
+        language_setting.formatter.trailing_commas = Some(json.formatter.trailing_commas);
         language_setting.formatter.enabled = Some(json.formatter.enabled);
         language_setting.formatter.line_width = json.formatter.line_width;
         language_setting.formatter.indent_width = json.formatter.indent_width.map(Into::into);
@@ -833,12 +833,14 @@ impl OverrideSettingPattern {
         if let Some(indent_style) = json_formatter.indent_style.or(self.formatter.indent_style) {
             options.set_indent_style(indent_style);
         }
-
         if let Some(indent_width) = json_formatter.indent_width.or(self.formatter.indent_width) {
             options.set_indent_width(indent_width)
         }
         if let Some(line_width) = json_formatter.line_width.or(self.formatter.line_width) {
             options.set_line_width(line_width);
+        }
+        if let Some(trailing_commas) = json_formatter.trailing_commas {
+            options.set_trailing_commas(trailing_commas);
         }
         let mut cache = self.cached_json_format_options.write().unwrap();
         let _ = cache.insert(options.clone());

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -342,7 +342,7 @@ impl From<JsonConfiguration> for LanguageSettings<JsonLanguage> {
 
         language_setting.parser.allow_comments = json.parser.allow_comments;
         language_setting.parser.allow_trailing_commas = json.parser.allow_trailing_commas;
-        language_setting.formatter.trailing_commas = Some(json.formatter.trailing_commas);
+        language_setting.formatter.trailing_commas = json.formatter.trailing_commas;
         language_setting.formatter.enabled = Some(json.formatter.enabled);
         language_setting.formatter.line_width = json.formatter.line_width;
         language_setting.formatter.indent_width = json.formatter.indent_width.map(Into::into);

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2651,12 +2651,12 @@
 		"TrailingCommas": {
 			"oneOf": [
 				{
-					"description": "The formatter will remove the trailing comma",
+					"description": "The formatter will remove the trailing commas",
 					"type": "string",
 					"enum": ["none"]
 				},
 				{
-					"description": "The trailing comma is allowed and advised",
+					"description": "The trailing commas are allowed and advised",
 					"type": "string",
 					"enum": ["all"]
 				}


### PR DESCRIPTION
## Summary

- Respect `json.formatter.trailingCommas` option in `overrides`
- Rename internal `trailing_comma`-named json-related vars to `trailing_commas` for consistency

Fixes #2009

## Test Plan

Several tests are added in `crates/biome_cli/tests/commands/format.rs` to show that `json.formatter.trailingCommas` works in `overrides`.
