### PR TITLE
feat(cli): add --staged flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   ```
   </details>
 
+- Added new `--staged` flag to the `check`, `format` and `lint` subcommands.
+
+  This new option allows users to apply the command _only_ to the files that are staged (the
+  ones that will be committed), which can be very useful to simplify writting git hook scripts
+  such as `pre-commit`. Contributed by @castarco
+
 #### Enhancements
 
 - Improve support of `.prettierignore` when migrating from Prettier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Added new `--staged` flag to the `check`, `format` and `lint` subcommands.
 
   This new option allows users to apply the command _only_ to the files that are staged (the
-  ones that will be committed), which can be very useful to simplify writting git hook scripts
+  ones that will be committed), which can be very useful to simplify writing git hook scripts
   such as `pre-commit`. Contributed by @castarco
 
 #### Enhancements

--- a/crates/biome_cli/src/changed.rs
+++ b/crates/biome_cli/src/changed.rs
@@ -28,7 +28,9 @@ pub(crate) fn get_changed_files(
     Ok(filtered_changed_files)
 }
 
-pub(crate) fn get_staged_files(fs: &DynRef<'_, dyn FileSystem>) -> Result<Vec<OsString>, CliDiagnostic> {
+pub(crate) fn get_staged_files(
+    fs: &DynRef<'_, dyn FileSystem>,
+) -> Result<Vec<OsString>, CliDiagnostic> {
     let staged_files = fs.get_staged_files()?;
 
     let filtered_staged_files = staged_files.iter().map(OsString::from).collect::<Vec<_>>();

--- a/crates/biome_cli/src/changed.rs
+++ b/crates/biome_cli/src/changed.rs
@@ -27,3 +27,11 @@ pub(crate) fn get_changed_files(
 
     Ok(filtered_changed_files)
 }
+
+pub(crate) fn get_staged_files(fs: &DynRef<'_, dyn FileSystem>) -> Result<Vec<OsString>, CliDiagnostic> {
+    let staged_files = fs.get_staged_files()?;
+
+    let filtered_staged_files = staged_files.iter().map(OsString::from).collect::<Vec<_>>();
+
+    Ok(filtered_staged_files)
+}

--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -122,8 +122,13 @@ pub(crate) fn check(
 
     let stdin = get_stdin(stdin_file_path, &mut *session.app.console, "check")?;
 
-    if since.is_some() && !changed {
-        return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
+    if since.is_some() {
+        if !changed {
+            return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
+        }
+        if staged {
+            return Err(CliDiagnostic::incompatible_arguments("since", "staged"));
+        }
     }
 
     if changed && staged {

--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -1,6 +1,7 @@
-use crate::changed::{get_changed_files, get_staged_files};
 use crate::cli_options::CliOptions;
-use crate::commands::{get_stdin, resolve_manifest, validate_configuration_diagnostics};
+use crate::commands::{
+    get_files_to_process, get_stdin, resolve_manifest, validate_configuration_diagnostics,
+};
 use crate::{
     execute_mode, setup_cli_subscriber, CliDiagnostic, CliSession, Execution, TraversalMode,
 };
@@ -122,23 +123,12 @@ pub(crate) fn check(
 
     let stdin = get_stdin(stdin_file_path, &mut *session.app.console, "check")?;
 
-    if since.is_some() {
-        if !changed {
-            return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
-        }
-        if staged {
-            return Err(CliDiagnostic::incompatible_arguments("since", "staged"));
-        }
+    if let Some(_paths) =
+        get_files_to_process(since, changed, staged, &session.app.fs, &fs_configuration)?
+    {
+        paths = _paths;
     }
 
-    if changed {
-        if staged {
-            return Err(CliDiagnostic::incompatible_arguments("changed", "staged"));
-        }
-        paths = get_changed_files(&session.app.fs, &fs_configuration, since)?;
-    } else if staged {
-        paths = get_staged_files(&session.app.fs)?;
-    }
     session
         .app
         .workspace

--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -131,11 +131,10 @@ pub(crate) fn check(
         }
     }
 
-    if changed && staged {
-        return Err(CliDiagnostic::incompatible_arguments("changed", "staged"));
-    }
-
     if changed {
+        if staged {
+            return Err(CliDiagnostic::incompatible_arguments("changed", "staged"));
+        }
         paths = get_changed_files(&session.app.fs, &fs_configuration, since)?;
     } else if staged {
         paths = get_staged_files(&session.app.fs)?;

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -158,8 +158,13 @@ pub(crate) fn format(
     let (vcs_base_path, gitignore_matches) =
         configuration.retrieve_gitignore_matches(&session.app.fs, vcs_base_path.as_deref())?;
 
-    if since.is_some() && !changed {
-        return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
+    if since.is_some() {
+        if !changed {
+            return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
+        }
+        if staged {
+            return Err(CliDiagnostic::incompatible_arguments("since", "staged"));
+        }
     }
 
     if changed && staged {

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -167,11 +167,10 @@ pub(crate) fn format(
         }
     }
 
-    if changed && staged {
-        return Err(CliDiagnostic::incompatible_arguments("changed", "staged"));
-    }
-
     if changed {
+        if staged {
+            return Err(CliDiagnostic::incompatible_arguments("changed", "staged"));
+        }
         paths = get_changed_files(&session.app.fs, &configuration, since)?;
     } else if staged {
         paths = get_staged_files(&session.app.fs)?;

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -1,4 +1,4 @@
-use crate::changed::get_changed_files;
+use crate::changed::{get_changed_files, get_staged_files};
 use crate::cli_options::CliOptions;
 use crate::commands::{get_stdin, resolve_manifest, validate_configuration_diagnostics};
 use crate::diagnostics::DeprecatedArgument;
@@ -30,6 +30,7 @@ pub(crate) struct FormatCommandPayload {
     pub(crate) write: bool,
     pub(crate) cli_options: CliOptions,
     pub(crate) paths: Vec<OsString>,
+    pub(crate) staged: bool,
     pub(crate) changed: bool,
     pub(crate) since: Option<String>,
 }
@@ -51,6 +52,7 @@ pub(crate) fn format(
         mut json_formatter,
         mut css_formatter,
         since,
+        staged,
         changed,
     } = payload;
     setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
@@ -160,8 +162,14 @@ pub(crate) fn format(
         return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
     }
 
+    if changed && staged {
+        return Err(CliDiagnostic::incompatible_arguments("changed", "staged"));
+    }
+
     if changed {
         paths = get_changed_files(&session.app.fs, &configuration, since)?;
+    } else if staged {
+        paths = get_staged_files(&session.app.fs)?;
     }
 
     session

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -97,8 +97,13 @@ pub(crate) fn lint(session: CliSession, payload: LintCommandPayload) -> Result<(
     let (vcs_base_path, gitignore_matches) =
         fs_configuration.retrieve_gitignore_matches(&session.app.fs, vcs_base_path.as_deref())?;
 
-    if since.is_some() && !changed {
-        return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
+    if since.is_some() {
+        if !changed {
+            return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
+        }
+        if staged {
+            return Err(CliDiagnostic::incompatible_arguments("since", "staged"));
+        }
     }
 
     if changed && staged {

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -106,11 +106,10 @@ pub(crate) fn lint(session: CliSession, payload: LintCommandPayload) -> Result<(
         }
     }
 
-    if changed && staged {
-        return Err(CliDiagnostic::incompatible_arguments("changed", "staged"));
-    }
-
     if changed {
+        if staged {
+            return Err(CliDiagnostic::incompatible_arguments("changed", "staged"));
+        }
         paths = get_changed_files(&session.app.fs, &fs_configuration, since)?;
     } else if staged {
         paths = get_staged_files(&session.app.fs)?;

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -1,6 +1,7 @@
-use crate::changed::{get_changed_files, get_staged_files};
 use crate::cli_options::CliOptions;
-use crate::commands::{get_stdin, resolve_manifest, validate_configuration_diagnostics};
+use crate::commands::{
+    get_files_to_process, get_stdin, resolve_manifest, validate_configuration_diagnostics,
+};
 use crate::{
     execute_mode, setup_cli_subscriber, CliDiagnostic, CliSession, Execution, TraversalMode,
 };
@@ -97,22 +98,10 @@ pub(crate) fn lint(session: CliSession, payload: LintCommandPayload) -> Result<(
     let (vcs_base_path, gitignore_matches) =
         fs_configuration.retrieve_gitignore_matches(&session.app.fs, vcs_base_path.as_deref())?;
 
-    if since.is_some() {
-        if !changed {
-            return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
-        }
-        if staged {
-            return Err(CliDiagnostic::incompatible_arguments("since", "staged"));
-        }
-    }
-
-    if changed {
-        if staged {
-            return Err(CliDiagnostic::incompatible_arguments("changed", "staged"));
-        }
-        paths = get_changed_files(&session.app.fs, &fs_configuration, since)?;
-    } else if staged {
-        paths = get_staged_files(&session.app.fs)?;
+    if let Some(_paths) =
+        get_files_to_process(since, changed, staged, &session.app.fs, &fs_configuration)?
+    {
+        paths = _paths;
     }
 
     let stdin = get_stdin(stdin_file_path, &mut *session.app.console, "lint")?;

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+use crate::changed::{get_changed_files, get_staged_files};
 use crate::cli_options::{cli_options, CliOptions, ColorsArg};
 use crate::diagnostics::DeprecatedConfigurationFile;
 use crate::execute::Stdin;
@@ -14,11 +15,11 @@ use biome_configuration::{
 use biome_configuration::{ConfigurationDiagnostic, PartialConfiguration};
 use biome_console::{markup, Console, ConsoleExt};
 use biome_diagnostics::{Diagnostic, PrintDiagnostic};
-use biome_fs::BiomePath;
+use biome_fs::{BiomePath, FileSystem};
 use biome_service::configuration::LoadedConfiguration;
 use biome_service::documentation::Doc;
 use biome_service::workspace::{OpenProjectParams, UpdateProjectParams};
-use biome_service::WorkspaceError;
+use biome_service::{DynRef, WorkspaceError};
 use bpaf::Bpaf;
 use std::ffi::OsString;
 use std::path::PathBuf;
@@ -522,6 +523,34 @@ pub(crate) fn get_stdin(
     };
 
     Ok(stdin)
+}
+
+fn get_files_to_process(
+    since: Option<String>,
+    changed: bool,
+    staged: bool,
+    fs: &DynRef<'_, dyn FileSystem>,
+    configuration: &PartialConfiguration,
+) -> Result<Option<Vec<OsString>>, CliDiagnostic> {
+    if since.is_some() {
+        if !changed {
+            return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
+        }
+        if staged {
+            return Err(CliDiagnostic::incompatible_arguments("since", "staged"));
+        }
+    }
+
+    if changed {
+        if staged {
+            return Err(CliDiagnostic::incompatible_arguments("changed", "staged"));
+        }
+        Ok(Some(get_changed_files(fs, configuration, since)?))
+    } else if staged {
+        Ok(Some(get_staged_files(fs)?))
+    } else {
+        Ok(None)
+    }
 }
 
 /// Tests that all CLI options adhere to the invariants expected by `bpaf`.

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -109,6 +109,11 @@ pub enum BiomeCommand {
         #[bpaf(long("stdin-file-path"), argument("PATH"), hide_usage)]
         stdin_file_path: Option<String>,
 
+        /// When set to true, only the files that have been staged (the ones prepared to be committed)
+        /// will be linted.
+        #[bpaf(long("staged"), switch)]
+        staged: bool,
+
         /// When set to true, only the files that have been changed compared to your `defaultBranch`
         /// configuration will be linted.
         #[bpaf(long("changed"), switch)]
@@ -150,6 +155,10 @@ pub enum BiomeCommand {
         /// Example: `echo 'let a;' | biome lint --stdin-file-path=file.js`
         #[bpaf(long("stdin-file-path"), argument("PATH"), hide_usage)]
         stdin_file_path: Option<String>,
+        /// When set to true, only the files that have been staged (the ones prepared to be committed)
+        /// will be linted.
+        #[bpaf(long("staged"), switch)]
+        staged: bool,
         /// When set to true, only the files that have been changed compared to your `defaultBranch`
         /// configuration will be linted.
         #[bpaf(long("changed"), switch)]
@@ -196,6 +205,11 @@ pub enum BiomeCommand {
         /// Writes formatted files to file system.
         #[bpaf(switch)]
         write: bool,
+
+        /// When set to true, only the files that have been staged (the ones prepared to be committed)
+        /// will be linted.
+        #[bpaf(long("staged"), switch)]
+        staged: bool,
 
         /// When set to true, only the files that have been changed compared to your `defaultBranch`
         /// configuration will be linted.

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -88,6 +88,7 @@ impl<'app> CliSession<'app> {
                 linter_enabled,
                 organize_imports_enabled,
                 formatter_enabled,
+                staged,
                 changed,
                 since,
             } => commands::check::check(
@@ -102,6 +103,7 @@ impl<'app> CliSession<'app> {
                     linter_enabled,
                     organize_imports_enabled,
                     formatter_enabled,
+                    staged,
                     changed,
                     since,
                 },
@@ -115,6 +117,7 @@ impl<'app> CliSession<'app> {
                 stdin_file_path,
                 vcs_configuration,
                 files_configuration,
+                staged,
                 changed,
                 since,
             } => commands::lint::lint(
@@ -128,6 +131,7 @@ impl<'app> CliSession<'app> {
                     stdin_file_path,
                     vcs_configuration,
                     files_configuration,
+                    staged,
                     changed,
                     since,
                 },
@@ -165,6 +169,7 @@ impl<'app> CliSession<'app> {
                 files_configuration,
                 json_formatter,
                 css_formatter,
+                staged,
                 changed,
                 since,
             } => commands::format::format(
@@ -180,6 +185,7 @@ impl<'app> CliSession<'app> {
                     files_configuration,
                     json_formatter,
                     css_formatter,
+                    staged,
                     changed,
                     since,
                 },

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -3014,14 +3014,7 @@ fn should_error_if_changed_flag_and_staged_flag_are_active_at_the_same_time() {
     let result = run_cli(
         DynRef::Borrowed(&mut fs),
         &mut console,
-        Args::from(
-            [
-                ("lint"),
-                "--staged",
-                "--changed"
-            ]
-            .as_slice(),
-        ),
+        Args::from([("lint"), "--staged", "--changed"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -3044,24 +3037,27 @@ fn should_only_processes_staged_files_when_staged_flag_is_set() {
     fs.set_on_get_changed_files(Box::new(|| vec![String::from("changed.js")]));
 
     // Staged (prepared to be committed)
-    fs.insert(Path::new("staged.js").into(), r#"console.log('staged');"#.as_bytes());
+    fs.insert(
+        Path::new("staged.js").into(),
+        r#"console.log('staged');"#.as_bytes(),
+    );
 
     // Changed (already recorded in git history)
-    fs.insert( Path::new("changed.js").into(), r#"console.log('changed');"#.as_bytes());
+    fs.insert(
+        Path::new("changed.js").into(),
+        r#"console.log('changed');"#.as_bytes(),
+    );
 
     // Unstaged (not yet recorded in git history, and not prepared to be committed)
-    fs.insert(Path::new("file2.js").into(), r#"console.log('file2');"#.as_bytes());
+    fs.insert(
+        Path::new("file2.js").into(),
+        r#"console.log('file2');"#.as_bytes(),
+    );
 
     let result = run_cli(
         DynRef::Borrowed(&mut fs),
         &mut console,
-        Args::from(
-            [
-                ("lint"),
-                "--staged",
-            ]
-            .as_slice(),
-        ),
+        Args::from([("lint"), "--staged"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -3100,19 +3096,19 @@ fn should_only_process_staged_file_if_its_included() {
         .as_bytes(),
     );
 
-    fs.insert(Path::new("file.js").into(), r#"console.log('file');"#.as_bytes());
-    fs.insert(Path::new("file2.js").into(), r#"console.log('file2');"#.as_bytes());
+    fs.insert(
+        Path::new("file.js").into(),
+        r#"console.log('file');"#.as_bytes(),
+    );
+    fs.insert(
+        Path::new("file2.js").into(),
+        r#"console.log('file2');"#.as_bytes(),
+    );
 
     let result = run_cli(
         DynRef::Borrowed(&mut fs),
         &mut console,
-        Args::from(
-            [
-                ("lint"),
-                "--staged",
-            ]
-            .as_slice(),
-        ),
+        Args::from([("lint"), "--staged"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -3149,19 +3145,19 @@ fn should_not_process_ignored_file_even_if_its_staged() {
         .as_bytes(),
     );
 
-    fs.insert(Path::new("file.js").into(), r#"console.log('file');"#.as_bytes());
-    fs.insert(Path::new("file2.js").into(), r#"console.log('file2');"#.as_bytes());
+    fs.insert(
+        Path::new("file.js").into(),
+        r#"console.log('file');"#.as_bytes(),
+    );
+    fs.insert(
+        Path::new("file2.js").into(),
+        r#"console.log('file2');"#.as_bytes(),
+    );
 
     let result = run_cli(
         DynRef::Borrowed(&mut fs),
         &mut console,
-        Args::from(
-            [
-                ("lint"),
-                "--staged",
-            ]
-            .as_slice(),
-        ),
+        Args::from([("lint"), "--staged"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -7,7 +7,7 @@ expression: content
 ```block
 Runs formatter, linter and import sorting to the requested files.
 
