### PR TITLE
feat(css_formatter): ValueListLayout::SingleLine

### DIFF
--- a/crates/biome_css_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_css_factory/src/generated/syntax_factory.rs
@@ -4126,7 +4126,7 @@ impl SyntaxFactory for CssSyntaxFactory {
                 children,
                 AnyCssDocumentMatcher::can_cast,
                 T ! [,],
-                true,
+                false,
             ),
             CSS_FONT_FAMILY_NAME_LIST => Self::make_separated_list_syntax(
                 kind,

--- a/crates/biome_css_formatter/src/utils/component_value_list.rs
+++ b/crates/biome_css_formatter/src/utils/component_value_list.rs
@@ -13,16 +13,18 @@ where
     I: AstNode<Language = CssLanguage> + IntoFormat<CssFormatContext>,
 {
     let layout = get_value_list_layout(node, f.context().comments());
+    let values = format_with(|f: &mut Formatter<'_, CssFormatContext>| {
+        f.fill()
+            .entries(&soft_line_break_or_space(), node.iter().formatted())
+            .finish()
+    });
 
     match layout {
         ValueListLayout::Fill => {
-            let values = format_with(|f: &mut Formatter<'_, CssFormatContext>| {
-                f.fill()
-                    .entries(&soft_line_break_or_space(), node.iter().formatted())
-                    .finish()
-            });
-
             write!(f, [group(&indent(&values))])
+        }
+        ValueListLayout::SingleValue => {
+            write!(f, [values])
         }
         // TODO: Add formatting for one-per-line once comma-separated lists are supported.
         ValueListLayout::OnePerLine => write!(f, [format_verbatim_node(node.syntax())]),
@@ -31,6 +33,23 @@ where
 
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum ValueListLayout {
+    /// Ensures the usage of a singular, consistent value.
+    ///
+    /// ```css
+    /// :root {
+    ///     --bs-gradient: linear-gradient(
+    ///         180deg,
+    ///         180deg,
+    ///         180deg,
+    ///         180deg,
+    ///         180deg,
+    ///         180deg,
+    ///         180deg
+    ///     );
+    /// }
+    /// ```
+    SingleValue,
+
     /// Tries to fit as many values on a single line as possible, then wraps
     /// and indents the next line to keep filling on that line, and so on.
     ///
@@ -60,11 +79,15 @@ pub(crate) enum ValueListLayout {
 /// Until the parser supports comma-separated lists, this will always return
 /// [ValueListLayout::Fill], since all space-separated lists are intentionally
 /// printed compactly.
-pub(crate) fn get_value_list_layout<N, I>(_list: &N, _: &CssComments) -> ValueListLayout
+pub(crate) fn get_value_list_layout<N, I>(list: &N, _: &CssComments) -> ValueListLayout
 where
     N: AstNodeList<Language = CssLanguage, Node = I> + AstNode<Language = CssLanguage>,
     I: AstNode<Language = CssLanguage> + IntoFormat<CssFormatContext>,
 {
     // TODO: Check for comments, check for the types of elements in the list, etc.
-    ValueListLayout::Fill
+    if list.len() == 1 {
+        ValueListLayout::SingleValue
+    } else {
+        ValueListLayout::Fill
+    }
 }

--- a/crates/biome_css_formatter/tests/quick_test.rs
+++ b/crates/biome_css_formatter/tests/quick_test.rs
@@ -13,8 +13,16 @@ mod language {
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
     let src = r#"
-.foo {
-    transform: translate(/* comment 9 */ 10px);
+:root {
+		--bs-gradient: linear-gradient(
+			180deg,
+          180deg,
+          180deg,
+          180deg,
+          180deg,
+          180deg,
+          180deg
+		);
 }
 
 "#;

--- a/crates/biome_css_formatter/tests/specs/css/atrule/font_face.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/font_face.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/atrule/font_face.css
 ---
-
 # Input
 
 ```css
@@ -145,5 +144,3 @@ Quote style: Double Quotes
 		url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/css/functions.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/functions.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/functions.css
 ---
-
 # Input
 
 ```css
@@ -40,26 +39,24 @@ div {
 	color: rgba(255, 255, 255, 1);
 	color: rgba(0, 1, 255, 1);
 	color: arbitrary(
-			really long list,
-			of complex parameter values,
-			each one on its own line
-		);
+		really long list,
+		of complex parameter values,
+		each one on its own line
+	);
 	color: more-arbitrary(
-			just,
-			has,
-			lots,
-			of,
-			individual,
-			parameters,
-			breaking,
-			over,
-			lines
-		);
+		just,
+		has,
+		lots,
+		of,
+		individual,
+		parameters,
+		breaking,
+		over,
+		lines
+	);
 	color: arbitrary(
-			one really long parameter value that itself will break over multiple lines
-				and fill together
-		);
+		one really long parameter value that itself will break over multiple lines
+			and fill together
+	);
 }
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/css/properties/all.css
+++ b/crates/biome_css_formatter/tests/specs/css/properties/all.css
@@ -2,11 +2,23 @@ div {
     all: InItial;
     all  : inherIT;
     all
-    : 
+    :
     revert-layer
     ;
 
     all  :   unknown-value  ;
     all  : a,
     value list ;
+}
+
+:root {
+	--bs-gradient: linear-gradient(
+		180deg,
+		180deg,
+		180deg,
+		180deg,
+		180deg,
+		180deg,
+		180deg
+	);
 }

--- a/crates/biome_css_formatter/tests/specs/css/properties/all.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/properties/all.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/properties/all.css
 ---
-
 # Input
 
 ```css
@@ -10,7 +9,7 @@ div {
     all: InItial;
     all  : inherIT;
     all
-    : 
+    :
     revert-layer
     ;
 
@@ -18,6 +17,19 @@ div {
     all  : a,
     value list ;
 }
+
+:root {
+	--bs-gradient: linear-gradient(
+		180deg,
+		180deg,
+		180deg,
+		180deg,
+		180deg,
+		180deg,
+		180deg
+	);
+}
+
 ```
 
 
@@ -44,6 +56,16 @@ div {
 	all: unknown-value;
 	all: a , value list;
 }
+
+:root {
+	--bs-gradient: linear-gradient(
+		180deg,
+		180deg,
+		180deg,
+		180deg,
+		180deg,
+		180deg,
+		180deg
+	);
+}
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/css/url.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/url.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/url.css
 ---
-
 # Input
 
 ```css
@@ -71,5 +70,3 @@ a {
 ```
    10: 		url(RobotoFlex-VariableFont_GRAD,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght.ttf);
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/css/value_fill.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/value_fill.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/value_fill.css
 ---
-
 # Input
 
 ```css
@@ -33,5 +32,3 @@ div {
 		going forever onward intothenight;
 }
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/css/variables.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/variables.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/variables.css
 ---
-
 # Input
 
 ```css
@@ -83,9 +82,9 @@ Quote style: Double Quotes
 	prop4: var(--prop, pink);
 
 	prop5: var(
-			--one-var-thats-super-long-on-its-own,
-			--super-long-just-enough-to-make-it-break-over-lines
-		);
+		--one-var-thats-super-long-on-its-own,
+		--super-long-just-enough-to-make-it-break-over-lines
+	);
 }
 
 .multiple {
@@ -95,5 +94,3 @@ Quote style: Double Quotes
 	prop: hsl(var(--hue, 0) var(--sat, 100) var(--light, 1));
 }
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/atrule/font-face.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/atrule/font-face.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/atrule/font-face.css
 ---
