### PR TITLE
chore(ci): free disk space, again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,10 @@ jobs:
     name: Format Rust Files
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Support longpaths
-        run: git config --system core.longpaths true
+        run: git config core.longpaths true
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Free Disk Space

--- a/.github/workflows/parser_conformance.yml
+++ b/.github/workflows/parser_conformance.yml
@@ -24,8 +24,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@v4
+
       - name: Support longpaths
-        run: git config --system core.longpaths true
+        run: git config core.longpaths true
 
       - name: Checkout PR Branch
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

There're permission issues when running `git config --system core.longpaths true`. I added the checkout steps back.

## Test Plan

CI on main should pass.
