### PR TITLE
fix(website): a small typo

### DIFF
--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -698,7 +698,7 @@ How big the indentation should be for JSON (and its super languages) files.
 
 The type of line ending for JSON (and its super languages) files.
 - `"lf"`, Line Feed only (`\n`), common on Linux and macOS as well as inside git repos;
-- , Carriage Return + Line Feed characters (`\r\n`), common on Windows;
+- `"crlf"`, Carriage Return + Line Feed characters (`\r\n`), common on Windows;
 - `"cr"`, Carriage Return character only (`\r`), used very rarely.
 
 > Default: `"lf"`


### PR DESCRIPTION
## Summary

A small typo in `configuration.mdx`