-
 # Input
 
 ```css
@@ -185,5 +184,3 @@ format(
     url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/comments/declaration.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/comments/declaration.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/comments/declaration.css
 ---
-
 # Input
 
 ```css
@@ -116,23 +115,25 @@ body
 -  /* comment 23 */
 -  color/* comment 24 */:/* comment 25 */ blue /* comment 26 */; /* comment 27 */
 -  transform/* comment 28 */:/* comment 29 */ translate(
-+  /* comment 23 */ /* comment 24 */ /* comment 25 */ color: blue /* comment 26 */; /* comment 27 */
-+  /* comment 28 */ /* comment 29 */ transform: translate(
-       /* comment 30 */ 10px /* comment 31 */
+-      /* comment 30 */ 10px /* comment 31 */
 -    )
 -    /* comment 32 */; /* comment 33 */
-+    ) /* comment 32 */; /* comment 33 */
++  /* comment 23 */ /* comment 24 */ /* comment 25 */ color: blue /* comment 26 */; /* comment 27 */
++  /* comment 28 */ /* comment 29 */ transform: translate(
++    /* comment 30 */ 10px /* comment 31 */
++  ) /* comment 32 */; /* comment 33 */
  }
  .foo {
 -  /* comment 34 */
 -  color/* comment 35 */ : /* comment 36 */ blue /* comment 37 */; /* comment 38 */
 -  transform/* comment 39 */ : /* comment 40 */ translate(
-+  /* comment 34 */ /* comment 35 */ /* comment 36 */ color: blue /* comment 37 */; /* comment 38 */
-+  /* comment 39 */ /* comment 40 */ transform: translate(
-       /* comment 41 */ 10px /* comment 42 */
+-      /* comment 41 */ 10px /* comment 42 */
 -    )
 -    /* comment 43 */; /* comment 44 */
-+    ) /* comment 43 */; /* comment 44 */
++  /* comment 34 */ /* comment 35 */ /* comment 36 */ color: blue /* comment 37 */; /* comment 38 */
++  /* comment 39 */ /* comment 40 */ transform: translate(
++    /* comment 41 */ 10px /* comment 42 */
++  ) /* comment 43 */; /* comment 44 */
  }
  .foo {
    /* comment 45 */
@@ -166,12 +167,12 @@ body
 +  /* comment 61 */ /* comment 62 */
 +  /* comment 63 */
 +  /* comment 64 */ transform: translate(
-+      /* comment 65 */
-+      /* comment 66 */
-+      /* comment 67 */ 10px /* comment 68 */
-+      /* comment 69 */
-+      /* comment 70 */
-+    ) /* comment 71 */; /* comment 74 */
++    /* comment 65 */
++    /* comment 66 */
++    /* comment 67 */ 10px /* comment 68 */
++    /* comment 69 */
++    /* comment 70 */
++  ) /* comment 71 */; /* comment 74 */
 +  /* comment 72 */
 +  /* comment 73 */
    /* comment 75 */
