### PR TITLE
fix(biome_fs): configuration resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ New entries must be placed in a section entitled `Unreleased`.
 Read
 our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
+## Unreleased
+
+### Analyzer
+
+### CLI
+
+- Fix configuration resolution. Biome is now able to correctly find the `biome.jsonc` configuration file when `--config-path` is explicitly set. Contributed by @Sec-ant
+
+### Configuration
+
+### Editors
+
+### Formatter
+
+### JavaScript APIs
+
+### Linter
+
+#### New features
+
+- Add rule [noEvolvingAny](https://biomejs.dev/linter/rules/no-evolving-any) to disallow variables from evolving into `any` type through reassignments. Contributed by @fujiyamaorange
+
+### Parser
+
 ## 1.6.2 (2024-03-22)
 
 ### Analyzer
@@ -46,12 +70,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Support applying lint fixes when calling the `lintContent` method of the `Biome` class ([#1956](https://github.com/biomejs/biome/pull/1956)). Contributed by @mnahkies
 
 ### Linter
-
-#### New features
-
-- Add rule [noEvolvingAny](https://biomejs.dev/linter/rules/no-evolving-any) to disallow variables from evolving into `any` type through reassignments.
-
-Contributed by @fujiyamaorange
 
 #### Bug fixes
 

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -21,7 +21,7 @@ pub struct CliOptions {
     #[bpaf(long("verbose"), switch, fallback(false))]
     pub verbose: bool,
 
-    /// Set the directory of the biome.json configuration file and disable default configuration file resolution.
+    /// Set the directory of the biome.json or biome.jsonc configuration file and disable default configuration file resolution.
     #[bpaf(long("config-path"), argument("PATH"), optional)]
     pub config_path: Option<String>,
 

--- a/crates/biome_cli/tests/cases/config_path.rs
+++ b/crates/biome_cli/tests/cases/config_path.rs
@@ -1,0 +1,55 @@
+use crate::run_cli;
+use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
+use biome_console::BufferConsole;
+use biome_fs::MemoryFileSystem;
+use biome_service::DynRef;
+use bpaf::Args;
+use std::path::Path;
+
+#[test]
+fn set_config_path() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("src/index.js");
+    fs.insert(file_path.into(), "a['b']  =  42;".as_bytes());
+
+    let config_path = Path::new("config/biome.jsonc");
+    fs.insert(
+        config_path.into(),
+        r#"
+        {
+          "organizeImports": {
+            "enabled": true
+          },
+          "linter": {
+            "enabled": false
+          },
+          "formatter": {
+            "enabled": true,
+          },
+          "javascript": {
+            "formatter": {
+              "quoteStyle": "single"
+            }
+          }
+        }"#
+        .as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("check"), ("--config-path=config"), ("src")].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "set_config_path",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/cases/mod.rs
+++ b/crates/biome_cli/tests/cases/mod.rs
@@ -3,6 +3,7 @@
 
 mod biome_json_support;
 mod config_extends;
+mod config_path;
 mod cts_files;
 mod diagnostics;
 mod handle_astro_files;

--- a/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path.snap
@@ -1,0 +1,61 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `config/biome.jsonc`
+
+```jsonc
+
+        {
+          "organizeImports": {
+            "enabled": true
+          },
+          "linter": {
+            "enabled": false
+          },
+          "formatter": {
+            "enabled": true,
+          },
+          "javascript": {
+            "formatter": {
+              "quoteStyle": "single"
+            }
+          }
+        }
+```
+
+## `src/index.js`
+
+```js
+a['b']  =  42;
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+src/index.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - a['b']··=··42;
+      1 │ + a['b']·=·42;
+      2 │ + 
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 2 errors.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -79,8 +79,8 @@ Global options applied to all commands
                               output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
-        --config-path=PATH    Set the directory of the biome.json configuration file and disable default
-                              configuration file resolution.
+        --config-path=PATH    Set the directory of the biome.json or biome.jsonc configuration file and
+                              disable default configuration file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
@@ -119,5 +119,3 @@ Available options:
     -h, --help                Prints help information
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -81,8 +81,8 @@ Global options applied to all commands
                               output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
-        --config-path=PATH    Set the directory of the biome.json configuration file and disable default
-                              configuration file resolution.
+        --config-path=PATH    Set the directory of the biome.json or biome.jsonc configuration file and
+                              disable default configuration file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
@@ -114,5 +114,3 @@ Available options:
     -h, --help                Prints help information
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -71,8 +71,8 @@ Global options applied to all commands
                               output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
-        --config-path=PATH    Set the directory of the biome.json configuration file and disable default
-                              configuration file resolution.
+        --config-path=PATH    Set the directory of the biome.json or biome.jsonc configuration file and
+                              disable default configuration file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
@@ -121,5 +121,3 @@ Available options:
     -h, --help                Prints help information
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -33,8 +33,8 @@ Global options applied to all commands
                               output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
-        --config-path=PATH    Set the directory of the biome.json configuration file and disable default
-                              configuration file resolution.
+        --config-path=PATH    Set the directory of the biome.json or biome.jsonc configuration file and
+                              disable default configuration file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
@@ -70,5 +70,3 @@ Available options:
     -h, --help                Prints help information
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
@@ -15,8 +15,8 @@ Global options applied to all commands
                               output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
-        --config-path=PATH    Set the directory of the biome.json configuration file and disable default
-                              configuration file resolution.
+        --config-path=PATH    Set the directory of the biome.json or biome.jsonc configuration file and
+                              disable default configuration file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
@@ -43,5 +43,3 @@ Available commands:
                               and map the Prettier's configuration into Biome's configuration file.
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -15,8 +15,8 @@ Global options applied to all commands
                               output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
-        --config-path=PATH    Set the directory of the biome.json configuration file and disable default
-                              configuration file resolution.
+        --config-path=PATH    Set the directory of the biome.json or biome.jsonc configuration file and
+                              disable default configuration file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
@@ -41,5 +41,3 @@ Available options:
     -h, --help                Prints help information
 
 ```
-
-

--- a/crates/biome_service/src/configuration/mod.rs
+++ b/crates/biome_service/src/configuration/mod.rs
@@ -245,9 +245,9 @@ type LoadConfig = Result<Option<ConfigurationPayload>, WorkspaceError>;
 pub struct ConfigurationPayload {
     /// The result of the deserialization
     pub deserialized: Deserialized<PartialConfiguration>,
-    /// The path of where the `biome.json` file was found. This contains the `biome.json` name.
+    /// The path of where the `biome.json` or `biome.jsonc` file was found. This contains the file name.
     pub configuration_file_path: PathBuf,
-    /// The base path of where the `biome.json` file was found.
+    /// The base path of where the `biome.json` or `biome.jsonc` file was found.
     /// This has to be used to resolve other configuration files.
     pub configuration_directory_path: PathBuf,
 }

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -15,6 +15,30 @@ New entries must be placed in a section entitled `Unreleased`.
 Read
 our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
+## Unreleased
+
+### Analyzer
+
+### CLI
+
+- Fix configuration resolution. Biome is now able to correctly find the `biome.jsonc` configuration file when `--config-path` is explicitly set. Contributed by @Sec-ant
+
+### Configuration
+
+### Editors
+
+### Formatter
+
+### JavaScript APIs
+
+### Linter
+
+#### New features
+
+- Add rule [noEvolvingAny](https://biomejs.dev/linter/rules/no-evolving-any) to disallow variables from evolving into `any` type through reassignments. Contributed by @fujiyamaorange
+
+### Parser
+
 ## 1.6.2 (2024-03-22)
 
 ### Analyzer
@@ -52,12 +76,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Support applying lint fixes when calling the `lintContent` method of the `Biome` class ([#1956](https://github.com/biomejs/biome/pull/1956)). Contributed by @mnahkies
 
 ### Linter
-
-#### New features
-
-- Add rule [noEvolvingAny](https://biomejs.dev/linter/rules/no-evolving-any) to disallow variables from evolving into `any` type through reassignments.
-
-Contributed by @fujiyamaorange
 
 #### Bug fixes
 


### PR DESCRIPTION
## Summary

I refactored the `auto_search` function that is used to find the configuration file. In the previous version of this function, the searching process would immediately stop if it couldn't find a `biome.json` file in the user provided base path, which isn't an expected behavior because `config-path` accepts a directory path, not a file path. So it should search all the possible alternatives, i.e. `biome.jsonc` file in the user provided path as well, and only returns an error if it cannot find any configuration file in that directory path.

Closes #2164.

## Test Plan

I added a test case to ensure that the `biome.jsonc` configuration file can now be correctly resolved in the user provided config path.
