### PR TITLE
fix(noUndeclaredDependencies): support imports of subpath exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,17 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [noUndeclaredDependencies](https://biomejs.dev/linter/rules/no-undeclared-dependencies/) now recognizes imports of subpath exports.
+
+  E.g., the following import statements no longer report errors if `@mui/material` and `tailwindcss` are installed as dependencies:
+
+  ```ts
+  import Button from "@mui/material/Button";
+  import { fontFamily } from "tailwindcss/defaultTheme";
+  ```
+
+  Contributed by @Sec-ant
+
 ### Parser
 
 #### Bug fixes

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_undeclared_dependencies.rs
@@ -44,16 +44,39 @@ impl Rule for NoUndeclaredDependencies {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let text = node.inner_string_text()?;
-        if !text.text().starts_with('.')
-            // Ignore imports using a protocol such as `node:`, `bun:`, `jsr:`, `https:`, and so on.
-            && !text.text().contains(':')
-            && !ctx.is_dependency(text.text())
-            && !ctx.is_dev_dependency(text.text())
-        {
-            return Some(());
+
+        let token_text = node.inner_string_text()?;
+        let text = token_text.text();
+
+        // Ignore relative path imports
+        // Ignore imports using a protocol such as `node:`, `bun:`, `jsr:`, `https:`, and so on.
+        if text.starts_with('.') || text.contains(':') {
+            return None;
         }
-        None
+
+        let package_name = match text.chars().position(|c| c == '/') {
+            Some(slash_index) => {
+                // scoped package: @mui/material/Button
+                // the package name is @mui/material, not @mui
+                if text.starts_with('@') {
+                    &text[..text[slash_index + 1..]
+                        .chars()
+                        .position(|c| c == '/')
+                        .map_or(text.len(), |i| i + slash_index + 1)]
+                }
+                // unscoped package
+                else {
+                    &text[..slash_index]
+                }
+            }
+            None => text,
+        };
+
+        if ctx.is_dependency(package_name) || ctx.is_dev_dependency(package_name) {
+            return None;
+        }
+
+        Some(())
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.js
@@ -12,3 +12,6 @@ import "node:assert";
 require("node:assert");
 
 import "bun:test";
+
+import Button from "@mui/material/Button";
+import { fontFamily } from "tailwindcss/defaultTheme";

--- a/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.js.snap
@@ -19,6 +19,7 @@ require("node:assert");
 
 import "bun:test";
 
+import Button from "@mui/material/Button";
+import { fontFamily } from "tailwindcss/defaultTheme";
+
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.package.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.package.json
@@ -1,6 +1,8 @@
 {
 	"dependencies": {
-		"react": "1.0.0"
+		"react": "1.0.0",
+		"@mui/material": "5.15.12",
+		"tailwindcss": "3.4.1"
 	},
 	"devDependencies": {
 		"@testing-library/react": "1.0.0"

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -60,6 +60,17 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [noUndeclaredDependencies](https://biomejs.dev/linter/rules/no-undeclared-dependencies/) now recognizes imports of subpath exports.
+
+  E.g., the following import statements no longer report errors if `@mui/material` and `tailwindcss` are installed as dependencies:
+
+  ```ts
+  import Button from "@mui/material/Button";
+  import { fontFamily } from "tailwindcss/defaultTheme";
+  ```
+
+  Contributed by @Sec-ant
+
 ### Parser
 
 #### Bug fixes


### PR DESCRIPTION
## Summary

Support imports of subpath exports in lint rule `noUndeclaredDependencies`.

It seems the support of import path aliases in `package.json` (also known as [subpath imports](https://nodejs.org/api/packages.html#subpath-imports)) or `tsconfig.json` needs further discussion so they're not implemented in this PR.

Now that we are using `oxc_resolver` for biome configurations, I think a better approach is to also use it for this rule. It can correctly handle subpath exports, subpath imports and tsconfig path aliases for us.

Related: #2012.

## Test Plan

Two valid cases of imports of subpath exports are added to the test snapshot.