@@ -201,14 +202,14 @@ a {
 .foo {
   /* comment 23 */ /* comment 24 */ /* comment 25 */ color: blue /* comment 26 */; /* comment 27 */
   /* comment 28 */ /* comment 29 */ transform: translate(
-      /* comment 30 */ 10px /* comment 31 */
-    ) /* comment 32 */; /* comment 33 */
+    /* comment 30 */ 10px /* comment 31 */
+  ) /* comment 32 */; /* comment 33 */
 }
 .foo {
   /* comment 34 */ /* comment 35 */ /* comment 36 */ color: blue /* comment 37 */; /* comment 38 */
   /* comment 39 */ /* comment 40 */ transform: translate(
-      /* comment 41 */ 10px /* comment 42 */
-    ) /* comment 43 */; /* comment 44 */
+    /* comment 41 */ 10px /* comment 42 */
+  ) /* comment 43 */; /* comment 44 */
 }
 .foo {
   /* comment 45 */
@@ -225,12 +226,12 @@ a {
   /* comment 61 */ /* comment 62 */
   /* comment 63 */
   /* comment 64 */ transform: translate(
-      /* comment 65 */
-      /* comment 66 */
-      /* comment 67 */ 10px /* comment 68 */
-      /* comment 69 */
-      /* comment 70 */
-    ) /* comment 71 */; /* comment 74 */
+    /* comment 65 */
+    /* comment 66 */
+    /* comment 67 */ 10px /* comment 68 */
+    /* comment 69 */
+    /* comment 70 */
+  ) /* comment 71 */; /* comment 74 */
   /* comment 72 */
   /* comment 73 */
   /* comment 75 */
@@ -276,5 +277,3 @@ body {
    18:   /* comment 23 */ /* comment 24 */ /* comment 25 */ color: blue /* comment 26 */; /* comment 27 */
    24:   /* comment 34 */ /* comment 35 */ /* comment 36 */ color: blue /* comment 37 */; /* comment 38 */
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/composes/composes.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/composes/composes.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/composes/composes.css
 ---
-
 # Input
 
 ```css
@@ -39,5 +38,3 @@ info: css/composes/composes.css
 ```
     3:     "a/long/file/path/exceeding/the/maximum/length/forcing/a/line-wrap/file.css";
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/fill-value/fill.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/fill-value/fill.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/fill-value/fill.css
 ---
-
 # Input
 
 ```css
@@ -45,5 +44,3 @@ div {
     sans-serif;
 }
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/grid/grid.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/grid/grid.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/grid/grid.css
 ---
-
 # Input
 
 ```css
@@ -565,5 +564,3 @@ grid.css:113:35 parse ━━━━━━━━━━━━━━━━━━━�
 ```
    71:   /* The. Worst. This one is shorthand for like everything here smashed into one. But rarely will you actually specify EVERYTHING. */
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/indent/indent.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/indent/indent.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/indent/indent.css
 ---
-
 # Input
 
 ```css
@@ -30,11 +29,10 @@ div {
 +  box-shadow: 0 0 1px 2px rgba(88, 144, 255, 0.75) , 0 1px 1px
 +    rgba(0, 0, 0, 0.15);
    padding-bottom: calc(
--    var(ads-help-tray-footer-with-support-link-height) +
-+      var(ads-help-tray-footer-with-support-link-height) +
-       var(ads-help-tray-header-height-new)
--  );
-+    );
+     var(ads-help-tray-footer-with-support-link-height) +
+-      var(ads-help-tray-header-height-new)
++    var(ads-help-tray-header-height-new)
+   );
  }
 ```
 
@@ -47,10 +45,8 @@ div {
   box-shadow: 0 0 1px 2px rgba(88, 144, 255, 0.75) , 0 1px 1px
     rgba(0, 0, 0, 0.15);
   padding-bottom: calc(
-      var(ads-help-tray-footer-with-support-link-height) +
-      var(ads-help-tray-header-height-new)
-    );
+    var(ads-help-tray-footer-with-support-link-height) +
+    var(ads-help-tray-header-height-new)
+  );
 }
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/parens/parens.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/parens/parens.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/parens/parens.css
 ---
-
 # Input
 
 ```css
