### PR TITLE
refactor(service): file source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Now Biome can detect the script language in Svelte and Vue script blocks more reliably ([#2245](https://github.com/biomejs/biome/issues/2245)). Contributed by @Sec-ant
 
+#### Enhancements
+
+- Complete the well-known file lists for JSON-like files. Trailing commas are allowed in `.jsonc` files by default. Some well-known files like `tsconfig.json` and `.babelrc` don't use the `.jsonc` extension but still allow comments and trailing commas. While others, such as `.eslintrc.json`, only allow comments. Biome is able to identify these files and adjusts the `json.parser.allowTrailingCommas` option accordingly to ensure they are correctly parsed. Contributed by @Sec-ant
+
 ### CLI
 
 #### New features

--- a/crates/biome_css_syntax/src/file_source.rs
+++ b/crates/biome_css_syntax/src/file_source.rs
@@ -31,6 +31,13 @@ impl CssFileSource {
         }
     }
 
+    /// Try to return the CSS file source corresponding to this file name from well-known files
+    pub fn try_from_well_known(file_name: &str) -> Result<Self, FileSourceError> {
+        // TODO: to be implemented
+        Err(FileSourceError::UnknownFileName(file_name.into()))
+    }
+
+    /// Try to return the CSS file source corresponding to this file extension
     pub fn try_from_extension(extension: &str) -> Result<Self, FileSourceError> {
         match extension {
             "css" => Ok(Self::css()),
@@ -41,11 +48,12 @@ impl CssFileSource {
         }
     }
 
-    pub fn try_from_well_known(file_name: &str) -> Result<Self, FileSourceError> {
-        // TODO: to be implemented
-        Err(FileSourceError::UnknownFileName(file_name.into()))
-    }
-
+    /// Try to return the CSS file source corresponding to this language ID
+    ///
+    /// See the [LSP spec] and [VS Code spec] for a list of language identifiers
+    ///
+    /// [LSP spec]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
+    /// [VS Code spec]: https://code.visualstudio.com/docs/languages/identifiers
     pub fn try_from_language_id(language_id: &str) -> Result<Self, FileSourceError> {
         match language_id {
             "css" => Ok(Self::css()),

--- a/crates/biome_css_syntax/src/file_source.rs
+++ b/crates/biome_css_syntax/src/file_source.rs
@@ -67,6 +67,8 @@ impl TryFrom<&Path> for CssFileSource {
             return Ok(file_source);
         }
 
+        // We assume the file extensions are case-insensitive
+        // and we use the lowercase form of them for pattern matching
         let extension = &path
             .extension()
             .and_then(OsStr::to_str)

--- a/crates/biome_css_syntax/src/file_source.rs
+++ b/crates/biome_css_syntax/src/file_source.rs
@@ -1,5 +1,5 @@
 use biome_rowan::FileSourceError;
-use std::path::Path;
+use std::{ffi::OsStr, path::Path};
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(
@@ -30,6 +30,28 @@ impl CssFileSource {
             variant: CssVariant::Standard,
         }
     }
+
+    pub fn try_from_extension(extension: &str) -> Result<Self, FileSourceError> {
+        match extension {
+            "css" => Ok(Self::css()),
+            _ => Err(FileSourceError::UnknownExtension(
+                Default::default(),
+                extension.into(),
+            )),
+        }
+    }
+
+    pub fn try_from_well_known(file_name: &str) -> Result<Self, FileSourceError> {
+        // TODO: to be implemented
+        Err(FileSourceError::UnknownFileName(file_name.into()))
+    }
+
+    pub fn try_from_language_id(language_id: &str) -> Result<Self, FileSourceError> {
+        match language_id {
+            "css" => Ok(Self::css()),
+            _ => Err(FileSourceError::UnknownLanguageId(language_id.into())),
+        }
+    }
 }
 
 impl TryFrom<&Path> for CssFileSource {
@@ -38,37 +60,19 @@ impl TryFrom<&Path> for CssFileSource {
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
         let file_name = path
             .file_name()
-            .ok_or_else(|| FileSourceError::MissingFileName(path.into()))?
-            .to_str()
+            .and_then(OsStr::to_str)
             .ok_or_else(|| FileSourceError::MissingFileName(path.into()))?;
 
-        let extension = path
+        if let Ok(file_source) = Self::try_from_well_known(file_name) {
+            return Ok(file_source);
+        }
+
+        let extension = &path
             .extension()
-            .ok_or_else(|| FileSourceError::MissingFileExtension(path.into()))?
-            .to_str()
+            .and_then(OsStr::to_str)
+            .map(str::to_lowercase)
             .ok_or_else(|| FileSourceError::MissingFileExtension(path.into()))?;
 
-        compute_source_type_from_path_or_extension(file_name, extension)
+        Self::try_from_extension(extension)
     }
-}
-
-/// It deduce the [CssFileSource] from the file name and its extension
-fn compute_source_type_from_path_or_extension(
-    file_name: &str,
-    extension: &str,
-) -> Result<CssFileSource, FileSourceError> {
-    let source_type = if file_name.ends_with(".css") {
-        CssFileSource::css()
-    } else {
-        match extension {
-            "css" => CssFileSource::css(),
-            _ => {
-                return Err(FileSourceError::UnknownExtension(
-                    file_name.into(),
-                    extension.into(),
-                ));
-            }
-        }
-    };
-    Ok(source_type)
 }

--- a/crates/biome_html_syntax/src/file_source.rs
+++ b/crates/biome_html_syntax/src/file_source.rs
@@ -26,6 +26,13 @@ impl HtmlFileSource {
         }
     }
 
+    /// Try to return the HTML file source corresponding to this file name from well-known files
+    pub fn try_from_well_known(file_name: &str) -> Result<Self, FileSourceError> {
+        // TODO: to be implemented
+        Err(FileSourceError::UnknownFileName(file_name.into()))
+    }
+
+    /// Try to return the HTML file source corresponding to this file extension
     pub fn try_from_extension(extension: &str) -> Result<Self, FileSourceError> {
         match extension {
             "html" => Ok(Self::html()),
@@ -37,11 +44,15 @@ impl HtmlFileSource {
         }
     }
 
-    pub fn try_from_well_known(file_name: &str) -> Result<Self, FileSourceError> {
-        // TODO: to be implemented
-        Err(FileSourceError::UnknownFileName(file_name.into()))
-    }
-
+    /// Try to return the HTML file source corresponding to this language ID
+    ///
+    /// See the [LSP spec] and [VS Code spec] for a list of language identifiers
+    ///
+    /// The language ID for Astro is registered by its [VS Code extension]
+    ///
+    /// [LSP spec]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
+    /// [VS Code spec]: https://code.visualstudio.com/docs/languages/identifiers
+    /// [VS Code extension]: https://github.com/withastro/language-tools/blob/0503392b80765c8a1292ddc9c063a1187425c187/packages/vscode/package.json#L140
     pub fn try_from_language_id(language_id: &str) -> Result<Self, FileSourceError> {
         match language_id {
             "html" => Ok(Self::html()),

--- a/crates/biome_html_syntax/src/file_source.rs
+++ b/crates/biome_html_syntax/src/file_source.rs
@@ -1,5 +1,5 @@
 use biome_rowan::FileSourceError;
-use std::path::Path;
+use std::{ffi::OsStr, path::Path};
 
 #[derive(Debug, Default, Clone)]
 pub struct HtmlFileSource {
@@ -25,6 +25,30 @@ impl HtmlFileSource {
             variant: HtmlVariant::Astro,
         }
     }
+
+    pub fn try_from_extension(extension: &str) -> Result<Self, FileSourceError> {
+        match extension {
+            "html" => Ok(Self::html()),
+            "astro" => Ok(Self::astro()),
+            _ => Err(FileSourceError::UnknownExtension(
+                Default::default(),
+                extension.into(),
+            )),
+        }
+    }
+
+    pub fn try_from_well_known(file_name: &str) -> Result<Self, FileSourceError> {
+        // TODO: to be implemented
+        Err(FileSourceError::UnknownFileName(file_name.into()))
+    }
+
+    pub fn try_from_language_id(language_id: &str) -> Result<Self, FileSourceError> {
+        match language_id {
+            "html" => Ok(Self::html()),
+            "astro" => Ok(Self::astro()),
+            _ => Err(FileSourceError::UnknownLanguageId(language_id.into())),
+        }
+    }
 }
 
 impl TryFrom<&Path> for HtmlFileSource {
@@ -33,33 +57,21 @@ impl TryFrom<&Path> for HtmlFileSource {
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
         let file_name = path
             .file_name()
-            .ok_or_else(|| FileSourceError::MissingFileName(path.into()))?
-            .to_str()
+            .and_then(OsStr::to_str)
             .ok_or_else(|| FileSourceError::MissingFileName(path.into()))?;
 
-        let extension = path
+        if let Ok(file_source) = Self::try_from_well_known(file_name) {
+            return Ok(file_source);
+        }
+
+        // We assume the file extensions are case-insensitive
+        // and we use the lowercase form of them for pattern matching
+        let extension = &path
             .extension()
-            .ok_or_else(|| FileSourceError::MissingFileExtension(path.into()))?
-            .to_str()
+            .and_then(OsStr::to_str)
+            .map(str::to_lowercase)
             .ok_or_else(|| FileSourceError::MissingFileExtension(path.into()))?;
 
-        compute_source_type_from_path_or_extension(file_name, extension)
+        Self::try_from_extension(extension)
     }
-}
-
-/// It deduce the [HtmlFileSource] from the file name and its extension
-fn compute_source_type_from_path_or_extension(
-    file_name: &str,
-    extension: &str,
-) -> Result<HtmlFileSource, FileSourceError> {
-    Ok(match extension {
-        "html" => HtmlFileSource::html(),
-        "astro" => HtmlFileSource::astro(),
-        _ => {
-            return Err(FileSourceError::UnknownExtension(
-                file_name.into(),
-                extension.into(),
-            ));
-        }
-    })
 }

--- a/crates/biome_js_syntax/src/file_source.rs
+++ b/crates/biome_js_syntax/src/file_source.rs
@@ -281,6 +281,13 @@ impl JsFileSource {
         }
     }
 
+    /// Try to return the JS file source corresponding to this file name from well-known files
+    pub fn try_from_well_known(file_name: &str) -> Result<Self, FileSourceError> {
+        // TODO: to be implemented
+        Err(FileSourceError::UnknownFileName(file_name.into()))
+    }
+
+    /// Try to return the JS file source corresponding to this file extension
     pub fn try_from_extension(extension: &str) -> Result<Self, FileSourceError> {
         match extension {
             "js" | "mjs" | "jsx" => Ok(Self::jsx()),
@@ -288,6 +295,8 @@ impl JsFileSource {
             "ts" => Ok(Self::ts()),
             "mts" | "cts" => Ok(Self::ts_restricted()),
             "tsx" => Ok(Self::tsx()),
+            // Note: the extension passed to this function can contain dots,
+            // this should be handled properly by the extension provider
             "d.ts" | "d.mts" | "d.cts" => Ok(Self::d_ts()),
             // TODO: Remove once we have full support of astro files
             "astro" => Ok(Self::astro()),
@@ -302,11 +311,12 @@ impl JsFileSource {
         }
     }
 
-    pub fn try_from_well_known(file_name: &str) -> Result<Self, FileSourceError> {
-        // TODO: to be implemented
-        Err(FileSourceError::UnknownFileName(file_name.into()))
-    }
-
+    /// Try to return the JS file source corresponding to this language ID
+    ///
+    /// See the [LSP spec] and [VS Code spec] for a list of language identifiers
+    ///
+    /// [LSP spec]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
+    /// [VS Code spec]: https://code.visualstudio.com/docs/languages/identifiers
     pub fn try_from_language_id(language_id: &str) -> Result<Self, FileSourceError> {
         match language_id {
             "javascript" => Ok(Self::js_module()),

--- a/crates/biome_js_syntax/src/file_source.rs
+++ b/crates/biome_js_syntax/src/file_source.rs
@@ -337,6 +337,8 @@ impl TryFrom<&Path> for JsFileSource {
             return Ok(file_source);
         }
 
+        // We assume the file extensions are case-insensitive
+        // and we use the lowercase form of them for pattern matching
         // TODO: This should be extracted to a dedicated function, maybe in biome_fs
         // because the same logic is also used in DocumentFileSource::from_path_optional
         // and we may support more and more extensions with more than one dots.

--- a/crates/biome_js_syntax/src/file_source.rs
+++ b/crates/biome_js_syntax/src/file_source.rs
@@ -1,5 +1,5 @@
 use biome_rowan::FileSourceError;
-use std::path::Path;
+use std::{ffi::OsStr, path::Path};
 
 /// Enum of the different ECMAScript standard versions.
 /// The versions are ordered in increasing order; The newest version comes last.
@@ -158,12 +158,12 @@ impl JsFileSource {
     }
 
     /// language: JS, variant: JSX, module_kind: Module, version: Latest
-    pub fn jsx() -> JsFileSource {
+    pub fn jsx() -> Self {
         Self::js_module().with_variant(LanguageVariant::Jsx)
     }
 
     /// language: TS, variant: Standard, module_kind: Module, version: Latest
-    pub fn ts() -> JsFileSource {
+    pub fn ts() -> Self {
         Self {
             language: Language::TypeScript {
                 definition_file: false,
@@ -173,18 +173,18 @@ impl JsFileSource {
     }
 
     /// language: TS, variant: StandardRestricted, module_kind: Module, version: Latest
-    pub fn ts_restricted() -> JsFileSource {
+    pub fn ts_restricted() -> Self {
         Self::ts().with_variant(LanguageVariant::StandardRestricted)
     }
 
     /// language: TS, variant: JSX, module_kind: Module, version: Latest
-    pub fn tsx() -> JsFileSource {
+    pub fn tsx() -> Self {
         Self::ts().with_variant(LanguageVariant::Jsx)
     }
 
     /// TypeScript definition file
     /// language: TS, ambient, variant: Standard, module_kind: Module, version: Latest
-    pub fn d_ts() -> JsFileSource {
+    pub fn d_ts() -> Self {
         Self {
             language: Language::TypeScript {
                 definition_file: true,
@@ -280,6 +280,48 @@ impl JsFileSource {
             }
         }
     }
+
+    pub fn try_from_extension(extension: &str) -> Result<Self, FileSourceError> {
+        match extension {
+            "js" | "mjs" | "jsx" => Ok(Self::jsx()),
+            "cjs" => Ok(Self::js_script()),
+            "ts" => Ok(Self::ts()),
+            "mts" | "cts" => Ok(Self::ts_restricted()),
+            "tsx" => Ok(Self::tsx()),
+            "d.ts" | "d.mts" | "d.cts" => Ok(Self::d_ts()),
+            // TODO: Remove once we have full support of astro files
+            "astro" => Ok(Self::astro()),
+            // TODO: Remove once we have full support of vue files
+            "vue" => Ok(Self::vue()),
+            // TODO: Remove once we have full support of svelte files
+            "svelte" => Ok(Self::svelte()),
+            _ => Err(FileSourceError::UnknownExtension(
+                Default::default(),
+                extension.into(),
+            )),
+        }
+    }
+
+    pub fn try_from_well_known(file_name: &str) -> Result<Self, FileSourceError> {
+        // TODO: to be implemented
+        Err(FileSourceError::UnknownFileName(file_name.into()))
+    }
+
+    pub fn try_from_language_id(language_id: &str) -> Result<Self, FileSourceError> {
+        match language_id {
+            "javascript" => Ok(Self::js_module()),
+            "typescript" => Ok(Self::ts()),
+            "javascriptreact" => Ok(Self::jsx()),
+            "typescriptreact" => Ok(Self::tsx()),
+            // TODO: Remove once we have full support of astro files
+            "astro" => Ok(Self::astro()),
+            // TODO: Remove once we have full support of vue files
+            "vue" => Ok(Self::vue()),
+            // TODO: Remove once we have full support of svelte files
+            "svelte" => Ok(Self::svelte()),
+            _ => Err(FileSourceError::UnknownLanguageId(language_id.into())),
+        }
+    }
 }
 
 impl TryFrom<&Path> for JsFileSource {
@@ -288,48 +330,42 @@ impl TryFrom<&Path> for JsFileSource {
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
         let file_name = path
             .file_name()
-            .ok_or_else(|| FileSourceError::MissingFileName(path.into()))?
-            .to_str()
+            .and_then(OsStr::to_str)
             .ok_or_else(|| FileSourceError::MissingFileName(path.into()))?;
 
-        let extension = path
-            .extension()
-            .ok_or_else(|| FileSourceError::MissingFileExtension(path.into()))?
-            .to_str()
-            .ok_or_else(|| FileSourceError::MissingFileExtension(path.into()))?;
-
-        compute_source_type_from_path_or_extension(file_name, extension)
-    }
-}
-
-/// It deduce the [JsFileSource] from the file name and its extension
-fn compute_source_type_from_path_or_extension(
-    file_name: &str,
-    extension: &str,
-) -> Result<JsFileSource, FileSourceError> {
-    let source_type = if file_name.ends_with(".d.ts")
-        || file_name.ends_with(".d.mts")
-        || file_name.ends_with(".d.cts")
-    {
-        JsFileSource::d_ts()
-    } else {
-        match extension {
-            "js" | "mjs" | "jsx" => JsFileSource::jsx(),
-            "cjs" => JsFileSource::js_script(),
-            "ts" => JsFileSource::ts(),
-            "mts" | "cts" => JsFileSource::ts_restricted(),
-            "tsx" => JsFileSource::tsx(),
-            // TODO: Remove once we have full support of astro files
-            "astro" => JsFileSource::astro(),
-            "vue" => JsFileSource::vue(),
-            "svelte" => JsFileSource::svelte(),
-            _ => {
-                return Err(FileSourceError::UnknownExtension(
-                    file_name.into(),
-                    extension.into(),
-                ));
-            }
+        if let Ok(file_source) = Self::try_from_well_known(file_name) {
+            return Ok(file_source);
         }
-    };
-    Ok(source_type)
+
+        // TODO: This should be extracted to a dedicated function, maybe in biome_fs
+        // because the same logic is also used in DocumentFileSource::from_path_optional
+        // and we may support more and more extensions with more than one dots.
+        let extension = &match path {
+            _ if path
+                .to_str()
+                .is_some_and(|p| p.to_lowercase().ends_with(".d.ts")) =>
+            {
+                Some("d.ts".to_owned())
+            }
+            _ if path
+                .to_str()
+                .is_some_and(|p| p.to_lowercase().ends_with(".d.mts")) =>
+            {
+                Some("d.mts".to_owned())
+            }
+            _ if path
+                .to_str()
+                .is_some_and(|p| p.to_lowercase().ends_with(".d.cts")) =>
+            {
+                Some("d.cts".to_owned())
+            }
+            path => path
+                .extension()
+                .and_then(OsStr::to_str)
+                .map(|s| s.to_lowercase()),
+        }
+        .ok_or_else(|| FileSourceError::MissingFileExtension(path.into()))?;
+
+        Self::try_from_extension(extension)
+    }
 }

--- a/crates/biome_json_syntax/src/file_source.rs
+++ b/crates/biome_json_syntax/src/file_source.rs
@@ -1,5 +1,5 @@
 use biome_rowan::FileSourceError;
-use std::path::Path;
+use std::{ffi::OsStr, path::Path};
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(
@@ -11,6 +11,108 @@ pub struct JsonFileSource {
 }
 
 impl JsonFileSource {
+    // Well known json-like files that support comments and trailing commas
+    // This list should be SORTED!
+    // Note: we shouldn't include machine generated files
+    const WELL_KNOWN_JSON_WITH_COMMENTS_AND_TRAILING_COMMAS_FILES: &'static [&'static str] = &[
+        // Uses `json5`, we treat them as JSONC for now:
+        // https://github.com/babel/babel/blob/3956c75123e713c5fa1d3279f6f92cfeac290173/packages/babel-core/src/config/files/configuration.ts#L341
+        ".babelrc",
+        ".babelrc.json",
+        // https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers#editing-the-devcontainerjson-file
+        ".devcontainer.json",
+        // Uses `jsonc-parser`:
+        // https://github.com/webhintio/hint/blob/6ef9b7cd0c9129ca5a53f30ef51812622ad3d459/packages/hint/src/lib/config.ts#L248
+        // https://github.com/webhintio/hint/blob/6ef9b7cd0c9129ca5a53f30ef51812622ad3d459/packages/utils-fs/src/load-json-file.ts#L1C35-L1C47
+        ".hintrc",
+        ".hintrc.json",
+        // Uses `jsonc_parser` and allows comments and trailing commas
+        // https://github.com/swc-project/swc/blob/ad932f0921411364b801b32f60eaf98f8629e812/crates/swc/src/lib.rs#L1028-L1029
+        ".swcrc",
+        // Uses `jju`, default is JSON5, we treat them as JSONC for now:
+        // https://github.com/microsoft/rushstack/blob/38f0de8ba9f29d337564409eba5639287784b756/apps/api-extractor/src/api/ExtractorConfig.ts#L532
+        // https://github.com/microsoft/rushstack/blob/38f0de8ba9f29d337564409eba5639287784b756/libraries/node-core-library/src/JsonFile.ts#L218
+        // https://github.com/microsoft/rushstack/blob/38f0de8ba9f29d337564409eba5639287784b756/libraries/node-core-library/src/JsonFile.ts#L583-L585
+        "api-documenter.json",
+        "api-extractor.json",
+        // See `.babelrc`
+        "babel.config.json",
+        // Uses `jsonc-parser`, and allows comments and trailing commas by default
+        // https://github.com/denoland/deno/blob/5a716d1d06f73800b280259204789260774d465d/cli/tools/registry/pm.rs#L114
+        "deno.json",
+        // See `.devcontainer.json`
+        "devcontainer.json",
+        // Uses `jsonc-parser`, and allows comments and trailing commas by default
+        // https://github.com/dprint/dprint/blob/f523f4db9750af5e73a9cdd3384ed9cd7e223e53/crates/dprint/src/configuration/manipulation.rs#L85
+        "dprint.json",
+        // See `tsconfig.json`
+        "jsconfig.json",
+        // Uses `jsonc-parser`, and allows comments and trailing commas by default
+        // https://github.com/jsr-io/jsr/blob/32d3481d32f566079d33ba2ec1b598ea0c38b32c/api/src/tarball.rs#L194-L198
+        // https://docs.rs/jsonc-parser/0.23.0/jsonc_parser/struct.ParseOptions.html
+        "jsr.json",
+        // vscode files
+        "language-configuration.json",
+        // Uses its own parser
+        // https://github.com/microsoft/TypeScript/blob/a2d37a5c606803c92c00069e01d7964529e01bee/src/compiler/commandLineParser.ts#L2111-L2117
+        // https://github.com/microsoft/TypeScript/blob/a2d37a5c606803c92c00069e01d7964529e01bee/src/compiler/parser.ts#L1433
+        // https://github.com/microsoft/TypeScript/blob/a2d37a5c606803c92c00069e01d7964529e01bee/src/compiler/parser.ts#L3536
+        // https://github.com/microsoft/TypeScript/blob/a2d37a5c606803c92c00069e01d7964529e01bee/src/compiler/parser.ts#L2583-L2587
+        "tsconfig.json",
+        // Uses the parser from TypeScript
+        // https://github.com/TypeStrong/typedoc/blob/30e614cd9e7b5a154afa6a78f2e54f16550bfb4f/src/lib/utils/options/readers/typedoc.ts#L74
+        "typedoc.json",
+        // vscode files
+        "typescript.json",
+    ];
+
+    // Well known json-like files that support comments but no trailing commas
+    // This list should be SORTED!
+    // Note: we shouldn't include machine generated files
+    const WELL_KNOWN_JSON_WITH_COMMENTS_FILES: &'static [&'static str] = &[
+        // Uses `yam` to parse the config, which only strip comments
+        // https://github.com/ember-cli/ember-cli/blob/0f7d0ccb52cdd20f17efbee79dd3f08ec6019cfc/lib/utilities/get-config.js#L7
+        // https://github.com/twokul/yam/blob/773e42548511977bf1e2b9b95c60496fe7f8a9df/lib/utils/io-utils.js#L45
+        ".ember-cli",
+        // `.eslintrc` is parsed as yaml, so we shouldn't include it here:
+        // https://github.com/eslint/eslintrc/blob/fb8d7ffbb27214686318a07e16ac8878aaafc805/lib/config-array-factory.js#L205-L225
+
+        // Uses `strip-json-comments`, which doesn't allow trailing commas by default
+        // https://github.com/eslint/eslintrc/blob/fb8d7ffbb27214686318a07e16ac8878aaafc805/lib/config-array-factory.js#L192
+        // https://github.com/sindresorhus/strip-json-comments/blob/85611bf8a07246bca27f949c997a1460c57bbe9f/index.js#L19
+        ".eslintrc.json",
+        // Uses `strip-json-comments`, which doesn't allow trailing commas by default
+        // https://github.com/jshint/jshint/blob/0a5644f8f529e252e7dd0c0d54334ae435b13de0/src/cli.js#L538
+        ".jscsrc",
+        // `.jsfmtrc` can be either an `ini` file or a `json` file (which will be parsed after `strip-with-comments`), so we shouldn't include it here.
+        // https://github.com/rdio/jsfmt?tab=readme-ov-file#jsfmtrc
+
+        // Uses `strip-json-comments`, which doesn't allow trailing commas by default
+        // https://github.com/jscs-dev/node-jscs/blob/38d33a0e455d965106ad3c8948c870f8f4e5dda9/lib/cli-config.js#L81
+        ".jshintrc",
+        // Just strip comments
+        // https://github.com/palantir/tslint/blob/285fc1db18d1fd24680d6a2282c6445abf1566ee/src/configuration.ts#L268
+        "tslint.json",
+    ];
+
+    // Well known json files
+    // This list should be SORTED!
+    // Source: https://github.com/github-linguist/linguist/blob/4ac734c15a96f9e16fd12330d0cb8de82274f700/lib/linguist/languages.yml#L3203-L3218
+    // Note: we shouldn't include machine generated files
+    const WELL_KNOWN_JSON_FILES: &'static [&'static str] = &[
+        ".all-contributorsrc",
+        ".arcconfig",
+        ".auto-changelog",
+        ".c8rc",
+        ".htmlhintrc",
+        ".imgbotconfig",
+        ".nycrc",
+        ".tern-config",
+        ".tern-project",
+        ".watchmanconfig",
+        "mcmod.info",
+    ];
+
     pub fn json() -> Self {
         Self {
             allow_trailing_commas: false,
@@ -18,30 +120,95 @@ impl JsonFileSource {
         }
     }
 
-    pub fn with_trailing_commas(mut self, option_value: bool) -> Self {
-        self.allow_trailing_commas = option_value;
+    pub fn with_allow_trailing_commas(mut self) -> Self {
+        self.allow_trailing_commas = true;
         self
     }
 
-    pub fn set_allow_trailing_commas(&mut self, option_value: bool) {
-        self.allow_trailing_commas = option_value;
-    }
-
-    pub fn get_allow_trailing_commas(&self) -> bool {
+    pub fn allow_trailing_commas(&self) -> bool {
         self.allow_trailing_commas
     }
 
-    pub fn with_comments(mut self, option_value: bool) -> Self {
-        self.allow_comments = option_value;
+    pub fn with_allow_comments(mut self) -> Self {
+        self.allow_comments = true;
         self
     }
 
-    pub fn set_allow_comments(&mut self, option_value: bool) {
-        self.allow_comments = option_value;
+    pub fn allow_comments(&self) -> bool {
+        self.allow_comments
     }
 
-    pub fn get_allow_comments(&self) -> bool {
-        self.allow_comments
+    pub fn is_well_known_json_with_comments_and_trailing_commas_file(filename: &str) -> bool {
+        Self::WELL_KNOWN_JSON_WITH_COMMENTS_AND_TRAILING_COMMAS_FILES
+            .binary_search(&filename)
+            .is_ok()
+    }
+
+    pub fn is_well_known_json_with_comments_file(file_name: &str) -> bool {
+        Self::WELL_KNOWN_JSON_WITH_COMMENTS_FILES
+            .binary_search(&file_name)
+            .is_ok()
+    }
+
+    pub fn is_well_known_json_file(file_name: &str) -> bool {
+        Self::WELL_KNOWN_JSON_FILES
+            .binary_search(&file_name)
+            .is_ok()
+    }
+
+    pub fn try_from_extension(extension: &str) -> Result<Self, FileSourceError> {
+        match extension {
+            // https://github.com/github-linguist/linguist/blob/4ac734c15a96f9e16fd12330d0cb8de82274f700/lib/linguist/languages.yml#L3183-L3202
+            "json" | "webapp" | "webmanifest" => Ok(Self::json()),
+            // https://github.com/github-linguist/linguist/blob/4ac734c15a96f9e16fd12330d0cb8de82274f700/lib/linguist/languages.yml#L3230-L3246
+            "jsonc"
+            | "code-snippets"
+            | "code-workspace"
+            | "sublime-build"
+            | "sublime-commands"
+            | "sublime-completions"
+            | "sublime-keymap"
+            | "sublime-macro"
+            | "sublime-menu"
+            | "sublime-mousemap"
+            | "sublime-project"
+            | "sublime-settings"
+            | "sublime-theme"
+            | "sublime-workspace"
+            | "sublime_metrics"
+            | "sublime_session" => Ok(Self::json()
+                .with_allow_comments()
+                .with_allow_trailing_commas()),
+            _ => Err(FileSourceError::UnknownExtension(
+                Default::default(),
+                extension.into(),
+            )),
+        }
+    }
+
+    pub fn try_from_well_known(file_name: &str) -> Result<Self, FileSourceError> {
+        if Self::is_well_known_json_with_comments_and_trailing_commas_file(file_name) {
+            return Ok(Self::json()
+                .with_allow_comments()
+                .with_allow_trailing_commas());
+        }
+        if Self::is_well_known_json_with_comments_file(file_name) {
+            return Ok(Self::json().with_allow_comments());
+        }
+        if Self::is_well_known_json_file(file_name) {
+            return Ok(Self::json());
+        }
+        Err(FileSourceError::UnknownFileName(file_name.into()))
+    }
+
+    pub fn try_from_language_id(language_id: &str) -> Result<Self, FileSourceError> {
+        match language_id {
+            "json" => Ok(Self::json()),
+            "jsonc" | "snippets" => Ok(Self::json()
+                .with_allow_comments()
+                .with_allow_trailing_commas()),
+            _ => Err(FileSourceError::UnknownLanguageId(language_id.into())),
+        }
     }
 }
 
@@ -51,38 +218,33 @@ impl TryFrom<&Path> for JsonFileSource {
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
         let file_name = path
             .file_name()
-            .ok_or_else(|| FileSourceError::MissingFileName(path.into()))?
-            .to_str()
+            .and_then(OsStr::to_str)
             .ok_or_else(|| FileSourceError::MissingFileName(path.into()))?;
 
-        let extension = path
+        if let Ok(file_source) = Self::try_from_well_known(file_name) {
+            return Ok(file_source);
+        }
+
+        let extension = &path
             .extension()
-            .ok_or_else(|| FileSourceError::MissingFileExtension(path.into()))?
-            .to_str()
+            .and_then(OsStr::to_str)
+            .map(str::to_lowercase)
             .ok_or_else(|| FileSourceError::MissingFileExtension(path.into()))?;
 
-        compute_source_type_from_path_or_extension(file_name, extension)
+        Self::try_from_extension(extension)
     }
 }
 
-/// It deduce the [JsonFileSource] from the file name and its extension
-fn compute_source_type_from_path_or_extension(
-    file_name: &str,
-    extension: &str,
-) -> Result<JsonFileSource, FileSourceError> {
-    let source_type = if file_name.ends_with(".json") {
-        JsonFileSource::json()
-    } else {
-        match extension {
-            "json" => JsonFileSource::json(),
-            "jsonc" => JsonFileSource::json().with_comments(true),
-            _ => {
-                return Err(FileSourceError::UnknownExtension(
-                    file_name.into(),
-                    extension.into(),
-                ));
-            }
-        }
-    };
-    Ok(source_type)
+#[test]
+fn test_order() {
+    for items in JsonFileSource::WELL_KNOWN_JSON_WITH_COMMENTS_AND_TRAILING_COMMAS_FILES.windows(2)
+    {
+        assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
+    }
+    for items in JsonFileSource::WELL_KNOWN_JSON_WITH_COMMENTS_FILES.windows(2) {
+        assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
+    }
+    for items in JsonFileSource::WELL_KNOWN_JSON_FILES.windows(2) {
+        assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
+    }
 }

--- a/crates/biome_json_syntax/src/file_source.rs
+++ b/crates/biome_json_syntax/src/file_source.rs
@@ -11,10 +11,66 @@ pub struct JsonFileSource {
 }
 
 impl JsonFileSource {
-    // Well known json-like files that support comments and trailing commas
+    // Well-known JSON files
+    // This list should be SORTED!
+    // Source: https://github.com/github-linguist/linguist/blob/4ac734c15a96f9e16fd12330d0cb8de82274f700/lib/linguist/languages.yml#L3203-L3218
+    // Note: we shouldn't include machine generated files
+    const WELL_KNOWN_JSON_FILES: &'static [&'static str] = &[
+        ".all-contributorsrc",
+        ".arcconfig",
+        ".auto-changelog",
+        // Uses `JSON.parse`
+        // https://github.com/bower/bower/blob/a0d44443245cbe52f3f0bd90c3f41274bc040c7a/packages/bower-config/lib/util/rc.js#L61
+        ".bowerrc",
+        ".c8rc",
+        ".htmlhintrc",
+        ".imgbotconfig",
+        // Uses `JSON.parse`
+        // https://github.com/reid/node-jslint/blob/1eefcc48116fe4fbc3b585ebd2922b3509f4f4de/lib/options.js#L31
+        ".jslintrc",
+        ".nycrc",
+        ".tern-config",
+        ".tern-project",
+        // Uses the `readJSON` from `fs-extra`
+        // https://github.com/vuejs/vue-cli/blob/f0f254e4bc81ed322eeb9f7de346e987e845068e/packages/%40vue/cli/lib/config.js#L8
+        ".vuerc",
+        ".watchmanconfig",
+        "mcmod.info",
+    ];
+
+    // Well-known JSON-like files that support comments but no trailing commas
     // This list should be SORTED!
     // Note: we shouldn't include machine generated files
-    const WELL_KNOWN_JSON_WITH_COMMENTS_AND_TRAILING_COMMAS_FILES: &'static [&'static str] = &[
+    const WELL_KNOWN_JSON_ALLOW_COMMENTS_FILES: &'static [&'static str] = &[
+        // Uses `yam` to parse the config, which only strip comments
+        // https://github.com/ember-cli/ember-cli/blob/0f7d0ccb52cdd20f17efbee79dd3f08ec6019cfc/lib/utilities/get-config.js#L7
+        // https://github.com/twokul/yam/blob/773e42548511977bf1e2b9b95c60496fe7f8a9df/lib/utils/io-utils.js#L45
+        ".ember-cli",
+        // `.eslintrc` is parsed as yaml, so we shouldn't include it here:
+        // https://github.com/eslint/eslintrc/blob/fb8d7ffbb27214686318a07e16ac8878aaafc805/lib/config-array-factory.js#L205-L225
+
+        // Uses `strip-json-comments`, which doesn't allow trailing commas by default
+        // https://github.com/eslint/eslintrc/blob/fb8d7ffbb27214686318a07e16ac8878aaafc805/lib/config-array-factory.js#L192
+        // https://github.com/sindresorhus/strip-json-comments/blob/85611bf8a07246bca27f949c997a1460c57bbe9f/index.js#L19
+        ".eslintrc.json",
+        // Uses `strip-json-comments`, which doesn't allow trailing commas by default
+        // https://github.com/jscs-dev/node-jscs/blob/38d33a0e455d965106ad3c8948c870f8f4e5dda9/lib/cli-config.js#L81
+        ".jscsrc",
+        // `.jsfmtrc` can be either an `ini` file or a `json` file (which will be parsed after `strip-with-comments`), so we shouldn't include it here.
+        // https://github.com/rdio/jsfmt?tab=readme-ov-file#jsfmtrc
+
+        // Uses `strip-json-comments`, which doesn't allow trailing commas by default
+        // https://github.com/jshint/jshint/blob/0a5644f8f529e252e7dd0c0d54334ae435b13de0/src/cli.js#L538
+        ".jshintrc",
+        // Just strip comments
+        // https://github.com/palantir/tslint/blob/285fc1db18d1fd24680d6a2282c6445abf1566ee/src/configuration.ts#L268
+        "tslint.json",
+    ];
+
+    // Well-known JSON-like files that support comments and trailing commas
+    // This list should be SORTED!
+    // Note: we shouldn't include machine generated files
+    const WELL_KNOWN_JSON_ALLOW_COMMENTS_AND_TRAILING_COMMAS_FILES: &'static [&'static str] = &[
         // Uses `json5`, we treat them as JSONC for now:
         // https://github.com/babel/babel/blob/3956c75123e713c5fa1d3279f6f92cfeac290173/packages/babel-core/src/config/files/configuration.ts#L341
         ".babelrc",
@@ -66,57 +122,24 @@ impl JsonFileSource {
         "typescript.json",
     ];
 
-    // Well known json-like files that support comments but no trailing commas
-    // This list should be SORTED!
-    // Note: we shouldn't include machine generated files
-    const WELL_KNOWN_JSON_WITH_COMMENTS_FILES: &'static [&'static str] = &[
-        // Uses `yam` to parse the config, which only strip comments
-        // https://github.com/ember-cli/ember-cli/blob/0f7d0ccb52cdd20f17efbee79dd3f08ec6019cfc/lib/utilities/get-config.js#L7
-        // https://github.com/twokul/yam/blob/773e42548511977bf1e2b9b95c60496fe7f8a9df/lib/utils/io-utils.js#L45
-        ".ember-cli",
-        // `.eslintrc` is parsed as yaml, so we shouldn't include it here:
-        // https://github.com/eslint/eslintrc/blob/fb8d7ffbb27214686318a07e16ac8878aaafc805/lib/config-array-factory.js#L205-L225
-
-        // Uses `strip-json-comments`, which doesn't allow trailing commas by default
-        // https://github.com/eslint/eslintrc/blob/fb8d7ffbb27214686318a07e16ac8878aaafc805/lib/config-array-factory.js#L192
-        // https://github.com/sindresorhus/strip-json-comments/blob/85611bf8a07246bca27f949c997a1460c57bbe9f/index.js#L19
-        ".eslintrc.json",
-        // Uses `strip-json-comments`, which doesn't allow trailing commas by default
-        // https://github.com/jshint/jshint/blob/0a5644f8f529e252e7dd0c0d54334ae435b13de0/src/cli.js#L538
-        ".jscsrc",
-        // `.jsfmtrc` can be either an `ini` file or a `json` file (which will be parsed after `strip-with-comments`), so we shouldn't include it here.
-        // https://github.com/rdio/jsfmt?tab=readme-ov-file#jsfmtrc
-
-        // Uses `strip-json-comments`, which doesn't allow trailing commas by default
-        // https://github.com/jscs-dev/node-jscs/blob/38d33a0e455d965106ad3c8948c870f8f4e5dda9/lib/cli-config.js#L81
-        ".jshintrc",
-        // Just strip comments
-        // https://github.com/palantir/tslint/blob/285fc1db18d1fd24680d6a2282c6445abf1566ee/src/configuration.ts#L268
-        "tslint.json",
-    ];
-
-    // Well known json files
-    // This list should be SORTED!
-    // Source: https://github.com/github-linguist/linguist/blob/4ac734c15a96f9e16fd12330d0cb8de82274f700/lib/linguist/languages.yml#L3203-L3218
-    // Note: we shouldn't include machine generated files
-    const WELL_KNOWN_JSON_FILES: &'static [&'static str] = &[
-        ".all-contributorsrc",
-        ".arcconfig",
-        ".auto-changelog",
-        ".c8rc",
-        ".htmlhintrc",
-        ".imgbotconfig",
-        ".nycrc",
-        ".tern-config",
-        ".tern-project",
-        ".watchmanconfig",
-        "mcmod.info",
-    ];
-
     pub fn json() -> Self {
         Self {
-            allow_trailing_commas: false,
             allow_comments: false,
+            allow_trailing_commas: false,
+        }
+    }
+
+    pub fn json_allow_comments() -> Self {
+        Self {
+            allow_comments: true,
+            allow_trailing_commas: false,
+        }
+    }
+
+    pub fn json_allow_comments_and_trailing_commas() -> Self {
+        Self {
+            allow_comments: true,
+            allow_trailing_commas: true,
         }
     }
 
@@ -138,28 +161,44 @@ impl JsonFileSource {
         self.allow_comments
     }
 
-    pub fn is_well_known_json_with_comments_and_trailing_commas_file(filename: &str) -> bool {
-        Self::WELL_KNOWN_JSON_WITH_COMMENTS_AND_TRAILING_COMMAS_FILES
-            .binary_search(&filename)
-            .is_ok()
-    }
-
-    pub fn is_well_known_json_with_comments_file(file_name: &str) -> bool {
-        Self::WELL_KNOWN_JSON_WITH_COMMENTS_FILES
-            .binary_search(&file_name)
-            .is_ok()
-    }
-
     pub fn is_well_known_json_file(file_name: &str) -> bool {
         Self::WELL_KNOWN_JSON_FILES
             .binary_search(&file_name)
             .is_ok()
     }
 
+    pub fn is_well_known_json_allow_comments_file(file_name: &str) -> bool {
+        Self::WELL_KNOWN_JSON_ALLOW_COMMENTS_FILES
+            .binary_search(&file_name)
+            .is_ok()
+    }
+
+    pub fn is_well_known_json_allow_comments_and_trailing_commas_file(filename: &str) -> bool {
+        Self::WELL_KNOWN_JSON_ALLOW_COMMENTS_AND_TRAILING_COMMAS_FILES
+            .binary_search(&filename)
+            .is_ok()
+    }
+
+    /// Try to return the JSON file source corresponding to this file name from well-known files
+    pub fn try_from_well_known(file_name: &str) -> Result<Self, FileSourceError> {
+        if Self::is_well_known_json_allow_comments_and_trailing_commas_file(file_name) {
+            return Ok(Self::json_allow_comments_and_trailing_commas());
+        }
+        if Self::is_well_known_json_allow_comments_file(file_name) {
+            return Ok(Self::json_allow_comments());
+        }
+        if Self::is_well_known_json_file(file_name) {
+            return Ok(Self::json());
+        }
+        Err(FileSourceError::UnknownFileName(file_name.into()))
+    }
+
+    /// Try to return the JSON file source corresponding to this file extension
     pub fn try_from_extension(extension: &str) -> Result<Self, FileSourceError> {
         match extension {
             // https://github.com/github-linguist/linguist/blob/4ac734c15a96f9e16fd12330d0cb8de82274f700/lib/linguist/languages.yml#L3183-L3202
-            "json" | "webapp" | "webmanifest" => Ok(Self::json()),
+            // https://www.w3.org/TR/json-ld/#application-ld-json
+            "json" | "jsonld" | "webapp" | "webmanifest" => Ok(Self::json()),
             // https://github.com/github-linguist/linguist/blob/4ac734c15a96f9e16fd12330d0cb8de82274f700/lib/linguist/languages.yml#L3230-L3246
             "jsonc"
             | "code-snippets"
@@ -176,9 +215,7 @@ impl JsonFileSource {
             | "sublime-theme"
             | "sublime-workspace"
             | "sublime_metrics"
-            | "sublime_session" => Ok(Self::json()
-                .with_allow_comments()
-                .with_allow_trailing_commas()),
+            | "sublime_session" => Ok(Self::json_allow_comments_and_trailing_commas()),
             _ => Err(FileSourceError::UnknownExtension(
                 Default::default(),
                 extension.into(),
@@ -186,27 +223,19 @@ impl JsonFileSource {
         }
     }
 
-    pub fn try_from_well_known(file_name: &str) -> Result<Self, FileSourceError> {
-        if Self::is_well_known_json_with_comments_and_trailing_commas_file(file_name) {
-            return Ok(Self::json()
-                .with_allow_comments()
-                .with_allow_trailing_commas());
-        }
-        if Self::is_well_known_json_with_comments_file(file_name) {
-            return Ok(Self::json().with_allow_comments());
-        }
-        if Self::is_well_known_json_file(file_name) {
-            return Ok(Self::json());
-        }
-        Err(FileSourceError::UnknownFileName(file_name.into()))
-    }
-
+    /// Try to return the JSON file source corresponding to this language ID
+    ///
+    /// See the [LSP spec] and [VS Code spec] for a list of language identifiers
+    ///
+    /// The language ID for code snippets is registered by [VS Code built-in extensions]
+    ///
+    /// [LSP spec]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
+    /// [VS Code spec]: https://code.visualstudio.com/docs/languages/identifiers
+    /// [VS Code built-in extensions]: https://github.com/microsoft/vscode/blob/f0ce480524258473372e0a2e9a07af6f64526010/extensions/json/package.json#L83
     pub fn try_from_language_id(language_id: &str) -> Result<Self, FileSourceError> {
         match language_id {
             "json" => Ok(Self::json()),
-            "jsonc" | "snippets" => Ok(Self::json()
-                .with_allow_comments()
-                .with_allow_trailing_commas()),
+            "jsonc" | "snippets" => Ok(Self::json_allow_comments_and_trailing_commas()),
             _ => Err(FileSourceError::UnknownLanguageId(language_id.into())),
         }
     }
@@ -239,11 +268,11 @@ impl TryFrom<&Path> for JsonFileSource {
 
 #[test]
 fn test_order() {
-    for items in JsonFileSource::WELL_KNOWN_JSON_WITH_COMMENTS_AND_TRAILING_COMMAS_FILES.windows(2)
+    for items in JsonFileSource::WELL_KNOWN_JSON_ALLOW_COMMENTS_AND_TRAILING_COMMAS_FILES.windows(2)
     {
         assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
     }
-    for items in JsonFileSource::WELL_KNOWN_JSON_WITH_COMMENTS_FILES.windows(2) {
+    for items in JsonFileSource::WELL_KNOWN_JSON_ALLOW_COMMENTS_FILES.windows(2) {
         assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
     }
     for items in JsonFileSource::WELL_KNOWN_JSON_FILES.windows(2) {

--- a/crates/biome_json_syntax/src/file_source.rs
+++ b/crates/biome_json_syntax/src/file_source.rs
@@ -225,6 +225,8 @@ impl TryFrom<&Path> for JsonFileSource {
             return Ok(file_source);
         }
 
+        // We assume the file extensions are case-insensitive
+        // and we use the lowercase form of them for pattern matching
         let extension = &path
             .extension()
             .and_then(OsStr::to_str)

--- a/crates/biome_rowan/src/file_source.rs
+++ b/crates/biome_rowan/src/file_source.rs
@@ -10,6 +10,10 @@ pub enum FileSourceError {
     MissingFileExtension(PathBuf),
     /// The source type is unknown
     UnknownExtension(String, String),
+    /// The file name is unknown (not a well-known file name)
+    UnknownFileName(String),
+    /// The language id is unknown
+    UnknownLanguageId(String),
 }
 
 impl std::error::Error for FileSourceError {}
@@ -25,6 +29,15 @@ impl Display for FileSourceError {
             }
             FileSourceError::UnknownExtension(_, extension) => {
                 write!(f, "The parser can't parse the extension '{extension}' yet")
+            }
+            FileSourceError::UnknownFileName(file_name) => {
+                write!(
+                    f,
+                    "The parser doesn't recognize the file name '{file_name}' yet"
+                )
+            }
+            FileSourceError::UnknownLanguageId(language_id) => {
+                write!(f, "The parser can't parse the language '{language_id}' yet")
             }
         }
     }

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -151,9 +151,9 @@ fn parse(
         biome_path,
         JsonParserOptions {
             allow_comments: parser.allow_comments
-                || optional_json_file_source.map_or(false, |x| x.get_allow_comments()),
+                || optional_json_file_source.map_or(false, |x| x.allow_comments()),
             allow_trailing_commas: parser.allow_trailing_commas
-                || optional_json_file_source.map_or(false, |x| x.get_allow_trailing_commas()),
+                || optional_json_file_source.map_or(false, |x| x.allow_trailing_commas()),
         },
     );
     let parse = biome_json_parser::parse_json_with_cache(text, cache, options);

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -150,6 +150,8 @@ impl DocumentFileSource {
             return Ok(file_source);
         }
 
+        // We assume the file extensions are case-insensitive
+        // and we use the lowercase form of them for pattern matching
         // TODO: This should be extracted to a dedicated function, maybe in biome_fs
         // because the same logic is also used in JsFileSource::try_from
         // and we may support more and more extensions with more than one dots.

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -88,7 +88,7 @@ impl DocumentFileSource {
         Err(FileSourceError::UnknownFileName(file_name.into()))
     }
 
-    // Returns the language corresponding to this file name
+    /// Returns the document file source corresponding to this file name from well-known files
     pub fn from_well_known(file_name: &str) -> Self {
         Self::try_from_well_known(file_name)
             .map_or(DocumentFileSource::Unknown, |file_source| file_source)
@@ -110,7 +110,7 @@ impl DocumentFileSource {
         ))
     }
 
-    /// Returns the language corresponding to this file extension
+    /// Returns the document file source corresponding to this file extension
     pub fn from_extension(extension: &str) -> Self {
         Self::try_from_extension(extension)
             .map_or(DocumentFileSource::Unknown, |file_source| file_source)
@@ -129,12 +129,12 @@ impl DocumentFileSource {
         Err(FileSourceError::UnknownLanguageId(language_id.into()))
     }
 
-    /// Returns the language corresponding to this language ID
+    /// Returns the document file source corresponding to this language ID
     ///
-    /// See the [microsoft spec]
-    /// for a list of language identifiers
+    /// See the [LSP spec] and [VS Code spec] for a list of language identifiers
     ///
-    /// [microsoft spec]: https://code.visualstudio.com/docs/languages/identifiers
+    /// [LSP spec]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
+    /// [VS Code spec]: https://code.visualstudio.com/docs/languages/identifiers
     pub fn from_language_id(language_id: &str) -> Self {
         Self::try_from_language_id(language_id)
             .map_or(DocumentFileSource::Unknown, |file_source| file_source)
@@ -184,12 +184,12 @@ impl DocumentFileSource {
         Self::try_from_extension(extension)
     }
 
-    /// Returns the language corresponding to the file path
+    /// Returns the document file source corresponding to the file path
     pub fn from_path(path: &Path) -> Self {
         Self::try_from_path(path).map_or(DocumentFileSource::Unknown, |file_source| file_source)
     }
 
-    /// Returns the language if it's not unknown, otherwise returns `other`.
+    /// Returns the document file source if it's not unknown, otherwise returns `other`.
     ///
     /// # Examples
     ///

--- a/crates/biome_service/tests/workspace.rs
+++ b/crates/biome_service/tests/workspace.rs
@@ -104,7 +104,7 @@ fn correctly_handle_json_files() {
     .unwrap();
     assert!(jsonc_file.format_file().is_ok());
 
-    // ".jsonc" file doesn't allow trailing commas
+    // ".jsonc" file allow trailing commas
     let jsonc_file = FileGuard::open(
         workspace.as_ref(),
         OpenFileParams {
@@ -115,7 +115,35 @@ fn correctly_handle_json_files() {
         },
     )
     .unwrap();
-    assert!(jsonc_file.format_file().is_err());
+    assert!(jsonc_file.format_file().is_ok());
+
+    // well-known json-with-comments file allows comments
+    let well_known_json_with_comments_file = FileGuard::open(
+        workspace.as_ref(),
+        OpenFileParams {
+            path: BiomePath::new(".eslintrc.json"),
+            content: r#"{"a": 42}//comment"#.into(),
+            version: 0,
+            document_file_source: None,
+        },
+    )
+    .unwrap();
+    assert!(well_known_json_with_comments_file.format_file().is_ok());
+
+    // well-known json-with-comments file doesn't allow trailing commas
+    let well_known_json_with_comments_file_with_trailing_commas = FileGuard::open(
+        workspace.as_ref(),
+        OpenFileParams {
+            path: BiomePath::new("dir/.eslintrc.json"),
+            content: r#"{"a": 42,}"#.into(),
+            version: 0,
+            document_file_source: None,
+        },
+    )
+    .unwrap();
+    assert!(well_known_json_with_comments_file_with_trailing_commas
+        .format_file()
+        .is_err());
 
     // well-known json-with-comments-and-trailing-commas file allows comments and trailing commas
     let well_known_json_with_comments_and_trailing_commas_file = FileGuard::open(

--- a/website/src/content/docs/guides/how-biome-works.mdx
+++ b/website/src/content/docs/guides/how-biome-works.mdx
@@ -177,6 +177,31 @@ Here are some well-known files that we specifically treat based on their file na
 
 ### JSON-like Files
 
+The following files are parsed as `JSON` files with both the options `json.parser.allowComments` and `json.parser.allowTrailingCommas` set to `false`.
+
+- `.all-contributorsrc`
+- `.arcconfig`
+- `.auto-changelog`
+- `.bowerrc`
+- `.c8rc`
+- `.htmlhintrc`
+- `.imgbotconfig`
+- `.jslintrc`
+- `.nycrc`
+- `.tern-config`
+- `.tern-project`
+- `.vuerc`
+- `.watchmanconfig`
+- `mcmod.info`
+
+The following files are parsed as `JSON` files with the options `json.parser.allowComments` set to `true` but `json.parser.allowTrailingCommas` set to `false`. This is because the tools consuming these files can only strip comments.
+
+- `.ember-cli`
+- `.eslintrc.json`
+- `.jscsrc`
+- `.jshintrc`
+- `tslint.json`
+
 The following files are parsed as `JSON` files with the options `json.parser.allowComments` and `json.parser.allowTrailingCommas` set to `true`. This is because the tools consuming these files are designed to accommodate such settings.
 
 - `.babelrc`
@@ -197,28 +222,6 @@ The following files are parsed as `JSON` files with the options `json.parser.all
 - `tsconfig.json`
 - `typedoc.json`
 - `typescript.json`
-
-The following files are parsed as `JSON` files with the options `json.parser.allowComments` set to `true` but `json.parser.allowTrailingCommas` set to `false`. This is because the tools consuming these files can only strip comments.
-
-- `.ember-cli`
-- `.eslintrc.json`
-- `.jscsrc`
-- `.jshintrc`
-- `tslint.json`
-
-The following files are parsed as `JSON` files with both the options `json.parser.allowComments` and `json.parser.allowTrailingCommas` set to `false`.
-
-- `.all-contributorsrc`
-- `.arcconfig`
-- `.auto-changelog`
-- `.c8rc`
-- `.htmlhintrc`
-- `.imgbotconfig`
-- `.nycrc`
-- `.tern-config`
-- `.tern-project`
-- `.watchmanconfig`
-- `mcmod.info`
 
 ## `include` and `ignore` explained
 

--- a/website/src/content/docs/guides/how-biome-works.mdx
+++ b/website/src/content/docs/guides/how-biome-works.mdx
@@ -175,23 +175,50 @@ The following files are currently ignored by Biome. This means that no diagnosti
 
 Here are some well-known files that we specifically treat based on their file names, rather than their extensions. Currently, the well-known files are JSON-like files only, but we may broaden the list to include other types when we support new parsers.
 
-The following files are parsed as **`JSON` files** with the options `json.parser.allowComments` and `json.parser.allowTrailingCommas` set to `true`. This is because the tools consuming these files are designed to accommodate such settings.
+### JSON-like Files
+
+The following files are parsed as `JSON` files with the options `json.parser.allowComments` and `json.parser.allowTrailingCommas` set to `true`. This is because the tools consuming these files are designed to accommodate such settings.
 
 - `.babelrc`
 - `.babelrc.json`
-- `.ember-cli`
-- `.eslintrc`
-- `.eslintrc.json`
+- `.devcontainer.json`
 - `.hintrc`
-- `.jsfmtrc`
-- `.jshintrc`
+- `.hintrc.json`
 - `.swcrc`
+- `api-documenter.json`
+- `api-extractor.json`
 - `babel.config.json`
+- `deno.json`
+- `devcontainer.json`
+- `dprint.json`
 - `jsconfig.json`
+- `jsr.json`
+- `language-configuration.json`
 - `tsconfig.json`
-- `tslint.json`
 - `typedoc.json`
 - `typescript.json`
+
+The following files are parsed as `JSON` files with the options `json.parser.allowComments` set to `true` but `json.parser.allowTrailingCommas` set to `false`. This is because the tools consuming these files can only strip comments.
+
+- `.ember-cli`
+- `.eslintrc.json`
+- `.jscsrc`
+- `.jshintrc`
+- `tslint.json`
+
+The following files are parsed as `JSON` files with both the options `json.parser.allowComments` and `json.parser.allowTrailingCommas` set to `false`.
+
+- `.all-contributorsrc`
+- `.arcconfig`
+- `.auto-changelog`
+- `.c8rc`
+- `.htmlhintrc`
+- `.imgbotconfig`
+- `.nycrc`
+- `.tern-config`
+- `.tern-project`
+- `.watchmanconfig`
+- `mcmod.info`
 
 ## `include` and `ignore` explained
 

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -23,6 +23,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Now Biome can detect the script language in Svelte and Vue script blocks more reliably ([#2245](https://github.com/biomejs/biome/issues/2245)). Contributed by @Sec-ant
 
+#### Enhancements
+
+- Complete the well-known file lists for JSON-like files. Trailing commas are allowed in `.jsonc` files by default. Some well-known files like `tsconfig.json` and `.babelrc` don't use the `.jsonc` extension but still allow comments and trailing commas. While others, such as `.eslintrc.json`, only allow comments. Biome is able to identify these files and adjusts the `json.parser.allowTrailingCommas` option accordingly to ensure they are correctly parsed. Contributed by @Sec-ant
+
 ### CLI
 
 #### New features

--- a/website/src/content/docs/internals/language-support.mdx
+++ b/website/src/content/docs/internals/language-support.mdx
@@ -36,6 +36,20 @@ Biome supports only the official syntax. The team starts development of the new 
 
 Biome supports TypeScript version 5.2.
 
+## JSONC Support
+
+JSONC stands for "JSON with Comments." This format is widely used by various tools like [VS Code](https://code.visualstudio.com/docs/languages/json#_json-with-comments), [TypeScript](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html), [Babel](https://babeljs.io/docs/config-files), etc. because it lets users add comments to configuration files. However, since JSONC isn't a strictly defined standard, there's some variation in how different tools handle trailing commas in JSONC files. To accommodate this, Biome doesn't provide a dedicated language configuration for JSONC. Instead, we've enhanced our JSON parsing and formatting capabilities with options like `json.parser.allowComments`, `json.parser.allowTrailingCommas`, and `json.formatter.trailingCommas`. This approach allows Biome to effectively support different variants of JSON files.
+
+For files with an extension name of `.jsonc` or those identified as `jsonc` according to the [language identifier](https://code.visualstudio.com/docs/languages/identifiers), Biome automatically applies the following default settings for parsing and formatting them:
+
+- `json.parser.allowComments`: `true`
+- `json.parser.allowTrailingCommas`: `true`
+- `json.formatter.trailingCommas`: `none`
+
+Please note, some well-known files like `tsconfig.json` and `.babelrc` don't use the `.jsonc` extension but still allow comments and trailing commas. While others, such as `.eslintrc.json`, only allow comments. Biome is able to identify these files and adjusts the `json.parser.allowTrailingCommas` option accordingly to ensure they are correctly parsed.
+
+[This section](../guides/how-biome-works#well-known-files) gives the full list of well-known files that Biome can recognize.
+
 ## HTML super languages support
 
 As of version `1.6.0`, these languages are **partially** supported. Biome will get better over time, and it will provide more options to tweak your project. As for today, there are some expectations and limitations to take in consideration:

--- a/website/src/content/docs/internals/language-support.mdx
+++ b/website/src/content/docs/internals/language-support.mdx
@@ -48,7 +48,7 @@ For files with an extension name of `.jsonc` or those identified as `jsonc` acco
 
 Please note, some well-known files like `tsconfig.json` and `.babelrc` don't use the `.jsonc` extension but still allow comments and trailing commas. While others, such as `.eslintrc.json`, only allow comments. Biome is able to identify these files and adjusts the `json.parser.allowTrailingCommas` option accordingly to ensure they are correctly parsed.
 
-[This section](../guides/how-biome-works#well-known-files) gives the full list of well-known files that Biome can recognize.
+[This section](../../guides/how-biome-works#well-known-files) gives the full list of well-known files that Biome can recognize.
 
 ## HTML super languages support
 


### PR DESCRIPTION
## Summary

- Refactor the file source calculation

  I noticed some code redundency and multiple sources of truth in file source calculation and that can be a hidden footgun maintaining-wise. So I tried to refactor the code in a cleaner way. I have very little exprience in tweaking the Rust code in a project level, so please correct me if I did something wrong.

- Complete the well-known json-like file lists

  This supersedes #2146.

## Test Plan

- Existing tests should pass.
- `WELL_KNOWN...` lists should be sorted for binary search, so a `test_order` function is added to ensure they're sorted.
- Different kinds of json-like files are tested in `crates/biome_service/tests/workspace.rs`
