### PR TITLE
docs(lint/noDuplicateTestHooks): fix rule source

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_duplicate_test_hooks.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_duplicate_test_hooks.rs
@@ -60,7 +60,7 @@ declare_rule! {
         version: "1.6.0",
         name: "noDuplicateTestHooks",
         recommended: true,
-        source: RuleSource::EslintJest("no-focused-tests"),
+        source: RuleSource::EslintJest("no-duplicate-hooks"),
         source_kind: RuleSourceKind::Inspired,
     }
 }

--- a/website/src/content/docs/linter/rules/no-duplicate-test-hooks.md
+++ b/website/src/content/docs/linter/rules/no-duplicate-test-hooks.md
@@ -8,7 +8,7 @@ title: noDuplicateTestHooks (since v1.6.0)
 This rule is part of the [nursery](/linter/rules/#nursery) group.
 :::
 
-Inspired from: <a href="https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md" target="_blank"><code>no-focused-tests</code></a>
+Inspired from: <a href="https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-duplicate-hooks.md" target="_blank"><code>no-duplicate-hooks</code></a>
 
 A `describe` block should not contain duplicate hooks.
 


### PR DESCRIPTION
## Summary

Fix rule source of `noDuplicateTestHooks`

## Test Plan

CI should pass.
