### PR TITLE
refactor: json file source

### DIFF
--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -519,8 +519,7 @@ impl Diagnostic for SourceFileNotSupported {
 }
 
 pub fn extension_error(path: &BiomePath) -> WorkspaceError {
-    let file_source = DocumentFileSource::from_path_and_known_filename(path)
-        .or(DocumentFileSource::from_path(path));
+    let file_source = DocumentFileSource::from_path(path);
     WorkspaceError::source_file_not_supported(
         file_source,
         path.clone().display().to_string(),

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -29,7 +29,7 @@ use biome_json_syntax::{JsonLanguage, JsonRoot, JsonSyntaxNode};
 use biome_parser::AnyParse;
 use biome_rowan::{AstNode, NodeCache};
 use biome_rowan::{TextRange, TextSize, TokenAtOffset};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -136,18 +136,6 @@ impl ExtensionHandler for JsonFileHandler {
     }
 }
 
-fn is_file_allowed(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|f| f.to_str())
-        .map(|f| {
-            super::DocumentFileSource::WELL_KNOWN_JSONC_FILES
-                .binary_search(&f)
-                .is_ok()
-        })
-        // default is false
-        .unwrap_or_default()
-}
-
 fn parse(
     biome_path: &BiomePath,
     file_source: DocumentFileSource,
@@ -162,17 +150,11 @@ fn parse(
         biome_path,
         JsonParserOptions {
             allow_comments: parser.allow_comments
-                || optional_json_file_source.map_or(false, |x| x.get_allow_comments())
-                || is_file_allowed(biome_path),
+                || optional_json_file_source.map_or(false, |x| x.get_allow_comments()),
             allow_trailing_commas: parser.allow_trailing_commas
-                || optional_json_file_source.map_or(false, |x| x.get_allow_trailing_commas())
-                || is_file_allowed(biome_path),
+                || optional_json_file_source.map_or(false, |x| x.get_allow_trailing_commas()),
         },
     );
-    if let Some(mut json_file_source) = optional_json_file_source {
-        json_file_source.set_allow_trailing_commas(options.allow_trailing_commas);
-        json_file_source.set_allow_comments(options.allow_comments);
-    }
     let parse = biome_json_parser::parse_json_with_cache(text, cache, options);
     let root = parse.syntax();
     let diagnostics = parse.into_diagnostics();

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -123,7 +123,7 @@ impl WorkspaceServer {
         move || {
             let file_source = self.get_file_source(path);
 
-            let language = DocumentFileSource::from_path_and_known_filename(path).or(file_source);
+            let language = DocumentFileSource::from_path(path).or(file_source);
             WorkspaceError::source_file_not_supported(
                 language,
                 path.clone().display().to_string(),
@@ -322,7 +322,7 @@ impl Workspace for WorkspaceServer {
             }
             Entry::Vacant(entry) => {
                 let capabilities = self.get_file_capabilities(&params.path);
-                let language = DocumentFileSource::from_path_and_known_filename(&params.path);
+                let language = DocumentFileSource::from_path(&params.path);
                 let path = params.path.as_path();
                 let settings = self.settings.read().unwrap();
                 let mut file_features = FileFeaturesResult::new();

--- a/crates/biome_service/tests/workspace.rs
+++ b/crates/biome_service/tests/workspace.rs
@@ -49,19 +49,86 @@ fn recognize_typescript_definition_file() {
 }
 
 #[test]
-fn recognize_jsonc_file() {
+fn correctly_handle_json_files() {
     let workspace = server();
 
-    let file = FileGuard::open(
+    // ".json" file
+    let json_file = FileGuard::open(
         workspace.as_ref(),
         OpenFileParams {
-            path: BiomePath::new("a.jsonc"),
+            path: BiomePath::new("a.json"),
+            content: r#"{"a": 42}"#.into(),
+            version: 0,
+            document_file_source: None,
+        },
+    )
+    .unwrap();
+    assert!(json_file.format_file().is_ok());
+
+    // ".json" file doesn't allow comments
+    let json_file_with_comments = FileGuard::open(
+        workspace.as_ref(),
+        OpenFileParams {
+            path: BiomePath::new("b.json"),
+            content: r#"{"a": 42}//comment"#.into(),
+            version: 0,
+            document_file_source: None,
+        },
+    )
+    .unwrap();
+    assert!(json_file_with_comments.format_file().is_err());
+
+    // ".json" file doesn't allow trailing commas
+    let json_file_with_trailing_commas = FileGuard::open(
+        workspace.as_ref(),
+        OpenFileParams {
+            path: BiomePath::new("c.json"),
+            content: r#"{"a": 42,}"#.into(),
+            version: 0,
+            document_file_source: None,
+        },
+    )
+    .unwrap();
+    assert!(json_file_with_trailing_commas.format_file().is_err());
+
+    // ".jsonc" file allows comments
+    let jsonc_file = FileGuard::open(
+        workspace.as_ref(),
+        OpenFileParams {
+            path: BiomePath::new("d.jsonc"),
+            content: r#"{"a": 42}//comment"#.into(),
+            version: 0,
+            document_file_source: None,
+        },
+    )
+    .unwrap();
+    assert!(jsonc_file.format_file().is_ok());
+
+    // ".jsonc" file doesn't allow trailing commas
+    let jsonc_file = FileGuard::open(
+        workspace.as_ref(),
+        OpenFileParams {
+            path: BiomePath::new("e.jsonc"),
+            content: r#"{"a": 42,}"#.into(),
+            version: 0,
+            document_file_source: None,
+        },
+    )
+    .unwrap();
+    assert!(jsonc_file.format_file().is_err());
+
+    // well-known json-with-comments-and-trailing-commas file allows comments and trailing commas
+    let well_known_json_with_comments_and_trailing_commas_file = FileGuard::open(
+        workspace.as_ref(),
+        OpenFileParams {
+            path: BiomePath::new("tsconfig.json"),
             content: r#"{"a": 42,}//comment"#.into(),
             version: 0,
             document_file_source: None,
         },
     )
     .unwrap();
-
-    assert!(file.format_file().is_ok());
+    assert!(well_known_json_with_comments_and_trailing_commas_file
+        .format_file()
+        .is_ok());
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1707,7 +1707,6 @@ export interface JsFileSource {
 export interface JsonFileSource {
 	allow_comments: boolean;
 	allow_trailing_commas: boolean;
-	variant: JsonVariant;
 }
 export interface CssFileSource {
 	variant: CssVariant;
@@ -1727,7 +1726,6 @@ export type LanguageVariant = "Standard" | "StandardRestricted" | "Jsx";
 Defaults to the latest stable ECMAScript standard. 
 	 */
 export type LanguageVersion = "ES2022" | "ESNext";
-export type JsonVariant = "Standard" | "Jsonc";
 /**
 	* The style of CSS contained in the file.
 

--- a/website/src/content/docs/guides/how-biome-works.mdx
+++ b/website/src/content/docs/guides/how-biome-works.mdx
@@ -166,13 +166,17 @@ The following files are currently ignored by Biome. This means that no diagnosti
 - `package-lock.json`
 - `yarn.lock`
 
-The following files are parsed as **`JSON` files** with  the options `json.parser.allowComments` and `json.parser.allowTrailingCommas` set to `true`. This is because editor tools like VSCode treat them like this.
+## Well-known Files
 
-- `.babelrc.json`
+Here are some well-known files that we specifically treat based on their file names, rather than their extensions. Currently, the well-known files are JSON-like files only, but we may broaden the list to include other types when we support new parsers.
+
+The following files are parsed as **`JSON` files** with the options `json.parser.allowComments` and `json.parser.allowTrailingCommas` set to `true`. This is because the tools consuming these files are designed to accommodate such settings.
+
 - `.babelrc`
+- `.babelrc.json`
 - `.ember-cli`
-- `.eslintrc.json`
 - `.eslintrc`
+- `.eslintrc.json`
 - `.hintrc`
 - `.jsfmtrc`
 - `.jshintrc`


### PR DESCRIPTION
## Summary

This PR addresses the TODO lists in #2141 and is a splitted PR from #2146 to not introduce new features. The main reason behind the changes is `JSONC` is not well-defined: some may support trailing commas, some may not:

- I removed the `variant` field in `JsonFileSource` to keep a single source of truth, because it already has fields `allow_trailing_commas` and `allow_comments`.

- I dropped the term `jsonc` because of its ambiguity in favor of using the fluent style API `json().with_comments(true)` and `json().with_comments(true).with_trailing_commas(true)` to properly reflect the main idea.

- Well-known files list is not touched. But I updated the document a bit.

## Test Plan

Different kinds of json-like files are tested in `crates/biome_service/tests/workspace.rs`
