### PR TITLE
fix(lsp): correctly resolve `extends` configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Correctly parse `.jsonc` files. Contributed by @Sec-ant
 
+- Correctly resolve external `extends` configs. Contributed by @Sec-ant
+
 ### Parser
 
 ## 1.6.1 (2024-03-12)

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -162,7 +162,11 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
 
     fn get_changed_files(&self, base: &str) -> io::Result<Vec<String>>;
 
-    fn resolve_configuration(&self, path: &str) -> Result<Resolution, ResolveError>;
+    fn resolve_configuration(
+        &self,
+        specifier: &str,
+        path: Option<&Path>,
+    ) -> Result<Resolution, ResolveError>;
 }
 
 /// Result of the auto search
@@ -331,8 +335,12 @@ where
         T::get_changed_files(self, base)
     }
 
-    fn resolve_configuration(&self, path: &str) -> Result<Resolution, ResolveError> {
-        T::resolve_configuration(self, path)
+    fn resolve_configuration(
+        &self,
+        specifier: &str,
+        path: Option<&Path>,
+    ) -> Result<Resolution, ResolveError> {
+        T::resolve_configuration(self, specifier, path)
     }
 }
 

--- a/crates/biome_fs/src/fs/memory.rs
+++ b/crates/biome_fs/src/fs/memory.rs
@@ -201,7 +201,11 @@ impl FileSystem for MemoryFileSystem {
         Ok(cb())
     }
 
-    fn resolve_configuration(&self, _path: &str) -> Result<Resolution, ResolveError> {
+    fn resolve_configuration(
+        &self,
+        _specifier: &str,
+        _path: Option<&Path>,
+    ) -> Result<Resolution, ResolveError> {
         todo!()
     }
 }

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -33,7 +33,7 @@ impl OsFileSystem {
             working_directory: Some(working_directory),
             configuration_resolver: AssertUnwindSafe(Resolver::new(ResolveOptions {
                 condition_names: vec!["node".to_string(), "import".to_string()],
-                extensions: vec!["*.json".to_string()],
+                extensions: vec!["*.json".to_string(), "*.jsonc".to_string()],
                 ..ResolveOptions::default()
             })),
         }
@@ -83,9 +83,17 @@ impl FileSystem for OsFileSystem {
         path.is_file()
     }
 
-    fn resolve_configuration(&self, specifier: &str) -> Result<Resolution, ResolveError> {
-        self.configuration_resolver
-            .resolve(self.working_directory().unwrap(), specifier)
+    fn resolve_configuration(
+        &self,
+        specifier: &str,
+        path: Option<&Path>,
+    ) -> Result<Resolution, ResolveError> {
+        if let Some(path) = path {
+            self.configuration_resolver.resolve(path, specifier)
+        } else {
+            self.configuration_resolver
+                .resolve(self.working_directory().unwrap_or_default(), specifier)
+        }
     }
 
     fn get_changed_files(&self, base: &str) -> io::Result<Vec<String>> {

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -141,6 +141,13 @@ impl LSPServer {
                             )),
                             kind: Some(WatchKind::all()),
                         },
+                        FileSystemWatcher {
+                            glob_pattern: GlobPattern::String(format!(
+                                "{}/biome.jsonc",
+                                base_path.display()
+                            )),
+                            kind: Some(WatchKind::all()),
+                        },
                         // TODO: Biome 2.0 remove it
                         FileSystemWatcher {
                             glob_pattern: GlobPattern::String(format!(

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -468,6 +468,7 @@ impl Session {
 
             Err(err) => {
                 error!("Couldn't load the configuration file, reason:\n {}", err);
+                self.client.log_message(MessageType::ERROR, &err).await;
                 ConfigurationStatus::Error
             }
         };

--- a/crates/biome_service/src/configuration/mod.rs
+++ b/crates/biome_service/src/configuration/mod.rs
@@ -602,7 +602,7 @@ impl PartialConfiguration {
             {
                 directory_path.join(path)
             } else {
-                fs.resolve_configuration(path.as_str())
+                fs.resolve_configuration(path.as_str(), Some(directory_path))
                     .map_err(|error| {
                         ConfigurationDiagnostic::cant_resolve(
                             fs.working_directory()

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -69,6 +69,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Correctly parse `.jsonc` files. Contributed by @Sec-ant
 
+- Correctly resolve external `extends` configs. Contributed by @Sec-ant
+
 ### Parser
 
 ## 1.6.1 (2024-03-12)


### PR DESCRIPTION
## Summary

This PR fixes an issue where the config files in external packages specified in the `extends` option cannot be resolved properly when running in LSP mode (e.g. integrated with an editor).

Fixes #2159.

## Test Plan

We didn't implement the method to resolve an external configuration file in a memory os, so I just test this locally with the VSCode extension.
