### PR TITLE
fix(config): group-level lint rules calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Linter
 
-#### Bug fixes
-
-- Correctly calculate enabled rules in lint rule groups. Now a specific rule belonging to a group can be enabled even if its group-level preset option `recommended` or `all` is `false` ([#2191](https://github.com/biomejs/biome/issues/2191)). Contributed by @Sec-ant
-
 ### Parser
 
 ## 1.6.3 (2024-03-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ New entries must be placed in a section entitled `Unreleased`.
 Read
 our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
+## Unreleased
+
+### Analyzer
+
+### CLI
+
+### Configuration
+
+#### Bug fixes
+
+- Correctly calculate enabled rules in lint rule groups. Now a specific rule belonging to a group can be enabled even if its group-level preset option `recommended` or `all` is `false` ([#2191](https://github.com/biomejs/biome/issues/2191)). Contributed by @Sec-ant
+
+### Editors
+
+### Formatter
+
+### JavaScript APIs
+
+### Linter
+
+#### Bug fixes
+
+- Correctly calculate enabled rules in lint rule groups. Now a specific rule belonging to a group can be enabled even if its group-level preset option `recommended` or `all` is `false` ([#2191](https://github.com/biomejs/biome/issues/2191)). Contributed by @Sec-ant
+
+### Parser
+
 ## 1.6.3 (2024-03-25)
 
 ### Analyzer

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -1919,6 +1919,52 @@ fn top_level_all_down_level_empty() {
 }
 
 #[test]
+fn group_level_disable_recommended_enable_specific() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    // useButtonType should be enabled.
+    let biome_json = r#"{
+        "linter": {
+            "rules": {
+                "a11y": {
+                    "recommended": false,
+                    "useButtonType": "error"
+                }
+            }
+        }
+    }"#;
+
+    let code = r#"
+    function SubmitButton() {
+        return <button>Submit</button>;
+    }    
+    "#;
+
+    let file_path = Path::new("fix.jsx");
+    fs.insert(file_path.into(), code.as_bytes());
+
+    let config_path = Path::new("biome.json");
+    fs.insert(config_path.into(), biome_json.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("lint"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "group_level_disable_recommended_enable_specific",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn ignore_configured_globals() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/group_level_disable_recommended_enable_specific.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/group_level_disable_recommended_enable_specific.snap
@@ -1,0 +1,64 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "a11y": {
+        "recommended": false,
+        "useButtonType": "error"
+      }
+    }
+  }
+}
+```
+
+## `fix.jsx`
+
+```jsx
+
+    function SubmitButton() {
+        return <button>Submit</button>;
+    }    
+    
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+fix.jsx:3:16 lint/a11y/useButtonType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Provide an explicit type prop for the button element.
+  
+    2 │     function SubmitButton() {
+  > 3 │         return <button>Submit</button>;
+      │                ^^^^^^^^
+    4 │     }····
+    5 │     
+  
+  i The default type of a button is submit, which causes the submission of a form when placed inside a `form` element. This is likely not the behaviour that you want inside a React application.
+  
+  i Allowed button types are: submit, button or reset
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 2 errors.
+```

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -564,13 +564,13 @@ impl A11y {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_recommended_unset(&self) -> bool {
+    pub(crate) fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) const fn is_all_unset(&self) -> bool {
+    pub(crate) fn is_all_unset(&self) -> bool {
         self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
@@ -1265,13 +1265,13 @@ impl Complexity {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_recommended_unset(&self) -> bool {
+    pub(crate) fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) const fn is_all_unset(&self) -> bool {
+    pub(crate) fn is_all_unset(&self) -> bool {
         self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
@@ -1985,13 +1985,13 @@ impl Correctness {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_recommended_unset(&self) -> bool {
+    pub(crate) fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) const fn is_all_unset(&self) -> bool {
+    pub(crate) fn is_all_unset(&self) -> bool {
         self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
@@ -2720,13 +2720,13 @@ impl Nursery {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_recommended_unset(&self) -> bool {
+    pub(crate) fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) const fn is_all_unset(&self) -> bool {
+    pub(crate) fn is_all_unset(&self) -> bool {
         self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
@@ -3146,13 +3146,13 @@ impl Performance {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_recommended_unset(&self) -> bool {
+    pub(crate) fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) const fn is_all_unset(&self) -> bool {
+    pub(crate) fn is_all_unset(&self) -> bool {
         self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
@@ -3292,13 +3292,13 @@ impl Security {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_recommended_unset(&self) -> bool {
+    pub(crate) fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) const fn is_all_unset(&self) -> bool {
+    pub(crate) fn is_all_unset(&self) -> bool {
         self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
@@ -3683,13 +3683,13 @@ impl Style {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_recommended_unset(&self) -> bool {
+    pub(crate) fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) const fn is_all_unset(&self) -> bool {
+    pub(crate) fn is_all_unset(&self) -> bool {
         self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
@@ -4699,13 +4699,13 @@ impl Suspicious {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_recommended_unset(&self) -> bool {
+    pub(crate) fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) const fn is_all_unset(&self) -> bool {
+    pub(crate) fn is_all_unset(&self) -> bool {
         self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -565,13 +565,13 @@ impl A11y {
         matches!(self.recommended, Some(true))
     }
     pub(crate) const fn is_recommended_unset(&self) -> bool {
-        matches!(self.recommended, None)
+        self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
     pub(crate) const fn is_all_unset(&self) -> bool {
-        matches!(self.all, None)
+        self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -1266,13 +1266,13 @@ impl Complexity {
         matches!(self.recommended, Some(true))
     }
     pub(crate) const fn is_recommended_unset(&self) -> bool {
-        matches!(self.recommended, None)
+        self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
     pub(crate) const fn is_all_unset(&self) -> bool {
-        matches!(self.all, None)
+        self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -1986,13 +1986,13 @@ impl Correctness {
         matches!(self.recommended, Some(true))
     }
     pub(crate) const fn is_recommended_unset(&self) -> bool {
-        matches!(self.recommended, None)
+        self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
     pub(crate) const fn is_all_unset(&self) -> bool {
-        matches!(self.all, None)
+        self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -2721,13 +2721,13 @@ impl Nursery {
         matches!(self.recommended, Some(true))
     }
     pub(crate) const fn is_recommended_unset(&self) -> bool {
-        matches!(self.recommended, None)
+        self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
     pub(crate) const fn is_all_unset(&self) -> bool {
-        matches!(self.all, None)
+        self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -3147,13 +3147,13 @@ impl Performance {
         matches!(self.recommended, Some(true))
     }
     pub(crate) const fn is_recommended_unset(&self) -> bool {
-        matches!(self.recommended, None)
+        self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
     pub(crate) const fn is_all_unset(&self) -> bool {
-        matches!(self.all, None)
+        self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -3293,13 +3293,13 @@ impl Security {
         matches!(self.recommended, Some(true))
     }
     pub(crate) const fn is_recommended_unset(&self) -> bool {
-        matches!(self.recommended, None)
+        self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
     pub(crate) const fn is_all_unset(&self) -> bool {
-        matches!(self.all, None)
+        self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -3684,13 +3684,13 @@ impl Style {
         matches!(self.recommended, Some(true))
     }
     pub(crate) const fn is_recommended_unset(&self) -> bool {
-        matches!(self.recommended, None)
+        self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
     pub(crate) const fn is_all_unset(&self) -> bool {
-        matches!(self.all, None)
+        self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -4700,13 +4700,13 @@ impl Suspicious {
         matches!(self.recommended, Some(true))
     }
     pub(crate) const fn is_recommended_unset(&self) -> bool {
-        matches!(self.recommended, None)
+        self.recommended.is_none()
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
     pub(crate) const fn is_all_unset(&self) -> bool {
-        matches!(self.all, None)
+        self.all.is_none()
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();

--- a/crates/biome_service/src/configuration/linter/rules.rs
+++ b/crates/biome_service/src/configuration/linter/rules.rs
@@ -232,12 +232,7 @@ impl Rules {
         let mut enabled_rules = IndexSet::new();
         let mut disabled_rules = IndexSet::new();
         if let Some(group) = self.a11y.as_ref() {
-            group.collect_preset_rules(
-                self.is_all(),
-                self.is_recommended(),
-                &mut enabled_rules,
-                &mut disabled_rules,
-            );
+            group.collect_preset_rules(self.is_all(), self.is_recommended(), &mut enabled_rules);
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
@@ -246,12 +241,7 @@ impl Rules {
             enabled_rules.extend(A11y::recommended_rules_as_filters());
         }
         if let Some(group) = self.complexity.as_ref() {
-            group.collect_preset_rules(
-                self.is_all(),
-                self.is_recommended(),
-                &mut enabled_rules,
-                &mut disabled_rules,
-            );
+            group.collect_preset_rules(self.is_all(), self.is_recommended(), &mut enabled_rules);
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
@@ -260,12 +250,7 @@ impl Rules {
             enabled_rules.extend(Complexity::recommended_rules_as_filters());
         }
         if let Some(group) = self.correctness.as_ref() {
-            group.collect_preset_rules(
-                self.is_all(),
-                self.is_recommended(),
-                &mut enabled_rules,
-                &mut disabled_rules,
-            );
+            group.collect_preset_rules(self.is_all(), self.is_recommended(), &mut enabled_rules);
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
@@ -278,7 +263,6 @@ impl Rules {
                 self.is_all() && biome_flags::is_unstable(),
                 self.is_recommended() && biome_flags::is_unstable(),
                 &mut enabled_rules,
-                &mut disabled_rules,
             );
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
@@ -288,12 +272,7 @@ impl Rules {
             enabled_rules.extend(Nursery::recommended_rules_as_filters());
         }
         if let Some(group) = self.performance.as_ref() {
-            group.collect_preset_rules(
-                self.is_all(),
-                self.is_recommended(),
-                &mut enabled_rules,
-                &mut disabled_rules,
-            );
+            group.collect_preset_rules(self.is_all(), self.is_recommended(), &mut enabled_rules);
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
@@ -302,12 +281,7 @@ impl Rules {
             enabled_rules.extend(Performance::recommended_rules_as_filters());
         }
         if let Some(group) = self.security.as_ref() {
-            group.collect_preset_rules(
-                self.is_all(),
-                self.is_recommended(),
-                &mut enabled_rules,
-                &mut disabled_rules,
-            );
+            group.collect_preset_rules(self.is_all(), self.is_recommended(), &mut enabled_rules);
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
@@ -316,12 +290,7 @@ impl Rules {
             enabled_rules.extend(Security::recommended_rules_as_filters());
         }
         if let Some(group) = self.style.as_ref() {
-            group.collect_preset_rules(
-                self.is_all(),
-                self.is_recommended(),
-                &mut enabled_rules,
-                &mut disabled_rules,
-            );
+            group.collect_preset_rules(self.is_all(), self.is_recommended(), &mut enabled_rules);
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
@@ -330,12 +299,7 @@ impl Rules {
             enabled_rules.extend(Style::recommended_rules_as_filters());
         }
         if let Some(group) = self.suspicious.as_ref() {
-            group.collect_preset_rules(
-                self.is_all(),
-                self.is_recommended(),
-                &mut enabled_rules,
-                &mut disabled_rules,
-            );
+            group.collect_preset_rules(self.is_all(), self.is_recommended(), &mut enabled_rules);
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
         } else if self.is_all() {
@@ -600,14 +564,14 @@ impl A11y {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_not_recommended(&self) -> bool {
-        matches!(self.recommended, Some(false))
+    pub(crate) const fn is_recommended_unset(&self) -> bool {
+        matches!(self.recommended, None)
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
+    pub(crate) const fn is_all_unset(&self) -> bool {
+        matches!(self.all, None)
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -937,19 +901,12 @@ impl A11y {
         parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
-        disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
-        if self.is_all() {
+        if self.is_all() || self.is_all_unset() && parent_is_all {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_recommended() {
-            enabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_not_recommended() {
-            disabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if parent_is_all {
-            enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended {
+        } else if self.is_recommended()
+            || self.is_recommended_unset() && parent_is_recommended && !parent_is_all
+        {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
@@ -1308,14 +1265,14 @@ impl Complexity {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_not_recommended(&self) -> bool {
-        matches!(self.recommended, Some(false))
+    pub(crate) const fn is_recommended_unset(&self) -> bool {
+        matches!(self.recommended, None)
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
+    pub(crate) const fn is_all_unset(&self) -> bool {
+        matches!(self.all, None)
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -1621,19 +1578,12 @@ impl Complexity {
         parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
-        disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
-        if self.is_all() {
+        if self.is_all() || self.is_all_unset() && parent_is_all {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_recommended() {
-            enabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_not_recommended() {
-            disabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if parent_is_all {
-            enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended {
+        } else if self.is_recommended()
+            || self.is_recommended_unset() && parent_is_recommended && !parent_is_all
+        {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
@@ -2035,14 +1985,14 @@ impl Correctness {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_not_recommended(&self) -> bool {
-        matches!(self.recommended, Some(false))
+    pub(crate) const fn is_recommended_unset(&self) -> bool {
+        matches!(self.recommended, None)
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
+    pub(crate) const fn is_all_unset(&self) -> bool {
+        matches!(self.all, None)
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -2432,19 +2382,12 @@ impl Correctness {
         parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
-        disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
-        if self.is_all() {
+        if self.is_all() || self.is_all_unset() && parent_is_all {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_recommended() {
-            enabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_not_recommended() {
-            disabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if parent_is_all {
-            enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended {
+        } else if self.is_recommended()
+            || self.is_recommended_unset() && parent_is_recommended && !parent_is_all
+        {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
@@ -2777,14 +2720,14 @@ impl Nursery {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_not_recommended(&self) -> bool {
-        matches!(self.recommended, Some(false))
+    pub(crate) const fn is_recommended_unset(&self) -> bool {
+        matches!(self.recommended, None)
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
+    pub(crate) const fn is_all_unset(&self) -> bool {
+        matches!(self.all, None)
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -3044,19 +2987,12 @@ impl Nursery {
         parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
-        disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
-        if self.is_all() {
+        if self.is_all() || self.is_all_unset() && parent_is_all {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_recommended() {
-            enabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_not_recommended() {
-            disabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if parent_is_all {
-            enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended {
+        } else if self.is_recommended()
+            || self.is_recommended_unset() && parent_is_recommended && !parent_is_all
+        {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
@@ -3210,14 +3146,14 @@ impl Performance {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_not_recommended(&self) -> bool {
-        matches!(self.recommended, Some(false))
+    pub(crate) const fn is_recommended_unset(&self) -> bool {
+        matches!(self.recommended, None)
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
+    pub(crate) const fn is_all_unset(&self) -> bool {
+        matches!(self.all, None)
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -3267,19 +3203,12 @@ impl Performance {
         parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
-        disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
-        if self.is_all() {
+        if self.is_all() || self.is_all_unset() && parent_is_all {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_recommended() {
-            enabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_not_recommended() {
-            disabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if parent_is_all {
-            enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended {
+        } else if self.is_recommended()
+            || self.is_recommended_unset() && parent_is_recommended && !parent_is_all
+        {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
@@ -3363,14 +3292,14 @@ impl Security {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_not_recommended(&self) -> bool {
-        matches!(self.recommended, Some(false))
+    pub(crate) const fn is_recommended_unset(&self) -> bool {
+        matches!(self.recommended, None)
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
+    pub(crate) const fn is_all_unset(&self) -> bool {
+        matches!(self.all, None)
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -3430,19 +3359,12 @@ impl Security {
         parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
-        disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
-        if self.is_all() {
+        if self.is_all() || self.is_all_unset() && parent_is_all {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_recommended() {
-            enabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_not_recommended() {
-            disabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if parent_is_all {
-            enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended {
+        } else if self.is_recommended()
+            || self.is_recommended_unset() && parent_is_recommended && !parent_is_all
+        {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
@@ -3761,14 +3683,14 @@ impl Style {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_not_recommended(&self) -> bool {
-        matches!(self.recommended, Some(false))
+    pub(crate) const fn is_recommended_unset(&self) -> bool {
+        matches!(self.recommended, None)
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
+    pub(crate) const fn is_all_unset(&self) -> bool {
+        matches!(self.all, None)
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -4208,19 +4130,12 @@ impl Style {
         parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
-        disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
-        if self.is_all() {
+        if self.is_all() || self.is_all_unset() && parent_is_all {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_recommended() {
-            enabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_not_recommended() {
-            disabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if parent_is_all {
-            enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended {
+        } else if self.is_recommended()
+            || self.is_recommended_unset() && parent_is_recommended && !parent_is_all
+        {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
@@ -4784,14 +4699,14 @@ impl Suspicious {
     pub(crate) fn is_recommended(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) const fn is_not_recommended(&self) -> bool {
-        matches!(self.recommended, Some(false))
+    pub(crate) const fn is_recommended_unset(&self) -> bool {
+        matches!(self.recommended, None)
     }
     pub(crate) fn is_all(&self) -> bool {
         matches!(self.all, Some(true))
     }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
+    pub(crate) const fn is_all_unset(&self) -> bool {
+        matches!(self.all, None)
     }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
@@ -5321,19 +5236,12 @@ impl Suspicious {
         parent_is_all: bool,
         parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
-        disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
-        if self.is_all() {
+        if self.is_all() || self.is_all_unset() && parent_is_all {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_recommended() {
-            enabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if self.is_not_all() {
-            disabled_rules.extend(Self::all_rules_as_filters());
-        } else if self.is_not_recommended() {
-            disabled_rules.extend(Self::recommended_rules_as_filters());
-        } else if parent_is_all {
-            enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended {
+        } else if self.is_recommended()
+            || self.is_recommended_unset() && parent_is_recommended && !parent_is_all
+        {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -35,10 +35,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Linter
 
-#### Bug fixes
-
-- Correctly calculate enabled rules in lint rule groups. Now a specific rule belonging to a group can be enabled even if its group-level preset option `recommended` or `all` is `false` ([#2191](https://github.com/biomejs/biome/issues/2191)). Contributed by @Sec-ant
-
 ### Parser
 
 ## 1.6.3 (2024-03-25)

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -15,6 +15,32 @@ New entries must be placed in a section entitled `Unreleased`.
 Read
 our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
+## Unreleased
+
+### Analyzer
+
+### CLI
+
+### Configuration
+
+#### Bug fixes
+
+- Correctly calculate enabled rules in lint rule groups. Now a specific rule belonging to a group can be enabled even if its group-level preset option `recommended` or `all` is `false` ([#2191](https://github.com/biomejs/biome/issues/2191)). Contributed by @Sec-ant
+
+### Editors
+
+### Formatter
+
+### JavaScript APIs
+
+### Linter
+
+#### Bug fixes
+
+- Correctly calculate enabled rules in lint rule groups. Now a specific rule belonging to a group can be enabled even if its group-level preset option `recommended` or `all` is `false` ([#2191](https://github.com/biomejs/biome/issues/2191)). Contributed by @Sec-ant
+
+### Parser
+
 ## 1.6.3 (2024-03-25)
 
 ### Analyzer

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -487,7 +487,7 @@ fn generate_struct(group: &str, rules: &BTreeMap<&'static str, RuleMetadata>) ->
                 matches!(self.recommended, Some(true))
             }
 
-            pub(crate) const fn is_recommended_unset(&self) -> bool {
+            pub(crate) fn is_recommended_unset(&self) -> bool {
                 self.recommended.is_none()
             }
 
@@ -495,7 +495,7 @@ fn generate_struct(group: &str, rules: &BTreeMap<&'static str, RuleMetadata>) ->
                 matches!(self.all, Some(true))
             }
 
-            pub(crate) const fn is_all_unset(&self) -> bool {
+            pub(crate) fn is_all_unset(&self) -> bool {
                 self.all.is_none()
             }
 

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -488,7 +488,7 @@ fn generate_struct(group: &str, rules: &BTreeMap<&'static str, RuleMetadata>) ->
             }
 
             pub(crate) const fn is_recommended_unset(&self) -> bool {
-                matches!(self.recommended, None)
+                self.recommended.is_none()
             }
 
             pub(crate) fn is_all(&self) -> bool {
@@ -496,7 +496,7 @@ fn generate_struct(group: &str, rules: &BTreeMap<&'static str, RuleMetadata>) ->
             }
 
             pub(crate) const fn is_all_unset(&self) -> bool {
-                matches!(self.all, None)
+                self.all.is_none()
             }
 
             pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {


### PR DESCRIPTION
## Summary

Correctly calculate enabled rules in lint rule groups.

This is the [Karnaugh map](https://en.wikipedia.org/wiki/Karnaugh_map) of lint group preset logic:

| Self (`A`, `R`) \ Parent (`A`, `R`) | (`N`, `F`) | (`N`, `T`) | (`F`, `F`) | (`F`, `T`) | (`T`, `F`) | (`T`, `T`) |
| :---------------------------------: | :--------: | :--------: | :--------: | :--------: | :--------: | :--------: |
|           **(`N`, `N`)**            |     -      |    `R`     |     -      |    `R`     |    `A`     |    `A`     |
|           **(`N`, `F`)**            |     -      |     -      |     -      |     -      |    `A`     |    `A`     |
|           **(`N`, `T`)**            |    `R`     |    `R`     |    `R`     |    `R`     |    `A`     |    `A`     |
|           **(`F`, `N`)**            |     -      |    `R`     |     -      |    `R`     |     -      |     -      |
|           **(`F`, `F`)**            |     -      |     -      |     -      |     -      |     -      |     -      |
|           **(`F`, `T`)**            |    `R`     |    `R`     |    `R`     |    `R`     |    `R`     |    `R`     |
|           **(`T`, `N`)**            |    `A`     |    `A`     |    `A`     |    `A`     |    `A`     |    `A`     |
|           **(`T`, `F`)**            |    `A`     |    `A`     |    `A`     |    `A`     |    `A`     |    `A`     |
|           **(`T`, `T`)**            |    `A`     |    `A`     |    `A`     |    `A`     |    `A`     |    `A`     |

`A`: `all`, `R`: `recommended`, `N`: `None`, `T`: `true`, `F`: `false`

And the code to implement the above logic is:

```rust
  if self.is_all() || self.is_all_unset() && parent_is_all {
      enabled_rules.extend(Self::all_rules_as_filters());
  } else if self.is_recommended() || self.is_recommended_unset() && parent_is_recommended && !parent_is_all {
      enabled_rules.extend(Self::recommended_rules_as_filters());
  }
```

When calculating the preset rules, we shouldn't populate the disabled rules set, because that will make specific rules cannot be enabled later.

Closes #2191.

## Test Plan

Added a test case borrowed from #2191.
