### PR TITLE
feat(migrate-prettier): support js configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   When loading a legacy ESLint configuration, Biome resolves the `extends` field.
   It resolves both shared configurations and plugin presets!
-  To do this, it invokes NodeJS.
+  To do this, it invokes _Node.js_.
 
   Biome relies on the metadata of its rules to determine the [equivalent rule of an ESLint rule](https://biomejs.dev/linter/rules-sources/).
   A Biome rule is either inspired or roughly identical to an ESLint rules.
@@ -103,7 +103,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   `@biomejs/biome migrate prettier` is now able to migrate Prettier configuration files
   ending with `js`, `mjs`, or `cjs` extensions.
-  To do this, Biome invokes NodeJs.
+  To do this, Biome invokes Node.js.
 
   Also, embedded Prettier configurations in `package.json` are now supported.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### CLI
 
-#### Bug fixes
-
-- Biome now tags the diagnostics emitted by `organizeImports` and `formatter` with correct severity levels, so they will be properly filtered by the flag `--diagnositic-level` ([#2288](https://github.com/biomejs/biome/issues/2288)). Contributed by @Sec-ant
-- Biome now correctly filters out files that are not present in the current directory when using the `--changed` flag [#1996](https://github.com/biomejs/biome/issues/1996).
-
 #### New features
 
 - Add a command to migrate from ESLint
@@ -103,6 +98,22 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Only negated glob patterns are not supported.
 
   Contributed by @Conaclos
+
+- Support JavaScript configuration files when migrating from Prettier
+
+  `@biomejs/biome migrate prettier` is now able to migrate Prettier configuration files
+  ending with `js`, `mjs`, or `cjs` extensions.
+  To do this, Biome invokes NodeJs.
+
+  Also, embedded Prettier configurations in `package.json` are now supported.
+
+  Contributed by @Conaclos
+
+#### Bug fixes
+
+- Biome now tags the diagnostics emitted by `organizeImports` and `formatter` with correct severity levels, so they will be properly filtered by the flag `--diagnositic-level` ([#2288](https://github.com/biomejs/biome/issues/2288)). Contributed by @Sec-ant
+
+- Biome now correctly filters out files that are not present in the current directory when using the `--changed` flag [#1996](https://github.com/biomejs/biome/issues/1996). Contributed by @castarco
 
 ### Configuration
 

--- a/crates/biome_cli/src/execute/migrate/eslint.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint.rs
@@ -29,7 +29,7 @@ use super::node;
 ///
 /// See https://eslint.org/docs/latest/use/configure/configuration-files-new
 const FLAT_CONFIG_FILES: [&str; 3] = [
-    // Prefixed with `./` to ensure that it is loadable via NodeJS's `import()`
+    // Prefixed with `./` to ensure that it is loadable via Node.js's `import()`
     "./eslint.config.js",
     "./eslint.config.mjs",
     "./eslint.config.cjs",
@@ -43,9 +43,9 @@ const FLAT_CONFIG_FILES: [&str; 3] = [
 /// It translates the priority of the files.
 /// For example, ESLint looks for `./.eslintrc.js` before looking for `./.eslintrc.json`.
 const LEGACY_CONFIG_FILES: [&str; 5] = [
-    // Prefixed with `./` to ensure that it is loadable via NodeJS's `import()`
+    // Prefixed with `./` to ensure that it is loadable via Node.js's `import()`
     "./.eslintrc.js",
-    // Prefixed with `./` to ensure that it is loadable via NodeJS's `import()`
+    // Prefixed with `./` to ensure that it is loadable via Node.js's `import()`
     "./.eslintrc.cjs",
     ".eslintrc.yaml",
     ".eslintrc.yml",

--- a/crates/biome_cli/src/execute/migrate/eslint.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint.rs
@@ -95,15 +95,12 @@ pub(crate) fn read_eslint_config(
             });
         }
     }
-    let path = Path::new(PACKAGE_JSON);
-    if fs.path_exists(path) {
-        // We don't report errors in `PACKAGE_JSON`.
-        if let Ok(data) = load_legacy_config_data(fs, path, console) {
-            return Ok(Config {
-                path: PACKAGE_JSON,
-                data: data.into(),
-            });
-        }
+    // We don't report an error if ESLint config is not embedded in `PACKAGE_JSON`.
+    if let Ok(data) = load_legacy_config_data(fs, Path::new(PACKAGE_JSON), console) {
+        return Ok(Config {
+            path: PACKAGE_JSON,
+            data: data.into(),
+        });
     }
     Err(CliDiagnostic::MigrateError(MigrationDiagnostic { reason: "The default ESLint configuration file `.eslintrc.*` was not found in the working directory.".to_string()}))
 }

--- a/crates/biome_cli/src/execute/migrate/ignorefile.rs
+++ b/crates/biome_cli/src/execute/migrate/ignorefile.rs
@@ -4,6 +4,8 @@ use biome_fs::{FileSystem, OpenOptions};
 use biome_service::DynRef;
 use indexmap::IndexSet;
 
+/// Read an ignore file that follows gitignore pattern syntax,
+/// and turn them into a list of UNIX glob patterns.
 pub(crate) fn read_ignore_file(
     fs: &DynRef<'_, dyn FileSystem>,
     ignore_filename: &str,

--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -1,9 +1,5 @@
 use crate::diagnostics::MigrationDiagnostic;
 use crate::CliDiagnostic;
-use biome_configuration::{
-    PartialConfiguration, PartialFormatterConfiguration, PartialJavascriptConfiguration,
-    PartialJavascriptFormatter, PlainIndentStyle,
-};
 use biome_console::{markup, Console, ConsoleExt};
 use biome_deserialize::json::deserialize_from_json_str;
 use biome_deserialize_macros::Deserializable;
@@ -13,7 +9,23 @@ use biome_fs::{FileSystem, OpenOptions};
 use biome_js_formatter::context::{ArrowParentheses, QuoteProperties, Semicolons, TrailingComma};
 use biome_json_parser::JsonParserOptions;
 use biome_service::DynRef;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+
+use super::node;
+
+#[derive(Debug, Default, Deserializable)]
+#[deserializable(unknown_fields = "allow")]
+pub(crate) struct PrettierPackageJson {
+    pub(crate) prettier: Option<PrettierConfiguration>,
+}
+
+#[derive(Debug)]
+pub(crate) struct Config {
+    /// Path of the ESlint config file
+    pub(crate) path: &'static str,
+    /// Resolved ESlint config
+    pub(crate) data: PrettierConfiguration,
+}
 
 #[derive(Clone, Debug, Deserializable, Eq, PartialEq)]
 #[deserializable(unknown_fields = "allow")]
@@ -48,7 +60,6 @@ impl Default for PrettierConfiguration {
     fn default() -> Self {
         Self {
             print_width: 80,
-
             use_tabs: false,
             trailing_comma: PrettierTrailingComma::default(),
             tab_width: 2,
@@ -96,18 +107,6 @@ enum QuoteProps {
     Preserve,
 }
 
-impl TryFrom<&str> for PrettierTrailingComma {
-    type Error = String;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value {
-            "all" => Ok(Self::All),
-            "none" => Ok(Self::None),
-            "es5" => Ok(Self::Es5),
-            _ => Err("Option not supported".to_string()),
-        }
-    }
-}
-
 impl From<PrettierTrailingComma> for TrailingComma {
     fn from(value: PrettierTrailingComma) -> Self {
         match value {
@@ -147,16 +146,18 @@ impl From<QuoteProps> for QuoteProperties {
     }
 }
 
-impl TryFrom<PrettierConfiguration> for PartialFormatterConfiguration {
+impl TryFrom<PrettierConfiguration> for biome_configuration::PartialConfiguration {
     type Error = String;
     fn try_from(value: PrettierConfiguration) -> Result<Self, Self::Error> {
+        let mut result = biome_configuration::PartialConfiguration::default();
+
         let line_width = LineWidth::try_from(value.print_width).map_err(|err| err.to_string())?;
         let indent_style = if value.use_tabs {
-            PlainIndentStyle::Tab
+            biome_configuration::PlainIndentStyle::Tab
         } else {
-            PlainIndentStyle::Space
+            biome_configuration::PlainIndentStyle::Space
         };
-        Ok(Self {
+        let formatter = biome_configuration::PartialFormatterConfiguration {
             indent_width: Some(value.tab_width),
             line_width: Some(line_width),
             indent_style: Some(indent_style),
@@ -168,12 +169,9 @@ impl TryFrom<PrettierConfiguration> for PartialFormatterConfiguration {
             enabled: Some(true),
             // deprecated
             indent_size: None,
-        })
-    }
-}
+        };
+        result.formatter = Some(formatter);
 
-impl From<PrettierConfiguration> for PartialJavascriptFormatter {
-    fn from(value: PrettierConfiguration) -> Self {
         let semicolons = if value.semi {
             Semicolons::Always
         } else {
@@ -189,7 +187,7 @@ impl From<PrettierConfiguration> for PartialJavascriptFormatter {
         } else {
             QuoteStyle::Double
         };
-        Self {
+        let js_formatter = biome_configuration::PartialJavascriptFormatter {
             indent_width: None,
             line_width: None,
             indent_style: None,
@@ -208,137 +206,137 @@ impl From<PrettierConfiguration> for PartialJavascriptFormatter {
             bracket_spacing: Some(value.bracket_spacing),
             jsx_quote_style: Some(jsx_quote_style),
             attribute_position: Some(AttributePosition::default()),
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-pub(crate) struct FromPrettierConfiguration {
-    /// Path of the Prettier configuration file
-    configuration_path: Option<PathBuf>,
-
-    /// The translated Biome configuration, from the Prettier configuration
-    formatter_configuration: Option<PartialFormatterConfiguration>,
-
-    /// The translated Biome configuration, from the Prettier configuration
-    javascript_formatter_configuration: Option<PartialJavascriptFormatter>,
-}
-
-impl FromPrettierConfiguration {
-    pub(crate) fn store_configuration(
-        &mut self,
-        (formatter, javascript_formatter): (
-            PartialFormatterConfiguration,
-            PartialJavascriptFormatter,
-        ),
-    ) {
-        self.formatter_configuration = Some(formatter);
-        self.javascript_formatter_configuration = Some(javascript_formatter);
-    }
-
-    pub(crate) fn store_configuration_path(&mut self, path: impl Into<PathBuf>) {
-        self.configuration_path = Some(path.into());
-    }
-
-    pub(crate) fn as_biome_configuration(&self) -> PartialConfiguration {
-        let mut configuration = PartialConfiguration {
-            formatter: self.formatter_configuration.clone(),
+        };
+        let js_config = biome_configuration::PartialJavascriptConfiguration {
+            formatter: Some(js_formatter),
             ..Default::default()
         };
-        if self.javascript_formatter_configuration.is_some() {
-            configuration.javascript = Some(PartialJavascriptConfiguration {
-                formatter: self.javascript_formatter_configuration.clone(),
-                ..Default::default()
-            });
-        }
-
-        configuration
-    }
-
-    pub(crate) fn has_configuration(&self) -> bool {
-        self.formatter_configuration.is_some() || self.javascript_formatter_configuration.is_some()
-    }
-
-    pub(crate) fn get_configuration_path(&self) -> Option<&Path> {
-        self.configuration_path.as_deref()
+        result.javascript = Some(js_config);
+        Ok(result)
     }
 }
 
-const CONFIG_FILES: [&str; 2] = [".prettierrc", ".prettierrc.json"];
+/// A Prettier config can be embedded in `package.json`
+const PACKAGE_JSON: &str = "package.json";
+
+/// Prettie config files ordered by precedence
+const CONFIG_FILES: [&str; 8] = [
+    ".prettierrc",
+    ".prettierrc.json",
+    // Prefixed with `./` to ensure that it is loadable via NodeJS's `import()`
+    "./.prettierrc.js",
+    "./prettier.config.js",
+    "./.prettierrc.mjs",
+    "./prettier.config.mjs",
+    "./.prettierrc.cjs",
+    "./prettier.config.cjs",
+];
+
+/// Prettier Ignore file. Use the same syntax as gitignore.
 pub(crate) const IGNORE_FILE: &str = ".prettierignore";
-/// This function is in charge of reading prettier files, deserialize its contents and convert them in a Biome configuration type
-pub(crate) fn read_prettier_files(
+
+/// This function is in charge of reading prettier files, deserialize its contents
+pub(crate) fn read_config_file(
     fs: &DynRef<'_, dyn FileSystem>,
     console: &mut dyn Console,
-) -> Result<FromPrettierConfiguration, CliDiagnostic> {
-    let mut from_prettier_configuration = FromPrettierConfiguration::default();
-    let mut prettier_config_content = String::new();
+) -> Result<Config, CliDiagnostic> {
+    // We don't report an error if Prettier config is not embedded in `PACKAGE_JSON`.
+    if let Ok(data) = load_config(fs, Path::new(PACKAGE_JSON), console) {
+        return Ok(Config {
+            path: PACKAGE_JSON,
+            data,
+        });
+    }
     for config_name in CONFIG_FILES {
-        let open_options = OpenOptions::default().read(true);
         let path = Path::new(config_name);
-        let file = fs.open_with_options(path, open_options);
-        match file {
-            Ok(mut file) => {
-                let result = file.read_to_string(&mut prettier_config_content);
-                if let Err(err) = result {
-                    return Err(CliDiagnostic::io_error(err));
-                }
-                from_prettier_configuration.store_configuration_path(path);
-
-                break;
-            }
-            Err(_) => {
-                continue;
-            }
+        if fs.path_exists(path) {
+            return Ok(Config {
+                path: config_name,
+                data: load_config(fs, path, console)?,
+            });
         }
     }
+    Err(CliDiagnostic::MigrateError(MigrationDiagnostic {
+        reason: "Biome couldn't find a Prettier configuration file.".to_string(),
+    }))
+}
 
-    if prettier_config_content.is_empty() {
-        return Err(CliDiagnostic::MigrateError(MigrationDiagnostic {
-            reason: "Biome couldn't find a Prettier configuration file.".to_string(),
-        }));
-    }
-
-    let deserialized = deserialize_from_json_str::<PrettierConfiguration>(
-        prettier_config_content.as_str(),
-        JsonParserOptions::default()
-            .with_allow_trailing_commas()
-            .with_allow_comments(),
-        "",
-    );
-
-    if deserialized.has_errors() {
-        let diagnostics = deserialized.into_diagnostics();
-        for diagnostic in diagnostics {
-            let diagnostic =
-                if let Some(path) = from_prettier_configuration.get_configuration_path() {
-                    diagnostic.with_file_path(path.display().to_string())
-                } else {
-                    diagnostic
-                };
-            console.error(markup! {{PrintDiagnostic::simple(&diagnostic)}});
+fn load_config(
+    fs: &DynRef<'_, dyn FileSystem>,
+    path: &Path,
+    console: &mut dyn Console,
+) -> Result<PrettierConfiguration, CliDiagnostic> {
+    let (deserialized, diagnostics) = match path.extension().and_then(|file_ext| file_ext.to_str())
+    {
+        Some("json") | None => {
+            let mut file = fs.open_with_options(path, OpenOptions::default().read(true))?;
+            let mut content = String::new();
+            file.read_to_string(&mut content)?;
+            if path.file_name().is_some_and(|name| name == PACKAGE_JSON) {
+                let (deserialized, _) = deserialize_from_json_str::<PrettierPackageJson>(
+                    &content,
+                    JsonParserOptions::default()
+                        .with_allow_trailing_commas()
+                        .with_allow_comments(),
+                    "",
+                )
+                .consume();
+                (
+                    deserialized.and_then(|packagejson| packagejson.prettier),
+                    vec![],
+                )
+            } else {
+                deserialize_from_json_str::<PrettierConfiguration>(
+                    &content,
+                    JsonParserOptions::default()
+                        .with_allow_trailing_commas()
+                        .with_allow_comments(),
+                    "",
+                )
+                .consume()
+            }
         }
-        return Err(CliDiagnostic::MigrateError(MigrationDiagnostic {
-            reason: "Could not deserialize the Prettier configuration file".to_string(),
-        }));
+        Some("js" | "mjs" | "cjs") => {
+            let node::Resolution { content, .. } = node::load_config(&path.to_string_lossy())?;
+            deserialize_from_json_str::<PrettierConfiguration>(
+                &content,
+                JsonParserOptions::default(),
+                "",
+            )
+            .consume()
+        }
+        Some(ext) => {
+            return Err(CliDiagnostic::MigrateError(MigrationDiagnostic {
+                reason: format!(
+                    "Prettier configuration ending with the extension `{ext}` are not supported."
+                ),
+            }))
+        }
+    };
+    let path_str = path.to_string_lossy();
+    for diagnostic in diagnostics.into_iter().filter(|diag| {
+        matches!(
+            diag.severity(),
+            biome_diagnostics::Severity::Fatal
+                | biome_diagnostics::Severity::Error
+                | biome_diagnostics::Severity::Warning
+        )
+    }) {
+        let diagnostic = diagnostic.with_file_path(path_str.to_string());
+        console.error(markup! {{PrintDiagnostic::simple(&diagnostic)}});
+    }
+    if let Some(result) = deserialized {
+        if result.end_of_line == EndOfLine::Auto {
+            console.log(markup! {
+                <Warn>"Prettier's `\"endOfLine\": \"auto\"` option is not supported in Biome. The default `\"lf\"` option is used instead."</Warn>
+            });
+        }
+        Ok(result)
     } else {
-        let prettier_configuration = deserialized.into_deserialized();
-        if let Some(prettier_configuration) = prettier_configuration {
-            if prettier_configuration.end_of_line == EndOfLine::Auto {
-                console.log(markup! {
-                    <Warn>"Prettier's `\"endOfLine\": \"auto\"` option is not supported in Biome. The default `\"lf\"` option is used instead."</Warn>
-                });
-            }
-            let formatter_configuration = prettier_configuration
-                .clone()
-                .try_into()
-                .map_err(|err| CliDiagnostic::MigrateError(MigrationDiagnostic { reason: err }))?;
-            let javascript_configuration = prettier_configuration.into();
-            from_prettier_configuration
-                .store_configuration((formatter_configuration, javascript_configuration));
-        }
+        Err(CliDiagnostic::MigrateError(MigrationDiagnostic {
+            reason: "Could not deserialize the Prettier configuration file".to_string(),
+        }))
     }
-    Ok(from_prettier_configuration)
 }
 
 #[cfg(test)]

--- a/crates/biome_cli/tests/commands/migrate_prettier.rs
+++ b/crates/biome_cli/tests/commands/migrate_prettier.rs
@@ -231,6 +231,72 @@ fn prettier_migrate_write() {
 }
 
 #[test]
+fn prettierjson_migrate_write() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let configuration = r#"{ "linter": { "enabled": true } }"#;
+    let prettier = r#"{ "useTabs": false, "semi": true, "singleQuote": true }"#;
+
+    let configuration_path = Path::new("biome.json");
+    fs.insert(configuration_path.into(), configuration.as_bytes());
+
+    let prettier_path = Path::new(".prettierrc.json");
+    fs.insert(prettier_path.into(), prettier.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("migrate"), "prettier", "--write"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "prettierjson_migrate_write",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn prettier_migrate_write_packagejson() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let configuration = r#"{ "linter": { "enabled": true } }"#;
+    let prettier = r#"{
+        "name": "Foo",
+        "version": "0.0.0",
+        "prettier": { "useTabs": false, "semi": true, "singleQuote": true }
+    }"#;
+
+    let configuration_path = Path::new("biome.json");
+    fs.insert(configuration_path.into(), configuration.as_bytes());
+
+    let prettier_path = Path::new("package.json");
+    fs.insert(prettier_path.into(), prettier.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("migrate"), "prettier", "--write"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "prettier_migrate_write_packagejson",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn prettier_migrate_write_with_ignore_file() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_packagejson.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_packagejson.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "attributePosition": "auto"
+  },
+  "linter": { "enabled": true },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingComma": "all",
+      "semicolons": "always",
+      "arrowParentheses": "always",
+      "bracketSpacing": true,
+      "bracketSameLine": false,
+      "quoteStyle": "single",
+      "attributePosition": "auto"
+    }
+  }
+}
+```
+
+## `package.json`
+
+```json
+{
+        "name": "Foo",
+        "version": "0.0.0",
+        "prettier": { "useTabs": false, "semi": true, "singleQuote": true }
+    }
+```
+
+# Emitted Messages
+
+```block
+package.json has been successfully migrated.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_yml_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_yml_file.snap
@@ -19,58 +19,9 @@ useTabs: true
 ```block
 migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Migration has encountered an error: Could not deserialize the Prettier configuration file
+  × Migration has encountered an error: Could not deserialize the Prettier configuration file.
+    Only JSON configurations are supported.
   
 
-
-```
-
-# Emitted Messages
-
-```block
-.prettierrc:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × String values must be double quoted.
-  
-  > 1 │ useTabs: true
-      │ ^^^^^^^
-  
-
-```
-
-```block
-.prettierrc:1:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × End of file expected
-  
-  > 1 │ useTabs: true
-      │        ^
-  
-  i Use an array for a sequence of values: `[1, 2]`
-  
-
-```
-
-```block
-.prettierrc:1:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × End of file expected
-  
-  > 1 │ useTabs: true
-      │          ^^^^
-  
-  i Use an array for a sequence of values: `[1, 2]`
-  
-
-```
-
-```block
-.prettierrc:1:1 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Incorrect type, expected an object, but received an array.
-  
-  > 1 │ useTabs: true
-      │ ^^^^^^^^^^^^^
-  
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettierjson_migrate_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettierjson_migrate_write.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "attributePosition": "auto"
+  },
+  "linter": { "enabled": true },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingComma": "all",
+      "semicolons": "always",
+      "arrowParentheses": "always",
+      "bracketSpacing": true,
+      "bracketSameLine": false,
+      "quoteStyle": "single",
+      "attributePosition": "auto"
+    }
+  }
+}
+```
+
+## `.prettierrc.json`
+
+```json
+{ "useTabs": false, "semi": true, "singleQuote": true }
+```
+
+# Emitted Messages
+
+```block
+.prettierrc.json has been successfully migrated.
+```

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -35,7 +35,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   When loading a legacy ESLint configuration, Biome resolves the `extends` field.
   It resolves both shared configurations and plugin presets!
-  To do this, it invokes NodeJS.
+  To do this, it invokes _Node.js_.
 
   Biome relies on the metadata of its rules to determine the [equivalent rule of an ESLint rule](https://biomejs.dev/linter/rules-sources/).
   A Biome rule is either inspired or roughly identical to an ESLint rules.
@@ -109,7 +109,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   `@biomejs/biome migrate prettier` is now able to migrate Prettier configuration files
   ending with `js`, `mjs`, or `cjs` extensions.
-  To do this, Biome invokes NodeJs.
+  To do this, Biome invokes Node.js.
 
   Also, embedded Prettier configurations in `package.json` are now supported.
 

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -25,11 +25,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### CLI
 
-#### Bug fixes
-
-- Biome now tags the diagnostics emitted by `organizeImports` and `formatter` with correct severity levels, so they will be properly filtered by the flag `--diagnositic-level` ([#2288](https://github.com/biomejs/biome/issues/2288)). Contributed by @Sec-ant
-- Biome now correctly filters out files that are not present in the current directory when using the `--changed` flag [#1996](https://github.com/biomejs/biome/issues/1996).
-
 #### New features
 
 - Add a command to migrate from ESLint
@@ -109,6 +104,22 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Only negated glob patterns are not supported.
 
   Contributed by @Conaclos
+
+- Support JavaScript configuration files when migrating from Prettier
+
+  `@biomejs/biome migrate prettier` is now able to migrate Prettier configuration files
+  ending with `js`, `mjs`, or `cjs` extensions.
+  To do this, Biome invokes NodeJs.
+
+  Also, embedded Prettier configurations in `package.json` are now supported.
+
+  Contributed by @Conaclos
+
+#### Bug fixes
+
+- Biome now tags the diagnostics emitted by `organizeImports` and `formatter` with correct severity levels, so they will be properly filtered by the flag `--diagnositic-level` ([#2288](https://github.com/biomejs/biome/issues/2288)). Contributed by @Sec-ant
+
+- Biome now correctly filters out files that are not present in the current directory when using the `--changed` flag [#1996](https://github.com/biomejs/biome/issues/1996). Contributed by @castarco
 
 ### Configuration
 


### PR DESCRIPTION
## Summary

This PR adds support for loading Prettier config files ending with a js-like extension.
I used the sane strategy as #2103: invoking `node` to resolve the file.
It also adds support for embedded Prettier config in `package.json`.

Remaining tasks

- [ ] ~Factorize more code between eslint and prettier~ (in a future PR?)
- [x] Add some tests if possible
- [x] Update the changelog

## Test plan

I manually tested