### PR TITLE
refactor(useNamingConvention): accept `PascalCase` for variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,20 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [style/useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention/) now accept `PAscalCase` for local and top-level variables.
+
+  This allows supporting local variables that hold a component or a regular class.
+  The following code is now accepted:
+
+  ```tsx
+  function loadComponent() {
+    const Component = getComponent();
+    return <Component />;
+  }
+  ```
+
+  Contributed by @Conaclos
+
 #### Bug fixes
 
 - Lint rules `useNodejsImportProtocol`, `useNodeAssertStrict`, `noRestrictedImports`, `noNodejsModules` will no longer check `declare module` statements anymore. Contributed by @Sec-ant

--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -43,9 +43,10 @@ declare_rule! {
     ///
     /// ### Variable names
     ///
-    /// All variables, including function parameters and catch parameters, are in [`camelCase`].
+    /// All variables, including function parameters, are in [`camelCase`] or [`PascalCase`].
+    /// Catch parameters are always in [`camelCase`].
     ///
-    /// Additionally, top-level variables declared as `const` or `var` may be in [`CONSTANT_CASE`] or [`PascalCase`].
+    /// Additionally, top-level variables declared as `const` or `var` may be in [`CONSTANT_CASE`].
     /// Top-level variables are declared at module or script level.
     /// Variables declared in a TypeScript `module` or `namespace` are also considered top-level.
     ///
@@ -60,8 +61,6 @@ declare_rule! {
     /// }
     ///
     /// export const A_CONSTANT = 5;
-    ///
-    /// export const Person = class {}
     ///
     /// let aVariable = 0;
     ///
@@ -81,7 +80,7 @@ declare_rule! {
     /// ```
     ///
     /// ```js,expect_diagnostic
-    /// function f(FirstParam) {}
+    /// function f(FIRST_PARAM) {}
     /// ```
     ///
     /// ### Function names
@@ -924,19 +923,12 @@ impl Named {
             | Named::ClassSetter
             | Named::ClassStaticMethod
             | Named::ClassStaticSetter
-            | Named::FunctionParameter
             | Named::IndexParameter
-            | Named::LocalConst
-            | Named::LocalLet
-            | Named::LocalVar
-            | Named::LocalVariable
-            | Named::LocalUsing
             | Named::ObjectGetter
             | Named::ObjectMethod
             | Named::ObjectProperty
             | Named::ObjectSetter
             | Named::ParameterProperty
-            | Named::TopLevelLet
             | Named::TypeMethod
             | Named::TypeProperty
             | Named::TypeSetter => SmallVec::from_slice(&[Case::Camel]),
@@ -956,8 +948,15 @@ impl Named {
             Named::ExportSource | Named::ImportSource => SmallVec::new(),
             Named::ExportNamespace
             | Named::Function
+            | Named::FunctionParameter
             | Named::ImportNamespace
-            | Named::Namespace => SmallVec::from_slice(&[Case::Camel, Case::Pascal]),
+            | Named::LocalConst
+            | Named::LocalLet
+            | Named::LocalVar
+            | Named::LocalVariable
+            | Named::LocalUsing
+            | Named::Namespace
+            | Named::TopLevelLet => SmallVec::from_slice(&[Case::Camel, Case::Pascal]),
         }
     }
 }

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidFunctionParameter.js
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidFunctionParameter.js
@@ -1,1 +1,1 @@
-function f(A, SpecialParameter, _snake_case, CONSTANT_CASE) {}
+function f(_snake_case, CONSTANT_CASE) {}

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidFunctionParameter.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidFunctionParameter.js.snap
@@ -4,80 +4,42 @@ expression: invalidFunctionParameter.js
 ---
 # Input
 ```jsx
-function f(A, SpecialParameter, _snake_case, CONSTANT_CASE) {}
+function f(_snake_case, CONSTANT_CASE) {}
 ```
 
 # Diagnostics
 ```
 invalidFunctionParameter.js:1:12 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This function parameter name should be in camelCase.
+  ! This function parameter name trimmed as `snake_case` should be in camelCase or PascalCase.
   
-  > 1 │ function f(A, SpecialParameter, _snake_case, CONSTANT_CASE) {}
-      │            ^
-  
-  i The name could be renamed to `a`.
-  
-  i Safe fix: Rename this symbol in camelCase.
-  
-  - function·f(A,·SpecialParameter,·_snake_case,·CONSTANT_CASE)·{}
-  + function·f(a,·SpecialParameter,·_snake_case,·CONSTANT_CASE)·{}
-  
-
-```
-
-```
-invalidFunctionParameter.js:1:15 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This function parameter name should be in camelCase.
-  
-  > 1 │ function f(A, SpecialParameter, _snake_case, CONSTANT_CASE) {}
-      │               ^^^^^^^^^^^^^^^^
-  
-  i The name could be renamed to `specialParameter`.
-  
-  i Safe fix: Rename this symbol in camelCase.
-  
-  - function·f(A,·SpecialParameter,·_snake_case,·CONSTANT_CASE)·{}
-  + function·f(A,·specialParameter,·_snake_case,·CONSTANT_CASE)·{}
-  
-
-```
-
-```
-invalidFunctionParameter.js:1:33 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This function parameter name trimmed as `snake_case` should be in camelCase.
-  
-  > 1 │ function f(A, SpecialParameter, _snake_case, CONSTANT_CASE) {}
-      │                                 ^^^^^^^^^^^
+  > 1 │ function f(_snake_case, CONSTANT_CASE) {}
+      │            ^^^^^^^^^^^
   
   i The name could be renamed to `_snakeCase`.
   
   i Safe fix: Rename this symbol in camelCase.
   
-  - function·f(A,·SpecialParameter,·_snake_case,·CONSTANT_CASE)·{}
-  + function·f(A,·SpecialParameter,·_snakeCase,·CONSTANT_CASE)·{}
+  - function·f(_snake_case,·CONSTANT_CASE)·{}
+  + function·f(_snakeCase,·CONSTANT_CASE)·{}
   
 
 ```
 
 ```
-invalidFunctionParameter.js:1:46 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidFunctionParameter.js:1:25 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This function parameter name should be in camelCase.
+  ! This function parameter name should be in camelCase or PascalCase.
   
-  > 1 │ function f(A, SpecialParameter, _snake_case, CONSTANT_CASE) {}
-      │                                              ^^^^^^^^^^^^^
+  > 1 │ function f(_snake_case, CONSTANT_CASE) {}
+      │                         ^^^^^^^^^^^^^
   
   i The name could be renamed to `constantCase`.
   
   i Safe fix: Rename this symbol in camelCase.
   
-  - function·f(A,·SpecialParameter,·_snake_case,·CONSTANT_CASE)·{}
-  + function·f(A,·SpecialParameter,·_snake_case,·constantCase)·{}
+  - function·f(_snake_case,·CONSTANT_CASE)·{}
+  + function·f(_snake_case,·constantCase)·{}
   
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidLocalVariable.js
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidLocalVariable.js
@@ -1,12 +1,4 @@
 export default function () {
-    const X = 0
-
-    const PascalCaseConst = 0
-
-    let PascalCaseLet
-
-    var PascalCaseVar
-
     const CONSTANT_CASE_CONST = 0
 
     let CONSTANT_CASE_LET

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidLocalVariable.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidLocalVariable.js.snap
@@ -5,14 +5,6 @@ expression: invalidLocalVariable.js
 # Input
 ```jsx
 export default function () {
-    const X = 0
-
-    const PascalCaseConst = 0
-
-    let PascalCaseLet
-
-    var PascalCaseVar
-
     const CONSTANT_CASE_CONST = 0
 
     let CONSTANT_CASE_LET
@@ -32,49 +24,49 @@ export function f() {
 ```
 invalidLocalVariable.js:2:11 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This local const name should be in camelCase.
+  ! This local const name should be in camelCase or PascalCase.
   
     1 │ export default function () {
-  > 2 │     const X = 0
-      │           ^
+  > 2 │     const CONSTANT_CASE_CONST = 0
+      │           ^^^^^^^^^^^^^^^^^^^
     3 │ 
-    4 │     const PascalCaseConst = 0
+    4 │     let CONSTANT_CASE_LET
   
-  i The name could be renamed to `x`.
+  i The name could be renamed to `constantCaseConst`.
   
   i Safe fix: Rename this symbol in camelCase.
   
      1  1 │   export default function () {
-     2    │ - ····const·X·=·0
-        2 │ + ····const·x·=·0
+     2    │ - ····const·CONSTANT_CASE_CONST·=·0
+        2 │ + ····const·constantCaseConst·=·0
      3  3 │   
-     4  4 │       const PascalCaseConst = 0
+     4  4 │       let CONSTANT_CASE_LET
   
 
 ```
 
 ```
-invalidLocalVariable.js:4:11 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidLocalVariable.js:4:9 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This local const name should be in camelCase.
+  ! This local let name should be in camelCase or PascalCase.
   
-    2 │     const X = 0
+    2 │     const CONSTANT_CASE_CONST = 0
     3 │ 
-  > 4 │     const PascalCaseConst = 0
-      │           ^^^^^^^^^^^^^^^
+  > 4 │     let CONSTANT_CASE_LET
+      │         ^^^^^^^^^^^^^^^^^
     5 │ 
-    6 │     let PascalCaseLet
+    6 │     var CONSTANT_CASE_VAR
   
-  i The name could be renamed to `pascalCaseConst`.
+  i The name could be renamed to `constantCaseLet`.
   
   i Safe fix: Rename this symbol in camelCase.
   
-     2  2 │       const X = 0
+     2  2 │       const CONSTANT_CASE_CONST = 0
      3  3 │   
-     4    │ - ····const·PascalCaseConst·=·0
-        4 │ + ····const·pascalCaseConst·=·0
+     4    │ - ····let·CONSTANT_CASE_LET
+        4 │ + ····let·constantCaseLet
      5  5 │   
-     6  6 │       let PascalCaseLet
+     6  6 │       var CONSTANT_CASE_VAR
   
 
 ```
@@ -82,51 +74,25 @@ invalidLocalVariable.js:4:11 lint/style/useNamingConvention  FIXABLE  ━━━�
 ```
 invalidLocalVariable.js:6:9 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This local let name should be in camelCase.
+  ! This local var name should be in camelCase or PascalCase.
   
-    4 │     const PascalCaseConst = 0
+    4 │     let CONSTANT_CASE_LET
     5 │ 
-  > 6 │     let PascalCaseLet
-      │         ^^^^^^^^^^^^^
-    7 │ 
-    8 │     var PascalCaseVar
+  > 6 │     var CONSTANT_CASE_VAR
+      │         ^^^^^^^^^^^^^^^^^
+    7 │ }
+    8 │ 
   
-  i The name could be renamed to `pascalCaseLet`.
+  i The name could be renamed to `constantCaseVar`.
   
   i Safe fix: Rename this symbol in camelCase.
   
-     4  4 │       const PascalCaseConst = 0
+     4  4 │       let CONSTANT_CASE_LET
      5  5 │   
-     6    │ - ····let·PascalCaseLet
-        6 │ + ····let·pascalCaseLet
-     7  7 │   
-     8  8 │       var PascalCaseVar
-  
-
-```
-
-```
-invalidLocalVariable.js:8:9 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This local var name should be in camelCase.
-  
-     6 │     let PascalCaseLet
-     7 │ 
-   > 8 │     var PascalCaseVar
-       │         ^^^^^^^^^^^^^
-     9 │ 
-    10 │     const CONSTANT_CASE_CONST = 0
-  
-  i The name could be renamed to `pascalCaseVar`.
-  
-  i Safe fix: Rename this symbol in camelCase.
-  
-     6  6 │       let PascalCaseLet
-     7  7 │   
-     8    │ - ····var·PascalCaseVar
-        8 │ + ····var·pascalCaseVar
-     9  9 │   
-    10 10 │       const CONSTANT_CASE_CONST = 0
+     6    │ - ····var·CONSTANT_CASE_VAR
+        6 │ + ····var·constantCaseVar
+     7  7 │   }
+     8  8 │   
   
 
 ```
@@ -134,108 +100,28 @@ invalidLocalVariable.js:8:9 lint/style/useNamingConvention  FIXABLE  ━━━�
 ```
 invalidLocalVariable.js:10:11 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This local const name should be in camelCase.
+  ! This local const name should be in camelCase or PascalCase.
   
-     8 │     var PascalCaseVar
-     9 │ 
-  > 10 │     const CONSTANT_CASE_CONST = 0
-       │           ^^^^^^^^^^^^^^^^^^^
-    11 │ 
-    12 │     let CONSTANT_CASE_LET
-  
-  i The name could be renamed to `constantCaseConst`.
-  
-  i Safe fix: Rename this symbol in camelCase.
-  
-     8  8 │       var PascalCaseVar
-     9  9 │   
-    10    │ - ····const·CONSTANT_CASE_CONST·=·0
-       10 │ + ····const·constantCaseConst·=·0
-    11 11 │   
-    12 12 │       let CONSTANT_CASE_LET
-  
-
-```
-
-```
-invalidLocalVariable.js:12:9 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This local let name should be in camelCase.
-  
-    10 │     const CONSTANT_CASE_CONST = 0
-    11 │ 
-  > 12 │     let CONSTANT_CASE_LET
-       │         ^^^^^^^^^^^^^^^^^
-    13 │ 
-    14 │     var CONSTANT_CASE_VAR
-  
-  i The name could be renamed to `constantCaseLet`.
-  
-  i Safe fix: Rename this symbol in camelCase.
-  
-    10 10 │       const CONSTANT_CASE_CONST = 0
-    11 11 │   
-    12    │ - ····let·CONSTANT_CASE_LET
-       12 │ + ····let·constantCaseLet
-    13 13 │   
-    14 14 │       var CONSTANT_CASE_VAR
-  
-
-```
-
-```
-invalidLocalVariable.js:14:9 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This local var name should be in camelCase.
-  
-    12 │     let CONSTANT_CASE_LET
-    13 │ 
-  > 14 │     var CONSTANT_CASE_VAR
-       │         ^^^^^^^^^^^^^^^^^
-    15 │ }
-    16 │ 
-  
-  i The name could be renamed to `constantCaseVar`.
-  
-  i Safe fix: Rename this symbol in camelCase.
-  
-    12 12 │       let CONSTANT_CASE_LET
-    13 13 │   
-    14    │ - ····var·CONSTANT_CASE_VAR
-       14 │ + ····var·constantCaseVar
-    15 15 │   }
-    16 16 │   
-  
-
-```
-
-```
-invalidLocalVariable.js:18:11 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This local const name should be in camelCase.
-  
-    17 │ export function f() {
-  > 18 │     const a_var = 0;
+     9 │ export function f() {
+  > 10 │     const a_var = 0;
        │           ^^^^^
-    19 │     console.log(a_var);
-    20 │     return a_var;
+    11 │     console.log(a_var);
+    12 │     return a_var;
   
   i The name could be renamed to `aVar`.
   
   i Safe fix: Rename this symbol in camelCase.
   
-    16 16 │   
-    17 17 │   export function f() {
-    18    │ - ····const·a_var·=·0;
-    19    │ - ····console.log(a_var);
-    20    │ - ····return·a_var;
-       18 │ + ····const·aVar·=·0;
-       19 │ + ····console.log(aVar);
-       20 │ + ····return·aVar;
-    21 21 │   }
-    22 22 │   
+     8  8 │   
+     9  9 │   export function f() {
+    10    │ - ····const·a_var·=·0;
+    11    │ - ····console.log(a_var);
+    12    │ - ····return·a_var;
+       10 │ + ····const·aVar·=·0;
+       11 │ + ····console.log(aVar);
+       12 │ + ····return·aVar;
+    13 13 │   }
+    14 14 │   
   
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidTopLevelVariable.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidTopLevelVariable.ts.snap
@@ -74,7 +74,7 @@ invalidTopLevelVariable.ts:4:12 lint/style/useNamingConvention ━━━━━�
 ```
 invalidTopLevelVariable.ts:6:12 lint/style/useNamingConvention ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This top-level let name should be in camelCase.
+  ! This top-level let name should be in camelCase or PascalCase.
   
     4 │ export var Unknown_Style_1 = 0
     5 │ 
@@ -124,7 +124,7 @@ invalidTopLevelVariable.ts:11:16 lint/style/useNamingConvention ━━━━━�
 ```
 invalidTopLevelVariable.ts:13:16 lint/style/useNamingConvention ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This top-level let name should be in camelCase.
+  ! This top-level let name should be in camelCase or PascalCase.
   
     11 │     export var Unknown_Style_1 = 0
     12 │ 
@@ -153,5 +153,3 @@ invalidTopLevelVariable.ts:16:14 lint/style/useNamingConvention ━━━━━�
   
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validComponentName.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validComponentName.js.snap
@@ -10,31 +10,3 @@ function loadWidgetComponent(widgetId) {
   return <Component />;
 }
 ```
-
-# Diagnostics
-```
-validComponentName.js:2:9 lint/style/useNamingConvention  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This local const name should be in camelCase.
-  
-    1 │ function loadWidgetComponent(widgetId) {
-  > 2 │   const Component = getWidgetComponent(widgetId);
-      │         ^^^^^^^^^
-    3 │   if (!Component) return null;
-    4 │   return <Component />;
-  
-  i The name could be renamed to `component`.
-  
-  i Safe fix: Rename this symbol in camelCase.
-  
-    1 1 │   function loadWidgetComponent(widgetId) {
-    2   │ - ··const·Component·=·getWidgetComponent(widgetId);
-    3   │ - ··if·(!Component)·return·null;
-    4   │ - ··return·<Component·/>;
-      2 │ + ··const·component·=·getWidgetComponent(widgetId);
-      3 │ + ··if·(!component)·return·null;
-      4 │ + ··return·<component·/>;
-    5 5 │   }
-  
-
-```

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validFunctionParameter.js
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validFunctionParameter.js
@@ -1,1 +1,1 @@
-function f(a, specialParameter, _unused, $1, stream$, _, $, __doubledUnderscore, __) {}
+function f(a, PascalCase, specialParameter, _unused, $1, stream$, _, $, __doubledUnderscore, __) {}

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validFunctionParameter.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validFunctionParameter.js.snap
@@ -4,7 +4,5 @@ expression: validFunctionParameter.js
 ---
 # Input
 ```jsx
-function f(a, specialParameter, _unused, $1, stream$, _, $, __doubledUnderscore, __) {}
+function f(a, PascalCase, specialParameter, _unused, $1, stream$, _, $, __doubledUnderscore, __) {}
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validLocalVariable.js
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validLocalVariable.js
@@ -14,4 +14,12 @@ export default function () {
     let _camelCaseLet
 
     var _camelCaseVar
+
+    const X = 0
+
+    const PascalCaseConst = 0
+
+    let PascalCaseLet
+
+    var PascalCaseVar
 }

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validLocalVariable.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validLocalVariable.js.snap
@@ -20,7 +20,13 @@ export default function () {
     let _camelCaseLet
 
     var _camelCaseVar
+
+    const X = 0
+
+    const PascalCaseConst = 0
+
+    let PascalCaseLet
+
+    var PascalCaseVar
 }
 ```
-
-

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -195,6 +195,20 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [style/useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention/) now accept `PAscalCase` for local and top-level variables.
+
+  This allows supporting local variables that hold a component or a regular class.
+  The following code is now accepted:
+
+  ```tsx
+  function loadComponent() {
+    const Component = getComponent();
+    return <Component />;
+  }
+  ```
+
+  Contributed by @Conaclos
+
 #### Bug fixes
 
 - Lint rules `useNodejsImportProtocol`, `useNodeAssertStrict`, `noRestrictedImports`, `noNodejsModules` will no longer check `declare module` statements anymore. Contributed by @Sec-ant

--- a/website/src/content/docs/linter/rules/use-naming-convention.md
+++ b/website/src/content/docs/linter/rules/use-naming-convention.md
@@ -17,9 +17,10 @@ All names can be prefixed and suffixed by underscores `_` and dollar signs `$`.
 
 ### Variable names
 
-All variables, including function parameters and catch parameters, are in [`camelCase`](https://en.wikipedia.org/wiki/Camel_case).
+All variables, including function parameters, are in [`camelCase`](https://en.wikipedia.org/wiki/Camel_case) or [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case).
+Catch parameters are always in [`camelCase`](https://en.wikipedia.org/wiki/Camel_case).
 
-Additionally, top-level variables declared as `const` or `var` may be in [`CONSTANT_CASE`](https://en.wikipedia.org/wiki/Snake_case) or [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case).
+Additionally, top-level variables declared as `const` or `var` may be in [`CONSTANT_CASE`](https://en.wikipedia.org/wiki/Snake_case).
 Top-level variables are declared at module or script level.
 Variables declared in a TypeScript `module` or `namespace` are also considered top-level.
 
@@ -34,8 +35,6 @@ function f(param, _unusedParam) {
 }
 
 export const A_CONSTANT = 5;
-
-export const Person = class {}
 
 let aVariable = 0;
 
@@ -52,7 +51,7 @@ let a_value = 0;
 
 <pre class="language-text"><code class="language-text">style/useNamingConvention.js:1:5 <a href="https://biomejs.dev/linter/rules/use-naming-convention">lint/style/useNamingConvention</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">This </span><span style="color: Orange;"><strong>top-level let</strong></span><span style="color: Orange;"> name should be in </span><span style="color: Orange;"><strong>camelCase</strong></span><span style="color: Orange;">.</span>
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">This </span><span style="color: Orange;"><strong>top-level let</strong></span><span style="color: Orange;"> name should be in </span><span style="color: Orange;"><strong>camelCase or PascalCase</strong></span><span style="color: Orange;">.</span>
   
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>let a_value = 0;
    <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
@@ -86,22 +85,22 @@ const fooYPosition = 0;
 </code></pre>
 
 ```jsx
-function f(FirstParam) {}
+function f(FIRST_PARAM) {}
 ```
 
 <pre class="language-text"><code class="language-text">style/useNamingConvention.js:1:12 <a href="https://biomejs.dev/linter/rules/use-naming-convention">lint/style/useNamingConvention</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">This </span><span style="color: Orange;"><strong>function parameter</strong></span><span style="color: Orange;"> name should be in </span><span style="color: Orange;"><strong>camelCase</strong></span><span style="color: Orange;">.</span>
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">This </span><span style="color: Orange;"><strong>function parameter</strong></span><span style="color: Orange;"> name should be in </span><span style="color: Orange;"><strong>camelCase or PascalCase</strong></span><span style="color: Orange;">.</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>function f(FirstParam) {}
-   <strong>   │ </strong>           <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>function f(FIRST_PARAM) {}
+   <strong>   │ </strong>           <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
   
 <strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">The name could be renamed to `firstParam`.</span>
   
 <strong><span style="color: lightgreen;">  </span></strong><strong><span style="color: lightgreen;">ℹ</span></strong> <span style="color: lightgreen;">Safe fix</span><span style="color: lightgreen;">: </span><span style="color: lightgreen;">Rename this symbol in </span><span style="color: lightgreen;"><strong>camelCase</strong></span><span style="color: lightgreen;">.</span>
   
-    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">f</span><span style="color: Tomato;">u</span><span style="color: Tomato;">n</span><span style="color: Tomato;">c</span><span style="color: Tomato;">t</span><span style="color: Tomato;">i</span><span style="color: Tomato;">o</span><span style="color: Tomato;">n</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">f</span><span style="color: Tomato;">(</span><span style="color: Tomato;"><strong>F</strong></span><span style="color: Tomato;"><strong>i</strong></span><span style="color: Tomato;"><strong>r</strong></span><span style="color: Tomato;"><strong>s</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>P</strong></span><span style="color: Tomato;"><strong>a</strong></span><span style="color: Tomato;"><strong>r</strong></span><span style="color: Tomato;"><strong>a</strong></span><span style="color: Tomato;"><strong>m</strong></span><span style="color: Tomato;">)</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">{</span><span style="color: Tomato;">}</span>
+    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">f</span><span style="color: Tomato;">u</span><span style="color: Tomato;">n</span><span style="color: Tomato;">c</span><span style="color: Tomato;">t</span><span style="color: Tomato;">i</span><span style="color: Tomato;">o</span><span style="color: Tomato;">n</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">f</span><span style="color: Tomato;">(</span><span style="color: Tomato;"><strong>F</strong></span><span style="color: Tomato;"><strong>I</strong></span><span style="color: Tomato;"><strong>R</strong></span><span style="color: Tomato;"><strong>S</strong></span><span style="color: Tomato;"><strong>T</strong></span><span style="color: Tomato;"><strong>_</strong></span><span style="color: Tomato;"><strong>P</strong></span><span style="color: Tomato;"><strong>A</strong></span><span style="color: Tomato;"><strong>R</strong></span><span style="color: Tomato;"><strong>A</strong></span><span style="color: Tomato;"><strong>M</strong></span><span style="color: Tomato;">)</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">{</span><span style="color: Tomato;">}</span>
       <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">f</span><span style="color: MediumSeaGreen;">u</span><span style="color: MediumSeaGreen;">n</span><span style="color: MediumSeaGreen;">c</span><span style="color: MediumSeaGreen;">t</span><span style="color: MediumSeaGreen;">i</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">n</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">f</span><span style="color: MediumSeaGreen;">(</span><span style="color: MediumSeaGreen;"><strong>f</strong></span><span style="color: MediumSeaGreen;"><strong>i</strong></span><span style="color: MediumSeaGreen;"><strong>r</strong></span><span style="color: MediumSeaGreen;"><strong>s</strong></span><span style="color: MediumSeaGreen;"><strong>t</strong></span><span style="color: MediumSeaGreen;"><strong>P</strong></span><span style="color: MediumSeaGreen;"><strong>a</strong></span><span style="color: MediumSeaGreen;"><strong>r</strong></span><span style="color: MediumSeaGreen;"><strong>a</strong></span><span style="color: MediumSeaGreen;"><strong>m</strong></span><span style="color: MediumSeaGreen;">)</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">{</span><span style="color: MediumSeaGreen;">}</span>
     <strong>2</strong> <strong>2</strong><strong> │ </strong>  
   


### PR DESCRIPTION
## Summary

Close #2367.
I simply decided to accept `PascalCase` for any variable or function parameter. This is a simple and backward-compatible fix.

Requiring a component to be in `PascalCase` would require traversing all references of a variable to check if one of its references is being used as a component. When I designed `useNamingConvention` I wanted to keep things simple and avoid looking at how a binding is used. I would like to preserve that simplicity.

## Test Plan

I updated the tests.