### PR TITLE
chore: fix typo in docs

### DIFF
--- a/website/src/content/docs/analyzer/index.mdx
+++ b/website/src/content/docs/analyzer/index.mdx
@@ -5,4 +5,4 @@ description: What the Biome analyzer provides
 
 Biome's analyzer intends to provide a series of features that users can leverage.
 
-For now, it only provides [import sorting](/analyzer/import-organizer) that sorts import statements in _JavaScript_-like files.
+For now, it only provides [import sorting](/analyzer/import-sorting) that sorts import statements in _JavaScript_-like files.


### PR DESCRIPTION
fix `import sorting` link.

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

[related link](https://biomejs.dev/analyzer/)

When I clicked `import sorting` link, the page is 404.
I fixed `import-organizer` to `import sorting`.

<img width="1431" alt="스크린샷 2024-03-31 오후 4 40 38" src="https://github.com/biomejs/biome/assets/79239852/1a0b67e3-d4f9-4d09-9dc3-2f933b671b28">

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

It's just a typo fix.

Thank you.

<!-- What demonstrates that your implementation is correct? -->
