### PR TITLE
feat(css_formatter): Incorrect spacing around `CssGenericDelimiter` elements.

### DIFF
--- a/crates/biome_css_formatter/src/utils/component_value_list.rs
+++ b/crates/biome_css_formatter/src/utils/component_value_list.rs
@@ -1,5 +1,5 @@
 use crate::comments::CssComments;
-use biome_css_syntax::CssLanguage;
+use biome_css_syntax::{CssGenericDelimiter, CssLanguage, CssSyntaxKind};
 use biome_formatter::FormatResult;
 use biome_formatter::{write, CstFormatContext};
 
@@ -14,9 +14,32 @@ where
 {
     let layout = get_value_list_layout(node, f.context().comments());
     let values = format_with(|f: &mut Formatter<'_, CssFormatContext>| {
-        f.fill()
-            .entries(&soft_line_break_or_space(), node.iter().formatted())
-            .finish()
+        let mut fill = f.fill();
+
+        for (element, formatted) in node.iter().zip(node.iter().formatted()) {
+            fill.entry(
+                &format_once(|f| {
+                    // If the current element is not a comma, insert a soft line break or a space.
+                    // Consider the CSS example: `font: first , second;`
+                    // The desired format is: `font: first, second;`
+                    // A separator should not be added before the comma because the comma acts as a `CssGenericDelimiter`.
+                    let is_comma = CssGenericDelimiter::cast_ref(element.syntax())
+                        .and_then(|node| node.value().ok())
+                        .map_or(false, |node|{
+                            node.kind() == CssSyntaxKind::COMMA
+                        });
+
+                    if !is_comma {
+                        write!(f, [soft_line_break_or_space()])?
+                    }
+
+                    Ok(())
+                }),
+                &formatted,
+            );
+        }
+
+        fill.finish()
     });
 
     match layout {

--- a/crates/biome_css_formatter/src/utils/component_value_list.rs
+++ b/crates/biome_css_formatter/src/utils/component_value_list.rs
@@ -25,9 +25,7 @@ where
                     // A separator should not be added before the comma because the comma acts as a `CssGenericDelimiter`.
                     let is_comma = CssGenericDelimiter::cast_ref(element.syntax())
                         .and_then(|node| node.value().ok())
-                        .map_or(false, |node|{
-                            node.kind() == CssSyntaxKind::COMMA
-                        });
+                        .map_or(false, |node| node.kind() == CssSyntaxKind::COMMA);
 
                     if !is_comma {
                         write!(f, [soft_line_break_or_space()])?

--- a/crates/biome_css_formatter/tests/specs/css/atrule/font_face.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/font_face.css.snap
@@ -114,33 +114,33 @@ Quote style: Double Quotes
 ```css
 @font-face {
 	font-family: "Open Sans";
-	src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
+	src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
 		url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 @font-face {
 	font-family: "Open Sans";
-	src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
+	src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
 		url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 @font-face {
 	font-family: "Open Sans";
-	src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
+	src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
 		url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 @font-face {
 	font-family: "Open Sans";
-	src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
+	src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
 		url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 @font-face {
 	font-family: "Open Sans";
-	src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
+	src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
 		url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 @font-face {
 	font-family: "Open Sans";
 
-	src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
+	src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
 		url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 ```

--- a/crates/biome_css_formatter/tests/specs/css/declaration_list.css
+++ b/crates/biome_css_formatter/tests/specs/css/declaration_list.css
@@ -11,17 +11,23 @@
 
 .empty-line {
     color: blue;
-    
+
     background-color: red;
 }
 .grouping {
 color: blue   ;color: green    ;
     color  : red ;
-    
+
 
         background-color:      red;
     font-size:   12px;
-    
-    
+
+
     font-weight   :   700;
+}
+
+a {
+	--bs-font-monospace: sfmono-regular /  menlo;
+	--bs-font-monospace: sfmono-regular , menlo , monaco , consolas ,
+	'Liberation Mono' , 'Courier New' , monospace;
 }

--- a/crates/biome_css_formatter/tests/specs/css/declaration_list.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/declaration_list.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/declaration_list.css
 ---
-
 # Input
 
 ```css
@@ -19,20 +18,27 @@ info: css/declaration_list.css
 
 .empty-line {
     color: blue;
-    
+
     background-color: red;
 }
 .grouping {
 color: blue   ;color: green    ;
     color  : red ;
-    
+
 
         background-color:      red;
     font-size:   12px;
-    
-    
+
+
     font-weight   :   700;
 }
+
+a {
+	--bs-font-monospace: sfmono-regular /  menlo;
+	--bs-font-monospace: sfmono-regular , menlo , monaco , consolas ,
+	'Liberation Mono' , 'Courier New' , monospace;
+}
+
 ```
 
 
@@ -84,6 +90,10 @@ Quote style: Double Quotes
 
 	font-weight: 700;
 }
+
+a {
+	--bs-font-monospace: sfmono-regular / menlo;
+	--bs-font-monospace: sfmono-regular, menlo, monaco, consolas,
+		"Liberation Mono", "Courier New", monospace;
+}
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/css/properties/all.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/properties/all.css.snap
@@ -54,7 +54,7 @@ div {
 	all: revert-layer;
 
 	all: unknown-value;
-	all: a , value list;
+	all: a, value list;
 }
 
 :root {

--- a/crates/biome_css_formatter/tests/specs/css/properties/border.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/properties/border.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/properties/border.css
 ---
-
 # Input
 
 ```css
@@ -70,7 +69,7 @@ div {
 	border: inherit;
 
 	border: zzz-unknown-value;
-	border: a , value list;
+	border: a, value list;
 
 	/* <line-style> */
 	border: solid;
@@ -90,5 +89,3 @@ div {
 	border: #000 medium dashed;
 }
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/css/properties/custom.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/properties/custom.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/properties/custom.css
 ---
-
 # Input
 
 ```css
@@ -44,10 +43,8 @@ div {
 	/* Custom property, always generic */
 	--custom-property: one-value;
 	--custom-property: multiple values;
-	--custom-property: delimited , values;
+	--custom-property: delimited, values;
 	--custom-property: delimited / slash / values;
-	--custom-property: mixed , delimiters / can be , used;
+	--custom-property: mixed, delimiters / can be, used;
 }
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/css/properties/generic.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/properties/generic.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/properties/generic.css
 ---
-
 # Input
 
 ```css
@@ -44,10 +43,8 @@ div {
 	/* Custom property, always generic */
 	unknown-property: one-value;
 	unknown-property: multiple values;
-	unknown-property: delimited , values;
+	unknown-property: delimited, values;
 	unknown-property: delimited / slash / values;
-	unknown-property: mixed , delimiters / can be , used;
+	unknown-property: mixed, delimiters / can be, used;
 }
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/atrule/font-face.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/atrule/font-face.css.snap
@@ -108,35 +108,35 @@ format(
    font-family: "Open Sans";
 -  src:
 -    url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
-+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
++  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
      url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
  }
  @font-face {
    font-family: "Open Sans";
 -  src:
 -    url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
-+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
++  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
      url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
  }
  @font-face {
    font-family: "Open Sans";
 -  src:
 -    url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
-+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
++  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
      url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
  }
  @font-face {
    font-family: "Open Sans";
 -  src:
 -    url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
-+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
++  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
      url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
  }
  @font-face {
    font-family: "Open Sans";
 -  src:
 -    url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
-+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
++  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
      url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
  }
  @font-face {
@@ -144,7 +144,7 @@ format(
  
 -  src:
 -    url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
-+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
++  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
      url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
  }
 ```
@@ -154,33 +154,33 @@ format(
 ```css
 @font-face {
   font-family: "Open Sans";
-  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
     url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 @font-face {
   font-family: "Open Sans";
-  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
     url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 @font-face {
   font-family: "Open Sans";
-  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
     url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 @font-face {
   font-family: "Open Sans";
-  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
     url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 @font-face {
   font-family: "Open Sans";
-  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
     url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 @font-face {
   font-family: "Open Sans";
 
-  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2") ,
+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
     url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
 }
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/css/comments/declaration.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/comments/declaration.css.snap
@@ -107,8 +107,8 @@ body
 -    local(/* comment 17 */ "Prettier" /* comment 18 */),
 -    /* comment 19 */ /* comment 20 */ url("http://prettier.com/font.woff")
 -      /* comment 21 */; /* comment 22 */
-+  /* comment 16 */ src: local(/* comment 17 */ "Prettier" /* comment 18 */)
-+    , /* comment 19 */ /* comment 20 */ url("http://prettier.com/font.woff") /* comment 21 */; /* comment 22 */
++  /* comment 16 */ src: local(/* comment 17 */ "Prettier" /* comment 18 */), /* comment 19 */
++    /* comment 20 */ url("http://prettier.com/font.woff") /* comment 21 */; /* comment 22 */
  }
  
  .foo {
@@ -195,8 +195,8 @@ a {
 
 @font-face {
   font-family: "Prettier";
-  /* comment 16 */ src: local(/* comment 17 */ "Prettier" /* comment 18 */)
-    , /* comment 19 */ /* comment 20 */ url("http://prettier.com/font.woff") /* comment 21 */; /* comment 22 */
+  /* comment 16 */ src: local(/* comment 17 */ "Prettier" /* comment 18 */), /* comment 19 */
+    /* comment 20 */ url("http://prettier.com/font.woff") /* comment 21 */; /* comment 22 */
 }
 
 .foo {
@@ -273,7 +273,8 @@ body {
 # Lines exceeding max width of 80 characters
 ```
     7:   /* comment 11 */ color: red /* comment 12 */ !important /* comment 13 */; /* comment 14 */
-   14:     , /* comment 19 */ /* comment 20 */ url("http://prettier.com/font.woff") /* comment 21 */; /* comment 22 */
+   13:   /* comment 16 */ src: local(/* comment 17 */ "Prettier" /* comment 18 */), /* comment 19 */
+   14:     /* comment 20 */ url("http://prettier.com/font.woff") /* comment 21 */; /* comment 22 */
    18:   /* comment 23 */ /* comment 24 */ /* comment 25 */ color: blue /* comment 26 */; /* comment 27 */
    24:   /* comment 34 */ /* comment 35 */ /* comment 36 */ color: blue /* comment 37 */; /* comment 38 */
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/css/fill-value/fill.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/fill-value/fill.css.snap
@@ -29,7 +29,7 @@ div {
 -    Helvetica,
 -    Arial,
 +    mix($warningbackgroundcolors, $warningbordercolors, 50%);
-+  $fontfamily: "Lato" , -apple-system , "Helvetica Neue" , helvetica , arial ,
++  $fontfamily: "Lato", -apple-system, "Helvetica Neue", helvetica, arial,
      sans-serif;
  }
 ```
@@ -40,7 +40,7 @@ div {
 div {
   border-left: 1px solid
     mix($warningbackgroundcolors, $warningbordercolors, 50%);
-  $fontfamily: "Lato" , -apple-system , "Helvetica Neue" , helvetica , arial ,
+  $fontfamily: "Lato", -apple-system, "Helvetica Neue", helvetica, arial,
     sans-serif;
 }
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/css/indent/indent.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/indent/indent.css.snap
@@ -26,7 +26,7 @@ div {
 -  box-shadow:
 -    0 0 1px 2px rgba(88, 144, 255, 0.75),
 -    0 1px 1px rgba(0, 0, 0, 0.15);
-+  box-shadow: 0 0 1px 2px rgba(88, 144, 255, 0.75) , 0 1px 1px
++  box-shadow: 0 0 1px 2px rgba(88, 144, 255, 0.75), 0 1px 1px
 +    rgba(0, 0, 0, 0.15);
    padding-bottom: calc(
      var(ads-help-tray-footer-with-support-link-height) +
@@ -42,7 +42,7 @@ div {
 div {
   background: var(fig-light-02) url(/images/inset-shadow-east-ltr.png) 100% 0
     repeat-y;
-  box-shadow: 0 0 1px 2px rgba(88, 144, 255, 0.75) , 0 1px 1px
+  box-shadow: 0 0 1px 2px rgba(88, 144, 255, 0.75), 0 1px 1px
     rgba(0, 0, 0, 0.15);
   padding-bottom: calc(
     var(ads-help-tray-footer-with-support-link-height) +

--- a/crates/biome_css_formatter/tests/specs/prettier/css/modules/modules.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/modules/modules.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/modules/modules.css
 ---
-
 # Input
 
 ```css
@@ -113,15 +112,6 @@ info: css/modules/modules.css
  }
  
  :global {
-@@ -34,7 +41,7 @@
- .root :global .text {
-   color: brown;
-   font-size: 24px;
--  font-family: helvetica, arial, sans-serif;
-+  font-family: helvetica , arial , sans-serif;
-   font-weight: 600;
- }
- 
 @@ -42,7 +49,7 @@
    localAlias: keyFromDep;
  }
@@ -179,7 +169,7 @@ third from colors
 .root :global .text {
   color: brown;
   font-size: 24px;
-  font-family: helvetica , arial , sans-serif;
+  font-family: helvetica, arial, sans-serif;
   font-weight: 600;
 }
 
@@ -451,5 +441,3 @@ modules.css:48:12 parse ━━━━━━━━━━━━━━━━━━�
   
 
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/url/url.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/url/url.css.snap
@@ -65,13 +65,13 @@ a {
 -    no-repeat url(foo.ttf?query=foo,bar,),
 -    no-repeat url(foo.woff2?foo=rgb\(255,255,0\))
 -    no-repeat url(RobotoFlex-VariableFont_GRAD,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght.ttf);
-+  background: no-repeat url(https://example.com/\)\).jpg) , no-repeat
-+    url(https://example.com/\(\(.jpg) , no-repeat
-+    url(https://example.com/\ \ .jpg) , no-repeat
-+    url(https://example.com/\)\).jpg   ) , no-repeat
-+    url(https://example.com/\(\(.jpg   ) , no-repeat
-+    url(https://example.com/\ \ .jpg   ) , no-repeat url(foo.ttf?query=foo,bar,)
-+    , no-repeat url(foo.woff2?foo=rgb\(255,255,0\)) no-repeat
++  background: no-repeat url(https://example.com/\)\).jpg), no-repeat
++    url(https://example.com/\(\(.jpg), no-repeat
++    url(https://example.com/\ \ .jpg), no-repeat
++    url(https://example.com/\)\).jpg   ), no-repeat
++    url(https://example.com/\(\(.jpg   ), no-repeat
++    url(https://example.com/\ \ .jpg   ), no-repeat url(foo.ttf?query=foo,bar,),
++    no-repeat url(foo.woff2?foo=rgb\(255,255,0\)) no-repeat
 +    url(RobotoFlex-VariableFont_GRAD,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght.ttf);
 +  ;
  }
@@ -99,13 +99,13 @@ a {
   content: url(https://example.com/\(\(.jpg   );
   content: url(https://example.com/\ \ .jpg   );
 
-  background: no-repeat url(https://example.com/\)\).jpg) , no-repeat
-    url(https://example.com/\(\(.jpg) , no-repeat
-    url(https://example.com/\ \ .jpg) , no-repeat
-    url(https://example.com/\)\).jpg   ) , no-repeat
-    url(https://example.com/\(\(.jpg   ) , no-repeat
-    url(https://example.com/\ \ .jpg   ) , no-repeat url(foo.ttf?query=foo,bar,)
-    , no-repeat url(foo.woff2?foo=rgb\(255,255,0\)) no-repeat
+  background: no-repeat url(https://example.com/\)\).jpg), no-repeat
+    url(https://example.com/\(\(.jpg), no-repeat
+    url(https://example.com/\ \ .jpg), no-repeat
+    url(https://example.com/\)\).jpg   ), no-repeat
+    url(https://example.com/\(\(.jpg   ), no-repeat
+    url(https://example.com/\ \ .jpg   ), no-repeat url(foo.ttf?query=foo,bar,),
+    no-repeat url(foo.woff2?foo=rgb\(255,255,0\)) no-repeat
     url(RobotoFlex-VariableFont_GRAD,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght.ttf);
   ;
 }


### PR DESCRIPTION


## Summary

Refactor CSS format handling in component value list

The 'format_with' function in 'component_value_list.rs' has been refactored to improve the handling of commas in CSS formatting. Before, it incorrectly added extra space or newlines before commas which disrupted the desired CSS formatting. The function has now been modified to check if current element is a comma before inserting a space or line break.


## Test Plan

`cargo test -p biome_css_formatter`