@@ -268,81 +267,7 @@ a {
 ```diff
 --- Prettier
 +++ Biome
-@@ -7,60 +7,60 @@
-   prop6: func(1px, 1px, 1px, func(1px, 1px, 1px, func(1px, 1px, 1px)));
-   prop7: func(1px, 1px, 1px, func(1px, 1px, 1px, func(1px, 1px, 1px)));
-   prop8: very-very-very-very-very-very-vey-very-very-long-func(
--    1px,
--    1px,
--    1px,
--    very-very-very-very-very-very-vey-very-very-long-func(
-       1px,
-       1px,
-       1px,
--      very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
--    )
--  );
-+      very-very-very-very-very-very-vey-very-very-long-func(
-+          1px,
-+          1px,
-+          1px,
-+          very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
-+        )
-+    );
-   prop9: very-very-very-very-very-very-vey-very-very-long-func(
--    1px,
--    1px,
--    1px,
--    very-very-very-very-very-very-vey-very-very-long-func(
-       1px,
-       1px,
-       1px,
--      very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
--    )
--  );
-+      very-very-very-very-very-very-vey-very-very-long-func(
-+          1px,
-+          1px,
-+          1px,
-+          very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
-+        )
-+    );
-   prop10: very-very-very-very-very-very-vey-very-very-long-func(
--    1px,
--    1px,
--    1px,
--    very-very-very-very-very-very-vey-very-very-long-func(
-       1px,
-       1px,
-       1px,
--      very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
--    )
--  );
-+      very-very-very-very-very-very-vey-very-very-long-func(
-+          1px,
-+          1px,
-+          1px,
-+          very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
-+        )
-+    );
-   prop11: very-very-very-very-very-very-vey-very-very-long-func(
--    1px,
--    1px,
--    1px,
--    very-very-very-very-very-very-vey-very-very-long-func(
-       1px,
-       1px,
-       1px,
--      very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
--    )
--  );
-+      very-very-very-very-very-very-vey-very-very-long-func(
-+          1px,
-+          1px,
-+          1px,
-+          very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
-+        )
-+    );
+@@ -53,14 +53,14 @@
  }
  
  .foo {
@@ -453,49 +378,49 @@ a {
   prop6: func(1px, 1px, 1px, func(1px, 1px, 1px, func(1px, 1px, 1px)));
   prop7: func(1px, 1px, 1px, func(1px, 1px, 1px, func(1px, 1px, 1px)));
   prop8: very-very-very-very-very-very-vey-very-very-long-func(
+    1px,
+    1px,
+    1px,
+    very-very-very-very-very-very-vey-very-very-long-func(
       1px,
       1px,
       1px,
-      very-very-very-very-very-very-vey-very-very-long-func(
-          1px,
-          1px,
-          1px,
-          very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
-        )
-    );
+      very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
+    )
+  );
   prop9: very-very-very-very-very-very-vey-very-very-long-func(
+    1px,
+    1px,
+    1px,
+    very-very-very-very-very-very-vey-very-very-long-func(
       1px,
       1px,
       1px,
-      very-very-very-very-very-very-vey-very-very-long-func(
-          1px,
-          1px,
-          1px,
-          very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
-        )
-    );
+      very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
+    )
+  );
   prop10: very-very-very-very-very-very-vey-very-very-long-func(
+    1px,
+    1px,
+    1px,
+    very-very-very-very-very-very-vey-very-very-long-func(
       1px,
       1px,
       1px,
-      very-very-very-very-very-very-vey-very-very-long-func(
-          1px,
-          1px,
-          1px,
-          very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
-        )
-    );
+      very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
+    )
+  );
   prop11: very-very-very-very-very-very-vey-very-very-long-func(
+    1px,
+    1px,
+    1px,
+    very-very-very-very-very-very-vey-very-very-long-func(
       1px,
       1px,
       1px,
-      very-very-very-very-very-very-vey-very-very-long-func(
-          1px,
-          1px,
-          1px,
-          very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
-        )
-    );
+      very-very-very-very-very-very-vey-very-very-long-func(1px, 1px, 1px)
+    )
+  );
 }
 
 .foo {
@@ -1516,5 +1441,3 @@ parens.css:252:37 parse ━━━━━━━━━━━━━━━━━━�
   149:   filter: progid:DXImageTransform.Microsoft.Shadow(color='#042b47', Direction=45, Strength=6) progid:DXImageTransform.Microsoft.Shadow(color='#042b47', Direction=135, Strength=6);
   150:   -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#fad59f, endColorstr=#fa9907)";
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/trailing-comma/var-func.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/trailing-comma/var-func.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/trailing-comma/var-func.css
 ---
-
 # Input
 
 ```css
@@ -46,5 +45,3 @@ info: css/trailing-comma/var-func.css
   --bar: var(   --baz1, --baz2    , );
 }
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/url/url.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/url/url.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/url/url.css
 ---
