### PR TITLE
fix(configuration): `extends` resolution strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Correctly calculate enabled rules in lint rule groups. Now a specific rule belonging to a group can be enabled even if its group-level preset option `recommended` or `all` is `false` ([#2191](https://github.com/biomejs/biome/issues/2191)). Contributed by @Sec-ant
 
+- Fix the resolution strategy of `extends` so it can work as most users would expect in both LSP and CLI ([#2231](https://github.com/biomejs/biome/issues/2231)):
+
+  - Absolute paths:
+    - As is.
+  - Relative paths:
+    - Resolve the extend configuration file relative to the directory where the current configuration file is.
+  - External modules:
+    1. First resolve the extend configuration file from the directory where the current configuration file is;
+    2. Fallback to resolve the extend configuration file from the working directory.
+
+  Contributed by @Sec-ant
+
 ### Editors
 
 ### Formatter

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration.snap
@@ -35,10 +35,8 @@ formatTYPO.json configuration ━━━━━━━━━━━━━━━━�
   
   Verbose advice
   
-    i Biome tried to load the configuration file  using formatTYPO.json as base path.
+    i Biome tried to load the extend configuration file from "formatTYPO.json".
     
 
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration_and_show_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration_and_show_verbose.snap
@@ -35,10 +35,8 @@ formatTYPO.json configuration ━━━━━━━━━━━━━━━━�
   
   Verbose advice
   
-    i Biome tried to load the configuration file  using formatTYPO.json as base path.
+    i Biome tried to load the extend configuration file from "formatTYPO.json".
     
 
 
 ```
-
-

--- a/crates/biome_service/src/configuration/mod.rs
+++ b/crates/biome_service/src/configuration/mod.rs
@@ -597,7 +597,7 @@ impl PartialConfiguration {
         let working_directory_path = fs.working_directory().unwrap_or_default();
         let is_configuration_directory_not_working_directory =
             canonicalize(&working_directory_path)
-                .is_ok_and(|w| canonicalize(&configuration_directory_path).is_ok_and(|c| w != c));
+                .is_ok_and(|w| canonicalize(configuration_directory_path).is_ok_and(|c| w != c));
 
         let mut deserialized_configurations = vec![];
         for extend_entry in extends.iter() {

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -36,7 +36,7 @@ export interface PartialConfiguration {
 	 */
 	css?: PartialCssConfiguration;
 	/**
-	 * A list of paths to other JSON files, used to extends the current configuration.
+	 * A list of paths or modules to other JSON files, used to extends the current configuration.
 	 */
 	extends?: StringSet;
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -16,7 +16,7 @@
 			]
 		},
 		"extends": {
-			"description": "A list of paths to other JSON files, used to extends the current configuration.",
+			"description": "A list of paths or modules to other JSON files, used to extends the current configuration.",
 			"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
 		},
 		"files": {

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -31,6 +31,18 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Correctly calculate enabled rules in lint rule groups. Now a specific rule belonging to a group can be enabled even if its group-level preset option `recommended` or `all` is `false` ([#2191](https://github.com/biomejs/biome/issues/2191)). Contributed by @Sec-ant
 
+- Fix the resolution strategy of `extends` so it can work as most users would expect in both LSP and CLI ([#2231](https://github.com/biomejs/biome/issues/2231)):
+
+  - Absolute paths:
+    - As is.
+  - Relative paths:
+    - Resolve the extend configuration file relative to the directory where the current configuration file is.
+  - External modules:
+    1. First resolve the extend configuration file from the directory where the current configuration file is;
+    2. Fallback to resolve the extend configuration file from the working directory.
+
+  Contributed by @Sec-ant
+
 ### Editors
 
 ### Formatter

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -36,7 +36,7 @@ If you have problems with resolving the physical file, you can use the one publi
 
 ## `extends`
 
-A list of paths to other JSON files. Biome resolves and applies the options of the files contained in the `extends` list, and eventually applies the options contained in the `biome.json` file.
+A list of paths or modules to other JSON files. Biome resolves and applies the options of the files contained in the `extends` list, and eventually applies the options contained in the `biome.json` file.
 
 ## `files`
 


### PR DESCRIPTION
## Summary

Fix the resolution strategy of `extends` so it can work as most users would expect in both LSP and CLI:

  - Absolute paths:
    - As is.
  - Relative paths:
    - Resolve the extend configuration file relative to the directory where the current configuration file is.
  - External modules:
    1. First resolve the extend configuration file from the directory where the current configuration file is;
    2. Fallback to resolve the extend configuration file from the working directory.

This also fixes a regression introduced in #2160.

I also updated a few configuration resolution diagnostics and schema comments to provide clearer messages for users.

Closes #2231.

## Test Plan

CI should pass. We cannot test module resolution atm. I tested the behavior locally.
