### PR TITLE
chore: `search` command infra

### DIFF
--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -401,12 +401,16 @@ impl BiomeCommand {
 
     pub fn log_level(&self) -> LoggingLevel {
         self.cli_options()
-            .map_or(LoggingLevel::default(), |cli_options| cli_options.log_level)
+            .map_or(LoggingLevel::default(), |cli_options| {
+                cli_options.log_level.clone()
+            })
     }
 
     pub fn log_kind(&self) -> LoggingKind {
         self.cli_options()
-            .map_or(LoggingKind::default(), |cli_options| cli_options.log_kind)
+            .map_or(LoggingKind::default(), |cli_options| {
+                cli_options.log_kind.clone()
+            })
     }
 }
 

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod init;
 pub(crate) mod lint;
 pub(crate) mod migrate;
 pub(crate) mod rage;
+pub(crate) mod search;
 pub(crate) mod version;
 
 #[derive(Debug, Clone, Bpaf)]
@@ -277,6 +278,40 @@ pub enum BiomeCommand {
         sub_command: Option<MigrateSubCommand>,
     },
 
+    /// Searches for Grit patterns across a project.
+    #[bpaf(command, hide)] // !! Command is hidden until ready for release.
+    Search {
+        /// The GritQL pattern to search for.
+        ///
+        /// Note that the search command (currently) does not support rewrites.
+        #[bpaf(positional("PATH"))]
+        pattern: String,
+
+        /// Single file, single path or list of paths.
+        #[bpaf(positional("PATH"), many)]
+        paths: Vec<OsString>,
+
+        #[bpaf(external, hide_usage)]
+        cli_options: CliOptions,
+
+        #[bpaf(external(partial_files_configuration), optional, hide_usage)]
+        files_configuration: Option<PartialFilesConfiguration>,
+
+        #[bpaf(external(partial_vcs_configuration), optional, hide_usage)]
+        vcs_configuration: Option<PartialVcsConfiguration>,
+
+        /// Use this option when you want to search through code piped from
+        /// `stdin`, and print the output to `stdout`.
+        ///
+        /// The file doesn't need to exist on disk, what matters is the
+        /// extension of the file. Based on the extension, Biome knows how to
+        /// parse the code.
+        ///
+        /// Example: `echo 'let a;' | biome search '`let $var`' --stdin-file-path=file.js`
+        #[bpaf(long("stdin-file-path"), argument("PATH"), hide_usage)]
+        stdin_file_path: Option<String>,
+    },
+
     /// A command to retrieve the documentation of various aspects of the CLI.
     ///
     /// ## Examples
