### PR TITLE
refactor: replace `ignoreReact` with `jsxRuntime` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,12 +194,11 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### New features
 
-- Add a new option `ignoreReact` to [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports).
+- Add a new option `jsxRuntime` to the `javascript` configuration. When set to `react_classic`, the [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) rules uses this information to make an exception for the React global that is required by the React Classic JSX transform.
 
-  When `ignoreReact` is enabled, Biome ignores imports of `React` from the `react` package.
-  The option is disabled by default.
+  This is only necessary for React users who haven't upgraded to the [new JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 
-  Contributed by @Conaclos
+  Contributed by @Conaclos and @arendjr
 
 - Implement [#2043](https://github.com/biomejs/biome/issues/2043): The React rule [`useExhaustiveDependencies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) is now also compatible with Preact hooks imported from `preact/hooks` or `preact/compat`. Contributed by @arendjr
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,7 +194,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### New features
 
-- Add a new option `jsxRuntime` to the `javascript` configuration. When set to `react_classic`, the [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) rules uses this information to make an exception for the React global that is required by the React Classic JSX transform.
+- Add a new option `jsxRuntime` to the `javascript` configuration. When set to `reactClassic`, the [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) rule uses this information to make an exception for the React global that is required by the React Classic JSX transform.
 
   This is only necessary for React users who haven't upgraded to the [new JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 

--- a/crates/biome_analyze/src/context.rs
+++ b/crates/biome_analyze/src/context.rs
@@ -1,4 +1,4 @@
-use crate::options::PreferredQuote;
+use crate::options::{JsxRuntime, PreferredQuote};
 use crate::{registry::RuleRoot, FromServices, Queryable, Rule, RuleKey, ServiceBag};
 use biome_diagnostics::{Error, Result};
 use std::ops::Deref;
@@ -19,6 +19,7 @@ where
     file_path: &'a Path,
     options: &'a R::Options,
     preferred_quote: &'a PreferredQuote,
+    jsx_runtime: JsxRuntime,
 }
 
 impl<'a, R> RuleContext<'a, R>
@@ -33,6 +34,7 @@ where
         file_path: &'a Path,
         options: &'a R::Options,
         preferred_quote: &'a PreferredQuote,
+        jsx_runtime: JsxRuntime,
     ) -> Result<Self, Error> {
         let rule_key = RuleKey::rule::<R>();
         Ok(Self {
@@ -44,6 +46,7 @@ where
             file_path,
             options,
             preferred_quote,
+            jsx_runtime,
         })
     }
 
@@ -95,6 +98,11 @@ where
     /// ```
     pub fn options(&self) -> &R::Options {
         self.options
+    }
+
+    /// Checks whether the JSX runtime matches the given value.
+    pub fn has_jsx_runtime(&self, jsx_runtime: JsxRuntime) -> bool {
+        self.jsx_runtime == jsx_runtime
     }
 
     /// Checks whether the provided text belongs to globals

--- a/crates/biome_analyze/src/context.rs
+++ b/crates/biome_analyze/src/context.rs
@@ -26,6 +26,7 @@ impl<'a, R> RuleContext<'a, R>
 where
     R: Rule + Sized + 'static,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         query_result: &'a RuleQueryResult<R>,
         root: &'a RuleRoot<R>,

--- a/crates/biome_analyze/src/options.rs
+++ b/crates/biome_analyze/src/options.rs
@@ -56,6 +56,9 @@ pub struct AnalyzerConfiguration {
 
     /// Allows to choose a different quote when applying fixes inside the lint rules
     pub preferred_quote: PreferredQuote,
+
+    /// Indicates the type of runtime or transformation used for interpreting JSX.
+    pub jsx_runtime: JsxRuntime,
 }
 
 /// A set of information useful to the analyzer infrastructure
@@ -67,6 +70,7 @@ pub struct AnalyzerOptions {
     /// The file that is being analyzed
     pub file_path: PathBuf,
 }
