### PR TITLE
chore: fix `@biomejs/biome` inconsistency in `package.json`

### DIFF
--- a/packages/@biomejs/biome/package.json
+++ b/packages/@biomejs/biome/package.json
@@ -30,7 +30,7 @@
         "format",
         "lint",
         "toolchain",
-				"JSON"
+        "JSON"
     ],
     "engines": {
         "node": ">=14.*"


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
Ever since JSON formatting was introduced, the `JSON` keyword was spaced with tabs instead of spaces for some reason, unlike every other line in `package.json`. The CLI should probably have caught this when formatting, idk why it never did. Should have probably done this in my previous PR ¯\\\_(ツ)\_\/¯
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
