### PR TITLE
fix(lint/useExhaustiveDependencies): unintended application of stable custom hook rules

### DIFF
--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -391,7 +391,15 @@ pub fn is_binding_react_stable(
     else {
         return false;
     };
+    let Some(function_name) = callee.get_callee_member_name() else {
+        return false;
+    };
+    let function_name = function_name.text_trimmed();
     stable_config.iter().any(|config| {
+        if !config.builtin && config.hook_name.as_str() != function_name {
+            return false;
+        }
+
         if config.builtin
             && !is_react_call_api(&callee, model, ReactLibrary::React, &config.hook_name)
         {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalid.js
@@ -1,0 +1,7 @@
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+
+function MyComponent25() {
+    const dispatch = useDispatch();
+    const doAction = useCallback(() => dispatch(someAction()), []);
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalid.js.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: stableResultInvalid.js
+---
+# Input
+```jsx
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+
+function MyComponent25() {
+    const dispatch = useDispatch();
+    const doAction = useCallback(() => dispatch(someAction()), []);
+}
+
+```
+
+# Diagnostics
+```
+stableResultInvalid.js:6:22 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook does not specify all of its dependencies: dispatch
+  
+    4 │ function MyComponent25() {
+    5 │     const dispatch = useDispatch();
+  > 6 │     const doAction = useCallback(() => dispatch(someAction()), []);
+      │                      ^^^^^^^^^^^
+    7 │ }
+    8 │ 
+  
+  i This dependency is not specified in the hook dependency list.
+  
+    4 │ function MyComponent25() {
+    5 │     const dispatch = useDispatch();
+  > 6 │     const doAction = useCallback(() => dispatch(someAction()), []);
+      │                                        ^^^^^^^^
+    7 │ }
+    8 │ 
+  
+  i Either include it or remove the dependency array
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalid.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalid.options.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+    "linter": {
+        "rules": {
+            "correctness": {
+                "useExhaustiveDependencies": {
+                    "level": "error",
+                    "options": {
+                        "hooks": [
+                            {
+                                "name": "otherCustomHook",
+                                "stableResult": true
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

`stableResult` works for hooks other than the specified name.

For instance, even if you change the name of `useDispatch` to something else, the tests will still pass.

https://github.com/biomejs/biome/blob/f5dd08679c752f3a9ec54fa54c5ee1d12cc13a97/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResult.options.json#L6-L16

In this PR, added a check to ensure the function names match the stable custom hook names.

However, it does not work when an alias is provided, as shown below:

```js
import { useCallback } from "react";
import { useDispatch as uD } from "react-redux";

function MyComponent25() {
    const dispatch = uD();
    const doAction = useCallback(() => dispatch(someAction()), []);
}
```

I am not very familiar with this project, so I would appreciate it if you could point out any mistakes I make.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

https://github.com/biomejs/biome/issues/1128

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
