### PR TITLE
fix(tests_infra): `TIME_REGEX` for snapshot redaction

### DIFF
--- a/crates/biome_cli/tests/snap_test.rs
+++ b/crates/biome_cli/tests/snap_test.rs
@@ -17,7 +17,7 @@ use std::fmt::Write as _;
 use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 
 lazy_static! {
-    static ref TIME_REGEX: Regex = Regex::new("\\s[0-9]+[(m|µ|n)]s.").unwrap();
+    static ref TIME_REGEX: Regex = Regex::new("\\s[0-9]+[m|µ|n]?s.").unwrap();
 }
 
 #[derive(Default)]


### PR DESCRIPTION
## Summary

Take time in seconds into account. It starts to be annoying so I want to change it. I hope this won't introduce any false positives.

## Test Plan

Shouldn't change existing snapshots.
