### PR TITLE
chore(ci): set git longpaths system-wide

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Support longpaths
-        run: git config core.longpaths true
+        run: git config --system core.longpaths true
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Free Disk Space

--- a/.github/workflows/parser_conformance.yml
+++ b/.github/workflows/parser_conformance.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Support longpaths
-        run: git config core.longpaths true
+        run: git config --system core.longpaths true
 
       - name: Checkout PR Branch
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Use `git config --system core.longpaths true` when we're not inside a git repo.

## Test Plan

CI on main should pass.
