### PR TITLE
fix(service): cached `JsFormatOptions` with overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Configuration
 
+#### Bug fixes
+
+- Complete the documentation and overrides support for options `lineEnd` and `attributePosition`. Contributed by @Sec-ant
+
 ### Editors
 
 ### Formatter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### CLI
 
+#### Bug fixes
+
 - Fix configuration resolution. Biome is now able to correctly find the `biome.jsonc` configuration file when `--config-path` is explicitly set. Contributed by @Sec-ant
+
+- JavaScript/TypeScript files of different variants (`.ts`, `.js`, `.tsx`, `.jsx`) in a single workspace now have stable formatting behaviors when running the CLI command in paths of different nested levels or in different operating systems ([#2080](https://github.com/biomejs/biome/issues/2080), [#2109](https://github.com/biomejs/biome/issues/2109)). Contributed by @Sec-ant
 
 ### Configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
-- Complete the documentation and overrides support for options `lineEnd` and `attributePosition`. Contributed by @Sec-ant
+- Complete the documentation and overrides support for options `formatter.lineEnding`, `[language].formatter.lineEnding`, `formatter.attributePosition` and `javascript.formatter.attributePosition`. Contributed by @Sec-ant
 
 ### Editors
 

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -29,7 +29,8 @@ The configuration that is contained inside the file `biome.json`
         --indent-width=NUMBER  The size of the indentation, 2 by default
         --line-ending=<lf|crlf|cr>  The type of line ending.
         --line-width=NUMBER   What's the max width of a line. Defaults to 80.
-        --attribute-position=<auto|multiline>  The attribute position style. By default auto.
+        --attribute-position=<multiline|auto>  The attribute position style in HTMLish languages. By
+                              default auto.
         --jsx-quote-style=<double|single>  The type of quotes used in JSX. Defaults to double.
         --quote-properties=<preserve|as-needed>  When properties in objects are quoted. Defaults to asNeeded.
         --trailing-comma=<all|es5|none>  Print trailing commas wherever possible in multi-line comma-separated
@@ -56,8 +57,8 @@ The configuration that is contained inside the file `biome.json`
         --javascript-formatter-line-width=NUMBER  What's the max width of a line applied to JavaScript
                               (and its super languages) files. Defaults to 80.
         --quote-style=<double|single>  The type of quotes used in JavaScript code. Defaults to double.
-        --javascript-attribute-position=<multiline|auto>  The attribute position style in JavaScript
-                              code. Defaults to auto.
+        --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx elements.
+                              Defaults to auto.
         --json-formatter-enabled=<true|false>  Control the formatter for JSON (and its super languages)
                               files.
         --json-formatter-indent-style=<tab|space>  The indent style applied to JSON (and its super languages)

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -31,7 +31,8 @@ The configuration that is contained inside the file `biome.json`
         --indent-width=NUMBER  The size of the indentation, 2 by default
         --line-ending=<lf|crlf|cr>  The type of line ending.
         --line-width=NUMBER   What's the max width of a line. Defaults to 80.
-        --attribute-position=<auto|multiline>  The attribute position style. By default auto.
+        --attribute-position=<multiline|auto>  The attribute position style in HTMLish languages. By
+                              default auto.
         --jsx-quote-style=<double|single>  The type of quotes used in JSX. Defaults to double.
         --quote-properties=<preserve|as-needed>  When properties in objects are quoted. Defaults to asNeeded.
         --trailing-comma=<all|es5|none>  Print trailing commas wherever possible in multi-line comma-separated
@@ -58,8 +59,8 @@ The configuration that is contained inside the file `biome.json`
         --javascript-formatter-line-width=NUMBER  What's the max width of a line applied to JavaScript
                               (and its super languages) files. Defaults to 80.
         --quote-style=<double|single>  The type of quotes used in JavaScript code. Defaults to double.
-        --javascript-attribute-position=<multiline|auto>  The attribute position style in JavaScript
-                              code. Defaults to auto.
+        --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx elements.
+                              Defaults to auto.
         --json-formatter-enabled=<true|false>  Control the formatter for JSON (and its super languages)
                               files.
         --json-formatter-indent-style=<tab|space>  The indent style applied to JSON (and its super languages)

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -15,7 +15,8 @@ Generic options applied to all files
         --indent-width=NUMBER  The size of the indentation, 2 by default
         --line-ending=<lf|crlf|cr>  The type of line ending.
         --line-width=NUMBER   What's the max width of a line. Defaults to 80.
-        --attribute-position=<auto|multiline>  The attribute position style. By default auto.
+        --attribute-position=<multiline|auto>  The attribute position style in HTMLish languages. By
+                              default auto.
 
 Formatting options specific to the JavaScript files
         --jsx-quote-style=<double|single>  The type of quotes used in JSX. Defaults to double.
@@ -44,8 +45,8 @@ Formatting options specific to the JavaScript files
         --javascript-formatter-line-width=NUMBER  What's the max width of a line applied to JavaScript
                               (and its super languages) files. Defaults to 80.
         --quote-style=<double|single>  The type of quotes used in JavaScript code. Defaults to double.
-        --javascript-attribute-position=<multiline|auto>  The attribute position style in JavaScript
-                              code. Defaults to auto.
+        --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx elements.
+                              Defaults to auto.
 
 Set of properties to integrate Biome with a VCS software.
         --vcs-client-kind=<git>  The kind of client.

--- a/crates/biome_service/src/configuration/formatter.rs
+++ b/crates/biome_service/src/configuration/formatter.rs
@@ -50,7 +50,7 @@ pub struct FormatterConfiguration {
     pub line_width: LineWidth,
 
     /// The attribute position style in HTMLish languages. By default auto.
-    #[partial(bpaf(long("attribute-position"), argument("auto|multiline"), optional))]
+    #[partial(bpaf(long("attribute-position"), argument("multiline|auto"), optional))]
     pub attribute_position: AttributePosition,
 
     /// A list of Unix shell style patterns. The formatter will ignore files/folders that will

--- a/crates/biome_service/src/configuration/formatter.rs
+++ b/crates/biome_service/src/configuration/formatter.rs
@@ -49,7 +49,7 @@ pub struct FormatterConfiguration {
     ))]
     pub line_width: LineWidth,
 
-    /// The attribute position style. By default auto.
+    /// The attribute position style in HTMLish languages. By default auto.
     #[partial(bpaf(long("attribute-position"), argument("auto|multiline"), optional))]
     pub attribute_position: AttributePosition,
 

--- a/crates/biome_service/src/configuration/javascript/formatter.rs
+++ b/crates/biome_service/src/configuration/javascript/formatter.rs
@@ -89,7 +89,7 @@ pub struct JavascriptFormatter {
     pub quote_style: QuoteStyle,
 
     // it's also a top-level configurable property.
-    /// The attribute position style in JSX/TSX languages. Defaults to auto.
+    /// The attribute position style in jsx elements. Defaults to auto.
     #[partial(bpaf(
         long("javascript-attribute-position"),
         argument("multiline|auto"),

--- a/crates/biome_service/src/configuration/javascript/formatter.rs
+++ b/crates/biome_service/src/configuration/javascript/formatter.rs
@@ -89,7 +89,7 @@ pub struct JavascriptFormatter {
     pub quote_style: QuoteStyle,
 
     // it's also a top-level configurable property.
-    /// The attribute position style in JavaScript code. Defaults to auto.
+    /// The attribute position style in JSX/TSX languages. Defaults to auto.
     #[partial(bpaf(
         long("javascript-attribute-position"),
         argument("multiline|auto"),

--- a/crates/biome_service/src/configuration/overrides.rs
+++ b/crates/biome_service/src/configuration/overrides.rs
@@ -140,7 +140,7 @@ pub struct OverrideFormatterConfiguration {
     pub line_width: Option<LineWidth>,
 
     /// The attribute position style.
-    #[bpaf(long("attribute-position"), argument("auto|multiline"), optional)]
+    #[bpaf(long("attribute-position"), argument("multiline|auto"), optional)]
     pub attribute_position: Option<AttributePosition>,
 }
 

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -929,7 +929,7 @@ impl OverrideSettingPattern {
     fn apply_overrides_to_json_parser_options(&self, options: &mut JsonParserOptions) {
         if let Ok(readonly_cache) = self.cached_json_parser_options.read() {
             if let Some(cached_options) = readonly_cache.as_ref() {
-                *options = cached_options.clone();
+                *options = *cached_options;
                 return;
             }
             drop(readonly_cache);
@@ -941,7 +941,7 @@ impl OverrideSettingPattern {
         options.allow_comments = json_parser.allow_comments;
 
         if let Ok(mut writeonly_cache) = self.cached_json_parser_options.write() {
-            let options = options.clone();
+            let options = *options;
             let _ = writeonly_cache.insert(options);
         }
     }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -781,7 +781,6 @@ impl OverrideSettingPattern {
                 *options = cached_options.clone();
                 return;
             }
-            drop(readonly_cache);
         }
 
         let js_formatter = &self.languages.javascript.formatter;
@@ -838,7 +837,6 @@ impl OverrideSettingPattern {
                 *options = cached_options.clone();
                 return;
             }
-            drop(readonly_cache);
         }
 
         let json_formatter = &self.languages.json.formatter;
@@ -872,7 +870,6 @@ impl OverrideSettingPattern {
                 *options = cached_options.clone();
                 return;
             }
-            drop(readonly_cache);
         }
 
         let css_formatter = &self.languages.css.formatter;
@@ -906,7 +903,6 @@ impl OverrideSettingPattern {
                 *options = cached_options.clone();
                 return;
             }
-            drop(readonly_cache);
         }
 
         let js_parser = &self.languages.javascript.parser;
@@ -925,7 +921,6 @@ impl OverrideSettingPattern {
                 *options = *cached_options;
                 return;
             }
-            drop(readonly_cache);
         }
 
         let json_parser = &self.languages.json.parser;

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -767,7 +767,7 @@ pub struct OverrideSettingPattern {
     // Cache
     // For js format options, we use the file source as the cache key because
     // the file source params will affect how tokens are treated during formatting.
-    // So we cannot reuse the same file source for all js-family files.
+    // So we cannot reuse the same format options for all js-family files.
     pub(crate) cached_js_format_options: RwLock<FxHashMap<JsFileSource, JsFormatOptions>>,
     pub(crate) cached_json_format_options: RwLock<Option<JsonFormatOptions>>,
     pub(crate) cached_css_format_options: RwLock<Option<CssFormatOptions>>,

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -785,9 +785,11 @@ impl OverrideSettingPattern {
         if let Some(indent_style) = js_formatter.indent_style.or(formatter.indent_style) {
             options.set_indent_style(indent_style);
         }
-
         if let Some(indent_width) = js_formatter.indent_width.or(formatter.indent_width) {
-            options.set_indent_width(indent_width)
+            options.set_indent_width(indent_width);
+        }
+        if let Some(line_ending) = js_formatter.line_ending.or(formatter.line_ending) {
+            options.set_line_ending(line_ending);
         }
         if let Some(line_width) = js_formatter.line_width.or(formatter.line_width) {
             options.set_line_width(line_width);
@@ -795,14 +797,14 @@ impl OverrideSettingPattern {
         if let Some(quote_style) = js_formatter.quote_style {
             options.set_quote_style(quote_style);
         }
-        if let Some(trailing_comma) = js_formatter.trailing_comma {
-            options.set_trailing_comma(trailing_comma);
+        if let Some(jsx_quote_style) = js_formatter.jsx_quote_style {
+            options.set_jsx_quote_style(jsx_quote_style);
         }
         if let Some(quote_properties) = js_formatter.quote_properties {
             options.set_quote_properties(quote_properties);
         }
-        if let Some(jsx_quote_style) = js_formatter.jsx_quote_style {
-            options.set_jsx_quote_style(jsx_quote_style);
+        if let Some(trailing_comma) = js_formatter.trailing_comma {
+            options.set_trailing_comma(trailing_comma);
         }
         if let Some(semicolons) = js_formatter.semicolons {
             options.set_semicolons(semicolons);
@@ -815,6 +817,9 @@ impl OverrideSettingPattern {
         }
         if let Some(bracket_same_line) = js_formatter.bracket_same_line {
             options.set_bracket_same_line(bracket_same_line);
+        }
+        if let Some(attribute_position) = js_formatter.attribute_position {
+            options.set_attribute_position(attribute_position);
         }
         let mut cache = self.cached_js_format_options.write().unwrap();
         let _ = cache.insert(options.clone());
@@ -829,14 +834,18 @@ impl OverrideSettingPattern {
         drop(cache);
 
         let json_formatter = &self.languages.json.formatter;
+        let formatter = &self.formatter;
 
-        if let Some(indent_style) = json_formatter.indent_style.or(self.formatter.indent_style) {
+        if let Some(indent_style) = json_formatter.indent_style.or(formatter.indent_style) {
             options.set_indent_style(indent_style);
         }
-        if let Some(indent_width) = json_formatter.indent_width.or(self.formatter.indent_width) {
+        if let Some(indent_width) = json_formatter.indent_width.or(formatter.indent_width) {
             options.set_indent_width(indent_width)
         }
-        if let Some(line_width) = json_formatter.line_width.or(self.formatter.line_width) {
+        if let Some(line_ending) = json_formatter.line_ending.or(formatter.line_ending) {
+            options.set_line_ending(line_ending);
+        }
+        if let Some(line_width) = json_formatter.line_width.or(formatter.line_width) {
             options.set_line_width(line_width);
         }
         if let Some(trailing_commas) = json_formatter.trailing_commas {
@@ -845,6 +854,7 @@ impl OverrideSettingPattern {
         let mut cache = self.cached_json_format_options.write().unwrap();
         let _ = cache.insert(options.clone());
     }
+
     fn css_format_options(&self, options: &mut CssFormatOptions) {
         let cache = self.cached_css_format_options.read().unwrap();
         if let Some(cached_options) = cache.as_ref() {
@@ -861,6 +871,9 @@ impl OverrideSettingPattern {
         }
         if let Some(indent_width) = css_formatter.indent_width.or(formatter.indent_width) {
             options.set_indent_width(indent_width)
+        }
+        if let Some(line_ending) = css_formatter.line_ending.or(formatter.line_ending) {
+            options.set_line_ending(line_ending);
         }
         if let Some(line_width) = css_formatter.line_width.or(formatter.line_width) {
             options.set_line_width(line_width);

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -841,13 +841,6 @@ impl OverrideSettingPattern {
             drop(readonly_cache);
         }
 
-        let cache = self.cached_json_format_options.read().unwrap();
-        if let Some(cached_options) = cache.as_ref() {
-            *options = cached_options.clone();
-            return;
-        }
-        drop(cache);
-
         let json_formatter = &self.languages.json.formatter;
         let formatter = &self.formatter;
 

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -112,7 +112,7 @@ export interface PartialFilesConfiguration {
  */
 export interface PartialFormatterConfiguration {
 	/**
-	 * The attribute position style. By default auto.
+	 * The attribute position style in HTMLish languages. By default auto.
 	 */
 	attributePosition?: AttributePosition;
 	enabled?: boolean;
@@ -296,7 +296,7 @@ export interface PartialJavascriptFormatter {
 	 */
 	arrowParentheses?: ArrowParentheses;
 	/**
-	 * The attribute position style in JavaScript code. Defaults to auto.
+	 * The attribute position style in JSX/TSX languages. Defaults to auto.
 	 */
 	attributePosition?: AttributePosition;
 	/**

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -296,7 +296,7 @@ export interface PartialJavascriptFormatter {
 	 */
 	arrowParentheses?: ArrowParentheses;
 	/**
-	 * The attribute position style in JSX/TSX languages. Defaults to auto.
+	 * The attribute position style in jsx elements. Defaults to auto.
 	 */
 	attributePosition?: AttributePosition;
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1135,7 +1135,7 @@
 					]
 				},
 				"attributePosition": {
-					"description": "The attribute position style in JSX/TSX languages. Defaults to auto.",
+					"description": "The attribute position style in jsx elements. Defaults to auto.",
 					"anyOf": [
 						{ "$ref": "#/definitions/AttributePosition" },
 						{ "type": "null" }

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1000,7 +1000,7 @@
 			"type": "object",
 			"properties": {
 				"attributePosition": {
-					"description": "The attribute position style. By default auto.",
+					"description": "The attribute position style in HTMLish languages. By default auto.",
 					"anyOf": [
 						{ "$ref": "#/definitions/AttributePosition" },
 						{ "type": "null" }
@@ -1135,7 +1135,7 @@
 					]
 				},
 				"attributePosition": {
-					"description": "The attribute position style in JavaScript code. Defaults to auto.",
+					"description": "The attribute position style in JSX/TSX languages. Defaults to auto.",
 					"anyOf": [
 						{ "$ref": "#/definitions/AttributePosition" },
 						{ "type": "null" }

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -25,6 +25,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Configuration
 
+#### Bug fixes
+
+- Complete the documentation and overrides support for options `lineEnd` and `attributePosition`. Contributed by @Sec-ant
+
 ### Editors
 
 ### Formatter

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -21,7 +21,11 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### CLI
 
+#### Bug fixes
+
 - Fix configuration resolution. Biome is now able to correctly find the `biome.jsonc` configuration file when `--config-path` is explicitly set. Contributed by @Sec-ant
+
+- JavaScript/TypeScript files of different variants (`.ts`, `.js`, `.tsx`, `.jsx`) in a single workspace now have stable formatting behaviors when running the CLI command in paths of different nested levels or in different operating systems ([#2080](https://github.com/biomejs/biome/issues/2080), [#2109](https://github.com/biomejs/biome/issues/2109)). Contributed by @Sec-ant
 
 ### Configuration
 

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -31,7 +31,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
-- Complete the documentation and overrides support for options `lineEnd` and `attributePosition`. Contributed by @Sec-ant
+- Complete the documentation and overrides support for options `formatter.lineEnding`, `[language].formatter.lineEnding`, `formatter.attributePosition` and `javascript.formatter.attributePosition`. Contributed by @Sec-ant
 
 ### Editors
 

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -226,8 +226,8 @@ Runs formatter, linter and import sorting to the requested files.
   The type of line ending.
 - **`    --line-width`**=_`NUMBER`_ &mdash; 
   What's the max width of a line. Defaults to 80.
-- **`    --attribute-position`**=_`<auto|multiline>`_ &mdash; 
-  The attribute position style. By default auto.
+- **`    --attribute-position`**=_`<multiline|auto>`_ &mdash; 
+  The attribute position style in HTMLish languages. By default auto.
 - **`    --jsx-quote-style`**=_`<double|single>`_ &mdash; 
   The type of quotes used in JSX. Defaults to double.
 - **`    --quote-properties`**=_`<preserve|as-needed>`_ &mdash; 
@@ -257,7 +257,7 @@ Runs formatter, linter and import sorting to the requested files.
 - **`    --quote-style`**=_`<double|single>`_ &mdash; 
   The type of quotes used in JavaScript code. Defaults to double.
 - **`    --javascript-attribute-position`**=_`<multiline|auto>`_ &mdash; 
-  The attribute position style in JavaScript code. Defaults to auto.
+  The attribute position style in jsx elements. Defaults to auto.
 - **`    --json-formatter-enabled`**=_`<true|false>`_ &mdash; 
   Control the formatter for JSON (and its super languages) files.
 - **`    --json-formatter-indent-style`**=_`<tab|space>`_ &mdash; 
@@ -450,8 +450,8 @@ Run the formatter on a set of files.
   The type of line ending.
 - **`    --line-width`**=_`NUMBER`_ &mdash; 
   What's the max width of a line. Defaults to 80.
-- **`    --attribute-position`**=_`<auto|multiline>`_ &mdash; 
-  The attribute position style. By default auto.
+- **`    --attribute-position`**=_`<multiline|auto>`_ &mdash; 
+  The attribute position style in HTMLish languages. By default auto.
 
 
 
@@ -485,7 +485,7 @@ Run the formatter on a set of files.
 - **`    --quote-style`**=_`<double|single>`_ &mdash; 
   The type of quotes used in JavaScript code. Defaults to double.
 - **`    --javascript-attribute-position`**=_`<multiline|auto>`_ &mdash; 
-  The attribute position style in JavaScript code. Defaults to auto.
+  The attribute position style in jsx elements. Defaults to auto.
 
 
 
@@ -621,8 +621,8 @@ Files won't be modified, the command is a read-only operation.
   The type of line ending.
 - **`    --line-width`**=_`NUMBER`_ &mdash; 
   What's the max width of a line. Defaults to 80.
-- **`    --attribute-position`**=_`<auto|multiline>`_ &mdash; 
-  The attribute position style. By default auto.
+- **`    --attribute-position`**=_`<multiline|auto>`_ &mdash; 
+  The attribute position style in HTMLish languages. By default auto.
 - **`    --jsx-quote-style`**=_`<double|single>`_ &mdash; 
   The type of quotes used in JSX. Defaults to double.
 - **`    --quote-properties`**=_`<preserve|as-needed>`_ &mdash; 
@@ -652,7 +652,7 @@ Files won't be modified, the command is a read-only operation.
 - **`    --quote-style`**=_`<double|single>`_ &mdash; 
   The type of quotes used in JavaScript code. Defaults to double.
 - **`    --javascript-attribute-position`**=_`<multiline|auto>`_ &mdash; 
-  The attribute position style in JavaScript code. Defaults to auto.
+  The attribute position style in jsx elements. Defaults to auto.
 - **`    --json-formatter-enabled`**=_`<true|false>`_ &mdash; 
   Control the formatter for JSON (and its super languages) files.
 - **`    --json-formatter-indent-style`**=_`<tab|space>`_ &mdash; 

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -45,7 +45,7 @@ A list of paths to other JSON files. Biome resolves and applies the options of t
 The maximum allowed size for source code files in bytes. Files above
 this limit will be ignored for performance reasons.
 
-> Default: 1024*1024 (1MB)
+> Default: `1048576` (1024*1024, 1MB)
 
 ### `files.ignore`
 
@@ -110,7 +110,7 @@ Biome won't emit diagnostics if it encounters files that can't handle.
 }
 ```
 
-> Default: false
+> Default: `false`
 
 ## `vcs`
 
@@ -120,7 +120,7 @@ Set of properties to integrate Biome with a VCS software.
 
 Whether Biome should integrate itself with the VCS client
 
-> Default: false
+> Default: `false`
 
 ### `vcs.clientKind`
 
@@ -383,7 +383,7 @@ Allows to format a document that has syntax errors.
 
 The style of the indentation. It can be `"tab"` or `"space"`.
 
-> Default: `tab`
+> Default: `"tab"`
 
 ### `formatter.indentSize`
 
@@ -400,17 +400,25 @@ How big the indentation should be.
 ### `formatter.lineEnding`
 
 The type of line ending.
-- `lf`, Line Feed only (`\n`), common on Linux and macOS as well as inside git repos
-- `crlf` Carriage Return + Line Feed characters (`\r\n`), common on Windows
-- `cr` Carriage Return character only (`\r`), used very rarely
+- `"lf"`, Line Feed only (`\n`), common on Linux and macOS as well as inside git repos;
+- `"crlf"`, Carriage Return + Line Feed characters (`\r\n`), common on Windows;
+- `"cr"`, Carriage Return character only (`\r`), used very rarely.
 
-> Default: `lf`
+> Default: `"lf"`
 
 ### `formatter.lineWidth`
 
 How many characters can be written on a single line.
 
 > Default: `80`
+
+### `formatter.attributePosition`
+
+The attribute position style in HTMLish languages. 
+- `"auto"`, the attributes are automatically formatted, and they will collapse in multiple lines only when they hit certain criteria;
+- `"multiline"`, the attributes are always formatted on multiple lines, regardless.
+
+> Default: `"auto"`
 
 ## `organizeImports`
 
@@ -496,38 +504,38 @@ Allows to support the unsafe/experimental parameter decorators.
 
 ### `javascript.formatter.quoteStyle`
 
-The type of quote used when representing string literals. It can be `single` or `double`.
+The type of quote used when representing string literals. It can be `"single"` or `"double"`.
 
-> Default: `double`
+> Default: `"double"`
 
 ### `javascript.formatter.jsxQuoteStyle`
 
-The type of quote used when representing jsx string literals. It can be `single` or `double`.
+The type of quote used when representing jsx string literals. It can be `"single"` or `"double"`.
 
-> Default: `double`
+> Default: `"double"`
 
 ### `javascript.formatter.quoteProperties`
 
-When properties inside objects should be quoted. It can be `asNeeded` or `preserve`.
+When properties inside objects should be quoted. It can be `"asNeeded"` or `"preserve"`.
 
-> Default: `asNeeded`
+> Default: `"asNeeded"`
 
 ### `javascript.formatter.trailingComma`
 
 Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Possible values:
-- `all`, the trailing comma is always added
-- `es5`, the trailing comma is added only in places where it's supported by older version of JavaScript
-- `none`, trailing commas are never added
+- `"all"`, the trailing comma is always added;
+- `"es5"`, the trailing comma is added only in places where it's supported by older version of JavaScript;
+- `"none"`, trailing commas are never added.
 
-> Default: `all`
+> Default: `"all"`
 
 ### `javascript.formatter.semicolons`
 
 It configures where the formatter prints semicolons:
-- `always`, the semicolons is always added at the end of each statement;
-- `asNeeded`, the semicolons are added only in places where it's needed, to protect from [ASI](https://en.wikibooks.org/wiki/JavaScript/Automatic_semicolon_insertion)
+- `"always"`, the semicolons is always added at the end of each statement;
+- `"asNeeded"`, the semicolons are added only in places where it's needed, to protect from [ASI](https://en.wikibooks.org/wiki/JavaScript/Automatic_semicolon_insertion).
 
-> Default: `always`
+> Default: `"always"`
 
 Example:
 
@@ -546,10 +554,10 @@ Example:
 ### `javascript.formatter.arrowParentheses`
 
 Whether to add non-necessary parentheses to arrow functions:
-- `always`, the parentheses are always added;
-- `asNeeded`, the parentheses are added only when they are needed;
+- `"always"`, the parentheses are always added;
+- `"asNeeded"`, the parentheses are added only when they are needed.
 
-> Default: `always`
+> Default: `"always"`
 
 ### `javascript.formatter.enabled`
 
@@ -561,7 +569,7 @@ Enables Biome's formatter for JavaScript (and its super languages) files.
 
 The style of the indentation for JavaScript (and its super languages) files. It can be `"tab"` or `"space"`.
 
-> Default: `tab`
+> Default: `"tab"`
 
 ### `javascript.formatter.indentSize`
 
@@ -578,11 +586,11 @@ How big the indentation should be for JavaScript (and its super languages) files
 ### `javascript.formatter.lineEnding`
 
 The type of line ending for JavaScript (and its super languages) files.
-- `lf`, Line Feed only (`\n`), common on Linux and macOS as well as inside git repos
-- `crlf` Carriage Return + Line Feed characters (`\r\n`), common on Windows
-- `cr` Carriage Return character only (`\r`), used very rarely
+- `"lf"`, Line Feed only (`\n`), common on Linux and macOS as well as inside git repos;
+- `"crlf"`, Carriage Return + Line Feed characters (`\r\n`), common on Windows;
+- `"cr"`, Carriage Return character only (`\r`), used very rarely.
 
-> Default: `lf`
+> Default: `"lf"`
 
 ### `javascript.formatter.lineWidth`
 
@@ -594,14 +602,21 @@ How many characters can be written on a single line in JavaScript (and its super
 
 Choose whether the ending `>` of a multi-line JSX element should be on the last attribute line or not
 
-> Default: false
+> Default: `false`
 
 ### `javascript.formatter.bracketSpacing`
 
 Choose whether spaces should be added between brackets and inner values
 
-> Default: true
+> Default: `true`
 
+### `javascript.formatter.attributePosition`
+
+The attribute position style in jsx/tsx languages. 
+- `"auto"`, the attributes are automatically formatted, and they will collapse in multiple lines only when they hit certain criteria;
+- `"multiline"`, the attributes are always formatted on multiple lines, regardless.
+
+> Default: `"auto"`
 
 ### `javascript.globals`
 
@@ -664,7 +679,7 @@ Enables Biome's formatter for JSON (and its super languages) files.
 
 The style of the indentation for JSON (and its super languages) files. It can be `"tab"` or `"space"`.
 
-> Default: `tab`
+> Default: `"tab"`
 
 
 ### `json.formatter.indentSize`
@@ -682,11 +697,11 @@ How big the indentation should be for JSON (and its super languages) files.
 ### `json.formatter.lineEnding`
 
 The type of line ending for JSON (and its super languages) files.
-- `lf`, Line Feed only (`\n`), common on Linux and macOS as well as inside git repos
-- `crlf` Carriage Return + Line Feed characters (`\r\n`), common on Windows
-- `cr` Carriage Return character only (`\r`), used very rarely
+- `"lf"`, Line Feed only (`\n`), common on Linux and macOS as well as inside git repos;
+- , Carriage Return + Line Feed characters (`\r\n`), common on Windows;
+- `"cr"`, Carriage Return character only (`\r`), used very rarely.
 
-> Default: `lf`
+> Default: `"lf"`
 
 ### `json.formatter.lineWidth`
 
@@ -699,10 +714,10 @@ How many characters can be written on a single line in JSON (and its super langu
 Print trailing commas wherever possible in multi-line comma-separated syntactic structures.
 
 Allowed values:
-- `none`: the trailing comma is removed;
-- `all`: the trailing comma is kept **and** preferred.
+- `"none"`: the trailing comma is removed;
+- `"all"`: the trailing comma is kept **and** preferred.
 
-> Default: `none`
+> Default: `"none"`
 
 ## `overrides`
 

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -612,7 +612,7 @@ Choose whether spaces should be added between brackets and inner values
 
 ### `javascript.formatter.attributePosition`
 
-The attribute position style in jsx/tsx languages. 
+The attribute position style in jsx elements. 
 - `"auto"`, the attributes are automatically formatted, and they will collapse in multiple lines only when they hit certain criteria;
 - `"multiline"`, the attributes are always formatted on multiple lines, regardless.
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where we cache the final options after we apply overrides to the options, and reuse them in other files in the same workspace. JavaScript/TypeScript files of different variants (`.ts`, `.js`, `.tsx`, `.jsx`) in a single workspace cannot share the same cache because they have different file source params which will affect how they are formatted. This PR uses the `JsFileSource` as the cache key so files of different file sources will have different cached options. Refer to https://github.com/biomejs/biome/issues/2109#issuecomment-2016358037 for more details.

Fixes #2080, fixes #2109.

As a side note/fix, I updated the overrides application functions and configuration doc on our website to take options `lineEnding` and `attributePosition` into account. They were not properly applied or documented. I grouped them into a dedicated commit: bd3aa2c.

## Test Plan

Unfortunately I cannot reproduce this issue in our memory filesystem. I think this problem has something to do with the IO overhead in different kinds of filesystems. I tested this fix locally with the provided minimal reproductions in https://github.com/biomejs/biome/issues/2080#issuecomment-2014744054 and https://github.com/biomejs/biome/issues/2109#issuecomment-2014644646 and this issue is fixed in those two cases.