### PR TITLE
fix(js_analyzer): add graphics-symbol role

### DIFF
--- a/crates/biome_aria/src/roles.rs
+++ b/crates/biome_aria/src/roles.rs
@@ -728,6 +728,23 @@ define_role! {
 }
 
 define_role! {
+    /// https://w3c.github.io/graphics-aria/#graphics-object
+    GraphicsObjectRole {
+        PROPS: [],
+        ROLES: ["group"],
+        CONCEPTS: &[("graphics-document", &[]), ("group", &[]), ("img", &[]), ("graphics-symbol", &[])],
+    }
+}
+
+define_role! {
+    /// https://w3c.github.io/graphics-aria/#graphics-symbol
+    GraphicsSymbolRole {
+        PROPS: [],
+        ROLES: ["img"],
+    }
+}
+
+define_role! {
     /// https://www.w3.org/TR/wai-aria-1.2/#time
     TimeRole {
         PROPS: [],
@@ -871,6 +888,9 @@ impl<'a> AriaRoles {
         "status",
         "contentinfo",
         "region",
+        "graphics-document",
+        "graphics-object",
+        "graphics-symbol",
     ];
 
     /// It returns the metadata of a role, if it exits.
@@ -916,6 +936,9 @@ impl<'a> AriaRoles {
             "figure" => &FigureRole as &dyn AriaRoleDefinition,
             "form" => &FormRole as &dyn AriaRoleDefinition,
             "generic" => &GenericRole as &dyn AriaRoleDefinition,
+            "graphics-document" => &GraphicsDocumentRole as &dyn AriaRoleDefinition,
+            "graphics-object" => &GraphicsObjectRole as &dyn AriaRoleDefinition,
+            "graphics-symbol" => &GraphicsSymbolRole as &dyn AriaRoleDefinition,
             "grid" => &GridRole as &dyn AriaRoleDefinition,
             "gridcell" => &GridCellRole as &dyn AriaRoleDefinition,
             "group" => &GroupRole as &dyn AriaRoleDefinition,
@@ -1176,6 +1199,8 @@ impl<'a> AriaRoles {
                 "definition" => &DefinitionRole as &dyn AriaRoleDefinitionWithConcepts,
                 "figure" => &FigureRole as &dyn AriaRoleDefinitionWithConcepts,
                 "form" => &FormRole as &dyn AriaRoleDefinitionWithConcepts,
+                "graphics-document" => &GraphicsDocumentRole as &dyn AriaRoleDefinitionWithConcepts,
+                "graphics-object" => &GraphicsObjectRole as &dyn AriaRoleDefinitionWithConcepts,
                 "grid" => &GridRole as &dyn AriaRoleDefinitionWithConcepts,
                 "gridcell" => &GridCellRole as &dyn AriaRoleDefinitionWithConcepts,
                 "group" => &GroupRole as &dyn AriaRoleDefinitionWithConcepts,

--- a/crates/biome_js_analyze/src/lint/a11y/no_svg_without_title.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_svg_without_title.rs
@@ -36,6 +36,10 @@ declare_rule! {
     /// </svg>
     /// ```
     ///
+    /// ```js
+    /// <svg role="presentation">foo</svg>
+    /// ```
+    ///
     /// ### Valid
     ///
     /// ```js
@@ -72,12 +76,25 @@ declare_rule! {
     ///     <span id="title">Pass</span>
     /// </svg>
     /// ```
+    /// ```js
+    /// <svg role="graphics-symbol"><rect /></svg>
+    /// ```
+    ///
+    /// ```js
+    /// <svg role="graphics-symbol img"><rect /></svg>
+    /// ```
+    ///
+    /// ```js
+    /// <svg aria-hidden><rect /></svg>
+    /// ```
+    ///
     ///
     /// ## Accessibility guidelines
     /// [Document Structure – SVG 1.1 (Second Edition)](https://www.w3.org/TR/SVG11/struct.html#DescriptionAndTitleElements)
     /// [ARIA: img role - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role)
     /// [Accessible SVGs | CSS-Tricks - CSS-Tricks](https://css-tricks.com/accessible-svgs/)
     /// [Contextually Marking up accessible images and SVGs | scottohara.me](https://www.scottohara.me/blog/2019/05/22/contextual-images-svgs-and-a11y.html)
+    /// [Accessible SVGs](https://www.unimelb.edu.au/accessibility/techniques/accessible-svgs)
     ///
     pub NoSvgWithoutTitle {
         version: "1.0.0",

--- a/website/src/content/docs/linter/rules/no-svg-without-title.md
+++ b/website/src/content/docs/linter/rules/no-svg-without-title.md
@@ -78,6 +78,10 @@ To make svg accessible, the following methods are available:
 </svg>
 ```
 
+```jsx
+<svg role="presentation">foo</svg>
+```
+
 ### Valid
 
 ```jsx
@@ -115,12 +119,35 @@ To make svg accessible, the following methods are available:
 </svg>
 ```
 
+```jsx
+<svg role="graphics-symbol"><rect /></svg>
+```
+
+```jsx
+<svg role="graphics-symbol img"><rect /></svg>
+```
+
+```jsx
+<svg aria-hidden><rect /></svg>
+```
+
+a11y/noSvgWithoutTitle.js:1:1 <a href="https://biomejs.dev/linter/rules/no-svg-without-title">lint/a11y/noSvgWithoutTitle</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Alternative text </span><span style="color: Tomato;"><strong>title</strong></span><span style="color: Tomato;"> element cannot be empty</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>&lt;svg aria-hidden&gt;&lt;rect /&gt;&lt;/svg&gt;
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">For accessibility purposes, </span><span style="color: lightgreen;"><strong>SVGs</strong></span><span style="color: lightgreen;"> should have an alternative text, provided via </span><span style="color: lightgreen;"><strong>title</strong></span><span style="color: lightgreen;"> element. If the svg element has role=&quot;img&quot;, you should add the </span><span style="color: lightgreen;"><strong>aria-label</strong></span><span style="color: lightgreen;"> or </span><span style="color: lightgreen;"><strong>aria-labelledby</strong></span><span style="color: lightgreen;"> attribute.</span>
+  
 ## Accessibility guidelines
 
 [Document Structure – SVG 1.1 (Second Edition)](https://www.w3.org/TR/SVG11/struct.html#DescriptionAndTitleElements)
 [ARIA: img role - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role)
 [Accessible SVGs | CSS-Tricks - CSS-Tricks](https://css-tricks.com/accessible-svgs/)
 [Contextually Marking up accessible images and SVGs | scottohara.me](https://www.scottohara.me/blog/2019/05/22/contextual-images-svgs-and-a11y.html)
+[Accessible SVGs](https://www.unimelb.edu.au/accessibility/techniques/accessible-svgs)
 
 ## Related links
 


### PR DESCRIPTION
## Summary

Adds the `graphics-symbol` ARIA role which should be replaceable with `img` for valid SVG ARIA roles (and is more descriptive for icons). Updates possible usage from current recommendations from [an article from University at Melbourne](https://www.unimelb.edu.au/accessibility/techniques/accessible-svgs).

`jsx-a11y` had this same problem at one point, but I think that’s been [fixed already](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/756) and that currently supports these roles for SVGs, so this should just bring parity with that (or at least, that’s the intention)

Also adds `graphics-document` and `graphics-object` roles for completeness…but I might have messed something up? Open to feedback if something’s in the wrong place 🙂 

## Test Plan

- [x] Tests updated