-
 # Input
 
 ```css
@@ -196,5 +195,3 @@ url.css:30:3 parse ━━━━━━━━━━━━━━━━━━━━�
     7:   src: url(RobotoFlex-VariableFont_GRAD,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght.ttf);
    27:     url(RobotoFlex-VariableFont_GRAD,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght.ttf);
 ```
-
-

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_document_error.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_document_error.css.snap
@@ -81,6 +81,7 @@ CssRoot {
                         ],
                     },
                     COMMA@164..199 "," [] [Whitespace(" "), Comments("/* Error in URL, reco ..."), Whitespace(" ")],
+                    missing element,
                 ],
                 block: CssRuleBlock {
                     l_curly_token: L_CURLY@199..200 "{" [] [],
@@ -143,6 +144,7 @@ CssRoot {
           2: CSS_BOGUS_DOCUMENT_MATCHER@151..164
             0: IDENT@151..164 "invalid-url" [Newline("\n"), Whitespace(" ")] []
           3: COMMA@164..199 "," [] [Whitespace(" "), Comments("/* Error in URL, reco ..."), Whitespace(" ")]
+          4: (empty)
         2: CSS_RULE_BLOCK@199..203
           0: L_CURLY@199..200 "{" [] []
           1: CSS_RULE_LIST@200..200

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -1408,7 +1408,7 @@ CssDocumentAtRule =
 	matchers: CssDocumentMatcherList
 	block: AnyCssRuleBlock
 
-CssDocumentMatcherList = AnyCssDocumentMatcher (',' AnyCssDocumentMatcher)* ','?
+CssDocumentMatcherList = (AnyCssDocumentMatcher (',' AnyCssDocumentMatcher)*)
 
 AnyCssDocumentMatcher =
 	CssUrlFunction


### PR DESCRIPTION
## Summary

This PR updates the `component_value_list` in the CSS formatter to include `ValueListLayout::SingleLine` format. It also refactors the function to determine the layout style according to the list length. This change anticipates further support for one-per-line comma-separated lists

## Test Plan

`cargo test`