@@ -321,7 +356,7 @@ impl MigrateSubCommand {
 }
 
 impl BiomeCommand {
-    pub const fn get_color(&self) -> Option<&ColorsArg> {
+    const fn cli_options(&self) -> Option<&CliOptions> {
         match self {
             BiomeCommand::Version(cli_options)
             | BiomeCommand::Rage(cli_options, ..)
@@ -329,7 +364,8 @@ impl BiomeCommand {
             | BiomeCommand::Lint { cli_options, .. }
             | BiomeCommand::Ci { cli_options, .. }
             | BiomeCommand::Format { cli_options, .. }
-            | BiomeCommand::Migrate { cli_options, .. } => cli_options.colors.as_ref(),
+            | BiomeCommand::Migrate { cli_options, .. }
+            | BiomeCommand::Search { cli_options, .. } => Some(cli_options),
             BiomeCommand::LspProxy(_, _)
             | BiomeCommand::Start(_)
             | BiomeCommand::Stop
@@ -340,23 +376,14 @@ impl BiomeCommand {
         }
     }
 
+    pub const fn get_color(&self) -> Option<&ColorsArg> {
+        self.cli_options()
+            .and_then(|cli_options| cli_options.colors.as_ref())
+    }
+
     pub const fn should_use_server(&self) -> bool {
-        match self {
-            BiomeCommand::Version(cli_options)
-            | BiomeCommand::Rage(cli_options, ..)
-            | BiomeCommand::Check { cli_options, .. }
-            | BiomeCommand::Lint { cli_options, .. }
-            | BiomeCommand::Ci { cli_options, .. }
-            | BiomeCommand::Format { cli_options, .. }
-            | BiomeCommand::Migrate { cli_options, .. } => cli_options.use_server,
-            BiomeCommand::Init(_)
-            | BiomeCommand::Start(_)
-            | BiomeCommand::Stop
-            | BiomeCommand::Explain { .. }
-            | BiomeCommand::LspProxy(_, _)
-            | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket => false,
-        }
+        self.cli_options()
+            .map_or(false, |cli_options| cli_options.use_server)
     }
 
     pub const fn has_metrics(&self) -> bool {
@@ -364,59 +391,18 @@ impl BiomeCommand {
     }
 
     pub fn is_verbose(&self) -> bool {
-        match self {
-            BiomeCommand::Check { cli_options, .. }
-            | BiomeCommand::Lint { cli_options, .. }
-            | BiomeCommand::Format { cli_options, .. }
-            | BiomeCommand::Ci { cli_options, .. }
-            | BiomeCommand::Migrate { cli_options, .. } => cli_options.verbose,
-            BiomeCommand::Version(_)
-            | BiomeCommand::Rage(..)
-            | BiomeCommand::Start(_)
-            | BiomeCommand::Stop
-            | BiomeCommand::Init(_)
-            | BiomeCommand::Explain { .. }
-            | BiomeCommand::LspProxy(_, _)
-            | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket => false,
-        }
+        self.cli_options()
+            .map_or(false, |cli_options| cli_options.verbose)
     }
 
     pub fn log_level(&self) -> LoggingLevel {
-        match self {
-            BiomeCommand::Check { cli_options, .. }
-            | BiomeCommand::Lint { cli_options, .. }
-            | BiomeCommand::Format { cli_options, .. }
-            | BiomeCommand::Ci { cli_options, .. }
-            | BiomeCommand::Migrate { cli_options, .. } => cli_options.log_level.clone(),
-            BiomeCommand::Version(_)
-            | BiomeCommand::LspProxy(_, _)
-            | BiomeCommand::Rage(..)
-            | BiomeCommand::Start(_)
-            | BiomeCommand::Stop
-            | BiomeCommand::Init(_)
-            | BiomeCommand::Explain { .. }
-            | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket => LoggingLevel::default(),
-        }
+        self.cli_options()
+            .map_or(LoggingLevel::default(), |cli_options| cli_options.log_level)
     }
+
     pub fn log_kind(&self) -> LoggingKind {
-        match self {
-            BiomeCommand::Check { cli_options, .. }
-            | BiomeCommand::Lint { cli_options, .. }
-            | BiomeCommand::Format { cli_options, .. }
-            | BiomeCommand::Ci { cli_options, .. }
-            | BiomeCommand::Migrate { cli_options, .. } => cli_options.log_kind.clone(),
-            BiomeCommand::Version(_)
-            | BiomeCommand::Rage(..)
-            | BiomeCommand::LspProxy(_, _)
-            | BiomeCommand::Start(_)
-            | BiomeCommand::Stop
-            | BiomeCommand::Init(_)
-            | BiomeCommand::Explain { .. }
-            | BiomeCommand::RunServer { .. }
-            | BiomeCommand::PrintSocket => LoggingKind::default(),
-        }
+        self.cli_options()
+            .map_or(LoggingKind::default(), |cli_options| cli_options.log_kind)
     }
 }
 

--- a/crates/biome_cli/src/commands/search.rs
+++ b/crates/biome_cli/src/commands/search.rs
@@ -1,0 +1,82 @@
+use crate::cli_options::CliOptions;
+use crate::commands::{get_stdin, resolve_manifest, validate_configuration_diagnostics};
+use crate::execute::ReportMode;
+use crate::{
+    execute_mode, setup_cli_subscriber, CliDiagnostic, CliSession, Execution, TraversalMode,
+};
+use biome_deserialize::Merge;
+use biome_service::configuration::vcs::PartialVcsConfiguration;
+use biome_service::configuration::{
+    load_configuration, LoadedConfiguration, PartialFilesConfiguration,
+};
+use biome_service::workspace::UpdateSettingsParams;
+use std::ffi::OsString;
+
+pub(crate) struct SearchCommandPayload {
+    pub(crate) cli_options: CliOptions,
+    pub(crate) files_configuration: Option<PartialFilesConfiguration>,
+    pub(crate) paths: Vec<OsString>,
+    pub(crate) pattern: String,
+    pub(crate) stdin_file_path: Option<String>,
+    pub(crate) vcs_configuration: Option<PartialVcsConfiguration>,
+}
+
+/// Handler for the "search" command of the Biome CLI
+pub(crate) fn search(
+    session: CliSession,
+    payload: SearchCommandPayload,
+) -> Result<(), CliDiagnostic> {
+    let SearchCommandPayload {
+        cli_options,
+        files_configuration,
+        mut paths,
+        pattern,
+        stdin_file_path,
+        vcs_configuration,
+    } = payload;
+    setup_cli_subscriber(cli_options.log_level.clone(), cli_options.log_kind.clone());
+
+    let loaded_configuration =
+        load_configuration(&session.app.fs, cli_options.as_configuration_base_path())?;
+    validate_configuration_diagnostics(
+        &loaded_configuration,
+        session.app.console,
+        cli_options.verbose,
+    )?;
+    resolve_manifest(&session)?;
+
+    let LoadedConfiguration {
+        mut configuration,
+        directory_path: configuration_path,
+        ..
+    } = loaded_configuration;
+
+    configuration.files.merge_with(files_configuration);
+    configuration.vcs.merge_with(vcs_configuration);
+
+    // check if support for git ignore files is enabled
+    let vcs_base_path = configuration_path.or(session.app.fs.working_directory());
+    let (vcs_base_path, gitignore_matches) =
+        configuration.retrieve_gitignore_matches(&session.app.fs, vcs_base_path.as_deref())?;
+
+    session
+        .app
+        .workspace
+        .update_settings(UpdateSettingsParams {
+            working_directory: session.app.fs.working_directory(),
+            configuration,
+            vcs_base_path,
+            gitignore_matches,
+        })?;
+
+    let console = &mut *session.app.console;
+    let stdin = get_stdin(stdin_file_path, console, "search")?;
+
+    let execution = if cli_options.json {
+        Execution::with_report(TraversalMode::Search { pattern, stdin }, ReportMode::Json)
+    } else {
+        Execution::new(TraversalMode::Search { pattern, stdin })
+    };
+
+    execute_mode(execution, session, &cli_options, paths)
+}

--- a/crates/biome_cli/src/commands/search.rs
+++ b/crates/biome_cli/src/commands/search.rs
@@ -29,7 +29,7 @@ pub(crate) fn search(
     let SearchCommandPayload {
         cli_options,
         files_configuration,
-        mut paths,
+        paths,
         pattern,
         stdin_file_path,
         vcs_configuration,

--- a/crates/biome_cli/src/execute/process_file.rs
+++ b/crates/biome_cli/src/execute/process_file.rs
@@ -255,7 +255,7 @@ pub(crate) fn process_file(ctx: &TraversalOptions, path: &Path) -> FileResult {
             TraversalMode::Migrate { .. } => {
                 unreachable!("The migration should not be called for this file")
             }
-            TraversalMode::Search { pattern, .. } => {
+            TraversalMode::Search { ref pattern, .. } => {
                 // the unsupported case should be handled already at this point
                 search(shared_context, path, pattern)
             }

--- a/crates/biome_cli/src/execute/process_file.rs
+++ b/crates/biome_cli/src/execute/process_file.rs
@@ -255,9 +255,9 @@ pub(crate) fn process_file(ctx: &TraversalOptions, path: &Path) -> FileResult {
             TraversalMode::Migrate { .. } => {
                 unreachable!("The migration should not be called for this file")
             }
-            TraversalMode::Search { .. } => {
+            TraversalMode::Search { pattern, .. } => {
                 // the unsupported case should be handled already at this point
-                search(shared_context, path)
+                search(shared_context, path, pattern)
             }
         }
     })

--- a/crates/biome_cli/src/execute/process_file/search.rs
+++ b/crates/biome_cli/src/execute/process_file/search.rs
@@ -1,0 +1,45 @@
+use crate::execute::diagnostics::ResultExt;
+use crate::execute::process_file::workspace_file::WorkspaceFile;
+use crate::execute::process_file::{FileResult, FileStatus, Message, SharedTraversalOptions};
+use biome_diagnostics::{category, Diagnostic, Error, Severity};
+use biome_service::workspace::RuleCategories;
+use std::path::Path;
+use std::sync::atomic::Ordering;
+use tracing::debug;
+
+pub(crate) fn search<'ctx>(ctx: &'ctx SharedTraversalOptions<'ctx, '_>, path: &Path) -> FileResult {
+    let mut workspace_file = WorkspaceFile::new(ctx, path)?;
+    search_with_guard(ctx, &mut workspace_file)
+}
+
+pub(crate) fn search_with_guard<'ctx>(
+    ctx: &'ctx SharedTraversalOptions<'ctx, '_>,
+    workspace_file: &mut WorkspaceFile,
+) -> FileResult {
+    tracing::info_span!("Processes searching", path =? workspace_file.path.display()).in_scope(
+        move || {
+            let max_diagnostics = ctx.remaining_diagnostics.load(Ordering::Relaxed);
+            debug!("Pulling diagnostics from parsed file");
+            let diagnostics_result = workspace_file
+                .guard()
+                .pull_diagnostics(RuleCategories::SYNTAX, max_diagnostics.into())
+                .with_file_path_and_code(
+                    workspace_file.path.display().to_string(),
+                    category!("format"),
+                )?;
+
+            let input = workspace_file.input()?;
+
+            let printed = workspace_file
+                .guard()
+                .search_file()
+                .with_file_path_and_code(
+                    workspace_file.path.display().to_string(),
+                    category!("search"),
+                )?;
+
+            // FIXME: Let's implement some actual searching here...
+            Ok(FileStatus::Unchanged)
+        },
+    )
+}

--- a/crates/biome_cli/src/execute/process_file/search.rs
+++ b/crates/biome_cli/src/execute/process_file/search.rs
@@ -1,20 +1,25 @@
 use crate::execute::diagnostics::ResultExt;
 use crate::execute::process_file::workspace_file::WorkspaceFile;
-use crate::execute::process_file::{FileResult, FileStatus, Message, SharedTraversalOptions};
-use biome_diagnostics::{category, Diagnostic, Error, Severity};
+use crate::execute::process_file::{FileResult, FileStatus, SharedTraversalOptions};
+use biome_diagnostics::category;
 use biome_service::workspace::RuleCategories;
 use std::path::Path;
 use std::sync::atomic::Ordering;
 use tracing::debug;
 
-pub(crate) fn search<'ctx>(ctx: &'ctx SharedTraversalOptions<'ctx, '_>, path: &Path) -> FileResult {
+pub(crate) fn search<'ctx>(
+    ctx: &'ctx SharedTraversalOptions<'ctx, '_>,
+    path: &Path,
+    pattern: String,
+) -> FileResult {
     let mut workspace_file = WorkspaceFile::new(ctx, path)?;
-    search_with_guard(ctx, &mut workspace_file)
+    search_with_guard(ctx, &mut workspace_file, pattern)
 }
 
 pub(crate) fn search_with_guard<'ctx>(
     ctx: &'ctx SharedTraversalOptions<'ctx, '_>,
     workspace_file: &mut WorkspaceFile,
+    pattern: String,
 ) -> FileResult {
     tracing::info_span!("Processes searching", path =? workspace_file.path.display()).in_scope(
         move || {
@@ -32,13 +37,13 @@ pub(crate) fn search_with_guard<'ctx>(
 
             let printed = workspace_file
                 .guard()
-                .search_file()
+                .search_pattern(pattern)
                 .with_file_path_and_code(
                     workspace_file.path.display().to_string(),
                     category!("search"),
                 )?;
 
-            // FIXME: Let's implement some actual searching here...
+            // FIXME: We need to report some real results here...
             Ok(FileStatus::Unchanged)
         },
     )

--- a/crates/biome_cli/src/execute/process_file/search.rs
+++ b/crates/biome_cli/src/execute/process_file/search.rs
@@ -2,40 +2,25 @@ use crate::execute::diagnostics::ResultExt;
 use crate::execute::process_file::workspace_file::WorkspaceFile;
 use crate::execute::process_file::{FileResult, FileStatus, SharedTraversalOptions};
 use biome_diagnostics::category;
-use biome_service::workspace::RuleCategories;
 use std::path::Path;
-use std::sync::atomic::Ordering;
-use tracing::debug;
 
 pub(crate) fn search<'ctx>(
     ctx: &'ctx SharedTraversalOptions<'ctx, '_>,
     path: &Path,
-    pattern: String,
+    pattern: &str,
 ) -> FileResult {
     let mut workspace_file = WorkspaceFile::new(ctx, path)?;
     search_with_guard(ctx, &mut workspace_file, pattern)
 }
 
 pub(crate) fn search_with_guard<'ctx>(
-    ctx: &'ctx SharedTraversalOptions<'ctx, '_>,
+    _ctx: &'ctx SharedTraversalOptions<'ctx, '_>,
     workspace_file: &mut WorkspaceFile,
-    pattern: String,
+    pattern: &str,
 ) -> FileResult {
     tracing::info_span!("Processes searching", path =? workspace_file.path.display()).in_scope(
         move || {
-            let max_diagnostics = ctx.remaining_diagnostics.load(Ordering::Relaxed);
-            debug!("Pulling diagnostics from parsed file");
-            let diagnostics_result = workspace_file
-                .guard()
-                .pull_diagnostics(RuleCategories::SYNTAX, max_diagnostics.into())
-                .with_file_path_and_code(
-                    workspace_file.path.display().to_string(),
-                    category!("format"),
-                )?;
-
-            let input = workspace_file.input()?;
-
-            let printed = workspace_file
+            let _result = workspace_file
                 .guard()
                 .search_pattern(pattern)
                 .with_file_path_and_code(

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -103,6 +103,10 @@ impl<'a> fmt::Display for SummaryTotal<'a> {
                     })
                 }
             }
+
+            TraversalMode::Search { .. } => fmt.write_markup(markup! {
+                "Searched "{files}" in "{self.2}
+            }),
         }
     }
 }
