### PR TITLE
chore(ci): add update contributors workflow

### DIFF
--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -1,0 +1,35 @@
+name: Update Contributors
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-contributors-and-create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+      - name: Install toolchain
+        uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f # v1
+        with:
+          bins: cargo-nextest
+          cache-base: main
+      - name: Update Contributors
+        run: cargo run --bin xtask_contributors -- --token ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Pull Request
+        id: create-pull-request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/update-contributors
+          title: "chore(website): update contributors"
+          body: ""
+          labels: A-Website

--- a/xtask/contributors/src/main.rs
+++ b/xtask/contributors/src/main.rs
@@ -19,12 +19,12 @@ fn main() -> Result<()> {
 
     Ok(())
 }
-const IMPORT_IMAGE: &str = "import { Image } from \"astro:assets\"";
+const IMPORT_IMAGE: &str = "import { Image } from \"astro:assets\";";
 
 fn write_contributors_in_community(root: PathBuf, contributors: &[Contributor]) -> Result<()> {
     let mut content = String::new();
 
-    content.push_str(format!("---\n // {} \n {}  \n---\n", PREAMBLE, IMPORT_IMAGE).as_str());
+    content.push_str(format!("---\n// {}\n{}\n---\n", PREAMBLE, IMPORT_IMAGE).as_str());
 
     let contributors_per_row = [5, 4, 6, 5, 3, 5, 4];
 
@@ -59,7 +59,7 @@ fn write_contributors_in_community(root: PathBuf, contributors: &[Contributor]) 
 fn write_contributors_in_credits(root: PathBuf, contributors: &[Contributor]) -> Result<()> {
     let mut content = String::new();
 
-    content.push_str(format!("---\n // {} \n {}  \n---\n", PREAMBLE, IMPORT_IMAGE).as_str());
+    content.push_str(format!("---\n// {}\n{}\n---\n", PREAMBLE, IMPORT_IMAGE).as_str());
 
     content.push('\n');
     content.push_str("<h2>Code contributors</h2>");


### PR DESCRIPTION
## Summary

Add a workflow to update contributors regularly. This workflow will create a PR to update the contributors list in `Community.astro` and `Contributors.astro`.

If the list doesn't need to be updated, this workflow will not create a PR.

This workflow can also be executed manually.

## Test Plan

Tested on my forked repo.
