### PR TITLE
fix: discrepancies on file source detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@ New entries must be placed in a section entitled `Unreleased`.
 Read
 our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
-## Ureleased
+## Unreleased
 
 ### Analyzer
 
 #### Bug fixes
 
 - The `noSuperWithoutExtends` rule now allows for calling `super()` in derived class constructors of class expressions ([#2108](https://github.com/biomejs/biome/issues/2108)). Contributed by @Sec-ant
+
+- Fix discrepancies on file source detection. Allow module syntax in `.cts` files ([#2114](https://github.com/biomejs/biome/issues/2114)). Contributed by @Sec-ant
 
 ### CLI
 
@@ -32,7 +34,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### Bug fixes
 
 - Fix [https://github.com/biomejs/biome/issues/1661](https://github.com/biomejs/biome/issues/1661). Now nested conditionals are aligned with Prettier's logic, and won't contain mixed spaced and tabs. Contributed by @ematipico
-
 
 ### JavaScript APIs
 

--- a/crates/biome_cli/tests/cases/cts_files.rs
+++ b/crates/biome_cli/tests/cases/cts_files.rs
@@ -1,0 +1,35 @@
+use crate::run_cli;
+use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
+use biome_console::BufferConsole;
+use biome_fs::MemoryFileSystem;
+use biome_service::DynRef;
+use bpaf::Args;
+use std::path::Path;
+
+#[test]
+fn should_allow_using_export_statements() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("a.cts");
+    fs.insert(
+        file_path.into(),
+        r#"export default { cjs: true };"#.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("lint"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_allow_using_export_statements",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/cases/mod.rs
+++ b/crates/biome_cli/tests/cases/mod.rs
@@ -3,6 +3,7 @@
 
 mod biome_json_support;
 mod config_extends;
+mod cts_files;
 mod diagnostics;
 mod handle_astro_files;
 mod handle_svelte_files;

--- a/crates/biome_cli/tests/snapshots/main_cases_cts_files/should_allow_using_export_statements.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_cts_files/should_allow_using_export_statements.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `a.cts`
+
+```cts
+export default { cjs: true };
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+```

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -2,7 +2,7 @@ use biome_analyze::{AnalysisFilter, AnalyzerAction, ControlFlow, Never, RuleFilt
 use biome_diagnostics::advice::CodeSuggestionAdvice;
 use biome_diagnostics::{DiagnosticExt, Severity};
 use biome_js_parser::{parse, JsParserOptions};
-use biome_js_syntax::{JsFileSource, JsLanguage, ModuleKind};
+use biome_js_syntax::{JsFileSource, JsLanguage};
 use biome_rowan::AstNode;
 use biome_test_utils::{
     assert_errors_are_absent, code_fix_to_string, create_analyzer_options, diagnostic_to_string,
@@ -220,9 +220,9 @@ pub(crate) fn run_suppression_test(input: &'static str, _: &str, _: &str, _: &st
 
     let input_file = Path::new(input);
     let file_name = input_file.file_name().and_then(OsStr::to_str).unwrap();
-    let file_ext = match input_file.extension().and_then(OsStr::to_str).unwrap() {
-        "cjs" => JsFileSource::js_module().with_module_kind(ModuleKind::Script),
+    let source_type = match input_file.extension().and_then(OsStr::to_str).unwrap() {
         "js" | "mjs" | "jsx" => JsFileSource::jsx(),
+        "cjs" => JsFileSource::js_script(),
         "ts" => JsFileSource::ts(),
         "mts" | "cts" => JsFileSource::ts_restricted(),
         "tsx" => JsFileSource::tsx(),
@@ -245,7 +245,7 @@ pub(crate) fn run_suppression_test(input: &'static str, _: &str, _: &str, _: &st
     analyze_and_snap(
         &mut snapshot,
         &input_code,
-        file_ext,
+        source_type,
         filter,
         file_name,
         input_file,

--- a/crates/biome_js_syntax/src/file_source.rs
+++ b/crates/biome_js_syntax/src/file_source.rs
@@ -314,8 +314,8 @@ fn compute_source_type_from_path_or_extension(
         JsFileSource::d_ts()
     } else {
         match extension {
-            "cjs" => JsFileSource::js_module().with_module_kind(ModuleKind::Script),
             "js" | "mjs" | "jsx" => JsFileSource::jsx(),
+            "cjs" => JsFileSource::js_script(),
             "ts" => JsFileSource::ts(),
             "mts" | "cts" => JsFileSource::ts_restricted(),
             "tsx" => JsFileSource::tsx(),

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -19,7 +19,7 @@ use biome_css_syntax::CssFileSource;
 use biome_diagnostics::{Diagnostic, Severity};
 use biome_formatter::Printed;
 use biome_fs::BiomePath;
-use biome_js_syntax::{EmbeddingKind, JsFileSource, ModuleKind, TextRange, TextSize};
+use biome_js_syntax::{EmbeddingKind, JsFileSource, TextRange, TextSize};
 use biome_json_syntax::JsonFileSource;
 use biome_parser::AnyParse;
 use biome_project::PackageJson;
@@ -95,23 +95,15 @@ impl DocumentFileSource {
         "typescript.json",
     ];
 
-    /// Returns the language corresponding to this language ID
-    ///
-    /// See the [microsoft spec]
-    /// for a list of language identifiers
-    ///
-    /// [microsoft spec]: https://code.visualstudio.com/docs/languages/identifiers
+    /// Returns the language corresponding to this file extension
     pub fn from_extension(s: &str) -> Self {
         match s.to_lowercase().as_str() {
-            "js" | "mjs" => JsFileSource::jsx().into(),
+            "js" | "mjs" | "jsx" => JsFileSource::jsx().into(),
             "cjs" => JsFileSource::js_script().into(),
-            "jsx" => JsFileSource::jsx().into(),
-            "ts" | "mts" => JsFileSource::ts().into(),
-            "cts" => JsFileSource::ts()
-                .with_module_kind(ModuleKind::Script)
-                .into(),
-            "d.ts" | "d.mts" | "d.cts" => JsFileSource::d_ts().into(),
+            "ts" => JsFileSource::ts().into(),
+            "mts" | "cts" => JsFileSource::ts_restricted().into(),
             "tsx" => JsFileSource::tsx().into(),
+            "d.ts" | "d.mts" | "d.cts" => JsFileSource::d_ts().into(),
             "json" => JsonFileSource::json().into(),
             "jsonc" => JsonFileSource::jsonc().into(),
             "astro" => JsFileSource::astro().into(),
@@ -135,7 +127,7 @@ impl DocumentFileSource {
             "javascriptreact" => JsFileSource::jsx().into(),
             "typescriptreact" => JsFileSource::tsx().into(),
             "json" => JsonFileSource::json().into(),
-            "jsonc" => JsonFileSource::json().into(),
+            "jsonc" => JsonFileSource::jsonc().into(),
             "astro" => JsFileSource::astro().into(),
             "vue" => JsFileSource::vue().into(),
             "svelte" => JsFileSource::svelte().into(),

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -15,13 +15,15 @@ New entries must be placed in a section entitled `Unreleased`.
 Read
 our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
-## Ureleased
+## Unreleased
 
 ### Analyzer
 
 #### Bug fixes
 
 - The `noSuperWithoutExtends` rule now allows for calling `super()` in derived class constructors of class expressions ([#2108](https://github.com/biomejs/biome/issues/2108)). Contributed by @Sec-ant
+
+- Fix discrepancies on file source detection. Allow module syntax in `.cts` files ([#2114](https://github.com/biomejs/biome/issues/2114)). Contributed by @Sec-ant
 
 ### CLI
 
@@ -38,7 +40,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### Bug fixes
 
 - Fix [https://github.com/biomejs/biome/issues/1661](https://github.com/biomejs/biome/issues/1661). Now nested conditionals are aligned with Prettier's logic, and won't contain mixed spaced and tabs. Contributed by @ematipico
-
 
 ### JavaScript APIs
 


### PR DESCRIPTION
## Summary

Fix discrepancies on file source detection. Allow module syntax in `.cts` files.

Fixes #2114.

## Test Plan

Added a test case to show that the following statement can be used in a `.cts` file:

```ts
export default { cjs: true };
```