### PR TITLE
docs(guides/how-biome-works): remove dangling phrase

### DIFF
--- a/website/src/content/docs/guides/how-biome-works.mdx
+++ b/website/src/content/docs/guides/how-biome-works.mdx
@@ -237,7 +237,6 @@ the working directory resolved by that script will be `frontend/`,
 the globs `src/**/*.js` and `src/**/*.ts` will have as "base" directory `frontend/`.
 
 Although `include` doesn't contain `test`, Biome will still traverse the folder.
-This i
 
 :::note
 `include` and `ignore` have a slightly different semantics.


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

In [How Biome works](https://biomejs.dev/guides/how-biome-works/) page, in [`include` and `ignore` explained](https://biomejs.dev/guides/how-biome-works/#include-and-ignore-explained) section there is a dangling phrase:

```text
This I
```

<img width="964" alt="dangling-phrase" src="https://github.com/biomejs/biome/assets/24919330/0164cc21-3712-4905-a806-bd0a19a82837">


I have removed it

## Test Plan

The phrase was removed after running the updated code on my machine via

```sh
pnpm --filter @biomejs/website start
```
