### PR TITLE
fix(configuration): enabled rules calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ New entries must be placed in a section entitled `Unreleased`.
 Read
 our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
+## Ureleased
+
+### Analyzer
+
+### CLI
+
+### Configuration
+
+#### Bug fixes
+
+- Fix enabled rules calculation. The precendence of individual rules, `all` and `recommend` presets in top-level and group-level configs is now correctly respected. More details can be seen in ([#2072](https://github.com/biomejs/biome/pull/2072)) ([#2028](https://github.com/biomejs/biome/issues/2028)). Contributed by @Sec-ant
+
+### Editors
+
+### Formatter
+
+### JavaScript APIs
+
+### Linter
+
+### Parser
+
 ## 1.6.1 (2024-03-12)
 
 ### CLI

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -1867,6 +1867,58 @@ fn top_level_not_all_down_level_all() {
 }
 
 #[test]
+fn top_level_all_down_level_empty() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    // style rules that are not recommended should be enabled.
+    let biome_json = r#"{
+        "linter": {
+            "rules": {
+                "all": true,
+                "nursery": {
+                    "all": false
+                },
+                "suspicious": {
+                    "all": false
+                },
+                "style": {}
+            }
+        }
+    }"#;
+
+    // style/noRestrictedGlobals
+    // style/noShoutyConstants
+    let code = r#"
+    console.log(event);
+    const FOO = "FOO";
+    console.log(FOO);
+    "#;
+
+    let file_path = Path::new("fix.js");
+    fs.insert(file_path.into(), code.as_bytes());
+
+    let config_path = Path::new("biome.json");
+    fs.insert(config_path.into(), biome_json.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("lint"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "top_level_all_down_level_empty",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn ignore_configured_globals() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_down_level_empty.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_down_level_empty.snap
@@ -1,0 +1,89 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "all": true,
+      "nursery": {
+        "all": false
+      },
+      "suspicious": {
+        "all": false
+      },
+      "style": {}
+    }
+  }
+}
+```
+
+## `fix.js`
+
+```js
+
+    console.log(event);
+    const FOO = "FOO";
+    console.log(FOO);
+    
+```
+
+# Emitted Messages
+
+```block
+fix.js:2:17 lint/style/noRestrictedGlobals ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not use the global variable event.
+  
+  > 2 │     console.log(event);
+      │                 ^^^^^
+    3 │     const FOO = "FOO";
+    4 │     console.log(FOO);
+  
+  i Use a local variable instead.
+  
+
+```
+
+```block
+fix.js:3:11 lint/style/noShoutyConstants  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Redundant constant declaration.
+  
+    2 │     console.log(event);
+  > 3 │     const FOO = "FOO";
+      │           ^^^^^^^^^^^
+    4 │     console.log(FOO);
+    5 │     
+  
+  i Used here.
+  
+    2 │     console.log(event);
+    3 │     const FOO = "FOO";
+  > 4 │     console.log(FOO);
+      │                 ^^^
+    5 │     
+  
+  i You should avoid declaring constants with a string that's the same
+        value as the variable name. It introduces a level of unnecessary
+        indirection when it's only two additional characters to inline.
+  
+  i Unsafe fix: Use the constant value directly
+  
+    1 1 │   
+    2 2 │       console.log(event);
+    3   │ - ····const·FOO·=·"FOO";
+    4   │ - ····console.log(FOO);
+      3 │ + ····console.log("FOO");
+    5 4 │       
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 2 warnings.
+```

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -224,6 +224,7 @@ impl Rules {
     pub(crate) const fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
+    #[allow(dead_code)]
     pub(crate) const fn is_not_all(&self) -> bool {
         matches!(self.all, Some(false))
     }
@@ -235,6 +236,7 @@ impl Rules {
         let mut disabled_rules = IndexSet::new();
         if let Some(group) = self.a11y.as_ref() {
             group.collect_preset_rules(
+                self.is_all(),
                 self.is_recommended(),
                 &mut enabled_rules,
                 &mut disabled_rules,
@@ -243,13 +245,12 @@ impl Rules {
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
             enabled_rules.extend(A11y::all_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(A11y::all_rules_as_filters());
         } else if self.is_recommended() {
             enabled_rules.extend(A11y::recommended_rules_as_filters());
         }
         if let Some(group) = self.complexity.as_ref() {
             group.collect_preset_rules(
+                self.is_all(),
                 self.is_recommended(),
                 &mut enabled_rules,
                 &mut disabled_rules,
@@ -258,13 +259,12 @@ impl Rules {
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
             enabled_rules.extend(Complexity::all_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Complexity::all_rules_as_filters());
         } else if self.is_recommended() {
             enabled_rules.extend(Complexity::recommended_rules_as_filters());
         }
         if let Some(group) = self.correctness.as_ref() {
             group.collect_preset_rules(
+                self.is_all(),
                 self.is_recommended(),
                 &mut enabled_rules,
                 &mut disabled_rules,
@@ -273,28 +273,26 @@ impl Rules {
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
             enabled_rules.extend(Correctness::all_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Correctness::all_rules_as_filters());
         } else if self.is_recommended() {
             enabled_rules.extend(Correctness::recommended_rules_as_filters());
         }
         if let Some(group) = self.nursery.as_ref() {
             group.collect_preset_rules(
-                self.is_recommended(),
+                self.is_all() && biome_flags::is_unstable(),
+                self.is_recommended() && biome_flags::is_unstable(),
                 &mut enabled_rules,
                 &mut disabled_rules,
             );
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
-        } else if self.is_all() {
+        } else if self.is_all() && biome_flags::is_unstable() {
             enabled_rules.extend(Nursery::all_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Nursery::all_rules_as_filters());
         } else if self.is_recommended() && biome_flags::is_unstable() {
             enabled_rules.extend(Nursery::recommended_rules_as_filters());
         }
         if let Some(group) = self.performance.as_ref() {
             group.collect_preset_rules(
+                self.is_all(),
                 self.is_recommended(),
                 &mut enabled_rules,
                 &mut disabled_rules,
@@ -303,13 +301,12 @@ impl Rules {
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
             enabled_rules.extend(Performance::all_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Performance::all_rules_as_filters());
         } else if self.is_recommended() {
             enabled_rules.extend(Performance::recommended_rules_as_filters());
         }
         if let Some(group) = self.security.as_ref() {
             group.collect_preset_rules(
+                self.is_all(),
                 self.is_recommended(),
                 &mut enabled_rules,
                 &mut disabled_rules,
@@ -318,13 +315,12 @@ impl Rules {
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
             enabled_rules.extend(Security::all_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Security::all_rules_as_filters());
         } else if self.is_recommended() {
             enabled_rules.extend(Security::recommended_rules_as_filters());
         }
         if let Some(group) = self.style.as_ref() {
             group.collect_preset_rules(
+                self.is_all(),
                 self.is_recommended(),
                 &mut enabled_rules,
                 &mut disabled_rules,
@@ -333,13 +329,12 @@ impl Rules {
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
             enabled_rules.extend(Style::all_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Style::all_rules_as_filters());
         } else if self.is_recommended() {
             enabled_rules.extend(Style::recommended_rules_as_filters());
         }
         if let Some(group) = self.suspicious.as_ref() {
             group.collect_preset_rules(
+                self.is_all(),
                 self.is_recommended(),
                 &mut enabled_rules,
                 &mut disabled_rules,
@@ -348,8 +343,6 @@ impl Rules {
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
             enabled_rules.extend(Suspicious::all_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Suspicious::all_rules_as_filters());
         } else if self.is_recommended() {
             enabled_rules.extend(Suspicious::recommended_rules_as_filters());
         }
@@ -944,19 +937,23 @@ impl A11y {
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
+        parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
         disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
         if self.is_all() {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended || self.is_recommended() {
+        } else if self.is_recommended() {
             enabled_rules.extend(Self::recommended_rules_as_filters());
-        }
-        if self.is_not_all() {
+        } else if self.is_not_all() {
             disabled_rules.extend(Self::all_rules_as_filters());
         } else if self.is_not_recommended() {
             disabled_rules.extend(Self::recommended_rules_as_filters());
+        } else if parent_is_all {
+            enabled_rules.extend(Self::all_rules_as_filters());
+        } else if parent_is_recommended {
+            enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
     pub(crate) fn get_rule_configuration(
@@ -1624,19 +1621,23 @@ impl Complexity {
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
+        parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
         disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
         if self.is_all() {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended || self.is_recommended() {
+        } else if self.is_recommended() {
             enabled_rules.extend(Self::recommended_rules_as_filters());
-        }
-        if self.is_not_all() {
+        } else if self.is_not_all() {
             disabled_rules.extend(Self::all_rules_as_filters());
         } else if self.is_not_recommended() {
             disabled_rules.extend(Self::recommended_rules_as_filters());
+        } else if parent_is_all {
+            enabled_rules.extend(Self::all_rules_as_filters());
+        } else if parent_is_recommended {
+            enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
     pub(crate) fn get_rule_configuration(
@@ -2431,19 +2432,23 @@ impl Correctness {
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
+        parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
         disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
         if self.is_all() {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended || self.is_recommended() {
+        } else if self.is_recommended() {
             enabled_rules.extend(Self::recommended_rules_as_filters());
-        }
-        if self.is_not_all() {
+        } else if self.is_not_all() {
             disabled_rules.extend(Self::all_rules_as_filters());
         } else if self.is_not_recommended() {
             disabled_rules.extend(Self::recommended_rules_as_filters());
+        } else if parent_is_all {
+            enabled_rules.extend(Self::all_rules_as_filters());
+        } else if parent_is_recommended {
+            enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
     pub(crate) fn get_rule_configuration(
@@ -2990,7 +2995,8 @@ impl Nursery {
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
-        _parent_is_recommended: bool,
+        parent_is_all: bool,
+        parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
         disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
@@ -2998,11 +3004,14 @@ impl Nursery {
             enabled_rules.extend(Self::all_rules_as_filters());
         } else if self.is_recommended() {
             enabled_rules.extend(Self::recommended_rules_as_filters());
-        }
-        if self.is_not_all() {
+        } else if self.is_not_all() {
             disabled_rules.extend(Self::all_rules_as_filters());
         } else if self.is_not_recommended() {
             disabled_rules.extend(Self::recommended_rules_as_filters());
+        } else if parent_is_all {
+            enabled_rules.extend(Self::all_rules_as_filters());
+        } else if parent_is_recommended {
+            enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
     pub(crate) fn get_rule_configuration(
@@ -3197,19 +3206,23 @@ impl Performance {
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
+        parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
         disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
         if self.is_all() {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended || self.is_recommended() {
+        } else if self.is_recommended() {
             enabled_rules.extend(Self::recommended_rules_as_filters());
-        }
-        if self.is_not_all() {
+        } else if self.is_not_all() {
             disabled_rules.extend(Self::all_rules_as_filters());
         } else if self.is_not_recommended() {
             disabled_rules.extend(Self::recommended_rules_as_filters());
+        } else if parent_is_all {
+            enabled_rules.extend(Self::all_rules_as_filters());
+        } else if parent_is_recommended {
+            enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
     pub(crate) fn get_rule_configuration(
@@ -3356,19 +3369,23 @@ impl Security {
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
+        parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
         disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
         if self.is_all() {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended || self.is_recommended() {
+        } else if self.is_recommended() {
             enabled_rules.extend(Self::recommended_rules_as_filters());
-        }
-        if self.is_not_all() {
+        } else if self.is_not_all() {
             disabled_rules.extend(Self::all_rules_as_filters());
         } else if self.is_not_recommended() {
             disabled_rules.extend(Self::recommended_rules_as_filters());
+        } else if parent_is_all {
+            enabled_rules.extend(Self::all_rules_as_filters());
+        } else if parent_is_recommended {
+            enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
     pub(crate) fn get_rule_configuration(
@@ -4130,19 +4147,23 @@ impl Style {
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
+        parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
         disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
         if self.is_all() {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended || self.is_recommended() {
+        } else if self.is_recommended() {
             enabled_rules.extend(Self::recommended_rules_as_filters());
-        }
-        if self.is_not_all() {
+        } else if self.is_not_all() {
             disabled_rules.extend(Self::all_rules_as_filters());
         } else if self.is_not_recommended() {
             disabled_rules.extend(Self::recommended_rules_as_filters());
+        } else if parent_is_all {
+            enabled_rules.extend(Self::all_rules_as_filters());
+        } else if parent_is_recommended {
+            enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
     pub(crate) fn get_rule_configuration(
@@ -5239,19 +5260,23 @@ impl Suspicious {
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
+        parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
         disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
         if self.is_all() {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended || self.is_recommended() {
+        } else if self.is_recommended() {
             enabled_rules.extend(Self::recommended_rules_as_filters());
-        }
-        if self.is_not_all() {
+        } else if self.is_not_all() {
             disabled_rules.extend(Self::all_rules_as_filters());
         } else if self.is_not_recommended() {
             disabled_rules.extend(Self::recommended_rules_as_filters());
+        } else if parent_is_all {
+            enabled_rules.extend(Self::all_rules_as_filters());
+        } else if parent_is_recommended {
+            enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
     pub(crate) fn get_rule_configuration(

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -224,10 +224,6 @@ impl Rules {
     pub(crate) const fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    #[allow(dead_code)]
-    pub(crate) const fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
-    }
     #[doc = r" It returns the enabled rules by default."]
     #[doc = r""]
     #[doc = r" The enabled rules are calculated from the difference with the disabled rules."]

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -15,6 +15,28 @@ New entries must be placed in a section entitled `Unreleased`.
 Read
 our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
+## Ureleased
+
+### Analyzer
+
+### CLI
+
+### Configuration
+
+#### Bug fixes
+
+- Fix enabled rules calculation. The precendence of individual rules, `all` and `recommend` presets in top-level and group-level configs is now correctly respected. More details can be seen in ([#2072](https://github.com/biomejs/biome/pull/2072)) ([#2028](https://github.com/biomejs/biome/issues/2028)). Contributed by @Sec-ant
+
+### Editors
+
+### Formatter
+
+### JavaScript APIs
+
+### Linter
+
+### Parser
+
 ## 1.6.1 (2024-03-12)
 
 ### CLI

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -243,11 +243,6 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
                 matches!(self.all, Some(true))
             }
 
-            #[allow(dead_code)]
-            pub(crate) const fn is_not_all(&self) -> bool {
-                matches!(self.all, Some(false))
-            }
-
             /// It returns the enabled rules by default.
             ///
             /// The enabled rules are calculated from the difference with the disabled rules.

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -91,21 +91,27 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
             #property_group_name: None
         });
 
-        let global_recommended = if group == "nursery" {
-            quote! { self.is_recommended() && biome_flags::is_unstable() }
+        let (global_all, global_recommended) = if group == "nursery" {
+            (
+                quote! { self.is_all() && biome_flags::is_unstable() },
+                quote! { self.is_recommended() && biome_flags::is_unstable() },
+            )
         } else {
-            quote! { self.is_recommended() }
+            (quote! { self.is_all() }, quote! { self.is_recommended() })
         };
 
         group_as_default_rules.push(quote! {
             if let Some(group) = self.#property_group_name.as_ref() {
-                group.collect_preset_rules(self.is_recommended(), &mut enabled_rules, &mut disabled_rules);
+                group.collect_preset_rules(
+                    #global_all,
+                    #global_recommended,
+                    &mut enabled_rules,
+                    &mut disabled_rules,
+                );
                 enabled_rules.extend(&group.get_enabled_rules());
                 disabled_rules.extend(&group.get_disabled_rules());
-            } else if self.is_all() {
+            } else if #global_all {
                 enabled_rules.extend(#group_struct_name::all_rules_as_filters());
-            } else if self.is_not_all() {
-                disabled_rules.extend(#group_struct_name::all_rules_as_filters());
             } else if #global_recommended {
                 enabled_rules.extend(#group_struct_name::recommended_rules_as_filters());
             }
@@ -237,6 +243,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
                 matches!(self.all, Some(true))
             }
 
+            #[allow(dead_code)]
             pub(crate) const fn is_not_all(&self) -> bool {
                 matches!(self.all, Some(false))
             }
@@ -398,17 +405,7 @@ fn generate_struct(group: &str, rules: &BTreeMap<&'static str, RuleMetadata>) ->
     let group_struct_name = Ident::new(&to_capitalized(group), Span::call_site());
 
     let number_of_recommended_rules = Literal::u8_unsuffixed(number_of_recommended_rules);
-    let (group_recommended, parent_parameter) = if group == "nursery" {
-        (
-            quote! { self.is_recommended() },
-            quote! { _parent_is_recommended: bool, },
-        )
-    } else {
-        (
-            quote! { parent_is_recommended || self.is_recommended() },
-            quote! { parent_is_recommended: bool, },
-        )
-    };
+
     quote! {
         #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
         #[deserializable(with_validator)]
@@ -518,19 +515,23 @@ fn generate_struct(group: &str, rules: &BTreeMap<&'static str, RuleMetadata>) ->
             /// Select preset rules
             pub(crate) fn collect_preset_rules(
                 &self,
-                #parent_parameter
+                parent_is_all: bool,
+                parent_is_recommended: bool,
                 enabled_rules: &mut IndexSet<RuleFilter>,
                 disabled_rules: &mut IndexSet<RuleFilter>,
             ) {
                 if self.is_all() {
                     enabled_rules.extend(Self::all_rules_as_filters());
-                } else if #group_recommended {
+                } else if self.is_recommended() {
                     enabled_rules.extend(Self::recommended_rules_as_filters());
-                }
-                if self.is_not_all() {
+                } else if self.is_not_all() {
                     disabled_rules.extend(Self::all_rules_as_filters());
                 } else if self.is_not_recommended() {
                     disabled_rules.extend(Self::recommended_rules_as_filters());
+                } else if parent_is_all {
+                    enabled_rules.extend(Self::all_rules_as_filters());
+                } else if parent_is_recommended {
+                    enabled_rules.extend(Self::recommended_rules_as_filters());
                 }
             }
 


### PR DESCRIPTION
## Summary

It turns out the existing function `as_enabled_rules` was calculating the enabled rules in a wrong way. The function is generated by codegen, so I fixed the logic in `xtask/codegen/src/generate_configuration.rs` and regenerated that file. I summarize the correct logic as follows:

### For non-nursery groups

- Group-level `all` and group-level `recommend` should take precedence over their top-level alternatives.
- When group-level `all` or group-level `recommend` is not present, it should fallback to check top-level `all` or top-level `recommend`.
- If the whole group-level config is not present, it should check top-level `all` or top-level `recommend`.

### For nursery group

- Group-level `all` and group-level `recommend` should take precedence over top-level alternatives. (same as non-nursery groups)
- When group-level `all` or group-level `recommend` is not present, it should fallback to check top-level `all` or top-level `recommend` **only in unstable releases**.
- If the whole group-level config is not present, it should check top-level `all` or top-level `recommend` **only in unstable releases**.

Fixes #2028.

## Test Plan

Since the nursery group is unstable because the rules in it may be promoted in later releases, I didn't add test cases for the nursery group. But I tested it locally and it works as expected.

I added a test case called `top_level_all_down_level_empty`. It's to check whether the non-recommended rules belonging to a group will be enabled if we have a top-level `all` as `true` and an empty config of that group. The expected result is they should be kept enabled. In current release (`v1.6.1`) they are wrongly disabled. I guess the reason why this issue isn't discovered earlier is because most rules under a group are recommended rules.