-Usage: check [--apply] [--apply-unsafe] [--changed] [--since=REF] [PATH]...
+Usage: check [--apply] [--apply-unsafe] [--staged] [--changed] [--since=REF] [PATH]...
 
 The configuration that is contained inside the file `biome.json`
         --vcs-client-kind=<git>  The kind of client.
@@ -116,6 +116,8 @@ Available options:
                               The file doesn't need to exist on disk, what matters is the extension of
                               the file. Based on the extension, Biome knows how to check the code.
                               Example: `echo 'let a;' | biome check --stdin-file-path=file.js`
+        --staged              When set to true, only the files that have been staged (the ones prepared
+                              to be committed) will be linted.
         --changed             When set to true, only the files that have been changed compared to your
                               `defaultBranch` configuration will be linted.
         --since=REF           Use this to specify the base branch to compare against when you're using

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -7,7 +7,7 @@ expression: content
 ```block
 Run the formatter on a set of files.
 
-Usage: format [--write] [--changed] [--since=REF] [PATH]...
+Usage: format [--write] [--staged] [--changed] [--since=REF] [PATH]...
 
 Generic options applied to all files
         --indent-style=<tab|space>  The indent style.
@@ -118,6 +118,8 @@ Available options:
                               the file. Based on the extension, Biome knows how to format the code.
                               Example: `echo 'let a;' | biome format --stdin-file-path=file.js`
         --write               Writes formatted files to file system.
+        --staged              When set to true, only the files that have been staged (the ones prepared
+                              to be committed) will be linted.
         --changed             When set to true, only the files that have been changed compared to your
                               `defaultBranch` configuration will be linted.
         --since=REF           Use this to specify the base branch to compare against when you're using

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -7,7 +7,7 @@ expression: content
 ```block
 Run various checks on a set of files.
 
