### PR TITLE
fix(biome_service): `.jsonc` file source and parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Rule `noUndeclaredVariables` now also checks for worker globals ([#2121](https://github.com/biomejs/biome/issues/2121)). Contributed by @Sec-ant
 
+### LSP
+
+#### Bug fixes
+
+- Correctly parse `.jsonc` files. Contributed by @Sec-ant
+
 ### Parser
 
 ## 1.6.1 (2024-03-12)

--- a/crates/biome_json_syntax/src/file_source.rs
+++ b/crates/biome_json_syntax/src/file_source.rs
@@ -1,13 +1,21 @@
 use biome_rowan::FileSourceError;
 use std::path::Path;
 
+// TODO: Jsonc is not well-defined, so some files may only support comments
+// but no trailing commas. We should reconsider whether to use Jsonc as a variant,
+// or just use something like: JsonWithComments, JsonWithCommentsAndTrailingCommas
+//
+// Currently, the "variant" key and other properties are making things duplicated
+// and error-prone.
+
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(
     Debug, Clone, Default, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize,
 )]
 pub struct JsonFileSource {
     variant: JsonVariant,
-    allow_trailing_comma: bool,
+    allow_trailing_commas: bool,
+    allow_comments: bool,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -24,28 +32,43 @@ impl JsonFileSource {
     pub fn json() -> Self {
         Self {
             variant: JsonVariant::Standard,
-            allow_trailing_comma: false,
+            allow_trailing_commas: false,
+            allow_comments: false,
         }
     }
 
     pub fn jsonc() -> Self {
         Self {
             variant: JsonVariant::Jsonc,
-            allow_trailing_comma: false,
+            allow_trailing_commas: true,
+            allow_comments: true,
         }
     }
 
-    pub fn with_trailing_comma(mut self, option_value: bool) -> Self {
-        self.allow_trailing_comma = option_value;
+    pub fn with_trailing_commas(mut self, option_value: bool) -> Self {
+        self.allow_trailing_commas = option_value;
         self
     }
 
-    pub fn set_allow_trailing_comma(&mut self, option_value: bool) {
-        self.allow_trailing_comma = option_value;
+    pub fn set_allow_trailing_commas(&mut self, option_value: bool) {
+        self.allow_trailing_commas = option_value;
     }
 
-    pub fn allows_trailing_comma(&self) -> bool {
-        self.allow_trailing_comma
+    pub fn get_allow_trailing_commas(&self) -> bool {
+        self.allow_trailing_commas
+    }
+
+    pub fn with_comments(mut self, option_value: bool) -> Self {
+        self.allow_comments = option_value;
+        self
+    }
+
+    pub fn set_allow_comments(&mut self, option_value: bool) {
+        self.allow_comments = option_value;
+    }
+
+    pub fn get_allow_comments(&self) -> bool {
+        self.allow_comments
     }
 
     pub const fn is_jsonc(&self) -> bool {

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -77,7 +77,12 @@ impl From<&Path> for DocumentFileSource {
 
 impl DocumentFileSource {
     /// Sorted array of files that are known as JSONC (JSON with comments).
-    pub(crate) const KNOWN_FILES_AS_JSONC: &'static [&'static str; 15] = &[
+    ///
+    /// TODO: We might want to narrow the list according to
+    /// https://github.com/prettier/prettier/issues/15945#issuecomment-1895371835
+    ///
+    /// We can settle with these for now until someone raise a issue
+    pub(crate) const WELL_KNOWN_JSONC_FILES: &'static [&'static str; 15] = &[
         ".babelrc",
         ".babelrc.json",
         ".ember-cli",
@@ -138,7 +143,7 @@ impl DocumentFileSource {
     }
 
     pub fn from_known_filename(s: &str) -> Self {
-        if Self::KNOWN_FILES_AS_JSONC.binary_search(&s).is_ok() {
+        if Self::WELL_KNOWN_JSONC_FILES.binary_search(&s).is_ok() {
             JsonFileSource::jsonc().into()
         } else {
             DocumentFileSource::Unknown
@@ -549,7 +554,7 @@ pub(crate) fn is_diagnostic_error(
 
 #[test]
 fn test_order() {
-    for items in DocumentFileSource::KNOWN_FILES_AS_JSONC.windows(2) {
+    for items in DocumentFileSource::WELL_KNOWN_JSONC_FILES.windows(2) {
         assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
     }
 }

--- a/crates/biome_service/tests/workspace.rs
+++ b/crates/biome_service/tests/workspace.rs
@@ -47,3 +47,21 @@ fn recognize_typescript_definition_file() {
 
     assert!(file.format_file().is_ok());
 }
+
+#[test]
+fn recognize_jsonc_file() {
+    let workspace = server();
+
+    let file = FileGuard::open(
+        workspace.as_ref(),
+        OpenFileParams {
+            path: BiomePath::new("a.jsonc"),
+            content: r#"{"a": 42,}//comment"#.into(),
+            version: 0,
+            document_file_source: None,
+        },
+    )
+    .unwrap();
+
+    assert!(file.format_file().is_ok());
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1705,7 +1705,8 @@ export interface JsFileSource {
 	version: LanguageVersion;
 }
 export interface JsonFileSource {
-	allow_trailing_comma: boolean;
+	allow_comments: boolean;
+	allow_trailing_commas: boolean;
 	variant: JsonVariant;
 }
 export interface CssFileSource {

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -59,6 +59,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Rule `noUndeclaredVariables` now also checks for worker globals ([#2121](https://github.com/biomejs/biome/issues/2121)). Contributed by @Sec-ant
 
+### LSP
+
+#### Bug fixes
+
+- Correctly parse `.jsonc` files. Contributed by @Sec-ant
+
 ### Parser
 
 ## 1.6.1 (2024-03-12)


### PR DESCRIPTION
## Summary

This PR fixes an issue where the server cannot correctly parse `.jsonc` files.

I still do not fully understand how CLI and LSP work, so I tweaked the code based on my understanding and left some comments. Please correct me if I did something unexpected.

## Test Plan

Added a test function in `workspace.rs` to show that it can correctly handle `.jsonc` files now.
