### PR TITLE
fix(js_analyzer): binary expression utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Analyzer
 
+#### Bug fixes
+
+- An operator with no spaces around in a binary expression no longer breaks the js analyzer ([#2243](https://github.com/biomejs/biome/issues/2243)). Contributed by @Sec-ant
+
 ### CLI
 
 ### Configuration

--- a/crates/biome_js_analyze/src/utils.rs
+++ b/crates/biome_js_analyze/src/utils.rs
@@ -100,9 +100,9 @@ pub(crate) fn find_variable_position(
         .map(|child| child.omit_parentheses())
         .filter(|child| child.syntax().text_trimmed() == variable)
         .map(|child| {
-            if child.syntax().text_trimmed_range().end() < operator_range.start() {
+            if child.syntax().text_trimmed_range().end() <= operator_range.start() {
                 return VariablePosition::Left;
-            } else if operator_range.end() < child.syntax().text_trimmed_range().start() {
+            } else if operator_range.end() <= child.syntax().text_trimmed_range().start() {
                 return VariablePosition::Right;
             }
 
@@ -185,5 +185,28 @@ mod test {
         );
 
         assert_eq!(position, None);
+    }
+
+    #[test]
+    fn find_variable_position_when_the_operator_has_no_spaces_around() {
+        let source = "l-c";
+        let parsed = parse(
+            source,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+
+        let binary_expression = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsBinaryExpression::cast);
+
+        let variable = "l";
+        let position = find_variable_position(
+            &binary_expression.expect("valid binary expression"),
+            variable,
+        );
+
+        assert_eq!(position, Some(VariablePosition::Left));
     }
 }

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -19,6 +19,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Analyzer
 
+#### Bug fixes
+
+- An operator with no spaces around in a binary expression no longer breaks the js analyzer ([#2243](https://github.com/biomejs/biome/issues/2243)). Contributed by @Sec-ant
+
 ### CLI
 
 ### Configuration


### PR DESCRIPTION
## Summary

This PR fixes an issue where an operator with no spaces around in a binary expression can break the js analyzer. Specifically when rule `lint/suspicious/noMisrefactoredShorthandAssign` is enabled.

Closes #2243

## Test Plan

Added a test case.
