### PR TITLE
fix(docs): improve wording of docs for global Number rules

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/use_is_nan.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_is_nan.rs
@@ -24,7 +24,7 @@ declare_rule! {
     ///
     /// Therefore, use `Number.isNaN()` or global `isNaN()` functions to test whether a value is `NaN`.
     ///
-    /// Note that `Number.isNaN()` and `isNaN()` [have not the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description).
+    /// Note that `Number.isNaN()` and `isNaN()` [do not have the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description).
     /// When the argument to `isNaN()` is not a number, the value is first coerced to a number.
     /// `Number.isNaN()` does not perform this coercion.
     /// Therefore, it is a more reliable way to test whether a value is `NaN`.

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_is_finite.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_is_finite.rs
@@ -11,7 +11,7 @@ use biome_rowan::{AstNode, BatchMutationExt};
 declare_rule! {
     /// Use `Number.isFinite` instead of global `isFinite`.
     ///
-    /// `Number.isFinite()` and `isFinite()` [have not the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite#difference_between_number.isfinite_and_global_isfinite).
+    /// `Number.isFinite()` and `isFinite()` [do not have the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite#difference_between_number.isfinite_and_global_isfinite).
     /// When the argument to `isFinite()` is not a number, the value is first coerced to a number.
     /// `Number.isFinite()` does not perform this coercion.
     /// Therefore, it is a more reliable way to test whether a number is finite.

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_is_nan.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_is_nan.rs
@@ -11,7 +11,7 @@ use biome_rowan::{AstNode, BatchMutationExt};
 declare_rule! {
     /// Use `Number.isNaN` instead of global `isNaN`.
     ///
-    /// `Number.isNaN()` and `isNaN()` [have not the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description).
+    /// `Number.isNaN()` and `isNaN()` [do not have the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description).
     /// When the argument to `isNaN()` is not a number, the value is first coerced to a number.
     /// `Number.isNaN()` does not perform this coercion.
     /// Therefore, it is a more reliable way to test whether a value is `NaN`.

--- a/website/src/content/docs/linter/rules/no-global-is-finite.md
+++ b/website/src/content/docs/linter/rules/no-global-is-finite.md
@@ -10,7 +10,7 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Use `Number.isFinite` instead of global `isFinite`.
 
-`Number.isFinite()` and `isFinite()` [have not the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite#difference_between_number.isfinite_and_global_isfinite).
+`Number.isFinite()` and `isFinite()` [do not have the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite#difference_between_number.isfinite_and_global_isfinite).
 When the argument to `isFinite()` is not a number, the value is first coerced to a number.
 `Number.isFinite()` does not perform this coercion.
 Therefore, it is a more reliable way to test whether a number is finite.

--- a/website/src/content/docs/linter/rules/no-global-is-nan.md
+++ b/website/src/content/docs/linter/rules/no-global-is-nan.md
@@ -10,7 +10,7 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Use `Number.isNaN` instead of global `isNaN`.
 
-`Number.isNaN()` and `isNaN()` [have not the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description).
+`Number.isNaN()` and `isNaN()` [do not have the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description).
 When the argument to `isNaN()` is not a number, the value is first coerced to a number.
 `Number.isNaN()` does not perform this coercion.
 Therefore, it is a more reliable way to test whether a value is `NaN`.

--- a/website/src/content/docs/linter/rules/use-is-nan.md
+++ b/website/src/content/docs/linter/rules/use-is-nan.md
@@ -22,7 +22,7 @@ Because `NaN` is unique in JavaScript by not being equal to anything, including 
 
 Therefore, use `Number.isNaN()` or global `isNaN()` functions to test whether a value is `NaN`.
 
-Note that `Number.isNaN()` and `isNaN()` [have not the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description).
+Note that `Number.isNaN()` and `isNaN()` [do not have the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description).
 When the argument to `isNaN()` is not a number, the value is first coerced to a number.
 `Number.isNaN()` does not perform this coercion.
 Therefore, it is a more reliable way to test whether a value is `NaN`.


### PR DESCRIPTION
This is a small change that fixes the back-to-front wording on the docs for the rules `noGlobalIsFinite`, `noGlobalIsNan` and `useIsNan`.
