### PR TITLE
fix(cli): error count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### CLI
 
+#### Bug fixes
+
+- Fix the printed error count ([#2048](https://github.com/biomejs/biome/issues/2048)). Contributed by @Sec-ant
+
 ### Configuration
 
 #### Bug fixes

--- a/crates/biome_cli/src/execute/process_file.rs
+++ b/crates/biome_cli/src/execute/process_file.rs
@@ -63,11 +63,8 @@ pub(crate) enum Message {
 }
 
 impl Message {
-    pub(crate) const fn is_error(&self) -> bool {
-        matches!(
-            self,
-            Message::Diff { .. } | Message::Diagnostics { .. } | Message::Failure
-        )
+    pub(crate) const fn is_failure(&self) -> bool {
+        matches!(self, Message::Failure)
     }
 }
 

--- a/crates/biome_cli/src/execute/process_file/check.rs
+++ b/crates/biome_cli/src/execute/process_file/check.rs
@@ -11,7 +11,7 @@ pub(crate) fn check_file<'ctx>(
     path: &Path,
     file_features: &'ctx FileFeaturesResult,
 ) -> FileResult {
-    let mut has_errors = false;
+    let mut has_failures = false;
     let mut workspace_file = WorkspaceFile::new(ctx, path)?;
     let mut changed = false;
     tracing::info_span!("Process check", path =? workspace_file.path.display()).in_scope(
@@ -24,15 +24,15 @@ pub(crate) fn check_file<'ctx>(
                             changed = true
                         }
                         if let FileStatus::Message(msg) = status {
-                            if msg.is_error() {
-                                has_errors = true
+                            if msg.is_failure() {
+                                has_failures = true;
                             }
                             ctx.push_message(msg);
                         }
                     }
                     Err(err) => {
                         ctx.push_message(err);
-                        has_errors = true;
+                        has_failures = true;
                     }
                 }
             }
@@ -44,15 +44,15 @@ pub(crate) fn check_file<'ctx>(
                             changed = true
                         }
                         if let FileStatus::Message(msg) = status {
-                            if msg.is_error() {
-                                has_errors = true
+                            if msg.is_failure() {
+                                has_failures = true;
                             }
                             ctx.push_message(msg);
                         }
                     }
                     Err(err) => {
                         ctx.push_message(err);
-                        has_errors = true;
+                        has_failures = true;
                     }
                 }
             }
@@ -65,20 +65,20 @@ pub(crate) fn check_file<'ctx>(
                             changed = true
                         }
                         if let FileStatus::Message(msg) = status {
-                            if msg.is_error() {
-                                has_errors = true
+                            if msg.is_failure() {
+                                has_failures = true;
                             }
                             ctx.push_message(msg);
                         }
                     }
                     Err(err) => {
                         ctx.push_message(err);
-                        has_errors = true;
+                        has_failures = true;
                     }
                 }
             }
 
