### PR TITLE
feat(lint/noUnusedImports): add ignoreReact option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,15 +43,20 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Linter
 
-#### Bug fixes
-
-- Lint rules `useNodejsImportProtocol`, `useNodeAssertStrict`, `noRestrictedImports`, `noNodejsModules` will no longer check `declare module` statements anymore. Contributed by @Sec-ant
-
 #### New features
+
+- Add a new option `ignoreReact` to [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports).
+
+  When `ignoreReact` is enabled, Biome ignores imports of `React` from the `react` package.
+  The option is disabled by default.
+
+  Contributed by @Conaclos
 
 #### Enhancements
 
 #### Bug fixes
+
+- Lint rules `useNodejsImportProtocol`, `useNodeAssertStrict`, `noRestrictedImports`, `noNodejsModules` will no longer check `declare module` statements anymore. Contributed by @Sec-ant
 
 ### Parser
 

--- a/crates/biome_js_analyze/src/react.rs
+++ b/crates/biome_js_analyze/src/react.rs
@@ -4,9 +4,10 @@ pub mod hooks;
 
 use biome_js_semantic::{Binding, SemanticModel};
 use biome_js_syntax::{
-    AnyJsCallArgument, AnyJsExpression, AnyJsMemberExpression, AnyJsNamedImportSpecifier,
-    AnyJsObjectMember, JsCallExpression, JsIdentifierBinding, JsImport, JsObjectExpression,
-    JsPropertyObjectMember, JsxMemberName, JsxReferenceIdentifier,
+    binding_ext::AnyJsBindingDeclaration, AnyJsCallArgument, AnyJsExpression,
+    AnyJsMemberExpression, AnyJsNamedImportSpecifier, AnyJsObjectMember, JsCallExpression,
+    JsIdentifierBinding, JsImport, JsObjectExpression, JsPropertyObjectMember, JsxMemberName,
+    JsxReferenceIdentifier,
 };
 use biome_rowan::{AstNode, AstSeparatedList};
 
@@ -290,4 +291,38 @@ fn is_named_react_export(binding: &Binding, lib: ReactLibrary, name: &str) -> Op
 
     let import = import_specifier.import_clause()?.parent::<JsImport>()?;
     Some(import.source_text().ok()?.text() == lib.import_name())