@@ -746,6 +750,9 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
             TraversalMode::Lint { .. } => file_features.supports_lint(),
             // Imagine if Biome can't handle its own configuration file...
             TraversalMode::Migrate { .. } => true,
+            // We do need to have a suitable parser, but in principle, every
+            // file is searchable.
+            TraversalMode::Search { .. } => true,
         }
     }
 

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -750,9 +750,7 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
             TraversalMode::Lint { .. } => file_features.supports_lint(),
             // Imagine if Biome can't handle its own configuration file...
             TraversalMode::Migrate { .. } => true,
-            // We do need to have a suitable parser, but in principle, every
-            // file is searchable.
-            TraversalMode::Search { .. } => true,
+            TraversalMode::Search { .. } => false,
         }
     }
 

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -9,6 +9,7 @@
 use biome_console::{ColorMode, Console};
 use biome_fs::OsFileSystem;
 use biome_service::{App, DynRef, Workspace, WorkspaceRef};
+use commands::search::SearchCommandPayload;
 use std::env;
 
 mod changed;
@@ -200,6 +201,24 @@ impl<'app> CliSession<'app> {
                 sub_command
                     .map(|sub_command| sub_command.is_prettier())
                     .unwrap_or_default(),
+            ),
+            BiomeCommand::Search {
+                cli_options,
+                files_configuration,
+                paths,
+                pattern,
+                stdin_file_path,
+                vcs_configuration,
+            } => commands::search::search(
+                self,
+                SearchCommandPayload {
+                    cli_options,
+                    files_configuration,
+                    paths,
+                    pattern,
+                    stdin_file_path,
+                    vcs_configuration,
+                },
             ),
             BiomeCommand::RunServer {
                 stop_on_disconnect,

--- a/crates/biome_cli/src/logging.rs
+++ b/crates/biome_cli/src/logging.rs
@@ -40,7 +40,7 @@ pub fn setup_cli_subscriber(level: LoggingLevel, kind: LoggingKind) {
     };
 }
 
