### PR TITLE
fix(website): result tab panel height

### DIFF
--- a/website/src/styles/playground/_results.scss
+++ b/website/src/styles/playground/_results.scss
@@ -11,6 +11,8 @@
 .results-tabs {
   height: 100%;
   width: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .mermaid {

--- a/website/src/styles/playground/_tabs.scss
+++ b/website/src/styles/playground/_tabs.scss
@@ -4,7 +4,7 @@
 .react-tabs__tab-panel  {
   display: none;
   flex-direction: column;
-  height: 100%;
+  flex-grow: 1;
   overflow: hidden;
 
   > pre[class*=language-] {


### PR DESCRIPTION
## Summary

This is a follow-up fix of https://github.com/biomejs/biome/pull/1855#issuecomment-1951023066. The result tab panel is no longer chopped off.

## Test Plan

Visually confirm the result tab panel can show all of its content.

![image](https://github.com/biomejs/biome/assets/10386119/fd74be23-1def-4409-8efc-4c240de42f04)

Code for quick testing:

```js
try {
	undefined;
	try {
		while (true) {
			if (Date.now() > 0) {
				undefined;
				break;
			}
		}
	} finally {
		if (Date.now() > 0) undefined;
	}
	if (Date.now() > 0) undefined;
} catch {
	undefined;
}
```
