### PR TITLE
fix(js_formatter): break long destructuring binding pattern  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Formatter
 
+#### Bug fixes
+
+- Fix [#2172](https://github.com/biomejs/biome/issues/2172) by breaking long object destructuring patterns. Contributed by @ah-yu
+
 ### JavaScript APIs
 
 ### Linter

--- a/crates/biome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
+++ b/crates/biome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-use biome_formatter::write;
+use biome_formatter::{format_args, write};
 use biome_js_syntax::JsObjectBindingPatternProperty;
 use biome_js_syntax::JsObjectBindingPatternPropertyFields;
 
@@ -20,14 +20,17 @@ impl FormatNodeRule<JsObjectBindingPatternProperty> for FormatJsObjectBindingPat
             init,
         } = node.as_fields();
 
+        let group_id = f.group_id("object_binding_pattern_property");
+
         write![
             f,
-            [
+            [group(&format_args![
                 member.format(),
                 colon_token.format(),
-                space(),
-                pattern.format(),
-            ]
+                group(&indent(&soft_line_break_or_space())).with_group_id(Some(group_id)),
+                line_suffix_boundary(),
+                indent_if_group_breaks(&pattern.format(), group_id)
+            ])]
         ]?;
 
         if let Some(init) = init {

--- a/crates/biome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
+++ b/crates/biome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<JsObjectBindingPatternProperty> for FormatJsObjectBindingPat
             init,
         } = node.as_fields();
 
-        let group_id = f.group_id("object_binding_pattern_property");
+        let group_id = f.group_id("assignment");
 
         write![
             f,

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js
@@ -2,3 +2,4 @@ let {a}=b
 let {d,b:c}=d
 let {x,y=c,z:pp=f,...g}=h
 let {aaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbbbbbb=cccccccccccccccccccc,dddddddddddddddddddd:eeeeeeeeeeeeeeeeeeee=ffffffffffffffffffff,...gggggggggggggggggggg}=h
+let {looooooooooooooooooooooooooooooooooooooooooong: loooooooooooooooooooooooooooooooooooooooooong }=h

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/binding/object_binding.js
 ---
-
 # Input
 
 ```js
@@ -10,7 +9,7 @@ let {a}=b
 let {d,b:c}=d
 let {x,y=c,z:pp=f,...g}=h
 let {aaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbbbbbb=cccccccccccccccccccc,dddddddddddddddddddd:eeeeeeeeeeeeeeeeeeee=ffffffffffffffffffff,...gggggggggggggggggggg}=h
-
+let {looooooooooooooooooooooooooooooooooooooooooong: loooooooooooooooooooooooooooooooooooooooooong }=h
 ```
 
 
@@ -46,6 +45,10 @@ let {
 	dddddddddddddddddddd: eeeeeeeeeeeeeeeeeeee = ffffffffffffffffffff,
 	...gggggggggggggggggggg
 } = h;
+let {
+	looooooooooooooooooooooooooooooooooooooooooong:
+		loooooooooooooooooooooooooooooooooooooooooong,
+} = h;
 ```
 
 ## Output 2
@@ -76,6 +79,8 @@ let {
 	dddddddddddddddddddd: eeeeeeeeeeeeeeeeeeee = ffffffffffffffffffff,
 	...gggggggggggggggggggg
 } = h;
+let {
+	looooooooooooooooooooooooooooooooooooooooooong:
+		loooooooooooooooooooooooooooooooooooooooooong,
+} = h;
 ```
-
-

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -29,6 +29,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Formatter
 
+#### Bug fixes
+
+- Fix [#2172](https://github.com/biomejs/biome/issues/2172) by breaking long object destructuring patterns. Contributed by @ah-yu
+
 ### JavaScript APIs
 
 ### Linter


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/2172

Align the IR of `JsObjectBindingPatternProperty` with Prettier.

```
group([
  group("fairlyLongObjectKeyLongEnoughToBreakCharacterLimit"),
  ":",
  group(indent(line), { id: Symbol.for("assignment") }),
  lineSuffixBoundary,
  indentIfBreak(
    "_fairlyLongValueNameLongEnoughToBreakCharacterLimit",
    { groupId: Symbol.for("assignment") },
  ),
]),
```

## Test Plan

Add a new test case and update the corresponding snapshot
