### PR TITLE
refactor(linter): allow multiple rule sources

### DIFF
--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -33,7 +33,7 @@ pub struct RuleMetadata {
     /// The kind of fix
     pub fix_kind: Option<FixKind>,
     /// The source URL of the rule
-    pub source: Option<RuleSource>,
+    pub sources: &'static [RuleSource],
     /// The source kind of the rule
     pub source_kind: Option<RuleSourceKind>,
 }
@@ -210,7 +210,7 @@ impl RuleSource {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Copy)]
 pub enum RuleSourceKind {
     /// The rule implements the same logic of the source
     #[default]
@@ -234,7 +234,7 @@ impl RuleMetadata {
             docs,
             recommended: false,
             fix_kind: None,
-            source: None,
+            sources: &[],
             source_kind: None,
         }
     }
@@ -254,8 +254,8 @@ impl RuleMetadata {
         self
     }
 
-    pub const fn source(mut self, source: RuleSource) -> Self {
-        self.source = Some(source);
+    pub const fn sources(mut self, sources: &'static [RuleSource]) -> Self {
+        self.sources = sources;
         //if self.source_kind.is_none() {
         //    self.source_kind = Some(RuleSourceKind::SameLogic);
         //}

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -51,6 +51,18 @@ pub(crate) fn migrate_eslint_any_rule(
             let rule = group.use_import_type.get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
+        "@typescript-eslint/default-param-last" => {
+            let group = rules.style.get_or_insert_with(Default::default);
+            let rule = group
+                .use_default_parameter_last
+                .get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
+        "@typescript-eslint/dot-notation" => {
+            let group = rules.complexity.get_or_insert_with(Default::default);
+            let rule = group.use_literal_keys.get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
         "@typescript-eslint/naming-convention" => {
             if !options.include_inspired {
                 results.has_inspired_rules = true;
@@ -59,6 +71,20 @@ pub(crate) fn migrate_eslint_any_rule(
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
                 .use_naming_convention
+                .get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
+        "@typescript-eslint/no-dupe-class-members" => {
+            let group = rules.suspicious.get_or_insert_with(Default::default);
+            let rule = group
+                .no_duplicate_class_members
+                .get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
+        "@typescript-eslint/no-empty-function" => {
+            let group = rules.suspicious.get_or_insert_with(Default::default);
+            let rule = group
+                .no_empty_block_statements
                 .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
@@ -100,6 +126,11 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
+        "@typescript-eslint/no-loss-of-precision" => {
+            let group = rules.correctness.get_or_insert_with(Default::default);
+            let rule = group.no_precision_loss.get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
         "@typescript-eslint/no-misused-new" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
@@ -122,6 +153,16 @@ pub(crate) fn migrate_eslint_any_rule(
         "@typescript-eslint/no-redeclare" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group.no_redeclare.get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
+        "@typescript-eslint/no-restricted-imports" => {
+            if !options.include_nursery {
+                return false;
+            }
+            let group = rules.nursery.get_or_insert_with(Default::default);
+            let rule = group
+                .no_restricted_imports
+                .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
         "@typescript-eslint/no-this-alias" => {
@@ -147,6 +188,11 @@ pub(crate) fn migrate_eslint_any_rule(
             let rule = group
                 .no_unsafe_declaration_merging
                 .get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
+        "@typescript-eslint/no-unused-vars" => {
+            let group = rules.correctness.get_or_insert_with(Default::default);
+            let rule = group.no_unused_variables.get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
         "@typescript-eslint/no-use-before-define" => {
@@ -231,6 +277,11 @@ pub(crate) fn migrate_eslint_any_rule(
         "@typescript-eslint/prefer-optional-chain" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group.use_optional_chain.get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
+        "@typescript-eslint/require-await" => {
+            let group = rules.suspicious.get_or_insert_with(Default::default);
+            let rule = group.use_await.get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
         "barrel-files/avoid-namespace-import" => {
@@ -690,9 +741,23 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
+        "no-empty-function" => {
+            let group = rules.suspicious.get_or_insert_with(Default::default);
+            let rule = group
+                .no_empty_block_statements
+                .get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
         "no-empty-pattern" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group.no_empty_pattern.get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
+        "no-empty-static-block" => {
+            let group = rules.suspicious.get_or_insert_with(Default::default);
+            let rule = group
+                .no_empty_block_statements
+                .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
         "no-eval" => {
@@ -829,6 +894,11 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
+        "no-redeclare" => {
+            let group = rules.suspicious.get_or_insert_with(Default::default);
+            let rule = group.no_redeclare.get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
         "no-regex-spaces" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
@@ -944,9 +1014,23 @@ pub(crate) fn migrate_eslint_any_rule(
             let rule = group.no_unused_variables.get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
+        "no-use-before-define" => {
+            let group = rules.correctness.get_or_insert_with(Default::default);
+            let rule = group
+                .no_invalid_use_before_declaration
+                .get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
         "no-useless-catch" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group.no_useless_catch.get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
+        "no-useless-constructor" => {
+            let group = rules.complexity.get_or_insert_with(Default::default);
+            let rule = group
+                .no_useless_constructor
+                .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
         "no-useless-rename" => {
@@ -1147,9 +1231,19 @@ pub(crate) fn migrate_eslint_any_rule(
             let rule = group.no_for_each.get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
+        "unicorn/no-for-loop" => {
+            let group = rules.style.get_or_insert_with(Default::default);
+            let rule = group.use_for_of.get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
         "unicorn/no-instanceof-array" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group.use_is_array.get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
+        "unicorn/no-static-only-class" => {
+            let group = rules.complexity.get_or_insert_with(Default::default);
+            let rule = group.no_static_only_class.get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
         "unicorn/no-thenable" => {

--- a/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
@@ -182,7 +182,7 @@ impl eslint_eslint::Rules {
         results: &mut MigrationResults,
     ) -> biome_config::Rules {
         let mut rules = biome_config::Rules::default();
-        for eslint_rule in self {
+        for eslint_rule in self.0 {
             migrate_eslint_rule(&mut rules, eslint_rule, options, results);
         }
         rules

--- a/crates/biome_cli/tests/commands/migrate_eslint.rs
+++ b/crates/biome_cli/tests/commands/migrate_eslint.rs
@@ -507,3 +507,36 @@ a/**
         result,
     ));
 }
+
+#[test]
+fn migrate_eslintrcjson_extended_rules() {
+    let biomejson = r#"{ "linter": { "enabled": true } }"#;
+    let eslintrc = r#"{
+        "rules": {
+            "dot-notation": 0,
+            "@typescript-eslint/dot-notation": 2,
+            "@typescript-eslint/no-dupe-class-members": 2,
+            "no-dupe-class-members": 0
+        }
+    }"#;
+
+    let mut fs = MemoryFileSystem::default();
+    fs.insert(Path::new("biome.json").into(), biomejson.as_bytes());
+    fs.insert(Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
+
+    let mut console = BufferConsole::default();
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(["migrate", "eslint"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "migrate_eslintrcjson_extended_rules",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrcjson_extended_rules.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrcjson_extended_rules.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{ "linter": { "enabled": true } }
+```
+
+## `.eslintrc.json`
+
+```json
+{
+        "rules": {
+            "dot-notation": 0,
+            "@typescript-eslint/dot-notation": 2,
+            "@typescript-eslint/no-dupe-class-members": 2,
+            "no-dupe-class-members": 0
+        }
+    }
+```
+
+# Emitted Messages
+
+```block
+biome.json migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Configuration file can be updated.
+  
+    1    │ - {·"linter":·{·"enabled":·true·}·}
+       1 │ + {
+       2 │ + → "linter":·{
+       3 │ + → → "enabled":·true,
+       4 │ + → → "rules":·{
+       5 │ + → → → "recommended":·false,
+       6 │ + → → → "complexity":·{·"useLiteralKeys":·"error"·},
+       7 │ + → → → "suspicious":·{·"noDuplicateClassMembers":·"off"·}
+       8 │ + → → }
+       9 │ + → }
+      10 │ + }
+      11 │ + 
+  
+
+```
+
+```block
+Run the command with the option --write to apply the changes.
+```

--- a/crates/biome_js_analyze/src/lint/a11y/no_access_key.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_access_key.rs
@@ -40,7 +40,7 @@ declare_rule! {
     pub NoAccessKey {
         version: "1.0.0",
         name: "noAccessKey",
-        source: RuleSource::EslintJsxA11y("no-access-key"),
+        sources: &[RuleSource::EslintJsxA11y("no-access-key")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
@@ -45,7 +45,7 @@ declare_rule! {
     pub NoAriaHiddenOnFocusable {
         version: "1.4.0",
         name: "noAriaHiddenOnFocusable",
-        source: RuleSource::EslintJsxA11y("no-aria-hidden-on-focusable"),
+        sources: &[RuleSource::EslintJsxA11y("no-aria-hidden-on-focusable")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/no_aria_unsupported_elements.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_aria_unsupported_elements.rs
@@ -36,7 +36,7 @@ declare_rule! {
     pub NoAriaUnsupportedElements {
         version: "1.0.0",
         name: "noAriaUnsupportedElements",
-        source: RuleSource::EslintJsxA11y("aria-unsupported-elements"),
+        sources: &[RuleSource::EslintJsxA11y("aria-unsupported-elements")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/no_autofocus.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_autofocus.rs
@@ -60,7 +60,7 @@ declare_rule! {
     pub NoAutofocus {
         version: "1.0.0",
         name: "noAutofocus",
-        source: RuleSource::EslintJsxA11y("no-autofocus"),
+        sources: &[RuleSource::EslintJsxA11y("no-autofocus")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/no_blank_target.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_blank_target.rs
@@ -51,7 +51,7 @@ declare_rule! {
     pub NoBlankTarget {
         version: "1.0.0",
         name: "noBlankTarget",
-        source: RuleSource::EslintReact("jsx-no-target-blank"),
+        sources: &[RuleSource::EslintReact("jsx-no-target-blank")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/no_distracting_elements.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_distracting_elements.rs
@@ -40,7 +40,7 @@ declare_rule! {
     pub NoDistractingElements {
         version: "1.0.0",
         name: "noDistractingElements",
-        source: RuleSource::EslintJsxA11y("no-distracting-elements"),
+        sources: &[RuleSource::EslintJsxA11y("no-distracting-elements")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/no_header_scope.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_header_scope.rs
@@ -40,7 +40,7 @@ declare_rule! {
     pub NoHeaderScope {
         version: "1.0.0",
         name: "noHeaderScope",
-        source: RuleSource::EslintJsxA11y("scope"),
+        sources: &[RuleSource::EslintJsxA11y("scope")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/no_interactive_element_to_noninteractive_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_interactive_element_to_noninteractive_role.rs
@@ -35,7 +35,7 @@ declare_rule! {
     pub NoInteractiveElementToNoninteractiveRole {
         version: "1.3.0",
         name: "noInteractiveElementToNoninteractiveRole",
-        source: RuleSource::EslintJsxA11y("no-interactive-element-to-noninteractive-role"),
+        sources: &[RuleSource::EslintJsxA11y("no-interactive-element-to-noninteractive-role")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_element_to_interactive_role.rs
@@ -48,7 +48,7 @@ declare_rule! {
     pub NoNoninteractiveElementToInteractiveRole {
         version: "1.0.0",
         name: "noNoninteractiveElementToInteractiveRole",
-        source: RuleSource::EslintJsxA11y("no-noninteractive-element-to-interactive-role"),
+        sources: &[RuleSource::EslintJsxA11y("no-noninteractive-element-to-interactive-role")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_tabindex.rs
@@ -51,7 +51,7 @@ declare_rule! {
     pub NoNoninteractiveTabindex {
         version: "1.0.0",
         name: "noNoninteractiveTabindex",
-        source: RuleSource::EslintJsxA11y("no-noninteractive-tabindex"),
+        sources: &[RuleSource::EslintJsxA11y("no-noninteractive-tabindex")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
@@ -51,7 +51,7 @@ declare_rule! {
     pub NoPositiveTabindex {
         version: "1.0.0",
         name: "noPositiveTabindex",
-        source: RuleSource::EslintJsxA11y("tabindex-no-positive"),
+        sources: &[RuleSource::EslintJsxA11y("tabindex-no-positive")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/no_redundant_alt.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_redundant_alt.rs
@@ -42,7 +42,7 @@ declare_rule! {
     pub NoRedundantAlt {
         version: "1.0.0",
         name: "noRedundantAlt",
-        source: RuleSource::EslintJsxA11y("no-redundant-roles"),
+        sources: &[RuleSource::EslintJsxA11y("no-redundant-roles")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_redundant_roles.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_redundant_roles.rs
@@ -46,7 +46,7 @@ declare_rule! {
     pub NoRedundantRoles {
         version: "1.0.0",
         name: "noRedundantRoles",
-        source: RuleSource::EslintJsxA11y("no-redundant-roles"),
+        sources: &[RuleSource::EslintJsxA11y("no-redundant-roles")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
@@ -46,7 +46,7 @@ declare_rule! {
     pub UseAltText {
         version: "1.0.0",
         name: "useAltText",
-        source: RuleSource::EslintJsxA11y("alt-text"),
+        sources: &[RuleSource::EslintJsxA11y("alt-text")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_anchor_content.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_anchor_content.rs
@@ -67,7 +67,7 @@ declare_rule! {
     pub UseAnchorContent {
         version: "1.0.0",
         name: "useAnchorContent",
-        source: RuleSource::EslintJsxA11y("anchor-has-content"),
+        sources: &[RuleSource::EslintJsxA11y("anchor-has-content")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/use_aria_activedescendant_with_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_aria_activedescendant_with_tabindex.rs
@@ -51,7 +51,7 @@ declare_rule! {
     pub UseAriaActivedescendantWithTabindex {
         version: "1.3.0",
         name: "useAriaActivedescendantWithTabindex",
-        source: RuleSource::EslintJsxA11y("aria-activedescendant-has-tabindex"),
+        sources: &[RuleSource::EslintJsxA11y("aria-activedescendant-has-tabindex")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/use_aria_props_for_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_aria_props_for_role.rs
@@ -41,7 +41,7 @@ declare_rule! {
     pub UseAriaPropsForRole {
         version: "1.0.0",
         name: "useAriaPropsForRole",
-        source: RuleSource::EslintJsxA11y("role-has-required-aria-props"),
+        sources: &[RuleSource::EslintJsxA11y("role-has-required-aria-props")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_button_type.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_button_type.rs
@@ -39,7 +39,7 @@ declare_rule! {
     pub UseButtonType {
         version: "1.0.0",
         name: "useButtonType",
-        source: RuleSource::EslintReact("button-has-type"),
+        sources: &[RuleSource::EslintReact("button-has-type")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_heading_content.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_heading_content.rs
@@ -47,7 +47,7 @@ declare_rule! {
     pub UseHeadingContent {
         version: "1.0.0",
         name: "useHeadingContent",
-        source: RuleSource::EslintJsxA11y("heading-has-content"),
+        sources: &[RuleSource::EslintJsxA11y("heading-has-content")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_html_lang.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_html_lang.rs
@@ -55,7 +55,7 @@ declare_rule! {
     pub UseHtmlLang {
         version: "1.0.0",
         name: "useHtmlLang",
-        source: RuleSource::EslintJsxA11y("html-has-lang"),
+        sources: &[RuleSource::EslintJsxA11y("html-has-lang")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_iframe_title.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_iframe_title.rs
@@ -61,7 +61,7 @@ declare_rule! {
     pub UseIframeTitle {
         version: "1.0.0",
         name: "useIframeTitle",
-        source: RuleSource::EslintJsxA11y("iframe-has-title"),
+        sources: &[RuleSource::EslintJsxA11y("iframe-has-title")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_key_with_click_events.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_key_with_click_events.rs
@@ -59,7 +59,7 @@ declare_rule! {
     pub UseKeyWithClickEvents {
         version: "1.0.0",
         name: "useKeyWithClickEvents",
-        source: RuleSource::EslintJsxA11y("click-events-have-key-events"),
+        sources: &[RuleSource::EslintJsxA11y("click-events-have-key-events")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_key_with_mouse_events.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_key_with_mouse_events.rs
@@ -42,7 +42,7 @@ declare_rule! {
     pub UseKeyWithMouseEvents {
         version: "1.0.0",
         name: "useKeyWithMouseEvents",
-        source: RuleSource::EslintJsxA11y("mouse-events-have-key-events"),
+        sources: &[RuleSource::EslintJsxA11y("mouse-events-have-key-events")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_media_caption.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_media_caption.rs
@@ -33,7 +33,7 @@ declare_rule! {
     pub UseMediaCaption {
         version: "1.0.0",
         name: "useMediaCaption",
-        source: RuleSource::EslintJsxA11y("media-has-caption"),
+        sources: &[RuleSource::EslintJsxA11y("media-has-caption")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
@@ -74,7 +74,7 @@ declare_rule! {
     pub UseValidAnchor {
         version: "1.0.0",
         name: "useValidAnchor",
-        source: RuleSource::EslintJsxA11y("anchor-is-valid"),
+        sources: &[RuleSource::EslintJsxA11y("anchor-is-valid")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_props.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_props.rs
@@ -28,7 +28,7 @@ declare_rule! {
     pub UseValidAriaProps {
         version: "1.0.0",
         name: "useValidAriaProps",
-        source: RuleSource::EslintJsxA11y("aria-props"),
+        sources: &[RuleSource::EslintJsxA11y("aria-props")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
@@ -67,7 +67,7 @@ declare_rule! {
     pub UseValidAriaRole {
         version: "1.4.0",
         name: "useValidAriaRole",
-        source: RuleSource::EslintJsxA11y("aria-role"),
+        sources: &[RuleSource::EslintJsxA11y("aria-role")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_values.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_values.rs
@@ -50,7 +50,7 @@ declare_rule! {
     pub UseValidAriaValues {
         version: "1.0.0",
         name: "useValidAriaValues",
-        source: RuleSource::EslintJsxA11y("aria-proptypes"),
+        sources: &[RuleSource::EslintJsxA11y("aria-proptypes")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_lang.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_lang.rs
@@ -31,7 +31,7 @@ declare_rule! {
     pub UseValidLang {
         version: "1.0.0",
         name: "useValidLang",
-        source: RuleSource::EslintJsxA11y("lang"),
+        sources: &[RuleSource::EslintJsxA11y("lang")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_banned_types.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_banned_types.rs
@@ -91,7 +91,7 @@ declare_rule! {
     pub NoBannedTypes {
         version: "1.0.0",
         name: "noBannedTypes",
-        source: RuleSource::EslintTypeScript("ban-types"),
+        sources: &[RuleSource::EslintTypeScript("ban-types")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/no_excessive_cognitive_complexity.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_excessive_cognitive_complexity.rs
@@ -72,7 +72,7 @@ declare_rule! {
     pub NoExcessiveCognitiveComplexity {
         version: "1.0.0",
         name: "noExcessiveCognitiveComplexity",
-        source: RuleSource::EslintSonarJs("cognitive-complexity"),
+        sources: &[RuleSource::EslintSonarJs("cognitive-complexity")],
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_extra_boolean_cast.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_extra_boolean_cast.rs
@@ -59,7 +59,7 @@ declare_rule! {
     pub NoExtraBooleanCast {
         version: "1.0.0",
         name: "noExtraBooleanCast",
-        source: RuleSource::Eslint("no-extra-boolean-cast"),
+        sources: &[RuleSource::Eslint("no-extra-boolean-cast")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/no_for_each.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_for_each.rs
@@ -61,7 +61,10 @@ declare_rule! {
     pub NoForEach {
         version: "1.0.0",
         name: "noForEach",
-        source: RuleSource::EslintUnicorn("no-array-for-each"),
+        sources: &[
+            RuleSource::EslintUnicorn("no-array-for-each"),
+            RuleSource::Clippy("needless_for_each"),
+        ],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_multiple_spaces_in_regular_expression_literals.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_multiple_spaces_in_regular_expression_literals.rs
@@ -49,7 +49,7 @@ declare_rule! {
     pub NoMultipleSpacesInRegularExpressionLiterals {
         version: "1.0.0",
         name: "noMultipleSpacesInRegularExpressionLiterals",
-        source: RuleSource::Eslint("no-regex-spaces"),
+        sources: &[RuleSource::Eslint("no-regex-spaces")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/no_static_only_class.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_static_only_class.rs
@@ -91,7 +91,10 @@ declare_rule! {
     pub NoStaticOnlyClass {
         version: "1.0.0",
         name: "noStaticOnlyClass",
-        source: RuleSource::EslintTypeScript("no-extraneous-class"),
+        sources: &[
+            RuleSource::EslintTypeScript("no-extraneous-class"),
+            RuleSource::EslintUnicorn("no-static-only-class"),
+        ],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
@@ -81,7 +81,7 @@ declare_rule! {
     pub NoThisInStatic {
         version: "1.3.1",
         name: "noThisInStatic",
-        source: RuleSource::EslintMysticatea("no-this-in-static"),
+        sources: &[RuleSource::EslintMysticatea("no-this-in-static")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_catch.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_catch.rs
@@ -53,7 +53,7 @@ declare_rule! {
     pub NoUselessCatch {
         version: "1.0.0",
         name: "noUselessCatch",
-        source: RuleSource::Eslint("no-useless-catch"),
+        sources: &[RuleSource::Eslint("no-useless-catch")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
@@ -118,7 +118,10 @@ declare_rule! {
     pub NoUselessConstructor {
         version: "1.0.0",
         name: "noUselessConstructor",
-        source: RuleSource::EslintTypeScript("no-useless-constructor"),
+        sources: &[
+            RuleSource::Eslint("no-useless-constructor"),
+            RuleSource::EslintTypeScript("no-useless-constructor"),
+        ],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_empty_export.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_empty_export.rs
@@ -45,7 +45,7 @@ declare_rule! {
     pub NoUselessEmptyExport {
         version: "1.0.0",
         name: "noUselessEmptyExport",
-        source: RuleSource::EslintTypeScript("no-useless-empty-export"),
+        sources: &[RuleSource::EslintTypeScript("no-useless-empty-export")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -62,7 +62,7 @@ declare_rule! {
     pub NoUselessFragments {
         version: "1.0.0",
         name: "noUselessFragments",
-        source: RuleSource::EslintReact("jsx-no-useless-fragment"),
+        sources: &[RuleSource::EslintReact("jsx-no-useless-fragment")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_label.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_label.rs
@@ -35,7 +35,7 @@ declare_rule! {
     pub NoUselessLabel {
         version: "1.0.0",
         name: "noUselessLabel",
-        source: RuleSource::Eslint("no-extra-label"),
+        sources: &[RuleSource::Eslint("no-extra-label")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_lone_block_statements.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_lone_block_statements.rs
@@ -46,7 +46,7 @@ declare_rule! {
     pub NoUselessLoneBlockStatements {
         version: "1.3.3",
         name: "noUselessLoneBlockStatements",
-        source: RuleSource::Eslint("no-lone-blocks"),
+        sources: &[RuleSource::Eslint("no-lone-blocks")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_rename.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_rename.rs
@@ -60,7 +60,7 @@ declare_rule! {
     pub NoUselessRename {
         version: "1.0.0",
         name: "noUselessRename",
-        source: RuleSource::Eslint("no-useless-rename"),
+        sources: &[RuleSource::Eslint("no-useless-rename")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_switch_case.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_switch_case.rs
@@ -60,7 +60,7 @@ declare_rule! {
     pub NoUselessSwitchCase {
         version: "1.0.0",
         name: "noUselessSwitchCase",
-        source: RuleSource::EslintUnicorn("no-useless-switch-case"),
+        sources: &[RuleSource::EslintUnicorn("no-useless-switch-case")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_this_alias.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_this_alias.rs
@@ -54,7 +54,7 @@ declare_rule! {
     pub NoUselessThisAlias {
         version: "1.0.0",
         name: "noUselessThisAlias",
-        source: RuleSource::EslintTypeScript("no-this-alias"),
+        sources: &[RuleSource::EslintTypeScript("no-this-alias")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
         fix_kind: FixKind::Safe,

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_type_constraint.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_type_constraint.rs
@@ -79,7 +79,7 @@ declare_rule! {
     pub NoUselessTypeConstraint {
         version: "1.0.0",
         name: "noUselessTypeConstraint",
-        source: RuleSource::EslintTypeScript("no-unnecessary-type-constraint"),
+        sources: &[RuleSource::EslintTypeScript("no-unnecessary-type-constraint")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/no_void.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_void.rs
@@ -20,7 +20,7 @@ declare_rule! {
     pub NoVoid {
         version: "1.0.0",
         name: "noVoid",
-        source: RuleSource::Eslint("no-void"),
+        sources: &[RuleSource::Eslint("no-void")],
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_with.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_with.rs
@@ -25,7 +25,7 @@ declare_rule! {
     pub NoWith {
         version: "1.0.0",
         name: "noWith",
-        source: RuleSource::Eslint("no-with"),
+        sources: &[RuleSource::Eslint("no-with")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
@@ -70,7 +70,7 @@ declare_rule! {
     pub UseArrowFunction {
         version: "1.0.0",
         name: "useArrowFunction",
-        source: RuleSource::Eslint("prefer-arrow-callback"),
+        sources: &[RuleSource::Eslint("prefer-arrow-callback")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
         fix_kind: FixKind::Safe,

--- a/crates/biome_js_analyze/src/lint/complexity/use_flat_map.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_flat_map.rs
@@ -34,7 +34,10 @@ declare_rule! {
     pub UseFlatMap {
         version: "1.0.0",
         name: "useFlatMap",
-        source: RuleSource::EslintUnicorn("prefer-array-flat-map"),
+        sources: &[
+            RuleSource::EslintUnicorn("prefer-array-flat-map"),
+            RuleSource::Clippy("map_flatten"),
+        ],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/use_literal_keys.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_literal_keys.rs
@@ -52,7 +52,10 @@ declare_rule! {
     pub UseLiteralKeys {
         version: "1.0.0",
         name: "useLiteralKeys",
-        source: RuleSource::Eslint("dot-notation"),
+        sources: &[
+            RuleSource::Eslint("dot-notation"),
+            RuleSource::EslintTypeScript("dot-notation")
+        ],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
@@ -76,7 +76,7 @@ declare_rule! {
     pub UseOptionalChain {
         version: "1.0.0",
         name: "useOptionalChain",
-        source: RuleSource::EslintTypeScript("prefer-optional-chain"),
+        sources: &[RuleSource::EslintTypeScript("prefer-optional-chain")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/use_regex_literals.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_regex_literals.rs
@@ -48,7 +48,7 @@ declare_rule! {
     pub UseRegexLiterals {
         version: "1.3.0",
         name: "useRegexLiterals",
-        source: RuleSource::Eslint("prefer-regex-literals"),
+        sources: &[RuleSource::Eslint("prefer-regex-literals")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_children_prop.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_children_prop.rs
@@ -25,7 +25,7 @@ declare_rule! {
     pub NoChildrenProp {
         version: "1.0.0",
         name: "noChildrenProp",
-        source: RuleSource::EslintReact("no-children-prop"),
+        sources: &[RuleSource::EslintReact("no-children-prop")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_const_assign.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_const_assign.rs
@@ -50,7 +50,7 @@ declare_rule! {
     pub NoConstAssign {
         version: "1.0.0",
         name: "noConstAssign",
-        source: RuleSource::Eslint("no-const-assign"),
+        sources: &[RuleSource::Eslint("no-const-assign")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_constant_condition.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_constant_condition.rs
@@ -82,7 +82,7 @@ declare_rule! {
     pub NoConstantCondition    {
         version: "1.0.0",
         name: "noConstantCondition",
-        source: RuleSource::Eslint("no-constant-condition"),
+        sources: &[RuleSource::Eslint("no-constant-condition")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_constructor_return.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_constructor_return.rs
@@ -46,7 +46,7 @@ declare_rule! {
     pub NoConstructorReturn {
         version: "1.0.0",
         name: "noConstructorReturn",
-        source: RuleSource::Eslint("no-constructor-return"),
+        sources: &[RuleSource::Eslint("no-constructor-return")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_empty_character_class_in_regex.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_empty_character_class_in_regex.rs
@@ -41,7 +41,7 @@ declare_rule! {
     pub NoEmptyCharacterClassInRegex {
         version: "1.3.0",
         name: "noEmptyCharacterClassInRegex",
-        source: RuleSource::Eslint("no-empty-character-class"),
+        sources: &[RuleSource::Eslint("no-empty-character-class")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_empty_pattern.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_empty_pattern.rs
@@ -35,7 +35,7 @@ declare_rule! {
     pub NoEmptyPattern {
         version: "1.0.0",
         name: "noEmptyPattern",
-        source: RuleSource::Eslint("no-empty-pattern"),
+        sources: &[RuleSource::Eslint("no-empty-pattern")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_global_object_calls.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_global_object_calls.rs
@@ -86,7 +86,7 @@ declare_rule! {
     pub NoGlobalObjectCalls {
         version: "1.0.0",
         name: "noGlobalObjectCalls",
-        source: RuleSource::Eslint("no-obj-calls"),
+        sources: &[RuleSource::Eslint("no-obj-calls")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_inner_declarations.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_inner_declarations.rs
@@ -88,7 +88,7 @@ declare_rule! {
     pub NoInnerDeclarations {
         version: "1.0.0",
         name: "noInnerDeclarations",
-        source: RuleSource::Eslint("no-inner-declarations"),
+        sources: &[RuleSource::Eslint("no-inner-declarations")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_constructor_super.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_constructor_super.rs
@@ -48,7 +48,7 @@ declare_rule! {
     pub NoInvalidConstructorSuper {
         version: "1.0.0",
         name: "noInvalidConstructorSuper",
-        source: RuleSource::Eslint("constructor-super"),
+        sources: &[RuleSource::Eslint("constructor-super")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_new_builtin.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_new_builtin.rs
@@ -52,7 +52,7 @@ declare_rule! {
     pub NoInvalidNewBuiltin {
         version: "1.3.0",
         name: "noInvalidNewBuiltin",
-        source: RuleSource::Eslint("no-new-native-nonconstructor"),
+        sources: &[RuleSource::Eslint("no-new-native-nonconstructor")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
@@ -60,7 +60,10 @@ declare_rule! {
     pub NoInvalidUseBeforeDeclaration {
         version: "1.5.0",
         name: "noInvalidUseBeforeDeclaration",
-        source: RuleSource::EslintTypeScript("no-use-before-define"),
+        sources: &[
+            RuleSource::Eslint("no-use-before-define"),
+            RuleSource::EslintTypeScript("no-use-before-define"),
+        ],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_new_symbol.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_new_symbol.rs
@@ -34,7 +34,7 @@ declare_rule! {
         version: "1.0.0",
         name: "noNewSymbol",
         recommended: false,
-        source: RuleSource::Eslint("no-new-symbol"),
+        sources: &[RuleSource::Eslint("no-new-symbol")],
         deprecated: "Use `noInvalidNewBuiltin` instead.",
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_nonoctal_decimal_escape.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_nonoctal_decimal_escape.rs
@@ -56,7 +56,7 @@ declare_rule! {
     pub NoNonoctalDecimalEscape {
         version: "1.0.0",
         name: "noNonoctalDecimalEscape",
-        source: RuleSource::Eslint("no-nonoctal-decimal-escape"),
+        sources: &[RuleSource::Eslint("no-nonoctal-decimal-escape")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_precision_loss.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_precision_loss.rs
@@ -48,7 +48,11 @@ declare_rule! {
     pub NoPrecisionLoss {
         version: "1.0.0",
         name: "noPrecisionLoss",
-        source: RuleSource::Eslint("no-loss-of-precision"),
+        sources: &[
+            RuleSource::Eslint("no-loss-of-precision"),
+            RuleSource::EslintTypeScript("no-loss-of-precision"),
+            RuleSource::Clippy("lossy_float_literal")
+        ],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_self_assign.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_self_assign.rs
@@ -66,7 +66,10 @@ declare_rule! {
     pub NoSelfAssign {
         version: "1.0.0",
         name: "noSelfAssign",
-        source: RuleSource::Eslint("no-self-assign"),
+        sources: &[
+            RuleSource::Eslint("no-self-assign"),
+            RuleSource::Clippy("self_assignment"),
+        ],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_setter_return.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_setter_return.rs
@@ -67,7 +67,7 @@ declare_rule! {
     pub NoSetterReturn {
         version: "1.0.0",
         name: "noSetterReturn",
-        source: RuleSource::Eslint("no-setter-return"),
+        sources: &[RuleSource::Eslint("no-setter-return")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_string_case_mismatch.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_string_case_mismatch.rs
@@ -34,7 +34,7 @@ declare_rule! {
     pub NoStringCaseMismatch {
         version: "1.0.0",
         name: "noStringCaseMismatch",
-        source: RuleSource::Clippy("match_str_case_mismatch"),
+        sources: &[RuleSource::Clippy("match_str_case_mismatch")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_switch_declarations.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_switch_declarations.rs
@@ -72,7 +72,7 @@ declare_rule! {
     pub NoSwitchDeclarations {
         version: "1.0.0",
         name: "noSwitchDeclarations",
-        source: RuleSource::Eslint("no-case-declarations"),
+        sources: &[RuleSource::Eslint("no-case-declarations")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
@@ -31,7 +31,7 @@ declare_rule! {
     pub NoUndeclaredVariables {
         version: "1.0.0",
         name: "noUndeclaredVariables",
-        source: RuleSource::Eslint("no-undef"),
+        sources: &[RuleSource::Eslint("no-undef")],
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_unreachable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unreachable.rs
@@ -50,7 +50,7 @@ declare_rule! {
     pub NoUnreachable {
         version: "1.0.0",
         name: "noUnreachable",
-        source: RuleSource::Eslint("no-unreachable"),
+        sources: &[RuleSource::Eslint("no-unreachable")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_unreachable_super.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unreachable_super.rs
@@ -64,7 +64,7 @@ declare_rule! {
     pub NoUnreachableSuper {
         version: "1.0.0",
         name: "noUnreachableSuper",
-        source: RuleSource::Eslint("no-this-before-super"),
+        sources: &[RuleSource::Eslint("no-this-before-super")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_unsafe_finally.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unsafe_finally.rs
@@ -127,7 +127,7 @@ declare_rule! {
     pub NoUnsafeFinally {
         version: "1.0.0",
         name: "noUnsafeFinally",
-        source: RuleSource::Eslint("no-unsafe-finally"),
+        sources: &[RuleSource::Eslint("no-unsafe-finally")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_unsafe_optional_chaining.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unsafe_optional_chaining.rs
@@ -64,7 +64,7 @@ declare_rule! {
     pub NoUnsafeOptionalChaining {
         version: "1.0.0",
         name: "noUnsafeOptionalChaining",
-        source: RuleSource::Eslint("no-unsafe-optional-chaining"),
+        sources: &[RuleSource::Eslint("no-unsafe-optional-chaining")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_labels.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_labels.rs
@@ -54,7 +54,7 @@ declare_rule! {
     pub NoUnusedLabels {
         version: "1.0.0",
         name: "noUnusedLabels",
-        source: RuleSource::Eslint("no-unused-labels"),
+        sources: &[RuleSource::Eslint("no-unused-labels")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
@@ -64,7 +64,7 @@ declare_rule! {
     pub NoUnusedPrivateClassMembers {
         version: "1.3.3",
         name: "noUnusedPrivateClassMembers",
-        source: RuleSource::Eslint("no-unused-private-class-members"),
+        sources: &[RuleSource::Eslint("no-unused-private-class-members")],
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -90,7 +90,10 @@ declare_rule! {
     pub NoUnusedVariables {
         version: "1.0.0",
         name: "noUnusedVariables",
-        source: RuleSource::Eslint("no-unused-vars"),
+        sources: &[
+            RuleSource::Eslint("no-unused-vars"),
+            RuleSource::EslintTypeScript("no-unused-vars"),
+        ],
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_void_elements_with_children.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_void_elements_with_children.rs
@@ -33,7 +33,7 @@ declare_rule! {
     pub NoVoidElementsWithChildren {
         version: "1.0.0",
         name: "noVoidElementsWithChildren",
-        source: RuleSource::EslintReact("void-dom-elements-no-children"),
+        sources: &[RuleSource::EslintReact("void-dom-elements-no-children")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -221,7 +221,7 @@ declare_rule! {
     pub UseExhaustiveDependencies {
         version: "1.0.0",
         name: "useExhaustiveDependencies",
-        source: RuleSource::EslintReactHooks("exhaustive-deps"),
+        sources: &[RuleSource::EslintReactHooks("exhaustive-deps")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
@@ -65,7 +65,7 @@ declare_rule! {
     pub UseHookAtTopLevel {
         version: "1.0.0",
         name: "useHookAtTopLevel",
-        source: RuleSource::EslintReactHooks("rules-of-hooks"),
+        sources: &[RuleSource::EslintReactHooks("rules-of-hooks")],
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/use_is_nan.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_is_nan.rs
@@ -62,7 +62,7 @@ declare_rule! {
     pub UseIsNan {
         version: "1.0.0",
         name: "useIsNan",
-        source: RuleSource::Eslint("use-isnan"),
+        sources: &[RuleSource::Eslint("use-isnan")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/use_valid_for_direction.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_valid_for_direction.rs
@@ -41,7 +41,7 @@ declare_rule! {
     pub UseValidForDirection {
         version: "1.0.0",
         name: "useValidForDirection",
-        source: RuleSource::Eslint("for-direction"),
+        sources: &[RuleSource::Eslint("for-direction")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/use_yield.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_yield.rs
@@ -39,7 +39,7 @@ declare_rule! {
     pub UseYield {
         version: "1.0.0",
         name: "useYield",
-        source: RuleSource::Eslint("require-yield"),
+        sources: &[RuleSource::Eslint("require-yield")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_barrel_file.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_barrel_file.rs
@@ -45,7 +45,7 @@ declare_rule! {
         version: "1.6.0",
         name: "noBarrelFile",
         recommended: false,
-        source: RuleSource::EslintBarrelFiles("avoid-namespace-import"),
+        sources: &[RuleSource::EslintBarrelFiles("avoid-namespace-import")],
         source_kind: RuleSourceKind::Inspired,
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_console.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_console.rs
@@ -23,7 +23,7 @@ declare_rule! {
     pub NoConsole {
         version: "1.6.0",
         name: "noConsole",
-        source: RuleSource::Eslint("no-console"),
+        sources: &[RuleSource::Eslint("no-console")],
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/nursery/no_done_callback.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_done_callback.rs
@@ -47,7 +47,7 @@ declare_rule! {
         version: "next",
         name: "noDoneCallback",
         recommended: true,
-        source: RuleSource::EslintJest("no-done-callback"),
+        sources: &[RuleSource::EslintJest("no-done-callback")],
         source_kind: RuleSourceKind::SameLogic,
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_duplicate_else_if.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_duplicate_else_if.rs
@@ -48,7 +48,7 @@ declare_rule! {
         version: "next",
         name: "noDuplicateElseIf",
         recommended: true,
-        source: RuleSource::Eslint("no-dupe-else-if"),
+        sources: &[RuleSource::Eslint("no-dupe-else-if")],
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/nursery/no_duplicate_test_hooks.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_duplicate_test_hooks.rs
@@ -60,7 +60,7 @@ declare_rule! {
         version: "1.6.0",
         name: "noDuplicateTestHooks",
         recommended: true,
-        source: RuleSource::EslintJest("no-duplicate-hooks"),
+        sources: &[RuleSource::EslintJest("no-duplicate-hooks")],
         source_kind: RuleSourceKind::Inspired,
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_excessive_nested_test_suites.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_excessive_nested_test_suites.rs
@@ -55,7 +55,7 @@ declare_rule! {
         version: "1.6.0",
         name: "noExcessiveNestedTestSuites",
         recommended: true,
-        source: RuleSource::EslintJest("max-nested-describe"),
+        sources: &[RuleSource::EslintJest("max-nested-describe")],
         source_kind: RuleSourceKind::SameLogic,
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_exports_in_test.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_exports_in_test.rs
@@ -40,7 +40,7 @@ declare_rule! {
         version: "1.6.0",
         name: "noExportsInTest",
         recommended: true,
-        source: RuleSource::EslintJest("no-export"),
+        sources: &[RuleSource::EslintJest("no-export")],
         source_kind: RuleSourceKind::Inspired,
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_focused_tests.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_focused_tests.rs
@@ -36,7 +36,7 @@ declare_rule! {
         version: "1.6.0",
         name: "noFocusedTests",
         recommended: true,
-        source: RuleSource::EslintJest("no-focused-tests"),
+        sources: &[RuleSource::EslintJest("no-focused-tests")],
         source_kind: RuleSourceKind::Inspired,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/nursery/no_misplaced_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misplaced_assertion.rs
@@ -81,7 +81,7 @@ declare_rule! {
         version: "next",
         name: "noMisplacedAssertion",
         recommended: false,
-        source: RuleSource::EslintJest("no-standalone-expect"),
+        sources: &[RuleSource::EslintJest("no-standalone-expect")],
         source_kind: RuleSourceKind::Inspired,
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_namespace_import.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_namespace_import.rs
@@ -32,7 +32,7 @@ declare_rule! {
         version: "1.6.0",
         name: "noNamespaceImport",
         recommended: false,
-        source: RuleSource::EslintBarrelFiles("avoid-namespace-import"),
+        sources: &[RuleSource::EslintBarrelFiles("avoid-namespace-import")],
         source_kind: RuleSourceKind::SameLogic,
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_nodejs_modules.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_nodejs_modules.rs
@@ -29,7 +29,7 @@ declare_rule! {
     pub NoNodejsModules {
         version: "1.5.0",
         name: "noNodejsModules",
-        source: RuleSource::EslintImport("no-nodejs-modules"),
+        sources: &[RuleSource::EslintImport("no-nodejs-modules")],
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_re_export_all.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_re_export_all.rs
@@ -34,7 +34,7 @@ declare_rule! {
         version: "1.6.0",
         name: "noReExportAll",
         recommended: false,
-        source: RuleSource::EslintBarrelFiles("avoid-re-export-all"),
+        sources: &[RuleSource::EslintBarrelFiles("avoid-re-export-all")],
         source_kind: RuleSourceKind::SameLogic,
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -27,7 +27,10 @@ declare_rule! {
     pub NoRestrictedImports {
         version: "1.6.0",
         name: "noRestrictedImports",
-        source: RuleSource::Eslint("no-restricted-imports"),
+        sources: &[
+            RuleSource::Eslint("no-restricted-imports"),
+            RuleSource::EslintTypeScript("no-restricted-imports"),
+        ],
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_skipped_tests.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_skipped_tests.rs
@@ -38,7 +38,7 @@ declare_rule! {
         version: "1.6.0",
         name: "noSkippedTests",
         recommended: false,
-        source: RuleSource::EslintJest("no-disabled-tests"),
+        sources: &[RuleSource::EslintJest("no-disabled-tests")],
         source_kind: RuleSourceKind::Inspired,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_ternary.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_ternary.rs
@@ -56,7 +56,7 @@ declare_rule! {
     pub NoUselessTernary {
         version: "1.5.0",
         name: "noUselessTernary",
-        source: RuleSource::Eslint("no-unneeded-ternary"),
+        sources: &[RuleSource::Eslint("no-unneeded-ternary")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/nursery/use_import_restrictions.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_import_restrictions.rs
@@ -75,7 +75,7 @@ declare_rule! {
     pub UseImportRestrictions {
         version: "1.0.0",
         name: "useImportRestrictions",
-        source: RuleSource::EslintImportAccess("eslint-plugin-import-access"),
+        sources: &[RuleSource::EslintImportAccess("eslint-plugin-import-access")],
         source_kind: RuleSourceKind::Inspired,
         recommended: false,
     }

--- a/crates/biome_js_analyze/src/lint/nursery/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_jsx_key_in_iterable.rs
@@ -38,7 +38,7 @@ declare_rule! {
     pub UseJsxKeyInIterable {
         version: "1.6.0",
         name: "useJsxKeyInIterable",
-        source: RuleSource::EslintReact("jsx-key"),
+        sources: &[RuleSource::EslintReact("jsx-key")],
         source_kind: RuleSourceKind::SameLogic,
         recommended: false,
     }

--- a/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html.rs
+++ b/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html.rs
@@ -28,7 +28,7 @@ declare_rule! {
     pub NoDangerouslySetInnerHtml {
         version: "1.0.0",
         name: "noDangerouslySetInnerHtml",
-        source: RuleSource::EslintReact("no-danger-with-children"),
+        sources: &[RuleSource::EslintReact("no-danger-with-children")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html_with_children.rs
+++ b/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html_with_children.rs
@@ -37,7 +37,7 @@ declare_rule! {
     pub NoDangerouslySetInnerHtmlWithChildren {
         version: "1.0.0",
         name: "noDangerouslySetInnerHtmlWithChildren",
-        source: RuleSource::EslintReact("no-danger"),
+        sources: &[RuleSource::EslintReact("no-danger")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/security/no_global_eval.rs
+++ b/crates/biome_js_analyze/src/lint/security/no_global_eval.rs
@@ -52,7 +52,7 @@ declare_rule! {
     pub NoGlobalEval {
         version: "1.5.0",
         name: "noGlobalEval",
-        source: RuleSource::Eslint("no-eval"),
+        sources: &[RuleSource::Eslint("no-eval")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/no_arguments.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_arguments.rs
@@ -27,7 +27,7 @@ declare_rule! {
     pub NoArguments {
         version: "1.0.0",
         name: "noArguments",
-        source: RuleSource::Eslint("prefer-rest-params"),
+        sources: &[RuleSource::Eslint("prefer-rest-params")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/no_comma_operator.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_comma_operator.rs
@@ -39,7 +39,7 @@ declare_rule! {
     pub NoCommaOperator {
         version: "1.0.0",
         name: "noCommaOperator",
-        source: RuleSource::Eslint("no-sequences"),
+        sources: &[RuleSource::Eslint("no-sequences")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/no_default_export.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_default_export.rs
@@ -59,7 +59,7 @@ declare_rule! {
     pub NoDefaultExport {
         version: "1.4.0",
         name: "noDefaultExport",
-        source: RuleSource::EslintImport("no-default-export"),
+        sources: &[RuleSource::EslintImport("no-default-export")],
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/no_implicit_boolean.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_implicit_boolean.rs
@@ -47,7 +47,7 @@ declare_rule! {
     pub NoImplicitBoolean {
         version: "1.0.0",
         name: "noImplicitBoolean",
-        source: RuleSource::EslintReact("jsx-boolean-value"),
+        sources: &[RuleSource::EslintReact("jsx-boolean-value")],
         recommended: false,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/style/no_inferrable_types.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_inferrable_types.rs
@@ -98,7 +98,7 @@ declare_rule! {
     pub NoInferrableTypes {
         version: "1.0.0",
         name: "noInferrableTypes",
-        source: RuleSource::EslintTypeScript("no-inferrable-types"),
+        sources: &[RuleSource::EslintTypeScript("no-inferrable-types")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/style/no_namespace.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_namespace.rs
@@ -48,7 +48,7 @@ declare_rule! {
     pub NoNamespace {
         version: "1.0.0",
         name: "noNamespace",
-        source: RuleSource::EslintTypeScript("no-namespace"),
+        sources: &[RuleSource::EslintTypeScript("no-namespace")],
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/no_negation_else.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_negation_else.rs
@@ -47,7 +47,10 @@ declare_rule! {
     pub NoNegationElse {
         version: "1.0.0",
         name: "noNegationElse",
-        source: RuleSource::Eslint("no-negated-condition"),
+        sources: &[
+            RuleSource::Eslint("no-negated-condition"),
+            RuleSource::Clippy("if_not_else"),
+        ],
         recommended: false,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/style/no_non_null_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_non_null_assertion.rs
@@ -48,7 +48,7 @@ declare_rule! {
     pub NoNonNullAssertion {
         version: "1.0.0",
         name: "noNonNullAssertion",
-        source: RuleSource::EslintTypeScript("no-non-null-assertion"),
+        sources: &[RuleSource::EslintTypeScript("no-non-null-assertion")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/no_parameter_assign.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_parameter_assign.rs
@@ -56,7 +56,7 @@ declare_rule! {
     pub NoParameterAssign {
         version: "1.0.0",
         name: "noParameterAssign",
-        source: RuleSource::Eslint("no-param-reassign"),
+        sources: &[RuleSource::Eslint("no-param-reassign")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/no_parameter_properties.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_parameter_properties.rs
@@ -33,7 +33,7 @@ declare_rule! {
     pub NoParameterProperties {
         version: "1.0.0",
         name: "noParameterProperties",
-        source: RuleSource::EslintTypeScript("parameter-properties"),
+        sources: &[RuleSource::EslintTypeScript("parameter-properties")],
         source_kind: RuleSourceKind::Inspired,
         recommended: false,
     }

--- a/crates/biome_js_analyze/src/lint/style/no_restricted_globals.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_restricted_globals.rs
@@ -48,7 +48,7 @@ declare_rule! {
     pub NoRestrictedGlobals {
         version: "1.0.0",
         name: "noRestrictedGlobals",
-        source: RuleSource::Eslint("no-restricted-globals"),
+        sources: &[RuleSource::Eslint("no-restricted-globals")],
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/no_unused_template_literal.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_unused_template_literal.rs
@@ -41,7 +41,7 @@ declare_rule! {
     pub NoUnusedTemplateLiteral {
         version: "1.0.0",
         name: "noUnusedTemplateLiteral",
-        source: RuleSource::EslintTypeScript("no-useless-template-literals"),
+        sources: &[RuleSource::EslintTypeScript("no-useless-template-literals")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/no_useless_else.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_useless_else.rs
@@ -88,7 +88,10 @@ declare_rule! {
     pub NoUselessElse {
         version: "1.3.0",
         name: "noUselessElse",
-        source: RuleSource::Eslint("no-else-return"),
+        sources: &[
+            RuleSource::Eslint("no-else-return"),
+            RuleSource::Clippy("redundant_else 	"),
+        ],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_js_analyze/src/lint/style/no_var.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_var.rs
@@ -39,7 +39,7 @@ declare_rule! {
     pub NoVar {
         version: "1.0.0",
         name: "noVar",
-        source: RuleSource::Eslint("no-var"),
+        sources: &[RuleSource::Eslint("no-var")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_as_const_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_as_const_assertion.rs
@@ -48,7 +48,7 @@ declare_rule! {
     pub UseAsConstAssertion {
         version: "1.3.0",
         name: "useAsConstAssertion",
-        source: RuleSource::EslintTypeScript("prefer-as-const"),
+        sources: &[RuleSource::EslintTypeScript("prefer-as-const")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_block_statements.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_block_statements.rs
@@ -68,7 +68,7 @@ declare_rule! {
     pub UseBlockStatements {
         version: "1.0.0",
         name: "useBlockStatements",
-        source: RuleSource::Eslint("curly"),
+        sources: &[RuleSource::Eslint("curly")],
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_collapsed_else_if.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_collapsed_else_if.rs
@@ -84,7 +84,10 @@ declare_rule! {
     pub UseCollapsedElseIf {
         version: "1.1.0",
         name: "useCollapsedElseIf",
-        source: RuleSource::Eslint("no-lonely-if"),
+        sources: &[
+            RuleSource::Eslint("no-lonely-if"),
+            RuleSource::Clippy("collapsible_else_if")
+        ],
         recommended: false,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_consistent_array_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_consistent_array_type.rs
@@ -70,7 +70,7 @@ declare_rule! {
     pub UseConsistentArrayType {
         version: "1.5.0",
         name: "useConsistentArrayType",
-        source: RuleSource::EslintTypeScript("array-type"),
+        sources: &[RuleSource::EslintTypeScript("array-type")],
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_const.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_const.rs
@@ -59,7 +59,7 @@ declare_rule! {
     pub UseConst {
         version: "1.0.0",
         name: "useConst",
-        source: RuleSource::Eslint("prefer-const"),
+        sources: &[RuleSource::Eslint("prefer-const")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_default_parameter_last.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_default_parameter_last.rs
@@ -51,7 +51,10 @@ declare_rule! {
     pub UseDefaultParameterLast {
         version: "1.0.0",
         name: "useDefaultParameterLast",
-        source: RuleSource::Eslint("default-param-last"),
+        sources: &[
+            RuleSource::Eslint("default-param-last"),
+            RuleSource::EslintTypeScript("default-param-last")
+        ],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_enum_initializers.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_enum_initializers.rs
@@ -67,7 +67,7 @@ declare_rule! {
     pub UseEnumInitializers {
         version: "1.0.0",
         name: "useEnumInitializers",
-        source: RuleSource::EslintTypeScript("prefer-enum-initializers"),
+        sources: &[RuleSource::EslintTypeScript("prefer-enum-initializers")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_exponentiation_operator.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_exponentiation_operator.rs
@@ -56,7 +56,7 @@ declare_rule! {
     pub UseExponentiationOperator {
         version: "1.0.0",
         name: "useExponentiationOperator",
-        source: RuleSource::Eslint("prefer-exponentiation-operator"),
+        sources: &[RuleSource::Eslint("prefer-exponentiation-operator")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_export_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_export_type.rs
@@ -60,7 +60,7 @@ declare_rule! {
     pub UseExportType {
         version: "1.5.0",
         name: "useExportType",
-        source: RuleSource::EslintTypeScript("consistent-type-exports"),
+        sources: &[RuleSource::EslintTypeScript("consistent-type-exports")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
         fix_kind: FixKind::Safe,

--- a/crates/biome_js_analyze/src/lint/style/use_filenaming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_filenaming_convention.rs
@@ -82,7 +82,7 @@ declare_rule! {
     pub UseFilenamingConvention {
         version: "1.5.0",
         name: "useFilenamingConvention",
-        source: RuleSource::EslintUnicorn("filename-case"),
+        sources: &[RuleSource::EslintUnicorn("filename-case")],
         source_kind: RuleSourceKind::Inspired,
         recommended: false,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_for_of.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_for_of.rs
@@ -43,7 +43,10 @@ declare_rule! {
     pub UseForOf {
         version: "1.5.0",
         name: "useForOf",
-        source: RuleSource::EslintTypeScript("prefer-for-of"),
+        sources: &[
+            RuleSource::EslintTypeScript("prefer-for-of"),
+            RuleSource::EslintUnicorn("no-for-loop"),
+        ],
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_fragment_syntax.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_fragment_syntax.rs
@@ -30,7 +30,7 @@ declare_rule! {
     pub UseFragmentSyntax {
         version: "1.0.0",
         name: "useFragmentSyntax",
-        source: RuleSource::EslintReact("jsx-fragments"),
+        sources: &[RuleSource::EslintReact("jsx-fragments")],
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_import_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_import_type.rs
@@ -67,7 +67,7 @@ declare_rule! {
     pub UseImportType {
         version: "1.5.0",
         name: "useImportType",
-        source: RuleSource::EslintTypeScript("consistent-type-imports"),
+        sources: &[RuleSource::EslintTypeScript("consistent-type-imports")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
         fix_kind: FixKind::Safe,

--- a/crates/biome_js_analyze/src/lint/style/use_literal_enum_members.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_literal_enum_members.rs
@@ -64,7 +64,7 @@ declare_rule! {
     pub UseLiteralEnumMembers {
         version: "1.0.0",
         name: "useLiteralEnumMembers",
-        source: RuleSource::EslintTypeScript("prefer-literal-enum-member"),
+        sources: &[RuleSource::EslintTypeScript("prefer-literal-enum-member")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -286,7 +286,7 @@ declare_rule! {
     pub UseNamingConvention {
         version: "1.0.0",
         name: "useNamingConvention",
-        source: RuleSource::EslintTypeScript("naming-convention"),
+        sources: &[RuleSource::EslintTypeScript("naming-convention")],
         source_kind: RuleSourceKind::Inspired,
         recommended: false,
         fix_kind: FixKind::Safe,

--- a/crates/biome_js_analyze/src/lint/style/use_nodejs_import_protocol.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_nodejs_import_protocol.rs
@@ -44,7 +44,7 @@ declare_rule! {
     pub UseNodejsImportProtocol {
         version: "1.5.0",
         name: "useNodejsImportProtocol",
-        source: RuleSource::EslintUnicorn("prefer-node-protocol"),
+        sources: &[RuleSource::EslintUnicorn("prefer-node-protocol")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_number_namespace.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_number_namespace.rs
@@ -68,7 +68,7 @@ declare_rule! {
     pub UseNumberNamespace {
         version: "1.5.0",
         name: "useNumberNamespace",
-        source: RuleSource::EslintUnicorn("prefer-number-properties"),
+        sources: &[RuleSource::EslintUnicorn("prefer-number-properties")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_numeric_literals.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_numeric_literals.rs
@@ -57,7 +57,7 @@ declare_rule! {
     pub UseNumericLiterals {
         version: "1.0.0",
         name: "useNumericLiterals",
-        source: RuleSource::Eslint("prefer-numeric-literals"),
+        sources: &[RuleSource::Eslint("prefer-numeric-literals")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_self_closing_elements.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_self_closing_elements.rs
@@ -57,7 +57,7 @@ declare_rule! {
     pub UseSelfClosingElements {
         version: "1.0.0",
         name: "useSelfClosingElements",
-        source: RuleSource::EslintStylistic("jsx-self-closing-comp"),
+        sources: &[RuleSource::EslintStylistic("jsx-self-closing-comp")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_shorthand_assign.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_shorthand_assign.rs
@@ -53,7 +53,7 @@ declare_rule! {
     pub UseShorthandAssign {
         version: "1.3.0",
         name: "useShorthandAssign",
-        source: RuleSource::Eslint("operator-assignment"),
+        sources: &[RuleSource::Eslint("operator-assignment")],
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_shorthand_function_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_shorthand_function_type.rs
@@ -81,7 +81,7 @@ declare_rule! {
     pub UseShorthandFunctionType {
         version: "1.5.0",
         name: "useShorthandFunctionType",
-        source: RuleSource::EslintTypeScript("prefer-function-type"),
+        sources: &[RuleSource::EslintTypeScript("prefer-function-type")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_single_var_declarator.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_single_var_declarator.rs
@@ -44,7 +44,7 @@ declare_rule! {
     pub UseSingleVarDeclarator {
         version: "1.0.0",
         name: "useSingleVarDeclarator",
-        source: RuleSource::Eslint("one-var"),
+        sources: &[RuleSource::Eslint("one-var")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_template.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_template.rs
@@ -50,7 +50,7 @@ declare_rule! {
     pub UseTemplate {
         version: "1.0.0",
         name: "useTemplate",
-        source: RuleSource::Eslint("prefer-template"),
+        sources: &[RuleSource::Eslint("prefer-template")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_approximative_numeric_constant.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_approximative_numeric_constant.rs
@@ -46,7 +46,7 @@ declare_rule! {
     pub NoApproximativeNumericConstant {
         version: "1.3.0",
         name: "noApproximativeNumericConstant",
-        source: RuleSource::Clippy("approx_constant"),
+        sources: &[RuleSource::Clippy("approx_constant")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
@@ -66,7 +66,7 @@ declare_rule! {
     pub NoArrayIndexKey {
         version: "1.0.0",
         name: "noArrayIndexKey",
-        source: RuleSource::EslintReact("no-array-index-key"),
+        sources: &[RuleSource::EslintReact("no-array-index-key")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_assign_in_expressions.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_assign_in_expressions.rs
@@ -44,7 +44,7 @@ declare_rule! {
     pub NoAssignInExpressions {
         version: "1.0.0",
         name: "noAssignInExpressions",
-        source: RuleSource::Eslint("no-cond-assign"),
+        sources: &[RuleSource::Eslint("no-cond-assign")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_async_promise_executor.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_async_promise_executor.rs
@@ -39,7 +39,7 @@ declare_rule! {
     pub NoAsyncPromiseExecutor {
         version: "1.0.0",
         name: "noAsyncPromiseExecutor",
-        source: RuleSource::Eslint("no-async-promise-executor"),
+        sources: &[RuleSource::Eslint("no-async-promise-executor")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_catch_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_catch_assign.rs
@@ -37,7 +37,7 @@ declare_rule! {
     pub NoCatchAssign {
         version: "1.0.0",
         name: "noCatchAssign",
-        source: RuleSource::Eslint("no-ex-assign"),
+        sources: &[RuleSource::Eslint("no-ex-assign")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_class_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_class_assign.rs
@@ -68,7 +68,7 @@ declare_rule! {
     pub NoClassAssign {
         version: "1.0.0",
         name: "noClassAssign",
-        source: RuleSource::Eslint("no-class-assign"),
+        sources: &[RuleSource::Eslint("no-class-assign")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_comment_text.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_comment_text.rs
@@ -38,7 +38,7 @@ declare_rule! {
     pub NoCommentText {
         version: "1.0.0",
         name: "noCommentText",
-        source: RuleSource::EslintReact("jsx-no-comment-textnodes"),
+        sources: &[RuleSource::EslintReact("jsx-no-comment-textnodes")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_compare_neg_zero.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_compare_neg_zero.rs
@@ -37,7 +37,7 @@ declare_rule! {
     pub NoCompareNegZero {
         version: "1.0.0",
         name: "noCompareNegZero",
-        source: RuleSource::Eslint("no-compare-neg-zero"),
+        sources: &[RuleSource::Eslint("no-compare-neg-zero")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_confusing_labels.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_confusing_labels.rs
@@ -50,7 +50,7 @@ declare_rule! {
     pub NoConfusingLabels {
         version: "1.0.0",
         name: "noConfusingLabels",
-        source: RuleSource::Eslint("no-labels"),
+        sources: &[RuleSource::Eslint("no-labels")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_confusing_void_type.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_confusing_void_type.rs
@@ -49,7 +49,7 @@ declare_rule! {
     pub NoConfusingVoidType {
         version: "1.2.0",
         name: "noConfusingVoidType",
-        source: RuleSource::EslintTypeScript("no-invalid-void-type"),
+        sources: &[RuleSource::EslintTypeScript("no-invalid-void-type")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_console_log.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_console_log.rs
@@ -36,7 +36,7 @@ declare_rule! {
     pub NoConsoleLog {
         version: "1.0.0",
         name: "noConsoleLog",
-        source: RuleSource::Eslint("no-console"),
+        sources: &[RuleSource::Eslint("no-console")],
         source_kind: RuleSourceKind::Inspired,
         recommended: false,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_control_characters_in_regex.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_control_characters_in_regex.rs
@@ -61,7 +61,7 @@ declare_rule! {
     pub NoControlCharactersInRegex {
         version: "1.0.0",
         name: "noControlCharactersInRegex",
-        source: RuleSource::Eslint("no-control-regex"),
+        sources: &[RuleSource::Eslint("no-control-regex")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_debugger.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_debugger.rs
@@ -29,7 +29,7 @@ declare_rule! {
     pub NoDebugger {
         version: "1.0.0",
         name: "noDebugger",
-        source: RuleSource::Eslint("no-debugger"),
+        sources: &[RuleSource::Eslint("no-debugger")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_double_equals.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_double_equals.rs
@@ -50,7 +50,7 @@ declare_rule! {
     pub NoDoubleEquals {
         version: "1.0.0",
         name: "noDoubleEquals",
-        source: RuleSource::Eslint("eqeqeq"),
+        sources: &[RuleSource::Eslint("eqeqeq")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_case.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_case.rs
@@ -83,7 +83,7 @@ declare_rule! {
     pub NoDuplicateCase {
         version: "1.0.0",
         name: "noDuplicateCase",
-        source: RuleSource::Eslint("no-duplicate-case"),
+        sources: &[RuleSource::Eslint("no-duplicate-case")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_class_members.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_class_members.rs
@@ -87,7 +87,10 @@ declare_rule! {
     pub NoDuplicateClassMembers {
         version: "1.0.0",
         name: "noDuplicateClassMembers",
-        source: RuleSource::Eslint("no-dupe-class-members"),
+        sources: &[
+            RuleSource::Eslint("no-dupe-class-members"),
+            RuleSource::EslintTypeScript("no-dupe-class-members")
+        ],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_jsx_props.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_jsx_props.rs
@@ -33,7 +33,7 @@ declare_rule! {
  pub NoDuplicateJsxProps {
         version: "1.0.0",
         name: "noDuplicateJsxProps",
-        source: RuleSource::EslintReact("jsx-no-duplicate-props"),
+        sources: &[RuleSource::EslintReact("jsx-no-duplicate-props")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
@@ -57,7 +57,7 @@ declare_rule! {
     pub NoDuplicateObjectKeys {
         version: "1.0.0",
         name: "noDuplicateObjectKeys",
-        source: RuleSource::Eslint("no-dupe-keys"),
+        sources: &[RuleSource::Eslint("no-dupe-keys")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_parameters.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_parameters.rs
@@ -40,7 +40,7 @@ declare_rule! {
     pub NoDuplicateParameters {
         version: "1.0.0",
         name: "noDuplicateParameters",
-        source: RuleSource::Eslint("no-dupe-args"),
+        sources: &[RuleSource::Eslint("no-dupe-args")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_empty_block_statements.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_empty_block_statements.rs
@@ -54,8 +54,12 @@ declare_rule! {
     pub NoEmptyBlockStatements {
         version: "1.3.0",
         name: "noEmptyBlockStatements",
-        // Include also `eslint/no-empty-static-block`
-        source: RuleSource::Eslint("no-empty"),
+        sources: &[
+            RuleSource::Eslint("no-empty"),
+            RuleSource::Eslint("no-empty-static-block"),
+            RuleSource::Eslint("no-empty-function"),
+            RuleSource::EslintTypeScript("no-empty-function"),
+        ],
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_empty_interface.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_empty_interface.rs
@@ -43,7 +43,7 @@ declare_rule! {
     pub NoEmptyInterface {
         version: "1.0.0",
         name: "noEmptyInterface",
-        source: RuleSource::EslintTypeScript("no-empty-interface"),
+        sources: &[RuleSource::EslintTypeScript("no-empty-interface")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
         fix_kind: FixKind::Safe,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_explicit_any.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_explicit_any.rs
@@ -54,7 +54,7 @@ declare_rule! {
     pub NoExplicitAny {
         version: "1.0.0",
         name: "noExplicitAny",
-        source: RuleSource::EslintTypeScript("no-explicit-any"),
+        sources: &[RuleSource::EslintTypeScript("no-explicit-any")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_extra_non_null_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_extra_non_null_assertion.rs
@@ -48,7 +48,7 @@ declare_rule! {
     pub NoExtraNonNullAssertion {
         version: "1.0.0",
         name: "noExtraNonNullAssertion",
-        source: RuleSource::EslintTypeScript("no-extra-non-null-assertion"),
+        sources: &[RuleSource::EslintTypeScript("no-extra-non-null-assertion")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_fallthrough_switch_clause.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_fallthrough_switch_clause.rs
@@ -55,7 +55,7 @@ declare_rule! {
     pub NoFallthroughSwitchClause {
         version: "1.0.0",
         name: "noFallthroughSwitchClause",
-        source: RuleSource::Eslint("no-fallthrough"),
+        sources: &[RuleSource::Eslint("no-fallthrough")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_function_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_function_assign.rs
@@ -96,7 +96,7 @@ declare_rule! {
     pub NoFunctionAssign {
         version: "1.0.0",
         name: "noFunctionAssign",
-        source: RuleSource::Eslint("no-func-assign"),
+        sources: &[RuleSource::Eslint("no-func-assign")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
@@ -41,7 +41,7 @@ declare_rule! {
     pub NoGlobalAssign {
         version: "1.5.0",
         name: "noGlobalAssign",
-        source: RuleSource::Eslint("no-global-assign"),
+        sources: &[RuleSource::Eslint("no-global-assign")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_import_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_import_assign.rs
@@ -52,7 +52,7 @@ declare_rule! {
     pub NoImportAssign {
         version: "1.0.0",
         name: "noImportAssign",
-        source: RuleSource::Eslint("no-import-assign"),
+        sources: &[RuleSource::Eslint("no-import-assign")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_label_var.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_label_var.rs
@@ -25,7 +25,7 @@ declare_rule! {
     pub NoLabelVar {
         version: "1.0.0",
         name: "noLabelVar",
-        source: RuleSource::Eslint("no-label-var"),
+        sources: &[RuleSource::Eslint("no-label-var")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misleading_character_class.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misleading_character_class.rs
@@ -61,7 +61,7 @@ declare_rule! {
     pub NoMisleadingCharacterClass {
         version: "1.5.0",
         name: "noMisleadingCharacterClass",
-        source: RuleSource::Eslint("no-misleading-character-class"),
+        sources: &[RuleSource::Eslint("no-misleading-character-class")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misleading_instantiator.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misleading_instantiator.rs
@@ -48,7 +48,7 @@ declare_rule! {
     pub NoMisleadingInstantiator {
         version: "1.3.0",
         name: "noMisleadingInstantiator",
-        source: RuleSource::EslintTypeScript("no-misused-new"),
+        sources: &[RuleSource::EslintTypeScript("no-misused-new")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misrefactored_shorthand_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misrefactored_shorthand_assign.rs
@@ -52,7 +52,7 @@ declare_rule! {
     pub NoMisrefactoredShorthandAssign {
         version: "1.3.0",
         name: "noMisrefactoredShorthandAssign",
-        source: RuleSource::Clippy("misrefactored_assign_op"),
+        sources: &[RuleSource::Clippy("misrefactored_assign_op")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_prototype_builtins.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_prototype_builtins.rs
@@ -42,7 +42,7 @@ declare_rule! {
     pub NoPrototypeBuiltins {
         version: "1.0.0",
         name: "noPrototypeBuiltins",
-        source: RuleSource::Eslint("no-prototype-builtins"),
+        sources: &[RuleSource::Eslint("no-prototype-builtins")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
@@ -61,7 +61,10 @@ declare_rule! {
     pub NoRedeclare {
         version: "1.0.0",
         name: "noRedeclare",
-        source: RuleSource::EslintTypeScript("no-redeclare"),
+        sources: &[
+            RuleSource::Eslint("no-redeclare"),
+            RuleSource::EslintTypeScript("no-redeclare"),
+        ],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_self_compare.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_self_compare.rs
@@ -27,7 +27,10 @@ declare_rule! {
     pub NoSelfCompare {
         version: "1.0.0",
         name: "noSelfCompare",
-        source: RuleSource::Eslint("no-self-compare"),
+        sources: &[
+            RuleSource::Eslint("no-self-compare"),
+            RuleSource::Clippy("eq_op"),
+        ],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_shadow_restricted_names.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_shadow_restricted_names.rs
@@ -33,7 +33,7 @@ declare_rule! {
     pub NoShadowRestrictedNames {
         version: "1.0.0",
         name: "noShadowRestrictedNames",
-        source: RuleSource::Eslint("no-shadow-restricted-names"),
+        sources: &[RuleSource::Eslint("no-shadow-restricted-names")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_sparse_array.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_sparse_array.rs
@@ -23,7 +23,7 @@ declare_rule! {
     pub NoSparseArray {
         version: "1.0.0",
         name: "noSparseArray",
-        source: RuleSource::Eslint("no-sparse-array"),
+        sources: &[RuleSource::Eslint("no-sparse-array")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_then_property.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_then_property.rs
@@ -86,7 +86,7 @@ declare_rule! {
     pub NoThenProperty {
         version: "1.5.0",
         name: "noThenProperty",
-        source: RuleSource::EslintUnicorn("no-thenable"),
+        sources: &[RuleSource::EslintUnicorn("no-thenable")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_declaration_merging.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_declaration_merging.rs
@@ -43,7 +43,7 @@ declare_rule! {
     pub NoUnsafeDeclarationMerging {
         version: "1.0.0",
         name: "noUnsafeDeclarationMerging",
-        source: RuleSource::EslintTypeScript("no-unsafe-declaration-merging"),
+        sources: &[RuleSource::EslintTypeScript("no-unsafe-declaration-merging")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_negation.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_negation.rs
@@ -36,7 +36,7 @@ declare_rule! {
     pub NoUnsafeNegation {
         version: "1.0.0",
         name: "noUnsafeNegation",
-        source: RuleSource::Eslint("no-unsafe-negation"),
+        sources: &[RuleSource::Eslint("no-unsafe-negation")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/use_await.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_await.rs
@@ -48,7 +48,10 @@ declare_rule! {
     pub UseAwait {
         version: "1.4.0",
         name: "useAwait",
-        source: RuleSource::Eslint("require-await"),
+        sources: &[
+            RuleSource::Eslint("require-await"),
+            RuleSource::EslintTypeScript("require-await"),
+        ],
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/use_default_switch_clause_last.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_default_switch_clause_last.rs
@@ -72,7 +72,7 @@ declare_rule! {
     pub UseDefaultSwitchClauseLast {
         version: "1.0.0",
         name: "useDefaultSwitchClauseLast",
-        source: RuleSource::Eslint("default-case-last"),
+        sources: &[RuleSource::Eslint("default-case-last")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/use_getter_return.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_getter_return.rs
@@ -60,7 +60,7 @@ declare_rule! {
     pub UseGetterReturn {
         version: "1.0.0",
         name: "useGetterReturn",
-        source: RuleSource::Eslint("getter-return"),
+        sources: &[RuleSource::Eslint("getter-return")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/use_is_array.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_is_array.rs
@@ -39,7 +39,7 @@ declare_rule! {
     pub UseIsArray {
         version: "1.0.0",
         name: "useIsArray",
-        source: RuleSource::EslintUnicorn("no-instanceof-array"),
+        sources: &[RuleSource::EslintUnicorn("no-instanceof-array")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/use_namespace_keyword.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_namespace_keyword.rs
@@ -44,7 +44,7 @@ declare_rule! {
     pub UseNamespaceKeyword {
         version: "1.0.0",
         name: "useNamespaceKeyword",
-        source: RuleSource::EslintTypeScript("prefer-namespace-keyword"),
+        sources: &[RuleSource::EslintTypeScript("prefer-namespace-keyword")],
         recommended: true,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/use_valid_typeof.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_valid_typeof.rs
@@ -72,7 +72,7 @@ declare_rule! {
     pub UseValidTypeof {
         version: "1.0.0",
         name: "useValidTypeof",
-        source: RuleSource::Eslint("valid-typeof"),
+        sources: &[RuleSource::Eslint("valid-typeof")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }

--- a/website/src/content/docs/linter/rules-sources.mdx
+++ b/website/src/content/docs/linter/rules-sources.mdx
@@ -31,8 +31,16 @@ Some **Biome** rules might **not** have options, compared to the original rule.
 | Clippy rule name | Biome rule name |
 | ---- | ---- |
 | [approx_constant](https://rust-lang.github.io/rust-clippy/master/#/approx_constant) |[noApproximativeNumericConstant](/linter/rules/no-approximative-numeric-constant) (inspired) |
+| [collapsible_else_if](https://rust-lang.github.io/rust-clippy/master/#/collapsible_else_if) |[useCollapsedElseIf](/linter/rules/use-collapsed-else-if) |
+| [eq_op](https://rust-lang.github.io/rust-clippy/master/#/eq_op) |[noSelfCompare](/linter/rules/no-self-compare) |
+| [if_not_else](https://rust-lang.github.io/rust-clippy/master/#/if_not_else) |[noNegationElse](/linter/rules/no-negation-else) |
+| [lossy_float_literal](https://rust-lang.github.io/rust-clippy/master/#/lossy_float_literal) |[noPrecisionLoss](/linter/rules/no-precision-loss) |
+| [map_flatten](https://rust-lang.github.io/rust-clippy/master/#/map_flatten) |[useFlatMap](/linter/rules/use-flat-map) |
 | [match_str_case_mismatch](https://rust-lang.github.io/rust-clippy/master/#/match_str_case_mismatch) |[noStringCaseMismatch](/linter/rules/no-string-case-mismatch) |
 | [misrefactored_assign_op](https://rust-lang.github.io/rust-clippy/master/#/misrefactored_assign_op) |[noMisrefactoredShorthandAssign](/linter/rules/no-misrefactored-shorthand-assign) |
+| [needless_for_each](https://rust-lang.github.io/rust-clippy/master/#/needless_for_each) |[noForEach](/linter/rules/no-for-each) |
+| [redundant_else 	](https://rust-lang.github.io/rust-clippy/master/#/redundant_else 	) |[noUselessElse](/linter/rules/no-useless-else) (inspired) |
+| [self_assignment](https://rust-lang.github.io/rust-clippy/master/#/self_assignment) |[noSelfAssign](/linter/rules/no-self-assign) |
 ### ESLint
 | ESLint rule name | Biome rule name |
 | ---- | ---- |
@@ -62,7 +70,9 @@ Some **Biome** rules might **not** have options, compared to the original rule.
 | [no-else-return](https://eslint.org/docs/latest/rules/no-else-return) |[noUselessElse](/linter/rules/no-useless-else) (inspired) |
 | [no-empty](https://eslint.org/docs/latest/rules/no-empty) |[noEmptyBlockStatements](/linter/rules/no-empty-block-statements) |
 | [no-empty-character-class](https://eslint.org/docs/latest/rules/no-empty-character-class) |[noEmptyCharacterClassInRegex](/linter/rules/no-empty-character-class-in-regex) |
+| [no-empty-function](https://eslint.org/docs/latest/rules/no-empty-function) |[noEmptyBlockStatements](/linter/rules/no-empty-block-statements) |
 | [no-empty-pattern](https://eslint.org/docs/latest/rules/no-empty-pattern) |[noEmptyPattern](/linter/rules/no-empty-pattern) |
+| [no-empty-static-block](https://eslint.org/docs/latest/rules/no-empty-static-block) |[noEmptyBlockStatements](/linter/rules/no-empty-block-statements) |
 | [no-eval](https://eslint.org/docs/latest/rules/no-eval) |[noGlobalEval](/linter/rules/no-global-eval) |
 | [no-ex-assign](https://eslint.org/docs/latest/rules/no-ex-assign) |[noCatchAssign](/linter/rules/no-catch-assign) |
 | [no-extra-boolean-cast](https://eslint.org/docs/latest/rules/no-extra-boolean-cast) |[noExtraBooleanCast](/linter/rules/no-extra-boolean-cast) |
@@ -85,6 +95,7 @@ Some **Biome** rules might **not** have options, compared to the original rule.
 | [no-obj-calls](https://eslint.org/docs/latest/rules/no-obj-calls) |[noGlobalObjectCalls](/linter/rules/no-global-object-calls) |
 | [no-param-reassign](https://eslint.org/docs/latest/rules/no-param-reassign) |[noParameterAssign](/linter/rules/no-parameter-assign) |
 | [no-prototype-builtins](https://eslint.org/docs/latest/rules/no-prototype-builtins) |[noPrototypeBuiltins](/linter/rules/no-prototype-builtins) |
+| [no-redeclare](https://eslint.org/docs/latest/rules/no-redeclare) |[noRedeclare](/linter/rules/no-redeclare) |
 | [no-regex-spaces](https://eslint.org/docs/latest/rules/no-regex-spaces) |[noMultipleSpacesInRegularExpressionLiterals](/linter/rules/no-multiple-spaces-in-regular-expression-literals) |
 | [no-restricted-globals](https://eslint.org/docs/latest/rules/no-restricted-globals) |[noRestrictedGlobals](/linter/rules/no-restricted-globals) |
 | [no-self-assign](https://eslint.org/docs/latest/rules/no-self-assign) |[noSelfAssign](/linter/rules/no-self-assign) |
@@ -102,7 +113,9 @@ Some **Biome** rules might **not** have options, compared to the original rule.
 | [no-unused-labels](https://eslint.org/docs/latest/rules/no-unused-labels) |[noUnusedLabels](/linter/rules/no-unused-labels) |
 | [no-unused-private-class-members](https://eslint.org/docs/latest/rules/no-unused-private-class-members) |[noUnusedPrivateClassMembers](/linter/rules/no-unused-private-class-members) |
 | [no-unused-vars](https://eslint.org/docs/latest/rules/no-unused-vars) |[noUnusedVariables](/linter/rules/no-unused-variables) |
+| [no-use-before-define](https://eslint.org/docs/latest/rules/no-use-before-define) |[noInvalidUseBeforeDeclaration](/linter/rules/no-invalid-use-before-declaration) |
 | [no-useless-catch](https://eslint.org/docs/latest/rules/no-useless-catch) |[noUselessCatch](/linter/rules/no-useless-catch) |
+| [no-useless-constructor](https://eslint.org/docs/latest/rules/no-useless-constructor) |[noUselessConstructor](/linter/rules/no-useless-constructor) |
 | [no-useless-rename](https://eslint.org/docs/latest/rules/no-useless-rename) |[noUselessRename](/linter/rules/no-useless-rename) |
 | [no-var](https://eslint.org/docs/latest/rules/no-var) |[noVar](/linter/rules/no-var) |
 | [no-void](https://eslint.org/docs/latest/rules/no-void) |[noVoid](/linter/rules/no-void) |
@@ -192,13 +205,18 @@ Some **Biome** rules might **not** have options, compared to the original rule.
 | [ban-types](https://typescript-eslint.io/rules/ban-types) |[noBannedTypes](/linter/rules/no-banned-types) (inspired) |
 | [consistent-type-exports](https://typescript-eslint.io/rules/consistent-type-exports) |[useExportType](/linter/rules/use-export-type) (inspired) |
 | [consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports) |[useImportType](/linter/rules/use-import-type) (inspired) |
+| [default-param-last](https://typescript-eslint.io/rules/default-param-last) |[useDefaultParameterLast](/linter/rules/use-default-parameter-last) |
+| [dot-notation](https://typescript-eslint.io/rules/dot-notation) |[useLiteralKeys](/linter/rules/use-literal-keys) |
 | [naming-convention](https://typescript-eslint.io/rules/naming-convention) |[useNamingConvention](/linter/rules/use-naming-convention) (inspired) |
+| [no-dupe-class-members](https://typescript-eslint.io/rules/no-dupe-class-members) |[noDuplicateClassMembers](/linter/rules/no-duplicate-class-members) |
+| [no-empty-function](https://typescript-eslint.io/rules/no-empty-function) |[noEmptyBlockStatements](/linter/rules/no-empty-block-statements) |
 | [no-empty-interface](https://typescript-eslint.io/rules/no-empty-interface) |[noEmptyInterface](/linter/rules/no-empty-interface) (inspired) |
 | [no-explicit-any](https://typescript-eslint.io/rules/no-explicit-any) |[noExplicitAny](/linter/rules/no-explicit-any) |
 | [no-extra-non-null-assertion](https://typescript-eslint.io/rules/no-extra-non-null-assertion) |[noExtraNonNullAssertion](/linter/rules/no-extra-non-null-assertion) |
 | [no-extraneous-class](https://typescript-eslint.io/rules/no-extraneous-class) |[noStaticOnlyClass](/linter/rules/no-static-only-class) |
 | [no-inferrable-types](https://typescript-eslint.io/rules/no-inferrable-types) |[noInferrableTypes](/linter/rules/no-inferrable-types) |
 | [no-invalid-void-type](https://typescript-eslint.io/rules/no-invalid-void-type) |[noConfusingVoidType](/linter/rules/no-confusing-void-type) |
+| [no-loss-of-precision](https://typescript-eslint.io/rules/no-loss-of-precision) |[noPrecisionLoss](/linter/rules/no-precision-loss) |
 | [no-misused-new](https://typescript-eslint.io/rules/no-misused-new) |[noMisleadingInstantiator](/linter/rules/no-misleading-instantiator) |
 | [no-namespace](https://typescript-eslint.io/rules/no-namespace) |[noNamespace](/linter/rules/no-namespace) |
 | [no-non-null-assertion](https://typescript-eslint.io/rules/no-non-null-assertion) |[noNonNullAssertion](/linter/rules/no-non-null-assertion) |
@@ -206,6 +224,7 @@ Some **Biome** rules might **not** have options, compared to the original rule.
 | [no-this-alias](https://typescript-eslint.io/rules/no-this-alias) |[noUselessThisAlias](/linter/rules/no-useless-this-alias) (inspired) |
 | [no-unnecessary-type-constraint](https://typescript-eslint.io/rules/no-unnecessary-type-constraint) |[noUselessTypeConstraint](/linter/rules/no-useless-type-constraint) |
 | [no-unsafe-declaration-merging](https://typescript-eslint.io/rules/no-unsafe-declaration-merging) |[noUnsafeDeclarationMerging](/linter/rules/no-unsafe-declaration-merging) |
+| [no-unused-vars](https://typescript-eslint.io/rules/no-unused-vars) |[noUnusedVariables](/linter/rules/no-unused-variables) |
 | [no-use-before-define](https://typescript-eslint.io/rules/no-use-before-define) |[noInvalidUseBeforeDeclaration](/linter/rules/no-invalid-use-before-declaration) |
 | [no-useless-constructor](https://typescript-eslint.io/rules/no-useless-constructor) |[noUselessConstructor](/linter/rules/no-useless-constructor) |
 | [no-useless-empty-export](https://typescript-eslint.io/rules/no-useless-empty-export) |[noUselessEmptyExport](/linter/rules/no-useless-empty-export) |
@@ -218,12 +237,15 @@ Some **Biome** rules might **not** have options, compared to the original rule.
 | [prefer-literal-enum-member](https://typescript-eslint.io/rules/prefer-literal-enum-member) |[useLiteralEnumMembers](/linter/rules/use-literal-enum-members) |
 | [prefer-namespace-keyword](https://typescript-eslint.io/rules/prefer-namespace-keyword) |[useNamespaceKeyword](/linter/rules/use-namespace-keyword) |
 | [prefer-optional-chain](https://typescript-eslint.io/rules/prefer-optional-chain) |[useOptionalChain](/linter/rules/use-optional-chain) |
+| [require-await](https://typescript-eslint.io/rules/require-await) |[useAwait](/linter/rules/use-await) |
 ### eslint-plugin-unicorn
 | eslint-plugin-unicorn rule name | Biome rule name |
 | ---- | ---- |
 | [filename-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/filename-case.md) |[useFilenamingConvention](/linter/rules/use-filenaming-convention) (inspired) |
 | [no-array-for-each](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-for-each.md) |[noForEach](/linter/rules/no-for-each) (inspired) |
+| [no-for-loop](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-for-loop.md) |[useForOf](/linter/rules/use-for-of) |
 | [no-instanceof-array](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-instanceof-array.md) |[useIsArray](/linter/rules/use-is-array) |
+| [no-static-only-class](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-static-only-class.md) |[noStaticOnlyClass](/linter/rules/no-static-only-class) |
 | [no-thenable](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-thenable.md) |[noThenProperty](/linter/rules/no-then-property) |
 | [no-useless-switch-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-switch-case.md) |[noUselessSwitchCase](/linter/rules/no-useless-switch-case) |
 | [prefer-array-flat-map](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat-map.md) |[useFlatMap](/linter/rules/use-flat-map) |

--- a/website/src/content/docs/linter/rules/no-duplicate-class-members.md
+++ b/website/src/content/docs/linter/rules/no-duplicate-class-members.md
@@ -10,6 +10,8 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Source: <a href="https://eslint.org/docs/latest/rules/no-dupe-class-members" target="_blank"><code>no-dupe-class-members</code></a>
 
+Source: <a href="https://typescript-eslint.io/rules/no-dupe-class-members" target="_blank"><code>no-dupe-class-members</code></a>
+
 Disallow duplicate class members.
 
 If there are declarations of the same name among class members,

--- a/website/src/content/docs/linter/rules/no-empty-block-statements.md
+++ b/website/src/content/docs/linter/rules/no-empty-block-statements.md
@@ -6,6 +6,12 @@ title: noEmptyBlockStatements (since v1.3.0)
 
 Source: <a href="https://eslint.org/docs/latest/rules/no-empty" target="_blank"><code>no-empty</code></a>
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-empty-static-block" target="_blank"><code>no-empty-static-block</code></a>
+
+Source: <a href="https://eslint.org/docs/latest/rules/no-empty-function" target="_blank"><code>no-empty-function</code></a>
+
+Source: <a href="https://typescript-eslint.io/rules/no-empty-function" target="_blank"><code>no-empty-function</code></a>
+
 Disallow empty block statements and static blocks.
 
 Empty static blocks and block statements, while not technically errors, usually occur due to refactoring that wasn’t completed. They can cause confusion when reading code.

--- a/website/src/content/docs/linter/rules/no-for-each.md
+++ b/website/src/content/docs/linter/rules/no-for-each.md
@@ -10,6 +10,8 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Source: <a href="https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-for-each.md" target="_blank"><code>no-array-for-each</code></a>
 
+Source: <a href="https://rust-lang.github.io/rust-clippy/master/#/needless_for_each" target="_blank"><code>needless_for_each</code></a>
+
 Prefer `for...of` statement instead of `Array.forEach`.
 
 Here's a summary of why `forEach` may be disallowed, and why `for...of` is preferred for almost any use-case of `forEach`:

--- a/website/src/content/docs/linter/rules/no-invalid-use-before-declaration.md
+++ b/website/src/content/docs/linter/rules/no-invalid-use-before-declaration.md
@@ -8,6 +8,8 @@ title: noInvalidUseBeforeDeclaration (since v1.5.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-use-before-define" target="_blank"><code>no-use-before-define</code></a>
+
 Source: <a href="https://typescript-eslint.io/rules/no-use-before-define" target="_blank"><code>no-use-before-define</code></a>
 
 Disallow the use of variables and function parameters before their declaration

--- a/website/src/content/docs/linter/rules/no-negation-else.md
+++ b/website/src/content/docs/linter/rules/no-negation-else.md
@@ -6,6 +6,8 @@ title: noNegationElse (since v1.0.0)
 
 Source: <a href="https://eslint.org/docs/latest/rules/no-negated-condition" target="_blank"><code>no-negated-condition</code></a>
 
+Source: <a href="https://rust-lang.github.io/rust-clippy/master/#/if_not_else" target="_blank"><code>if_not_else</code></a>
+
 Disallow negation in the condition of an `if` statement if it has an `else` clause.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-precision-loss.md
+++ b/website/src/content/docs/linter/rules/no-precision-loss.md
@@ -10,6 +10,10 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Source: <a href="https://eslint.org/docs/latest/rules/no-loss-of-precision" target="_blank"><code>no-loss-of-precision</code></a>
 
+Source: <a href="https://typescript-eslint.io/rules/no-loss-of-precision" target="_blank"><code>no-loss-of-precision</code></a>
+
+Source: <a href="https://rust-lang.github.io/rust-clippy/master/#/lossy_float_literal" target="_blank"><code>lossy_float_literal</code></a>
+
 Disallow literal numbers that lose precision
 
 ## Examples

--- a/website/src/content/docs/linter/rules/no-redeclare.md
+++ b/website/src/content/docs/linter/rules/no-redeclare.md
@@ -8,6 +8,8 @@ title: noRedeclare (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-redeclare" target="_blank"><code>no-redeclare</code></a>
+
 Source: <a href="https://typescript-eslint.io/rules/no-redeclare" target="_blank"><code>no-redeclare</code></a>
 
 Disallow variable, function, class, and type redeclarations in the same scope.

--- a/website/src/content/docs/linter/rules/no-restricted-imports.md
+++ b/website/src/content/docs/linter/rules/no-restricted-imports.md
@@ -10,6 +10,8 @@ This rule is part of the [nursery](/linter/rules/#nursery) group.
 
 Source: <a href="https://eslint.org/docs/latest/rules/no-restricted-imports" target="_blank"><code>no-restricted-imports</code></a>
 
+Source: <a href="https://typescript-eslint.io/rules/no-restricted-imports" target="_blank"><code>no-restricted-imports</code></a>
+
 Disallow specified modules when loaded by import or require.
 
 ## Options

--- a/website/src/content/docs/linter/rules/no-self-assign.md
+++ b/website/src/content/docs/linter/rules/no-self-assign.md
@@ -10,6 +10,8 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Source: <a href="https://eslint.org/docs/latest/rules/no-self-assign" target="_blank"><code>no-self-assign</code></a>
 
+Source: <a href="https://rust-lang.github.io/rust-clippy/master/#/self_assignment" target="_blank"><code>self_assignment</code></a>
+
 Disallow assignments where both sides are exactly the same.
 
 Self assignments have no effect, so probably those are an error due to incomplete refactoring.

--- a/website/src/content/docs/linter/rules/no-self-compare.md
+++ b/website/src/content/docs/linter/rules/no-self-compare.md
@@ -10,6 +10,8 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Source: <a href="https://eslint.org/docs/latest/rules/no-self-compare" target="_blank"><code>no-self-compare</code></a>
 
+Source: <a href="https://rust-lang.github.io/rust-clippy/master/#/eq_op" target="_blank"><code>eq_op</code></a>
+
 Disallow comparisons where both sides are exactly the same.
 
 >Comparing a variable against itself is usually an error, either a typo or refactoring error. It is confusing to the reader and may potentially introduce a runtime error.

--- a/website/src/content/docs/linter/rules/no-static-only-class.md
+++ b/website/src/content/docs/linter/rules/no-static-only-class.md
@@ -10,6 +10,8 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Source: <a href="https://typescript-eslint.io/rules/no-extraneous-class" target="_blank"><code>no-extraneous-class</code></a>
 
+Source: <a href="https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-static-only-class.md" target="_blank"><code>no-static-only-class</code></a>
+
 This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace.
 
 Users who come from a [OOP](https://en.wikipedia.org/wiki/Object-oriented_programming) paradigm may wrap their utility functions in an extra class,

--- a/website/src/content/docs/linter/rules/no-unused-variables.md
+++ b/website/src/content/docs/linter/rules/no-unused-variables.md
@@ -6,6 +6,8 @@ title: noUnusedVariables (since v1.0.0)
 
 Source: <a href="https://eslint.org/docs/latest/rules/no-unused-vars" target="_blank"><code>no-unused-vars</code></a>
 
+Source: <a href="https://typescript-eslint.io/rules/no-unused-vars" target="_blank"><code>no-unused-vars</code></a>
+
 Disallow unused variables.
 
 There is an exception to this rule:

--- a/website/src/content/docs/linter/rules/no-useless-constructor.md
+++ b/website/src/content/docs/linter/rules/no-useless-constructor.md
@@ -8,6 +8,8 @@ title: noUselessConstructor (since v1.0.0)
 This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
+Source: <a href="https://eslint.org/docs/latest/rules/no-useless-constructor" target="_blank"><code>no-useless-constructor</code></a>
+
 Source: <a href="https://typescript-eslint.io/rules/no-useless-constructor" target="_blank"><code>no-useless-constructor</code></a>
 
 Disallow unnecessary constructors.

--- a/website/src/content/docs/linter/rules/no-useless-else.md
+++ b/website/src/content/docs/linter/rules/no-useless-else.md
@@ -10,6 +10,8 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Inspired from: <a href="https://eslint.org/docs/latest/rules/no-else-return" target="_blank"><code>no-else-return</code></a>
 
+Inspired from: <a href="https://rust-lang.github.io/rust-clippy/master/#/redundant_else 	" target="_blank"><code>redundant_else 	</code></a>
+
 Disallow `else` block when the `if` block breaks early.
 
 If an `if` block breaks early using a breaking statement (`return`, `break`, `continue`, or `throw`),

--- a/website/src/content/docs/linter/rules/use-await.md
+++ b/website/src/content/docs/linter/rules/use-await.md
@@ -6,6 +6,8 @@ title: useAwait (since v1.4.0)
 
 Source: <a href="https://eslint.org/docs/latest/rules/require-await" target="_blank"><code>require-await</code></a>
 
+Source: <a href="https://typescript-eslint.io/rules/require-await" target="_blank"><code>require-await</code></a>
+
 Ensure `async` functions utilize `await`.
 
 This rule reports `async` functions that lack an `await` expression. As `async`

--- a/website/src/content/docs/linter/rules/use-collapsed-else-if.md
+++ b/website/src/content/docs/linter/rules/use-collapsed-else-if.md
@@ -6,6 +6,8 @@ title: useCollapsedElseIf (since v1.1.0)
 
 Source: <a href="https://eslint.org/docs/latest/rules/no-lonely-if" target="_blank"><code>no-lonely-if</code></a>
 
+Source: <a href="https://rust-lang.github.io/rust-clippy/master/#/collapsible_else_if" target="_blank"><code>collapsible_else_if</code></a>
+
 Enforce using `else if` instead of nested `if` in `else` clauses.
 
 If an `if` statement is the only statement in the `else` block, it is often clearer to use an `else if` form.

--- a/website/src/content/docs/linter/rules/use-default-parameter-last.md
+++ b/website/src/content/docs/linter/rules/use-default-parameter-last.md
@@ -10,6 +10,8 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Source: <a href="https://eslint.org/docs/latest/rules/default-param-last" target="_blank"><code>default-param-last</code></a>
 
+Source: <a href="https://typescript-eslint.io/rules/default-param-last" target="_blank"><code>default-param-last</code></a>
+
 Enforce default function parameters and optional function parameters to be last.
 
 Default and optional parameters that precede a required parameter cannot be omitted at call site.

--- a/website/src/content/docs/linter/rules/use-flat-map.md
+++ b/website/src/content/docs/linter/rules/use-flat-map.md
@@ -10,6 +10,8 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Source: <a href="https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat-map.md" target="_blank"><code>prefer-array-flat-map</code></a>
 
+Source: <a href="https://rust-lang.github.io/rust-clippy/master/#/map_flatten" target="_blank"><code>map_flatten</code></a>
+
 Promotes the use of `.flatMap()` when `map().flat()` are used together.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-for-of.md
+++ b/website/src/content/docs/linter/rules/use-for-of.md
@@ -6,6 +6,8 @@ title: useForOf (since v1.5.0)
 
 Source: <a href="https://typescript-eslint.io/rules/prefer-for-of" target="_blank"><code>prefer-for-of</code></a>
 
+Source: <a href="https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-for-loop.md" target="_blank"><code>no-for-loop</code></a>
+
 This rule recommends a `for-of` loop when in a `for` loop, the index used to extract an item from the iterated array.
 
 ## Examples

--- a/website/src/content/docs/linter/rules/use-literal-keys.md
+++ b/website/src/content/docs/linter/rules/use-literal-keys.md
@@ -10,6 +10,8 @@ This rule is recommended by Biome. A diagnostic error will appear when linting y
 
 Source: <a href="https://eslint.org/docs/latest/rules/dot-notation" target="_blank"><code>dot-notation</code></a>
 
+Source: <a href="https://typescript-eslint.io/rules/dot-notation" target="_blank"><code>dot-notation</code></a>
+
 Enforce the usage of a literal access to properties over computed property access.
 
 ## Examples

--- a/xtask/codegen/src/generate_migrate_eslint.rs
+++ b/xtask/codegen/src/generate_migrate_eslint.rs
@@ -88,7 +88,7 @@ impl<L: Language> RegistryVisitor<L> for EslintLintRulesVisitor {
         R::Query: Queryable<Language = L>,
         <R::Query as Queryable>::Output: Clone,
     {
-        if let Some(source) = R::METADATA.source {
+        for source in R::METADATA.sources {
             if source.is_eslint() || source.is_eslint_plugin() {
                 self.0.insert(
                     source.to_namespaced_rule_name(),

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -262,7 +262,7 @@ fn generate_group(
             meta.version,
             is_recommended,
             has_code_action,
-            meta.source.as_ref(),
+            meta.sources,
             meta.source_kind.as_ref(),
         ) {
             Ok(summary) => {
@@ -307,7 +307,7 @@ fn generate_rule(
     version: &'static str,
     is_recommended: bool,
     has_fix_kind: bool,
-    source: Option<&RuleSource>,
+    sources: &[RuleSource],
     source_kind: Option<&RuleSourceKind>,
 ) -> Result<Vec<Event<'static>>> {
     let mut content = Vec::new();
@@ -352,9 +352,9 @@ fn generate_rule(
         writeln!(content)?;
     }
 
-    if let Some(source) = source {
+    for source in sources {
         let (source_rule_url, source_rule_name) = source.as_url_and_rule_name();
-        match source_kind.cloned().unwrap_or_default() {
+        match source_kind.copied().unwrap_or_default() {
             RuleSourceKind::Inspired => {
                 write!(content, "Inspired from: ")?;
             }

--- a/xtask/lintdoc/src/rules_sources.rs
+++ b/xtask/lintdoc/src/rules_sources.rs
@@ -50,34 +50,36 @@ description: A page that maps lint rules from other sources to Biome
 
     for (rule_name, metadata) in rules {
         let kebab_rule_name = Case::Kebab.convert(rule_name);
-        if let Some(source) = &metadata.source {
-            let set = rules_by_source.get_mut(&format!("{source}"));
-            if let Some(set) = set {
-                set.insert(SourceSet {
-                    biome_rule_name: rule_name.to_string(),
-                    biome_link: format!("/linter/rules/{}", kebab_rule_name),
-                    source_link: source.to_rule_url(),
-                    source_rule_name: source.as_rule_name().to_string(),
-                    inspired: metadata
-                        .source_kind
-                        .map_or(false, |kind| kind.is_inspired()),
-                });
-            } else {
-                let mut set = BTreeSet::new();
-                set.insert(SourceSet {
-                    biome_rule_name: rule_name.to_string(),
-                    biome_link: format!("/linter/rules/{}", kebab_rule_name),
-                    source_link: source.to_rule_url(),
-                    source_rule_name: source.as_rule_name().to_string(),
-                    inspired: metadata.source_kind.map_or(true, |kind| kind.is_inspired()),
-                });
-                rules_by_source.insert(format!("{source}"), set);
-            }
-        } else {
+        if metadata.sources.is_empty() {
             exclusive_biome_rules.insert((
                 rule_name.to_string(),
                 format!("/linter/rules/{}", kebab_rule_name),
             ));
+        } else {
+            for source in metadata.sources {
+                let set = rules_by_source.get_mut(&format!("{source}"));
+                if let Some(set) = set {
+                    set.insert(SourceSet {
+                        biome_rule_name: rule_name.to_string(),
+                        biome_link: format!("/linter/rules/{}", kebab_rule_name),
+                        source_link: source.to_rule_url(),
+                        source_rule_name: source.as_rule_name().to_string(),
+                        inspired: metadata
+                            .source_kind
+                            .map_or(false, |kind| kind.is_inspired()),
+                    });
+                } else {
+                    let mut set = BTreeSet::new();
+                    set.insert(SourceSet {
+                        biome_rule_name: rule_name.to_string(),
+                        biome_link: format!("/linter/rules/{}", kebab_rule_name),
+                        source_link: source.to_rule_url(),
+                        source_rule_name: source.as_rule_name().to_string(),
+                        inspired: metadata.source_kind.map_or(true, |kind| kind.is_inspired()),
+                    });
+                    rules_by_source.insert(format!("{source}"), set);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

This PR allows specifying several sources for a rule.
We assume that every source has the same source kind.

I also updated the rule metadata and I changed the data structure used by `migrate eslint` in order to preserve the order of rules.
This order is important because a rule may override another rule if they have the same source.

## Test Plan

I added a test for testing the migration with several rules that share the same Biome rule.