-Usage: lint [--apply] [--apply-unsafe] [--changed] [--since=REF] [PATH]...
+Usage: lint [--apply] [--apply-unsafe] [--staged] [--changed] [--since=REF] [PATH]...
 
 Set of properties to integrate Biome with a VCS software.
         --vcs-client-kind=<git>  The kind of client.
@@ -66,6 +66,8 @@ Available options:
                               The file doesn't need to exist on disk, what matters is the extension of
                               the file. Based on the extension, Biome knows how to lint the code.
                               Example: `echo 'let a;' | biome lint --stdin-file-path=file.js`
+        --staged              When set to true, only the files that have been staged (the ones prepared
+                              to be committed) will be linted.
         --changed             When set to true, only the files that have been changed compared to your
                               `defaultBranch` configuration will be linted.
         --since=REF           Use this to specify the base branch to compare against when you're using

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_changed_flag_and_staged_flag_are_active_at_the_same_time.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_changed_flag_and_staged_flag_are_active_at_the_same_time.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+# Termination Message
+
+```block
+flags/invalid ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Incompatible arguments changed and staged
+  
+
+
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_process_ignored_file_even_if_its_staged.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_process_ignored_file_even_if_its_staged.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "files": {
+    "ignore": ["file.js"]
+  },
+  "vcs": {
+    "defaultBranch": "main"
+  }
+}
+```
+
+## `file.js`
+
+```js
+console.log('file');
+```
+
+## `file2.js`
+
+```js
+console.log('file2');
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × No files were processed in the specified paths.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Checked 0 files in <TIME>. No fixes needed.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_only_process_staged_file_if_its_included.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_only_process_staged_file_if_its_included.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "files": {
+    "include": ["file.js"]
+  },
+  "vcs": {
+    "defaultBranch": "main"
+  }
+}
+```
+
+## `file.js`
+
+```js
+console.log('file');
+```
+
+## `file2.js`
+
+```js
+console.log('file2');
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_only_processes_staged_files_when_staged_flag_is_set.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_only_processes_staged_files_when_staged_flag_is_set.snap
@@ -1,0 +1,27 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `changed.js`
+
+```js
+console.log('changed');
+```
+
+## `file2.js`
+
+```js
+console.log('file2');
+```
+
+## `staged.js`
+
+```js
+console.log('staged');
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+```

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -180,6 +180,8 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
 
     fn get_changed_files(&self, base: &str) -> io::Result<Vec<String>>;
 
+    fn get_staged_files(&self) -> io::Result<Vec<String>>;
+
     fn resolve_configuration(
         &self,
         specifier: &str,
@@ -359,6 +361,10 @@ where
 
     fn get_changed_files(&self, base: &str) -> io::Result<Vec<String>> {
         T::get_changed_files(self, base)
+    }
+
+    fn get_staged_files(&self) -> io::Result<Vec<String>> {
+        T::get_staged_files(self)
     }
 
     fn resolve_configuration(

--- a/crates/biome_fs/src/fs/memory.rs
+++ b/crates/biome_fs/src/fs/memory.rs
@@ -29,6 +29,7 @@ pub struct MemoryFileSystem {
     errors: FxHashMap<PathBuf, ErrorEntry>,
     allow_write: bool,
     on_get_changed_files: OnGetChangedFiles,
+    on_get_staged_files: OnGetChangedFiles,
 }
 
 impl Default for MemoryFileSystem {
@@ -38,6 +39,9 @@ impl Default for MemoryFileSystem {
             errors: Default::default(),
             allow_write: true,
             on_get_changed_files: Some(Arc::new(AssertUnwindSafe(Mutex::new(Some(Box::new(
+                Vec::new,
+            )))))),
+            on_get_staged_files: Some(Arc::new(AssertUnwindSafe(Mutex::new(Some(Box::new(
                 Vec::new,
             )))))),
         }
@@ -109,6 +113,13 @@ impl MemoryFileSystem {
         cfn: Box<dyn FnOnce() -> Vec<String> + Send + RefUnwindSafe + 'static>,
     ) {
         self.on_get_changed_files = Some(Arc::new(AssertUnwindSafe(Mutex::new(Some(cfn)))));
+    }
+
+    pub fn set_on_get_staged_files(
+        &mut self,
+        cfn: Box<dyn FnOnce() -> Vec<String> + Send + RefUnwindSafe + 'static>,
+    ) {
+        self.on_get_staged_files = Some(Arc::new(AssertUnwindSafe(Mutex::new(Some(cfn)))));
     }
 }
 
@@ -201,6 +212,16 @@ impl FileSystem for MemoryFileSystem {
 
     fn get_changed_files(&self, _base: &str) -> io::Result<Vec<String>> {
         let cb_arc = self.on_get_changed_files.as_ref().unwrap().clone();
+
+        let mut cb_guard = cb_arc.lock();
+
+        let cb = cb_guard.take().unwrap();
+
+        Ok(cb())
+    }
+
+    fn get_staged_files(&self) -> io::Result<Vec<String>> {
+        let cb_arc = self.on_get_staged_files.as_ref().unwrap().clone();
 
         let mut cb_guard = cb_arc.lock();
 

--- a/crates/biome_fs/src/fs/memory.rs
+++ b/crates/biome_fs/src/fs/memory.rs
@@ -28,8 +28,8 @@ pub struct MemoryFileSystem {
     files: AssertUnwindSafe<RwLock<FxHashMap<PathBuf, FileEntry>>>,
     errors: FxHashMap<PathBuf, ErrorEntry>,
     allow_write: bool,
-    on_get_changed_files: OnGetChangedFiles,
     on_get_staged_files: OnGetChangedFiles,
+    on_get_changed_files: OnGetChangedFiles,
 }
 
 impl Default for MemoryFileSystem {
@@ -38,10 +38,10 @@ impl Default for MemoryFileSystem {
             files: Default::default(),
             errors: Default::default(),
             allow_write: true,
-            on_get_changed_files: Some(Arc::new(AssertUnwindSafe(Mutex::new(Some(Box::new(
+            on_get_staged_files: Some(Arc::new(AssertUnwindSafe(Mutex::new(Some(Box::new(
                 Vec::new,
             )))))),
-            on_get_staged_files: Some(Arc::new(AssertUnwindSafe(Mutex::new(Some(Box::new(
+            on_get_changed_files: Some(Arc::new(AssertUnwindSafe(Mutex::new(Some(Box::new(
                 Vec::new,
             )))))),
         }

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -128,6 +128,7 @@ impl FileSystem for OsFileSystem {
         let output = Command::new("git")
             .arg("diff")
             .arg("--name-only")
+            .arg("--relative")
             .arg("--staged")
             // A: added
             // C: copied

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -123,6 +123,25 @@ impl FileSystem for OsFileSystem {
             .map(|l| l.to_string())
             .collect())
     }
+
+    fn get_staged_files(&self) -> io::Result<Vec<String>> {
+        let output = Command::new("git")
+            .arg("diff")
+            .arg("--name-only")
+            .arg("--staged")
+            // A: added
+            // C: copied
+            // M: modified
+            // R: renamed
+            // Source: https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203
+            .arg("--diff-filter=ACMR")
+            .output()?;
+
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(|l| l.to_string())
+            .collect())
+    }
 }
 
 struct OsFile {

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -176,7 +176,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Added new `--staged` flag to the `check`, `format` and `lint` subcommands.
 
   This new option allows users to apply the command _only_ to the files that are staged (the
-  ones that will be committed), which can be very useful to simplify writting git hook scripts
+  ones that will be committed), which can be very useful to simplify writing git hook scripts
   such as `pre-commit`. Contributed by @castarco
 
 #### Enhancements

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -173,6 +173,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   ```
   </details>
 
