### PR TITLE
fix(noSuperWithoutExtends): detect class expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Analyzer
 
+#### Bug fixes
+
+- The `noSuperWithoutExtends` rule now allows for calling `super()` in derived class constructors of class expressions ([#2108](https://github.com/biomejs/biome/issues/2108)). Contributed by @Sec-ant
+
 ### CLI
 
 ### Configuration

--- a/crates/biome_js_analyze/tests/specs/correctness/noSuperWithoutExtends/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noSuperWithoutExtends/valid.js
@@ -1,0 +1,8 @@
+class A {}
+class B {
+	a = class extends A {
+		constructor(_) {
+			super();
+		}
+	};
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noSuperWithoutExtends/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noSuperWithoutExtends/valid.js.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```jsx
+class A {}
+class B {
+	a = class extends A {
+		constructor(_) {
+			super();
+		}
+	};
+}
+
+```

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -19,6 +19,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Analyzer
 
+#### Bug fixes
+
+- The `noSuperWithoutExtends` rule now allows for calling `super()` in derived class constructors of class expressions ([#2108](https://github.com/biomejs/biome/issues/2108)). Contributed by @Sec-ant
+
 ### CLI
 
 ### Configuration


### PR DESCRIPTION
## Summary

This rule should also check the extends clause of a class expression.

Fixes #2108.

## Test Plan

I added a valid test case:

```ts
class A {}
class B {
	a = class extends A {
		constructor(_) {
			super();
		}
	};
}
```
