### PR TITLE
fix(file_handler): svelte & vue script language parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Analyzer
 
+#### Bug fixes
+
+- Now Biome can detect the script language in Svelte and Vue script blocks more reliably ([#2245](https://github.com/biomejs/biome/issues/2245)). Contributed by @Sec-ant
+
 ### CLI
 
 #### Bug fixes

--- a/crates/biome_cli/tests/cases/handle_svelte_files.rs
+++ b/crates/biome_cli/tests/cases/handle_svelte_files.rs
@@ -6,15 +6,27 @@ use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
-const SVELTE_FILE_IMPORTS_BEFORE: &str = r#"<script setup lang="ts">
+const SVELTE_FILE_IMPORTS_BEFORE: &str = r#"<script lang="ts">
 import Button from "./components/Button.svelte";
 import * as svelteUse from "svelte-use";
 </script>
 <div></div>"#;
 
-const SVELTE_FILE_IMPORTS_AFTER: &str = r#"<script setup lang="ts">
+const SVELTE_FILE_IMPORTS_AFTER: &str = r#"<script lang="ts">
 import * as svelteUse from "svelte-use";
 import Button from "./components/Button.svelte";
+</script>
+<div></div>"#;
+
+const SVELTE_TS_CONTEXT_MODULE_FILE_UNFORMATTED: &str = r#"<script context="module" lang="ts">
+import     Button     from "./components/Button.svelte";
+const hello  :      string      = "world";
+</script>
+<div></div>"#;
+
+const SVELTE_TS_CONTEXT_MODULE_FILE_FORMATTED: &str = r#"<script context="module" lang="ts">
+import Button from "./components/Button.svelte";
+const hello: string = "world";
 </script>
 <div></div>"#;
 
@@ -23,9 +35,9 @@ fn sorts_imports_check() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let astro_file_path = Path::new("file.svelte");
+    let svelte_file_path = Path::new("file.svelte");
     fs.insert(
-        astro_file_path.into(),
+        svelte_file_path.into(),
         SVELTE_FILE_IMPORTS_BEFORE.as_bytes(),
     );
 
@@ -37,7 +49,7 @@ fn sorts_imports_check() {
                 ("check"),
                 "--formatter-enabled=false",
                 "--linter-enabled=false",
-                astro_file_path.as_os_str().to_str().unwrap(),
+                svelte_file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
         ),
@@ -45,7 +57,7 @@ fn sorts_imports_check() {
 
     assert!(result.is_err(), "run_cli returned {result:?}");
 
-    assert_file_contents(&fs, astro_file_path, SVELTE_FILE_IMPORTS_BEFORE);
+    assert_file_contents(&fs, svelte_file_path, SVELTE_FILE_IMPORTS_BEFORE);
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
@@ -61,9 +73,9 @@ fn sorts_imports_write() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let astro_file_path = Path::new("file.svelte");
+    let svelte_file_path = Path::new("file.svelte");
     fs.insert(
-        astro_file_path.into(),
+        svelte_file_path.into(),
         SVELTE_FILE_IMPORTS_BEFORE.as_bytes(),
     );
 
@@ -76,7 +88,7 @@ fn sorts_imports_write() {
                 "--formatter-enabled=false",
                 "--linter-enabled=false",
                 "--apply",
-                astro_file_path.as_os_str().to_str().unwrap(),
+                svelte_file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
         ),
@@ -84,11 +96,86 @@ fn sorts_imports_write() {
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
-    assert_file_contents(&fs, astro_file_path, SVELTE_FILE_IMPORTS_AFTER);
+    assert_file_contents(&fs, svelte_file_path, SVELTE_FILE_IMPORTS_AFTER);
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "sorts_imports_write",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_svelte_ts_context_module_files() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let svelte_file_path = Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        SVELTE_TS_CONTEXT_MODULE_FILE_UNFORMATTED.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), svelte_file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_file_contents(
+        &fs,
+        svelte_file_path,
+        SVELTE_TS_CONTEXT_MODULE_FILE_UNFORMATTED,
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_svelte_ts_context_module_files",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_svelte_ts_context_module_files_write() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let svelte_file_path = Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        SVELTE_TS_CONTEXT_MODULE_FILE_UNFORMATTED.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                "format",
+                "--write",
+                svelte_file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(
+        &fs,
+        svelte_file_path,
+        SVELTE_TS_CONTEXT_MODULE_FILE_FORMATTED,
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_svelte_ts_context_module_files_write",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_ts_context_module_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_ts_context_module_files.snap
@@ -1,0 +1,47 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.svelte`
+
+```svelte
+<script context="module" lang="ts">
+import     Button     from "./components/Button.svelte";
+const hello  :      string      = "world";
+</script>
+<div></div>
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.svelte format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1 1 │   <script context="module" lang="ts">
+    2   │ - import·····Button·····from·"./components/Button.svelte";
+    3   │ - const·hello··:······string······=·"world";
+      2 │ + import·Button·from·"./components/Button.svelte";
+      3 │ + const·hello:·string·=·"world";
+    4 4 │   </script>
+    5 5 │   <div></div>
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_ts_context_module_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_ts_context_module_files_write.snap
@@ -5,9 +5,9 @@ expression: content
 ## `file.svelte`
 
 ```svelte
-<script lang="ts">
-import * as svelteUse from "svelte-use";
+<script context="module" lang="ts">
 import Button from "./components/Button.svelte";
+const hello: string = "world";
 </script>
 <div></div>
 ```
@@ -15,5 +15,5 @@ import Button from "./components/Button.svelte";
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. Fixed 1 file.
+Formatted 1 file in <TIME>. Fixed 1 file.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
@@ -5,7 +5,7 @@ expression: content
 ## `file.svelte`
 
 ```svelte
-<script setup lang="ts">
+<script lang="ts">
 import Button from "./components/Button.svelte";
 import * as svelteUse from "svelte-use";
 </script>
@@ -30,7 +30,7 @@ file.svelte organizeImports ━━━━━━━━━━━━━━━━━�
 
   × Import statements could be sorted:
   
-    1 1 │   <script setup lang="ts">
+    1 1 │   <script lang="ts">
     2   │ - import·Button·from·"./components/Button.svelte";
     3   │ - import·*·as·svelteUse·from·"svelte-use";
       2 │ + import·*·as·svelteUse·from·"svelte-use";

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -564,7 +564,7 @@ pub(crate) fn is_diagnostic_error(
 /// We use the JSX parser at the moment to parse the opening tag. So the opening tag should be first
 /// matched by regular expressions.
 ///
-/// TODO: We should change the parser when HTMLish languages are supported.
+// TODO: We should change the parser when HTMLish languages are supported.
 pub(crate) fn parse_lang_from_script_opening_tag(script_opening_tag: &str) -> Language {
     parse(
         script_opening_tag,

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -11,12 +11,14 @@ use crate::WorkspaceError;
 use biome_formatter::Printed;
 use biome_fs::BiomePath;
 use biome_js_parser::{parse_js_with_cache, JsParserOptions};
-use biome_js_syntax::{EmbeddingKind, JsFileSource, TextRange, TextSize};
+use biome_js_syntax::{EmbeddingKind, JsFileSource, Language, TextRange, TextSize};
 use biome_parser::AnyParse;
 use biome_rowan::NodeCache;
 use lazy_static::lazy_static;
 use regex::{Match, Regex};
 use tracing::debug;
+
+use super::parse_lang_from_script_opening_tag;
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct SvelteFileHandler;
@@ -24,13 +26,7 @@ pub struct SvelteFileHandler;
 lazy_static! {
     // https://regex101.com/r/E4n4hh/3
     pub static ref SVELTE_FENCE: Regex = Regex::new(
-        r#"(?ixms)(?:<script[^>]?)
-            (?:
-            (?:(lang)\s*=\s*['"](?P<lang>[^'"]*)['"])
-            |
-            (?:(\w+)\s*(?:=\s*['"]([^'"]*)['"])?)
-            )*
-        [^>]*>\n(?P<script>(?U:.*))</script>"#
+        r#"(?ixms)(?<opening><script[^>]*>)\n(?P<script>(?U:.*))</script>"#
     )
     .unwrap();
 }
@@ -73,13 +69,17 @@ impl SvelteFileHandler {
     }
 
     pub fn file_source(text: &str) -> JsFileSource {
-        let matches = SVELTE_FENCE.captures(text);
-        matches
-            .and_then(|captures| captures.name("lang"))
-            .filter(|lang| lang.as_str() == "ts")
-            .map_or(JsFileSource::js_module(), |_| {
-                JsFileSource::ts().with_embedding_kind(EmbeddingKind::Svelte)
+        SVELTE_FENCE
+            .captures(text)
+            .and_then(|captures| {
+                match parse_lang_from_script_opening_tag(captures.name("opening")?.as_str()) {
+                    Language::JavaScript => None,
+                    Language::TypeScript { .. } => {
+                        Some(JsFileSource::ts().with_embedding_kind(EmbeddingKind::Svelte))
+                    }
+                }
             })
+            .map_or(JsFileSource::js_module(), |fs| fs)
     }
 }
 
@@ -119,20 +119,12 @@ fn parse(
     _settings: SettingsHandle,
     cache: &mut NodeCache,
 ) -> ParseResult {
-    let matches = SVELTE_FENCE.captures(text);
-    let script = match matches {
-        Some(ref captures) => &text[captures.name("script").unwrap().range()],
-        _ => "",
-    };
+    let script = SvelteFileHandler::input(text);
+    let file_source = SvelteFileHandler::file_source(text);
 
-    let language = matches
-        .and_then(|captures| captures.name("lang"))
-        .filter(|lang| lang.as_str() == "ts")
-        .map_or(JsFileSource::js_module(), |_| JsFileSource::ts());
+    debug!("Parsing file with language {:?}", file_source);
 
-    debug!("Parsing file with language {:?}", language);
-
-    let parse = parse_js_with_cache(script, language, JsParserOptions::default(), cache);
+    let parse = parse_js_with_cache(script, file_source, JsParserOptions::default(), cache);
     let root = parse.syntax();
     let diagnostics = parse.into_diagnostics();
 
@@ -142,11 +134,7 @@ fn parse(
             root.as_send().unwrap(),
             diagnostics,
         ),
-        language: Some(if language.is_typescript() {
-            JsFileSource::ts().into()
-        } else {
-            JsFileSource::js_module().into()
-        }),
+        language: Some(file_source.into()),
     }
 }
 

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -19,6 +19,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Analyzer
 
+#### Bug fixes
+
+- Now Biome can detect the script language in Svelte and Vue script blocks more reliably ([#2245](https://github.com/biomejs/biome/issues/2245)). Contributed by @Sec-ant
+
 ### CLI
 
 #### Bug fixes


### PR DESCRIPTION
## Summary

Use the JSX flavor JavaScript parser to parse the opening tags of the script blocks in Svelte and Vue files so we can parse the language of the script in them more reliably.

Closes #2245.

## Test Plan

Test cases are added.