-            if has_errors {
+            if has_failures {
                 Ok(FileStatus::Message(Message::Failure))
             } else if changed {
                 Ok(FileStatus::Changed)

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_formatter_no_linter.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_formatter_no_linter.snap
@@ -54,7 +54,5 @@ test.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_linter_not_formatter.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_linter_not_formatter.snap
@@ -79,8 +79,6 @@ test.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 Found 1 warning.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_resolves_when_using_config_path.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_resolves_when_using_config_path.snap
@@ -69,7 +69,5 @@ test.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path.snap
@@ -57,5 +57,5 @@ src/index.js format ━━━━━━━━━━━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_no_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_no_verbose.snap
@@ -35,7 +35,5 @@ src/file.js format ━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_verbose.snap
@@ -131,7 +131,5 @@ src/folder_0/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_astro_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_astro_files.snap
@@ -45,5 +45,5 @@ file.astro:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
@@ -43,7 +43,5 @@ file.astro organizeImports ━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
@@ -43,7 +43,5 @@ file.svelte organizeImports ━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_js_files.snap
@@ -103,5 +103,5 @@ file.vue:4:1 lint/style/noVar  FIXABLE  ━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 3 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_ts_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_ts_files.snap
@@ -125,5 +125,5 @@ file.vue:4:1 lint/style/noVar  FIXABLE  ━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 5 errors.
+Found 4 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
@@ -43,7 +43,5 @@ file.vue organizeImports ━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/all_rules.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/all_rules.snap
@@ -64,7 +64,5 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/apply_bogus_argument.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/apply_bogus_argument.snap
@@ -53,7 +53,5 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 3 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/apply_unsafe_with_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/apply_unsafe_with_error.snap
@@ -70,8 +70,6 @@ test2.js:3:16 lint/style/noArguments ━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
-Found 6 errors.
+Checked 2 files in <TIME>. Fixed 2 files.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_json_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_json_files.snap
@@ -67,7 +67,5 @@ test.json format ━━━━━━━━━━━━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/config_recommended_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/config_recommended_group.snap
@@ -67,7 +67,5 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/deprecated_suppression_comment.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/deprecated_suppression_comment.snap
@@ -85,5 +85,5 @@ file.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 3 errors.
+Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/downgrade_severity.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/downgrade_severity.snap
@@ -65,8 +65,6 @@ file.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 Found 1 warning.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/ignore_configured_globals.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/ignore_configured_globals.snap
@@ -46,7 +46,5 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/ignore_vcs_ignored_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/ignore_vcs_ignored_file.snap
@@ -77,7 +77,5 @@ file1.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/ignore_vcs_ignored_file_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/ignore_vcs_ignored_file_via_cli.snap
@@ -71,7 +71,5 @@ file1.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/ignore_vcs_os_independent_parse.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/ignore_vcs_os_independent_parse.snap
@@ -67,7 +67,5 @@ file1.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/ignores_unknown_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/ignores_unknown_file.snap
@@ -42,7 +42,5 @@ test.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/lint_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/lint_error.snap
@@ -66,7 +66,5 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 5 errors.
+Found 3 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/max_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/max_diagnostics.snap
@@ -162,7 +162,5 @@ Diagnostics not shown: 50.
 
 ```block
 Checked 20 files in <TIME>. No fixes needed.
-Found 100 errors.
+Found 60 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/max_diagnostics_default.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/max_diagnostics_default.snap
@@ -302,7 +302,5 @@ Diagnostics not shown: 100.
 
 ```block
 Checked 40 files in <TIME>. No fixes needed.
-Found 200 errors.
+Found 120 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/maximum_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/maximum_diagnostics.snap
@@ -533,7 +533,5 @@ Diagnostics not shown: 77.
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 23 errors.
+Found 21 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/no_lint_if_linter_is_disabled.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/no_lint_if_linter_is_disabled.snap
@@ -48,7 +48,5 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/nursery_unstable.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/nursery_unstable.snap
@@ -50,7 +50,5 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/parse_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/parse_error.snap
@@ -68,7 +68,5 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 3 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/print_verbose.snap
@@ -66,7 +66,5 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 5 errors.
+Found 3 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_apply_correct_file_source.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_apply_correct_file_source.snap
@@ -51,7 +51,5 @@ file.ts format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_not_disable_recommended_rules_for_a_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_not_disable_recommended_rules_for_a_group.snap
@@ -77,7 +77,5 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_not_enable_all_recommended_rules.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_not_enable_all_recommended_rules.snap
@@ -77,7 +77,5 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_show_formatter_diagnostics_for_files_ignored_by_linter.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_show_formatter_diagnostics_for_files_ignored_by_linter.snap
@@ -57,5 +57,5 @@ build/file.js format ━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check.snap
@@ -38,7 +38,5 @@ check.js organizeImports ━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/suppression_syntax_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/suppression_syntax_error.snap
@@ -48,7 +48,5 @@ check.js:1:15 suppressions/parse ━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/top_level_all_down_level_not_all.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/top_level_all_down_level_not_all.snap
@@ -163,8 +163,6 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 Found 5 warnings.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/top_level_not_all_down_level_all.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/top_level_not_all_down_level_all.snap
@@ -126,7 +126,5 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 6 errors.
+Found 4 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_check/upgrade_severity.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/upgrade_severity.snap
@@ -70,7 +70,5 @@ file.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_linter.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_linter.snap
@@ -52,7 +52,5 @@ file.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_linter_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_linter_via_cli.snap
@@ -36,7 +36,5 @@ file.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_formatter_linter_organize_imports.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_formatter_linter_organize_imports.snap
@@ -81,7 +81,5 @@ file.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 3 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_lint_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_lint_error.snap
@@ -66,7 +66,5 @@ ci.js format ━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 5 errors.
+Found 3 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_parse_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_parse_error.snap
@@ -68,7 +68,5 @@ ci.js format ━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 3 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_runs_linter_not_formatter_issue_3495.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_runs_linter_not_formatter_issue_3495.snap
@@ -54,7 +54,5 @@ file.js:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 3 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/correctly_handles_ignored_and_not_ignored_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/correctly_handles_ignored_and_not_ignored_files.snap
@@ -84,7 +84,5 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 2 files in <TIME>. No fixes needed.
-Found 5 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/formatting_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/formatting_error.snap
@@ -35,7 +35,5 @@ ci.js format ━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ignore_vcs_ignored_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ignore_vcs_ignored_file.snap
@@ -77,7 +77,5 @@ file1.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ignore_vcs_ignored_file_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ignore_vcs_ignored_file_via_cli.snap
@@ -68,7 +68,5 @@ file1.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ignores_unknown_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ignores_unknown_file.snap
@@ -42,7 +42,5 @@ test.js format ━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/max_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/max_diagnostics.snap
@@ -17,7 +17,5 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 60 files in <TIME>. No fixes needed.
-Found 120 errors.
+Found 60 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/max_diagnostics_default.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/max_diagnostics_default.snap
@@ -17,7 +17,5 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 60 files in <TIME>. No fixes needed.
-Found 120 errors.
+Found 60 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/print_verbose.snap
@@ -66,7 +66,5 @@ ci.js format ━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 5 errors.
+Found 3 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/all_rules.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/all_rules.snap
@@ -48,7 +48,5 @@ fix.js:1:2 lint/suspicious/noCompareNegZero  FIXABLE  ━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/apply_bogus_argument.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/apply_bogus_argument.snap
@@ -34,7 +34,5 @@ fix.js:1:22 parse ━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/apply_unsafe_with_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/apply_unsafe_with_error.snap
@@ -66,8 +66,6 @@ test2.js:3:16 lint/style/noArguments ━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
-Found 4 errors.
+Checked 2 files in <TIME>. Fixed 2 files.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/check_json_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/check_json_files.snap
@@ -55,7 +55,5 @@ test.json:1:3 lint/nursery/noDuplicateJsonKeys ━━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/config_recommended_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/config_recommended_group.snap
@@ -55,7 +55,5 @@ check.js:1:1 lint/correctness/noInvalidNewBuiltin  FIXABLE  ━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/group_level_disable_recommended_enable_specific.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/group_level_disable_recommended_enable_specific.snap
@@ -60,5 +60,5 @@ fix.jsx:3:16 lint/a11y/useButtonType ━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_vcs_ignored_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_vcs_ignored_file.snap
@@ -65,7 +65,5 @@ file1.js:1:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_vcs_ignored_file_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_vcs_ignored_file_via_cli.snap
@@ -59,7 +59,5 @@ file1.js:1:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_subdir.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_subdir.snap
@@ -65,7 +65,5 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 
 ```block
 Checked 2 files in <TIME>. No fixes needed.
-Found 3 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_symlinked_subdir.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_symlinked_subdir.snap
@@ -65,7 +65,5 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 
 ```block
 Checked 2 files in <TIME>. No fixes needed.
-Found 3 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_error.snap
@@ -56,7 +56,5 @@ check.js:1:6 lint/correctness/noConstantCondition ━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 3 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_syntax_rules.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_syntax_rules.snap
@@ -34,7 +34,5 @@ check.js:1:17 parse/noDuplicatePrivateClassMembers ━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/max_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/max_diagnostics.snap
@@ -162,7 +162,5 @@ Diagnostics not shown: 30.
 
 ```block
 Checked 20 files in <TIME>. No fixes needed.
-Found 60 errors.
+Found 40 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/max_diagnostics_default.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/max_diagnostics_default.snap
@@ -302,7 +302,5 @@ Diagnostics not shown: 60.
 
 ```block
 Checked 40 files in <TIME>. No fixes needed.
-Found 120 errors.
+Found 80 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/maximum_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/maximum_diagnostics.snap
@@ -533,7 +533,5 @@ Diagnostics not shown: 76.
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 21 errors.
+Found 20 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/no_unused_dependencies.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/no_unused_dependencies.snap
@@ -66,7 +66,5 @@ fix.js:2:8 lint/nursery/noUndeclaredDependencies ━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/nursery_unstable.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/nursery_unstable.snap
@@ -37,7 +37,5 @@ check.js:1:4 lint/suspicious/noAssignInExpressions ━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/parse_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/parse_error.snap
@@ -42,7 +42,5 @@ check.js:2:1 parse ━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/print_verbose.snap
@@ -56,7 +56,5 @@ check.js:1:6 lint/correctness/noConstantCondition ━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 3 errors.
+Found 2 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_disable_recommended_rules_for_a_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_disable_recommended_rules_for_a_group.snap
@@ -67,7 +67,5 @@ fix.js:3:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/suppression_syntax_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/suppression_syntax_error.snap
@@ -36,7 +36,5 @@ check.js:1:15 suppressions/parse ━━━━━━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_not_all_down_level_all.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_not_all_down_level_all.snap
@@ -106,7 +106,5 @@ fix.js:4:5 lint/style/noVar  FIXABLE  ━━━━━━━━━━━━━━
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 4 errors.
+Found 3 errors.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/upgrade_severity.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/upgrade_severity.snap
@@ -54,7 +54,5 @@ file.js:1:1 lint/style/noNegationElse  FIXABLE  ━━━━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_configuration/override_globals.snap
+++ b/crates/biome_cli/tests/snapshots/main_configuration/override_globals.snap
@@ -68,7 +68,5 @@ tests/test.js:3:9 lint/correctness/noUndeclaredVariables ━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes needed.
-Found 2 errors.
+Found 1 error.
 ```
-
-

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -25,6 +25,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### CLI
 
+#### Bug fixes
+
+- Fix the printed error count ([#2048](https://github.com/biomejs/biome/issues/2048)). Contributed by @Sec-ant
+
 ### Configuration
 
 #### Bug fixes


### PR DESCRIPTION
## Summary

Fix the mis-counted error count printed in stdout.

I also noticed there are cases where one parse error can emit two identical diagnostics. But I think that should be addressed in another PR.

## Test Plan

Just updated the exisiting snapshots. I checked each of them and the result should be good.