+- Added new `--staged` flag to the `check`, `format` and `lint` subcommands.
+
+  This new option allows users to apply the command _only_ to the files that are staged (the
+  ones that will be committed), which can be very useful to simplify writting git hook scripts
+  such as `pre-commit`. Contributed by @castarco
+
 #### Enhancements
 
 - Improve support of `.prettierignore` when migrating from Prettier


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR introduces a new `--staged` flag that allows `biome` to select only the files that are staged to be committed.

### Motivation

#### Long version

- Fixes #2296
- Related Discord discussion: https://discord.com/channels/1132231889290285117/1222450681919832134

#### TLDR

There is some semblance with `--changed`, but its behaviour is different:
- `--changed` is useful to run certain checks in CI environment, selecting only the files that changed between two git "refs" (they can be explicit or implicit).
- In contrast, `--staged` is useful in local environments, to be used in git hooks such as `pre-commit`.

## Test Plan

- I introduced new unit tests covering basic behaviour changes
- I tested the generated binary manually to verify that it works exactly as expected

## "Mixed" Performance Results

What follows is for a very small repository.

### When there are no changes

Performance is slightly better

<img width="660" alt="Screenshot 2024-04-04 at 14 28 49" src="https://github.com/biomejs/biome/assets/251364/a502f0ea-cd72-4ea2-8759-5395871f3f61">

### When there is a small number of changes 

Performance is slightly worse 🤔, I suspect that this because of the extra `git` call.

<img width="660" alt="Screenshot 2024-04-04 at 14 28 28" src="https://github.com/biomejs/biome/assets/251364/da69a25f-c060-475c-9b2e-5a9e9bfb64ac">

I hypothesize that this extra overhead should be "absorbed" in bigger repositories with many more files.