### PR TITLE
chore(ci): do not cache nightly channel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
         uses: moonrepo/setup-rust@v1
         with:
           channel: nightly
-          cache-base: main
+          cache: false
       - name: Install udeps
         run: cargo install cargo-udeps --locked
       - name: Run udeps


### PR DESCRIPTION
## Summary

Warmup strategy doesn't work well with rust nightly channels because we will then always save two copies of toolchains in our runner, one is the stable from the warmup branch and the other is the nightly. Therefore it can eat up the space quickly.

So I disabled the cache for nightly channel toolchains. It's **nightly**, so I think it will be fine.

## Test Plan

Jobs requiring nightly channel toolchains shouldn't fail.
