### PR TITLE
fix: migrate prettier auto endofline to LF as it's the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Fix discrepancies on file source detection. Allow module syntax in `.cts` files ([#2114](https://github.com/biomejs/biome/issues/2114)). Contributed by @Sec-ant
 
+- Smoother handling of endOfLine auto in prettier migration (#2145) defaulting to `lf`. Contributed by @eMerzh
+
 ### CLI
 
 #### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,13 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Fix discrepancies on file source detection. Allow module syntax in `.cts` files ([#2114](https://github.com/biomejs/biome/issues/2114)). Contributed by @Sec-ant
 
-- Smoother handling of endOfLine auto in prettier migration (#2145) defaulting to `lf`. Contributed by @eMerzh
-
 ### CLI
 
 #### Bug fixes
 
 - Fixes [#2131](https://github.com/biomejs/biome/issues/2131), where folders were incorrectly ignored when running the command `check`. Now folders are correctly ignored based on their command. Contributed by @ematipico
+
+- Smoother handling of `"endOfLine": "auto"` in prettier migration: falling back to `"lf"` ([#2145](https://github.com/biomejs/biome/pull/2145)). Contributed by @eMerzh
 
 ### Configuration
 

--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -72,6 +72,7 @@ enum EndOfLine {
     Lf,
     Crlf,
     Cr,
+    Auto,
 }
 
 #[derive(Clone, Debug, Default, Deserializable, Eq, PartialEq)]
@@ -134,6 +135,7 @@ impl From<EndOfLine> for LineEnding {
             EndOfLine::Lf => LineEnding::Lf,
             EndOfLine::Crlf => LineEnding::Crlf,
             EndOfLine::Cr => LineEnding::Cr,
+            EndOfLine::Auto => LineEnding::default(),
         }
     }
 }
@@ -342,8 +344,12 @@ pub(crate) fn read_prettier_files(
         }));
     } else {
         let prettier_configuration = deserialized.into_deserialized();
-
         if let Some(prettier_configuration) = prettier_configuration {
+            if prettier_configuration.end_of_line == EndOfLine::Auto {
+                console.log(markup! {
+                    <Warn>"Warning: Prettier's `\"endOfLine\": \"auto\"` option is not supported in Biome. Using the default 'lf' option."</Warn>
+                });
+            }
             let formatter_configuration = prettier_configuration
                 .clone()
                 .try_into()

--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -347,7 +347,7 @@ pub(crate) fn read_prettier_files(
         if let Some(prettier_configuration) = prettier_configuration {
             if prettier_configuration.end_of_line == EndOfLine::Auto {
                 console.log(markup! {
-                    <Warn>"Warning: Prettier's `\"endOfLine\": \"auto\"` option is not supported in Biome. Using the default 'lf' option."</Warn>
+                    <Warn>"Prettier's `\"endOfLine\": \"auto\"` option is not supported in Biome. The default `\"lf\"` option is used instead."</Warn>
                 });
             }
             let formatter_configuration = prettier_configuration

--- a/crates/biome_cli/tests/commands/migrate.rs
+++ b/crates/biome_cli/tests/commands/migrate.rs
@@ -165,6 +165,37 @@ fn prettier_migrate() {
 }
 
 #[test]
+fn prettier_migrate_end_of_line() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let configuration = r#"{}"#;
+    let prettier = r#"{ "endOfLine": "auto" }"#;
+
+    let configuration_path = Path::new("biome.json");
+    fs.insert(configuration_path.into(), configuration.as_bytes());
+
+    let prettier_path = Path::new(".prettierrc");
+    fs.insert(prettier_path.into(), prettier.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("migrate"), "prettier"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "prettier_migrate_end_of_line",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn prettier_migrate_with_ignore() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/prettier_migrate_end_of_line.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/prettier_migrate_end_of_line.snap
@@ -1,0 +1,60 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{}
+```
+
+## `.prettierrc`
+
+```prettierrc
+{ "endOfLine": "auto" }
+```
+
+# Emitted Messages
+
+```block
+Prettier's `"endOfLine": "auto"` option is not supported in Biome. The default `"lf"` option is used instead.
+```
+
+```block
+biome.json migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Configuration file can be updated.
+  
+    1    │ - {}
+       1 │ + {
+       2 │ + → "formatter":·{
+       3 │ + → → "enabled":·true,
+       4 │ + → → "formatWithErrors":·false,
+       5 │ + → → "indentStyle":·"space",
+       6 │ + → → "indentWidth":·2,
+       7 │ + → → "lineEnding":·"lf",
+       8 │ + → → "lineWidth":·80,
+       9 │ + → → "attributePosition":·"auto"
+      10 │ + → },
+      11 │ + → "javascript":·{
+      12 │ + → → "formatter":·{
+      13 │ + → → → "jsxQuoteStyle":·"double",
+      14 │ + → → → "quoteProperties":·"asNeeded",
+      15 │ + → → → "trailingComma":·"all",
+      16 │ + → → → "semicolons":·"asNeeded",
+      17 │ + → → → "arrowParentheses":·"always",
+      18 │ + → → → "bracketSpacing":·true,
+      19 │ + → → → "bracketSameLine":·false,
+      20 │ + → → → "quoteStyle":·"single",
+      21 │ + → → → "attributePosition":·"auto"
+      22 │ + → → }
+      23 │ + → }
+      24 │ + }
+      25 │ + 
+  
+
+```
+
+```block
+Run the command with the option --write to apply the changes.
+```

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -25,13 +25,13 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Fix discrepancies on file source detection. Allow module syntax in `.cts` files ([#2114](https://github.com/biomejs/biome/issues/2114)). Contributed by @Sec-ant
 
-- Smoother handling of endOfLine auto in prettier migration (#2145) defaulting to `lf`. Contributed by @eMerzh
-
 ### CLI
 
 #### Bug fixes
 
 - Fixes [#2131](https://github.com/biomejs/biome/issues/2131), where folders were incorrectly ignored when running the command `check`. Now folders are correctly ignored based on their command. Contributed by @ematipico
+
+- Smoother handling of `"endOfLine": "auto"` in prettier migration: falling back to `"lf"` ([#2145](https://github.com/biomejs/biome/pull/2145)). Contributed by @eMerzh
 
 ### Configuration
 

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -25,6 +25,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Fix discrepancies on file source detection. Allow module syntax in `.cts` files ([#2114](https://github.com/biomejs/biome/issues/2114)). Contributed by @Sec-ant
 
+- Smoother handling of endOfLine auto in prettier migration (#2145) defaulting to `lf`. Contributed by @eMerzh
+
 ### CLI
 
 #### Bug fixes


### PR DESCRIPTION
## Summary

I tried to migrate from prettier, and the migration failed because of unsupported option

#2138 


## Test Plan

you can migrate a prettierrc like this 
```json
{
	"printWidth": 120,
	"useTabs": true,
	"tabWidth": 2,
	"singleQuote": true,
	"semi": false,
	"trailingComma": "all",
	"bracketSameLine": false,
	"arrowParens": "avoid",
	"endOfLine": "auto"
}
```

I KNOW that auto won't be supported, but i think it's better for the UX to continue the flow with the best option possible instead of stopping in error

feel free to close if you disagree
