### PR TITLE
feat(biome_service): well-known json-like files

### DIFF
--- a/crates/biome_json_syntax/src/file_source.rs
+++ b/crates/biome_json_syntax/src/file_source.rs
@@ -18,29 +18,21 @@ impl JsonFileSource {
         }
     }
 
-    pub fn with_trailing_commas(mut self, option_value: bool) -> Self {
-        self.allow_trailing_commas = option_value;
+    pub fn with_allow_trailing_commas(mut self) -> Self {
+        self.allow_trailing_commas = true;
         self
     }
 
-    pub fn set_allow_trailing_commas(&mut self, option_value: bool) {
-        self.allow_trailing_commas = option_value;
-    }
-
-    pub fn get_allow_trailing_commas(&self) -> bool {
+    pub fn allow_trailing_commas(&self) -> bool {
         self.allow_trailing_commas
     }
 
-    pub fn with_comments(mut self, option_value: bool) -> Self {
-        self.allow_comments = option_value;
+    pub fn with_allow_comments(mut self) -> Self {
+        self.allow_comments = true;
         self
     }
 
-    pub fn set_allow_comments(&mut self, option_value: bool) {
-        self.allow_comments = option_value;
-    }
-
-    pub fn get_allow_comments(&self) -> bool {
+    pub fn allow_comments(&self) -> bool {
         self.allow_comments
     }
 }
@@ -75,7 +67,26 @@ fn compute_source_type_from_path_or_extension(
     } else {
         match extension {
             "json" => JsonFileSource::json(),
-            "jsonc" => JsonFileSource::json().with_comments(true),
+            // We support comments and trailing commas for `.jsonc` files
+            // https://github.com/github-linguist/linguist/blob/4ac734c15a96f9e16fd12330d0cb8de82274f700/lib/linguist/languages.yml#L3230-L3246
+            "jsonc"
+            | "code-snippets"
+            | "code-workspace"
+            | "sublime-build"
+            | "sublime-commands"
+            | "sublime-completions"
+            | "sublime-keymap"
+            | "sublime-macro"
+            | "sublime-menu"
+            | "sublime-mousemap"
+            | "sublime-project"
+            | "sublime-settings"
+            | "sublime-theme"
+            | "sublime-workspace"
+            | "sublime_metrics"
+            | "sublime_session" => JsonFileSource::json()
+                .with_allow_comments()
+                .with_allow_trailing_commas(),
             _ => {
                 return Err(FileSourceError::UnknownExtension(
                     file_name.into(),

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -151,9 +151,9 @@ fn parse(
         biome_path,
         JsonParserOptions {
             allow_comments: parser.allow_comments
-                || optional_json_file_source.map_or(false, |x| x.get_allow_comments()),
+                || optional_json_file_source.map_or(false, |x| x.allow_comments()),
             allow_trailing_commas: parser.allow_trailing_commas
-                || optional_json_file_source.map_or(false, |x| x.get_allow_trailing_commas()),
+                || optional_json_file_source.map_or(false, |x| x.allow_trailing_commas()),
         },
     );
     let parse = biome_json_parser::parse_json_with_cache(text, cache, options);

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -81,26 +81,84 @@ impl DocumentFileSource {
     // Well known json-like files that support comments and trailing commas
     // This list should be SORTED!
     const WELL_KNOWN_JSON_WITH_COMMENTS_AND_TRAILING_COMMAS_FILES: &'static [&'static str] = &[
+        // Uses `json5`, we treat them as JSONC for now:
+        // https://github.com/babel/babel/blob/3956c75123e713c5fa1d3279f6f92cfeac290173/packages/babel-core/src/config/files/configuration.ts#L341
         ".babelrc",
         ".babelrc.json",
-        ".ember-cli",
-        ".eslintrc",
-        ".eslintrc.json",
+        // https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers#editing-the-devcontainerjson-file
+        ".devcontainer.json",
+        // Uses `jsonc-parser`:
+        // https://github.com/webhintio/hint/blob/6ef9b7cd0c9129ca5a53f30ef51812622ad3d459/packages/hint/src/lib/config.ts#L248
+        // https://github.com/webhintio/hint/blob/6ef9b7cd0c9129ca5a53f30ef51812622ad3d459/packages/utils-fs/src/load-json-file.ts#L1C35-L1C47
         ".hintrc",
-        ".jsfmtrc",
-        ".jshintrc",
+        ".hintrc.json",
+        // Uses `jsonc_parser` and allows comments and trailing commas
+        // https://github.com/swc-project/swc/blob/ad932f0921411364b801b32f60eaf98f8629e812/crates/swc/src/lib.rs#L1028-L1029
         ".swcrc",
+        // Uses `jju`, default is JSON5, we treat them as JSONC for now:
+        // https://github.com/microsoft/rushstack/blob/38f0de8ba9f29d337564409eba5639287784b756/apps/api-extractor/src/api/ExtractorConfig.ts#L532
+        // https://github.com/microsoft/rushstack/blob/38f0de8ba9f29d337564409eba5639287784b756/libraries/node-core-library/src/JsonFile.ts#L218
+        // https://github.com/microsoft/rushstack/blob/38f0de8ba9f29d337564409eba5639287784b756/libraries/node-core-library/src/JsonFile.ts#L583-L585
+        "api-documenter.json",
+        "api-extractor.json",
+        // See `.babelrc`
         "babel.config.json",
+        // Uses `jsonc-parser`, and allows comments and trailing commas by default
+        // https://github.com/denoland/deno/blob/5a716d1d06f73800b280259204789260774d465d/cli/tools/registry/pm.rs#L114
+        "deno.json",
+        // See `.devcontainer.json`
+        "devcontainer.json",
+        // Uses `jsonc-parser`, and allows comments and trailing commas by default
+        // https://github.com/dprint/dprint/blob/f523f4db9750af5e73a9cdd3384ed9cd7e223e53/crates/dprint/src/configuration/manipulation.rs#L85
+        "dprint.json",
+        // See `tsconfig.json`
         "jsconfig.json",
+        // Uses `jsonc-parser`, and allows comments and trailing commas by default
+        // https://github.com/jsr-io/jsr/blob/32d3481d32f566079d33ba2ec1b598ea0c38b32c/api/src/tarball.rs#L194-L198
+        // https://docs.rs/jsonc-parser/0.23.0/jsonc_parser/struct.ParseOptions.html
+        "jsr.json",
+        // vscode files
+        "language-configuration.json",
+        // Uses its own parser
+        // https://github.com/microsoft/TypeScript/blob/a2d37a5c606803c92c00069e01d7964529e01bee/src/compiler/commandLineParser.ts#L2111-L2117
+        // https://github.com/microsoft/TypeScript/blob/a2d37a5c606803c92c00069e01d7964529e01bee/src/compiler/parser.ts#L1433
+        // https://github.com/microsoft/TypeScript/blob/a2d37a5c606803c92c00069e01d7964529e01bee/src/compiler/parser.ts#L3536
+        // https://github.com/microsoft/TypeScript/blob/a2d37a5c606803c92c00069e01d7964529e01bee/src/compiler/parser.ts#L2583-L2587
         "tsconfig.json",
-        "tslint.json",
+        // Uses the parser from TypeScript
+        // https://github.com/TypeStrong/typedoc/blob/30e614cd9e7b5a154afa6a78f2e54f16550bfb4f/src/lib/utils/options/readers/typedoc.ts#L74
         "typedoc.json",
+        // vscode files
         "typescript.json",
     ];
 
     // Well known json-like files that support comments but no trailing commas
     // This list should be SORTED!
-    const WELL_KNOWN_JSON_WITH_COMMENTS_FILES: &'static [&'static str] = &[];
+    const WELL_KNOWN_JSON_WITH_COMMENTS_FILES: &'static [&'static str] = &[
+        // Uses `yam` to parse the config, which only strip comments
+        // https://github.com/ember-cli/ember-cli/blob/0f7d0ccb52cdd20f17efbee79dd3f08ec6019cfc/lib/utilities/get-config.js#L7
+        // https://github.com/twokul/yam/blob/773e42548511977bf1e2b9b95c60496fe7f8a9df/lib/utils/io-utils.js#L45
+        ".ember-cli",
+        // `.eslintrc` is parsed as yaml, so we shouldn't include it here:
+        // https://github.com/eslint/eslintrc/blob/fb8d7ffbb27214686318a07e16ac8878aaafc805/lib/config-array-factory.js#L205-L225
+
+        // Uses `strip-json-comments`, which doesn't allow trailing commas by default
+        // https://github.com/eslint/eslintrc/blob/fb8d7ffbb27214686318a07e16ac8878aaafc805/lib/config-array-factory.js#L192
+        // https://github.com/sindresorhus/strip-json-comments/blob/85611bf8a07246bca27f949c997a1460c57bbe9f/index.js#L19
+        ".eslintrc.json",
+        // Uses `strip-json-comments`, which doesn't allow trailing commas by default
+        // https://github.com/jshint/jshint/blob/0a5644f8f529e252e7dd0c0d54334ae435b13de0/src/cli.js#L538
+        ".jscsrc",
+        // `.jsfmtrc` can be either an `ini` file or a `json` file (which will be parsed after `strip-with-comments`), so we shouldn't include it here.
+        // https://github.com/rdio/jsfmt?tab=readme-ov-file#jsfmtrc
+
+        // Uses `strip-json-comments`, which doesn't allow trailing commas by default
+        // https://github.com/jscs-dev/node-jscs/blob/38d33a0e455d965106ad3c8948c870f8f4e5dda9/lib/cli-config.js#L81
+        ".jshintrc",
+        // Just strip comments
+        // https://github.com/palantir/tslint/blob/285fc1db18d1fd24680d6a2282c6445abf1566ee/src/configuration.ts#L268
+        "tslint.json",
+    ];
 
     /// Returns the language corresponding to this file extension
     pub fn from_extension(s: &str) -> Self {
@@ -112,7 +170,26 @@ impl DocumentFileSource {
             "tsx" => JsFileSource::tsx().into(),
             "d.ts" | "d.mts" | "d.cts" => JsFileSource::d_ts().into(),
             "json" => JsonFileSource::json().into(),
-            "jsonc" => JsonFileSource::json().with_comments(true).into(),
+            // https://github.com/github-linguist/linguist/blob/4ac734c15a96f9e16fd12330d0cb8de82274f700/lib/linguist/languages.yml#L3230-L3246
+            "jsonc"
+            | "code-snippets"
+            | "code-workspace"
+            | "sublime-build"
+            | "sublime-commands"
+            | "sublime-completions"
+            | "sublime-keymap"
+            | "sublime-macro"
+            | "sublime-menu"
+            | "sublime-mousemap"
+            | "sublime-project"
+            | "sublime-settings"
+            | "sublime-theme"
+            | "sublime-workspace"
+            | "sublime_metrics"
+            | "sublime_session" => JsonFileSource::json()
+                .with_allow_comments()
+                .with_allow_trailing_commas()
+                .into(),
             "astro" => JsFileSource::astro().into(),
             "vue" => JsFileSource::vue().into(),
             "svelte" => JsFileSource::svelte().into(),
@@ -134,7 +211,10 @@ impl DocumentFileSource {
             "javascriptreact" => JsFileSource::jsx().into(),
             "typescriptreact" => JsFileSource::tsx().into(),
             "json" => JsonFileSource::json().into(),
-            "jsonc" => JsonFileSource::json().with_comments(true).into(),
+            "jsonc" | "snippets" => JsonFileSource::json()
+                .with_allow_comments()
+                .with_allow_trailing_commas()
+                .into(),
             "astro" => JsFileSource::astro().into(),
             "vue" => JsFileSource::vue().into(),
             "svelte" => JsFileSource::svelte().into(),
@@ -177,8 +257,8 @@ impl DocumentFileSource {
         {
             return Some(
                 JsonFileSource::json()
-                    .with_comments(true)
-                    .with_trailing_commas(true)
+                    .with_allow_comments()
+                    .with_allow_trailing_commas()
                     .into(),
             );
         }
@@ -186,7 +266,7 @@ impl DocumentFileSource {
             .binary_search(&filename)
             .is_ok()
         {
-            return Some(JsonFileSource::json().with_comments(true).into());
+            return Some(JsonFileSource::json().with_allow_comments().into());
         }
         None
     }
@@ -295,7 +375,7 @@ impl biome_console::fmt::Display for DocumentFileSource {
                 }
             }
             DocumentFileSource::Json(json) => {
-                if json.get_allow_comments() {
+                if json.allow_comments() {
                     fmt.write_markup(markup! { "JSONC" })
                 } else {
                     fmt.write_markup(markup! { "JSON" })

--- a/crates/biome_service/tests/workspace.rs
+++ b/crates/biome_service/tests/workspace.rs
@@ -104,7 +104,7 @@ fn correctly_handle_json_files() {
     .unwrap();
     assert!(jsonc_file.format_file().is_ok());
 
-    // ".jsonc" file doesn't allow trailing commas
+    // ".jsonc" file allow trailing commas
     let jsonc_file = FileGuard::open(
         workspace.as_ref(),
         OpenFileParams {
@@ -115,7 +115,35 @@ fn correctly_handle_json_files() {
         },
     )
     .unwrap();
-    assert!(jsonc_file.format_file().is_err());
+    assert!(jsonc_file.format_file().is_ok());
+
+    // well-known json-with-comments file allows comments
+    let well_known_json_with_comments_file = FileGuard::open(
+        workspace.as_ref(),
+        OpenFileParams {
+            path: BiomePath::new(".eslintrc.json"),
+            content: r#"{"a": 42}//comment"#.into(),
+            version: 0,
+            document_file_source: None,
+        },
+    )
+    .unwrap();
+    assert!(well_known_json_with_comments_file.format_file().is_ok());
+
+    // well-known json-with-comments file doesn't allow trailing commas
+    let well_known_json_with_comments_file_with_trailing_commas = FileGuard::open(
+        workspace.as_ref(),
+        OpenFileParams {
+            path: BiomePath::new("dir/.eslintrc.json"),
+            content: r#"{"a": 42,}"#.into(),
+            version: 0,
+            document_file_source: None,
+        },
+    )
+    .unwrap();
+    assert!(well_known_json_with_comments_file_with_trailing_commas
+        .format_file()
+        .is_err());
 
     // well-known json-with-comments-and-trailing-commas file allows comments and trailing commas
     let well_known_json_with_comments_and_trailing_commas_file = FileGuard::open(

--- a/website/src/content/docs/guides/how-biome-works.mdx
+++ b/website/src/content/docs/guides/how-biome-works.mdx
@@ -179,19 +179,30 @@ The following files are parsed as **`JSON` files** with the options `json.parser
 
 - `.babelrc`
 - `.babelrc.json`
-- `.ember-cli`
-- `.eslintrc`
-- `.eslintrc.json`
+- `.devcontainer.json`
 - `.hintrc`
-- `.jsfmtrc`
-- `.jshintrc`
+- `.hintrc.json`
 - `.swcrc`
+- `api-documenter.json`
+- `api-extractor.json`
 - `babel.config.json`
+- `deno.json`
+- `devcontainer.json`
+- `dprint.json`
 - `jsconfig.json`
+- `jsr.json`
+- `language-configuration.json`
 - `tsconfig.json`
-- `tslint.json`
 - `typedoc.json`
 - `typescript.json`
+
+The following files are parsed as **`JSON` files** with the options `json.parser.allowComments` set to `true` but `json.parser.allowTrailingCommas` set to `false`. This is because the tools consuming these files can only strip comments.
+
+- `.ember-cli`
+- `.eslintrc.json`
+- `.jscsrc`
+- `.jshintrc`
+- `tslint.json`
 
 ## `include` and `ignore` explained
 

--- a/website/src/content/docs/internals/language-support.mdx
+++ b/website/src/content/docs/internals/language-support.mdx
@@ -36,6 +36,20 @@ Biome supports only the official syntax. The team starts development of the new 
 
 Biome supports TypeScript version 5.2.
 
+## JSONC Support
+
+JSONC stands for "JSON with Comments." This format is widely used by various tools like [VS Code](https://code.visualstudio.com/docs/languages/json#_json-with-comments), [TypeScript](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html), [Babel](https://babeljs.io/docs/config-files), etc. because it lets users add comments to configuration files. However, since JSONC isn't a strictly defined standard, there's some variation in how different tools handle trailing commas in JSONC files. To accommodate this, Biome doesn't provide a dedicated language configuration for JSONC. Instead, we've enhanced our JSON parsing and formatting capabilities with options like `json.parser.allowComments`, `json.parser.allowTrailingCommas`, and `json.formatter.trailingCommas`. This approach allows Biome to effectively support different variants of JSON files.
+
+For files with an extension name of `.jsonc` or those identified as `jsonc` according to the [language identifier](https://code.visualstudio.com/docs/languages/identifiers), Biome automatically applies the following default settings for parsing and formatting them:
+
+- `json.parser.allowComments`: `true`
+- `json.parser.allowTrailingCommas`: `true`
+- `json.formatter.trailingCommas`: `none`
+
+Please note, some well-known files like `tsconfig.json` and `.babelrc` don't use the `.jsonc` extension but still allow comments and trailing commas. While others, such as `.eslintrc.json`, only allow comments. Biome is able to identify these files and adjusts the `json.parser.allowTrailingCommas` option accordingly to ensure they are correctly parsed.
+
+[This section](../guides/how-biome-works#well-known-files) gives the full list of well-known files that Biome can recognize.
+
 ## HTML super languages support
 
 As of version `1.6.0`, these languages are **partially** supported. Biome will get better over time, and it will provide more options to tweak your project. As for today, there are some expectations and limitations to take in consideration:


### PR DESCRIPTION
## Summary

I updated two well-known files list, ones is `WELL_KNOWN_JSON_WITH_COMMENTS_AND_TRAILING_COMMAS_FILES` and the other is `WELL_KNOWN_JSON_WITH_COMMENTS_FILES`. And I tried my best to document the sources to justify why the file should belong to that list.

## Test Plan

- `WELL_KNOWN...` lists should be sorted for binary search, so a `test_order` function is added to ensure they're sorted.
- Different kinds of json-like files are tested in `crates/biome_service/tests/workspace.rs`
