### PR TITLE
feat(migrate-prettier): support `overrides` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Add a command to migrate from ESLint
 
-  `@biomejs/biome migrate eslint` allows you to migrate an ESLint configuration to Biome.
+  `biome migrate eslint` allows you to migrate an ESLint configuration to Biome.
   The command supports [legacy ESLint configurations](https://eslint.org/docs/latest/use/configure/configuration-files) and [new flat ESLint configurations](https://eslint.org/docs/latest/use/configure/configuration-files-new).
   Legacy ESLint configurations using the YAML format are not supported.
 
@@ -57,7 +57,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   }
   ```
 
-  `@biomejs/biome migrate eslint --write` changes the Biome configuration as follows:
+  `biome migrate eslint --write` changes the Biome configuration as follows:
 
   ```json
   {
@@ -83,7 +83,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   }
   ```
 
-  Also, if the working diretcory contains `.eslintignore`, then Biome migrates the glob patterns.
+  Also, if the working directory contains `.eslintignore`, then Biome migrates the glob patterns.
   Nested `.eslintignore` in subdirectories and negated glob patterns are not supported.
 
   If you find any issue, please don't hesitate to report them.
@@ -101,12 +101,15 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Support JavaScript configuration files when migrating from Prettier
 
-  `@biomejs/biome migrate prettier` is now able to migrate Prettier configuration files
+  `biome migrate prettier` is now able to migrate Prettier configuration files
   ending with `js`, `mjs`, or `cjs` extensions.
   To do this, Biome invokes Node.js.
 
   Also, embedded Prettier configurations in `package.json` are now supported.
 
+  Contributed by @Conaclos
+
+- Support `overrides` field in Prettier configuration files when migrating from Prettier. 
   Contributed by @Conaclos
 
 #### Bug fixes

--- a/crates/biome_cli/tests/commands/migrate_prettier.rs
+++ b/crates/biome_cli/tests/commands/migrate_prettier.rs
@@ -368,3 +368,45 @@ fn prettier_migrate_write_biome_jsonc() {
         result,
     ));
 }
+
+#[test]
+fn prettier_migrate_overrides() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let configuration = r#"{ "formatter": { "enabled": true } }"#;
+    let prettier = r#"{
+        "overrides": [{
+            "files": ["**/*.test.js"],
+            "options": { "useTabs": false }
+        }, {
+            "files": ["**/*.spec.js"],
+            "options": { "semi": true, "singleQuote": true }
+        }, {
+            "files": ["**/*.ts"],
+            "options": { "useTabs": false, "semi": true, "singleQuote": true }
+        }]
+    }"#;
+
+    let configuration_path = Path::new("biome.json");
+    fs.insert(configuration_path.into(), configuration.as_bytes());
+
+    let prettier_path = Path::new(".prettierrc");
+    fs.insert(prettier_path.into(), prettier.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("migrate"), "prettier"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "prettier_migrate_overrides",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_overrides.snap
@@ -1,0 +1,83 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{ "formatter": { "enabled": true } }
+```
+
+## `.prettierrc`
+
+```prettierrc
+{
+        "overrides": [{
+            "files": ["**/*.test.js"],
+            "options": { "useTabs": false }
+        }, {
+            "files": ["**/*.spec.js"],
+            "options": { "semi": true, "singleQuote": true }
+        }, {
+            "files": ["**/*.ts"],
+            "options": { "useTabs": false, "semi": true, "singleQuote": true }
+        }]
+    }
+```
+
+# Emitted Messages
+
+```block
+biome.json migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Configuration file can be updated.
+  
+    1    │ - {·"formatter":·{·"enabled":·true·}·}
+       1 │ + {
+       2 │ + → "formatter":·{
+       3 │ + → → "enabled":·true,
+       4 │ + → → "formatWithErrors":·false,
+       5 │ + → → "indentStyle":·"space",
+       6 │ + → → "indentWidth":·2,
+       7 │ + → → "lineEnding":·"lf",
+       8 │ + → → "lineWidth":·80,
+       9 │ + → → "attributePosition":·"auto"
+      10 │ + → },
+      11 │ + → "javascript":·{
+      12 │ + → → "formatter":·{
+      13 │ + → → → "jsxQuoteStyle":·"double",
+      14 │ + → → → "quoteProperties":·"asNeeded",
+      15 │ + → → → "trailingComma":·"all",
+      16 │ + → → → "semicolons":·"asNeeded",
+      17 │ + → → → "arrowParentheses":·"always",
+      18 │ + → → → "bracketSpacing":·true,
+      19 │ + → → → "bracketSameLine":·false,
+      20 │ + → → → "quoteStyle":·"single",
+      21 │ + → → → "attributePosition":·"auto"
+      22 │ + → → }
+      23 │ + → },
+      24 │ + → "overrides":·[
+      25 │ + → → {·"include":·["**/*.test.js"],·"formatter":·{·"indentStyle":·"space"·}·},
+      26 │ + → → {
+      27 │ + → → → "include":·["**/*.spec.js"],
+      28 │ + → → → "javascript":·{
+      29 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
+      30 │ + → → → }
+      31 │ + → → },
+      32 │ + → → {
+      33 │ + → → → "include":·["**/*.ts"],
+      34 │ + → → → "javascript":·{
+      35 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
+      36 │ + → → → },
+      37 │ + → → → "formatter":·{·"indentStyle":·"space"·}
+      38 │ + → → }
+      39 │ + → ]
+      40 │ + }
+      41 │ + 
+  
+
+```
+
+```block
+Run the command with the option --write to apply the changes.
+```

