### PR TITLE
fix(lint_rules): false positives of several rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Linter
 
+#### Bug fixes
+
+- Lint rules `useNodejsImportProtocol`, `useNodeAssertStrict`, `noRestrictedImports`, `noNodejsModules` will no longer check `declare module` statements anymore. Contributed by @Sec-ant
+
 #### New features
 
 #### Enhancements

--- a/crates/biome_js_analyze/src/lint/nursery/no_nodejs_modules.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_nodejs_modules.rs
@@ -41,7 +41,11 @@ impl Rule for NoNodejsModules {
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let module_name = ctx.query().module_name_token()?;
+        let node = ctx.query();
+        if node.is_in_ts_module_declaration() {
+            return None;
+        }
+        let module_name = node.module_name_token()?;
         is_node_builtin_module(&inner_string_text(&module_name))
             .then_some(module_name.text_trimmed_range())
     }

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -49,7 +49,11 @@ impl Rule for NoRestrictedImports {
     type Options = Box<RestrictedImportsOptions>;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let module_name = ctx.query().module_name_token()?;
+        let node = ctx.query();
+        if node.is_in_ts_module_declaration() {
+            return None;
+        }
+        let module_name = node.module_name_token()?;
         let inner_text = inner_string_text(&module_name);
 
         ctx.options()

--- a/crates/biome_js_analyze/src/lint/nursery/use_node_assert_strict.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_node_assert_strict.rs
@@ -42,12 +42,13 @@ impl Rule for UseNodeAssertStrict {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-
-        let text = node.module_name_token()?;
-        if inner_string_text(&text) == "node:assert" {
-            return Some(text);
+        if node.is_in_ts_module_declaration() {
+            return None;
         }
-
+        let module_name = node.module_name_token()?;
+        if inner_string_text(&module_name) == "node:assert" {
+            return Some(module_name);
+        }
         None
     }
 

--- a/crates/biome_js_analyze/src/lint/style/use_nodejs_import_protocol.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_nodejs_import_protocol.rs
@@ -57,7 +57,11 @@ impl Rule for UseNodejsImportProtocol {
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let module_name = ctx.query().module_name_token()?;
+        let node = ctx.query();
+        if node.is_in_ts_module_declaration() {
+            return None;
+        }
+        let module_name = node.module_name_token()?;
         is_node_module_without_protocol(&inner_string_text(&module_name)).then_some(module_name)
     }
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noNodejsModules/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noNodejsModules/valid.ts
@@ -1,0 +1,1 @@
+declare module "node:fs" {}

--- a/crates/biome_js_analyze/tests/specs/nursery/noNodejsModules/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noNodejsModules/valid.ts.snap
@@ -1,0 +1,8 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```ts
+declare module "node:fs" {}
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.options.json
@@ -6,7 +6,9 @@
 				"noRestrictedImports": {
 					"level": "error",
 					"options": {
-						"paths": {}
+						"paths": {
+							"node:fs": "Importing from node:fs is forbidden"
+						}
 					}
 				}
 			}

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts
@@ -1,0 +1,1 @@
+declare module "node:fs" {}

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts.snap
@@ -1,0 +1,8 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```ts
+declare module "node:fs" {}
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useNodeAssertStrict/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNodeAssertStrict/valid.ts
@@ -1,0 +1,1 @@
+declare module "node:assert" {}

--- a/crates/biome_js_analyze/tests/specs/nursery/useNodeAssertStrict/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNodeAssertStrict/valid.ts.snap
@@ -1,0 +1,8 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```ts
+declare module "node:assert" {}
+```

--- a/crates/biome_js_analyze/tests/specs/style/useNodejsImportProtocol/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useNodejsImportProtocol/valid.ts
@@ -1,0 +1,1 @@
+declare module "module" {}

--- a/crates/biome_js_analyze/tests/specs/style/useNodejsImportProtocol/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNodejsImportProtocol/valid.ts.snap
@@ -1,0 +1,8 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```ts
+declare module "module" {}
+```

--- a/crates/biome_js_syntax/src/import_ext.rs
+++ b/crates/biome_js_syntax/src/import_ext.rs
@@ -319,11 +319,11 @@ impl AnyJsImportSpecifierLike {
     /// let module_source = make::js_module_source(make::js_string_literal("foo"));
     /// let module_declaration = make::ts_external_module_declaration(module_token, module_source).build();
     /// let any_import_specifier = AnyJsImportSpecifierLike::JsModuleSource(module_declaration.source().expect("module source"));
-    /// assert!(any_import_specifier.is_in_module_declaration());
+    /// assert!(any_import_specifier.is_in_ts_module_declaration());
     ///
     /// let module_source = make::js_module_source(make::js_string_literal("bar"));
     /// let any_import_specifier = AnyJsImportSpecifierLike::JsModuleSource(module_source);
-    /// assert!(!any_import_specifier.is_in_module_declaration());
+    /// assert!(!any_import_specifier.is_in_ts_module_declaration());
     /// ```
     pub fn is_in_ts_module_declaration(&self) -> bool {
         // It will first has to be a JsModuleSource

--- a/crates/biome_js_syntax/src/import_ext.rs
+++ b/crates/biome_js_syntax/src/import_ext.rs
@@ -326,7 +326,7 @@ impl AnyJsImportSpecifierLike {
     /// assert!(!any_import_specifier.is_in_ts_module_declaration());
     /// ```
     pub fn is_in_ts_module_declaration(&self) -> bool {
-        // It will first has to be a JsModuleSource
+        // It first has to be a JsModuleSource
         if !matches!(self, AnyJsImportSpecifierLike::JsModuleSource(_)) {
             return false;
         }

--- a/crates/biome_js_syntax/src/import_ext.rs
+++ b/crates/biome_js_syntax/src/import_ext.rs
@@ -332,9 +332,7 @@ impl AnyJsImportSpecifierLike {
         }
         // Then test whether its parent is a TsExternalModuleDeclaration
         if let Some(parent_syntax_kind) = self.syntax().parent().kind() {
-            if TsExternalModuleDeclaration::can_cast(parent_syntax_kind) {
-                return true;
-            }
+            return TsExternalModuleDeclaration::can_cast(parent_syntax_kind);
         }
         false
     }

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -35,6 +35,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Linter
 
+#### Bug fixes
+
+- Lint rules `useNodejsImportProtocol`, `useNodeAssertStrict`, `noRestrictedImports`, `noNodejsModules` will no longer check `declare module` statements anymore. Contributed by @Sec-ant
+
 #### New features
 
 #### Enhancements


### PR DESCRIPTION
## Summary

Rules `useNodejsImportProtocol`, `useNodeAssertStrict`, `noRestrictedImports` and `noNodejsModules` shouldn't check `declare module` statements.

```ts
declare module "node:assert" {} // <-- shouldn't check the module specifier at this place
```

I added a helper function `is_in_ts_module_declaration` to `AnyJsImportSpecifierLike`.

## Test Plan

Added a doc test for the helper function `is_in_ts_module_declaration`. Added valid cases for these rules.
