### PR TITLE
chore: derive `Copy` on `LoggingKind` and `LoggingLevel`

### DIFF
--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -46,7 +46,7 @@ pub(crate) fn check(
         since,
         changed,
     } = payload;
-    setup_cli_subscriber(cli_options.log_level.clone(), cli_options.log_kind.clone());
+    setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
 
     let fix_file_mode = if apply && apply_unsafe {
         return Err(CliDiagnostic::incompatible_arguments(

--- a/crates/biome_cli/src/commands/ci.rs
+++ b/crates/biome_cli/src/commands/ci.rs
@@ -35,7 +35,7 @@ pub(crate) fn ci(session: CliSession, payload: CiCommandPayload) -> Result<(), C
         since,
         changed,
     } = payload;
-    setup_cli_subscriber(cli_options.log_level.clone(), cli_options.log_kind.clone());
+    setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
 
     let loaded_configuration =
         load_configuration(&session.app.fs, cli_options.as_configuration_base_path())?;

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -51,7 +51,7 @@ pub(crate) fn format(
         since,
         changed,
     } = payload;
-    setup_cli_subscriber(cli_options.log_level.clone(), cli_options.log_kind.clone());
+    setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
 
     let loaded_configuration =
         load_configuration(&session.app.fs, cli_options.as_configuration_base_path())?;

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -40,7 +40,7 @@ pub(crate) fn lint(session: CliSession, payload: LintCommandPayload) -> Result<(
         changed,
         since,
     } = payload;
-    setup_cli_subscriber(cli_options.log_level.clone(), cli_options.log_kind.clone());
+    setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
 
     let fix_file_mode = if apply && apply_unsafe {
         return Err(CliDiagnostic::incompatible_arguments(

--- a/crates/biome_cli/src/commands/migrate.rs
+++ b/crates/biome_cli/src/commands/migrate.rs
@@ -23,7 +23,7 @@ pub(crate) fn migrate(
         directory_path,
         file_path,
     } = load_configuration(&session.app.fs, base_path)?;
-    setup_cli_subscriber(cli_options.log_level.clone(), cli_options.log_kind.clone());
+    setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
 
     if let (Some(path), Some(directory_path)) = (file_path, directory_path) {
         execute_mode(

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -401,16 +401,12 @@ impl BiomeCommand {
 
     pub fn log_level(&self) -> LoggingLevel {
         self.cli_options()
-            .map_or(LoggingLevel::default(), |cli_options| {
-                cli_options.log_level.clone()
-            })
+            .map_or(LoggingLevel::default(), |cli_options| cli_options.log_level)
     }
 
     pub fn log_kind(&self) -> LoggingKind {
         self.cli_options()
-            .map_or(LoggingKind::default(), |cli_options| {
-                cli_options.log_kind.clone()
-            })
+            .map_or(LoggingKind::default(), |cli_options| cli_options.log_kind)
     }
 }
 

--- a/crates/biome_cli/src/commands/search.rs
+++ b/crates/biome_cli/src/commands/search.rs
@@ -34,7 +34,7 @@ pub(crate) fn search(
         stdin_file_path,
         vcs_configuration,
     } = payload;
-    setup_cli_subscriber(cli_options.log_level.clone(), cli_options.log_kind.clone());
+    setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
 
     let loaded_configuration =
         load_configuration(&session.app.fs, cli_options.as_configuration_base_path())?;

--- a/crates/biome_cli/src/logging.rs
+++ b/crates/biome_cli/src/logging.rs
@@ -40,7 +40,7 @@ pub fn setup_cli_subscriber(level: LoggingLevel, kind: LoggingKind) {
     };
 }
 
-#[derive(Debug, Default, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Copy, Debug, Default, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub enum LoggingLevel {
     /// No logs should be shown
     #[default]
@@ -52,7 +52,7 @@ pub enum LoggingLevel {
 }
 
 impl LoggingLevel {
-    fn to_filter_level(&self) -> Option<LevelFilter> {
+    fn to_filter_level(self) -> Option<LevelFilter> {
         match self {
             LoggingLevel::None => None,
             LoggingLevel::Info => Some(LevelFilter::INFO),
@@ -138,7 +138,7 @@ impl<S> Filter<S> for LoggingFilter {
 }
 
 /// The kind of logging
-#[derive(Debug, Default, Clone, Eq, PartialEq)]
+#[derive(Copy, Debug, Default, Clone, Eq, PartialEq)]
 pub enum LoggingKind {
     /// A pretty log on multiple lines with nice colours
     #[default]


### PR DESCRIPTION
## Summary

Deriving `Copy` makes it so that types can be copied without needing to explicitly call `.clone()`. This makes the type a little easier to work with, and also indicates there is no hidden performance cost to copying it. As such, it should only be derived on types that don't require allocations. For enums where the variants have no custom fields, deriving `Copy` is generally safe, as long as no future variants with custom fields are anticipated either.

See also: https://doc.rust-lang.org/std/marker/trait.Copy.html#when-should-my-type-be-copy

## Test Plan

CI should remain green.
