### PR TITLE
fix(`useJsxKeyInIterable`): unwrap parenthesized expressions

### DIFF
--- a/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/semantic_analyzers/nursery/use_jsx_key_in_iterable.rs
@@ -130,7 +130,7 @@ fn handle_collections(
             let node = node.ok()?;
             // no need to handle spread case, if the spread argument is itself a list it
             // will be handled during list declaration
-            let node = node.as_any_js_expression()?;
+            let node = AnyJsExpression::cast(node.into_syntax())?;
             handle_potential_react_component(node, model, is_inside_jsx)
         })
         .collect()
@@ -196,7 +196,7 @@ fn handle_iterators(
                 .filter_map(|statement| {
                     let statement = statement.as_js_return_statement()?;
                     let returned_value = statement.argument()?;
-                    handle_potential_react_component(&returned_value, model, is_inside_jsx)
+                    handle_potential_react_component(returned_value, model, is_inside_jsx)
                 })
                 .collect::<Vec<_>>();
 
@@ -206,14 +206,7 @@ fn handle_iterators(
             let body = callback.body().ok()?;
             match body {
                 AnyJsFunctionBody::AnyJsExpression(expr) => {
-                    // unwrap parenthesized expression
-                    let mut inner_expr = expr;
-                    while let AnyJsExpression::JsParenthesizedExpression(parenthesized_expr) =
-                        inner_expr
-                    {
-                        inner_expr = parenthesized_expr.expression().ok()?;
-                    }
-                    handle_potential_react_component(&inner_expr, model, is_inside_jsx)
+                    handle_potential_react_component(expr, model, is_inside_jsx)
                         .map(|state| vec![state])
                 }
                 AnyJsFunctionBody::JsFunctionBody(body) => {
@@ -223,7 +216,7 @@ fn handle_iterators(
                         .filter_map(|statement| {
                             let statement = statement.as_js_return_statement()?;
                             let returned_value = statement.argument()?;
-                            handle_potential_react_component(&returned_value, model, is_inside_jsx)
+                            handle_potential_react_component(returned_value, model, is_inside_jsx)
                         })
                         .collect::<Vec<_>>();
                     Some(res)
@@ -235,10 +228,11 @@ fn handle_iterators(
 }
 
 fn handle_potential_react_component(
-    node: &AnyJsExpression,
+    node: AnyJsExpression,
     model: &SemanticModel,
     is_inside_jsx: bool,
 ) -> Option<UseJsxKeyInIterableState> {
+    let node = unwrap_parenthesis(node)?;
     if is_inside_jsx {
         if let Some(node) = ReactComponentExpression::cast_ref(node.syntax()) {
             let range = handle_react_component(node, model)?;
@@ -358,4 +352,13 @@ fn has_key_prop(props: &JsObjectExpression) -> bool {
             _ => false,
         }
     })
+}
+
+// unwrap parenthesized expression
+fn unwrap_parenthesis(expr: AnyJsExpression) -> Option<AnyJsExpression> {
+    let mut inner_expr = expr;
+    while let AnyJsExpression::JsParenthesizedExpression(parenthesized_expr) = inner_expr {
+        inner_expr = parenthesized_expr.expression().ok()?;
+    }
+    Some(inner_expr)
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/useJsxKeyInIterable/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useJsxKeyInIterable/invalid.jsx
@@ -37,3 +37,5 @@ React.Children.map(c => React.cloneElement(c));
 (<h1>{data.map(c => xyz)}</h1>)
 
 (<h1>{data.map(c => (<h1></h1>))}</h1>)
+
+(<h1>{data.map(c => {return (<h1></h1>)})}</h1>)

--- a/crates/biome_js_analyze/tests/specs/nursery/useJsxKeyInIterable/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useJsxKeyInIterable/invalid.jsx.snap
@@ -43,6 +43,8 @@ React.Children.map(c => React.cloneElement(c));
 (<h1>{data.map(c => xyz)}</h1>)
 
 (<h1>{data.map(c => (<h1></h1>))}</h1>)
+
+(<h1>{data.map(c => {return (<h1></h1>)})}</h1>)
 ```
 
 # Diagnostics
@@ -605,6 +607,25 @@ invalid.jsx:39:22 lint/nursery/useJsxKeyInIterable ━━━━━━━━━�
     38 │ 
   > 39 │ (<h1>{data.map(c => (<h1></h1>))}</h1>)
        │                      ^^^^
+    40 │ 
+    41 │ (<h1>{data.map(c => {return (<h1></h1>)})}</h1>)
+  
+  i The order of the items may change, and having a key can help React identify which item was moved.
+  
+  i Check the React documentation. 
+  
+
+```
+
+```
+invalid.jsx:41:30 lint/nursery/useJsxKeyInIterable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing key property for this element in iterable.
+  
+    39 │ (<h1>{data.map(c => (<h1></h1>))}</h1>)
+    40 │ 
+  > 41 │ (<h1>{data.map(c => {return (<h1></h1>)})}</h1>)
+       │                              ^^^^
   
   i The order of the items may change, and having a key can help React identify which item was moved.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useJsxKeyInIterable/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useJsxKeyInIterable/valid.jsx
@@ -44,3 +44,5 @@ React.Children.map(c => React.cloneElement(c, {key: c}));
 (<h1>{data.map(c => <h1 key={c}></h1>)}</h1>)
 
 (<h1>{data.map(c => (<h1 key={c}></h1>))}</h1>)
+
+(<h1>{data.map(c => {return (<h1 key={c}></h1>)})}</h1>)

--- a/crates/biome_js_analyze/tests/specs/nursery/useJsxKeyInIterable/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useJsxKeyInIterable/valid.jsx.snap
@@ -50,4 +50,6 @@ React.Children.map(c => React.cloneElement(c, {key: c}));
 (<h1>{data.map(c => <h1 key={c}></h1>)}</h1>)
 
 (<h1>{data.map(c => (<h1 key={c}></h1>))}</h1>)
+
+(<h1>{data.map(c => {return (<h1 key={c}></h1>)})}</h1>)
 ```


### PR DESCRIPTION
## Summary

This is a follow-up of #2016 to handle all parenthesized expressions.

See https://github.com/biomejs/biome/issues/2011#issuecomment-1993783800

## Test Plan

New test cases are added and should pass.