### PR TITLE
fix(json-schema): remove field `options` for rules without options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,30 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- `options` is no longer required for rules without any options ([#2313](https://github.com/biomejs/biome/issues/2313)).
+
+  Previously, the JSON schema required to set `options` to `null` when an object is used to set the diagnostic level of a rule without any option.
+  However, if `options` is set to `null`, Biome emits an error.
+
+  The schema is now fixed and it no longer requires specifying `options`.
+  This makes the following configuration valid:
+
+  ```json
+  {
+    "linter": {
+      "rules": {
+        "style": {
+          "noDefaultExport": {
+            "level": "off"
+          }
+        }
+      }
+    }
+  }
+  ```
+
+  Contributed by @Conaclos
+
 ### Editors
 
 ### Formatter

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1847,10 +1847,9 @@
 		},
 		"RuleWithNoOptions": {
 			"type": "object",
-			"required": ["level", "options"],
+			"required": ["level"],
 			"properties": {
-				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
-				"options": { "type": "null" }
+				"level": { "$ref": "#/definitions/RulePlainConfiguration" }
 			},
 			"additionalProperties": false
 		},

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -133,6 +133,30 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- `options` is no longer required for rules without any options ([#2313](https://github.com/biomejs/biome/issues/2313)).
+
+  Previously, the JSON schema required to set `options` to `null` when an object is used to set the diagnostic level of a rule without any option.
+  However, if `options` is set to `null`, Biome emits an error.
+
+  The schema is now fixed and it no longer requires specifying `options`.
+  This makes the following configuration valid:
+
+  ```json
+  {
+    "linter": {
+      "rules": {
+        "style": {
+          "noDefaultExport": {
+            "level": "off"
+          }
+        }
+      }
+    }
+  }
+  ```
+
+  Contributed by @Conaclos
+
 ### Editors
 
 ### Formatter

--- a/xtask/codegen/src/generate_schema.rs
+++ b/xtask/codegen/src/generate_schema.rs
@@ -59,6 +59,12 @@ fn rename_partial_references_in_schema(mut schema: RootSchema) -> RootSchema {
                 key = stripped.to_string();
             } else if key == "RuleWithOptions_for_Null" {
                 key = "RuleWithNoOptions".to_string();
+                if let Schema::Object(schema_object) = &mut schema {
+                    if let Some(object) = &mut schema_object.object {
+                        object.required.remove("options");
+                        object.properties.remove("options");
+                    }
+                }
             } else if key == "RuleConfiguration_for_Null" {
                 key = "RuleConfiguration".to_string();
             } else if let Some(stripped) = key.strip_prefix("RuleWithOptions_for_") {


### PR DESCRIPTION
## Summary

Fix #2313 by completely removing `options` form the JSON schema for rules without any option.

## Test Plan

I manually tested the schema.
