### PR TITLE
ci: add renovate to monitor dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "timezone": "Europe/Gibraltar",
+  "schedule": ["0 9 * * 1"],
+  "assignees": ["@biomejs/maintainers", "@biomejs/core-contributors"],
+  "packageRules": [
+    {
+      "groupName": "github-actions",
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "groupName": "Rust crates",
+      "matchManagers": ["cargo"],
+      "matchFileNames": ["crates/**", "xtask/**"],
+      "ignoreDeps": ["syn", "quote"]
+    },
+    {
+      "groupName": "Website",
+      "matchFileNames": ["website/package.json"],
+      "matchManagers": ["npm"]
+    },
+    {
+      "groupName": "@biomjes packages",
+      "matchFileNames": ["packages/**"],
+      "matchManagers": ["npm"]
+    }
+  ]
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds [renovate](https://docs.renovatebot.com/) to the repository. It adds four groups to monitor:
- github actions
- rust crates
- website
- npm packages

For Rust crates, `syn` and `quote` are ignored for now.

It will open PRs every Monday at 9AM GMT and it will tag the teams @biomejs/core-contributors  and @biomejs/maintainers 


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Merge it. It will create a new issue with the label "Dashboard". That issue can't be closed.

<!-- What demonstrates that your implementation is correct? -->
