### PR TITLE
chore(ci): revert `wasm-pack` dev mode change

### DIFF
--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build WASM module for the web
-        run: wasm-pack build --dev --out-dir ../../packages/@biomejs/wasm-web --target web --scope biomedev crates/biome_wasm
+        run: wasm-pack build --out-dir ../../packages/@biomejs/wasm-web --target web --scope biomedev crates/biome_wasm
       - name: Install libraries
         run: pnpm i --filter @biomejs/website
       - name: Build JS


### PR DESCRIPTION
## Summary

The problematic commit: https://github.com/biomejs/biome/pull/2166/files#diff-16233821c7a54e3f17c4c0e1ddff269adc1dc764c80887e10e242fecbaa1efcd

I was hoping to accelerate the building process but this will trigger a build error. So revert the change.

## Test Plan

CI should pass.
