### PR TITLE
fix(lint): `noSvgWithoutTitle` valid case to use `aria-hidden` correctly

### DIFF
--- a/crates/biome_js_analyze/src/lint/a11y/no_svg_without_title.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_svg_without_title.rs
@@ -85,7 +85,7 @@ declare_rule! {
     /// ```
     ///
     /// ```js
-    /// <svg aria-hidden><rect /></svg>
+    /// <svg aria-hidden="true"><rect /></svg>
     /// ```
     ///
     ///

--- a/website/src/content/docs/linter/rules/no-svg-without-title.md
+++ b/website/src/content/docs/linter/rules/no-svg-without-title.md
@@ -128,19 +128,9 @@ To make svg accessible, the following methods are available:
 ```
 
 ```jsx
-<svg aria-hidden><rect /></svg>
+<svg aria-hidden="true"><rect /></svg>
 ```
 
-a11y/noSvgWithoutTitle.js:1:1 <a href="https://biomejs.dev/linter/rules/no-svg-without-title">lint/a11y/noSvgWithoutTitle</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Alternative text </span><span style="color: Tomato;"><strong>title</strong></span><span style="color: Tomato;"> element cannot be empty</span>
-  
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>&lt;svg aria-hidden&gt;&lt;rect /&gt;&lt;/svg&gt;
-   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>2 │ </strong>
-  
-<strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">For accessibility purposes, </span><span style="color: lightgreen;"><strong>SVGs</strong></span><span style="color: lightgreen;"> should have an alternative text, provided via </span><span style="color: lightgreen;"><strong>title</strong></span><span style="color: lightgreen;"> element. If the svg element has role=&quot;img&quot;, you should add the </span><span style="color: lightgreen;"><strong>aria-label</strong></span><span style="color: lightgreen;"> or </span><span style="color: lightgreen;"><strong>aria-labelledby</strong></span><span style="color: lightgreen;"> attribute.</span>
-  
 ## Accessibility guidelines
 
 [Document Structure – SVG 1.1 (Second Edition)](https://www.w3.org/TR/SVG11/struct.html#DescriptionAndTitleElements)


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Address the @Sec-ant 's comment : https://github.com/biomejs/biome/pull/2294#issuecomment-2041512217
Thanks for the report!
The valid case `<svg aria-hidden><rect /></svg>` needs `aria-hidden="true"` because the attribute is default false.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Executed `just gen-lint` and checked that emits no errors.
<!-- What demonstrates that your implementation is correct? -->
