### PR TITLE
Fixed a typo in the docs

### DIFF
--- a/website/src/content/docs/analyzer/index.mdx
+++ b/website/src/content/docs/analyzer/index.mdx
@@ -108,7 +108,7 @@ import { Grid } from "../components/Grid.jsx";
 // group 1, the polyfill/shim
 import "../polyfills/array/flatMap";
 
-// group 2, the files tha require the polyfill/shim
+// group 2, the files that require the polyfill/shim
 import { functionThatUsesFlatMap } from "./utils.js";
 ```
 


### PR DESCRIPTION
Fixed a typo in one of the code blocks of the documentation.

## Summary
There was a typo on the documentation website, specifically [here](https://biomejs.dev/analyzer/)
![image](https://github.com/biomejs/biome/assets/73862378/6bedb5c7-51e2-409d-84a0-b374ae3d4243)


## Test Plan
It's just a typo-fix so no test is needed.