-#[derive(Copy, Debug, Default, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub enum LoggingLevel {
     /// No logs should be shown
     #[default]
@@ -138,7 +138,7 @@ impl<S> Filter<S> for LoggingFilter {
 }
 
 /// The kind of logging
-#[derive(Copy, Debug, Default, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub enum LoggingKind {
     /// A pretty log on multiple lines with nice colours
     #[default]

--- a/crates/biome_cli/src/logging.rs
+++ b/crates/biome_cli/src/logging.rs
@@ -40,7 +40,7 @@ pub fn setup_cli_subscriber(level: LoggingLevel, kind: LoggingKind) {
     };
 }
 
-#[derive(Debug, Default, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Copy, Debug, Default, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub enum LoggingLevel {
     /// No logs should be shown
     #[default]
@@ -138,7 +138,7 @@ impl<S> Filter<S> for LoggingFilter {
 }
 
 /// The kind of logging
-#[derive(Debug, Default, Clone, Eq, PartialEq)]
+#[derive(Copy, Debug, Default, Clone, Eq, PartialEq)]
 pub enum LoggingKind {
     /// A pretty log on multiple lines with nice colours
     #[default]

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -239,6 +239,7 @@ define_categories! {
     "migrate",
     "deserialize",
     "project",
+    "search",
     "internalError/io",
     "internalError/fs",
     "internalError/panic",

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -666,6 +666,20 @@ impl RageEntry {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SearchPatternParams {
+    pub path: BiomePath,
+    pub pattern: String,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SearchResults {
+    pub file: BiomePath,
+    pub matches: Vec<TextRange>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct IsPathIgnoredParams {
     pub biome_path: BiomePath,
     pub features: Vec<FeatureName>,
@@ -754,6 +768,9 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
 
     /// Returns debug information about this workspace.
     fn rage(&self, params: RageParams) -> Result<RageResult, WorkspaceError>;
+
+    /// Searches a file for matches of the given pattern.
+    fn search_pattern(&self, params: SearchPatternParams) -> Result<SearchResults, WorkspaceError>;
 
     /// Returns information about the server this workspace is connected to or `None` if the workspace isn't connected to a server.
     fn server_info(&self) -> Option<&ServerInfo>;
@@ -883,10 +900,10 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
         })
     }
 
-    pub fn search_file(&self) -> Result<SearchResults, WorkspaceError> {
-        self.workspace.search_file(SearchFileParams {
+    pub fn search_pattern(&self, pattern: String) -> Result<SearchResults, WorkspaceError> {
+        self.workspace.search_pattern(SearchPatternParams {
             path: self.path.clone(),
-            pattern: self.pattern.clone(),
+            pattern,
         })
     }
 }

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -116,16 +116,17 @@ impl FileFeaturesResult {
             .is_some_and(|file_name| FileFeaturesResult::PROTECTED_FILES.contains(&file_name))
     }
 
-    /// By default, all features are not supported by a file.
-    const WORKSPACE_FEATURES: [(FeatureName, SupportKind); 3] = [
+    /// By default, only search is supported.
+    const WORKSPACE_FEATURES: [(FeatureName, SupportKind); 4] = [
         (FeatureName::Lint, SupportKind::FileNotSupported),
         (FeatureName::Format, SupportKind::FileNotSupported),
         (FeatureName::OrganizeImports, SupportKind::FileNotSupported),
+        (FeatureName::Search, SupportKind::Supported),
     ];
 
     pub fn new() -> Self {
         Self {
-            features_supported: HashMap::from(FileFeaturesResult::WORKSPACE_FEATURES),
+            features_supported: HashMap::from(Self::WORKSPACE_FEATURES),
         }
     }
 
@@ -360,6 +361,7 @@ pub enum FeatureName {
     Format,
     Lint,
     OrganizeImports,
+    Search,
 }
 
 #[derive(Debug, Default)]
@@ -374,12 +376,19 @@ impl FeaturesBuilder {
         self.0.push(FeatureName::Format);
         self
     }
+
     pub fn with_linter(mut self) -> Self {
         self.0.push(FeatureName::Lint);
         self
     }
+
     pub fn with_organize_imports(mut self) -> Self {
         self.0.push(FeatureName::OrganizeImports);
+        self
+    }
+
+    pub fn with_search(mut self) -> Self {
+        self.0.push(FeatureName::Search);
         self
     }
 
@@ -871,6 +880,13 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
     pub fn organize_imports(&self) -> Result<OrganizeImportsResult, WorkspaceError> {
         self.workspace.organize_imports(OrganizeImportsParams {
             path: self.path.clone(),
+        })
+    }
+
+    pub fn search_file(&self) -> Result<SearchResults, WorkspaceError> {
+        self.workspace.search_file(SearchFileParams {
+            path: self.path.clone(),
+            pattern: self.pattern.clone(),
         })
     }
 }

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -116,12 +116,12 @@ impl FileFeaturesResult {
             .is_some_and(|file_name| FileFeaturesResult::PROTECTED_FILES.contains(&file_name))
     }
 
-    /// By default, only search is supported.
+    /// By default, all features are not supported by a file.
     const WORKSPACE_FEATURES: [(FeatureName, SupportKind); 4] = [
         (FeatureName::Lint, SupportKind::FileNotSupported),
         (FeatureName::Format, SupportKind::FileNotSupported),
         (FeatureName::OrganizeImports, SupportKind::FileNotSupported),
-        (FeatureName::Search, SupportKind::Supported),
+        (FeatureName::Search, SupportKind::FileNotSupported),
     ];
 
     pub fn new() -> Self {
@@ -900,10 +900,10 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
         })
     }
 
-    pub fn search_pattern(&self, pattern: String) -> Result<SearchResults, WorkspaceError> {
+    pub fn search_pattern(&self, pattern: &str) -> Result<SearchResults, WorkspaceError> {
         self.workspace.search_pattern(SearchPatternParams {
             path: self.path.clone(),
-            pattern,
+            pattern: pattern.to_owned(),
         })
     }
 }

--- a/crates/biome_service/src/workspace/client.rs
+++ b/crates/biome_service/src/workspace/client.rs
@@ -16,8 +16,8 @@ use super::{
     ChangeFileParams, CloseFileParams, FixFileParams, FixFileResult, FormatFileParams,
     FormatOnTypeParams, FormatRangeParams, GetControlFlowGraphParams, GetFormatterIRParams,
     GetSyntaxTreeParams, GetSyntaxTreeResult, OpenFileParams, PullActionsParams, PullActionsResult,
-    PullDiagnosticsParams, PullDiagnosticsResult, RenameParams, RenameResult,
-    SupportsFeatureParams, UpdateSettingsParams,
+    PullDiagnosticsParams, PullDiagnosticsResult, RenameParams, RenameResult, SearchPatternParams,
+    SearchResults, SupportsFeatureParams, UpdateSettingsParams,
 };
 
 pub struct WorkspaceClient<T> {
@@ -190,6 +190,10 @@ where
 
     fn rage(&self, params: RageParams) -> Result<RageResult, WorkspaceError> {
         self.request("biome/rage", params)
+    }
+
+    fn search_pattern(&self, params: SearchPatternParams) -> Result<SearchResults, WorkspaceError> {
+        self.request("biome/search_pattern", params)
     }
 
     fn server_info(&self) -> Option<&ServerInfo> {

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -309,6 +309,7 @@ impl WorkspaceServer {
                     &organize_imports.ignored_files,
                 )
             }
+            FeatureName::Search => return false, // There is no search-specific config.
         };
         let is_feature_included = feature_included_files.is_empty()
             || is_dir(path)

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -3,7 +3,8 @@ use super::{
     FormatOnTypeParams, FormatRangeParams, GetControlFlowGraphParams, GetFormatterIRParams,
     GetSyntaxTreeParams, GetSyntaxTreeResult, OpenFileParams, OpenProjectParams, PullActionsParams,
     PullActionsResult, PullDiagnosticsParams, PullDiagnosticsResult, RenameResult,
-    SupportsFeatureParams, UpdateProjectParams, UpdateSettingsParams,
+    SearchPatternParams, SearchResults, SupportsFeatureParams, UpdateProjectParams,
+    UpdateSettingsParams,
 };
 use crate::file_handlers::{
     Capabilities, CodeActionsParams, DocumentFileSource, FixAllParams, LintParams, ParseResult,
@@ -712,6 +713,14 @@ impl Workspace for WorkspaceServer {
         ];
 
         Ok(RageResult { entries })
+    }
+
+    fn search_pattern(&self, params: SearchPatternParams) -> Result<SearchResults, WorkspaceError> {
+        // FIXME: Let's implement some real matching here...
+        Ok(SearchResults {
+            file: params.path,
+            matches: Vec::new(),
+        })
     }
 
     fn server_info(&self) -> Option<&ServerInfo> {

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -4,7 +4,7 @@ export interface SupportsFeatureParams {
 	features: FeatureName[];
 	path: BiomePath;
 }
-export type FeatureName = "Format" | "Lint" | "OrganizeImports";
+export type FeatureName = "Format" | "Lint" | "OrganizeImports" | "Search";
 export interface BiomePath {
 	path: string;
 }
@@ -2021,6 +2021,7 @@ export type Category =
 	| "migrate"
 	| "deserialize"
 	| "project"
+	| "search"
 	| "internalError/io"
 	| "internalError/fs"
 	| "internalError/panic"


### PR DESCRIPTION
## Summary

This adds the infrastructure for implementing the `biome search` command, but the actual implementation will be left for a future PR. The command remains hidden through the `bpaf` options as long as implementation is not complete.

## Test Plan

Everything should remain green.
