### PR TITLE
chore: enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
I saw some outdated actions, so this PR enables dependabot which will open PRs to update them and also check daily for new updates.

I could have also enabled it for npm packages and rust crates but I didn't to avoid cluttering this repo with dependabot PRs. We use *many* dependencies.

iirc dependabot doesn't check external actions like https://github.com/biomejs/biome/blob/main/.github/actions/free-disk-space/action.yaml, those will have to be manually updated. Considering that the action only uses one action with tag main it shouldn't be a problem
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
