### PR TITLE
fix(service): script block detection in `.svelte` and `.vue` files with `CRLF`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - `useExhaustiveDependencies` correctly reports missing dependencies declared
   using function declarations ([#2362](https://github.com/biomejs/biome/issues/2362)).
   Contributed by @arendjr
+- Biome now can handle `.svelte` and `.vue` files with `CRLF` as the end-of-line sequence. Contributed by @Sec-ant
 
 #### Enhancements
 

--- a/crates/biome_cli/tests/cases/handle_astro_files.rs
+++ b/crates/biome_cli/tests/cases/handle_astro_files.rs
@@ -51,6 +51,9 @@ import { getLocale } from "astro:i18n";
 ---
 <div></div>"#;
 
+const ASTRO_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED: &str =
+    "---\r\n  const a    = \"b\";\r\n---\r\n<div></div>";
+
 #[test]
 fn format_astro_files() {
     let mut fs = MemoryFileSystem::default();
@@ -140,6 +143,40 @@ fn format_empty_astro_files_write() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "format_empty_astro_files_write",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_astro_carriage_return_line_feed_files() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let astro_file_path = Path::new("file.astro");
+    fs.insert(
+        astro_file_path.into(),
+        ASTRO_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), astro_file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_file_contents(
+        &fs,
+        astro_file_path,
+        ASTRO_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED,
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_astro_carriage_return_line_feed_files",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/cases/handle_svelte_files.rs
+++ b/crates/biome_cli/tests/cases/handle_svelte_files.rs
@@ -30,6 +30,9 @@ const hello: string = "world";
 </script>
 <div></div>"#;
 
+const SVELTE_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED: &str =
+    "<script>\r\n  const a    = \"b\";\r\n</script>\r\n<div></div>";
+
 #[test]
 fn sorts_imports_check() {
     let mut fs = MemoryFileSystem::default();
@@ -176,6 +179,40 @@ fn format_svelte_ts_context_module_files_write() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "format_svelte_ts_context_module_files_write",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_svelte_carriage_return_line_feed_files() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let svelte_file_path = Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        SVELTE_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), svelte_file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_file_contents(
+        &fs,
+        svelte_file_path,
+        SVELTE_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED,
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_svelte_carriage_return_line_feed_files",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/cases/handle_vue_files.rs
+++ b/crates/biome_cli/tests/cases/handle_vue_files.rs
@@ -70,6 +70,9 @@ import Button from "./components/Button.vue";
 </script>
 <template></template>"#;
 
+const VUE_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED: &str =
+    "<script>\r\n  const a    = \"b\";\r\n</script>\r\n<template></template>";
+
 #[test]
 fn format_vue_implicit_js_files() {
     let mut fs = MemoryFileSystem::default();
@@ -327,6 +330,40 @@ fn format_empty_vue_ts_files_write() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "format_empty_vue_ts_files_write",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_vue_carriage_return_line_feed_files() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let vue_file_path = Path::new("file.vue");
+    fs.insert(
+        vue_file_path.into(),
+        VUE_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_file_contents(
+        &fs,
+        vue_file_path,
+        VUE_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED,
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_vue_carriage_return_line_feed_files",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_astro_carriage_return_line_feed_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_astro_carriage_return_line_feed_files.snap
@@ -1,0 +1,44 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.astro`
+
+```astro
+---
+  const a    = "b";
+---
+<div></div>
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.astro format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1 1 │   ---␍
+    2   │ - ··const·a····=·"b";␍
+      2 │ + const·a·=·"b";
+    3 3 │   ---␍
+    4 4 │   <div></div>
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_carriage_return_line_feed_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_carriage_return_line_feed_files.snap
@@ -1,0 +1,44 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.svelte`
+
+```svelte
+<script>
+  const a    = "b";
+</script>
+<div></div>
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.svelte format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1 1 │   <script>␍
+    2   │ - ··const·a····=·"b";␍
+      2 │ + const·a·=·"b";
+    3 3 │   </script>␍
+    4 4 │   <div></div>
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_carriage_return_line_feed_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_carriage_return_line_feed_files.snap
@@ -1,0 +1,44 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.vue`
+
+```vue
+<script>
+  const a    = "b";
+</script>
+<template></template>
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.vue format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1 1 │   <script>␍
+    2   │ - ··const·a····=·"b";␍
+      2 │ + const·a·=·"b";
+    3 3 │   </script>␍
+    4 4 │   <template></template>
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 1 error.
+```

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -24,9 +24,9 @@ use super::parse_lang_from_script_opening_tag;
 pub struct SvelteFileHandler;
 
 lazy_static! {
-    // https://regex101.com/r/E4n4hh/3
+    // https://regex101.com/r/E4n4hh/4
     pub static ref SVELTE_FENCE: Regex = Regex::new(
-        r#"(?ixms)(?<opening><script[^>]*>)\n(?P<script>(?U:.*))</script>"#
+        r#"(?ixs)(?<opening><script[^>]*>)\r?\n(?<script>(?U:.*))</script>"#
     )
     .unwrap();
 }
@@ -73,7 +73,9 @@ impl SvelteFileHandler {
             .captures(text)
             .and_then(|captures| {
                 match parse_lang_from_script_opening_tag(captures.name("opening")?.as_str()) {
-                    Language::JavaScript => None,
+                    Language::JavaScript => {
+                        Some(JsFileSource::js_module().with_embedding_kind(EmbeddingKind::Svelte))
+                    }
                     Language::TypeScript { .. } => {
                         Some(JsFileSource::ts().with_embedding_kind(EmbeddingKind::Svelte))
                     }

--- a/crates/biome_service/src/file_handlers/vue.rs
+++ b/crates/biome_service/src/file_handlers/vue.rs
@@ -73,7 +73,9 @@ impl VueFileHandler {
             .captures(text)
             .and_then(|captures| {
                 match parse_lang_from_script_opening_tag(captures.name("opening")?.as_str()) {
-                    Language::JavaScript => None,
+                    Language::JavaScript => {
+                        Some(JsFileSource::js_module().with_embedding_kind(EmbeddingKind::Vue))
+                    }
                     Language::TypeScript { .. } => {
                         Some(JsFileSource::ts().with_embedding_kind(EmbeddingKind::Vue))
                     }

--- a/crates/biome_service/src/file_handlers/vue.rs
+++ b/crates/biome_service/src/file_handlers/vue.rs
@@ -24,9 +24,9 @@ use super::parse_lang_from_script_opening_tag;
 pub struct VueFileHandler;
 
 lazy_static! {
-    // https://regex101.com/r/E4n4hh/3
+    // https://regex101.com/r/E4n4hh/4
     pub static ref VUE_FENCE: Regex = Regex::new(
-        r#"(?ixms)(?<opening><script[^>]*>)\n(?P<script>(?U:.*))</script>"#
+        r#"(?ixs)(?<opening><script[^>]*>)\r?\n(?<script>(?U:.*))</script>"#
     )
     .unwrap();
 }

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -28,6 +28,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - `useExhaustiveDependencies` correctly reports missing dependencies declared
   using function declarations ([#2362](https://github.com/biomejs/biome/issues/2362)).
   Contributed by @arendjr
+- Biome now can handle `.svelte` and `.vue` files with `CRLF` as the end-of-line sequence. Contributed by @Sec-ant
 
 #### Enhancements
 


### PR DESCRIPTION
## Summary

Windows users may use `CRLF` as the end-of-line sequence in their files. This PR fixes the regexes we use to detect script blocks in `.svelte` and `.vue` files to take carriage returns into account.

## Test Plan

Test cases added.
