### PR TITLE
fix(cli): skip files outside the current directory when using --changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### Bug fixes
 
 - Biome now tags the diagnostics emitted by `organizeImports` and `formatter` with correct severity levels, so they will be properly filtered by the flag `--diagnositic-level` ([#2288](https://github.com/biomejs/biome/issues/2288)). Contributed by @Sec-ant
+- Biome now correctly filters out files that are not present in the current directory when using the `--changed` flag [#1996](https://github.com/biomejs/biome/issues/1996).
 
 #### New features
 

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -100,6 +100,7 @@ impl FileSystem for OsFileSystem {
         let output = Command::new("git")
             .arg("diff")
             .arg("--name-only")
+            .arg("--relative")
             // A: added
             // C: copied
             // M: modified

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -24,6 +24,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### Bug fixes
 
 - Biome now tags the diagnostics emitted by `organizeImports` and `formatter` with correct severity levels, so they will be properly filtered by the flag `--diagnositic-level` ([#2288](https://github.com/biomejs/biome/issues/2288)). Contributed by @Sec-ant
+- Biome now correctly filters out files that are not present in the current directory when using the `--changed` flag [#1996](https://github.com/biomejs/biome/issues/1996).
 
 #### New features
 


### PR DESCRIPTION
## Summary

When running `lint`, `check` or `format` with the flag `--changed`, ensure that files outside the current directory are filtered out before processing them.

Fixes #1996 .

## Test Plan

- Tested it manually at different nested directory levels (including the "root" directory).
- Note that it is difficult to introduce an automated regression test without big changes because the memory filesystem used in tests doesn't allow us to check if the flags we pass to `git` are correct or not.
