### PR TITLE
chore(ci): update `setup-rust` cache strategy

### DIFF
--- a/.github/workflows/bench_cli.yml
+++ b/.github/workflows/bench_cli.yml
@@ -35,6 +35,10 @@ jobs:
 
       - name: Install toolchain
         uses: moonrepo/setup-rust@v1
+        with:
+          channel: stable
+          cache-target: release
+          cache-base: main
 
       - name: Install hyperfine
         run: cargo install hyperfine

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,6 +43,7 @@ jobs:
           channel: stable
           cache-target: release
           bins: cargo-codspeed
+          cache-base: main
 
       - name: Compile
         run: cargo codspeed build --features codspeed -p xtask_bench

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           components: rustfmt
           bins: taplo-cli
+          cache-base: main
       - name: Run rustfmt
         run: |
           cargo fmt --all --verbose -- --check
@@ -49,6 +50,7 @@ jobs:
         uses: moonrepo/setup-rust@v1
         with:
           components: clippy
+          cache-base: main
       - name: Run cargo check
         run: cargo check --workspace --all-targets --release
       - name: Run clippy
@@ -66,6 +68,7 @@ jobs:
         uses: moonrepo/setup-rust@v1
         with:
           channel: nightly
+          cache-base: main
       - name: Install udeps
         run: cargo install cargo-udeps --locked
       - name: Run udeps
@@ -89,6 +92,7 @@ jobs:
         uses: moonrepo/setup-rust@v1
         with:
           bins: cargo-nextest
+          cache-base: main
       - name: Run tests on ${{ matrix.os }}
         run: cargo nextest run --workspace --verbose
       - name: Clean cache
@@ -114,6 +118,9 @@ jobs:
         uses: ./.github/actions/free-disk-space
       - name: Install toolchain
         uses: moonrepo/setup-rust@v1
+        with:
+          cache-target: release
+          cache-base: main
       - name: Compile
         run: cargo build --release --locked -p xtask_coverage
       - name: Run Test262 suite

--- a/.github/workflows/parser_conformance.yml
+++ b/.github/workflows/parser_conformance.yml
@@ -40,6 +40,9 @@ jobs:
 
       - name: Install toolchain
         uses: moonrepo/setup-rust@v1
+        with:
+          cache-target: release
+          cache-base: main
 
       - name: Compile
         run: cargo build --release --locked -p xtask_coverage

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           components: rustfmt
           bins: taplo-cli
+          cache-base: main
       - name: Run format
         run: |
           cargo fmt --all --check
@@ -53,6 +54,7 @@ jobs:
         uses: moonrepo/setup-rust@v1
         with:
           components: clippy
+          cache-base: main
       - name: Run clippy
         run: cargo lint
 
@@ -88,6 +90,7 @@ jobs:
         uses: moonrepo/setup-rust@v1
         with:
           bins: cargo-nextest
+          cache-base: main
       - name: Run tests
         run: cargo nextest run --workspace --verbose
       - name: Run doctests
@@ -116,6 +119,9 @@ jobs:
         uses: ./.github/actions/free-disk-space
       - name: Install toolchain
         uses: moonrepo/setup-rust@v1
+        with:
+          cache-target: release
+          cache-base: main
       - name: Build main binary
         run: cargo build -p biome_cli --release
       - name: Install Node.js
@@ -157,6 +163,8 @@ jobs:
         uses: ./.github/actions/free-disk-space
       - name: Install toolchain
         uses: moonrepo/setup-rust@v1
+        with:
+          cache-base: main
       - name: Run doc command
         run: cargo documentation
 
@@ -170,6 +178,8 @@ jobs:
         uses: ./.github/actions/free-disk-space
       - name: Install toolchain
         uses: moonrepo/setup-rust@v1
+        with:
+          cache-base: main
       - name: Run the grammar codegen
         run: cargo codegen grammar
       - name: Run the analyzer codegen

--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -60,10 +60,12 @@ jobs:
       - uses: pnpm/action-setup@v3
       - name: Install toolchain
         uses: moonrepo/setup-rust@v1
+        with:
+          cache-base: main
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build WASM module for the web
-        run: wasm-pack build --out-dir ../../packages/@biomejs/wasm-web --target web --scope biomedev crates/biome_wasm
+        run: wasm-pack build --dev --out-dir ../../packages/@biomejs/wasm-web --target web --scope biomedev crates/biome_wasm
       - name: Install libraries
         run: pnpm i --filter @biomejs/website
       - name: Build JS

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -40,6 +40,9 @@ jobs:
       - uses: pnpm/action-setup@v3
       - name: Install toolchain
         uses: moonrepo/setup-rust@v1
+        with:
+          cache-target: release
+          cache-base: main
       - name: Install libraries
         run: pnpm --filter @biomejs/js-api i
       - name: Compile backends


### PR DESCRIPTION
## Summary

Our CI is encountering this error: `Failed to save: Cache service responded with 429 during upload chunk.`, which seems that the rate limit is triggered by our frequent cache-updating requests.

To solve this issue, this PR changes the `setup-rust` steps to use the **[warmup strategy](https://github.com/moonrepo/setup-rust?tab=readme-ov-file#warmup-strategy)**. This strategy will relax the granularity of the cache keys, and only save caches when the workflow is running on the main branch.

I also updated the `cache-target` options for some jobs, because they're building in release mode but caching the debug target.

## Test Plan

CI should pass and the new cache strategy should work as expected.
