### PR TITLE
fix(configuration): `.jsonc` config deserialization in `extends`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Now setting group level `all` to `false` can disable recommended rules from that group when top level `recommended` is `true` or unset. Contributed by @Sec-ant
 
+- Biome configuration files can correctly extends `.jsonc` configuration files now ([#2279](https://github.com/biomejs/biome/issues/2279)). Contributed by @Sec-ant
+
 #### Enhancements
 
 - Biome now displays the location of a parsing error for its configuration file ([#1627](https://github.com/biomejs/biome/issues/1627)).

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -107,7 +107,7 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
                             Err(err) => {
                                 if !is_searching_in_parent_dir && should_error_if_file_not_found {
                                     let error_message = format!(
-                                        "Biome couldn't read the config file {:?}, reason:\n {}",
+                                        "Biome couldn't read the file {:?}, reason:\n {}",
                                         file_path, err
                                     );
                                     errors.push((
@@ -128,7 +128,7 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
                     Err(err) => {
                         if !is_searching_in_parent_dir && should_error_if_file_not_found {
                             let error_message = format!(
-                                "Biome couldn't find the config file {:?}, reason:\n {}",
+                                "Biome couldn't find the file {:?}, reason:\n {}",
                                 file_path, err
                             );
                             errors.push((

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -14,6 +14,7 @@ use biome_fs::{AutoSearchResult, ConfigName, FileSystem, OpenOptions};
 use biome_js_analyze::metadata;
 use biome_json_formatter::context::JsonFormatOptions;
 use biome_json_parser::{parse_json, JsonParserOptions};
+use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::io::ErrorKind;
 use std::iter::FusedIterator;
@@ -413,7 +414,12 @@ impl PartialConfigurationExt for PartialConfiguration {
             })?;
             let deserialized = deserialize_from_json_str::<PartialConfiguration>(
                 content.as_str(),
-                JsonParserOptions::default(),
+                match config_path.extension().and_then(OsStr::to_str) {
+                    Some("json") => JsonParserOptions::default(),
+                    _ => JsonParserOptions::default()
+                        .with_allow_comments()
+                        .with_allow_trailing_commas(),
+                },
                 "",
             );
             deserialized_configurations.push(deserialized)

--- a/crates/biome_service/tests/spec_tests.rs
+++ b/crates/biome_service/tests/spec_tests.rs
@@ -6,8 +6,8 @@ use std::ffi::OsStr;
 use std::fs::read_to_string;
 use std::path::Path;
 
-tests_macros::gen_tests! {"tests/invalid/**/*.{json}", crate::run_invalid_configurations, "module"}
-tests_macros::gen_tests! {"tests/valid/**/*.{json}", crate::run_valid_configurations, "module"}
+tests_macros::gen_tests! {"tests/invalid/**/*.{json,jsonc}", crate::run_invalid_configurations, "module"}
+tests_macros::gen_tests! {"tests/valid/**/*.{json,jsonc}", crate::run_valid_configurations, "module"}
 
 fn run_invalid_configurations(input: &'static str, _: &str, _: &str, _: &str) {
     let input_file = Path::new(input);
@@ -75,7 +75,9 @@ fn run_valid_configurations(input: &'static str, _: &str, _: &str, _: &str) {
         ),
         "jsonc" => deserialize_from_json_str::<PartialConfiguration>(
             input_code.as_str(),
-            JsonParserOptions::default().with_allow_comments(),
+            JsonParserOptions::default()
+                .with_allow_comments()
+                .with_allow_trailing_commas(),
             "",
         ),
         _ => {

--- a/crates/biome_service/tests/valid/extends_jsonc_m.json
+++ b/crates/biome_service/tests/valid/extends_jsonc_m.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./extends_jsonc_s.jsonc"]
+}

--- a/crates/biome_service/tests/valid/extends_jsonc_s.jsonc
+++ b/crates/biome_service/tests/valid/extends_jsonc_s.jsonc
@@ -1,0 +1,5 @@
+{
+  "linter": {
+    "enabled": false, // linter is disabled
+  }
+}

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -143,6 +143,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Now setting group level `all` to `false` can disable recommended rules from that group when top level `recommended` is `true` or unset. Contributed by @Sec-ant
 
+- Biome configuration files can correctly extends `.jsonc` configuration files now ([#2279](https://github.com/biomejs/biome/issues/2279)). Contributed by @Sec-ant
+
 #### Enhancements
 
 - Biome now displays the location of a parsing error for its configuration file ([#1627](https://github.com/biomejs/biome/issues/1627)).


### PR DESCRIPTION
## Summary

We were using the default JSON parser options for extended configuration deserialization. The PR fixes the parser options with a more forgiving settings for none `.json` configuration files.

## Test Plan

Added a test case.
