### PR TITLE
fix(auto_search): `biome.jsonc` resolution

### DIFF
--- a/crates/biome_cli/tests/commands/rage.rs
+++ b/crates/biome_cli/tests/commands/rage.rs
@@ -84,6 +84,41 @@ fn with_configuration() {
 }
 
 #[test]
+fn with_jsonc_configuration() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    // issue #2008 is only reproducible when using absolute paths
+    // so we insert an absolute path here
+    fs.insert(
+        PathBuf::from("/dir/biome.jsonc"),
+        r#"{
+  "formatter": {
+    // disable formatter
+    "enabled": false,
+  }
+}"#,
+    );
+
+    // TODO: but how to cd into dir and run rage?
+    let result = run_rage(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("rage")].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_rage_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "with_jsonc_configuration",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn with_malformed_configuration() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/commands/rage.rs
+++ b/crates/biome_cli/tests/commands/rage.rs
@@ -87,11 +87,8 @@ fn with_configuration() {
 fn with_jsonc_configuration() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
-
-    // issue #2008 is only reproducible when using absolute paths
-    // so we insert an absolute path here
     fs.insert(
-        PathBuf::from("/dir/biome.jsonc"),
+        Path::new("biome.jsonc").to_path_buf(),
         r#"{
   "formatter": {
     // disable formatter
@@ -100,7 +97,6 @@ fn with_jsonc_configuration() {
 }"#,
     );
 
-    // TODO: but how to cd into dir and run rage?
     let result = run_rage(
         DynRef::Borrowed(&mut fs),
         &mut console,

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_jsonc_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_jsonc_configuration.snap
@@ -1,0 +1,46 @@
+---
+source: crates/biome_cli/tests/commands/rage.rs
+expression: content
+---
+## `/dir/biome.jsonc`
+
+```jsonc
+{
+  "formatter": {
+    // disable formatter
+    "enabled": false,
+  }
+}
+```
+
+# Emitted Messages
+
+```block
+CLI:
+  Version:                      0.0.0
+  Color support:                **PLACEHOLDER**
+
+Platform:
+  CPU Architecture:             **PLACEHOLDER**
+  OS:                           **PLACEHOLDER**
+
+Environment:
+  BIOME_LOG_DIR:                **PLACEHOLDER**
+  NO_COLOR:                     **PLACEHOLDER**
+  TERM:                         **PLACEHOLDER**
+  JS_RUNTIME_VERSION:           unset
+  JS_RUNTIME_NAME:              unset
+  NODE_PACKAGE_MANAGER:         unset
+
+Biome Configuration:
+  Status:                       unset
+
+Server:
+  Version:                      0.0.0
+  Name:                         biome_lsp
+  CPU Architecture:             **PLACEHOLDER**
+  OS:                           **PLACEHOLDER**
+
+Workspace:
+  Open Documents:               0
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_jsonc_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_jsonc_configuration.snap
@@ -2,9 +2,9 @@
 source: crates/biome_cli/tests/commands/rage.rs
 expression: content
 ---
-## `/dir/biome.jsonc`
+## `biome.jsonc`
 
-```jsonc
+```json
 {
   "formatter": {
     // disable formatter
@@ -33,7 +33,11 @@ Environment:
   NODE_PACKAGE_MANAGER:         unset
 
 Biome Configuration:
-  Status:                       unset
+  Status:                       Loaded successfully
+  Formatter disabled:           true
+  Linter disabled:              false
+  Organize imports disabled:    false
+  VCS disabled:                 true
 
 Server:
   Version:                      0.0.0


### PR DESCRIPTION
## Summary

I refactored the `auto_search` function in `crates/biome_fs/src/fs.rs` a bit. It was trying to search in parent directories first and then alternatives (`biome.jsonc`). This approach led to an issue where the mutable `file_path` variable was erroneously set to the root path `/` upon searching for the next alternative, thereby causing an incorrect `file_directory_path`.

I switched the loops so it will search alternatives first and then traverse up to parent directories. Additionally, I have made adjustments to error handling to align with this new search logic. However, I am uncertain if this modification aligns with the expected behavior and would greatly appreciate confirmation.

Fixes #2008.

## Test Plan

I tested it locally by running `cargo build -p biome_cli` first and tested that binary in another folder with a `biome.jsonc` file by running the `rage` command. It is now able to correctly resolve the `biome.jsonc` config file.

I attempted to add a test in `crates/biome_cli/tests/commands/rage.rs` but I couldn't figure out how to use absolute file paths and change `cwd` in a memory file system. So I included only a draft of the intended test and am seeking assistance to properly implement this test.