### PR TITLE
Add operation parsing rule for GraphQL parser

### DIFF
--- a/crates/biome_graphql_factory/src/generated/node_factory.rs
+++ b/crates/biome_graphql_factory/src/generated/node_factory.rs
@@ -429,7 +429,7 @@ pub fn graphql_float_value(graphql_float_literal_token: SyntaxToken) -> GraphqlF
 }
 pub fn graphql_fragment_definition(
     fragment_token: SyntaxToken,
-    name: GraphqlFragmentName,
+    name: GraphqlName,
     type_condition: GraphqlTypeCondition,
     directives: GraphqlDirectiveList,
     selection_set: GraphqlSelectionSet,
@@ -445,15 +445,9 @@ pub fn graphql_fragment_definition(
         ],
     ))
 }
-pub fn graphql_fragment_name(name: GraphqlName) -> GraphqlFragmentName {
-    GraphqlFragmentName::unwrap_cast(SyntaxNode::new_detached(
-        GraphqlSyntaxKind::GRAPHQL_FRAGMENT_NAME,
-        [Some(SyntaxElement::Node(name.into_syntax()))],
-    ))
-}
 pub fn graphql_fragment_spread(
     dotdotdot_token: SyntaxToken,
-    name: GraphqlFragmentName,
+    name: GraphqlName,
     directives: GraphqlDirectiveList,
 ) -> GraphqlFragmentSpread {
     GraphqlFragmentSpread::unwrap_cast(SyntaxNode::new_detached(

--- a/crates/biome_graphql_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_graphql_factory/src/generated/syntax_factory.rs
@@ -741,7 +741,7 @@ impl SyntaxFactory for GraphqlSyntaxFactory {
                 }
                 slots.next_slot();
                 if let Some(element) = &current_element {
-                    if GraphqlFragmentName::can_cast(element.kind()) {
+                    if GraphqlName::can_cast(element.kind()) {
                         slots.mark_present();
                         current_element = elements.next();
                     }
@@ -776,25 +776,6 @@ impl SyntaxFactory for GraphqlSyntaxFactory {
                 }
                 slots.into_node(GRAPHQL_FRAGMENT_DEFINITION, children)
             }
-            GRAPHQL_FRAGMENT_NAME => {
-                let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<1usize> = RawNodeSlots::default();
-                let mut current_element = elements.next();
-                if let Some(element) = &current_element {
-                    if GraphqlName::can_cast(element.kind()) {
-                        slots.mark_present();
-                        current_element = elements.next();
-                    }
-                }
-                slots.next_slot();
-                if current_element.is_some() {
-                    return RawSyntaxNode::new(
-                        GRAPHQL_FRAGMENT_NAME.to_bogus(),
-                        children.into_iter().map(Some),
-                    );
-                }
-                slots.into_node(GRAPHQL_FRAGMENT_NAME, children)
-            }
             GRAPHQL_FRAGMENT_SPREAD => {
                 let mut elements = (&children).into_iter();
                 let mut slots: RawNodeSlots<3usize> = RawNodeSlots::default();
@@ -807,7 +788,7 @@ impl SyntaxFactory for GraphqlSyntaxFactory {
                 }
                 slots.next_slot();
                 if let Some(element) = &current_element {
-                    if GraphqlFragmentName::can_cast(element.kind()) {
+                    if GraphqlName::can_cast(element.kind()) {
                         slots.mark_present();
                         current_element = elements.next();
                     }

--- a/crates/biome_graphql_parser/src/lexer/mod.rs
+++ b/crates/biome_graphql_parser/src/lexer/mod.rs
@@ -149,6 +149,7 @@ impl<'src> GraphqlLexer<'src> {
             b'.' => self.consume_ellipsis(),
             b':' => self.consume_byte(T![:]),
             b'\n' | b'\r' | b'\t' | b' ' => self.consume_newline_or_whitespaces(),
+            b',' => self.consume_commas(),
             b'"' => self.consume_string(),
             b'=' => self.consume_byte(T![=]),
             b'@' => self.consume_byte(T![@]),
@@ -714,6 +715,15 @@ impl<'src> GraphqlLexer<'src> {
             }
         }
         COMMENT
+    }
+
+    fn consume_commas(&mut self) -> GraphqlSyntaxKind {
+        while self.current_byte() == Some(b',') {
+            self.assert_byte(b',');
+            self.advance(1);
+        }
+
+        COMMA
     }
 }
 

--- a/crates/biome_graphql_parser/src/lexer/tests.rs
+++ b/crates/biome_graphql_parser/src/lexer/tests.rs
@@ -364,3 +364,30 @@ fn dot() {
         ERROR_TOKEN:1
     }
 }
+
+#[test]
+fn trivia() {
+    assert_lex! {
+        r#",  ,
+        ,,,,,"#,
+        COMMA:1,
+        WHITESPACE:2,
+        COMMA:1,
+        NEWLINE:1,
+        WHITESPACE:8,
+        COMMA:5
+    }
+
+    assert_lex! {
+        r#"(1,  , ,,,,,2)"#,
+        L_PAREN:1,
+        GRAPHQL_INT_LITERAL:1,
+        COMMA:1,
+        WHITESPACE:2,
+        COMMA:1,
+        WHITESPACE:1,
+        COMMA:5,
+        GRAPHQL_INT_LITERAL:1,
+        R_PAREN:1
+    }
+}

--- a/crates/biome_graphql_parser/src/parser/argument.rs
+++ b/crates/biome_graphql_parser/src/parser/argument.rs
@@ -1,0 +1,81 @@
+use crate::parser::{parse_name, GraphqlParser};
+use biome_graphql_syntax::{
+    GraphqlSyntaxKind::{self, *},
+    T,
+};
+use biome_parser::{
+    parse_lists::ParseNodeList, parse_recovery::ParseRecovery, parsed_syntax::ParsedSyntax,
+    prelude::ParsedSyntax::*, Parser,
+};
+
+use super::{
+    is_at_name,
+    parse_error::{expected_argument, expected_value},
+    value::parse_value,
+};
+
+struct ArgumentListParseRecovery;
+
+impl ParseRecovery for ArgumentListParseRecovery {
+    type Kind = GraphqlSyntaxKind;
+    type Parser<'source> = GraphqlParser<'source>;
+    const RECOVERED_KIND: Self::Kind = GRAPHQL_ARGUMENT;
+
+    fn is_at_recovered(&self, p: &mut Self::Parser<'_>) -> bool {
+        is_at_name(p)
+    }
+}
+
+#[derive(Default)]
+struct ArgumentList;
+
+impl ParseNodeList for ArgumentList {
+    type Kind = GraphqlSyntaxKind;
+    type Parser<'source> = GraphqlParser<'source>;
+
+    const LIST_KIND: Self::Kind = GRAPHQL_ARGUMENT_LIST;
+
+    fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
+        parse_argument(p)
+    }
+
+    fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
+        p.at(T![')'])
+    }
+
+    fn recover(
+        &mut self,
+        p: &mut Self::Parser<'_>,
+        parsed_element: ParsedSyntax,
+    ) -> biome_parser::parse_recovery::RecoveryResult {
+        parsed_element.or_recover(p, &ArgumentListParseRecovery, expected_argument)
+    }
+}
+
+#[inline]
+pub(crate) fn parse_arguments(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !p.at(T!['(']) {
+        return Absent;
+    }
+
+    let m = p.start();
+    p.bump(T!['(']);
+    ArgumentList.parse_list(p);
+    p.expect(T![')']);
+
+    Present(m.complete(p, GRAPHQL_ARGUMENTS))
+}
+
+#[inline]
+fn parse_argument(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_name(p) {
+        return Absent;
+    }
+
+    let m = p.start();
+    parse_name(p).ok();
+    p.expect(T![:]);
+    parse_value(p).or_add_diagnostic(p, expected_value);
+
+    Present(m.complete(p, GRAPHQL_ARGUMENT))
+}

--- a/crates/biome_graphql_parser/src/parser/argument.rs
+++ b/crates/biome_graphql_parser/src/parser/argument.rs
@@ -73,6 +73,8 @@ fn parse_argument(p: &mut GraphqlParser) -> ParsedSyntax {
     }
 
     let m = p.start();
+
+    // name is checked for in `is_at_name`
     parse_name(p).ok();
     p.expect(T![:]);
     parse_value(p).or_add_diagnostic(p, expected_value);

--- a/crates/biome_graphql_parser/src/parser/definitions/operation.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/operation.rs
@@ -1,7 +1,16 @@
 use crate::parser::{
+    argument::parse_arguments,
     directive::DirectiveList,
-    parse_error::{expected_any_selection, expected_name, expected_selection_set},
-    parse_name, GraphqlParser,
+    is_at_name,
+    parse_error::{
+        expected_any_selection, expected_named_type, expected_selection_set, expected_type,
+        expected_value, expected_variable_definition,
+    },
+    parse_name,
+    r#type::{parse_named_type, parse_type},
+    value::parse_value,
+    variable::{is_at_variable, parse_variable},
+    GraphqlParser,
 };
 use biome_graphql_syntax::{
     GraphqlSyntaxKind::{self, *},
@@ -12,70 +21,11 @@ use biome_parser::{
     prelude::ParsedSyntax::*, token_set, Parser, TokenSet,
 };
 
-pub(crate) const OPERATION_TYPE: TokenSet<GraphqlSyntaxKind> =
+const OPERATION_TYPE: TokenSet<GraphqlSyntaxKind> =
     token_set![T![query], T![mutation], T![subscription]];
 
-/// https://spec.graphql.org/October2021/#sec-Language.Operations.Query-shorthand
-#[inline]
-pub(crate) fn parse_operation_definition(p: &mut GraphqlParser) -> ParsedSyntax {
-    if !is_at_operation(p) {
-        return Absent;
-    }
-
-    if p.at_ts(OPERATION_TYPE) {
-        // TODO: parse variables
-        let m = p.start();
-        {
-            let m = p.start();
-            p.bump_ts(OPERATION_TYPE);
-            m.complete(p, GRAPHQL_OPERATION_TYPE);
-        }
-
-        // we don't need diagnostic here, because name is optional
-        parse_name(p).ok();
-
-        DirectiveList.parse_list(p);
-        parse_selection_set(p).or_add_diagnostic(p, expected_selection_set);
-
-        Present(m.complete(p, GRAPHQL_OPERATION_DEFINITION))
-    } else {
-        parse_selection_set(p)
-    }
-}
-
-#[inline]
-pub(crate) fn is_at_operation(p: &mut GraphqlParser<'_>) -> bool {
-    p.at_ts(OPERATION_TYPE) || is_at_selection_set(p)
-}
-
-#[inline]
-fn parse_selection_set(p: &mut GraphqlParser) -> ParsedSyntax {
-    let m = p.start();
-    p.expect(T!['{']);
-    SelectionList::new().parse_list(p);
-    p.expect(T!['}']);
-    Present(m.complete(p, GRAPHQL_SELECTION_SET))
-}
-
-struct SelectionListParseRecovery;
-
-impl ParseRecovery for SelectionListParseRecovery {
-    type Kind = GraphqlSyntaxKind;
-    type Parser<'source> = GraphqlParser<'source>;
-    const RECOVERED_KIND: Self::Kind = GRAPHQL_BOGUS_SELECTION;
-
-    fn is_at_recovered(&self, p: &mut Self::Parser<'_>) -> bool {
-        is_at_selection(p)
-    }
-}
-
-pub(crate) struct SelectionList;
-
-impl SelectionList {
-    pub(crate) fn new() -> Self {
-        Self
-    }
-}
+#[derive(Default)]
+struct SelectionList;
 
 impl ParseNodeList for SelectionList {
     type Kind = GraphqlSyntaxKind;
@@ -100,38 +50,225 @@ impl ParseNodeList for SelectionList {
     }
 }
 
+struct SelectionListParseRecovery;
+
+impl ParseRecovery for SelectionListParseRecovery {
+    type Kind = GraphqlSyntaxKind;
+    type Parser<'source> = GraphqlParser<'source>;
+    const RECOVERED_KIND: Self::Kind = GRAPHQL_BOGUS_SELECTION;
+
+    fn is_at_recovered(&self, p: &mut Self::Parser<'_>) -> bool {
+        is_at_selection(p)
+    }
+}
+
+#[derive(Default)]
+struct VariableDefinitionList;
+
+impl ParseNodeList for VariableDefinitionList {
+    type Kind = GraphqlSyntaxKind;
+    type Parser<'source> = GraphqlParser<'source>;
+
+    const LIST_KIND: Self::Kind = GRAPHQL_VARIABLE_DEFINITION_LIST;
+
+    fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
+        parse_variable_definition(p)
+    }
+
+    fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
+        p.at(T![')'])
+    }
+
+    fn recover(
+        &mut self,
+        p: &mut Self::Parser<'_>,
+        parsed_element: ParsedSyntax,
+    ) -> biome_parser::parse_recovery::RecoveryResult {
+        parsed_element.or_recover(
+            p,
+            &VariableDefinitionListParseRecovery,
+            expected_variable_definition,
+        )
+    }
+}
+
+struct VariableDefinitionListParseRecovery;
+
+impl ParseRecovery for VariableDefinitionListParseRecovery {
+    type Kind = GraphqlSyntaxKind;
+    type Parser<'source> = GraphqlParser<'source>;
+    const RECOVERED_KIND: Self::Kind = GRAPHQL_VARIABLE_DEFINITION;
+
+    fn is_at_recovered(&self, p: &mut Self::Parser<'_>) -> bool {
+        is_at_variable(p)
+    }
+}
+
+/// https://spec.graphql.org/October2021/#sec-Language.Operations.Query-shorthand
+#[inline]
+pub(crate) fn parse_operation_definition(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_operation(p) {
+        return Absent;
+    }
+
+    if !p.at_ts(OPERATION_TYPE) {
+        return parse_selection_set(p);
+    }
+
+    let m = p.start();
+    {
+        let m = p.start();
+        p.bump_ts(OPERATION_TYPE);
+        m.complete(p, GRAPHQL_OPERATION_TYPE);
+    }
+
+    // we don't need diagnostic here, because name is optional
+    parse_name(p).ok();
+    // we don't need diagnostic here, because variable definitions are optional
+    parse_variable_definitions(p).ok();
+
+    DirectiveList.parse_list(p);
+    parse_selection_set(p).or_add_diagnostic(p, expected_selection_set);
+
+    Present(m.complete(p, GRAPHQL_OPERATION_DEFINITION))
+}
+
+#[inline]
+fn parse_selection_set(p: &mut GraphqlParser) -> ParsedSyntax {
+    let m = p.start();
+    p.expect(T!['{']);
+    SelectionList.parse_list(p);
+    p.expect(T!['}']);
+    Present(m.complete(p, GRAPHQL_SELECTION_SET))
+}
+
 #[inline]
 fn parse_selection(p: &mut GraphqlParser) -> ParsedSyntax {
-    // TODO: parse any selection
-    match p.cur() {
-        DOT3 => todo!(),
-        _ if is_at_field(p) => parse_field(p),
-        _ => Absent,
+    if is_at_field(p) {
+        parse_field(p)
+    } else if is_at_fragment(p) {
+        parse_fragment(p)
+    } else {
+        Absent
     }
 }
 
 #[inline]
 fn parse_field(p: &mut GraphqlParser) -> ParsedSyntax {
-    // TODO: parse alias, arguments, nested selection set
+    if !is_at_field(p) {
+        return Absent;
+    }
     let m = p.start();
-    parse_name(p).or_add_diagnostic(p, expected_name);
+    let next_token = p.lookahead();
+    if next_token == T![:] {
+        let m = p.start();
+        parse_name(p).ok();
+        p.bump(T![:]);
+        m.complete(p, GRAPHQL_ALIAS);
+    }
+    parse_name(p).ok();
+
+    // arguments are optional
+    parse_arguments(p).ok();
     DirectiveList.parse_list(p);
+
+    if is_at_selection_set(p) {
+        parse_selection_set(p).ok();
+    }
     Present(m.complete(p, GRAPHQL_FIELD))
 }
 
 #[inline]
-pub(crate) fn is_at_selection_set(p: &mut GraphqlParser<'_>) -> bool {
+fn parse_fragment(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !p.at(DOT3) {
+        return Absent;
+    }
+    let m = p.start();
+    p.bump(DOT3);
+    if is_at_name(p) {
+        parse_name(p).ok();
+        DirectiveList.parse_list(p);
+        Present(m.complete(p, GRAPHQL_FRAGMENT_SPREAD))
+    } else {
+        if p.at(T![on]) {
+            let m = p.start();
+            p.bump(T![on]);
+            parse_named_type(p).or_add_diagnostic(p, expected_named_type);
+            m.complete(p, GRAPHQL_TYPE_CONDITION);
+        }
+        DirectiveList.parse_list(p);
+        parse_selection_set(p).or_add_diagnostic(p, expected_selection_set);
+        Present(m.complete(p, GRAPHQL_INLINE_FRAGMENT))
+    }
+}
+
+#[inline]
+fn parse_variable_definitions(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !p.at(T!['(']) {
+        return Absent;
+    }
+
+    let m = p.start();
+
+    p.bump(T!['(']);
+    VariableDefinitionList.parse_list(p);
+    p.expect(T![')']);
+
+    Present(m.complete(p, GRAPHQL_VARIABLE_DEFINITIONS))
+}
+
+#[inline]
+fn parse_variable_definition(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_variable(p) {
+        return Absent;
+    }
+
+    let m = p.start();
+
+    parse_variable(p).ok();
+    p.expect(T![:]);
+    parse_type(p).or_add_diagnostic(p, expected_type);
+
+    // default value is optional
+    parse_default_value(p).ok();
+    DirectiveList.parse_list(p);
+
+    Present(m.complete(p, GRAPHQL_VARIABLE_DEFINITION))
+}
+
+#[inline]
+fn parse_default_value(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !p.at(T![=]) {
+        return Absent;
+    }
+
+    let m = p.start();
+    p.bump(T![=]);
+    parse_value(p).or_add_diagnostic(p, expected_value);
+    Present(m.complete(p, GRAPHQL_DEFAULT_VALUE))
+}
+
+#[inline]
+pub(crate) fn is_at_operation(p: &mut GraphqlParser<'_>) -> bool {
+    p.at_ts(OPERATION_TYPE) || is_at_selection_set(p)
+}
+
+#[inline]
+fn is_at_selection_set(p: &GraphqlParser) -> bool {
     p.at(T!['{'])
 }
 
 #[inline]
-pub(crate) fn is_at_selection(p: &mut GraphqlParser<'_>) -> bool {
-    // TODO: any selection
-    is_at_field(p)
+fn is_at_selection(p: &GraphqlParser) -> bool {
+    is_at_field(p) || is_at_fragment(p)
 }
 
 #[inline]
-pub(crate) fn is_at_field(p: &mut GraphqlParser<'_>) -> bool {
-    // TODO: handle arguments
-    p.at(GRAPHQL_NAME)
+fn is_at_field(p: &GraphqlParser) -> bool {
+    is_at_name(p)
+}
+
+#[inline]
+fn is_at_fragment(p: &GraphqlParser) -> bool {
+    p.at(DOT3)
 }

--- a/crates/biome_graphql_parser/src/parser/definitions/operation.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/operation.rs
@@ -3,8 +3,8 @@ use crate::parser::{
     directive::DirectiveList,
     is_at_name,
     parse_error::{
-        expected_any_selection, expected_named_type, expected_selection_set, expected_type,
-        expected_value, expected_variable_definition,
+        expected_any_selection, expected_named_type, expected_type, expected_value,
+        expected_variable_definition,
     },
     parse_name,
     r#type::{parse_named_type, parse_type},
@@ -128,7 +128,7 @@ pub(crate) fn parse_operation_definition(p: &mut GraphqlParser) -> ParsedSyntax 
     parse_variable_definitions(p).ok();
 
     DirectiveList.parse_list(p);
-    parse_selection_set(p).or_add_diagnostic(p, expected_selection_set);
+    parse_selection_set(p).ok();
 
     Present(m.complete(p, GRAPHQL_OPERATION_DEFINITION))
 }
@@ -197,7 +197,7 @@ fn parse_fragment(p: &mut GraphqlParser) -> ParsedSyntax {
             m.complete(p, GRAPHQL_TYPE_CONDITION);
         }
         DirectiveList.parse_list(p);
-        parse_selection_set(p).or_add_diagnostic(p, expected_selection_set);
+        parse_selection_set(p).ok();
         Present(m.complete(p, GRAPHQL_INLINE_FRAGMENT))
     }
 }

--- a/crates/biome_graphql_parser/src/parser/definitions/operation.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/operation.rs
@@ -159,6 +159,8 @@ fn parse_field(p: &mut GraphqlParser) -> ParsedSyntax {
         return Absent;
     }
     let m = p.start();
+    // This is currently the only time we need to lookahead
+    // so there is no need to implement NthToken to use nth_at
     let next_token = p.lookahead();
     if next_token == T![:] {
         let m = p.start();

--- a/crates/biome_graphql_parser/src/parser/definitions/operation.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/operation.rs
@@ -111,7 +111,7 @@ pub(crate) fn parse_operation_definition(p: &mut GraphqlParser) -> ParsedSyntax 
         return Absent;
     }
 
-    if !p.at_ts(OPERATION_TYPE) {
+    if is_at_selection_set(p) {
         return parse_selection_set(p);
     }
 
@@ -180,7 +180,7 @@ fn parse_field(p: &mut GraphqlParser) -> ParsedSyntax {
 
 #[inline]
 fn parse_fragment(p: &mut GraphqlParser) -> ParsedSyntax {
-    if !p.at(DOT3) {
+    if !is_at_fragment(p) {
         return Absent;
     }
     let m = p.start();

--- a/crates/biome_graphql_parser/src/parser/directive.rs
+++ b/crates/biome_graphql_parser/src/parser/directive.rs
@@ -8,7 +8,7 @@ use biome_parser::{
     prelude::ParsedSyntax::*, Parser,
 };
 
-use super::parse_error::expected_directive;
+use super::{argument::parse_arguments, parse_error::expected_directive};
 struct DirectiveListParseRecovery;
 
 impl ParseRecovery for DirectiveListParseRecovery {
@@ -48,11 +48,6 @@ impl ParseNodeList for DirectiveList {
 }
 
 #[inline]
-fn is_at_directive(p: &mut GraphqlParser<'_>) -> bool {
-    p.at(T![@])
-}
-
-#[inline]
 pub(crate) fn parse_directive(p: &mut GraphqlParser) -> ParsedSyntax {
     if !p.at(T![@]) {
         return Absent;
@@ -61,7 +56,14 @@ pub(crate) fn parse_directive(p: &mut GraphqlParser) -> ParsedSyntax {
     let m = p.start();
     p.bump(T![@]);
     parse_name(p).or_add_diagnostic(p, expected_name);
-    // TODO: parse arguments
+
+    // arguments are optional
+    parse_arguments(p).ok();
 
     Present(m.complete(p, GRAPHQL_DIRECTIVE))
+}
+
+#[inline]
+fn is_at_directive(p: &mut GraphqlParser<'_>) -> bool {
+    p.at(T![@])
 }

--- a/crates/biome_graphql_parser/src/parser/mod.rs
+++ b/crates/biome_graphql_parser/src/parser/mod.rs
@@ -1,6 +1,10 @@
+mod argument;
 mod definitions;
 mod directive;
 mod parse_error;
+mod r#type;
+mod value;
+mod variable;
 use crate::token_source::GraphqlTokenSource;
 use biome_graphql_syntax::GraphqlSyntaxKind::{self, *};
 use biome_parser::diagnostic::merge_diagnostics;
@@ -24,7 +28,6 @@ impl<'source> GraphqlParser<'source> {
         }
     }
 
-    #[allow(unused)]
     pub fn lookahead(&mut self) -> GraphqlSyntaxKind {
         self.source.lookahead()
     }
@@ -87,4 +90,9 @@ fn parse_name(p: &mut GraphqlParser) -> ParsedSyntax {
     let m = p.start();
     p.bump(GRAPHQL_NAME);
     Present(m.complete(p, GRAPHQL_NAME))
+}
+
+#[inline]
+fn is_at_name(p: &GraphqlParser) -> bool {
+    p.at(GRAPHQL_NAME)
 }

--- a/crates/biome_graphql_parser/src/parser/parse_error.rs
+++ b/crates/biome_graphql_parser/src/parser/parse_error.rs
@@ -11,8 +11,7 @@ pub(crate) fn expected_selection_set(p: &GraphqlParser, range: TextRange) -> Par
 }
 
 pub(crate) fn expected_any_selection(p: &GraphqlParser, range: TextRange) -> ParseDiagnostic {
-    // TODO: any selection
-    expected_any(&["field", "fragment spread"], range, p)
+    expected_any(&["field", "fragment spread", "inline fragment"], range, p)
 }
 
 pub(crate) fn expected_name(p: &GraphqlParser, range: TextRange) -> ParseDiagnostic {
@@ -21,4 +20,32 @@ pub(crate) fn expected_name(p: &GraphqlParser, range: TextRange) -> ParseDiagnos
 
 pub(crate) fn expected_directive(p: &GraphqlParser, range: TextRange) -> ParseDiagnostic {
     expected_node("directive", range, p)
+}
+
+pub(crate) fn expected_named_type(p: &GraphqlParser, range: TextRange) -> ParseDiagnostic {
+    expected_node("named type", range, p)
+}
+
+pub(crate) fn expected_named_or_list_type(p: &GraphqlParser, range: TextRange) -> ParseDiagnostic {
+    expected_any(&["named type", "list type"], range, p)
+}
+
+pub(crate) fn expected_type(p: &GraphqlParser, range: TextRange) -> ParseDiagnostic {
+    expected_node("type", range, p)
+}
+
+pub(crate) fn expected_value(p: &GraphqlParser, range: TextRange) -> ParseDiagnostic {
+    expected_node("value", range, p)
+}
+
+pub(crate) fn expected_object_field(p: &GraphqlParser, range: TextRange) -> ParseDiagnostic {
+    expected_node("object field", range, p)
+}
+
+pub(crate) fn expected_argument(p: &GraphqlParser, range: TextRange) -> ParseDiagnostic {
+    expected_node("argument", range, p)
+}
+
+pub(crate) fn expected_variable_definition(p: &GraphqlParser, range: TextRange) -> ParseDiagnostic {
+    expected_node("variable definition", range, p)
 }

--- a/crates/biome_graphql_parser/src/parser/parse_error.rs
+++ b/crates/biome_graphql_parser/src/parser/parse_error.rs
@@ -6,10 +6,6 @@ pub(crate) fn expected_any_definition(p: &GraphqlParser, range: TextRange) -> Pa
     expected_node("definition", range, p)
 }
 
-pub(crate) fn expected_selection_set(p: &GraphqlParser, range: TextRange) -> ParseDiagnostic {
-    expected_node("selection set", range, p)
-}
-
 pub(crate) fn expected_any_selection(p: &GraphqlParser, range: TextRange) -> ParseDiagnostic {
     expected_any(&["field", "fragment spread", "inline fragment"], range, p)
 }

--- a/crates/biome_graphql_parser/src/parser/type.rs
+++ b/crates/biome_graphql_parser/src/parser/type.rs
@@ -1,0 +1,53 @@
+use crate::parser::{parse_name, GraphqlParser};
+use biome_graphql_syntax::{GraphqlSyntaxKind::*, T};
+use biome_parser::{parsed_syntax::ParsedSyntax, prelude::ParsedSyntax::*, Parser};
+
+use super::{
+    is_at_name,
+    parse_error::{expected_named_or_list_type, expected_type},
+};
+
+#[inline]
+pub(crate) fn parse_type(p: &mut GraphqlParser) -> ParsedSyntax {
+    let m = p.start();
+    let node = if is_at_list_type(p) {
+        parse_list_type(p)
+    } else {
+        parse_named_type(p)
+    };
+    if p.at(T![!]) {
+        p.bump(T![!]);
+        // case like `a: !`
+        node.or_add_diagnostic(p, expected_named_or_list_type);
+        Present(m.complete(p, GRAPHQL_NON_NULL_TYPE))
+    } else {
+        m.abandon(p);
+        node
+    }
+}
+
+#[inline]
+fn parse_list_type(p: &mut GraphqlParser) -> ParsedSyntax {
+    let m = p.start();
+    p.expect(T!['[']);
+    parse_type(p).or_add_diagnostic(p, expected_type);
+    p.expect(T![']']);
+
+    Present(m.complete(p, GRAPHQL_LIST_TYPE))
+}
+
+#[inline]
+pub(crate) fn parse_named_type(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_name(p) {
+        return Absent;
+    }
+    let m = p.start();
+    parse_name(p).ok();
+
+    Present(m.complete(p, GRAPHQL_NAMED_TYPE))
+}
+
+#[inline]
+fn is_at_list_type(p: &GraphqlParser) -> bool {
+    p.at(T!['['])
+}

--- a/crates/biome_graphql_parser/src/parser/type.rs
+++ b/crates/biome_graphql_parser/src/parser/type.rs
@@ -1,6 +1,8 @@
 use crate::parser::{parse_name, GraphqlParser};
 use biome_graphql_syntax::{GraphqlSyntaxKind::*, T};
-use biome_parser::{parsed_syntax::ParsedSyntax, prelude::ParsedSyntax::*, Parser};
+use biome_parser::{
+    parsed_syntax::ParsedSyntax, prelude::ParsedSyntax::*, CompletedMarker, Parser,
+};
 
 use super::{
     is_at_name,
@@ -11,13 +13,13 @@ use super::{
 pub(crate) fn parse_type(p: &mut GraphqlParser) -> ParsedSyntax {
     let m = p.start();
     let node = if is_at_list_type(p) {
-        parse_list_type(p)
+        Present(parse_list_type(p))
     } else {
         parse_named_type(p)
     };
     if p.at(T![!]) {
         p.bump(T![!]);
-        // case like `a: !`
+        // cases like `a: !`, having `!` without a type is invalid
         node.or_add_diagnostic(p, expected_named_or_list_type);
         Present(m.complete(p, GRAPHQL_NON_NULL_TYPE))
     } else {
@@ -27,13 +29,15 @@ pub(crate) fn parse_type(p: &mut GraphqlParser) -> ParsedSyntax {
 }
 
 #[inline]
-fn parse_list_type(p: &mut GraphqlParser) -> ParsedSyntax {
+fn parse_list_type(p: &mut GraphqlParser) -> CompletedMarker {
+    // without '[' this type will be a named type
+    // so we expect '[' to be present for list type
     let m = p.start();
     p.expect(T!['[']);
     parse_type(p).or_add_diagnostic(p, expected_type);
     p.expect(T![']']);
 
-    Present(m.complete(p, GRAPHQL_LIST_TYPE))
+    m.complete(p, GRAPHQL_LIST_TYPE)
 }
 
 #[inline]

--- a/crates/biome_graphql_parser/src/parser/value.rs
+++ b/crates/biome_graphql_parser/src/parser/value.rs
@@ -1,0 +1,278 @@
+/// Parse all inpul value
+/// https://spec.graphql.org/October2021/#sec-Input-Values
+use crate::parser::{parse_name, GraphqlParser};
+use biome_graphql_syntax::{
+    GraphqlSyntaxKind::{self, *},
+    T,
+};
+use biome_parser::{
+    parse_lists::ParseNodeList, parse_recovery::ParseRecovery, parsed_syntax::ParsedSyntax,
+    prelude::ParsedSyntax::*, token_set, Parser, TokenSet,
+};
+
+use super::{
+    is_at_name,
+    parse_error::{expected_object_field, expected_value},
+    variable::{is_at_variable, parse_variable},
+};
+
+const BOOLEAN_VALUE_SET: TokenSet<GraphqlSyntaxKind> = token_set![TRUE_KW, FALSE_KW];
+
+struct ListValueElementListParseRecovery;
+
+impl ParseRecovery for ListValueElementListParseRecovery {
+    type Kind = GraphqlSyntaxKind;
+    type Parser<'source> = GraphqlParser<'source>;
+    const RECOVERED_KIND: Self::Kind = GRAPHQL_BOGUS_VALUE;
+
+    fn is_at_recovered(&self, p: &mut Self::Parser<'_>) -> bool {
+        is_at_value(p)
+    }
+}
+
+#[derive(Default)]
+struct ListValueElementList;
+
+impl ParseNodeList for ListValueElementList {
+    type Kind = GraphqlSyntaxKind;
+    type Parser<'source> = GraphqlParser<'source>;
+
+    const LIST_KIND: Self::Kind = GRAPHQL_LIST_VALUE_ELEMENT_LIST;
+
+    fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
+        parse_value(p)
+    }
+
+    fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
+        p.at(T![']'])
+    }
+
+    fn recover(
+        &mut self,
+        p: &mut Self::Parser<'_>,
+        parsed_element: ParsedSyntax,
+    ) -> biome_parser::parse_recovery::RecoveryResult {
+        parsed_element.or_recover(p, &ListValueElementListParseRecovery, expected_value)
+    }
+}
+
+struct ObjectValueMemberListParseRecovery;
+
+impl ParseRecovery for ObjectValueMemberListParseRecovery {
+    type Kind = GraphqlSyntaxKind;
+    type Parser<'source> = GraphqlParser<'source>;
+    const RECOVERED_KIND: Self::Kind = GRAPHQL_OBJECT_FIELD;
+
+    fn is_at_recovered(&self, p: &mut Self::Parser<'_>) -> bool {
+        is_at_name(p)
+    }
+}
+
+#[derive(Default)]
+struct ObjectValueMemberList;
+
+impl ParseNodeList for ObjectValueMemberList {
+    type Kind = GraphqlSyntaxKind;
+    type Parser<'source> = GraphqlParser<'source>;
+
+    const LIST_KIND: Self::Kind = GRAPHQL_OBJECT_VALUE_MEMBER_LIST;
+
+    fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
+        parse_object_field(p)
+    }
+
+    fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
+        p.at(T!['}'])
+    }
+
+    fn recover(
+        &mut self,
+        p: &mut Self::Parser<'_>,
+        parsed_element: ParsedSyntax,
+    ) -> biome_parser::parse_recovery::RecoveryResult {
+        parsed_element.or_recover(
+            p,
+            &ObjectValueMemberListParseRecovery,
+            expected_object_field,
+        )
+    }
+}
+
+#[inline]
+pub(crate) fn parse_value(p: &mut GraphqlParser) -> ParsedSyntax {
+    if is_at_variable(p) {
+        parse_variable(p)
+    } else if is_at_int(p) {
+        parse_int(p)
+    } else if is_at_float(p) {
+        parse_float(p)
+    } else if is_at_string(p) {
+        parse_string(p)
+    } else if is_at_boolean(p) {
+        parse_boolean(p)
+    } else if is_at_null(p) {
+        parse_null(p)
+    } else if is_at_enum(p) {
+        parse_enum(p)
+    } else if is_at_list(p) {
+        parse_list(p)
+    } else if is_at_object(p) {
+        parse_object(p)
+    } else {
+        return Absent;
+    }
+}
+
+#[inline]
+fn parse_int(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_int(p) {
+        return Absent;
+    }
+    let m = p.start();
+    p.bump(GRAPHQL_INT_LITERAL);
+    Present(m.complete(p, GRAPHQL_INT_VALUE))
+}
+
+#[inline]
+fn parse_float(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_float(p) {
+        return Absent;
+    }
+    let m = p.start();
+    p.bump(GRAPHQL_FLOAT_LITERAL);
+    Present(m.complete(p, GRAPHQL_FLOAT_VALUE))
+}
+
+#[inline]
+fn parse_string(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_string(p) {
+        return Absent;
+    }
+    let m = p.start();
+    p.bump(GRAPHQL_STRING_LITERAL);
+    Present(m.complete(p, GRAPHQL_STRING_VALUE))
+}
+
+#[inline]
+fn parse_boolean(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_boolean(p) {
+        return Absent;
+    }
+    let m = p.start();
+    p.bump_ts(BOOLEAN_VALUE_SET);
+    Present(m.complete(p, GRAPHQL_BOOLEAN_VALUE))
+}
+
+#[inline]
+fn parse_null(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_null(p) {
+        return Absent;
+    }
+    let m = p.start();
+    p.bump(T![null]);
+    Present(m.complete(p, GRAPHQL_NULL_VALUE))
+}
+
+#[inline]
+fn parse_enum(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_enum(p) {
+        return Absent;
+    }
+    let m = p.start();
+    parse_name(p).ok();
+    Present(m.complete(p, GRAPHQL_ENUM_VALUE))
+}
+
+#[inline]
+fn parse_list(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_list(p) {
+        return Absent;
+    }
+    let m = p.start();
+    p.bump(T!['[']);
+    ListValueElementList.parse_list(p);
+    p.expect(T![']']);
+    Present(m.complete(p, GRAPHQL_LIST_VALUE))
+}
+
+#[inline]
+fn parse_object(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_object(p) {
+        return Absent;
+    }
+    let m = p.start();
+    p.bump(T!['{']);
+    ObjectValueMemberList.parse_list(p);
+    p.expect(T!['}']);
+    Present(m.complete(p, GRAPHQL_OBJECT_VALUE))
+}
+
+#[inline]
+fn parse_object_field(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_object_field(p) {
+        return Absent;
+    }
+    let m = p.start();
+    parse_name(p).ok();
+    p.expect(T![:]);
+    parse_value(p).or_add_diagnostic(p, expected_value);
+    Present(m.complete(p, GRAPHQL_OBJECT_FIELD))
+}
+
+#[inline]
+fn is_at_value(p: &GraphqlParser) -> bool {
+    is_at_variable(p)
+        || is_at_int(p)
+        || is_at_float(p)
+        || is_at_string(p)
+        || is_at_boolean(p)
+        || is_at_null(p)
+        || is_at_enum(p)
+        || is_at_list(p)
+        || is_at_object(p)
+}
+
+#[inline]
+fn is_at_int(p: &GraphqlParser) -> bool {
+    p.at(GRAPHQL_INT_LITERAL)
+}
+
+#[inline]
+fn is_at_float(p: &GraphqlParser) -> bool {
+    p.at(GRAPHQL_FLOAT_LITERAL)
+}
+
+#[inline]
+fn is_at_string(p: &GraphqlParser) -> bool {
+    p.at(GRAPHQL_STRING_LITERAL)
+}
+
+#[inline]
+fn is_at_boolean(p: &GraphqlParser) -> bool {
+    p.at_ts(BOOLEAN_VALUE_SET)
+}
+
+#[inline]
+fn is_at_null(p: &GraphqlParser) -> bool {
+    p.at(T![null])
+}
+
+#[inline]
+fn is_at_enum(p: &GraphqlParser) -> bool {
+    is_at_name(p)
+}
+
+#[inline]
+fn is_at_list(p: &GraphqlParser) -> bool {
+    p.at(T!['['])
+}
+
+#[inline]
+fn is_at_object(p: &GraphqlParser) -> bool {
+    p.at(T!['{'])
+}
+
+#[inline]
+fn is_at_object_field(p: &GraphqlParser) -> bool {
+    is_at_name(p)
+}

--- a/crates/biome_graphql_parser/src/parser/variable.rs
+++ b/crates/biome_graphql_parser/src/parser/variable.rs
@@ -1,0 +1,23 @@
+use crate::parser::GraphqlParser;
+use biome_graphql_syntax::{GraphqlSyntaxKind::*, T};
+use biome_parser::{parsed_syntax::ParsedSyntax, prelude::ParsedSyntax::*, Parser};
+
+use super::{parse_error::expected_name, parse_name};
+
+#[inline]
+pub(crate) fn parse_variable(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_variable(p) {
+        return Absent;
+    }
+
+    let m = p.start();
+    p.bump(T![$]);
+    parse_name(p).or_add_diagnostic(p, expected_name);
+
+    Present(m.complete(p, GRAPHQL_VARIABLE))
+}
+
+#[inline]
+pub(crate) fn is_at_variable(p: &GraphqlParser) -> bool {
+    p.at(T![$])
+}

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/operation.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/operation.graphql
@@ -1,0 +1,3 @@
+query likeStory
+
+

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/operation.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/operation.graphql.snap
@@ -1,0 +1,75 @@
+---
+source: crates/biome_graphql_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```graphql
+query likeStory
+
+
+
+```
+
+## AST
+
+```
+GraphqlRoot {
+    bom_token: missing (optional),
+    definitions: GraphqlDefinitionList [
+        GraphqlOperationDefinition {
+            ty: GraphqlOperationType {
+                value_token: QUERY_KW@0..6 "query" [] [Whitespace(" ")],
+            },
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@6..15 "likeStory" [] [],
+            },
+            variables: missing (optional),
+            directives: GraphqlDirectiveList [],
+            selection_set: GraphqlSelectionSet {
+                l_curly_token: missing (required),
+                selections: GraphqlSelectionList [],
+                r_curly_token: missing (required),
+            },
+        },
+    ],
+    eof_token: EOF@15..18 "" [Newline("\n"), Newline("\n"), Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: GRAPHQL_ROOT@0..18
+  0: (empty)
+  1: GRAPHQL_DEFINITION_LIST@0..15
+    0: GRAPHQL_OPERATION_DEFINITION@0..15
+      0: GRAPHQL_OPERATION_TYPE@0..6
+        0: QUERY_KW@0..6 "query" [] [Whitespace(" ")]
+      1: GRAPHQL_NAME@6..15
+        0: GRAPHQL_NAME@6..15 "likeStory" [] []
+      2: (empty)
+      3: GRAPHQL_DIRECTIVE_LIST@15..15
+      4: GRAPHQL_SELECTION_SET@15..15
+        0: (empty)
+        1: GRAPHQL_SELECTION_LIST@15..15
+        2: (empty)
+  2: EOF@15..18 "" [Newline("\n"), Newline("\n"), Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+operation.graphql:4:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `{` but instead the file ends
+  
+  > 4 │ 
+      │ 
+  
+  i the file ends here
+  
+  > 4 │ 
+      │ 
+  
+```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/directive.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/directive.graphql
@@ -1,0 +1,13 @@
+{
+  hero @deprecated
+}
+
+{
+  hero @deprecated(reason: "Deprecated")
+}
+
+{
+  hero
+		@deprecated(reason: "Deprecated")
+		@addExternalFields(source: "profiles")
+}

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/directive.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/directive.graphql.snap
@@ -1,0 +1,240 @@
+---
+source: crates/biome_graphql_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```graphql
+{
+  hero @deprecated
+}
+
+{
+  hero @deprecated(reason: "Deprecated")
+}
+
+{
+  hero
+		@deprecated(reason: "Deprecated")
+		@addExternalFields(source: "profiles")
+}
+
+```
+
+## AST
+
+```
+GraphqlRoot {
+    bom_token: missing (optional),
+    definitions: GraphqlDefinitionList [
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@0..1 "{" [] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@1..9 "hero" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                    },
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [
+                        GraphqlDirective {
+                            at_token: AT@9..10 "@" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@10..20 "deprecated" [] [],
+                            },
+                            arguments: missing (optional),
+                        },
+                    ],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@20..22 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@22..25 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@25..33 "hero" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                    },
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [
+                        GraphqlDirective {
+                            at_token: AT@33..34 "@" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@34..44 "deprecated" [] [],
+                            },
+                            arguments: GraphqlArguments {
+                                l_paren_token: L_PAREN@44..45 "(" [] [],
+                                arguments: GraphqlArgumentList [
+                                    GraphqlArgument {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@45..51 "reason" [] [],
+                                        },
+                                        colon_token: COLON@51..53 ":" [] [Whitespace(" ")],
+                                        value: GraphqlStringValue {
+                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@53..65 "\"Deprecated\"" [] [],
+                                        },
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@65..66 ")" [] [],
+                            },
+                        },
+                    ],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@66..68 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@68..71 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@71..78 "hero" [Newline("\n"), Whitespace("  ")] [],
+                    },
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [
+                        GraphqlDirective {
+                            at_token: AT@78..82 "@" [Newline("\n"), Whitespace("\t\t")] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@82..92 "deprecated" [] [],
+                            },
+                            arguments: GraphqlArguments {
+                                l_paren_token: L_PAREN@92..93 "(" [] [],
+                                arguments: GraphqlArgumentList [
+                                    GraphqlArgument {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@93..99 "reason" [] [],
+                                        },
+                                        colon_token: COLON@99..101 ":" [] [Whitespace(" ")],
+                                        value: GraphqlStringValue {
+                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@101..113 "\"Deprecated\"" [] [],
+                                        },
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@113..114 ")" [] [],
+                            },
+                        },
+                        GraphqlDirective {
+                            at_token: AT@114..118 "@" [Newline("\n"), Whitespace("\t\t")] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@118..135 "addExternalFields" [] [],
+                            },
+                            arguments: GraphqlArguments {
+                                l_paren_token: L_PAREN@135..136 "(" [] [],
+                                arguments: GraphqlArgumentList [
+                                    GraphqlArgument {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@136..142 "source" [] [],
+                                        },
+                                        colon_token: COLON@142..144 ":" [] [Whitespace(" ")],
+                                        value: GraphqlStringValue {
+                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@144..154 "\"profiles\"" [] [],
+                                        },
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@154..155 ")" [] [],
+                            },
+                        },
+                    ],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@155..157 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@157..158 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: GRAPHQL_ROOT@0..158
+  0: (empty)
+  1: GRAPHQL_DEFINITION_LIST@0..157
+    0: GRAPHQL_SELECTION_SET@0..22
+      0: L_CURLY@0..1 "{" [] []
+      1: GRAPHQL_SELECTION_LIST@1..20
+        0: GRAPHQL_FIELD@1..20
+          0: (empty)
+          1: GRAPHQL_NAME@1..9
+            0: GRAPHQL_NAME@1..9 "hero" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@9..20
+            0: GRAPHQL_DIRECTIVE@9..20
+              0: AT@9..10 "@" [] []
+              1: GRAPHQL_NAME@10..20
+                0: GRAPHQL_NAME@10..20 "deprecated" [] []
+              2: (empty)
+          4: (empty)
+      2: R_CURLY@20..22 "}" [Newline("\n")] []
+    1: GRAPHQL_SELECTION_SET@22..68
+      0: L_CURLY@22..25 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@25..66
+        0: GRAPHQL_FIELD@25..66
+          0: (empty)
+          1: GRAPHQL_NAME@25..33
+            0: GRAPHQL_NAME@25..33 "hero" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@33..66
+            0: GRAPHQL_DIRECTIVE@33..66
+              0: AT@33..34 "@" [] []
+              1: GRAPHQL_NAME@34..44
+                0: GRAPHQL_NAME@34..44 "deprecated" [] []
+              2: GRAPHQL_ARGUMENTS@44..66
+                0: L_PAREN@44..45 "(" [] []
+                1: GRAPHQL_ARGUMENT_LIST@45..65
+                  0: GRAPHQL_ARGUMENT@45..65
+                    0: GRAPHQL_NAME@45..51
+                      0: GRAPHQL_NAME@45..51 "reason" [] []
+                    1: COLON@51..53 ":" [] [Whitespace(" ")]
+                    2: GRAPHQL_STRING_VALUE@53..65
+                      0: GRAPHQL_STRING_LITERAL@53..65 "\"Deprecated\"" [] []
+                2: R_PAREN@65..66 ")" [] []
+          4: (empty)
+      2: R_CURLY@66..68 "}" [Newline("\n")] []
+    2: GRAPHQL_SELECTION_SET@68..157
+      0: L_CURLY@68..71 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@71..155
+        0: GRAPHQL_FIELD@71..155
+          0: (empty)
+          1: GRAPHQL_NAME@71..78
+            0: GRAPHQL_NAME@71..78 "hero" [Newline("\n"), Whitespace("  ")] []
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@78..155
+            0: GRAPHQL_DIRECTIVE@78..114
+              0: AT@78..82 "@" [Newline("\n"), Whitespace("\t\t")] []
+              1: GRAPHQL_NAME@82..92
+                0: GRAPHQL_NAME@82..92 "deprecated" [] []
+              2: GRAPHQL_ARGUMENTS@92..114
+                0: L_PAREN@92..93 "(" [] []
+                1: GRAPHQL_ARGUMENT_LIST@93..113
+                  0: GRAPHQL_ARGUMENT@93..113
+                    0: GRAPHQL_NAME@93..99
+                      0: GRAPHQL_NAME@93..99 "reason" [] []
+                    1: COLON@99..101 ":" [] [Whitespace(" ")]
+                    2: GRAPHQL_STRING_VALUE@101..113
+                      0: GRAPHQL_STRING_LITERAL@101..113 "\"Deprecated\"" [] []
+                2: R_PAREN@113..114 ")" [] []
+            1: GRAPHQL_DIRECTIVE@114..155
+              0: AT@114..118 "@" [Newline("\n"), Whitespace("\t\t")] []
+              1: GRAPHQL_NAME@118..135
+                0: GRAPHQL_NAME@118..135 "addExternalFields" [] []
+              2: GRAPHQL_ARGUMENTS@135..155
+                0: L_PAREN@135..136 "(" [] []
+                1: GRAPHQL_ARGUMENT_LIST@136..154
+                  0: GRAPHQL_ARGUMENT@136..154
+                    0: GRAPHQL_NAME@136..142
+                      0: GRAPHQL_NAME@136..142 "source" [] []
+                    1: COLON@142..144 ":" [] [Whitespace(" ")]
+                    2: GRAPHQL_STRING_VALUE@144..154
+                      0: GRAPHQL_STRING_LITERAL@144..154 "\"profiles\"" [] []
+                2: R_PAREN@154..155 ")" [] []
+          4: (empty)
+      2: R_CURLY@155..157 "}" [Newline("\n")] []
+  2: EOF@157..158 "" [Newline("\n")] []
+
+```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/operation.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/operation.graphql
@@ -2,6 +2,29 @@ query {
   likeStory
 }
 
+# shorthand
 {
-  field
+  likeStory
+}
+
+mutation {
+	likeStory
+}
+
+subscription {
+	storyLiked
+}
+
+# with variables
+query ($storyId: ID!) {
+	likeStory(storyId: $storyId)
+}
+
+query ($storyId: ID = "1") {
+	likeStory(storyId: $storyId)
+}
+
+# with directives
+query ($storyId: ID!) @skip(if: true){
+	likeStory(storyId: $storyId)
 }

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/operation.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/operation.graphql.snap
@@ -8,8 +8,31 @@ query {
   likeStory
 }
 
+# shorthand
 {
-  field
+  likeStory
+}
+
+mutation {
+	likeStory
+}
+
+subscription {
+	storyLiked
+}
+
+# with variables
+query ($storyId: ID!) {
+	likeStory(storyId: $storyId)
+}
+
+query ($storyId: ID = "1") {
+	likeStory(storyId: $storyId)
+}
+
+# with directives
+query ($storyId: ID!) @skip(if: true){
+	likeStory(storyId: $storyId)
 }
 
 ```
@@ -44,31 +67,293 @@ GraphqlRoot {
             },
         },
         GraphqlSelectionSet {
-            l_curly_token: L_CURLY@21..24 "{" [Newline("\n"), Newline("\n")] [],
+            l_curly_token: L_CURLY@21..36 "{" [Newline("\n"), Newline("\n"), Comments("# shorthand"), Newline("\n")] [],
             selections: GraphqlSelectionList [
                 GraphqlField {
                     alias: missing (optional),
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@24..32 "field" [Newline("\n"), Whitespace("  ")] [],
+                        value_token: GRAPHQL_NAME@36..48 "likeStory" [Newline("\n"), Whitespace("  ")] [],
                     },
                     arguments: missing (optional),
                     directives: GraphqlDirectiveList [],
                     selection_set: missing (optional),
                 },
             ],
-            r_curly_token: R_CURLY@32..34 "}" [Newline("\n")] [],
+            r_curly_token: R_CURLY@48..50 "}" [Newline("\n")] [],
+        },
+        GraphqlOperationDefinition {
+            ty: GraphqlOperationType {
+                value_token: MUTATION_KW@50..61 "mutation" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            },
+            name: missing (optional),
+            variables: missing (optional),
+            directives: GraphqlDirectiveList [],
+            selection_set: GraphqlSelectionSet {
+                l_curly_token: L_CURLY@61..62 "{" [] [],
+                selections: GraphqlSelectionList [
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@62..73 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        arguments: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@73..75 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlOperationDefinition {
+            ty: GraphqlOperationType {
+                value_token: SUBSCRIPTION_KW@75..90 "subscription" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            },
+            name: missing (optional),
+            variables: missing (optional),
+            directives: GraphqlDirectiveList [],
+            selection_set: GraphqlSelectionSet {
+                l_curly_token: L_CURLY@90..91 "{" [] [],
+                selections: GraphqlSelectionList [
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@91..103 "storyLiked" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        arguments: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@103..105 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlOperationDefinition {
+            ty: GraphqlOperationType {
+                value_token: QUERY_KW@105..130 "query" [Newline("\n"), Newline("\n"), Comments("# with variables"), Newline("\n")] [Whitespace(" ")],
+            },
+            name: missing (optional),
+            variables: GraphqlVariableDefinitions {
+                l_paren_token: L_PAREN@130..131 "(" [] [],
+                elements: GraphqlVariableDefinitionList [
+                    GraphqlVariableDefinition {
+                        variable: GraphqlVariable {
+                            dollar_token: DOLLAR@131..132 "$" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@132..139 "storyId" [] [],
+                            },
+                        },
+                        colon_token: COLON@139..141 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNonNullType {
+                            base: GraphqlNamedType {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@141..143 "ID" [] [],
+                                },
+                            },
+                            excl_token: BANG@143..144 "!" [] [],
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_paren_token: R_PAREN@144..146 ")" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [],
+            selection_set: GraphqlSelectionSet {
+                l_curly_token: L_CURLY@146..147 "{" [] [],
+                selections: GraphqlSelectionList [
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@147..158 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        arguments: GraphqlArguments {
+                            l_paren_token: L_PAREN@158..159 "(" [] [],
+                            arguments: GraphqlArgumentList [
+                                GraphqlArgument {
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@159..166 "storyId" [] [],
+                                    },
+                                    colon_token: COLON@166..168 ":" [] [Whitespace(" ")],
+                                    value: GraphqlVariable {
+                                        dollar_token: DOLLAR@168..169 "$" [] [],
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@169..176 "storyId" [] [],
+                                        },
+                                    },
+                                },
+                            ],
+                            r_paren_token: R_PAREN@176..177 ")" [] [],
+                        },
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@177..179 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlOperationDefinition {
+            ty: GraphqlOperationType {
+                value_token: QUERY_KW@179..187 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            },
+            name: missing (optional),
+            variables: GraphqlVariableDefinitions {
+                l_paren_token: L_PAREN@187..188 "(" [] [],
+                elements: GraphqlVariableDefinitionList [
+                    GraphqlVariableDefinition {
+                        variable: GraphqlVariable {
+                            dollar_token: DOLLAR@188..189 "$" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@189..196 "storyId" [] [],
+                            },
+                        },
+                        colon_token: COLON@196..198 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@198..201 "ID" [] [Whitespace(" ")],
+                            },
+                        },
+                        default: GraphqlDefaultValue {
+                            eq_token: EQ@201..203 "=" [] [Whitespace(" ")],
+                            value: GraphqlStringValue {
+                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@203..206 "\"1\"" [] [],
+                            },
+                        },
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_paren_token: R_PAREN@206..208 ")" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [],
+            selection_set: GraphqlSelectionSet {
+                l_curly_token: L_CURLY@208..209 "{" [] [],
+                selections: GraphqlSelectionList [
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@209..220 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        arguments: GraphqlArguments {
+                            l_paren_token: L_PAREN@220..221 "(" [] [],
+                            arguments: GraphqlArgumentList [
+                                GraphqlArgument {
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@221..228 "storyId" [] [],
+                                    },
+                                    colon_token: COLON@228..230 ":" [] [Whitespace(" ")],
+                                    value: GraphqlVariable {
+                                        dollar_token: DOLLAR@230..231 "$" [] [],
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@231..238 "storyId" [] [],
+                                        },
+                                    },
+                                },
+                            ],
+                            r_paren_token: R_PAREN@238..239 ")" [] [],
+                        },
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@239..241 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlOperationDefinition {
+            ty: GraphqlOperationType {
+                value_token: QUERY_KW@241..267 "query" [Newline("\n"), Newline("\n"), Comments("# with directives"), Newline("\n")] [Whitespace(" ")],
+            },
+            name: missing (optional),
+            variables: GraphqlVariableDefinitions {
+                l_paren_token: L_PAREN@267..268 "(" [] [],
+                elements: GraphqlVariableDefinitionList [
+                    GraphqlVariableDefinition {
+                        variable: GraphqlVariable {
+                            dollar_token: DOLLAR@268..269 "$" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@269..276 "storyId" [] [],
+                            },
+                        },
+                        colon_token: COLON@276..278 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNonNullType {
+                            base: GraphqlNamedType {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@278..280 "ID" [] [],
+                                },
+                            },
+                            excl_token: BANG@280..281 "!" [] [],
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_paren_token: R_PAREN@281..283 ")" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [
+                GraphqlDirective {
+                    at_token: AT@283..284 "@" [] [],
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@284..288 "skip" [] [],
+                    },
+                    arguments: GraphqlArguments {
+                        l_paren_token: L_PAREN@288..289 "(" [] [],
+                        arguments: GraphqlArgumentList [
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@289..291 "if" [] [],
+                                },
+                                colon_token: COLON@291..293 ":" [] [Whitespace(" ")],
+                                value: GraphqlBooleanValue {
+                                    value_token: TRUE_KW@293..297 "true" [] [],
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@297..298 ")" [] [],
+                    },
+                },
+            ],
+            selection_set: GraphqlSelectionSet {
+                l_curly_token: L_CURLY@298..299 "{" [] [],
+                selections: GraphqlSelectionList [
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@299..310 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        arguments: GraphqlArguments {
+                            l_paren_token: L_PAREN@310..311 "(" [] [],
+                            arguments: GraphqlArgumentList [
+                                GraphqlArgument {
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@311..318 "storyId" [] [],
+                                    },
+                                    colon_token: COLON@318..320 ":" [] [Whitespace(" ")],
+                                    value: GraphqlVariable {
+                                        dollar_token: DOLLAR@320..321 "$" [] [],
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@321..328 "storyId" [] [],
+                                        },
+                                    },
+                                },
+                            ],
+                            r_paren_token: R_PAREN@328..329 ")" [] [],
+                        },
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@329..331 "}" [Newline("\n")] [],
+            },
         },
     ],
-    eof_token: EOF@34..35 "" [Newline("\n")] [],
+    eof_token: EOF@331..332 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..35
+0: GRAPHQL_ROOT@0..332
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..34
+  1: GRAPHQL_DEFINITION_LIST@0..331
     0: GRAPHQL_OPERATION_DEFINITION@0..21
       0: GRAPHQL_OPERATION_TYPE@0..6
         0: QUERY_KW@0..6 "query" [] [Whitespace(" ")]
@@ -86,17 +371,198 @@ GraphqlRoot {
             3: GRAPHQL_DIRECTIVE_LIST@19..19
             4: (empty)
         2: R_CURLY@19..21 "}" [Newline("\n")] []
-    1: GRAPHQL_SELECTION_SET@21..34
-      0: L_CURLY@21..24 "{" [Newline("\n"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@24..32
-        0: GRAPHQL_FIELD@24..32
+    1: GRAPHQL_SELECTION_SET@21..50
+      0: L_CURLY@21..36 "{" [Newline("\n"), Newline("\n"), Comments("# shorthand"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@36..48
+        0: GRAPHQL_FIELD@36..48
           0: (empty)
-          1: GRAPHQL_NAME@24..32
-            0: GRAPHQL_NAME@24..32 "field" [Newline("\n"), Whitespace("  ")] []
+          1: GRAPHQL_NAME@36..48
+            0: GRAPHQL_NAME@36..48 "likeStory" [Newline("\n"), Whitespace("  ")] []
           2: (empty)
-          3: GRAPHQL_DIRECTIVE_LIST@32..32
+          3: GRAPHQL_DIRECTIVE_LIST@48..48
           4: (empty)
-      2: R_CURLY@32..34 "}" [Newline("\n")] []
-  2: EOF@34..35 "" [Newline("\n")] []
+      2: R_CURLY@48..50 "}" [Newline("\n")] []
+    2: GRAPHQL_OPERATION_DEFINITION@50..75
+      0: GRAPHQL_OPERATION_TYPE@50..61
+        0: MUTATION_KW@50..61 "mutation" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: (empty)
+      2: (empty)
+      3: GRAPHQL_DIRECTIVE_LIST@61..61
+      4: GRAPHQL_SELECTION_SET@61..75
+        0: L_CURLY@61..62 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@62..73
+          0: GRAPHQL_FIELD@62..73
+            0: (empty)
+            1: GRAPHQL_NAME@62..73
+              0: GRAPHQL_NAME@62..73 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@73..73
+            4: (empty)
+        2: R_CURLY@73..75 "}" [Newline("\n")] []
+    3: GRAPHQL_OPERATION_DEFINITION@75..105
+      0: GRAPHQL_OPERATION_TYPE@75..90
+        0: SUBSCRIPTION_KW@75..90 "subscription" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: (empty)
+      2: (empty)
+      3: GRAPHQL_DIRECTIVE_LIST@90..90
+      4: GRAPHQL_SELECTION_SET@90..105
+        0: L_CURLY@90..91 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@91..103
+          0: GRAPHQL_FIELD@91..103
+            0: (empty)
+            1: GRAPHQL_NAME@91..103
+              0: GRAPHQL_NAME@91..103 "storyLiked" [Newline("\n"), Whitespace("\t")] []
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@103..103
+            4: (empty)
+        2: R_CURLY@103..105 "}" [Newline("\n")] []
+    4: GRAPHQL_OPERATION_DEFINITION@105..179
+      0: GRAPHQL_OPERATION_TYPE@105..130
+        0: QUERY_KW@105..130 "query" [Newline("\n"), Newline("\n"), Comments("# with variables"), Newline("\n")] [Whitespace(" ")]
+      1: (empty)
+      2: GRAPHQL_VARIABLE_DEFINITIONS@130..146
+        0: L_PAREN@130..131 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@131..144
+          0: GRAPHQL_VARIABLE_DEFINITION@131..144
+            0: GRAPHQL_VARIABLE@131..139
+              0: DOLLAR@131..132 "$" [] []
+              1: GRAPHQL_NAME@132..139
+                0: GRAPHQL_NAME@132..139 "storyId" [] []
+            1: COLON@139..141 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@141..144
+              0: GRAPHQL_NAMED_TYPE@141..143
+                0: GRAPHQL_NAME@141..143
+                  0: GRAPHQL_NAME@141..143 "ID" [] []
+              1: BANG@143..144 "!" [] []
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@144..144
+        2: R_PAREN@144..146 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@146..146
+      4: GRAPHQL_SELECTION_SET@146..179
+        0: L_CURLY@146..147 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@147..177
+          0: GRAPHQL_FIELD@147..177
+            0: (empty)
+            1: GRAPHQL_NAME@147..158
+              0: GRAPHQL_NAME@147..158 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: GRAPHQL_ARGUMENTS@158..177
+              0: L_PAREN@158..159 "(" [] []
+              1: GRAPHQL_ARGUMENT_LIST@159..176
+                0: GRAPHQL_ARGUMENT@159..176
+                  0: GRAPHQL_NAME@159..166
+                    0: GRAPHQL_NAME@159..166 "storyId" [] []
+                  1: COLON@166..168 ":" [] [Whitespace(" ")]
+                  2: GRAPHQL_VARIABLE@168..176
+                    0: DOLLAR@168..169 "$" [] []
+                    1: GRAPHQL_NAME@169..176
+                      0: GRAPHQL_NAME@169..176 "storyId" [] []
+              2: R_PAREN@176..177 ")" [] []
+            3: GRAPHQL_DIRECTIVE_LIST@177..177
+            4: (empty)
+        2: R_CURLY@177..179 "}" [Newline("\n")] []
+    5: GRAPHQL_OPERATION_DEFINITION@179..241
+      0: GRAPHQL_OPERATION_TYPE@179..187
+        0: QUERY_KW@179..187 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: (empty)
+      2: GRAPHQL_VARIABLE_DEFINITIONS@187..208
+        0: L_PAREN@187..188 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@188..206
+          0: GRAPHQL_VARIABLE_DEFINITION@188..206
+            0: GRAPHQL_VARIABLE@188..196
+              0: DOLLAR@188..189 "$" [] []
+              1: GRAPHQL_NAME@189..196
+                0: GRAPHQL_NAME@189..196 "storyId" [] []
+            1: COLON@196..198 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NAMED_TYPE@198..201
+              0: GRAPHQL_NAME@198..201
+                0: GRAPHQL_NAME@198..201 "ID" [] [Whitespace(" ")]
+            3: GRAPHQL_DEFAULT_VALUE@201..206
+              0: EQ@201..203 "=" [] [Whitespace(" ")]
+              1: GRAPHQL_STRING_VALUE@203..206
+                0: GRAPHQL_STRING_LITERAL@203..206 "\"1\"" [] []
+            4: GRAPHQL_DIRECTIVE_LIST@206..206
+        2: R_PAREN@206..208 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@208..208
+      4: GRAPHQL_SELECTION_SET@208..241
+        0: L_CURLY@208..209 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@209..239
+          0: GRAPHQL_FIELD@209..239
+            0: (empty)
+            1: GRAPHQL_NAME@209..220
+              0: GRAPHQL_NAME@209..220 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: GRAPHQL_ARGUMENTS@220..239
+              0: L_PAREN@220..221 "(" [] []
+              1: GRAPHQL_ARGUMENT_LIST@221..238
+                0: GRAPHQL_ARGUMENT@221..238
+                  0: GRAPHQL_NAME@221..228
+                    0: GRAPHQL_NAME@221..228 "storyId" [] []
+                  1: COLON@228..230 ":" [] [Whitespace(" ")]
+                  2: GRAPHQL_VARIABLE@230..238
+                    0: DOLLAR@230..231 "$" [] []
+                    1: GRAPHQL_NAME@231..238
+                      0: GRAPHQL_NAME@231..238 "storyId" [] []
+              2: R_PAREN@238..239 ")" [] []
+            3: GRAPHQL_DIRECTIVE_LIST@239..239
+            4: (empty)
+        2: R_CURLY@239..241 "}" [Newline("\n")] []
+    6: GRAPHQL_OPERATION_DEFINITION@241..331
+      0: GRAPHQL_OPERATION_TYPE@241..267
+        0: QUERY_KW@241..267 "query" [Newline("\n"), Newline("\n"), Comments("# with directives"), Newline("\n")] [Whitespace(" ")]
+      1: (empty)
+      2: GRAPHQL_VARIABLE_DEFINITIONS@267..283
+        0: L_PAREN@267..268 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@268..281
+          0: GRAPHQL_VARIABLE_DEFINITION@268..281
+            0: GRAPHQL_VARIABLE@268..276
+              0: DOLLAR@268..269 "$" [] []
+              1: GRAPHQL_NAME@269..276
+                0: GRAPHQL_NAME@269..276 "storyId" [] []
+            1: COLON@276..278 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@278..281
+              0: GRAPHQL_NAMED_TYPE@278..280
+                0: GRAPHQL_NAME@278..280
+                  0: GRAPHQL_NAME@278..280 "ID" [] []
+              1: BANG@280..281 "!" [] []
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@281..281
+        2: R_PAREN@281..283 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@283..298
+        0: GRAPHQL_DIRECTIVE@283..298
+          0: AT@283..284 "@" [] []
+          1: GRAPHQL_NAME@284..288
+            0: GRAPHQL_NAME@284..288 "skip" [] []
+          2: GRAPHQL_ARGUMENTS@288..298
+            0: L_PAREN@288..289 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@289..297
+              0: GRAPHQL_ARGUMENT@289..297
+                0: GRAPHQL_NAME@289..291
+                  0: GRAPHQL_NAME@289..291 "if" [] []
+                1: COLON@291..293 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_BOOLEAN_VALUE@293..297
+                  0: TRUE_KW@293..297 "true" [] []
+            2: R_PAREN@297..298 ")" [] []
+      4: GRAPHQL_SELECTION_SET@298..331
+        0: L_CURLY@298..299 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@299..329
+          0: GRAPHQL_FIELD@299..329
+            0: (empty)
+            1: GRAPHQL_NAME@299..310
+              0: GRAPHQL_NAME@299..310 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: GRAPHQL_ARGUMENTS@310..329
+              0: L_PAREN@310..311 "(" [] []
+              1: GRAPHQL_ARGUMENT_LIST@311..328
+                0: GRAPHQL_ARGUMENT@311..328
+                  0: GRAPHQL_NAME@311..318
+                    0: GRAPHQL_NAME@311..318 "storyId" [] []
+                  1: COLON@318..320 ":" [] [Whitespace(" ")]
+                  2: GRAPHQL_VARIABLE@320..328
+                    0: DOLLAR@320..321 "$" [] []
+                    1: GRAPHQL_NAME@321..328
+                      0: GRAPHQL_NAME@321..328 "storyId" [] []
+              2: R_PAREN@328..329 ")" [] []
+            3: GRAPHQL_DIRECTIVE_LIST@329..329
+            4: (empty)
+        2: R_CURLY@329..331 "}" [Newline("\n")] []
+  2: EOF@331..332 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/selection_set.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/selection_set.graphql
@@ -1,0 +1,114 @@
+{
+	hero
+}
+
+# with nested fields
+{
+	hero {
+		name,
+		age
+	}
+}
+
+# with argument
+{
+	hero(name: "Tony Stark")
+}
+
+{
+	hero(name: "Tony Stark") {
+		country,
+		name,
+		age
+	}
+}
+
+{
+	hero(
+		name: "Tony Stark",
+		age: 53,
+		height: 6.1
+		alive: false,
+		location: null
+		birthplace: {city: "New York", state: "NY", country: "USA"}
+		friends: ["Pepper", "Rhodey"]
+	) {
+		country,
+		name,
+		age,
+		height(unit: FOOT),
+		wife(name: "Pepper"){
+			name
+		}
+	}
+}
+
+{
+	hero(name: $name)
+}
+
+# with aliases
+{
+  ironMan: hero(name: "Tony Stark")
+}
+
+{
+  ironMan: hero(name: "Tony Stark") {
+		country,
+		name,
+		age,
+		firstWife: wife(name: "Pepper"){
+			name
+		}
+	}
+}
+
+# with directives
+{
+  hero @deprecated
+}
+
+{
+  ironMan: hero(name: "Tony Stark") @deprecated {
+		country @deprecated,
+		name,
+		age
+	}
+}
+
+# Fragment spread
+{
+  ...heroFragment
+}
+
+{
+  ...heroFragment @deprecated
+}
+
+{
+  ironMan: hero(name: "Tony Stark") @deprecated {
+		...heroAttributes
+	}
+}
+
+# Inline Fragment spread
+{
+  ... {
+		hero
+	}
+}
+
+{
+  ... @deprecated {
+		hero
+	}
+}
+
+{
+  ironMan: hero(name: "Tony Stark") @deprecated {
+		... on Hero @deprecated {
+			name,
+			age
+		}
+	}
+}

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/selection_set.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/selection_set.graphql.snap
@@ -1,0 +1,1630 @@
+---
+source: crates/biome_graphql_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```graphql
+{
+	hero
+}
+
+# with nested fields
+{
+	hero {
+		name,
+		age
+	}
+}
+
+# with argument
+{
+	hero(name: "Tony Stark")
+}
+
+{
+	hero(name: "Tony Stark") {
+		country,
+		name,
+		age
+	}
+}
+
+{
+	hero(
+		name: "Tony Stark",
+		age: 53,
+		height: 6.1
+		alive: false,
+		location: null
+		birthplace: {city: "New York", state: "NY", country: "USA"}
+		friends: ["Pepper", "Rhodey"]
+	) {
+		country,
+		name,
+		age,
+		height(unit: FOOT),
+		wife(name: "Pepper"){
+			name
+		}
+	}
+}
+
+{
+	hero(name: $name)
+}
+
+# with aliases
+{
+  ironMan: hero(name: "Tony Stark")
+}
+
+{
+  ironMan: hero(name: "Tony Stark") {
+		country,
+		name,
+		age,
+		firstWife: wife(name: "Pepper"){
+			name
+		}
+	}
+}
+
+# with directives
+{
+  hero @deprecated
+}
+
+{
+  ironMan: hero(name: "Tony Stark") @deprecated {
+		country @deprecated,
+		name,
+		age
+	}
+}
+
+# Fragment spread
+{
+  ...heroFragment
+}
+
+{
+  ...heroFragment @deprecated
+}
+
+{
+  ironMan: hero(name: "Tony Stark") @deprecated {
+		...heroAttributes
+	}
+}
+
+# Inline Fragment spread
+{
+  ... {
+		hero
+	}
+}
+
+{
+  ... @deprecated {
+		hero
+	}
+}
+
+{
+  ironMan: hero(name: "Tony Stark") @deprecated {
+		... on Hero @deprecated {
+			name,
+			age
+		}
+	}
+}
+
+```
+
+## AST
+
+```
+GraphqlRoot {
+    bom_token: missing (optional),
+    definitions: GraphqlDefinitionList [
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@0..1 "{" [] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@1..7 "hero" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@7..9 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@9..33 "{" [Newline("\n"), Newline("\n"), Comments("# with nested fields"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@33..40 "hero" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    },
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [],
+                    selection_set: GraphqlSelectionSet {
+                        l_curly_token: L_CURLY@40..41 "{" [] [],
+                        selections: GraphqlSelectionList [
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@41..49 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@49..55 "age" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                        ],
+                        r_curly_token: R_CURLY@55..58 "}" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@58..60 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@60..79 "{" [Newline("\n"), Newline("\n"), Comments("# with argument"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@79..85 "hero" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                    arguments: GraphqlArguments {
+                        l_paren_token: L_PAREN@85..86 "(" [] [],
+                        arguments: GraphqlArgumentList [
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@86..90 "name" [] [],
+                                },
+                                colon_token: COLON@90..92 ":" [] [Whitespace(" ")],
+                                value: GraphqlStringValue {
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@92..104 "\"Tony Stark\"" [] [],
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@104..105 ")" [] [],
+                    },
+                    directives: GraphqlDirectiveList [],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@105..107 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@107..110 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@110..116 "hero" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                    arguments: GraphqlArguments {
+                        l_paren_token: L_PAREN@116..117 "(" [] [],
+                        arguments: GraphqlArgumentList [
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@117..121 "name" [] [],
+                                },
+                                colon_token: COLON@121..123 ":" [] [Whitespace(" ")],
+                                value: GraphqlStringValue {
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@123..135 "\"Tony Stark\"" [] [],
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@135..137 ")" [] [Whitespace(" ")],
+                    },
+                    directives: GraphqlDirectiveList [],
+                    selection_set: GraphqlSelectionSet {
+                        l_curly_token: L_CURLY@137..138 "{" [] [],
+                        selections: GraphqlSelectionList [
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@138..149 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@149..157 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@157..163 "age" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                        ],
+                        r_curly_token: R_CURLY@163..166 "}" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@166..168 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@168..171 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@171..177 "hero" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                    arguments: GraphqlArguments {
+                        l_paren_token: L_PAREN@177..178 "(" [] [],
+                        arguments: GraphqlArgumentList [
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@178..185 "name" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@185..187 ":" [] [Whitespace(" ")],
+                                value: GraphqlStringValue {
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@187..200 "\"Tony Stark\"" [] [Skipped(",")],
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@200..206 "age" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@206..208 ":" [] [Whitespace(" ")],
+                                value: GraphqlIntValue {
+                                    graphql_int_literal_token: GRAPHQL_INT_LITERAL@208..211 "53" [] [Skipped(",")],
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@211..220 "height" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@220..222 ":" [] [Whitespace(" ")],
+                                value: GraphqlFloatValue {
+                                    graphql_float_literal_token: GRAPHQL_FLOAT_LITERAL@222..225 "6.1" [] [],
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@225..233 "alive" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@233..235 ":" [] [Whitespace(" ")],
+                                value: GraphqlBooleanValue {
+                                    value_token: FALSE_KW@235..241 "false" [] [Skipped(",")],
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@241..252 "location" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@252..254 ":" [] [Whitespace(" ")],
+                                value: GraphqlNullValue {
+                                    null_token: NULL_KW@254..258 "null" [] [],
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@258..271 "birthplace" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@271..273 ":" [] [Whitespace(" ")],
+                                value: GraphqlObjectValue {
+                                    l_curly_token: L_CURLY@273..274 "{" [] [],
+                                    members: GraphqlObjectValueMemberList [
+                                        GraphqlObjectField {
+                                            name: GraphqlName {
+                                                value_token: GRAPHQL_NAME@274..278 "city" [] [],
+                                            },
+                                            colon_token: COLON@278..280 ":" [] [Whitespace(" ")],
+                                            value: GraphqlStringValue {
+                                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@280..292 "\"New York\"" [] [Skipped(","), Whitespace(" ")],
+                                            },
+                                        },
+                                        GraphqlObjectField {
+                                            name: GraphqlName {
+                                                value_token: GRAPHQL_NAME@292..297 "state" [] [],
+                                            },
+                                            colon_token: COLON@297..299 ":" [] [Whitespace(" ")],
+                                            value: GraphqlStringValue {
+                                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@299..305 "\"NY\"" [] [Skipped(","), Whitespace(" ")],
+                                            },
+                                        },
+                                        GraphqlObjectField {
+                                            name: GraphqlName {
+                                                value_token: GRAPHQL_NAME@305..312 "country" [] [],
+                                            },
+                                            colon_token: COLON@312..314 ":" [] [Whitespace(" ")],
+                                            value: GraphqlStringValue {
+                                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@314..319 "\"USA\"" [] [],
+                                            },
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@319..320 "}" [] [],
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@320..330 "friends" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@330..332 ":" [] [Whitespace(" ")],
+                                value: GraphqlListValue {
+                                    l_brack_token: L_BRACK@332..333 "[" [] [],
+                                    elements: GraphqlListValueElementList [
+                                        GraphqlStringValue {
+                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@333..343 "\"Pepper\"" [] [Skipped(","), Whitespace(" ")],
+                                        },
+                                        GraphqlStringValue {
+                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@343..351 "\"Rhodey\"" [] [],
+                                        },
+                                    ],
+                                    r_brack_token: R_BRACK@351..352 "]" [] [],
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@352..356 ")" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    },
+                    directives: GraphqlDirectiveList [],
+                    selection_set: GraphqlSelectionSet {
+                        l_curly_token: L_CURLY@356..357 "{" [] [],
+                        selections: GraphqlSelectionList [
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@357..368 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@368..376 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@376..383 "age" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@383..392 "height" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                arguments: GraphqlArguments {
+                                    l_paren_token: L_PAREN@392..393 "(" [] [],
+                                    arguments: GraphqlArgumentList [
+                                        GraphqlArgument {
+                                            name: GraphqlName {
+                                                value_token: GRAPHQL_NAME@393..397 "unit" [] [],
+                                            },
+                                            colon_token: COLON@397..399 ":" [] [Whitespace(" ")],
+                                            value: GraphqlEnumValue {
+                                                graphql_name: GraphqlName {
+                                                    value_token: GRAPHQL_NAME@399..403 "FOOT" [] [],
+                                                },
+                                            },
+                                        },
+                                    ],
+                                    r_paren_token: R_PAREN@403..405 ")" [] [Skipped(",")],
+                                },
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@405..412 "wife" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                arguments: GraphqlArguments {
+                                    l_paren_token: L_PAREN@412..413 "(" [] [],
+                                    arguments: GraphqlArgumentList [
+                                        GraphqlArgument {
+                                            name: GraphqlName {
+                                                value_token: GRAPHQL_NAME@413..417 "name" [] [],
+                                            },
+                                            colon_token: COLON@417..419 ":" [] [Whitespace(" ")],
+                                            value: GraphqlStringValue {
+                                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@419..427 "\"Pepper\"" [] [],
+                                            },
+                                        },
+                                    ],
+                                    r_paren_token: R_PAREN@427..428 ")" [] [],
+                                },
+                                directives: GraphqlDirectiveList [],
+                                selection_set: GraphqlSelectionSet {
+                                    l_curly_token: L_CURLY@428..429 "{" [] [],
+                                    selections: GraphqlSelectionList [
+                                        GraphqlField {
+                                            alias: missing (optional),
+                                            name: GraphqlName {
+                                                value_token: GRAPHQL_NAME@429..437 "name" [Newline("\n"), Whitespace("\t\t\t")] [],
+                                            },
+                                            arguments: missing (optional),
+                                            directives: GraphqlDirectiveList [],
+                                            selection_set: missing (optional),
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@437..441 "}" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                            },
+                        ],
+                        r_curly_token: R_CURLY@441..444 "}" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@444..446 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@446..449 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@449..455 "hero" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                    arguments: GraphqlArguments {
+                        l_paren_token: L_PAREN@455..456 "(" [] [],
+                        arguments: GraphqlArgumentList [
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@456..460 "name" [] [],
+                                },
+                                colon_token: COLON@460..462 ":" [] [Whitespace(" ")],
+                                value: GraphqlVariable {
+                                    dollar_token: DOLLAR@462..463 "$" [] [],
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@463..467 "name" [] [],
+                                    },
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@467..468 ")" [] [],
+                    },
+                    directives: GraphqlDirectiveList [],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@468..470 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@470..488 "{" [Newline("\n"), Newline("\n"), Comments("# with aliases"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: GraphqlAlias {
+                        value: GraphqlName {
+                            value_token: GRAPHQL_NAME@488..498 "ironMan" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@498..500 ":" [] [Whitespace(" ")],
+                    },
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@500..504 "hero" [] [],
+                    },
+                    arguments: GraphqlArguments {
+                        l_paren_token: L_PAREN@504..505 "(" [] [],
+                        arguments: GraphqlArgumentList [
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@505..509 "name" [] [],
+                                },
+                                colon_token: COLON@509..511 ":" [] [Whitespace(" ")],
+                                value: GraphqlStringValue {
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@511..523 "\"Tony Stark\"" [] [],
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@523..524 ")" [] [],
+                    },
+                    directives: GraphqlDirectiveList [],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@524..526 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@526..529 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: GraphqlAlias {
+                        value: GraphqlName {
+                            value_token: GRAPHQL_NAME@529..539 "ironMan" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@539..541 ":" [] [Whitespace(" ")],
+                    },
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@541..545 "hero" [] [],
+                    },
+                    arguments: GraphqlArguments {
+                        l_paren_token: L_PAREN@545..546 "(" [] [],
+                        arguments: GraphqlArgumentList [
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@546..550 "name" [] [],
+                                },
+                                colon_token: COLON@550..552 ":" [] [Whitespace(" ")],
+                                value: GraphqlStringValue {
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@552..564 "\"Tony Stark\"" [] [],
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@564..566 ")" [] [Whitespace(" ")],
+                    },
+                    directives: GraphqlDirectiveList [],
+                    selection_set: GraphqlSelectionSet {
+                        l_curly_token: L_CURLY@566..567 "{" [] [],
+                        selections: GraphqlSelectionList [
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@567..578 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@578..586 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@586..593 "age" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                            GraphqlField {
+                                alias: GraphqlAlias {
+                                    value: GraphqlName {
+                                        value_token: GRAPHQL_NAME@593..605 "firstWife" [Newline("\n"), Whitespace("\t\t")] [],
+                                    },
+                                    colon_token: COLON@605..607 ":" [] [Whitespace(" ")],
+                                },
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@607..611 "wife" [] [],
+                                },
+                                arguments: GraphqlArguments {
+                                    l_paren_token: L_PAREN@611..612 "(" [] [],
+                                    arguments: GraphqlArgumentList [
+                                        GraphqlArgument {
+                                            name: GraphqlName {
+                                                value_token: GRAPHQL_NAME@612..616 "name" [] [],
+                                            },
+                                            colon_token: COLON@616..618 ":" [] [Whitespace(" ")],
+                                            value: GraphqlStringValue {
+                                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@618..626 "\"Pepper\"" [] [],
+                                            },
+                                        },
+                                    ],
+                                    r_paren_token: R_PAREN@626..627 ")" [] [],
+                                },
+                                directives: GraphqlDirectiveList [],
+                                selection_set: GraphqlSelectionSet {
+                                    l_curly_token: L_CURLY@627..628 "{" [] [],
+                                    selections: GraphqlSelectionList [
+                                        GraphqlField {
+                                            alias: missing (optional),
+                                            name: GraphqlName {
+                                                value_token: GRAPHQL_NAME@628..636 "name" [Newline("\n"), Whitespace("\t\t\t")] [],
+                                            },
+                                            arguments: missing (optional),
+                                            directives: GraphqlDirectiveList [],
+                                            selection_set: missing (optional),
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@636..640 "}" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                            },
+                        ],
+                        r_curly_token: R_CURLY@640..643 "}" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@643..645 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@645..666 "{" [Newline("\n"), Newline("\n"), Comments("# with directives"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@666..674 "hero" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                    },
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [
+                        GraphqlDirective {
+                            at_token: AT@674..675 "@" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@675..685 "deprecated" [] [],
+                            },
+                            arguments: missing (optional),
+                        },
+                    ],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@685..687 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@687..690 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: GraphqlAlias {
+                        value: GraphqlName {
+                            value_token: GRAPHQL_NAME@690..700 "ironMan" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@700..702 ":" [] [Whitespace(" ")],
+                    },
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@702..706 "hero" [] [],
+                    },
+                    arguments: GraphqlArguments {
+                        l_paren_token: L_PAREN@706..707 "(" [] [],
+                        arguments: GraphqlArgumentList [
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@707..711 "name" [] [],
+                                },
+                                colon_token: COLON@711..713 ":" [] [Whitespace(" ")],
+                                value: GraphqlStringValue {
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@713..725 "\"Tony Stark\"" [] [],
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@725..727 ")" [] [Whitespace(" ")],
+                    },
+                    directives: GraphqlDirectiveList [
+                        GraphqlDirective {
+                            at_token: AT@727..728 "@" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@728..739 "deprecated" [] [Whitespace(" ")],
+                            },
+                            arguments: missing (optional),
+                        },
+                    ],
+                    selection_set: GraphqlSelectionSet {
+                        l_curly_token: L_CURLY@739..740 "{" [] [],
+                        selections: GraphqlSelectionList [
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@740..751 "country" [Newline("\n"), Whitespace("\t\t")] [Whitespace(" ")],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [
+                                    GraphqlDirective {
+                                        at_token: AT@751..752 "@" [] [],
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@752..763 "deprecated" [] [Skipped(",")],
+                                        },
+                                        arguments: missing (optional),
+                                    },
+                                ],
+                                selection_set: missing (optional),
+                            },
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@763..771 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@771..777 "age" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                        ],
+                        r_curly_token: R_CURLY@777..780 "}" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@780..782 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@782..803 "{" [Newline("\n"), Newline("\n"), Comments("# Fragment spread"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlFragmentSpread {
+                    dotdotdot_token: DOT3@803..809 "..." [Newline("\n"), Whitespace("  ")] [],
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@809..821 "heroFragment" [] [],
+                    },
+                    directives: GraphqlDirectiveList [],
+                },
+            ],
+            r_curly_token: R_CURLY@821..823 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@823..826 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlFragmentSpread {
+                    dotdotdot_token: DOT3@826..832 "..." [Newline("\n"), Whitespace("  ")] [],
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@832..845 "heroFragment" [] [Whitespace(" ")],
+                    },
+                    directives: GraphqlDirectiveList [
+                        GraphqlDirective {
+                            at_token: AT@845..846 "@" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@846..856 "deprecated" [] [],
+                            },
+                            arguments: missing (optional),
+                        },
+                    ],
+                },
+            ],
+            r_curly_token: R_CURLY@856..858 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@858..861 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: GraphqlAlias {
+                        value: GraphqlName {
+                            value_token: GRAPHQL_NAME@861..871 "ironMan" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@871..873 ":" [] [Whitespace(" ")],
+                    },
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@873..877 "hero" [] [],
+                    },
+                    arguments: GraphqlArguments {
+                        l_paren_token: L_PAREN@877..878 "(" [] [],
+                        arguments: GraphqlArgumentList [
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@878..882 "name" [] [],
+                                },
+                                colon_token: COLON@882..884 ":" [] [Whitespace(" ")],
+                                value: GraphqlStringValue {
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@884..896 "\"Tony Stark\"" [] [],
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@896..898 ")" [] [Whitespace(" ")],
+                    },
+                    directives: GraphqlDirectiveList [
+                        GraphqlDirective {
+                            at_token: AT@898..899 "@" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@899..910 "deprecated" [] [Whitespace(" ")],
+                            },
+                            arguments: missing (optional),
+                        },
+                    ],
+                    selection_set: GraphqlSelectionSet {
+                        l_curly_token: L_CURLY@910..911 "{" [] [],
+                        selections: GraphqlSelectionList [
+                            GraphqlFragmentSpread {
+                                dotdotdot_token: DOT3@911..917 "..." [Newline("\n"), Whitespace("\t\t")] [],
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@917..931 "heroAttributes" [] [],
+                                },
+                                directives: GraphqlDirectiveList [],
+                            },
+                        ],
+                        r_curly_token: R_CURLY@931..934 "}" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@934..936 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@936..964 "{" [Newline("\n"), Newline("\n"), Comments("# Inline Fragment spread"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlInlineFragment {
+                    dotdotdot_token: DOT3@964..971 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                    type_condition: missing (optional),
+                    directives: GraphqlDirectiveList [],
+                    selection_set: GraphqlSelectionSet {
+                        l_curly_token: L_CURLY@971..972 "{" [] [],
+                        selections: GraphqlSelectionList [
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@972..979 "hero" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                        ],
+                        r_curly_token: R_CURLY@979..982 "}" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@982..984 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@984..987 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlInlineFragment {
+                    dotdotdot_token: DOT3@987..994 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                    type_condition: missing (optional),
+                    directives: GraphqlDirectiveList [
+                        GraphqlDirective {
+                            at_token: AT@994..995 "@" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@995..1006 "deprecated" [] [Whitespace(" ")],
+                            },
+                            arguments: missing (optional),
+                        },
+                    ],
+                    selection_set: GraphqlSelectionSet {
+                        l_curly_token: L_CURLY@1006..1007 "{" [] [],
+                        selections: GraphqlSelectionList [
+                            GraphqlField {
+                                alias: missing (optional),
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@1007..1014 "hero" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                arguments: missing (optional),
+                                directives: GraphqlDirectiveList [],
+                                selection_set: missing (optional),
+                            },
+                        ],
+                        r_curly_token: R_CURLY@1014..1017 "}" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@1017..1019 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@1019..1022 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: GraphqlAlias {
+                        value: GraphqlName {
+                            value_token: GRAPHQL_NAME@1022..1032 "ironMan" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@1032..1034 ":" [] [Whitespace(" ")],
+                    },
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@1034..1038 "hero" [] [],
+                    },
+                    arguments: GraphqlArguments {
+                        l_paren_token: L_PAREN@1038..1039 "(" [] [],
+                        arguments: GraphqlArgumentList [
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@1039..1043 "name" [] [],
+                                },
+                                colon_token: COLON@1043..1045 ":" [] [Whitespace(" ")],
+                                value: GraphqlStringValue {
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@1045..1057 "\"Tony Stark\"" [] [],
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@1057..1059 ")" [] [Whitespace(" ")],
+                    },
+                    directives: GraphqlDirectiveList [
+                        GraphqlDirective {
+                            at_token: AT@1059..1060 "@" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@1060..1071 "deprecated" [] [Whitespace(" ")],
+                            },
+                            arguments: missing (optional),
+                        },
+                    ],
+                    selection_set: GraphqlSelectionSet {
+                        l_curly_token: L_CURLY@1071..1072 "{" [] [],
+                        selections: GraphqlSelectionList [
+                            GraphqlInlineFragment {
+                                dotdotdot_token: DOT3@1072..1079 "..." [Newline("\n"), Whitespace("\t\t")] [Whitespace(" ")],
+                                type_condition: GraphqlTypeCondition {
+                                    on_token: ON_KW@1079..1082 "on" [] [Whitespace(" ")],
+                                    ty: GraphqlNamedType {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@1082..1087 "Hero" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                },
+                                directives: GraphqlDirectiveList [
+                                    GraphqlDirective {
+                                        at_token: AT@1087..1088 "@" [] [],
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@1088..1099 "deprecated" [] [Whitespace(" ")],
+                                        },
+                                        arguments: missing (optional),
+                                    },
+                                ],
+                                selection_set: GraphqlSelectionSet {
+                                    l_curly_token: L_CURLY@1099..1100 "{" [] [],
+                                    selections: GraphqlSelectionList [
+                                        GraphqlField {
+                                            alias: missing (optional),
+                                            name: GraphqlName {
+                                                value_token: GRAPHQL_NAME@1100..1109 "name" [Newline("\n"), Whitespace("\t\t\t")] [Skipped(",")],
+                                            },
+                                            arguments: missing (optional),
+                                            directives: GraphqlDirectiveList [],
+                                            selection_set: missing (optional),
+                                        },
+                                        GraphqlField {
+                                            alias: missing (optional),
+                                            name: GraphqlName {
+                                                value_token: GRAPHQL_NAME@1109..1116 "age" [Newline("\n"), Whitespace("\t\t\t")] [],
+                                            },
+                                            arguments: missing (optional),
+                                            directives: GraphqlDirectiveList [],
+                                            selection_set: missing (optional),
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@1116..1120 "}" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                            },
+                        ],
+                        r_curly_token: R_CURLY@1120..1123 "}" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@1123..1125 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@1125..1126 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: GRAPHQL_ROOT@0..1126
+  0: (empty)
+  1: GRAPHQL_DEFINITION_LIST@0..1125
+    0: GRAPHQL_SELECTION_SET@0..9
+      0: L_CURLY@0..1 "{" [] []
+      1: GRAPHQL_SELECTION_LIST@1..7
+        0: GRAPHQL_FIELD@1..7
+          0: (empty)
+          1: GRAPHQL_NAME@1..7
+            0: GRAPHQL_NAME@1..7 "hero" [Newline("\n"), Whitespace("\t")] []
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@7..7
+          4: (empty)
+      2: R_CURLY@7..9 "}" [Newline("\n")] []
+    1: GRAPHQL_SELECTION_SET@9..60
+      0: L_CURLY@9..33 "{" [Newline("\n"), Newline("\n"), Comments("# with nested fields"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@33..58
+        0: GRAPHQL_FIELD@33..58
+          0: (empty)
+          1: GRAPHQL_NAME@33..40
+            0: GRAPHQL_NAME@33..40 "hero" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@40..40
+          4: GRAPHQL_SELECTION_SET@40..58
+            0: L_CURLY@40..41 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@41..55
+              0: GRAPHQL_FIELD@41..49
+                0: (empty)
+                1: GRAPHQL_NAME@41..49
+                  0: GRAPHQL_NAME@41..49 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@49..49
+                4: (empty)
+              1: GRAPHQL_FIELD@49..55
+                0: (empty)
+                1: GRAPHQL_NAME@49..55
+                  0: GRAPHQL_NAME@49..55 "age" [Newline("\n"), Whitespace("\t\t")] []
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@55..55
+                4: (empty)
+            2: R_CURLY@55..58 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@58..60 "}" [Newline("\n")] []
+    2: GRAPHQL_SELECTION_SET@60..107
+      0: L_CURLY@60..79 "{" [Newline("\n"), Newline("\n"), Comments("# with argument"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@79..105
+        0: GRAPHQL_FIELD@79..105
+          0: (empty)
+          1: GRAPHQL_NAME@79..85
+            0: GRAPHQL_NAME@79..85 "hero" [Newline("\n"), Whitespace("\t")] []
+          2: GRAPHQL_ARGUMENTS@85..105
+            0: L_PAREN@85..86 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@86..104
+              0: GRAPHQL_ARGUMENT@86..104
+                0: GRAPHQL_NAME@86..90
+                  0: GRAPHQL_NAME@86..90 "name" [] []
+                1: COLON@90..92 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@92..104
+                  0: GRAPHQL_STRING_LITERAL@92..104 "\"Tony Stark\"" [] []
+            2: R_PAREN@104..105 ")" [] []
+          3: GRAPHQL_DIRECTIVE_LIST@105..105
+          4: (empty)
+      2: R_CURLY@105..107 "}" [Newline("\n")] []
+    3: GRAPHQL_SELECTION_SET@107..168
+      0: L_CURLY@107..110 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@110..166
+        0: GRAPHQL_FIELD@110..166
+          0: (empty)
+          1: GRAPHQL_NAME@110..116
+            0: GRAPHQL_NAME@110..116 "hero" [Newline("\n"), Whitespace("\t")] []
+          2: GRAPHQL_ARGUMENTS@116..137
+            0: L_PAREN@116..117 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@117..135
+              0: GRAPHQL_ARGUMENT@117..135
+                0: GRAPHQL_NAME@117..121
+                  0: GRAPHQL_NAME@117..121 "name" [] []
+                1: COLON@121..123 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@123..135
+                  0: GRAPHQL_STRING_LITERAL@123..135 "\"Tony Stark\"" [] []
+            2: R_PAREN@135..137 ")" [] [Whitespace(" ")]
+          3: GRAPHQL_DIRECTIVE_LIST@137..137
+          4: GRAPHQL_SELECTION_SET@137..166
+            0: L_CURLY@137..138 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@138..163
+              0: GRAPHQL_FIELD@138..149
+                0: (empty)
+                1: GRAPHQL_NAME@138..149
+                  0: GRAPHQL_NAME@138..149 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@149..149
+                4: (empty)
+              1: GRAPHQL_FIELD@149..157
+                0: (empty)
+                1: GRAPHQL_NAME@149..157
+                  0: GRAPHQL_NAME@149..157 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@157..157
+                4: (empty)
+              2: GRAPHQL_FIELD@157..163
+                0: (empty)
+                1: GRAPHQL_NAME@157..163
+                  0: GRAPHQL_NAME@157..163 "age" [Newline("\n"), Whitespace("\t\t")] []
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@163..163
+                4: (empty)
+            2: R_CURLY@163..166 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@166..168 "}" [Newline("\n")] []
+    4: GRAPHQL_SELECTION_SET@168..446
+      0: L_CURLY@168..171 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@171..444
+        0: GRAPHQL_FIELD@171..444
+          0: (empty)
+          1: GRAPHQL_NAME@171..177
+            0: GRAPHQL_NAME@171..177 "hero" [Newline("\n"), Whitespace("\t")] []
+          2: GRAPHQL_ARGUMENTS@177..356
+            0: L_PAREN@177..178 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@178..352
+              0: GRAPHQL_ARGUMENT@178..200
+                0: GRAPHQL_NAME@178..185
+                  0: GRAPHQL_NAME@178..185 "name" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@185..187 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@187..200
+                  0: GRAPHQL_STRING_LITERAL@187..200 "\"Tony Stark\"" [] [Skipped(",")]
+              1: GRAPHQL_ARGUMENT@200..211
+                0: GRAPHQL_NAME@200..206
+                  0: GRAPHQL_NAME@200..206 "age" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@206..208 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_INT_VALUE@208..211
+                  0: GRAPHQL_INT_LITERAL@208..211 "53" [] [Skipped(",")]
+              2: GRAPHQL_ARGUMENT@211..225
+                0: GRAPHQL_NAME@211..220
+                  0: GRAPHQL_NAME@211..220 "height" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@220..222 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_FLOAT_VALUE@222..225
+                  0: GRAPHQL_FLOAT_LITERAL@222..225 "6.1" [] []
+              3: GRAPHQL_ARGUMENT@225..241
+                0: GRAPHQL_NAME@225..233
+                  0: GRAPHQL_NAME@225..233 "alive" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@233..235 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_BOOLEAN_VALUE@235..241
+                  0: FALSE_KW@235..241 "false" [] [Skipped(",")]
+              4: GRAPHQL_ARGUMENT@241..258
+                0: GRAPHQL_NAME@241..252
+                  0: GRAPHQL_NAME@241..252 "location" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@252..254 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_NULL_VALUE@254..258
+                  0: NULL_KW@254..258 "null" [] []
+              5: GRAPHQL_ARGUMENT@258..320
+                0: GRAPHQL_NAME@258..271
+                  0: GRAPHQL_NAME@258..271 "birthplace" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@271..273 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_OBJECT_VALUE@273..320
+                  0: L_CURLY@273..274 "{" [] []
+                  1: GRAPHQL_OBJECT_VALUE_MEMBER_LIST@274..319
+                    0: GRAPHQL_OBJECT_FIELD@274..292
+                      0: GRAPHQL_NAME@274..278
+                        0: GRAPHQL_NAME@274..278 "city" [] []
+                      1: COLON@278..280 ":" [] [Whitespace(" ")]
+                      2: GRAPHQL_STRING_VALUE@280..292
+                        0: GRAPHQL_STRING_LITERAL@280..292 "\"New York\"" [] [Skipped(","), Whitespace(" ")]
+                    1: GRAPHQL_OBJECT_FIELD@292..305
+                      0: GRAPHQL_NAME@292..297
+                        0: GRAPHQL_NAME@292..297 "state" [] []
+                      1: COLON@297..299 ":" [] [Whitespace(" ")]
+                      2: GRAPHQL_STRING_VALUE@299..305
+                        0: GRAPHQL_STRING_LITERAL@299..305 "\"NY\"" [] [Skipped(","), Whitespace(" ")]
+                    2: GRAPHQL_OBJECT_FIELD@305..319
+                      0: GRAPHQL_NAME@305..312
+                        0: GRAPHQL_NAME@305..312 "country" [] []
+                      1: COLON@312..314 ":" [] [Whitespace(" ")]
+                      2: GRAPHQL_STRING_VALUE@314..319
+                        0: GRAPHQL_STRING_LITERAL@314..319 "\"USA\"" [] []
+                  2: R_CURLY@319..320 "}" [] []
+              6: GRAPHQL_ARGUMENT@320..352
+                0: GRAPHQL_NAME@320..330
+                  0: GRAPHQL_NAME@320..330 "friends" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@330..332 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_LIST_VALUE@332..352
+                  0: L_BRACK@332..333 "[" [] []
+                  1: GRAPHQL_LIST_VALUE_ELEMENT_LIST@333..351
+                    0: GRAPHQL_STRING_VALUE@333..343
+                      0: GRAPHQL_STRING_LITERAL@333..343 "\"Pepper\"" [] [Skipped(","), Whitespace(" ")]
+                    1: GRAPHQL_STRING_VALUE@343..351
+                      0: GRAPHQL_STRING_LITERAL@343..351 "\"Rhodey\"" [] []
+                  2: R_BRACK@351..352 "]" [] []
+            2: R_PAREN@352..356 ")" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: GRAPHQL_DIRECTIVE_LIST@356..356
+          4: GRAPHQL_SELECTION_SET@356..444
+            0: L_CURLY@356..357 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@357..441
+              0: GRAPHQL_FIELD@357..368
+                0: (empty)
+                1: GRAPHQL_NAME@357..368
+                  0: GRAPHQL_NAME@357..368 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@368..368
+                4: (empty)
+              1: GRAPHQL_FIELD@368..376
+                0: (empty)
+                1: GRAPHQL_NAME@368..376
+                  0: GRAPHQL_NAME@368..376 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@376..376
+                4: (empty)
+              2: GRAPHQL_FIELD@376..383
+                0: (empty)
+                1: GRAPHQL_NAME@376..383
+                  0: GRAPHQL_NAME@376..383 "age" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@383..383
+                4: (empty)
+              3: GRAPHQL_FIELD@383..405
+                0: (empty)
+                1: GRAPHQL_NAME@383..392
+                  0: GRAPHQL_NAME@383..392 "height" [Newline("\n"), Whitespace("\t\t")] []
+                2: GRAPHQL_ARGUMENTS@392..405
+                  0: L_PAREN@392..393 "(" [] []
+                  1: GRAPHQL_ARGUMENT_LIST@393..403
+                    0: GRAPHQL_ARGUMENT@393..403
+                      0: GRAPHQL_NAME@393..397
+                        0: GRAPHQL_NAME@393..397 "unit" [] []
+                      1: COLON@397..399 ":" [] [Whitespace(" ")]
+                      2: GRAPHQL_ENUM_VALUE@399..403
+                        0: GRAPHQL_NAME@399..403
+                          0: GRAPHQL_NAME@399..403 "FOOT" [] []
+                  2: R_PAREN@403..405 ")" [] [Skipped(",")]
+                3: GRAPHQL_DIRECTIVE_LIST@405..405
+                4: (empty)
+              4: GRAPHQL_FIELD@405..441
+                0: (empty)
+                1: GRAPHQL_NAME@405..412
+                  0: GRAPHQL_NAME@405..412 "wife" [Newline("\n"), Whitespace("\t\t")] []
+                2: GRAPHQL_ARGUMENTS@412..428
+                  0: L_PAREN@412..413 "(" [] []
+                  1: GRAPHQL_ARGUMENT_LIST@413..427
+                    0: GRAPHQL_ARGUMENT@413..427
+                      0: GRAPHQL_NAME@413..417
+                        0: GRAPHQL_NAME@413..417 "name" [] []
+                      1: COLON@417..419 ":" [] [Whitespace(" ")]
+                      2: GRAPHQL_STRING_VALUE@419..427
+                        0: GRAPHQL_STRING_LITERAL@419..427 "\"Pepper\"" [] []
+                  2: R_PAREN@427..428 ")" [] []
+                3: GRAPHQL_DIRECTIVE_LIST@428..428
+                4: GRAPHQL_SELECTION_SET@428..441
+                  0: L_CURLY@428..429 "{" [] []
+                  1: GRAPHQL_SELECTION_LIST@429..437
+                    0: GRAPHQL_FIELD@429..437
+                      0: (empty)
+                      1: GRAPHQL_NAME@429..437
+                        0: GRAPHQL_NAME@429..437 "name" [Newline("\n"), Whitespace("\t\t\t")] []
+                      2: (empty)
+                      3: GRAPHQL_DIRECTIVE_LIST@437..437
+                      4: (empty)
+                  2: R_CURLY@437..441 "}" [Newline("\n"), Whitespace("\t\t")] []
+            2: R_CURLY@441..444 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@444..446 "}" [Newline("\n")] []
+    5: GRAPHQL_SELECTION_SET@446..470
+      0: L_CURLY@446..449 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@449..468
+        0: GRAPHQL_FIELD@449..468
+          0: (empty)
+          1: GRAPHQL_NAME@449..455
+            0: GRAPHQL_NAME@449..455 "hero" [Newline("\n"), Whitespace("\t")] []
+          2: GRAPHQL_ARGUMENTS@455..468
+            0: L_PAREN@455..456 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@456..467
+              0: GRAPHQL_ARGUMENT@456..467
+                0: GRAPHQL_NAME@456..460
+                  0: GRAPHQL_NAME@456..460 "name" [] []
+                1: COLON@460..462 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_VARIABLE@462..467
+                  0: DOLLAR@462..463 "$" [] []
+                  1: GRAPHQL_NAME@463..467
+                    0: GRAPHQL_NAME@463..467 "name" [] []
+            2: R_PAREN@467..468 ")" [] []
+          3: GRAPHQL_DIRECTIVE_LIST@468..468
+          4: (empty)
+      2: R_CURLY@468..470 "}" [Newline("\n")] []
+    6: GRAPHQL_SELECTION_SET@470..526
+      0: L_CURLY@470..488 "{" [Newline("\n"), Newline("\n"), Comments("# with aliases"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@488..524
+        0: GRAPHQL_FIELD@488..524
+          0: GRAPHQL_ALIAS@488..500
+            0: GRAPHQL_NAME@488..498
+              0: GRAPHQL_NAME@488..498 "ironMan" [Newline("\n"), Whitespace("  ")] []
+            1: COLON@498..500 ":" [] [Whitespace(" ")]
+          1: GRAPHQL_NAME@500..504
+            0: GRAPHQL_NAME@500..504 "hero" [] []
+          2: GRAPHQL_ARGUMENTS@504..524
+            0: L_PAREN@504..505 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@505..523
+              0: GRAPHQL_ARGUMENT@505..523
+                0: GRAPHQL_NAME@505..509
+                  0: GRAPHQL_NAME@505..509 "name" [] []
+                1: COLON@509..511 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@511..523
+                  0: GRAPHQL_STRING_LITERAL@511..523 "\"Tony Stark\"" [] []
+            2: R_PAREN@523..524 ")" [] []
+          3: GRAPHQL_DIRECTIVE_LIST@524..524
+          4: (empty)
+      2: R_CURLY@524..526 "}" [Newline("\n")] []
+    7: GRAPHQL_SELECTION_SET@526..645
+      0: L_CURLY@526..529 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@529..643
+        0: GRAPHQL_FIELD@529..643
+          0: GRAPHQL_ALIAS@529..541
+            0: GRAPHQL_NAME@529..539
+              0: GRAPHQL_NAME@529..539 "ironMan" [Newline("\n"), Whitespace("  ")] []
+            1: COLON@539..541 ":" [] [Whitespace(" ")]
+          1: GRAPHQL_NAME@541..545
+            0: GRAPHQL_NAME@541..545 "hero" [] []
+          2: GRAPHQL_ARGUMENTS@545..566
+            0: L_PAREN@545..546 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@546..564
+              0: GRAPHQL_ARGUMENT@546..564
+                0: GRAPHQL_NAME@546..550
+                  0: GRAPHQL_NAME@546..550 "name" [] []
+                1: COLON@550..552 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@552..564
+                  0: GRAPHQL_STRING_LITERAL@552..564 "\"Tony Stark\"" [] []
+            2: R_PAREN@564..566 ")" [] [Whitespace(" ")]
+          3: GRAPHQL_DIRECTIVE_LIST@566..566
+          4: GRAPHQL_SELECTION_SET@566..643
+            0: L_CURLY@566..567 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@567..640
+              0: GRAPHQL_FIELD@567..578
+                0: (empty)
+                1: GRAPHQL_NAME@567..578
+                  0: GRAPHQL_NAME@567..578 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@578..578
+                4: (empty)
+              1: GRAPHQL_FIELD@578..586
+                0: (empty)
+                1: GRAPHQL_NAME@578..586
+                  0: GRAPHQL_NAME@578..586 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@586..586
+                4: (empty)
+              2: GRAPHQL_FIELD@586..593
+                0: (empty)
+                1: GRAPHQL_NAME@586..593
+                  0: GRAPHQL_NAME@586..593 "age" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@593..593
+                4: (empty)
+              3: GRAPHQL_FIELD@593..640
+                0: GRAPHQL_ALIAS@593..607
+                  0: GRAPHQL_NAME@593..605
+                    0: GRAPHQL_NAME@593..605 "firstWife" [Newline("\n"), Whitespace("\t\t")] []
+                  1: COLON@605..607 ":" [] [Whitespace(" ")]
+                1: GRAPHQL_NAME@607..611
+                  0: GRAPHQL_NAME@607..611 "wife" [] []
+                2: GRAPHQL_ARGUMENTS@611..627
+                  0: L_PAREN@611..612 "(" [] []
+                  1: GRAPHQL_ARGUMENT_LIST@612..626
+                    0: GRAPHQL_ARGUMENT@612..626
+                      0: GRAPHQL_NAME@612..616
+                        0: GRAPHQL_NAME@612..616 "name" [] []
+                      1: COLON@616..618 ":" [] [Whitespace(" ")]
+                      2: GRAPHQL_STRING_VALUE@618..626
+                        0: GRAPHQL_STRING_LITERAL@618..626 "\"Pepper\"" [] []
+                  2: R_PAREN@626..627 ")" [] []
+                3: GRAPHQL_DIRECTIVE_LIST@627..627
+                4: GRAPHQL_SELECTION_SET@627..640
+                  0: L_CURLY@627..628 "{" [] []
+                  1: GRAPHQL_SELECTION_LIST@628..636
+                    0: GRAPHQL_FIELD@628..636
+                      0: (empty)
+                      1: GRAPHQL_NAME@628..636
+                        0: GRAPHQL_NAME@628..636 "name" [Newline("\n"), Whitespace("\t\t\t")] []
+                      2: (empty)
+                      3: GRAPHQL_DIRECTIVE_LIST@636..636
+                      4: (empty)
+                  2: R_CURLY@636..640 "}" [Newline("\n"), Whitespace("\t\t")] []
+            2: R_CURLY@640..643 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@643..645 "}" [Newline("\n")] []
+    8: GRAPHQL_SELECTION_SET@645..687
+      0: L_CURLY@645..666 "{" [Newline("\n"), Newline("\n"), Comments("# with directives"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@666..685
+        0: GRAPHQL_FIELD@666..685
+          0: (empty)
+          1: GRAPHQL_NAME@666..674
+            0: GRAPHQL_NAME@666..674 "hero" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@674..685
+            0: GRAPHQL_DIRECTIVE@674..685
+              0: AT@674..675 "@" [] []
+              1: GRAPHQL_NAME@675..685
+                0: GRAPHQL_NAME@675..685 "deprecated" [] []
+              2: (empty)
+          4: (empty)
+      2: R_CURLY@685..687 "}" [Newline("\n")] []
+    9: GRAPHQL_SELECTION_SET@687..782
+      0: L_CURLY@687..690 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@690..780
+        0: GRAPHQL_FIELD@690..780
+          0: GRAPHQL_ALIAS@690..702
+            0: GRAPHQL_NAME@690..700
+              0: GRAPHQL_NAME@690..700 "ironMan" [Newline("\n"), Whitespace("  ")] []
+            1: COLON@700..702 ":" [] [Whitespace(" ")]
+          1: GRAPHQL_NAME@702..706
+            0: GRAPHQL_NAME@702..706 "hero" [] []
+          2: GRAPHQL_ARGUMENTS@706..727
+            0: L_PAREN@706..707 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@707..725
+              0: GRAPHQL_ARGUMENT@707..725
+                0: GRAPHQL_NAME@707..711
+                  0: GRAPHQL_NAME@707..711 "name" [] []
+                1: COLON@711..713 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@713..725
+                  0: GRAPHQL_STRING_LITERAL@713..725 "\"Tony Stark\"" [] []
+            2: R_PAREN@725..727 ")" [] [Whitespace(" ")]
+          3: GRAPHQL_DIRECTIVE_LIST@727..739
+            0: GRAPHQL_DIRECTIVE@727..739
+              0: AT@727..728 "@" [] []
+              1: GRAPHQL_NAME@728..739
+                0: GRAPHQL_NAME@728..739 "deprecated" [] [Whitespace(" ")]
+              2: (empty)
+          4: GRAPHQL_SELECTION_SET@739..780
+            0: L_CURLY@739..740 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@740..777
+              0: GRAPHQL_FIELD@740..763
+                0: (empty)
+                1: GRAPHQL_NAME@740..751
+                  0: GRAPHQL_NAME@740..751 "country" [Newline("\n"), Whitespace("\t\t")] [Whitespace(" ")]
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@751..763
+                  0: GRAPHQL_DIRECTIVE@751..763
+                    0: AT@751..752 "@" [] []
+                    1: GRAPHQL_NAME@752..763
+                      0: GRAPHQL_NAME@752..763 "deprecated" [] [Skipped(",")]
+                    2: (empty)
+                4: (empty)
+              1: GRAPHQL_FIELD@763..771
+                0: (empty)
+                1: GRAPHQL_NAME@763..771
+                  0: GRAPHQL_NAME@763..771 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@771..771
+                4: (empty)
+              2: GRAPHQL_FIELD@771..777
+                0: (empty)
+                1: GRAPHQL_NAME@771..777
+                  0: GRAPHQL_NAME@771..777 "age" [Newline("\n"), Whitespace("\t\t")] []
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@777..777
+                4: (empty)
+            2: R_CURLY@777..780 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@780..782 "}" [Newline("\n")] []
+    10: GRAPHQL_SELECTION_SET@782..823
+      0: L_CURLY@782..803 "{" [Newline("\n"), Newline("\n"), Comments("# Fragment spread"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@803..821
+        0: GRAPHQL_FRAGMENT_SPREAD@803..821
+          0: DOT3@803..809 "..." [Newline("\n"), Whitespace("  ")] []
+          1: GRAPHQL_NAME@809..821
+            0: GRAPHQL_NAME@809..821 "heroFragment" [] []
+          2: GRAPHQL_DIRECTIVE_LIST@821..821
+      2: R_CURLY@821..823 "}" [Newline("\n")] []
+    11: GRAPHQL_SELECTION_SET@823..858
+      0: L_CURLY@823..826 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@826..856
+        0: GRAPHQL_FRAGMENT_SPREAD@826..856
+          0: DOT3@826..832 "..." [Newline("\n"), Whitespace("  ")] []
+          1: GRAPHQL_NAME@832..845
+            0: GRAPHQL_NAME@832..845 "heroFragment" [] [Whitespace(" ")]
+          2: GRAPHQL_DIRECTIVE_LIST@845..856
+            0: GRAPHQL_DIRECTIVE@845..856
+              0: AT@845..846 "@" [] []
+              1: GRAPHQL_NAME@846..856
+                0: GRAPHQL_NAME@846..856 "deprecated" [] []
+              2: (empty)
+      2: R_CURLY@856..858 "}" [Newline("\n")] []
+    12: GRAPHQL_SELECTION_SET@858..936
+      0: L_CURLY@858..861 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@861..934
+        0: GRAPHQL_FIELD@861..934
+          0: GRAPHQL_ALIAS@861..873
+            0: GRAPHQL_NAME@861..871
+              0: GRAPHQL_NAME@861..871 "ironMan" [Newline("\n"), Whitespace("  ")] []
+            1: COLON@871..873 ":" [] [Whitespace(" ")]
+          1: GRAPHQL_NAME@873..877
+            0: GRAPHQL_NAME@873..877 "hero" [] []
+          2: GRAPHQL_ARGUMENTS@877..898
+            0: L_PAREN@877..878 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@878..896
+              0: GRAPHQL_ARGUMENT@878..896
+                0: GRAPHQL_NAME@878..882
+                  0: GRAPHQL_NAME@878..882 "name" [] []
+                1: COLON@882..884 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@884..896
+                  0: GRAPHQL_STRING_LITERAL@884..896 "\"Tony Stark\"" [] []
+            2: R_PAREN@896..898 ")" [] [Whitespace(" ")]
+          3: GRAPHQL_DIRECTIVE_LIST@898..910
+            0: GRAPHQL_DIRECTIVE@898..910
+              0: AT@898..899 "@" [] []
+              1: GRAPHQL_NAME@899..910
+                0: GRAPHQL_NAME@899..910 "deprecated" [] [Whitespace(" ")]
+              2: (empty)
+          4: GRAPHQL_SELECTION_SET@910..934
+            0: L_CURLY@910..911 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@911..931
+              0: GRAPHQL_FRAGMENT_SPREAD@911..931
+                0: DOT3@911..917 "..." [Newline("\n"), Whitespace("\t\t")] []
+                1: GRAPHQL_NAME@917..931
+                  0: GRAPHQL_NAME@917..931 "heroAttributes" [] []
+                2: GRAPHQL_DIRECTIVE_LIST@931..931
+            2: R_CURLY@931..934 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@934..936 "}" [Newline("\n")] []
+    13: GRAPHQL_SELECTION_SET@936..984
+      0: L_CURLY@936..964 "{" [Newline("\n"), Newline("\n"), Comments("# Inline Fragment spread"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@964..982
+        0: GRAPHQL_INLINE_FRAGMENT@964..982
+          0: DOT3@964..971 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+          1: (empty)
+          2: GRAPHQL_DIRECTIVE_LIST@971..971
+          3: GRAPHQL_SELECTION_SET@971..982
+            0: L_CURLY@971..972 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@972..979
+              0: GRAPHQL_FIELD@972..979
+                0: (empty)
+                1: GRAPHQL_NAME@972..979
+                  0: GRAPHQL_NAME@972..979 "hero" [Newline("\n"), Whitespace("\t\t")] []
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@979..979
+                4: (empty)
+            2: R_CURLY@979..982 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@982..984 "}" [Newline("\n")] []
+    14: GRAPHQL_SELECTION_SET@984..1019
+      0: L_CURLY@984..987 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@987..1017
+        0: GRAPHQL_INLINE_FRAGMENT@987..1017
+          0: DOT3@987..994 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+          1: (empty)
+          2: GRAPHQL_DIRECTIVE_LIST@994..1006
+            0: GRAPHQL_DIRECTIVE@994..1006
+              0: AT@994..995 "@" [] []
+              1: GRAPHQL_NAME@995..1006
+                0: GRAPHQL_NAME@995..1006 "deprecated" [] [Whitespace(" ")]
+              2: (empty)
+          3: GRAPHQL_SELECTION_SET@1006..1017
+            0: L_CURLY@1006..1007 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@1007..1014
+              0: GRAPHQL_FIELD@1007..1014
+                0: (empty)
+                1: GRAPHQL_NAME@1007..1014
+                  0: GRAPHQL_NAME@1007..1014 "hero" [Newline("\n"), Whitespace("\t\t")] []
+                2: (empty)
+                3: GRAPHQL_DIRECTIVE_LIST@1014..1014
+                4: (empty)
+            2: R_CURLY@1014..1017 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@1017..1019 "}" [Newline("\n")] []
+    15: GRAPHQL_SELECTION_SET@1019..1125
+      0: L_CURLY@1019..1022 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@1022..1123
+        0: GRAPHQL_FIELD@1022..1123
+          0: GRAPHQL_ALIAS@1022..1034
+            0: GRAPHQL_NAME@1022..1032
+              0: GRAPHQL_NAME@1022..1032 "ironMan" [Newline("\n"), Whitespace("  ")] []
+            1: COLON@1032..1034 ":" [] [Whitespace(" ")]
+          1: GRAPHQL_NAME@1034..1038
+            0: GRAPHQL_NAME@1034..1038 "hero" [] []
+          2: GRAPHQL_ARGUMENTS@1038..1059
+            0: L_PAREN@1038..1039 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@1039..1057
+              0: GRAPHQL_ARGUMENT@1039..1057
+                0: GRAPHQL_NAME@1039..1043
+                  0: GRAPHQL_NAME@1039..1043 "name" [] []
+                1: COLON@1043..1045 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@1045..1057
+                  0: GRAPHQL_STRING_LITERAL@1045..1057 "\"Tony Stark\"" [] []
+            2: R_PAREN@1057..1059 ")" [] [Whitespace(" ")]
+          3: GRAPHQL_DIRECTIVE_LIST@1059..1071
+            0: GRAPHQL_DIRECTIVE@1059..1071
+              0: AT@1059..1060 "@" [] []
+              1: GRAPHQL_NAME@1060..1071
+                0: GRAPHQL_NAME@1060..1071 "deprecated" [] [Whitespace(" ")]
+              2: (empty)
+          4: GRAPHQL_SELECTION_SET@1071..1123
+            0: L_CURLY@1071..1072 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@1072..1120
+              0: GRAPHQL_INLINE_FRAGMENT@1072..1120
+                0: DOT3@1072..1079 "..." [Newline("\n"), Whitespace("\t\t")] [Whitespace(" ")]
+                1: GRAPHQL_TYPE_CONDITION@1079..1087
+                  0: ON_KW@1079..1082 "on" [] [Whitespace(" ")]
+                  1: GRAPHQL_NAMED_TYPE@1082..1087
+                    0: GRAPHQL_NAME@1082..1087
+                      0: GRAPHQL_NAME@1082..1087 "Hero" [] [Whitespace(" ")]
+                2: GRAPHQL_DIRECTIVE_LIST@1087..1099
+                  0: GRAPHQL_DIRECTIVE@1087..1099
+                    0: AT@1087..1088 "@" [] []
+                    1: GRAPHQL_NAME@1088..1099
+                      0: GRAPHQL_NAME@1088..1099 "deprecated" [] [Whitespace(" ")]
+                    2: (empty)
+                3: GRAPHQL_SELECTION_SET@1099..1120
+                  0: L_CURLY@1099..1100 "{" [] []
+                  1: GRAPHQL_SELECTION_LIST@1100..1116
+                    0: GRAPHQL_FIELD@1100..1109
+                      0: (empty)
+                      1: GRAPHQL_NAME@1100..1109
+                        0: GRAPHQL_NAME@1100..1109 "name" [Newline("\n"), Whitespace("\t\t\t")] [Skipped(",")]
+                      2: (empty)
+                      3: GRAPHQL_DIRECTIVE_LIST@1109..1109
+                      4: (empty)
+                    1: GRAPHQL_FIELD@1109..1116
+                      0: (empty)
+                      1: GRAPHQL_NAME@1109..1116
+                        0: GRAPHQL_NAME@1109..1116 "age" [Newline("\n"), Whitespace("\t\t\t")] []
+                      2: (empty)
+                      3: GRAPHQL_DIRECTIVE_LIST@1116..1116
+                      4: (empty)
+                  2: R_CURLY@1116..1120 "}" [Newline("\n"), Whitespace("\t\t")] []
+            2: R_CURLY@1120..1123 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@1123..1125 "}" [Newline("\n")] []
+  2: EOF@1125..1126 "" [Newline("\n")] []
+
+```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/type.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/type.graphql
@@ -1,0 +1,4 @@
+query ($storyId: ID!, $like: Boolean, $comments: [String!], $tags: [String!]!, $posts: [PostInput]!) {
+	likeStory(storyId: $storyId)
+}
+

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/type.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/type.graphql.snap
@@ -1,0 +1,290 @@
+---
+source: crates/biome_graphql_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```graphql
+query ($storyId: ID!, $like: Boolean, $comments: [String!], $tags: [String!]!, $posts: [PostInput]!) {
+	likeStory(storyId: $storyId)
+}
+
+
+```
+
+## AST
+
+```
+GraphqlRoot {
+    bom_token: missing (optional),
+    definitions: GraphqlDefinitionList [
+        GraphqlOperationDefinition {
+            ty: GraphqlOperationType {
+                value_token: QUERY_KW@0..6 "query" [] [Whitespace(" ")],
+            },
+            name: missing (optional),
+            variables: GraphqlVariableDefinitions {
+                l_paren_token: L_PAREN@6..7 "(" [] [],
+                elements: GraphqlVariableDefinitionList [
+                    GraphqlVariableDefinition {
+                        variable: GraphqlVariable {
+                            dollar_token: DOLLAR@7..8 "$" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@8..15 "storyId" [] [],
+                            },
+                        },
+                        colon_token: COLON@15..17 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNonNullType {
+                            base: GraphqlNamedType {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@17..19 "ID" [] [],
+                                },
+                            },
+                            excl_token: BANG@19..22 "!" [] [Skipped(","), Whitespace(" ")],
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlVariableDefinition {
+                        variable: GraphqlVariable {
+                            dollar_token: DOLLAR@22..23 "$" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@23..27 "like" [] [],
+                            },
+                        },
+                        colon_token: COLON@27..29 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@29..38 "Boolean" [] [Skipped(","), Whitespace(" ")],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlVariableDefinition {
+                        variable: GraphqlVariable {
+                            dollar_token: DOLLAR@38..39 "$" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@39..47 "comments" [] [],
+                            },
+                        },
+                        colon_token: COLON@47..49 ":" [] [Whitespace(" ")],
+                        ty: GraphqlListType {
+                            l_brack_token: L_BRACK@49..50 "[" [] [],
+                            element: GraphqlNonNullType {
+                                base: GraphqlNamedType {
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@50..56 "String" [] [],
+                                    },
+                                },
+                                excl_token: BANG@56..57 "!" [] [],
+                            },
+                            r_brack_token: R_BRACK@57..60 "]" [] [Skipped(","), Whitespace(" ")],
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlVariableDefinition {
+                        variable: GraphqlVariable {
+                            dollar_token: DOLLAR@60..61 "$" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@61..65 "tags" [] [],
+                            },
+                        },
+                        colon_token: COLON@65..67 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNonNullType {
+                            base: GraphqlListType {
+                                l_brack_token: L_BRACK@67..68 "[" [] [],
+                                element: GraphqlNonNullType {
+                                    base: GraphqlNamedType {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@68..74 "String" [] [],
+                                        },
+                                    },
+                                    excl_token: BANG@74..75 "!" [] [],
+                                },
+                                r_brack_token: R_BRACK@75..76 "]" [] [],
+                            },
+                            excl_token: BANG@76..79 "!" [] [Skipped(","), Whitespace(" ")],
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlVariableDefinition {
+                        variable: GraphqlVariable {
+                            dollar_token: DOLLAR@79..80 "$" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@80..85 "posts" [] [],
+                            },
+                        },
+                        colon_token: COLON@85..87 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNonNullType {
+                            base: GraphqlListType {
+                                l_brack_token: L_BRACK@87..88 "[" [] [],
+                                element: GraphqlNamedType {
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@88..97 "PostInput" [] [],
+                                    },
+                                },
+                                r_brack_token: R_BRACK@97..98 "]" [] [],
+                            },
+                            excl_token: BANG@98..99 "!" [] [],
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_paren_token: R_PAREN@99..101 ")" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [],
+            selection_set: GraphqlSelectionSet {
+                l_curly_token: L_CURLY@101..102 "{" [] [],
+                selections: GraphqlSelectionList [
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@102..113 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        arguments: GraphqlArguments {
+                            l_paren_token: L_PAREN@113..114 "(" [] [],
+                            arguments: GraphqlArgumentList [
+                                GraphqlArgument {
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@114..121 "storyId" [] [],
+                                    },
+                                    colon_token: COLON@121..123 ":" [] [Whitespace(" ")],
+                                    value: GraphqlVariable {
+                                        dollar_token: DOLLAR@123..124 "$" [] [],
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@124..131 "storyId" [] [],
+                                        },
+                                    },
+                                },
+                            ],
+                            r_paren_token: R_PAREN@131..132 ")" [] [],
+                        },
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@132..134 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@134..136 "" [Newline("\n"), Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: GRAPHQL_ROOT@0..136
+  0: (empty)
+  1: GRAPHQL_DEFINITION_LIST@0..134
+    0: GRAPHQL_OPERATION_DEFINITION@0..134
+      0: GRAPHQL_OPERATION_TYPE@0..6
+        0: QUERY_KW@0..6 "query" [] [Whitespace(" ")]
+      1: (empty)
+      2: GRAPHQL_VARIABLE_DEFINITIONS@6..101
+        0: L_PAREN@6..7 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@7..99
+          0: GRAPHQL_VARIABLE_DEFINITION@7..22
+            0: GRAPHQL_VARIABLE@7..15
+              0: DOLLAR@7..8 "$" [] []
+              1: GRAPHQL_NAME@8..15
+                0: GRAPHQL_NAME@8..15 "storyId" [] []
+            1: COLON@15..17 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@17..22
+              0: GRAPHQL_NAMED_TYPE@17..19
+                0: GRAPHQL_NAME@17..19
+                  0: GRAPHQL_NAME@17..19 "ID" [] []
+              1: BANG@19..22 "!" [] [Skipped(","), Whitespace(" ")]
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@22..22
+          1: GRAPHQL_VARIABLE_DEFINITION@22..38
+            0: GRAPHQL_VARIABLE@22..27
+              0: DOLLAR@22..23 "$" [] []
+              1: GRAPHQL_NAME@23..27
+                0: GRAPHQL_NAME@23..27 "like" [] []
+            1: COLON@27..29 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NAMED_TYPE@29..38
+              0: GRAPHQL_NAME@29..38
+                0: GRAPHQL_NAME@29..38 "Boolean" [] [Skipped(","), Whitespace(" ")]
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@38..38
+          2: GRAPHQL_VARIABLE_DEFINITION@38..60
+            0: GRAPHQL_VARIABLE@38..47
+              0: DOLLAR@38..39 "$" [] []
+              1: GRAPHQL_NAME@39..47
+                0: GRAPHQL_NAME@39..47 "comments" [] []
+            1: COLON@47..49 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_LIST_TYPE@49..60
+              0: L_BRACK@49..50 "[" [] []
+              1: GRAPHQL_NON_NULL_TYPE@50..57
+                0: GRAPHQL_NAMED_TYPE@50..56
+                  0: GRAPHQL_NAME@50..56
+                    0: GRAPHQL_NAME@50..56 "String" [] []
+                1: BANG@56..57 "!" [] []
+              2: R_BRACK@57..60 "]" [] [Skipped(","), Whitespace(" ")]
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@60..60
+          3: GRAPHQL_VARIABLE_DEFINITION@60..79
+            0: GRAPHQL_VARIABLE@60..65
+              0: DOLLAR@60..61 "$" [] []
+              1: GRAPHQL_NAME@61..65
+                0: GRAPHQL_NAME@61..65 "tags" [] []
+            1: COLON@65..67 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@67..79
+              0: GRAPHQL_LIST_TYPE@67..76
+                0: L_BRACK@67..68 "[" [] []
+                1: GRAPHQL_NON_NULL_TYPE@68..75
+                  0: GRAPHQL_NAMED_TYPE@68..74
+                    0: GRAPHQL_NAME@68..74
+                      0: GRAPHQL_NAME@68..74 "String" [] []
+                  1: BANG@74..75 "!" [] []
+                2: R_BRACK@75..76 "]" [] []
+              1: BANG@76..79 "!" [] [Skipped(","), Whitespace(" ")]
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@79..79
+          4: GRAPHQL_VARIABLE_DEFINITION@79..99
+            0: GRAPHQL_VARIABLE@79..85
+              0: DOLLAR@79..80 "$" [] []
+              1: GRAPHQL_NAME@80..85
+                0: GRAPHQL_NAME@80..85 "posts" [] []
+            1: COLON@85..87 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@87..99
+              0: GRAPHQL_LIST_TYPE@87..98
+                0: L_BRACK@87..88 "[" [] []
+                1: GRAPHQL_NAMED_TYPE@88..97
+                  0: GRAPHQL_NAME@88..97
+                    0: GRAPHQL_NAME@88..97 "PostInput" [] []
+                2: R_BRACK@97..98 "]" [] []
+              1: BANG@98..99 "!" [] []
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@99..99
+        2: R_PAREN@99..101 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@101..101
+      4: GRAPHQL_SELECTION_SET@101..134
+        0: L_CURLY@101..102 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@102..132
+          0: GRAPHQL_FIELD@102..132
+            0: (empty)
+            1: GRAPHQL_NAME@102..113
+              0: GRAPHQL_NAME@102..113 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: GRAPHQL_ARGUMENTS@113..132
+              0: L_PAREN@113..114 "(" [] []
+              1: GRAPHQL_ARGUMENT_LIST@114..131
+                0: GRAPHQL_ARGUMENT@114..131
+                  0: GRAPHQL_NAME@114..121
+                    0: GRAPHQL_NAME@114..121 "storyId" [] []
+                  1: COLON@121..123 ":" [] [Whitespace(" ")]
+                  2: GRAPHQL_VARIABLE@123..131
+                    0: DOLLAR@123..124 "$" [] []
+                    1: GRAPHQL_NAME@124..131
+                      0: GRAPHQL_NAME@124..131 "storyId" [] []
+              2: R_PAREN@131..132 ")" [] []
+            3: GRAPHQL_DIRECTIVE_LIST@132..132
+            4: (empty)
+        2: R_CURLY@132..134 "}" [Newline("\n")] []
+  2: EOF@134..136 "" [Newline("\n"), Newline("\n")] []
+
+```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/value.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/value.graphql
@@ -1,0 +1,12 @@
+{
+	field_value(
+		int_value: 1,
+		float_value: 1.1,
+		string_value: "string",
+		boolean_value: true,
+		null_value: null,
+		enum_value: AN_ENUM_VALUE,
+		list_value: [1, 2, 3],
+		object_value: {key: "value"}
+	)
+}

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/value.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/value.graphql.snap
@@ -1,0 +1,238 @@
+---
+source: crates/biome_graphql_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```graphql
+{
+	field_value(
+		int_value: 1,
+		float_value: 1.1,
+		string_value: "string",
+		boolean_value: true,
+		null_value: null,
+		enum_value: AN_ENUM_VALUE,
+		list_value: [1, 2, 3],
+		object_value: {key: "value"}
+	)
+}
+
+```
+
+## AST
+
+```
+GraphqlRoot {
+    bom_token: missing (optional),
+    definitions: GraphqlDefinitionList [
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@0..1 "{" [] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@1..14 "field_value" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                    arguments: GraphqlArguments {
+                        l_paren_token: L_PAREN@14..15 "(" [] [],
+                        arguments: GraphqlArgumentList [
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@15..27 "int_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@27..29 ":" [] [Whitespace(" ")],
+                                value: GraphqlIntValue {
+                                    graphql_int_literal_token: GRAPHQL_INT_LITERAL@29..31 "1" [] [Skipped(",")],
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@31..45 "float_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@45..47 ":" [] [Whitespace(" ")],
+                                value: GraphqlFloatValue {
+                                    graphql_float_literal_token: GRAPHQL_FLOAT_LITERAL@47..51 "1.1" [] [Skipped(",")],
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@51..66 "string_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@66..68 ":" [] [Whitespace(" ")],
+                                value: GraphqlStringValue {
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@68..77 "\"string\"" [] [Skipped(",")],
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@77..93 "boolean_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@93..95 ":" [] [Whitespace(" ")],
+                                value: GraphqlBooleanValue {
+                                    value_token: TRUE_KW@95..100 "true" [] [Skipped(",")],
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@100..113 "null_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@113..115 ":" [] [Whitespace(" ")],
+                                value: GraphqlNullValue {
+                                    null_token: NULL_KW@115..120 "null" [] [Skipped(",")],
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@120..133 "enum_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@133..135 ":" [] [Whitespace(" ")],
+                                value: GraphqlEnumValue {
+                                    graphql_name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@135..149 "AN_ENUM_VALUE" [] [Skipped(",")],
+                                    },
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@149..162 "list_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@162..164 ":" [] [Whitespace(" ")],
+                                value: GraphqlListValue {
+                                    l_brack_token: L_BRACK@164..165 "[" [] [],
+                                    elements: GraphqlListValueElementList [
+                                        GraphqlIntValue {
+                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@165..168 "1" [] [Skipped(","), Whitespace(" ")],
+                                        },
+                                        GraphqlIntValue {
+                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@168..171 "2" [] [Skipped(","), Whitespace(" ")],
+                                        },
+                                        GraphqlIntValue {
+                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@171..172 "3" [] [],
+                                        },
+                                    ],
+                                    r_brack_token: R_BRACK@172..174 "]" [] [Skipped(",")],
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@174..189 "object_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@189..191 ":" [] [Whitespace(" ")],
+                                value: GraphqlObjectValue {
+                                    l_curly_token: L_CURLY@191..192 "{" [] [],
+                                    members: GraphqlObjectValueMemberList [
+                                        GraphqlObjectField {
+                                            name: GraphqlName {
+                                                value_token: GRAPHQL_NAME@192..195 "key" [] [],
+                                            },
+                                            colon_token: COLON@195..197 ":" [] [Whitespace(" ")],
+                                            value: GraphqlStringValue {
+                                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@197..204 "\"value\"" [] [],
+                                            },
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@204..205 "}" [] [],
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@205..208 ")" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                    directives: GraphqlDirectiveList [],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@208..210 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@210..211 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: GRAPHQL_ROOT@0..211
+  0: (empty)
+  1: GRAPHQL_DEFINITION_LIST@0..210
+    0: GRAPHQL_SELECTION_SET@0..210
+      0: L_CURLY@0..1 "{" [] []
+      1: GRAPHQL_SELECTION_LIST@1..208
+        0: GRAPHQL_FIELD@1..208
+          0: (empty)
+          1: GRAPHQL_NAME@1..14
+            0: GRAPHQL_NAME@1..14 "field_value" [Newline("\n"), Whitespace("\t")] []
+          2: GRAPHQL_ARGUMENTS@14..208
+            0: L_PAREN@14..15 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@15..205
+              0: GRAPHQL_ARGUMENT@15..31
+                0: GRAPHQL_NAME@15..27
+                  0: GRAPHQL_NAME@15..27 "int_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@27..29 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_INT_VALUE@29..31
+                  0: GRAPHQL_INT_LITERAL@29..31 "1" [] [Skipped(",")]
+              1: GRAPHQL_ARGUMENT@31..51
+                0: GRAPHQL_NAME@31..45
+                  0: GRAPHQL_NAME@31..45 "float_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@45..47 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_FLOAT_VALUE@47..51
+                  0: GRAPHQL_FLOAT_LITERAL@47..51 "1.1" [] [Skipped(",")]
+              2: GRAPHQL_ARGUMENT@51..77
+                0: GRAPHQL_NAME@51..66
+                  0: GRAPHQL_NAME@51..66 "string_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@66..68 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@68..77
+                  0: GRAPHQL_STRING_LITERAL@68..77 "\"string\"" [] [Skipped(",")]
+              3: GRAPHQL_ARGUMENT@77..100
+                0: GRAPHQL_NAME@77..93
+                  0: GRAPHQL_NAME@77..93 "boolean_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@93..95 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_BOOLEAN_VALUE@95..100
+                  0: TRUE_KW@95..100 "true" [] [Skipped(",")]
+              4: GRAPHQL_ARGUMENT@100..120
+                0: GRAPHQL_NAME@100..113
+                  0: GRAPHQL_NAME@100..113 "null_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@113..115 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_NULL_VALUE@115..120
+                  0: NULL_KW@115..120 "null" [] [Skipped(",")]
+              5: GRAPHQL_ARGUMENT@120..149
+                0: GRAPHQL_NAME@120..133
+                  0: GRAPHQL_NAME@120..133 "enum_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@133..135 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_ENUM_VALUE@135..149
+                  0: GRAPHQL_NAME@135..149
+                    0: GRAPHQL_NAME@135..149 "AN_ENUM_VALUE" [] [Skipped(",")]
+              6: GRAPHQL_ARGUMENT@149..174
+                0: GRAPHQL_NAME@149..162
+                  0: GRAPHQL_NAME@149..162 "list_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@162..164 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_LIST_VALUE@164..174
+                  0: L_BRACK@164..165 "[" [] []
+                  1: GRAPHQL_LIST_VALUE_ELEMENT_LIST@165..172
+                    0: GRAPHQL_INT_VALUE@165..168
+                      0: GRAPHQL_INT_LITERAL@165..168 "1" [] [Skipped(","), Whitespace(" ")]
+                    1: GRAPHQL_INT_VALUE@168..171
+                      0: GRAPHQL_INT_LITERAL@168..171 "2" [] [Skipped(","), Whitespace(" ")]
+                    2: GRAPHQL_INT_VALUE@171..172
+                      0: GRAPHQL_INT_LITERAL@171..172 "3" [] []
+                  2: R_BRACK@172..174 "]" [] [Skipped(",")]
+              7: GRAPHQL_ARGUMENT@174..205
+                0: GRAPHQL_NAME@174..189
+                  0: GRAPHQL_NAME@174..189 "object_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@189..191 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_OBJECT_VALUE@191..205
+                  0: L_CURLY@191..192 "{" [] []
+                  1: GRAPHQL_OBJECT_VALUE_MEMBER_LIST@192..204
+                    0: GRAPHQL_OBJECT_FIELD@192..204
+                      0: GRAPHQL_NAME@192..195
+                        0: GRAPHQL_NAME@192..195 "key" [] []
+                      1: COLON@195..197 ":" [] [Whitespace(" ")]
+                      2: GRAPHQL_STRING_VALUE@197..204
+                        0: GRAPHQL_STRING_LITERAL@197..204 "\"value\"" [] []
+                  2: R_CURLY@204..205 "}" [] []
+            2: R_PAREN@205..208 ")" [Newline("\n"), Whitespace("\t")] []
+          3: GRAPHQL_DIRECTIVE_LIST@208..208
+          4: (empty)
+      2: R_CURLY@208..210 "}" [Newline("\n")] []
+  2: EOF@210..211 "" [Newline("\n")] []
+
+```

--- a/crates/biome_graphql_syntax/src/generated/macros.rs
+++ b/crates/biome_graphql_syntax/src/generated/macros.rs
@@ -107,10 +107,6 @@ macro_rules! map_syntax_node {
                         unsafe { $crate::GraphqlFragmentDefinition::new_unchecked(node) };
                     $body
                 }
-                $crate::GraphqlSyntaxKind::GRAPHQL_FRAGMENT_NAME => {
-                    let $pattern = unsafe { $crate::GraphqlFragmentName::new_unchecked(node) };
-                    $body
-                }
                 $crate::GraphqlSyntaxKind::GRAPHQL_FRAGMENT_SPREAD => {
                     let $pattern = unsafe { $crate::GraphqlFragmentSpread::new_unchecked(node) };
                     $body

--- a/crates/biome_graphql_syntax/src/generated/nodes.rs
+++ b/crates/biome_graphql_syntax/src/generated/nodes.rs
@@ -991,7 +991,7 @@ impl GraphqlFragmentDefinition {
     pub fn fragment_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
-    pub fn name(&self) -> SyntaxResult<GraphqlFragmentName> {
+    pub fn name(&self) -> SyntaxResult<GraphqlName> {
         support::required_node(&self.syntax, 1usize)
     }
     pub fn type_condition(&self) -> SyntaxResult<GraphqlTypeCondition> {
@@ -1016,44 +1016,10 @@ impl Serialize for GraphqlFragmentDefinition {
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct GraphqlFragmentDefinitionFields {
     pub fragment_token: SyntaxResult<SyntaxToken>,
-    pub name: SyntaxResult<GraphqlFragmentName>,
+    pub name: SyntaxResult<GraphqlName>,
     pub type_condition: SyntaxResult<GraphqlTypeCondition>,
     pub directives: GraphqlDirectiveList,
     pub selection_set: SyntaxResult<GraphqlSelectionSet>,
-}
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct GraphqlFragmentName {
-    pub(crate) syntax: SyntaxNode,
-}
-impl GraphqlFragmentName {
-    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
-    #[doc = r" or a match on [SyntaxNode::kind]"]
-    #[inline]
-    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
-        Self { syntax }
-    }
-    pub fn as_fields(&self) -> GraphqlFragmentNameFields {
-        GraphqlFragmentNameFields { name: self.name() }
-    }
-    pub fn name(&self) -> SyntaxResult<GraphqlName> {
-        support::required_node(&self.syntax, 0usize)
-    }
-}
-#[cfg(feature = "serde")]
-impl Serialize for GraphqlFragmentName {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.as_fields().serialize(serializer)
-    }
-}
-#[cfg_attr(feature = "serde", derive(Serialize))]
-pub struct GraphqlFragmentNameFields {
-    pub name: SyntaxResult<GraphqlName>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct GraphqlFragmentSpread {
@@ -1079,7 +1045,7 @@ impl GraphqlFragmentSpread {
     pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
-    pub fn name(&self) -> SyntaxResult<GraphqlFragmentName> {
+    pub fn name(&self) -> SyntaxResult<GraphqlName> {
         support::required_node(&self.syntax, 1usize)
     }
     pub fn directives(&self) -> GraphqlDirectiveList {
@@ -1098,7 +1064,7 @@ impl Serialize for GraphqlFragmentSpread {
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct GraphqlFragmentSpreadFields {
     pub dotdotdot_token: SyntaxResult<SyntaxToken>,
-    pub name: SyntaxResult<GraphqlFragmentName>,
+    pub name: SyntaxResult<GraphqlName>,
     pub directives: GraphqlDirectiveList,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -4693,44 +4659,6 @@ impl From<GraphqlFragmentDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
-impl AstNode for GraphqlFragmentName {
-    type Language = Language;
-    const KIND_SET: SyntaxKindSet<Language> =
-        SyntaxKindSet::from_raw(RawSyntaxKind(GRAPHQL_FRAGMENT_NAME as u16));
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == GRAPHQL_FRAGMENT_NAME
-    }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
-        } else {
-            None
-        }
-    }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
-    fn into_syntax(self) -> SyntaxNode {
-        self.syntax
-    }
-}
-impl std::fmt::Debug for GraphqlFragmentName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GraphqlFragmentName")
-            .field("name", &support::DebugSyntaxResult(self.name()))
-            .finish()
-    }
-}
-impl From<GraphqlFragmentName> for SyntaxNode {
-    fn from(n: GraphqlFragmentName) -> SyntaxNode {
-        n.syntax
-    }
-}
-impl From<GraphqlFragmentName> for SyntaxElement {
-    fn from(n: GraphqlFragmentName) -> SyntaxElement {
-        n.syntax.into()
-    }
-}
 impl AstNode for GraphqlFragmentSpread {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -8322,11 +8250,6 @@ impl std::fmt::Display for GraphqlFloatValue {
     }
 }
 impl std::fmt::Display for GraphqlFragmentDefinition {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
-    }
-}
-impl std::fmt::Display for GraphqlFragmentName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }

--- a/crates/biome_graphql_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_graphql_syntax/src/generated/nodes_mut.rs
@@ -434,7 +434,7 @@ impl GraphqlFragmentDefinition {
                 .splice_slots(0usize..=0usize, once(Some(element.into()))),
         )
     }
-    pub fn with_name(self, element: GraphqlFragmentName) -> Self {
+    pub fn with_name(self, element: GraphqlName) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
@@ -459,14 +459,6 @@ impl GraphqlFragmentDefinition {
         )
     }
 }
-impl GraphqlFragmentName {
-    pub fn with_name(self, element: GraphqlName) -> Self {
-        Self::unwrap_cast(
-            self.syntax
-                .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
-        )
-    }
-}
 impl GraphqlFragmentSpread {
     pub fn with_dotdotdot_token(self, element: SyntaxToken) -> Self {
         Self::unwrap_cast(
@@ -474,7 +466,7 @@ impl GraphqlFragmentSpread {
                 .splice_slots(0usize..=0usize, once(Some(element.into()))),
         )
     }
-    pub fn with_name(self, element: GraphqlFragmentName) -> Self {
+    pub fn with_name(self, element: GraphqlName) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),

--- a/crates/biome_graphql_syntax/src/lib.rs
+++ b/crates/biome_graphql_syntax/src/lib.rs
@@ -97,7 +97,7 @@ impl TryFrom<GraphqlSyntaxKind> for TriviaPieceKind {
                 GraphqlSyntaxKind::NEWLINE => Ok(TriviaPieceKind::Newline),
                 GraphqlSyntaxKind::WHITESPACE => Ok(TriviaPieceKind::Whitespace),
                 // https://spec.graphql.org/October2021/#sec-Insignificant-Commas
-                GraphqlSyntaxKind::COMMA => Ok(TriviaPieceKind::Whitespace),
+                GraphqlSyntaxKind::COMMA => Ok(TriviaPieceKind::Skipped),
                 GraphqlSyntaxKind::COMMENT => Ok(TriviaPieceKind::SingleLineComment),
                 _ => unreachable!("Not Trivia"),
             }

--- a/xtask/codegen/graphql.ungram
+++ b/xtask/codegen/graphql.ungram
@@ -109,7 +109,7 @@ AnyGraphqlSelection =
 	| GraphqlInlineFragment
 	| GraphqlBogusSelection
 
-// { "a": b(c: d) @ef {...} }
+// { a: b(c: d) @ef {...} }
 //   ^^^^^^^^^^^^^^^^^^^^^^
 // https://spec.graphql.org/October2021/#sec-Language.Fields
 GraphqlField =
@@ -119,7 +119,7 @@ GraphqlField =
 	directives: GraphqlDirectiveList
 	selection_set: GraphqlSelectionSet?
 
-// { "a": b }
+// { a: b }
 //   ^^^
 // https://spec.graphql.org/October2021/#Alias
 GraphqlAlias =
@@ -149,7 +149,7 @@ GraphqlArgument =
 // https://spec.graphql.org/October2021/#sec-Language.Fragments
 GraphqlFragmentSpread =
 	'...'
-	name: GraphqlFragmentName
+	name: GraphqlName
 	directives: GraphqlDirectiveList
 
 // { ... on A { b } }
@@ -165,13 +165,10 @@ GraphqlInlineFragment =
 // https://spec.graphql.org/October2021/#sec-Language.Fragments
 GraphqlFragmentDefinition =
 	'fragment'
-	name: GraphqlFragmentName
+	name: GraphqlName
 	type_condition: GraphqlTypeCondition
 	directives: GraphqlDirectiveList
 	selection_set: GraphqlSelectionSet
-
-GraphqlFragmentName =
-	name: GraphqlName
 
 GraphqlTypeCondition =
 	'on'


### PR DESCRIPTION
## Summary

This PR implement the operation parsing rule, allowing the GraphQL parser to parse [query/mutation operation](https://spec.graphql.org/October2021/#sec-Language.Operations). This PR only parse the happy path with basic recovery strategy, another PR will be raised to handle the error path

## Test Plan

All tests for the parser should pass