+}
+
+/// Checks if `binding` is an import of the global name of `lib`.
+pub(crate) fn is_global_react_import(binding: &JsIdentifierBinding, lib: ReactLibrary) -> bool {
+    if !binding
+        .name_token()
+        .is_ok_and(|name| name.text_trimmed() == lib.global_name())
+    {
+        return false;
+    };
+    let Some(decl) = binding.declaration() else {
+        return false;
+    };
+    // This must be a default import or a namespace import
+    let syntax = match decl {
+        AnyJsBindingDeclaration::JsNamedImportSpecifier(specifier) => {
+            if !specifier.name().is_ok_and(|name| name.is_default()) {
+                return false;
+            }
+            specifier.into_syntax()
+        }
+        AnyJsBindingDeclaration::JsDefaultImportSpecifier(specifier) => specifier.into_syntax(),
+        AnyJsBindingDeclaration::JsNamespaceImportSpecifier(specifier) => specifier.into_syntax(),
+        _ => {
+            return false;
+        }
+    };
+    // Check import source
+    syntax
+        .ancestors()
+        .skip(1)
+        .find_map(JsImport::cast)
+        .and_then(|import| import.source_text().ok())
+        .is_some_and(|source| source.text() == lib.import_name())
 }

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-unused-react.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-unused-react.jsx
@@ -1,0 +1,8 @@
+import X from "react"
+import * as X from "react"
+import { default as X } from "react"
+
+import React from "x"
+import * as React from "x"
+import { default as React } from "x"
+import React, { useEffect } from "x"

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-unused-react.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-unused-react.jsx.snap
@@ -1,0 +1,199 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid-unused-react.jsx
+---
+# Input
+```jsx
+import X from "react"
+import * as X from "react"
+import { default as X } from "react"
+
+import React from "x"
+import * as React from "x"
+import { default as React } from "x"
+import React, { useEffect } from "x"
+
+```
+
+# Diagnostics
+```
+invalid-unused-react.jsx:1:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+  > 1 │ import X from "react"
+      │        ^
+    2 │ import * as X from "react"
+    3 │ import { default as X } from "react"
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Safe fix: Remove the unused import.
+  
+    1 │ import·X·from·"react"
+      │ ---------------------
+
+```
+
+```
+invalid-unused-react.jsx:2:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+    1 │ import X from "react"
+  > 2 │ import * as X from "react"
+      │             ^
+    3 │ import { default as X } from "react"
+    4 │ 
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Safe fix: Remove the unused import.
+  
+    1 1 │   import X from "react"
+    2   │ - import·*·as·X·from·"react"
+    3 2 │   import { default as X } from "react"
+    4 3 │   
+  
+
+```
+
+```
+invalid-unused-react.jsx:3:21 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+    1 │ import X from "react"
+    2 │ import * as X from "react"
+  > 3 │ import { default as X } from "react"
+      │                     ^
+    4 │ 
+    5 │ import React from "x"
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Safe fix: Remove the unused import.
+  
+    1 1 │   import X from "react"
+    2 2 │   import * as X from "react"
+    3   │ - import·{·default·as·X·}·from·"react"
+    4 3 │   
+    5 4 │   import React from "x"
+  
+
+```
+
+```
+invalid-unused-react.jsx:5:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+    3 │ import { default as X } from "react"
+    4 │ 
+  > 5 │ import React from "x"
+      │        ^^^^^
+    6 │ import * as React from "x"
+    7 │ import { default as React } from "x"
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Safe fix: Remove the unused import.
+  
+    2 2 │   import * as X from "react"
+    3 3 │   import { default as X } from "react"
+    4   │ - 
+    5   │ - import·React·from·"x"
+    6 4 │   import * as React from "x"
+    7 5 │   import { default as React } from "x"
+  
+
+```
+
+```
+invalid-unused-react.jsx:6:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+    5 │ import React from "x"
+  > 6 │ import * as React from "x"
+      │             ^^^^^
+    7 │ import { default as React } from "x"
+    8 │ import React, { useEffect } from "x"
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Safe fix: Remove the unused import.
+  
+    4 4 │   
+    5 5 │   import React from "x"
+    6   │ - import·*·as·React·from·"x"
+    7 6 │   import { default as React } from "x"
+    8 7 │   import React, { useEffect } from "x"
+  
+
+```
+
+```
+invalid-unused-react.jsx:7:21 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+    5 │ import React from "x"
+    6 │ import * as React from "x"
+  > 7 │ import { default as React } from "x"
+      │                     ^^^^^
+    8 │ import React, { useEffect } from "x"
+    9 │ 
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Safe fix: Remove the unused import.
+  
+    5 5 │   import React from "x"
+    6 6 │   import * as React from "x"
+    7   │ - import·{·default·as·React·}·from·"x"
+    8 7 │   import React, { useEffect } from "x"
+    9 8 │   
+  
+
+```
+
+```
+invalid-unused-react.jsx:8:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+    6 │ import * as React from "x"
+    7 │ import { default as React } from "x"
+  > 8 │ import React, { useEffect } from "x"
+      │        ^^^^^
+    9 │ 
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Safe fix: Remove the unused import.
+  
+    8 │ import·React,·{·useEffect·}·from·"x"
+      │        -------                      
+
+```
+
+```
+invalid-unused-react.jsx:8:17 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+    6 │ import * as React from "x"
+    7 │ import { default as React } from "x"
+  > 8 │ import React, { useEffect } from "x"
+      │                 ^^^^^^^^^
+    9 │ 
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Safe fix: Remove the unused import.
+  
+    8 │ import·React,·{·useEffect·}·from·"x"
+      │             ---------------         
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-unused-react.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-unused-react.options.json
@@ -1,0 +1,14 @@
+{
+    "linter": {
+        "rules": {
+            "correctness": {
+                "noUnusedImports": {
+                    "level": "error",
+                    "options": {
+                        "ignoreReact": true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-unused-react.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-unused-react.jsx
@@ -1,0 +1,3 @@
+import React from "react"
+import { default as React } from "react"
+import * as React from "react"

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-unused-react.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-unused-react.jsx.snap
@@ -1,0 +1,11 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-unused-react.jsx
+---
+# Input
+```jsx
+import React from "react"
+import { default as React } from "react"
+import * as React from "react"
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-unused-react.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-unused-react.options.json
@@ -1,0 +1,14 @@
+{
+    "linter": {
+        "rules": {
+            "correctness": {
+                "noUnusedImports": {
+                    "level": "error",
+                    "options": {
+                        "ignoreReact": true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -834,7 +834,7 @@ export interface Correctness {
 	/**
 	 * Disallow unused imports.
 	 */
-	noUnusedImports?: RuleConfiguration_for_Null;
+	noUnusedImports?: RuleConfiguration_for_UnusedImportsOptions;
 	/**
 	 * Disallow unused labels.
 	 */
@@ -1481,6 +1481,9 @@ export type RuleConfiguration_for_ValidAriaRoleOptions =
 export type RuleConfiguration_for_ComplexityOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_ComplexityOptions;
+export type RuleConfiguration_for_UnusedImportsOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_UnusedImportsOptions;
 export type RuleConfiguration_for_HooksOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_HooksOptions;
@@ -1517,6 +1520,10 @@ export interface RuleWithOptions_for_ValidAriaRoleOptions {
 export interface RuleWithOptions_for_ComplexityOptions {
 	level: RulePlainConfiguration;
 	options: ComplexityOptions;
+}
+export interface RuleWithOptions_for_UnusedImportsOptions {
+	level: RulePlainConfiguration;
+	options: UnusedImportsOptions;
 }
 export interface RuleWithOptions_for_HooksOptions {
 	level: RulePlainConfiguration;
@@ -1562,6 +1569,12 @@ export interface ComplexityOptions {
 	 * The maximum complexity score that we allow. Anything higher is considered excessive.
 	 */
 	maxAllowedComplexity: number;
+}
+export interface UnusedImportsOptions {
+	/**
+	 * Ignore `React` imports from the `react` package when set to `true`.
+	 */
+	ignoreReact: boolean;
 }
 /**
  * Options for the rule `useExhaustiveDependencies`

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -737,7 +737,7 @@
 				"noUnusedImports": {
 					"description": "Disallow unused imports.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/UnusedImportsConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1872,6 +1872,15 @@
 			},
 			"additionalProperties": false
 		},
+		"RuleWithUnusedImportsOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
+				"options": { "$ref": "#/definitions/UnusedImportsOptions" }
+			},
+			"additionalProperties": false
+		},
 		"RuleWithUtilityClassSortingOptions": {
 			"type": "object",
 			"required": ["level", "options"],
@@ -2696,6 +2705,23 @@
 					"enum": ["all"]
 				}
 			]
+		},
+		"UnusedImportsConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithUnusedImportsOptions" }
+			]
+		},
+		"UnusedImportsOptions": {
+			"type": "object",
+			"required": ["ignoreReact"],
+			"properties": {
+				"ignoreReact": {
+					"description": "Ignore `React` imports from the `react` package when set to `true`.",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
 		},
 		"UtilityClassSortingConfiguration": {
 			"anyOf": [

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -49,15 +49,20 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Linter
 
-#### Bug fixes
-
-- Lint rules `useNodejsImportProtocol`, `useNodeAssertStrict`, `noRestrictedImports`, `noNodejsModules` will no longer check `declare module` statements anymore. Contributed by @Sec-ant
-
 #### New features
+
+- Add a new option `ignoreReact` to [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports).
+
+  When `ignoreReact` is enabled, Biome ignores imports of `React` from the `react` package.
+  The option is disabled by default.
+
+  Contributed by @Conaclos
 
 #### Enhancements
 
 #### Bug fixes
+
+- Lint rules `useNodejsImportProtocol`, `useNodeAssertStrict`, `noRestrictedImports`, `noNodejsModules` will no longer check `declare module` statements anymore. Contributed by @Sec-ant
 
 ### Parser
 

--- a/website/src/content/docs/linter/rules/no-unused-imports.md
+++ b/website/src/content/docs/linter/rules/no-unused-imports.md
@@ -14,6 +14,25 @@ Note that the leading trivia, e.g., comments or newlines preceding
 the unused imports will also be removed. So that comment directives
 like `@ts-expect-error` won't be transferred to a wrong place.
 
+## Options
+
+The rule provides a single option `ignoreReact`.
+When this option is set to `true`, imports named `React` from the package `react` are ignored.
+`ignoreReact` is disabled by default.
+
+```json
+{
+    "//": "...",
+    "options": {
+        "ignoreReact": true
+    }
+}
+```
+
+This option should only be necessary if you cannot upgrade to a React version that supports the new JSX runtime.
+In the new JSX runtime, you no longer need to import `React`.
+You can find more details in [this comment](https://github.com/biomejs/biome/issues/571#issuecomment-1774026734).
+
 ## Examples
 
 ### Invalid


### PR DESCRIPTION
## Summary

Fix #571

Add a new option to `noUnusedImports` to ignore imports of React.
This was requested by many users.

## Test Plan

I added new tests.