### PR TITLE
docs(website): Getting Started and Formatter improvements

### DIFF
--- a/website/src/content/docs/formatter/index.mdx
+++ b/website/src/content/docs/formatter/index.mdx
@@ -41,23 +41,23 @@ The following defaults are applied:
 {
   "formatter": {
     "enabled": true,
-    "ignore": [],
     "formatWithErrors": false,
+    "ignore": [],
+    "attributePosition": "auto",
     "indentStyle": "tab",
     "indentWidth": 2,
-    "lineWidth": 80,
     "lineEnding": "lf",
-    "attributePosition": "auto"
+    "lineWidth": 80
   },
   "javascript": {
     "formatter": {
       "arrowParentheses":"always",
-      "jsxQuoteStyle": "double",
-      "semicolons": "always",
-      "trailingComma": "all",
-      "quoteProperties": "asNeeded",
       "bracketSameLine": false,
-      "bracketSpacing": true
+      "bracketSpacing": true,
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "semicolons": "always",
+      "trailingComma": "all"
     }
   },
   "json": {
@@ -70,9 +70,9 @@ The following defaults are applied:
 
 The main language-agnostic options supported by the Biome formatter are:
 
-- indent style (default: `tab`): Use spaces or tabs for indention
-- tab width (default: `2`): The number of spaces per indention level
-- line width (default: `80`): The column width at which Biome wraps code
+- indent style (default: `tab`): Use spaces or tabs for indention;
+- line width (default: `80`): The column width at which Biome wraps code;
+- tab width (default: `2`): The number of spaces per indention level.
 
 See the [configuration reference](/reference/configuration/#formatter) for more details.
 

--- a/website/src/content/docs/formatter/index.mdx
+++ b/website/src/content/docs/formatter/index.mdx
@@ -10,16 +10,6 @@ It follows a similar [philosophy to Prettier](https://prettier.io/docs/en/option
 only supporting a few options to avoid debates over styles, turning into debates over Biome options.
 It deliberately [resists the urge to add new options](https://github.com/prettier/prettier/issues/40) to prevent [bike-shed discussions](https://en.wikipedia.org/wiki/Law_of_triviality) in teams so they can focus on what really matters instead.
 
-## Options
-
-The language agnostic options supported by Biome are:
-
-- indent style (default: `tab`): Use spaces or tabs for indention
-- tab width (default: `2`): The number of spaces per indention level
-- line width (default: `80`): The column width at which Biome wraps code
-
-Other formatting options are available for specific languages as well.  See the [configuration](/reference/configuration) options for details.
-
 ## Use the formatter with the CLI
 
 By default, the formatter **checks** the code and emit diagnostics if there are changes in formatting:
@@ -36,24 +26,56 @@ Use the  `--help` flag to know what are the available options:
 
 Or check the [CLI reference section](/reference/cli#biomeformat).
 
-## Configuration
+## Options
 
-You may want to [configure Biome](/reference/configuration/#formatter) using `biome.json`.
+Biome provides some options to tune the behavior of its formatter.
+Differently from other tools, Biome separates language agnostic options from language-specific options.
+
+The formatter options can be set on the [CLI](reference/cli/#biome-format) or in the configuration file `biome.json`.
+Biome doesn't support `.editorconfig` [yet](https://github.com/biomejs/biome/issues/1724).
+
+It's recommended to use the configuration file to ensure that both the Biome CLI and the Biome LSP apply the same options.
 The following defaults are applied:
 
 ```json title="biome.json"
 {
   "formatter": {
     "enabled": true,
+    "ignore": [],
     "formatWithErrors": false,
     "indentStyle": "tab",
     "indentWidth": 2,
     "lineWidth": 80,
     "lineEnding": "lf",
-    "ignore": []
+    "attributePosition": "auto"
+  },
+  "javascript": {
+    "formatter": {
+      "arrowParentheses":"always",
+      "jsxQuoteStyle": "double",
+      "semicolons": "always",
+      "trailingComma": "all",
+      "quoteProperties": "asNeeded",
+      "bracketSameLine": false,
+      "bracketSpacing": true
+    }
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "none"
+    }
   }
 }
 ```
+
+The main language agnostic options supported by the Biome formatter are:
+
+- indent style (default: `tab`): Use spaces or tabs for indention
+- tab width (default: `2`): The number of spaces per indention level
+- line width (default: `80`): The column width at which Biome wraps code
+
+See the [configuration reference](/reference/configuration/#formatter) for more details.
+
 
 ## Ignoring Code
 
@@ -88,27 +110,4 @@ const expr =
     -1,
     0,
   ];
-```
-## Per language configuration
-
-Differently from other tools, Biome places options belong to a language in a different place of its configuration.
-
-### JavaScript
-
-Following, the default applied to JavaScript files:
-
-```json title="biome.json"
-{
-  "javascript": {
-    "formatter": {
-      "arrowParentheses":"always",
-      "jsxQuoteStyle": "double",
-      "semicolons": "always",
-      "trailingComma": "all",
-      "quoteProperties": "asNeeded",
-      "bracketSpacing": true,
-      "bracketSameLine": false
-    }
-  }
-}
 ```

--- a/website/src/content/docs/formatter/index.mdx
+++ b/website/src/content/docs/formatter/index.mdx
@@ -29,9 +29,9 @@ Or check the [CLI reference section](/reference/cli#biomeformat).
 ## Options
 
 Biome provides some options to tune the behavior of its formatter.
-Differently from other tools, Biome separates language agnostic options from language-specific options.
+Differently from other tools, Biome separates language-agnostic options from language-specific options.
 
-The formatter options can be set on the [CLI](reference/cli/#biome-format) or in the configuration file `biome.json`.
+The formatter options can be set on the [CLI](reference/cli/#biome-format) or in the `biome.json` configuration file.
 Biome doesn't support `.editorconfig` [yet](https://github.com/biomejs/biome/issues/1724).
 
 It's recommended to use the configuration file to ensure that both the Biome CLI and the Biome LSP apply the same options.
@@ -68,7 +68,7 @@ The following defaults are applied:
 }
 ```
 
-The main language agnostic options supported by the Biome formatter are:
+The main language-agnostic options supported by the Biome formatter are:
 
 - indent style (default: `tab`): Use spaces or tabs for indention
 - tab width (default: `2`): The number of spaces per indention level

--- a/website/src/content/docs/formatter/index.mdx
+++ b/website/src/content/docs/formatter/index.mdx
@@ -5,7 +5,7 @@ description: How to use the Biome formatter.
 
 import PackageManagerBiomeCommand from "@/components/PackageManagerBiomeCommand.astro";
 
-Biome is an opinionated formatter that has the goal to stop all ongoing debates over styles.
+Biome is an opinionated formatter.
 It follows a similar [philosophy to Prettier](https://prettier.io/docs/en/option-philosophy.html),
 only supporting a few options to avoid debates over styles, turning into debates over Biome options.
 It deliberately [resists the urge to add new options](https://github.com/prettier/prettier/issues/40) to prevent [bike-shed discussions](https://en.wikipedia.org/wiki/Law_of_triviality) in teams so they can focus on what really matters instead.

--- a/website/src/content/docs/guides/getting-started.mdx
+++ b/website/src/content/docs/guides/getting-started.mdx
@@ -63,22 +63,8 @@ Alternatively, you can run `biome init --jsonc` to emit a `biome.jsonc` file ins
 
 <PackageManagerBiomeCommand command="init --jsonc"/>
 
-```json title="biome.jsonc"
-{
-  "$schema": "https://biomejs.dev/schemas/1.6.4/schema.json",
-  "organizeImports": {
-    "enabled": false
-  },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true
-    }
-  }
-}
-```
-
 The `linter.enabled: true` enables the linter and `rules.recommended: true` enables the [recommended rules](/linter/rules/).
+This corresponds to the default settings.
 
 Formatting is enabled **by default**, but you can [disable](/reference/configuration/#formatterenabled) it by explicitly using `formatter.enabled: false`.
 
@@ -88,7 +74,7 @@ Biome CLI comes with many commands and options, so you can use only what you nee
 
 You can format files and directories using the [`format`](/reference/cli#biome-format) command and the `--write` option:
 
-<PackageManagerBiomeCommand command="format <files> --write"/>
+<PackageManagerBiomeCommand command="format --write <files>"/>
 
 You can lint and apply [safe fixes](/linter#safe-fixes) to files and directories using the [`lint`](/reference/cli#biome-lint) command with the `--apply`:
 
@@ -112,6 +98,7 @@ We recommend installing an editor plugin to get the most out of Biome. Check out
 
 If you're using Node.js, the recommended way to run Biome in CI is to use [your favourite package manager](/guides/getting-started#installation).
 This ensures that your CI pipeline uses the same version of Biome as you do inside the editor or when running local CLI commands.
+Alternatively, you can use dedicated [CI Actions](/recipes/continuous-integration/).
 
 ## Next Steps
 

--- a/website/src/content/docs/ja/formatter/index.mdx
+++ b/website/src/content/docs/ja/formatter/index.mdx
@@ -40,19 +40,38 @@ Biomeがサポートする、言語に依存しないオプションは以下の
 
 `biome.json`を使用して、[フォーマッターを設定](/reference/configuration/#formatter)することができます。以下はデフォルトの設定です。
 
-```json
+```json title="biome.json"
 {
   "formatter": {
     "enabled": true,
+    "ignore": [],
     "formatWithErrors": false,
     "indentStyle": "tab",
     "indentWidth": 2,
     "lineWidth": 80,
     "lineEnding": "lf",
-    "ignore": []
+    "attributePosition": "auto"
+  },
+  "javascript": {
+    "formatter": {
+      "arrowParentheses":"always",
+      "jsxQuoteStyle": "double",
+      "semicolons": "always",
+      "trailingComma": "all",
+      "quoteProperties": "asNeeded",
+      "bracketSameLine": false,
+      "bracketSpacing": true
+    }
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "none"
+    }
   }
 }
 ```
+
+他のツールと違って、Biomeは言語ごとに関するオプションを設定することができます。
 
 ## コードのformatを無効にする
 
@@ -88,28 +107,3 @@ const expr =
     0,
   ];
 ```
-
-## 言語ごとの設定
-
-他のツールと違って、Biomeは言語ごとに関するオプションを設定することができます。
-
-### JavaScript
-
-以下は、JavaScript のファイルに適用されるデフォルトの設定です：
-
-```json title="biome.json"
-{
-  "javascript": {
-    "formatter": {
-      "arrowParentheses":"always",
-      "jsxQuoteStyle": "double",
-      "semicolons": "always",
-      "trailingComma": "all",
-      "quoteProperties": "asNeeded",
-      "bracketSpacing": true,
-      "bracketSameLine": false
-    }
-  }
-}
-```
-

--- a/website/src/content/docs/ja/formatter/index.mdx
+++ b/website/src/content/docs/ja/formatter/index.mdx
@@ -44,23 +44,23 @@ Biomeがサポートする、言語に依存しないオプションは以下の
 {
   "formatter": {
     "enabled": true,
-    "ignore": [],
     "formatWithErrors": false,
+    "ignore": [],
+    "attributePosition": "auto",
     "indentStyle": "tab",
     "indentWidth": 2,
-    "lineWidth": 80,
     "lineEnding": "lf",
-    "attributePosition": "auto"
+    "lineWidth": 80
   },
   "javascript": {
     "formatter": {
       "arrowParentheses":"always",
-      "jsxQuoteStyle": "double",
-      "semicolons": "always",
-      "trailingComma": "all",
-      "quoteProperties": "asNeeded",
       "bracketSameLine": false,
-      "bracketSpacing": true
+      "bracketSpacing": true,
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "semicolons": "always",
+      "trailingComma": "all"
     }
   },
   "json": {

--- a/website/src/content/docs/ja/guides/getting-started.mdx
+++ b/website/src/content/docs/ja/guides/getting-started.mdx
@@ -67,7 +67,7 @@ Biome CLIには多くのコマンドとオプションが用意されている�
 
 [`format`](/ja/reference/cli#biome-format) コマンドを `--write` オプションを指定し実行することで、ファイルやディレクトリをformatできます。
 
-<PackageManagerBiomeCommand command="format <files> --write"/>
+<PackageManagerBiomeCommand command="format --write <files>"/>
 
 [`lint`](/ja/reference/cli#biome-lint) コマンドを `--apply` オプションを指定し実行することで、ファイルやディレクトリに対してLintを実行し、[安全な修正](/ja/linter#安全な修正safe-fixes)を適用できます。
 

--- a/website/src/content/docs/pt-br/formatter/index.mdx
+++ b/website/src/content/docs/pt-br/formatter/index.mdx
@@ -45,11 +45,29 @@ Os seguintes padrões são aplicados:
 {
   "formatter": {
     "enabled": true,
+    "ignore": [],
     "formatWithErrors": false,
     "indentStyle": "tab",
     "indentWidth": 2,
     "lineWidth": 80,
-    "ignore": []
+    "lineEnding": "lf",
+    "attributePosition": "auto"
+  },
+  "javascript": {
+    "formatter": {
+      "arrowParentheses":"always",
+      "jsxQuoteStyle": "double",
+      "semicolons": "always",
+      "trailingComma": "all",
+      "quoteProperties": "asNeeded",
+      "bracketSameLine": false,
+      "bracketSpacing": true
+    }
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "none"
+    }
   }
 }
 ```

--- a/website/src/content/docs/pt-br/formatter/index.mdx
+++ b/website/src/content/docs/pt-br/formatter/index.mdx
@@ -45,23 +45,23 @@ Os seguintes padrões são aplicados:
 {
   "formatter": {
     "enabled": true,
-    "ignore": [],
     "formatWithErrors": false,
+    "ignore": [],
+    "attributePosition": "auto",
     "indentStyle": "tab",
     "indentWidth": 2,
-    "lineWidth": 80,
     "lineEnding": "lf",
-    "attributePosition": "auto"
+    "lineWidth": 80
   },
   "javascript": {
     "formatter": {
       "arrowParentheses":"always",
-      "jsxQuoteStyle": "double",
-      "semicolons": "always",
-      "trailingComma": "all",
-      "quoteProperties": "asNeeded",
       "bracketSameLine": false,
-      "bracketSpacing": true
+      "bracketSpacing": true,
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "semicolons": "always",
+      "trailingComma": "all"
     }
   },
   "json": {

--- a/website/src/content/docs/pt-br/guides/getting-started.mdx
+++ b/website/src/content/docs/pt-br/guides/getting-started.mdx
@@ -69,7 +69,7 @@ O CLI do Biome vem com vários comandos e opções, então você utiliza só o q
 
 Você pode formatar arquivos e diretórios usando o comando [`format`](/reference/cli#biome-format) com o parâmetro `--write`:
 
-<PackageManagerBiomeCommand command="format <files> --write"/>
+<PackageManagerBiomeCommand command="format --write <files>"/>
 
 Você pode analisar e aplicar [correções seguras](/pt-br/linter#correções-seguras) em arquivos e diretórios utilizando o comando [`lint`](/reference/cli#biome-lint) com o parâmetro `--apply`:
 

--- a/website/src/content/docs/zh-cn/formatter/index.mdx
+++ b/website/src/content/docs/zh-cn/formatter/index.mdx
@@ -41,11 +41,29 @@ Biome支持的与语言无关的选项有：
 {
   "formatter": {
     "enabled": true,
+    "ignore": [],
     "formatWithErrors": false,
     "indentStyle": "tab",
     "indentWidth": 2,
     "lineWidth": 80,
-    "ignore": []
+    "lineEnding": "lf",
+    "attributePosition": "auto"
+  },
+  "javascript": {
+    "formatter": {
+      "arrowParentheses":"always",
+      "jsxQuoteStyle": "double",
+      "semicolons": "always",
+      "trailingComma": "all",
+      "quoteProperties": "asNeeded",
+      "bracketSameLine": false,
+      "bracketSpacing": true
+    }
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "none"
+    }
   }
 }
 ```
@@ -84,197 +102,3 @@ const expr =
     0,
   ];
 ```
-
-## 与Prettier的差异
-
-与Prettier存在一些差异。
-
-### 类属性上的虚假或重复修饰符
-
-输入
-
-```ts title="example.ts"
-// 多个可访问性修饰符
-class Foo {
-  private a = 1;
-}
-
-// 带有函数体的声明函数
-declare function foo() {};
-
-// 无效使用abstract
-class Bar {
-  abstract foo;
-}
-
-// 重复的Readonly
-class Read {
-  readonly x: number;
-}
-```
-
-差异
-
-```ts title="example.ts" del={3, 8, 13, 19} ins={4, 9, 14, 20}
-// 多个可访问性修饰符
-class Foo {
-  private a = 1;
-  private a = 1;
-}
-
-// 带有函数体的声明函数
-declare function foo() {};
-declare function foo() {};
-
-// 无效使用abstract
-class Bar {
-  abstract foo;
-  abstract foo;
-}
-
-// 重复的Readonly
-class Read {
-  readonly x: number;
-  readonly x: number;
-}
-```
-
-#### 原因
-
-Prettier基于Babel的JS/TS解析非常宽松，并且允许忽略多个错误。Biome的解析器故意比Prettier更严格，正确断言这些测试中的语句是无效的。函数的重复修饰符在语义上无效，函数声明不允许有主体，非抽象类不能有抽象属性等。
-
-在Prettier中，这些错误不被视为解析错误，并且AST仍然以适当的节点构建出来。在格式化时，Prettier只是将这些节点视为正常节点并相应地进行格式化。
-
-在Biome中，解析错误会导致一个Bogus节点，它可以包含任意数量的有效节点、无效节点和/或原始令牌。在格式化时，Biome将Bogus节点视为纯文本，将其原样打印到生成的代码中，而不进行任何格式化，因为尝试进行格式化可能是不正确的并引起语义更改。
-
-对于类属性，Prettier的当前解析策略还使用布尔字段表示修饰符，这意味着每种修饰符只能出现一次（可访问性修饰符存储为单个字符串）。在打印时，Prettier只查看布尔列表，并决定要重新打印哪些修饰符。Biome相反保留修饰符列表，这意味着重复的修饰符仍然存在并可进行分析（因此解析错误消息中有关重复修饰符和排序的信息）。在打印出Bogus节点时，此列表仍然保持不变，打印未格式化的文本会导致这些修饰符继续存在。
-
-Biome可以解决这个问题的方法。一种可能性是在格式化时尝试解释Bogus节点并构建有效节点。如果可以构建有效节点，则像正常节点一样进行格式化，否则按原样打印Bogus文本，就像当前所做的那样。然而，这很混乱，并引入了一种形式的解析逻辑到格式化程序中，这实际上没有意义。
-
-另一个选择是在解析器中引入一种形式的“语法上有效的Bogus节点”，它接受这些纯语义错误（重复修饰符、非抽象类中的抽象属性）。它将继续像正常一样构建节点（实际上与Prettier的行为相匹配），但将它们存储在一个新的Bogus节点中，其中包括诊断信息。在格式化时，这些特殊的Bogus节点将尝试格式化内部节点，然后在出现错误时回退（现有的`format_or_verbatim`实用程序已经执行此操作）。这样可以保持解析和格式化逻辑彼此分离，但会使解析器更复杂，允许考虑无效状态为半有效。
-
-### Prettier不会取消引用一些在JavaScript中有效的对象属性。
-
-```js title="example.js"
-const obj = {
-  a: true,
-  b: true,
-  "𐊧": true,
-};
-```
-
-差异
-
-```js title="exmaple.js" del={4} ins={5}
-const obj = {
-  a: true,
-  b: true,
-  "𐊧": true,
-  𐊧: true,
-};
-```
-
-#### 原因
-
-Prettier和Biome都会取消引用在JavaScript中有效的对象和类属性。Prettier [仅取消引用有效的ES5标识符](https://github.com/prettier/prettier/blob/a5d502513e5de4819a41fd90b9be7247146effc7/src/language-js/utils/index.js#L646)。
-
-在ES2015已经广泛应用的生态系统中，这似乎是一种遗留的限制。因此，我们决定在这里偏离，并取消引用ES2015+中的所有有效的JavaScript标识符。
-
-一个可能的解决方法是引入一个配置来设置项目使用的ECMAScript版本。然后，我们可以根据该版本调整取消引用行为。将ECMAScript版本设置为“ES5”可以与Prettier的行为相匹配。
-
-### Prettier对计算键中的赋值具有不一致的行为。
-
-输入
-
-```js title="example.js"
-a = {
-  [(this.resource = resource)]: 1,
-};
-```
-
-差异
-
-```js title="example.js" del={2} ins={3}
-a = {
-  [(this.resource = resource)]: 1,
-  [(this.resource = resource)]: 1,
-};
-```
-
-#### 原因
-
-Prettier和Biome在某些情况下，会在括号中包含一些赋值表达式，特别是在条件语句中。这样可以识别可能是比较的表达式。
-
-Prettier的行为是不一致的，因为它在对象属性的计算键中添加括号，但在类属性的计算键中不添加括号，如下面的示例所示：
-
-输入
-
-```js title="example.js"
-a = {
-  [(x = 0)]: 1,
-};
-
-class C {
-  [x = 0] = 1;
-}
-```
-
-输出
-
-```js title="example.js"
-a = {
-  [(x = 0)]: 1,
-};
-
-class C {
-  [x = 0] = 1;
-}
-```
-
-[Playground链接](https://biomejs.dev/playground?enabledLinting=false&code=YQAgAD0AIAB7AAoAIAAgAFsAeAAgAD0AIAAwAF0AOgAgADEALAAKAH0ACgAKAGMAbABhAHMAcwAgAEMAIAB7AAoAIAAgACAAIABbAHgAIAA9ACAAMABdACAAPQAgADEACgB9AAoA)
-
-为了保持一致，我们决定与Prettier分歧，并省略括号。或者，我们可以在对象或类的计算键中包含任何赋值。
-
-### Prettier接受接口的类型参数中的错误修饰符。
-
-输入
-
-```ts title="example.js"
-interface L<const in T> {}
-```
-
-差异
-
-```ts title="example.js" del={1} ins={2}
-interface L<const in T> {}
-interface L<const in T> {}
-```
-
-#### 原因
-
-如前所述，Prettier基于Babel的JS/TS解析非常宽松，允许忽略多个错误。Biome的解析器故意比Prettier更严格，正确断言接口的类型参数不允许使用`const`修饰符。
-
-在Prettier中，这个错误不被视为解析错误，AST仍然以适当的节点构建。在格式化时，Prettier会将这些节点视为正常节点并进行相应的格式化。
-
-在Biome中，解析错误会导致Bogus节点，它可以包含任意数量的有效节点、无效节点和/或原始令牌。在格式化时，Biome将Bogus节点视为纯文本，将其原样打印到生成的代码中，而不进行任何格式化，因为尝试格式化可能是不正确的并引起语义更改。
-
-### Prettier在箭头函数的类型参数中添加尾随逗号，即使不需要。
-
-输入
-
-```tsx title="example.tsx"
-<T = unknown,>() => {};
-```
-
-差异
-
-```tsx title="example.tsx" del={1} ins={2}
-<T = unknown,>() => {};
-<T = unknown,>() => {};
-```
-
-#### 原因
-
-在某些特定情况下，箭头函数的类型参数列表需要一个尾随逗号，以区分它与JSX元素。当提供默认类型时，不需要尾随逗号。在这里，我们与Prettier分歧，因为我们认为它更好地尊重了Prettier的原始意图，即仅在必要时添加尾随逗号。
-
-或者，我们可以在对象或类的计算键中包含任何赋值。

--- a/website/src/content/docs/zh-cn/formatter/index.mdx
+++ b/website/src/content/docs/zh-cn/formatter/index.mdx
@@ -41,23 +41,23 @@ Biome支持的与语言无关的选项有：
 {
   "formatter": {
     "enabled": true,
-    "ignore": [],
     "formatWithErrors": false,
+    "ignore": [],
+    "attributePosition": "auto",
     "indentStyle": "tab",
     "indentWidth": 2,
-    "lineWidth": 80,
     "lineEnding": "lf",
-    "attributePosition": "auto"
+    "lineWidth": 80
   },
   "javascript": {
     "formatter": {
       "arrowParentheses":"always",
-      "jsxQuoteStyle": "double",
-      "semicolons": "always",
-      "trailingComma": "all",
-      "quoteProperties": "asNeeded",
       "bracketSameLine": false,
-      "bracketSpacing": true
+      "bracketSpacing": true,
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "semicolons": "always",
+      "trailingComma": "all"
     }
   },
   "json": {

--- a/website/src/content/docs/zh-cn/guides/getting-started.mdx
+++ b/website/src/content/docs/zh-cn/guides/getting-started.mdx
@@ -66,7 +66,7 @@ Biome CLI提供了许多命令和选项，因此您可以只使用您需要的�
 
 您可以使用[`format`](/reference/cli#biome-format)命令和`--write`选项格式化文件和目录：
 
-<PackageManagerBiomeCommand command="format <files> --write"/>
+<PackageManagerBiomeCommand command="format --write <files>"/>
 
 您可以使用[`lint`](/reference/cli#biome-lint)命令和`--apply`选项来对文件和目录进行代码检查并应用[安全修复](/linter#safe-fixes)：
 


### PR DESCRIPTION
## Summary

This PR provides some minor improvements to the website docs:

- Getting Started
  - Remove some redundancies: we claim several times that Biome is opinionated.
  - Remove the jsonc code sample.
    It doesn't add so much value.
  - `format --write <files>` is more natural to users and simplify its modification when copied on the CLI
  - Add a link to our dedicated CI action
- Formatter
  - Merge general and language-specific options in a single code sample.
    Users reading this section for the first time might stop at the general options and wonder if Biome supports formatting options such as `arrowParentheses`.
    It seems better to put all the options in the same place.
    This also makes it easier to copy and paste the config.

## Test Plan

Ci should pass.