+
 impl AnalyzerOptions {
     pub fn globals(&self) -> Vec<&str> {
         self.configuration
@@ -74,6 +78,10 @@ impl AnalyzerOptions {
             .iter()
             .map(|global| global.as_str())
             .collect()
+    }
+
+    pub fn jsx_runtime(&self) -> JsxRuntime {
+        self.configuration.jsx_runtime
     }
 
     pub fn rule_options<R: 'static>(&self) -> Option<R::Options>
@@ -109,4 +117,11 @@ impl PreferredQuote {
     pub const fn is_single(&self) -> bool {
         matches!(self, Self::Single)
     }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum JsxRuntime {
+    #[default]
+    Transparent,
+    ReactClassic,
 }

--- a/crates/biome_analyze/src/registry.rs
+++ b/crates/biome_analyze/src/registry.rs
@@ -412,6 +412,7 @@ impl<L: Language + Default> RegistryRule<L> {
             let query_result = <R::Query as Queryable>::unwrap_match(params.services, query_result);
             let globals = params.options.globals();
             let preferred_quote = params.options.preferred_quote();
+            let jsx_runtime = params.options.jsx_runtime();
             let options = params.options.rule_options::<R>().unwrap_or_default();
             let ctx = match RuleContext::new(
                 &query_result,
@@ -421,6 +422,7 @@ impl<L: Language + Default> RegistryRule<L> {
                 &params.options.file_path,
                 &options,
                 preferred_quote,
+                jsx_runtime,
             ) {
                 Ok(ctx) => ctx,
                 Err(error) => return Err(error),

--- a/crates/biome_analyze/src/signals.rs
+++ b/crates/biome_analyze/src/signals.rs
@@ -357,6 +357,7 @@ where
             &self.options.file_path,
             &options,
             preferred_quote,
+            self.options.jsx_runtime(),
         )
         .ok()?;
 
@@ -374,7 +375,8 @@ where
             &globals,
             &self.options.file_path,
             &options,
-            &self.options.configuration.preferred_quote,
+            &self.options.preferred_quote(),
+            self.options.jsx_runtime(),
         )
         .ok();
         if let Some(ctx) = ctx {
@@ -419,7 +421,8 @@ where
             &globals,
             &self.options.file_path,
             &options,
-            &self.options.configuration.preferred_quote,
+            &self.options.preferred_quote(),
+            self.options.jsx_runtime(),
         )
         .ok();
         if let Some(ctx) = ctx {

--- a/crates/biome_analyze/src/signals.rs
+++ b/crates/biome_analyze/src/signals.rs
@@ -375,7 +375,7 @@ where
             &globals,
             &self.options.file_path,
             &options,
-            &self.options.preferred_quote(),
+            self.options.preferred_quote(),
             self.options.jsx_runtime(),
         )
         .ok();
@@ -421,7 +421,7 @@ where
             &globals,
             &self.options.file_path,
             &options,
-            &self.options.preferred_quote(),
+            self.options.preferred_quote(),
             self.options.jsx_runtime(),
         )
         .ok();

--- a/crates/biome_configuration/src/javascript/mod.rs
+++ b/crates/biome_configuration/src/javascript/mod.rs
@@ -85,7 +85,7 @@ impl FromStr for JsxRuntime {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "transparent" => Ok(Self::Transparent),
-            "reactClassic" => Ok(Self::ReactClassic),
+            "react-classic" | "reactClassic" => Ok(Self::ReactClassic),
             _ => Err("Unexpected value".to_string()),
         }
     }

--- a/crates/biome_configuration/src/javascript/mod.rs
+++ b/crates/biome_configuration/src/javascript/mod.rs
@@ -1,5 +1,7 @@
 mod formatter;
 
+use std::str::FromStr;
+
 use biome_deserialize::StringSet;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use bpaf::Bpaf;
@@ -28,6 +30,10 @@ pub struct JavascriptConfiguration {
     #[partial(bpaf(hide))]
     pub globals: StringSet,
 
+    /// Indicates the type of runtime or transformation used for interpreting JSX.
+    #[partial(bpaf(hide))]
+    pub jsx_runtime: JsxRuntime,
+
     #[partial(type, bpaf(external(partial_javascript_organize_imports), optional))]
     pub organize_imports: JavascriptOrganizeImports,
 }
@@ -49,4 +55,38 @@ pub struct JavascriptParser {
     /// These decorators belong to an old proposal, and they are subject to change.
     #[partial(bpaf(hide))]
     pub unsafe_parameter_decorators_enabled: bool,
+}
+
+/// Indicates the type of runtime or transformation used for interpreting JSX.
+#[derive(
+    Bpaf, Clone, Copy, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize,
+)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum JsxRuntime {
+    /// Indicates a modern or native JSX environment, that doesn't require
+    /// special handling by Biome.
+    #[default]
+    Transparent,
+
+    /// Indicates a classic React environment that requires the `React` import.
+    ///
+    /// Corresponds to the `react` value for the `jsx` option in TypeScript's
+    /// `tsconfig.json`.
+    ///
+    /// This option should only be necessary if you cannot upgrade to a React
+    /// version that supports the new JSX runtime. For more information about
+    /// the old vs. new JSX runtime, please see:
+    /// https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
+    ReactClassic,
+}
+
+impl FromStr for JsxRuntime {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "transparent" => Ok(Self::Transparent),
+            "reactClassic" => Ok(Self::ReactClassic),
+            _ => Err("Unexpected value".to_string()),
+        }
+    }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
@@ -4,10 +4,10 @@ use crate::{
     JsRuleAction,
 };
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
+    context::RuleContext, declare_rule, options::JsxRuntime, ActionCategory, FixKind, Rule,
+    RuleDiagnostic,
 };
 use biome_console::markup;