--- a/crates/biome_configuration/src/css.rs
+++ b/crates/biome_configuration/src/css.rs
@@ -1,4 +1,4 @@
-use crate::{deserialize_line_width, serialize_line_width, PlainIndentStyle};
+use crate::PlainIndentStyle;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use biome_formatter::{LineEnding, LineWidth, QuoteStyle};
 use bpaf::Bpaf;
@@ -57,10 +57,6 @@ pub struct CssFormatter {
     pub line_ending: Option<LineEnding>,
 
     /// What's the max width of a line applied to CSS (and its super languages) files. Defaults to 80.
-    #[partial(serde(
-        deserialize_with = "deserialize_line_width",
-        serialize_with = "serialize_line_width"
-    ))]
     #[partial(bpaf(long("css-formatter-line-width"), argument("NUMBER"), optional))]
     pub line_width: Option<LineWidth>,
 

--- a/crates/biome_configuration/src/formatter.rs
+++ b/crates/biome_configuration/src/formatter.rs
@@ -39,10 +39,6 @@ pub struct FormatterConfiguration {
 
     /// What's the max width of a line. Defaults to 80.
     #[partial(bpaf(long("line-width"), argument("NUMBER"), optional))]
-    #[partial(serde(
-        deserialize_with = "deserialize_line_width",
-        serialize_with = "serialize_line_width"
-    ))]
     pub line_width: LineWidth,
 
     /// The attribute position style in HTMLish languages. By default auto.
@@ -114,22 +110,6 @@ impl From<PlainIndentStyle> for IndentStyle {
             PlainIndentStyle::Space => IndentStyle::Space,
         }
     }
-}
-
-pub fn deserialize_line_width<'de, D>(deserializer: D) -> Result<Option<LineWidth>, D::Error>
-where
-    D: serde::de::Deserializer<'de>,
-{
-    let value: u16 = Deserialize::deserialize(deserializer)?;
-    let line_width = LineWidth::try_from(value).map_err(serde::de::Error::custom)?;
-    Ok(Some(line_width))
-}
-
-pub fn serialize_line_width<S>(line_width: &Option<LineWidth>, s: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::ser::Serializer,
-{
-    s.serialize_u16(line_width.unwrap_or_default().get())
 }
 
 #[derive(

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -1,5 +1,4 @@
 use crate::PlainIndentStyle;
-use crate::{deserialize_line_width, serialize_line_width};
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use biome_formatter::{AttributePosition, LineEnding, LineWidth, QuoteStyle};
 use biome_js_formatter::context::trailing_comma::TrailingComma;
@@ -75,10 +74,6 @@ pub struct JavascriptFormatter {
     pub line_ending: Option<LineEnding>,
 
     /// What's the max width of a line applied to JavaScript (and its super languages) files. Defaults to 80.
-    #[partial(serde(
-        deserialize_with = "deserialize_line_width",
-        serialize_with = "serialize_line_width"
-    ))]
     #[partial(bpaf(long("javascript-formatter-line-width"), argument("NUMBER"), optional))]
     pub line_width: Option<LineWidth>,
 

--- a/crates/biome_configuration/src/json.rs
+++ b/crates/biome_configuration/src/json.rs
@@ -1,4 +1,4 @@
-use crate::{deserialize_line_width, serialize_line_width, PlainIndentStyle};
+use crate::PlainIndentStyle;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use biome_formatter::{LineEnding, LineWidth};
 use biome_json_formatter::context::TrailingCommas;
