### PR TITLE
fix(lint/noRedeclare): don't report type param and param with same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,26 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Code fixes of [useImportType](https://biomejs.dev/linter/rules/use-import-type) and [useExportType](https://biomejs.dev/linter/rules/use-export-type) now handle multiline statements ([#2041](https://github.com/biomejs/biome/issues/2041)).
   Contributed by @Conaclos
 
+- [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare) no longer reports type parameter and parameter with identical names ([#1992](https://github.com/biomejs/biome/issues/1992)).
+
+  The following code is no longer reported:
+
+  ```ts
+  function f<a>(a: a) {}
+  ```
+
+  Contributed by @Conaclos
+
+- [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare) now reports duplicate type parameters in a same declaration.
+
+  The following type parameters are now reported as a redeclaraion:
+
+  ```ts
+  function f<T, T>() {}
+  ```
+
+  Contributed by @Conaclos
+
 ### Parser
 
 

--- a/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_redeclare.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/suspicious/no_redeclare.rs
@@ -129,7 +129,9 @@ fn check_redeclarations_in_single_scope(scope: &Scope, redeclarations: &mut Vec<
                 //   A type parameter can be redeclared if they are in different declarations.
                 if !(first_decl.is_mergeable(&decl)
                     || first_decl.is_parameter_like() && decl.is_parameter_like()
-                    || first_decl.is_type_parameter() && decl.is_type_parameter())
+                    || first_decl.is_type_parameter()
+                        && decl.is_type_parameter()
+                        && first_decl.syntax().parent() != decl.syntax().parent())
                 {
                     redeclarations.push(Redeclaration {
                         name,

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/invalid.ts
@@ -4,3 +4,5 @@ class C {
 		var a;
 	}
 }
+
+function f<T, T>() {}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/invalid.ts.snap
@@ -11,6 +11,8 @@ class C {
 	}
 }
 
+function f<T, T>() {}
+
 ```
 
 # Diagnostics
@@ -34,6 +36,28 @@ invalid.ts:4:7 lint/suspicious/noRedeclare ━━━━━━━━━━━━�
       │ 		    ^
     4 │ 		var a;
     5 │ 	}
+  
+
+```
+
+```
+invalid.ts:8:15 lint/suspicious/noRedeclare ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'T'. Consider to delete it or rename it.
+  
+    6 │ }
+    7 │ 
+  > 8 │ function f<T, T>() {}
+      │               ^
+    9 │ 
+  
+  i 'T' is defined here:
+  
+    6 │ }
+    7 │ 
+  > 8 │ function f<T, T>() {}
+      │            ^
+    9 │ 
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-declaration-merging.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-declaration-merging.ts
@@ -126,3 +126,7 @@ function g(A, { B }) {
 	interface A {}
 	interface B {}
 }
+
+export function h<a>(a: a) {
+	return a;
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-declaration-merging.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-declaration-merging.ts.snap
@@ -133,6 +133,10 @@ function g(A, { B }) {
 	interface B {}
 }
 
+export function h<a>(a: a) {
+	return a;
+}
+
 ```
 
 

--- a/crates/biome_js_syntax/src/binding_ext.rs
+++ b/crates/biome_js_syntax/src/binding_ext.rs
@@ -134,7 +134,8 @@ impl AnyJsBindingDeclaration {
             (
                 AnyJsBindingDeclaration::TsTypeAliasDeclaration(_)
                 | AnyJsBindingDeclaration::TsInterfaceDeclaration(_)
-                | AnyJsBindingDeclaration::TsModuleDeclaration(_),
+                | AnyJsBindingDeclaration::TsModuleDeclaration(_)
+                | AnyJsBindingDeclaration::TsTypeParameter(_),
                 AnyJsBindingDeclaration::JsFunctionDeclaration(_)
                 | AnyJsBindingDeclaration::JsArrayBindingPatternElement(_)
                 | AnyJsBindingDeclaration::JsArrayBindingPatternRestElement(_)

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -40,6 +40,26 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Code fixes of [useImportType](https://biomejs.dev/linter/rules/use-import-type) and [useExportType](https://biomejs.dev/linter/rules/use-export-type) now handle multiline statements ([#2041](https://github.com/biomejs/biome/issues/2041)).
   Contributed by @Conaclos
 
+- [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare) no longer reports type parameter and parameter with identical names ([#1992](https://github.com/biomejs/biome/issues/1992)).
+
+  The following code is no longer reported:
+
+  ```ts
+  function f<a>(a: a) {}
+  ```
+
+  Contributed by @Conaclos
+
+- [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare) now reports duplicate type parameters in a same declaration.
+
+  The following type parameters are now reported as a redeclaraion:
+
+  ```ts
+  function f<T, T>() {}
+  ```
+
+  Contributed by @Conaclos
+
 ### Parser
 
 


### PR DESCRIPTION
## Summary

Fix #1992

[noRedeclare](https://biomejs.dev/linter/rules/no-redeclare) no longer reports type parameter and parameter with identical names.
The following code is no longer reported:

```ts
function f<a>(a: a) {}
```

I also fixed a regression: duplicate type parameters in a same declaration were no longer reported.

## Test Plan

I added non-regression tests.