-use biome_deserialize_macros::Deserializable;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
 use biome_js_semantic::ReferencesExtensions;
@@ -16,10 +16,6 @@ use biome_js_syntax::{
     JsIdentifierBinding, JsImport, JsLanguage, JsNamedImportSpecifierList, JsSyntaxNode, T,
 };
 use biome_rowan::{AstNode, AstSeparatedList, BatchMutation, BatchMutationExt};
-use serde::{Deserialize, Serialize};
-
-#[cfg(feature = "schemars")]
-use schemars::JsonSchema;
 
 declare_rule! {
     /// Disallow unused imports.
@@ -34,22 +30,9 @@ declare_rule! {
     ///
     /// ## Options
     ///
-    /// The rule provides a single option `ignoreReact`.
-    /// When this option is set to `true`, imports named `React` from the package `react` are ignored.
-    /// `ignoreReact` is disabled by default.
-    ///
-    /// ```json
-    /// {
-    ///     "//": "...",
-    ///     "options": {
-    ///         "ignoreReact": true
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// This option should only be necessary if you cannot upgrade to a React version that supports the new JSX runtime.
-    /// In the new JSX runtime, you no longer need to import `React`.
-    /// You can find more details in [this comment](https://github.com/biomejs/biome/issues/571#issuecomment-1774026734).
+    /// This rule respects the [`jsxRuntime`](https://biomejs.dev/reference/configuration/#javascriptjsxruntime)
+    /// setting and will make an exception for React globals if it is set to
+    /// `"reactClassic"`.
     ///
     /// ## Examples
     ///
@@ -105,7 +88,7 @@ impl Rule for NoUnusedImports {
     type Query = Semantic<JsIdentifierBinding>;
     type State = ();
     type Signals = Option<Self::State>;
-    type Options = UnusedImportsOptions;
+    type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let binding = ctx.query();
@@ -113,7 +96,9 @@ impl Rule for NoUnusedImports {
         if !is_import(&declaration) {
             return None;
         }
-        if ctx.options().ignore_react && is_global_react_import(binding, ReactLibrary::React) {
+        if ctx.has_jsx_runtime(JsxRuntime::ReactClassic)
+            && is_global_react_import(binding, ReactLibrary::React)
+        {
             return None;
         }
         let model = ctx.model();
@@ -180,14 +165,6 @@ impl Rule for NoUnusedImports {
             message: markup! { "Remove the unused import." }.to_owned(),
         })
     }
-}
-
-#[derive(Clone, Debug, Default, Deserializable, Deserialize, Eq, PartialEq, Serialize)]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct UnusedImportsOptions {
-    /// Ignore `React` imports from the `react` package when set to `true`.
-    ignore_react: bool,
 }
 
 fn remove_import_specifier(

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-unused-react.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-unused-react.options.json
@@ -2,13 +2,11 @@
     "linter": {
         "rules": {
             "correctness": {
-                "noUnusedImports": {
-                    "level": "error",
-                    "options": {
-                        "ignoreReact": true
-                    }
-                }
+                "noUnusedImports": "error"
             }
         }
+    },
+    "javascript": {
+        "jsxRuntime": "reactClassic"
     }
 }

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-unused-react.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-unused-react.options.json
@@ -2,13 +2,11 @@
     "linter": {
         "rules": {
             "correctness": {
-                "noUnusedImports": {
-                    "level": "error",
-                    "options": {
-                        "ignoreReact": true
-                    }
-                }
+                "noUnusedImports": "error"
             }
         }
+    },
+    "javascript": {
+        "jsxRuntime": "reactClassic"
     }
 }

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -44,6 +44,8 @@ impl ServiceLanguage for CssLanguage {
     type OrganizeImportsSettings = ();
     type FormatOptions = CssFormatOptions;
     type ParserSettings = CssParserSettings;
+    type EnvironmentSettings = ();
+
     fn lookup_settings(language: &LanguageListSettings) -> &LanguageSettings<Self> {
         &language.css
     }

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -56,6 +56,8 @@ impl ServiceLanguage for JsonLanguage {
     type OrganizeImportsSettings = ();
     type FormatOptions = JsonFormatOptions;
     type ParserSettings = JsonParserSettings;
+    type EnvironmentSettings = ();
+
     fn lookup_settings(language: &LanguageListSettings) -> &LanguageSettings<Self> {
         &language.json
     }
@@ -397,6 +399,7 @@ fn compute_analyzer_options(settings: &SettingsHandle, file_path: PathBuf) -> An
         rules: to_analyzer_rules(settings.as_ref(), file_path.as_path()),
         globals: vec![],
         preferred_quote: PreferredQuote::Double,
+        jsx_runtime: Default::default(),
     };
     AnalyzerOptions {
         configuration,

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -2,6 +2,7 @@ use crate::workspace::DocumentFileSource;
 use crate::{Matcher, WorkspaceError};
 use biome_analyze::AnalyzerRules;
 use biome_configuration::diagnostics::InvalidIgnorePattern;
+use biome_configuration::javascript::JsxRuntime;
 use biome_configuration::organize_imports::OrganizeImports;
 use biome_configuration::{
     push_to_analyzer_rules, ConfigurationDiagnostic, CssConfiguration, FilesConfiguration,
@@ -314,6 +315,8 @@ pub struct LanguageListSettings {
 impl From<JavascriptConfiguration> for LanguageSettings<JsLanguage> {
     fn from(javascript: JavascriptConfiguration) -> Self {
         let mut language_setting: LanguageSettings<JsLanguage> = LanguageSettings::default();
+        language_setting.environment = javascript.jsx_runtime.into();
+
         let formatter = javascript.formatter;
         language_setting.formatter.quote_style = Some(formatter.quote_style);
         language_setting.formatter.jsx_quote_style = Some(formatter.jsx_quote_style);
@@ -381,6 +384,9 @@ pub trait ServiceLanguage: biome_rowan::Language {
     /// Settings that belong to the parser
     type ParserSettings: Default;
 
+    /// Settings related to the environment/runtime in which the language is used.
+    type EnvironmentSettings: Default;
+
     /// Read the settings type for this language from the [LanguageListSettings] map
     fn lookup_settings(languages: &LanguageListSettings) -> &LanguageSettings<Self>;
 
@@ -411,6 +417,9 @@ pub struct LanguageSettings<L: ServiceLanguage> {
 
     /// Parser settings for this language
     pub parser: L::ParserSettings,
+
+    /// Environment settings for this language
+    pub environment: L::EnvironmentSettings,
 }
 
 /// Filesystem settings for the entire workspace
@@ -587,6 +596,21 @@ impl OverrideSettings {
             })
             .cloned()
             .unwrap_or_default()
+    }
+
+    pub fn override_jsx_runtime(&self, path: &BiomePath, base_setting: JsxRuntime) -> JsxRuntime {
+        self.patterns
+            .iter()
+            .fold(base_setting, |jsx_runtime, pattern| {
+                let included = pattern.include.matches_path(path);
+                let excluded = pattern.exclude.matches_path(path);
+
+                if included && !excluded {
+                    pattern.languages.javascript.environment.jsx_runtime
+                } else {
+                    jsx_runtime
+                }
+            })
     }
 
     /// It scans the current override rules and return the formatting options that of the first override is matched
@@ -1154,6 +1178,10 @@ fn to_javascript_language_settings(
         .globals
         .map(StringSet::into_index_set)
         .or_else(|| parent_settings.globals.clone());
+
+    language_setting.environment.jsx_runtime = conf
+        .jsx_runtime
+        .unwrap_or(parent_settings.environment.jsx_runtime);
 
     language_setting
 }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -315,7 +315,6 @@ pub struct LanguageListSettings {
 impl From<JavascriptConfiguration> for LanguageSettings<JsLanguage> {
     fn from(javascript: JavascriptConfiguration) -> Self {
         let mut language_setting: LanguageSettings<JsLanguage> = LanguageSettings::default();
-        language_setting.environment = javascript.jsx_runtime.into();
 
         let formatter = javascript.formatter;
         language_setting.formatter.quote_style = Some(formatter.quote_style);
@@ -334,6 +333,7 @@ impl From<JavascriptConfiguration> for LanguageSettings<JsLanguage> {
             javascript.parser.unsafe_parameter_decorators_enabled;
 
         language_setting.globals = Some(javascript.globals.into_index_set());
+        language_setting.environment = javascript.jsx_runtime.into();
 
         language_setting
     }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -163,6 +163,10 @@ export interface PartialJavascriptConfiguration {
 If defined here, they should not emit diagnostics. 
 	 */
 	globals?: StringSet;
+	/**
+	 * Indicates the type of runtime or transformation used for interpreting JSX.
+	 */
+	jsx_runtime?: JsxRuntime;
 	organize_imports?: PartialJavascriptOrganizeImports;
 	/**
 	 * Parsing options
@@ -352,6 +356,10 @@ export interface PartialJavascriptFormatter {
 	 */
 	trailingComma?: TrailingComma;
 }
+/**
+ * Indicates the type of runtime or transformation used for interpreting JSX.
+ */
+export type JsxRuntime = "Transparent" | "ReactClassic";
 export interface PartialJavascriptOrganizeImports {}
 /**
  * Options that changes how the JavaScript parser behaves
@@ -834,7 +842,7 @@ export interface Correctness {
 	/**
 	 * Disallow unused imports.
 	 */
-	noUnusedImports?: RuleConfiguration_for_UnusedImportsOptions;
+	noUnusedImports?: RuleConfiguration_for_Null;
 	/**
 	 * Disallow unused labels.
 	 */
@@ -1481,9 +1489,6 @@ export type RuleConfiguration_for_ValidAriaRoleOptions =
 export type RuleConfiguration_for_ComplexityOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_ComplexityOptions;
-export type RuleConfiguration_for_UnusedImportsOptions =
-	| RulePlainConfiguration
-	| RuleWithOptions_for_UnusedImportsOptions;
 export type RuleConfiguration_for_HooksOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_HooksOptions;
@@ -1520,10 +1525,6 @@ export interface RuleWithOptions_for_ValidAriaRoleOptions {
 export interface RuleWithOptions_for_ComplexityOptions {
 	level: RulePlainConfiguration;
 	options: ComplexityOptions;
-}
-export interface RuleWithOptions_for_UnusedImportsOptions {
-	level: RulePlainConfiguration;
-	options: UnusedImportsOptions;
 }
 export interface RuleWithOptions_for_HooksOptions {
 	level: RulePlainConfiguration;
@@ -1569,12 +1570,6 @@ export interface ComplexityOptions {
 	 * The maximum complexity score that we allow. Anything higher is considered excessive.
 	 */
 	maxAllowedComplexity: number;
-}
-export interface UnusedImportsOptions {
-	/**
-	 * Ignore `React` imports from the `react` package when set to `true`.
-	 */
-	ignoreReact: boolean;
 }
 /**
  * Options for the rule `useExhaustiveDependencies`

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -737,7 +737,7 @@
 				"noUnusedImports": {
 					"description": "Disallow unused imports.",
 					"anyOf": [
-						{ "$ref": "#/definitions/UnusedImportsConfiguration" },
+						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1107,6 +1107,10 @@
 					"description": "A list of global bindings that should be ignored by the analyzers\n\nIf defined here, they should not emit diagnostics.",
 					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
 				},
+				"jsx_runtime": {
+					"description": "Indicates the type of runtime or transformation used for interpreting JSX.",
+					"anyOf": [{ "$ref": "#/definitions/JsxRuntime" }, { "type": "null" }]
+				},
 				"organize_imports": {
 					"anyOf": [
 						{ "$ref": "#/definitions/JavascriptOrganizeImports" },
@@ -1300,6 +1304,21 @@
 				}
 			},
 			"additionalProperties": false
+		},
+		"JsxRuntime": {
+			"description": "Indicates the type of runtime or transformation used for interpreting JSX.",
+			"oneOf": [
+				{
+					"description": "Indicates a modern or native JSX environment, that doesn't require special handling by Biome.",
+					"type": "string",
+					"enum": ["Transparent"]
+				},
+				{
+					"description": "Indicates a classic React environment that requires the `React` import.\n\nCorresponds to the `react` value for the `jsx` option in TypeScript's `tsconfig.json`.\n\nThis option should only be necessary if you cannot upgrade to a React version that supports the new JSX runtime. For more information about the old vs. new JSX runtime, please see: https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html",
+					"type": "string",
+					"enum": ["ReactClassic"]
+				}
+			]
 		},
 		"LineEnding": {
 			"oneOf": [
@@ -1865,15 +1884,6 @@
 			"properties": {
 				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
 				"options": { "$ref": "#/definitions/RestrictedImportsOptions" }
-			},
-			"additionalProperties": false
-		},
-		"RuleWithUnusedImportsOptions": {
-			"type": "object",
-			"required": ["level", "options"],
-			"properties": {
-				"level": { "$ref": "#/definitions/RulePlainConfiguration" },
-				"options": { "$ref": "#/definitions/UnusedImportsOptions" }
 			},
 			"additionalProperties": false
 		},
@@ -2701,23 +2711,6 @@
 					"enum": ["all"]
 				}
 			]
-		},
-		"UnusedImportsConfiguration": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithUnusedImportsOptions" }
-			]
-		},
-		"UnusedImportsOptions": {
-			"type": "object",
-			"required": ["ignoreReact"],
-			"properties": {
-				"ignoreReact": {
-					"description": "Ignore `React` imports from the `react` package when set to `true`.",
-					"type": "boolean"
-				}
-			},
-			"additionalProperties": false
 		},
 		"UtilityClassSortingConfiguration": {
 			"anyOf": [

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -200,12 +200,11 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### New features
 
-- Add a new option `ignoreReact` to [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports).
+- Add a new option `jsxRuntime` to the `javascript` configuration. When set to `react_classic`, the [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) rules uses this information to make an exception for the React global that is required by the React Classic JSX transform.
 
-  When `ignoreReact` is enabled, Biome ignores imports of `React` from the `react` package.
-  The option is disabled by default.
+  This is only necessary for React users who haven't upgraded to the [new JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 
-  Contributed by @Conaclos
+  Contributed by @Conaclos and @arendjr
 
 - Implement [#2043](https://github.com/biomejs/biome/issues/2043): The React rule [`useExhaustiveDependencies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) is now also compatible with Preact hooks imported from `preact/hooks` or `preact/compat`. Contributed by @arendjr
 

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -200,7 +200,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### New features
 
-- Add a new option `jsxRuntime` to the `javascript` configuration. When set to `react_classic`, the [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) rules uses this information to make an exception for the React global that is required by the React Classic JSX transform.
+- Add a new option `jsxRuntime` to the `javascript` configuration. When set to `reactClassic`, the [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) rule uses this information to make an exception for the React global that is required by the React Classic JSX transform.
 
   This is only necessary for React users who haven't upgraded to the [new JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 

--- a/website/src/content/docs/linter/rules/no-unused-imports.md
+++ b/website/src/content/docs/linter/rules/no-unused-imports.md
@@ -16,22 +16,9 @@ like `@ts-expect-error` won't be transferred to a wrong place.
 
 ## Options
 
-The rule provides a single option `ignoreReact`.
-When this option is set to `true`, imports named `React` from the package `react` are ignored.
-`ignoreReact` is disabled by default.
-
-```json
-{
-    "//": "...",
-    "options": {
-        "ignoreReact": true
-    }
-}
-```
-
-This option should only be necessary if you cannot upgrade to a React version that supports the new JSX runtime.
-In the new JSX runtime, you no longer need to import `React`.
-You can find more details in [this comment](https://github.com/biomejs/biome/issues/571#issuecomment-1774026734).
+This rule respects the [`jsxRuntime`](https://biomejs.dev/reference/configuration/#javascriptjsxruntime)
+setting and will make an exception for React globals if it is set to
+`"reactClassic"`.
 
 ## Examples
 

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -622,8 +622,6 @@ The attribute position style in jsx elements.
 
 A list of global names that Biome should ignore (analyzer, linter, etc.)
 
-
-
 ```json title="biome.json"
 {
   "javascript": {
@@ -631,6 +629,29 @@ A list of global names that Biome should ignore (analyzer, linter, etc.)
   }
 }
 ```
+
+### `javascript.jsxRuntime`
+
+Indicates the type of runtime or transformation used for interpreting JSX.
+
+- `"transparent"` &mdash; Indicates a modern or native JSX environment, that
+  doesn't require special handling by Biome.
+- `"reactClassic"` &mdash; Indicates a classic React environment that requires
+  the `React` import. Corresponds to the `react` value for the
+  `jsx` option in TypeScript's [`tsconfig.json`](https://www.typescriptlang.org/tsconfig#jsx).
+
+```json title="biome.json"
+{
+  "javascript": {
+    "jsxRuntime": "reactClassic"
+  }
+}
+```
+
+For more information about the old vs. new JSX runtime, please see:
+https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
+
+> Default: `"transparent"`
 
 ## `json`
 


### PR DESCRIPTION
## Summary

This replaces the `ignoreReact` setting for the `noUnusedImports` hook with a JavaScript-global `jsxRuntime` setting. This will allow it to be reused by the `useImportType` rule.

See discussion: https://github.com/biomejs/biome/issues/2004

## Test Plan

Automated tests are updated and still passing.
