### PR TITLE
fix(lint/useImportType): respect `jsxRuntime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,7 +196,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### New features
 
-- Add a new option `jsxRuntime` to the `javascript` configuration. When set to `reactClassic`, the [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) rule uses this information to make an exception for the React global that is required by the React Classic JSX transform.
+- Add a new option `jsxRuntime` to the `javascript` configuration. When set to `reactClassic`, the [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) and [useImportType](https://biomejs.dev/linter/rules/use-import-type) rules use this information to make exceptions for the React global that is required by the React Classic JSX transform.
 
   This is only necessary for React users who haven't upgraded to the [new JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 

--- a/crates/biome_analyze/src/context.rs
+++ b/crates/biome_analyze/src/context.rs
@@ -101,9 +101,9 @@ where
         self.options
     }
 
-    /// Checks whether the JSX runtime matches the given value.
-    pub fn has_jsx_runtime(&self, jsx_runtime: JsxRuntime) -> bool {
-        self.jsx_runtime == jsx_runtime
+    /// Returns the JSX runtime in use.
+    pub fn jsx_runtime(&self) -> JsxRuntime {
+        self.jsx_runtime
     }
 
     /// Checks whether the provided text belongs to globals

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
@@ -96,7 +96,7 @@ impl Rule for NoUnusedImports {
         if !is_import(&declaration) {
             return None;
         }
-        if ctx.has_jsx_runtime(JsxRuntime::ReactClassic)
+        if ctx.jsx_runtime() == JsxRuntime::ReactClassic
             && is_global_react_import(binding, ReactLibrary::React)
         {
             return None;

--- a/crates/biome_js_analyze/src/lint/style/use_import_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_import_type.rs
@@ -145,7 +145,7 @@ impl Rule for UseImportType {
                     AnyJsCombinedSpecifier::JsNamespaceImportSpecifier(namespace_specifier) => {
                         let namespace_binding = namespace_specifier.local_name().ok()?;
                         let namespace_binding = namespace_binding.as_js_identifier_binding()?;
-                        if ctx.has_jsx_runtime(JsxRuntime::ReactClassic)
+                        if ctx.jsx_runtime() == JsxRuntime::ReactClassic
                             && is_global_react_import(namespace_binding, ReactLibrary::React)
                         {
                             return None;
@@ -166,7 +166,7 @@ impl Rule for UseImportType {
             AnyJsImportClause::JsImportDefaultClause(clause) => {
                 let default_binding = clause.default_specifier().ok()?.local_name().ok()?;
                 let default_binding = default_binding.as_js_identifier_binding()?;
-                if ctx.has_jsx_runtime(JsxRuntime::ReactClassic)
+                if ctx.jsx_runtime() == JsxRuntime::ReactClassic
                     && is_global_react_import(default_binding, ReactLibrary::React)
                 {
                     return None;
@@ -185,7 +185,7 @@ impl Rule for UseImportType {
             AnyJsImportClause::JsImportNamespaceClause(clause) => {
                 let namespace_binding = clause.namespace_specifier().ok()?.local_name().ok()?;
                 let namespace_binding = namespace_binding.as_js_identifier_binding()?;
-                if ctx.has_jsx_runtime(JsxRuntime::ReactClassic)
+                if ctx.jsx_runtime() == JsxRuntime::ReactClassic
                     && is_global_react_import(namespace_binding, ReactLibrary::React)
                 {
                     return None;

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-unused-react-types.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-unused-react-types.options.json
@@ -1,0 +1,12 @@
+{
+    "linter": {
+        "rules": {
+            "style": {
+                "useImportType": "error"
+            }
+        }
+    },
+    "javascript": {
+        "jsxRuntime": "reactClassic"
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-unused-react-types.tsx
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-unused-react-types.tsx
@@ -1,0 +1,7 @@
+import * as ReactTypes from "react";
+
+function Component() {
+    const onClick = (event: ReactTypes.MouseEvent) => { };
+
+    return <div onClick={onClick}></div>;
+}

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-unused-react-types.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-unused-react-types.tsx.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid-unused-react-types.tsx
+---
+# Input
+```tsx
+import * as ReactTypes from "react";
+
+function Component() {
+    const onClick = (event: ReactTypes.MouseEvent) => { };
+
+    return <div onClick={onClick}></div>;
+}
+
+```
+
+# Diagnostics
+```
+invalid-unused-react-types.tsx:1:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! All these imports are only used as types.
+  
+  > 1 │ import * as ReactTypes from "react";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ 
+    3 │ function Component() {
+  
+  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  
+  i Safe fix: Use import type.
+  
+    1 │ import·type·*·as·ReactTypes·from·"react";
+      │        +++++                             
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react-types.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react-types.options.json
@@ -1,0 +1,12 @@
+{
+    "linter": {
+        "rules": {
+            "style": {
+                "useImportType": "error"
+            }
+        }
+    },
+    "javascript": {
+        "jsxRuntime": "reactClassic"
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react-types.tsx
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react-types.tsx
@@ -1,0 +1,7 @@
+import * as React from "react";
+
+function Component() {
+    const onClick = (event: React.MouseEvent) => { };
+
+    return <div onClick={onClick}></div>;
+}

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react-types.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react-types.tsx.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-unused-react-types.tsx
+---
+# Input
+```tsx
+import * as React from "react";
+
+function Component() {
+    const onClick = (event: React.MouseEvent) => { };
+
+    return <div onClick={onClick}></div>;
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react.options.json
@@ -1,0 +1,12 @@
+{
+    "linter": {
+        "rules": {
+            "style": {
+                "useImportType": "error"
+            }
+        }
+    },
+    "javascript": {
+        "jsxRuntime": "reactClassic"
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react.tsx
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function Component() {
+    const onClick = (event: React.MouseEvent) => { };
+
+    return <div onClick={onClick}></div>;
+}

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react.tsx.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-unused-react.tsx
+---
+# Input
+```tsx
+import React from "react";
+
+function Component() {
+    const onClick = (event: React.MouseEvent) => { };
+
+    return <div onClick={onClick}></div>;
+}
+
+```

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -202,7 +202,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### New features
 
-- Add a new option `jsxRuntime` to the `javascript` configuration. When set to `reactClassic`, the [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) rule uses this information to make an exception for the React global that is required by the React Classic JSX transform.
+- Add a new option `jsxRuntime` to the `javascript` configuration. When set to `reactClassic`, the [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports) and [useImportType](https://biomejs.dev/linter/rules/use-import-type) rules use this information to make exceptions for the React global that is required by the React Classic JSX transform.
 
   This is only necessary for React users who haven't upgraded to the [new JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 

--- a/website/src/content/docs/linter/rules/use-import-type.md
+++ b/website/src/content/docs/linter/rules/use-import-type.md
@@ -19,6 +19,12 @@ This also ensures that some modules are not loaded at runtime.
 The rule ensures that all imports used only as a type use a type-only `import`.
 It also groups inline type imports into a grouped `import type`.
 
+## Options
+
+This rule respects the [`jsxRuntime`](https://biomejs.dev/reference/configuration/#javascriptjsxruntime)
+setting and will make an exception for React globals if it is set to
+`"reactClassic"`.
+
 ## Examples
 
 ### Invalid


### PR DESCRIPTION
## Summary

Don't treat `React` as a type-only import when the `jsxRuntime` is set to `reactClassic`.

Fixes #2004.

## Test Plan

Test cases added.
