### PR TITLE
fix(codegen): new lint rule generation

### DIFF
--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -24,7 +24,7 @@ _Just_ is not part of the rust toolchain, you have to install it with [a package
 
 _Biome_ follows a naming convention according to what the rule do:
 
-1. Forbid a concept
+- Forbid a concept
 
    ```block
    no<Concept>
@@ -33,7 +33,7 @@ _Biome_ follows a naming convention according to what the rule do:
    When a rule's sole intention is to **forbid a single concept** - such as disallowing the use of `debugger` statements - the rule should be named using the `no` prefix.
    For example, the rule to disallow the use of `debugger` statements is named `noDebugger`.
 
-1. Mandate a concept
+- Mandate a concept
 
    ```block
    use<Concept>
@@ -62,13 +62,13 @@ Let's say we want to create a new rule called `myRuleName`, which uses the seman
    ```
    The script will create a new **lint** rule for the _JavaScript_ language, inside the `biome_js_analyze`
 
-1. The `Ast` query type allows you to query the AST of a program.
-1. The `State` type doesn't have to be used, so it can be considered optional. However, it has to be defined as `type State = ()`.
-1. Implement the `run` function:
+2. The `Ast` query type allows you to query the AST of a program.
+3. The `State` type doesn't have to be used, so it can be considered optional. However, it has to be defined as `type State = ()`.
+4. Implement the `run` function:
 
    This function is called every time the analyzer finds a match for the query specified by the rule, and may return zero or more "signals".
 
-1. Implement the `diagnostic` function. Follow the [pillars](#explain-a-rule-to-the-user):
+5. Implement the `diagnostic` function. Follow the [pillars](#explain-a-rule-to-the-user):
 
    ```rust,ignore
    impl Rule for UseAwesomeTricks {
@@ -78,8 +78,8 @@ Let's say we want to create a new rule called `myRuleName`, which uses the seman
    ```
 
    While implementing the diagnostic, please keep [Biome's technical principals](https://biomejs.dev/internals/philosophy/#technical) in mind.
-   
-1. Implement the optional `action` function, if we are able to provide a code action:
+
+6. Implement the optional `action` function, if we are able to provide a code action:
 
    ```rust,ignore
    impl Rule for UseAwesomeTricks {

--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -24,7 +24,7 @@ _Just_ is not part of the rust toolchain, you have to install it with [a package
 
 _Biome_ follows a naming convention according to what the rule do:
 
-- Forbid a concept
+1. Forbid a concept
 
    ```block
    no<Concept>
@@ -33,7 +33,7 @@ _Biome_ follows a naming convention according to what the rule do:
    When a rule's sole intention is to **forbid a single concept** - such as disallowing the use of `debugger` statements - the rule should be named using the `no` prefix.
    For example, the rule to disallow the use of `debugger` statements is named `noDebugger`.
 
-- Mandate a concept
+1. Mandate a concept
 
    ```block
    use<Concept>
@@ -62,13 +62,13 @@ Let's say we want to create a new rule called `myRuleName`, which uses the seman
    ```
    The script will create a new **lint** rule for the _JavaScript_ language, inside the `biome_js_analyze`
 
-2. The `Ast` query type allows you to query the AST of a program.
-3. The `State` type doesn't have to be used, so it can be considered optional. However, it has to be defined as `type State = ()`.
-4. Implement the `run` function:
+1. The `Ast` query type allows you to query the AST of a program.
+1. The `State` type doesn't have to be used, so it can be considered optional. However, it has to be defined as `type State = ()`.
+1. Implement the `run` function:
 
    This function is called every time the analyzer finds a match for the query specified by the rule, and may return zero or more "signals".
 
-5. Implement the `diagnostic` function. Follow the [pillars](#explain-a-rule-to-the-user):
+1. Implement the `diagnostic` function. Follow the [pillars](#explain-a-rule-to-the-user):
 
    ```rust,ignore
    impl Rule for UseAwesomeTricks {
@@ -79,7 +79,7 @@ Let's say we want to create a new rule called `myRuleName`, which uses the seman
 
    While implementing the diagnostic, please keep [Biome's technical principals](https://biomejs.dev/internals/philosophy/#technical) in mind.
 
-6. Implement the optional `action` function, if we are able to provide a code action:
+1. Implement the optional `action` function, if we are able to provide a code action:
 
    ```rust,ignore
    impl Rule for UseAwesomeTricks {

--- a/xtask/codegen/src/generate_new_lintrule.rs
+++ b/xtask/codegen/src/generate_new_lintrule.rs
@@ -190,8 +190,8 @@ impl Rule for {rule_name_upper_camel} {{
 pub fn generate_new_lintrule(kind: RuleKind, rule_name: &str) {
     let crate_folder = match kind {
         RuleKind::Js => project_root().join("crates/biome_js_analyze"),
-        RuleKind::Json => project_root().join("crates/biome_js_analyze"),
-        RuleKind::Css => project_root().join("crates/biome_js_analyze"),
+        RuleKind::Json => project_root().join("crates/biome_json_analyze"),
+        RuleKind::Css => project_root().join("crates/biome_css_analyze"),
     };
     let rule_folder = crate_folder.join("src/lint/nursery");
     let test_folder = crate_folder.join("tests/specs/nursery");
@@ -248,6 +248,6 @@ pub fn generate_new_lintrule(kind: RuleKind, rule_name: &str) {
         test_folder.display()
     );
     if std::fs::File::open(&test_file).is_err() {
-        let _ = std::fs::write(test_file, "\n\n var a = 1;\na = 2;\n a = 3;");
+        let _ = std::fs::write(test_file, "\n\n var a = 1;\na = 2;\na = 3;");
     }
 }

--- a/xtask/codegen/src/generate_new_lintrule.rs
+++ b/xtask/codegen/src/generate_new_lintrule.rs
@@ -80,15 +80,16 @@ impl Rule for {rule_name_upper_camel} {{
         None
     }}
 
-    fn diagnostic(_ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {{
+    fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {{
         //
         // Read our guidelines to write great diagnostics:
         // https://docs.rs/biome_analyze/latest/biome_analyze/#what-a-rule-should-say-to-the-user
         //
+        let node = ctx.query();
         Some(
             RuleDiagnostic::new(
                 rule_category!(),
-                reference.range(),
+                node.range(),
                 markup! {{
                     "Variable is read here."
                 }},

--- a/xtask/codegen/src/generate_new_lintrule.rs
+++ b/xtask/codegen/src/generate_new_lintrule.rs
@@ -192,7 +192,7 @@ pub fn generate_new_lintrule(kind: RuleKind, rule_name: &str) {
         RuleKind::Json => project_root().join("crates/biome_js_analyze"),
         RuleKind::Css => project_root().join("crates/biome_js_analyze"),
     };
-    let rule_folder = crate_folder.join("src/lint");
+    let rule_folder = crate_folder.join("src/lint/nursery");
     let test_folder = crate_folder.join("tests/specs/nursery");
     let rule_name_upper_camel = rule_name.to_camel();
     let rule_name_snake = rule_name.to_snake();

--- a/xtask/codegen/src/generate_new_lintrule.rs
+++ b/xtask/codegen/src/generate_new_lintrule.rs
@@ -36,6 +36,7 @@ fn generate_rule_template(
 }};
 use biome_console::markup;
 use biome_js_syntax::JsIdentifierBinding;
+use biome_rowan::AstNode;
 
 declare_rule! {{
     /// Succinct description of the rule.

--- a/xtask/codegen/src/generate_new_lintrule.rs
+++ b/xtask/codegen/src/generate_new_lintrule.rs
@@ -60,7 +60,7 @@ declare_rule! {{
     /// ### Valid
     ///
     /// ```js
-    /// var a = 1;
+    /// // var a = 1;
     /// ```
     ///
     pub {rule_name_upper_camel} {{
@@ -77,8 +77,8 @@ impl Rule for {rule_name_upper_camel} {{
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {{
-        let binding = ctx.query();
-        None
+        let _binding = ctx.query();
+        Some(())
     }}
 
     fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {{
@@ -239,7 +239,7 @@ pub fn generate_new_lintrule(kind: RuleKind, rule_name: &str) {
     if std::fs::File::open(&test_file).is_err() {
         let _ = std::fs::write(
             test_file,
-            "/* should not generate diagnostics */\n\n var a = 1;",
+            "/* should not generate diagnostics */\n// var a = 1;",
         );
     }
 
@@ -248,6 +248,6 @@ pub fn generate_new_lintrule(kind: RuleKind, rule_name: &str) {
         test_folder.display()
     );
     if std::fs::File::open(&test_file).is_err() {
-        let _ = std::fs::write(test_file, "\n\n var a = 1;\na = 2;\na = 3;");
+        let _ = std::fs::write(test_file, "var a = 1;\na = 2;\na = 3;");
     }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

In `generate_new_lintrule.rs`, this PR fixes 
- to use `node.range()` because `reference` isn't defined
- to locate new lint rule in `src/lint/nursery`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Executed `just new-js-lintrule ruleName` without fail

<!-- What demonstrates that your implementation is correct? -->
