### PR TITLE
chore: mark `pnpm-lock.yaml` as a generated file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto eol=lf
+**/generated/* linguist-generated=true text=auto eol=lf
 crates/biome_unicode_table/src/tables.rs linguist-generated=true text=auto eol=lf
 **/generated/* linguist-generated=true text=auto eol=lf
 crates/biome_js_analyze/src/analyzers.rs linguist-generated=true text=auto eol=lf
@@ -14,6 +15,7 @@ website/src/pages/lint/rules/**/*.md linguist-generated=true text=auto eol=lf
 website/src/components/generated/.astro linguist-generated=true text=auto eol=lf
 packages/@biomejs/biome/configuration_schema.json linguist-generated=true text=auto eol=lf
 crates/biome_service/src/configuration/parse/json/rules.rs linguist-generated=true text=auto eol=lf
+**/pnpm-lock.yaml linguist-generated=true text=auto eol=lf
 crates/biome_js_formatter/tests/**/*.ts.prettier-snap linguist-language=TypeScript
 crates/biome_js_formatter/tests/**/*.js.prettier-snap linguist-language=JavaScript
 crates/biome_js_formatter/tests/**/*.ts.snap linguist-language=Markdown

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 * text=auto eol=lf
-**/generated/* linguist-generated=true text=auto eol=lf
 crates/biome_unicode_table/src/tables.rs linguist-generated=true text=auto eol=lf
 **/generated/* linguist-generated=true text=auto eol=lf
 crates/biome_js_analyze/src/analyzers.rs linguist-generated=true text=auto eol=lf


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Lockfiles are generated files, and as such they should be marked as generated.

`package-lock.json` (npm) lockfiles are detected as generated on GitHub by default, so I think there is no reason not to set this as generated, as it ignores the file for the repo's language statistics and hides it by default in diffs.

See https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github and https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#generated-code

Note that there are multiple pnpm lockfiles in this repo, which is not ideal as pnpm workspaces should only have one lockfile at root (iirc). I'll investigate more and try to open a PR fixing that, unless someone else does it before me

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
