### PR TITLE
fix(cli): skip traversing `fifo` or `socket` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,15 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### Bug fixes
 
 - Now Biome can detect the script language in Svelte and Vue script blocks more reliably ([#2245](https://github.com/biomejs/biome/issues/2245)). Contributed by @Sec-ant
+
 - `useExhaustiveDependencies` no longer reports recursive calls as missing
   dependencies ([#2361](https://github.com/biomejs/biome/issues/2361)).
   Contributed by @arendjr
+
 - `useExhaustiveDependencies` correctly reports missing dependencies declared
   using function declarations ([#2362](https://github.com/biomejs/biome/issues/2362)).
   Contributed by @arendjr
+
 - Biome now can handle `.svelte` and `.vue` files with `CRLF` as the end-of-line sequence. Contributed by @Sec-ant
 
 #### Enhancements
@@ -128,6 +131,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Biome now tags the diagnostics emitted by `organizeImports` and `formatter` with correct severity levels, so they will be properly filtered by the flag `--diagnositic-level` ([#2288](https://github.com/biomejs/biome/issues/2288)). Contributed by @Sec-ant
 
 - Biome now correctly filters out files that are not present in the current directory when using the `--changed` flag [#1996](https://github.com/biomejs/biome/issues/1996). Contributed by @castarco
+
+- Biome now skips traversing `fifo` or `socket` files ([#2311](https://github.com/biomejs/biome/issues/2311)). Contributed by @Sec-ant
 
 ### Configuration
 

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -499,7 +499,8 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
     }
 
     fn can_handle(&self, biome_path: &BiomePath) -> bool {
-        if !self.fs.path_is_file(biome_path.as_path()) {
+        let path = biome_path.as_path();
+        if self.fs.path_is_dir(path) || self.fs.path_is_symlink(path) {
             // handle:
             // - directories
             // - symlinks
@@ -517,6 +518,11 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
                     false
                 });
             return can_handle;
+        }
+
+        // bail on fifo and socket files
+        if !self.fs.path_is_file(path) {
+            return false;
         }
 
         let file_features = self.workspace.file_features(SupportsFeatureParams {

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -350,11 +350,11 @@ where
     }
 
     fn path_is_dir(&self, path: &Path) -> bool {
-        T::path_is_dir(&self, path)
+        T::path_is_dir(self, path)
     }
 
     fn path_is_symlink(&self, path: &Path) -> bool {
-        T::path_is_symlink(&self, path)
+        T::path_is_symlink(self, path)
     }
 
     fn get_changed_files(&self, base: &str) -> io::Result<Vec<String>> {

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -62,6 +62,12 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
     /// Checks if the given path is a regular file
     fn path_is_file(&self, path: &Path) -> bool;
 
+    /// Checks if the given path is a directory
+    fn path_is_dir(&self, path: &Path) -> bool;
+
+    /// Checks if the given path is a symlink
+    fn path_is_symlink(&self, path: &Path) -> bool;
+
     /// Method that takes a path to a folder `file_path`, and a `file_name`. It attempts to find
     /// and read the file from that folder and if not found, it reads the parent directories recursively
     /// until:
@@ -341,6 +347,14 @@ where
 
     fn path_is_file(&self, path: &Path) -> bool {
         T::path_is_file(self, path)
+    }
+
+    fn path_is_dir(&self, path: &Path) -> bool {
+        T::path_is_dir(&self, path)
+    }
+
+    fn path_is_symlink(&self, path: &Path) -> bool {
+        T::path_is_symlink(&self, path)
     }
 
     fn get_changed_files(&self, base: &str) -> io::Result<Vec<String>> {

--- a/crates/biome_fs/src/fs/memory.rs
+++ b/crates/biome_fs/src/fs/memory.rs
@@ -191,6 +191,14 @@ impl FileSystem for MemoryFileSystem {
         files.get(path).is_some()
     }
 
+    fn path_is_dir(&self, path: &Path) -> bool {
+        !self.path_is_file(path)
+    }
+
+    fn path_is_symlink(&self, _path: &Path) -> bool {
+        false
+    }
+
     fn get_changed_files(&self, _base: &str) -> io::Result<Vec<String>> {
         let cb_arc = self.on_get_changed_files.as_ref().unwrap().clone();
 

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -83,6 +83,14 @@ impl FileSystem for OsFileSystem {
         path.is_file()
     }
 
+    fn path_is_dir(&self, path: &Path) -> bool {
+        path.is_dir()
+    }
+
+    fn path_is_symlink(&self, path: &Path) -> bool {
+        path.is_symlink()
+    }
+
     fn resolve_configuration(
         &self,
         specifier: &str,

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -22,12 +22,15 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### Bug fixes
 
 - Now Biome can detect the script language in Svelte and Vue script blocks more reliably ([#2245](https://github.com/biomejs/biome/issues/2245)). Contributed by @Sec-ant
+
 - `useExhaustiveDependencies` no longer reports recursive calls as missing
   dependencies ([#2361](https://github.com/biomejs/biome/issues/2361)).
   Contributed by @arendjr
+
 - `useExhaustiveDependencies` correctly reports missing dependencies declared
   using function declarations ([#2362](https://github.com/biomejs/biome/issues/2362)).
   Contributed by @arendjr
+
 - Biome now can handle `.svelte` and `.vue` files with `CRLF` as the end-of-line sequence. Contributed by @Sec-ant
 
 #### Enhancements
@@ -134,6 +137,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Biome now tags the diagnostics emitted by `organizeImports` and `formatter` with correct severity levels, so they will be properly filtered by the flag `--diagnositic-level` ([#2288](https://github.com/biomejs/biome/issues/2288)). Contributed by @Sec-ant
 
 - Biome now correctly filters out files that are not present in the current directory when using the `--changed` flag [#1996](https://github.com/biomejs/biome/issues/1996). Contributed by @castarco
+
+- Biome now skips traversing `fifo` or `socket` files ([#2311](https://github.com/biomejs/biome/issues/2311)). Contributed by @Sec-ant
 
 ### Configuration
 


### PR DESCRIPTION
## Summary

Skip traversing `fifo` or `socket` files. The code now will only handle files, directories or symlinks.

Closes #2311

## Test Plan

Tested locally.