### PR TITLE
fix(lsp): quick fix code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
-- Fix configuration resolution. Biome is now able to correctly find the `biome.jsonc` configuration file when `--config-path` is explicitly set. Contributed by @Sec-ant
+- Fix configuration resolution. Biome is now able to correctly find the `biome.jsonc` configuration file when `--config-path` is explicitly set ([#2164](https://github.com/biomejs/biome/issues/2164)). Contributed by @Sec-ant
 
 - JavaScript/TypeScript files of different variants (`.ts`, `.js`, `.tsx`, `.jsx`) in a single workspace now have stable formatting behaviors when running the CLI command in paths of different nested levels or in different operating systems ([#2080](https://github.com/biomejs/biome/issues/2080), [#2109](https://github.com/biomejs/biome/issues/2109)). Contributed by @Sec-ant
 
@@ -42,6 +42,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### New features
 
 - Add rule [noEvolvingAny](https://biomejs.dev/linter/rules/no-evolving-any) to disallow variables from evolving into `any` type through reassignments. Contributed by @fujiyamaorange
+
+### LSP
+
+#### Bug fixes
+
+- Quickfix action no longer autofixes lint rule errors on save when `linter` is disabled ([#2161](https://github.com/biomejs/biome/issues/2161)). Contributed by @Sec-ant
 
 ### Parser
 

--- a/crates/biome_lsp/src/handlers/analysis.rs
+++ b/crates/biome_lsp/src/handlers/analysis.rs
@@ -149,8 +149,22 @@ pub(crate) fn code_actions(
             if has_quick_fix && action.suggestion.applicability == Applicability::MaybeIncorrect {
                 return None;
             }
+            // Filter out source.organizeImports.biome action when organize imports is not supported.
             if action.category.matches("source.organizeImports.biome")
                 && !file_features.supports_organize_imports()
+            {
+                return None;
+            }
+            // Filter out quickfix.biome action when lint is not supported.
+            // But keep JavaScript parse rules because they're not configurable
+            // and should be considered as a parse action
+            if action.category.matches("quickfix.biome")
+                && action.rule_name.as_ref().map_or(true, |(_, name)| {
+                    name != "noDuplicatePrivateClassMembers"
+                        && name != "noInitializerWithDefinite"
+                        && name != "noSuperWithoutExtends"
+                })
+                && !file_features.supports_lint()
             {
                 return None;
             }

--- a/crates/biome_lsp/src/handlers/analysis.rs
+++ b/crates/biome_lsp/src/handlers/analysis.rs
@@ -156,16 +156,7 @@ pub(crate) fn code_actions(
                 return None;
             }
             // Filter out quickfix.biome action when lint is not supported.
-            // But keep JavaScript parse rules because they're not configurable
-            // and should be considered as a parse action
-            if action.category.matches("quickfix.biome")
-                && action.rule_name.as_ref().map_or(true, |(_, name)| {
-                    name != "noDuplicatePrivateClassMembers"
-                        && name != "noInitializerWithDefinite"
-                        && name != "noSuperWithoutExtends"
-                })
-                && !file_features.supports_lint()
-            {
+            if action.category.matches("quickfix.biome") && !file_features.supports_lint() {
                 return None;
             }
             // Remove actions that do not match the categories requested by the

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -23,7 +23,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
-- Fix configuration resolution. Biome is now able to correctly find the `biome.jsonc` configuration file when `--config-path` is explicitly set. Contributed by @Sec-ant
+- Fix configuration resolution. Biome is now able to correctly find the `biome.jsonc` configuration file when `--config-path` is explicitly set ([#2164](https://github.com/biomejs/biome/issues/2164)). Contributed by @Sec-ant
 
 - JavaScript/TypeScript files of different variants (`.ts`, `.js`, `.tsx`, `.jsx`) in a single workspace now have stable formatting behaviors when running the CLI command in paths of different nested levels or in different operating systems ([#2080](https://github.com/biomejs/biome/issues/2080), [#2109](https://github.com/biomejs/biome/issues/2109)). Contributed by @Sec-ant
 
@@ -48,6 +48,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### New features
 
 - Add rule [noEvolvingAny](https://biomejs.dev/linter/rules/no-evolving-any) to disallow variables from evolving into `any` type through reassignments. Contributed by @fujiyamaorange
+
+### LSP
+
+#### Bug fixes
+
+- Quickfix action no longer autofixes lint rule errors on save when `linter` is disabled ([#2161](https://github.com/biomejs/biome/issues/2161)). Contributed by @Sec-ant
 
 ### Parser
 


### PR DESCRIPTION
## Summary

- Quick fix shouldn't pull lint fix actions when the linter is disabled in the config.
- Also fix some errors in the changelog.

Closes #2161.

## Test Plan

I didn't figure out a way to add test cases for this fix. I tested it locally with the VSCode Extension and it works as expected.
