### PR TITLE
fix(noUndeclaredDependencies): false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### Bug fixes
 
 - Rule `noUndeclaredDependencies` now also validates `peerDependencies` and `optionalDependencies` ([#2122](https://github.com/biomejs/biome/issues/2122)). Contributed by @Sec-ant
+- Rule `noUndeclaredDependencies` won't check `declare module` statements anymore ([#2123](https://github.com/biomejs/biome/issues/2123)). Contributed by @Sec-ant
 
 ### Parser
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Linter
 
+#### Bug fixes
+
+- Rule `noUndeclaredDependencies` now also validates `peerDependencies` and `optionalDependencies` ([#2122](https://github.com/biomejs/biome/issues/2122)). Contributed by @Sec-ant
+
 ### Parser
 
 ## 1.6.1 (2024-03-12)

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_undeclared_dependencies.rs
@@ -66,7 +66,11 @@ impl Rule for NoUndeclaredDependencies {
         }
         let package_name = &text[..pointer];
 
-        if ctx.is_dependency(package_name) || ctx.is_dev_dependency(package_name) {
+        if ctx.is_dependency(package_name)
+            || ctx.is_dev_dependency(package_name)
+            || ctx.is_peer_dependency(package_name)
+            || ctx.is_optional_dependency(package_name)
+        {
             return None;
         }
 

--- a/crates/biome_js_analyze/src/analyzers/nursery/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/analyzers/nursery/no_undeclared_dependencies.rs
@@ -1,8 +1,8 @@
 use crate::manifest_services::Manifest;
 use biome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use biome_console::markup;
-use biome_js_syntax::AnyJsImportSpecifierLike;
-use biome_rowan::AstNode;
+use biome_js_syntax::{AnyJsImportSpecifierLike, TsExternalModuleDeclaration};
+use biome_rowan::{AstNode, SyntaxNodeOptionExt};
 
 declare_rule! {
     /// Disallow the use of dependencies that aren't specified in the `package.json`.
@@ -44,6 +44,14 @@ impl Rule for NoUndeclaredDependencies {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
+
+        if let Some(parent_syntax_kind) = node.syntax().parent().kind() {
+            // Ignore module declaration statements:
+            // declare module "jest";
+            if TsExternalModuleDeclaration::can_cast(parent_syntax_kind) {
+                return None;
+            }
+        }
 
         let token_text = node.inner_string_text()?;
         let text = token_text.text();

--- a/crates/biome_js_analyze/src/manifest_services.rs
+++ b/crates/biome_js_analyze/src/manifest_services.rs
@@ -21,7 +21,10 @@ impl ManifestServices {
         self.manifest.dev_dependencies.contains(specifier)
     }
 
-    #[allow(dead_code)]
+    pub(crate) fn is_peer_dependency(&self, specifier: &str) -> bool {
+        self.manifest.peer_dependencies.contains(specifier)
+    }
+
     pub(crate) fn is_optional_dependency(&self, specifier: &str) -> bool {
         self.manifest.optional_dependencies.contains(specifier)
     }

--- a/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.d.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.d.ts
@@ -1,0 +1,5 @@
+declare module "jest";
+declare module "*.scss" {
+	const content: Record<string, string>;
+	export default content;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.d.ts.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.d.ts
+---
+# Input
+```ts
+declare module "jest";
+declare module "*.scss" {
+	const content: Record<string, string>;
+	export default content;
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.js
@@ -15,3 +15,6 @@ import "bun:test";
 
 import Button from "@mui/material/Button";
 import { fontFamily } from "tailwindcss/defaultTheme";
+
+import "peer-dep";
+import "optional-dep";

--- a/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.js.snap
@@ -22,4 +22,7 @@ import "bun:test";
 import Button from "@mui/material/Button";
 import { fontFamily } from "tailwindcss/defaultTheme";
 
+import "peer-dep";
+import "optional-dep";
+
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.package.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUndeclaredDependencies/valid.package.json
@@ -6,5 +6,11 @@
 	},
 	"devDependencies": {
 		"@testing-library/react": "1.0.0"
+	},
+	"peerDependencies": {
+		"peer-dep": "1.0.0"
+	},
+	"optionalDependencies": {
+		"optional-dep": "1.0.0"
 	}
 }

--- a/crates/biome_project/src/node_js_project/package_json.rs
+++ b/crates/biome_project/src/node_js_project/package_json.rs
@@ -15,6 +15,7 @@ pub struct PackageJson {
     pub description: Option<String>,
     pub dependencies: Dependencies,
     pub dev_dependencies: Dependencies,
+    pub peer_dependencies: Dependencies,
     pub optional_dependencies: Dependencies,
     pub license: Option<(String, TextRange)>,
 }
@@ -103,6 +104,12 @@ impl DeserializationVisitor for PackageJsonVisitor {
                         result.dev_dependencies = deps;
                     }
                 }
+                "peerDependencies" => {
+                    if let Some(deps) = Deserializable::deserialize(&value, &key_text, diagnostics)
+                    {
+                        result.peer_dependencies = deps;
+                    }
+                }
                 "optionalDependencies" => {
                     if let Some(deps) = Deserializable::deserialize(&value, &key_text, diagnostics)
                     {
@@ -111,7 +118,7 @@ impl DeserializationVisitor for PackageJsonVisitor {
                 }
                 _ => {
                     // each package can add their own field, so we should ignore any extraneous key
-                    // and only deserialize the ones that Rome deems important
+                    // and only deserialize the ones that Biome deems important
                 }
             }
         }

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -48,6 +48,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### Bug fixes
 
 - Rule `noUndeclaredDependencies` now also validates `peerDependencies` and `optionalDependencies` ([#2122](https://github.com/biomejs/biome/issues/2122)). Contributed by @Sec-ant
+- Rule `noUndeclaredDependencies` won't check `declare module` statements anymore ([#2123](https://github.com/biomejs/biome/issues/2123)). Contributed by @Sec-ant
 
 ### Parser
 

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -45,6 +45,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Linter
 
+#### Bug fixes
+
+- Rule `noUndeclaredDependencies` now also validates `peerDependencies` and `optionalDependencies` ([#2122](https://github.com/biomejs/biome/issues/2122)). Contributed by @Sec-ant
+
 ### Parser
 
 ## 1.6.1 (2024-03-12)


### PR DESCRIPTION
## Summary

This PR fixes some false positives reported by the rule `noUndeclaredDependencies`.

- The rule should validate `peerDependencies` and `optionalDependencies` in `package.json`. Fixes #2122.
- The rule shouldn't report module specifiers in TS external module declaration. Fixes #2123.

## Test Plan

New valid test cases are added.
