### PR TITLE
chore: remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,6 @@ dependencies = [
  "biome_deserialize",
  "biome_deserialize_macros",
  "biome_diagnostics",
- "biome_flags",
  "biome_formatter",
  "biome_fs",
  "biome_js_formatter",
@@ -172,7 +171,6 @@ dependencies = [
  "biome_rowan",
  "biome_service",
  "biome_text_edit",
- "biome_text_size",
  "bpaf",
  "crossbeam",
  "dashmap",
@@ -232,7 +230,6 @@ dependencies = [
  "biome_test_utils",
  "insta",
  "lazy_static",
- "rustc-hash",
  "tests_macros",
 ]
 
@@ -308,8 +305,6 @@ dependencies = [
  "indexmap 1.9.3",
  "schemars",
  "serde",
- "serde_json",
- "tracing",
 ]
 
 [[package]]
@@ -413,7 +408,6 @@ dependencies = [
 name = "biome_fs"
 version = "0.5.4"
 dependencies = [
- "biome_console",
  "biome_diagnostics",
  "crossbeam",
  "directories",
@@ -474,8 +468,6 @@ dependencies = [
  "biome_js_parser",
  "biome_js_semantic",
  "biome_js_syntax",
- "biome_json_factory",
- "biome_json_syntax",
  "biome_project",
  "biome_rowan",
  "biome_test_utils",
@@ -484,13 +476,11 @@ dependencies = [
  "countme",
  "insta",
  "lazy_static",
- "log",
  "natord",
  "roaring",
  "rustc-hash",
  "schemars",
  "serde",
- "serde_json",
  "smallvec",
  "tests_macros",
 ]
@@ -507,7 +497,6 @@ dependencies = [
 name = "biome_js_formatter"
 version = "0.5.4"
 dependencies = [
- "biome_console",
  "biome_deserialize",
  "biome_deserialize_macros",
  "biome_diagnostics",
@@ -518,12 +507,10 @@ dependencies = [
  "biome_js_factory",
  "biome_js_parser",
  "biome_js_syntax",
- "biome_json_syntax",
  "biome_parser",
  "biome_rowan",
  "biome_text_size",
  "biome_unicode_table",
- "cfg-if",
  "countme",
  "iai",
  "insta",
@@ -534,7 +521,6 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tests_macros",
- "tracing",
  "unicode-width",
 ]
 
@@ -550,7 +536,6 @@ dependencies = [
  "biome_rowan",
  "biome_unicode_table",
  "bitflags 2.3.1",
- "cfg-if",
  "drop_bomb",
  "expect-test",
  "indexmap 1.9.3",
@@ -598,7 +583,6 @@ name = "biome_js_transform"
 version = "0.5.4"
 dependencies = [
  "biome_analyze",
- "biome_console",
  "biome_diagnostics",
  "biome_js_factory",
  "biome_js_formatter",
@@ -698,15 +682,11 @@ dependencies = [
  "biome_analyze",
  "biome_console",
  "biome_diagnostics",
- "biome_formatter",
  "biome_fs",
- "biome_js_formatter",
  "biome_rowan",
  "biome_service",
  "biome_text_edit",
  "futures",
- "indexmap 1.9.3",
- "log",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -855,16 +835,12 @@ dependencies = [
  "biome_console",
  "biome_deserialize",
  "biome_diagnostics",
- "biome_js_parser",
- "biome_js_syntax",
  "biome_json_parser",
- "biome_json_syntax",
  "biome_project",
  "biome_rowan",
  "biome_service",
  "countme",
  "json_comments",
- "serde",
  "serde_json",
  "similar",
 ]
@@ -3716,11 +3692,9 @@ version = "0.0.0"
 dependencies = [
  "ansi_rgb",
  "biome_analyze",
- "biome_console",
  "biome_css_formatter",
  "biome_css_parser",
  "biome_css_syntax",
- "biome_diagnostics",
  "biome_formatter",
  "biome_js_analyze",
  "biome_js_formatter",
@@ -3732,10 +3706,8 @@ dependencies = [
  "biome_parser",
  "biome_rowan",
  "codspeed-criterion-compat",
- "countme",
  "criterion",
  "mimalloc",
- "regex",
  "tikv-jemallocator",
  "ureq",
  "url",
@@ -3747,7 +3719,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "biome_analyze",
- "biome_aria",
  "biome_cli",
  "biome_diagnostics",
  "biome_js_analyze",
@@ -3786,7 +3757,6 @@ dependencies = [
  "html-escape",
  "pico-args",
  "serde",
- "serde_json",
  "ureq",
  "xtask",
 ]
@@ -3839,7 +3809,6 @@ dependencies = [
  "biome_analyze",
  "biome_console",
  "biome_diagnostics",
- "biome_formatter",
  "biome_js_analyze",
  "biome_js_parser",
  "biome_js_syntax",

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -24,7 +24,6 @@ biome_console            = { workspace = true }
 biome_deserialize        = { workspace = true }
 biome_deserialize_macros = { workspace = true }
 biome_diagnostics        = { workspace = true }
-biome_flags              = { workspace = true }
 biome_formatter          = { workspace = true }
 biome_fs                 = { workspace = true }
 biome_js_formatter       = { workspace = true }
@@ -36,7 +35,6 @@ biome_migrate            = { workspace = true }
 biome_rowan              = { workspace = true }
 biome_service            = { workspace = true }
 biome_text_edit          = { workspace = true }
-biome_text_size          = { workspace = true }
 bpaf                     = { workspace = true, features = ["bright-color"] }
 crossbeam                = { workspace = true }
 dashmap                  = { workspace = true }

--- a/crates/biome_css_analyze/Cargo.toml
+++ b/crates/biome_css_analyze/Cargo.toml
@@ -19,7 +19,6 @@ biome_css_syntax  = { workspace = true }
 biome_diagnostics = { workspace = true }
 biome_rowan       = { workspace = true }
 lazy_static       = { workspace = true }
-rustc-hash        = { workspace = true }
 
 [dev-dependencies]
 biome_css_factory = { path = "../biome_css_factory" }

--- a/crates/biome_deserialize/Cargo.toml
+++ b/crates/biome_deserialize/Cargo.toml
@@ -21,8 +21,6 @@ bitflags                 = { workspace = true }
 indexmap                 = { workspace = true, features = ["serde"] }
 schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true }
-serde_json               = { workspace = true }
-tracing                  = { workspace = true }
 
 [features]
 schema = ["schemars", "schemars/indexmap"]

--- a/crates/biome_fs/Cargo.toml
+++ b/crates/biome_fs/Cargo.toml
@@ -13,7 +13,6 @@ version              = "0.5.4"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-biome_console     = { workspace = true }
 biome_diagnostics = { workspace = true }
 crossbeam         = { workspace = true }
 directories       = "5.0.1"

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -21,19 +21,15 @@ biome_diagnostics        = { workspace = true }
 biome_js_factory         = { workspace = true }
 biome_js_semantic        = { workspace = true }
 biome_js_syntax          = { workspace = true }
-biome_json_factory       = { workspace = true }
-biome_json_syntax        = { workspace = true }
 biome_project            = { workspace = true }
 biome_rowan              = { workspace = true }
 biome_unicode_table      = { workspace = true }
 lazy_static              = { workspace = true }
-log                      = "0.4.20"
 natord                   = "1.0.9"
 roaring                  = "0.10.1"
 rustc-hash               = { workspace = true }
 schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true, features = ["derive"] }
-serde_json               = { workspace = true }
 smallvec                 = { workspace = true }
 
 [dev-dependencies]

--- a/crates/biome_js_formatter/Cargo.toml
+++ b/crates/biome_js_formatter/Cargo.toml
@@ -13,22 +13,18 @@ version              = "0.5.4"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-biome_console                = { workspace = true }
 biome_deserialize            = { workspace = true }
 biome_deserialize_macros     = { workspace = true }
 biome_diagnostics_categories = { workspace = true }
 biome_formatter              = { workspace = true }
 biome_js_factory             = { workspace = true }
 biome_js_syntax              = { workspace = true }
-biome_json_syntax            = { workspace = true }
 biome_rowan                  = { workspace = true }
 biome_text_size              = { workspace = true }
 biome_unicode_table          = { workspace = true }
-cfg-if                       = "1.0.0"
 schemars                     = { workspace = true, optional = true }
 serde                        = { workspace = true, features = ["derive"], optional = true }
 smallvec                     = { workspace = true }
-tracing                      = { workspace = true }
 unicode-width                = "0.1.9"
 
 [dev-dependencies]

--- a/crates/biome_js_parser/Cargo.toml
+++ b/crates/biome_js_parser/Cargo.toml
@@ -19,7 +19,6 @@ biome_parser        = { workspace = true }
 biome_rowan         = { workspace = true }
 biome_unicode_table = { workspace = true }
 bitflags            = { workspace = true }
-cfg-if              = "1.0.0"
 drop_bomb           = "0.1.5"
 indexmap            = { workspace = true }
 rustc-hash          = { workspace = true }

--- a/crates/biome_js_transform/Cargo.toml
+++ b/crates/biome_js_transform/Cargo.toml
@@ -14,7 +14,6 @@ version              = "0.5.4"
 
 [dependencies]
 biome_analyze     = { workspace = true }
-biome_console     = { workspace = true }
 biome_diagnostics = { workspace = true }
 biome_js_factory  = { workspace = true }
 biome_js_syntax   = { workspace = true }

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -14,25 +14,21 @@ version              = "0.0.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow             = "1.0.52"
-biome_analyze      = { workspace = true }
-biome_console      = { workspace = true }
-biome_diagnostics  = { workspace = true }
-biome_formatter    = { workspace = true }
-biome_fs           = { workspace = true }
-biome_js_formatter = { workspace = true }
-biome_rowan        = { workspace = true }
-biome_service      = { workspace = true }
-biome_text_edit    = { workspace = true }
-futures            = "0.3"
-indexmap           = { workspace = true }
-log                = "0.4.20"
-rustc-hash         = { workspace = true }
-serde              = { workspace = true, features = ["derive"] }
-serde_json         = { workspace = true }
-tokio              = { workspace = true, features = ["rt", "io-std"] }
-tower-lsp          = { version = "0.19.0" }
-tracing            = { workspace = true, features = ["attributes"] }
+anyhow            = "1.0.52"
+biome_analyze     = { workspace = true }
+biome_console     = { workspace = true }
+biome_diagnostics = { workspace = true }
+biome_fs          = { workspace = true }
+biome_rowan       = { workspace = true }
+biome_service     = { workspace = true }
+biome_text_edit   = { workspace = true }
+futures           = "0.3"
+rustc-hash        = { workspace = true }
+serde             = { workspace = true, features = ["derive"] }
+serde_json        = { workspace = true }
+tokio             = { workspace = true, features = ["rt", "io-std"] }
+tower-lsp         = { version = "0.19.0" }
+tracing           = { workspace = true, features = ["attributes"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }

--- a/crates/biome_test_utils/Cargo.toml
+++ b/crates/biome_test_utils/Cargo.toml
@@ -18,16 +18,12 @@ biome_analyze     = { workspace = true }
 biome_console     = { workspace = true }
 biome_deserialize = { workspace = true }
 biome_diagnostics = { workspace = true }
-biome_js_parser   = { workspace = true }
-biome_js_syntax   = { workspace = true }
 biome_json_parser = { workspace = true }
-biome_json_syntax = { workspace = true }
 biome_project     = { workspace = true }
 biome_rowan       = { workspace = true }
 biome_service     = { workspace = true }
 countme           = { workspace = true, features = ["enable"] }
 json_comments     = "0.2.1"
-serde             = { workspace = true }
 serde_json        = { workspace = true }
 similar           = { version = "2.2.1" }
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,6 @@ rome_all = []
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = { version = "1.3.0", features = ["derive"] }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
 biome_analyze = { path = "../crates/biome_analyze" }
 biome_diagnostics = { path = "../crates/biome_diagnostics" }
@@ -26,7 +25,6 @@ biome_js_parser = { path = "../crates/biome_js_parser" }
 biome_js_syntax = { path = "../crates/biome_js_syntax" }
 biome_json_formatter = { path = "../crates/biome_json_formatter" }
 biome_json_parser = { path = "../crates/biome_json_parser" }
-biome_json_syntax = { path = "../crates/biome_json_syntax" }
 biome_service = { path = "../crates/biome_service" }
 similar = { version = "2.2.1" }
 

--- a/xtask/bench/Cargo.toml
+++ b/xtask/bench/Cargo.toml
@@ -6,11 +6,9 @@ version = "0.0.0"
 
 [dependencies]
 biome_analyze        = { workspace = true }
-biome_console        = { workspace = true }
 biome_css_formatter  = { workspace = true }
 biome_css_parser     = { workspace = true }
 biome_css_syntax     = { workspace = true }
-biome_diagnostics    = { workspace = true }
 biome_formatter      = { workspace = true }
 biome_js_analyze     = { workspace = true }
 biome_js_formatter   = { workspace = true }
@@ -26,11 +24,8 @@ biome_rowan          = { workspace = true }
 ansi_rgb                  = "0.2.0"
 codspeed-criterion-compat = { version = "2.3.3", optional = true }
 criterion                 = "0.5.1"
-regex                     = "1.5.5"
 ureq                      = "2.7.1"
 url                       = "2.2.2"
-
-countme = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1.29"

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -21,7 +21,6 @@ walkdir        = "2.3.2"
 xtask          = { path = '../', version = "0.0" }
 
 biome_analyze        = { workspace = true, optional = true }
-biome_aria           = { workspace = true, optional = true }
 biome_cli            = { workspace = true, optional = true }
 biome_diagnostics    = { workspace = true, optional = true }
 biome_js_analyze     = { workspace = true, optional = true }

--- a/xtask/contributors/Cargo.toml
+++ b/xtask/contributors/Cargo.toml
@@ -8,7 +8,6 @@ version = "0.0.0"
 html-escape = "0.2.11"
 pico-args   = "0.5.0"
 serde       = { version = "1.0.133", features = ["derive"] }
-serde_json  = { version = "1.0.74" }
 ureq        = { version = "2.4.0", features = ["json"] }
 xtask       = { path = '../', version = "0.0" }
 

--- a/xtask/lintdoc/Cargo.toml
+++ b/xtask/lintdoc/Cargo.toml
@@ -8,7 +8,6 @@ version = "0.0.0"
 biome_analyze      = { workspace = true }
 biome_console      = { workspace = true }
 biome_diagnostics  = { workspace = true }
-biome_formatter    = { workspace = true }
 biome_js_analyze   = { workspace = true }
 biome_js_parser    = { workspace = true }
 biome_js_syntax    = { workspace = true }


### PR DESCRIPTION
## Summary

I used [cargo-machette](https://github.com/bnjbvr/cargo-machete) to detect unused dependencies.
Unfortunately we cannot use this on CI because there are false positives.

## Test Plan

CI should pass.
