### PR TITLE
Update usage commands for Yarn and PNPM

### DIFF
--- a/website/src/components/PackageManagerBiomeCommand.astro
+++ b/website/src/components/PackageManagerBiomeCommand.astro
@@ -6,7 +6,8 @@ interface Props {
 }
 
 const { command } = Astro.props;
-const biome = "@biomejs/biome";
+const biomePackage = "@biomejs/biome";
+const biomeBin = "biome";
 ---
 <script>
 	import "@/frontend-scripts/package-manager-commands";
@@ -36,17 +37,17 @@ const biome = "@biomejs/biome";
 </ul>
 
 <pre data-name="npm" class="package-manager-command language-shellsession active">
-	<Code code={`npx ${biome} ${command}`} lang="bash"  />
+	<Code code={`npx ${biomePackage} ${command}`} lang="bash"  />
 </pre>
 <pre data-name="yarn" class="package-manager-command language-shellsession">
-	<Code code={`yarn dlx ${biome} ${command}`} lang="bash"  />
+	<Code code={`yarn ${biomeBin} ${command}`} lang="bash"  />
 </pre>
 <pre data-name="pnpm" class="package-manager-command language-shellsession">
-	<Code code={`pnpm dlx ${biome} ${command}`} lang="bash"  />
+	<Code code={`pnpm ${biomeBin} ${command}`} lang="bash"  />
 </pre>
 <pre data-name="bun" class="package-manager-command language-shellsession">
-	<Code code={`bunx ${biome} ${command}`} lang="bash"  />
+	<Code code={`bunx ${biomePackage} ${command}`} lang="bash"  />
 </pre>
 <pre data-name="deno" class="package-manager-command language-shellsession">
-	<Code code={`deno run -A npm:${biome} ${command}`} lang="bash"  />
+	<Code code={`deno run -A npm:${biomePackage} ${command}`} lang="bash"  />
 </pre>


### PR DESCRIPTION
## Summary

Both Yarn and PNPM shouldn't use `dlx` to execute Biome, since it bypasses the installed version. Instead, they can directly call the installed binary through a more convenient command.

Note that `npx` (and I assume `bunx`) can also use the binary name instead of the package name *if the package is installed*, but it's somewhat unsafe for them to use the binary name because it gets interpreted as a different package if Biome is not installed.

Addresses #1986.

## Test Plan

None needed.
