### PR TITLE
docs: fix broken links on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ cargo t test_some_function --show-output
 
 ## Checks
 
-When you finished your work, and you are ready to **commit and open a PR**, there are few other 
+When you finished your work, and you are ready to **commit and open a PR**, there are few other
 things you would need to run and check:
 - `just f` (alias for `just format`), formats Rust and TOML files.
 - `just l` (alias for `just lint`), run the linter for the whole project.
@@ -225,7 +225,7 @@ to the `knope.toml` file, which we use for changelog generation.
 
 ### Analyzers and lint rules
 
-To know the technical details of how our analyzer works, how to create a rule and how to write tests, please check our [internal page](https://github.com/biomejs/biome/blob/main/crates/biome_analyzer/CONTRIBUTING.md)
+To know the technical details of how our analyzer works, how to create a rule and how to write tests, please check our [internal page](https://github.com/biomejs/biome/blob/main/crates/biome_analyze/CONTRIBUTING.md)
 
 ### Parser
 
@@ -233,7 +233,7 @@ To know the technical details of how our parser works and how to write test, ple
 
 ### Formatter
 
-To know the technical details of how our formatter works and how to write test, please check our [internal page](https://github.com/biomejs/biome/blob/main/crates/biome_formatter/CONTRIBUTING.md)
+To know the technical details of how our formatter works and how to write test, please check our [internal page](https://docs.rs/biome_formatter/latest/biome_formatter/)
 
 
 ## Crate dependencies


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes broken links on CONTRIBUTING.md. 
- Analyzer: change `biome_analyzer` to `biome_analyze`
- Formatter: currently we don't have CONTRIBUTING.md and it says on Rust doc comments, so use that for now.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Jump to the links from the diff files

<!-- What demonstrates that your implementation is correct? -->