@@ -62,10 +62,6 @@ pub struct JsonFormatter {
     pub line_ending: Option<LineEnding>,
 
     /// What's the max width of a line applied to JSON (and its super languages) files. Defaults to 80.
-    #[partial(serde(
-        deserialize_with = "deserialize_line_width",
-        serialize_with = "serialize_line_width"
-    ))]
     #[partial(bpaf(long("json-formatter-line-width"), argument("NUMBER"), optional))]
     pub line_width: Option<LineWidth>,
 

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -26,8 +26,8 @@ pub use css::{
     PartialCssFormatter,
 };
 pub use formatter::{
-    deserialize_line_width, partial_formatter_configuration, serialize_line_width,
-    FormatterConfiguration, PartialFormatterConfiguration, PlainIndentStyle,
+    partial_formatter_configuration, FormatterConfiguration, PartialFormatterConfiguration,
+    PlainIndentStyle,
 };
 pub use javascript::{
     partial_javascript_configuration, JavascriptConfiguration, JavascriptFormatter,

--- a/crates/biome_configuration/src/overrides.rs
+++ b/crates/biome_configuration/src/overrides.rs
@@ -1,7 +1,6 @@
 use super::javascript::PartialJavascriptConfiguration;
 use super::json::PartialJsonConfiguration;
 use super::PartialCssConfiguration;
-use crate::formatter::{deserialize_line_width, serialize_line_width};
 use crate::{
     partial_css_configuration, partial_javascript_configuration, partial_json_configuration,
     PlainIndentStyle, Rules,
@@ -92,11 +91,13 @@ impl FromStr for OverridePattern {
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct OverrideFormatterConfiguration {
     // if `false`, it disables the feature. `true` by default
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[bpaf(hide)]
     pub enabled: Option<bool>,
 
     /// Stores whether formatting should be allowed to proceed if a given file
     /// has syntax errors
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[bpaf(hide)]
     pub format_with_errors: Option<bool>,
 
@@ -122,14 +123,12 @@ pub struct OverrideFormatterConfiguration {
     pub line_ending: Option<LineEnding>,
 
     /// What's the max width of a line. Defaults to 80.
-    #[serde(
-        deserialize_with = "deserialize_line_width",
-        serialize_with = "serialize_line_width"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[bpaf(long("line-width"), argument("NUMBER"), optional)]
     pub line_width: Option<LineWidth>,
 
     /// The attribute position style.
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[bpaf(long("attribute-position"), argument("multiline|auto"), optional)]
     pub attribute_position: Option<AttributePosition>,
 }

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -229,7 +229,7 @@ impl From<u8> for IndentWidth {
 #[derive(Clone, Copy, Debug, Eq, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    derive(serde::Serialize, schemars::JsonSchema),
     serde(rename_all = "camelCase")
 )]
 pub struct LineWidth(u16);
@@ -268,6 +268,18 @@ impl Deserializable for LineWidth {
             value.range(),
         ));
         None
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for LineWidth {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value: u16 = serde::Deserialize::deserialize(deserializer)?;
+        let line_width = LineWidth::try_from(value).map_err(serde::de::Error::custom)?;
+        Ok(line_width)
     }
 }
 

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1579,16 +1579,14 @@
 			"properties": {
 				"attributePosition": {
 					"description": "The attribute position style.",
-					"default": null,
 					"anyOf": [
 						{ "$ref": "#/definitions/AttributePosition" },
 						{ "type": "null" }
 					]
 				},
-				"enabled": { "default": null, "type": ["boolean", "null"] },
+				"enabled": { "type": ["boolean", "null"] },
 				"formatWithErrors": {
 					"description": "Stores whether formatting should be allowed to proceed if a given file has syntax errors",
-					"default": null,
 					"type": ["boolean", "null"]
 				},
 				"indentSize": {
@@ -1616,7 +1614,6 @@
 				},
 				"lineWidth": {
 					"description": "What's the max width of a line. Defaults to 80.",
-					"default": 80,
 					"anyOf": [{ "$ref": "#/definitions/LineWidth" }, { "type": "null" }]
 				}
 			},

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -29,7 +29,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Add a command to migrate from ESLint
 
-  `@biomejs/biome migrate eslint` allows you to migrate an ESLint configuration to Biome.
+  `biome migrate eslint` allows you to migrate an ESLint configuration to Biome.
   The command supports [legacy ESLint configurations](https://eslint.org/docs/latest/use/configure/configuration-files) and [new flat ESLint configurations](https://eslint.org/docs/latest/use/configure/configuration-files-new).
   Legacy ESLint configurations using the YAML format are not supported.
 
@@ -63,7 +63,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   }
   ```
 
-  `@biomejs/biome migrate eslint --write` changes the Biome configuration as follows:
+  `biome migrate eslint --write` changes the Biome configuration as follows:
 
   ```json
   {
@@ -89,7 +89,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   }
   ```
 
-  Also, if the working diretcory contains `.eslintignore`, then Biome migrates the glob patterns.
+  Also, if the working directory contains `.eslintignore`, then Biome migrates the glob patterns.
   Nested `.eslintignore` in subdirectories and negated glob patterns are not supported.
 
   If you find any issue, please don't hesitate to report them.
@@ -107,12 +107,15 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Support JavaScript configuration files when migrating from Prettier
 
-  `@biomejs/biome migrate prettier` is now able to migrate Prettier configuration files
+  `biome migrate prettier` is now able to migrate Prettier configuration files
   ending with `js`, `mjs`, or `cjs` extensions.
   To do this, Biome invokes Node.js.
 
   Also, embedded Prettier configurations in `package.json` are now supported.
 
+  Contributed by @Conaclos
+
+- Support `overrides` field in Prettier configuration files when migrating from Prettier. 
   Contributed by @Conaclos
 
 #### Bug fixes


### PR DESCRIPTION
## Summary

This PR adds the support for the `overrides` field in Prettier configuration.
While I was testing the feature, I noticed missing serde's `skip_serialization_if = Option::is_none` for some fields of the Biome configuration file. I added them.

## Test Plan

I added a test.