### PR TITLE
fix(project): fix JSON schema for stable hook options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Biome configuration files can correctly extends `.jsonc` configuration files now ([#2279](https://github.com/biomejs/biome/issues/2279)). Contributed by @Sec-ant
 
+- Fixed the JSON schema for React hooks configuration ([#2396](https://github.com/biomejs/biome/issues/2396)). Contributed by @arendjr
+
 #### Enhancements
 
 - Biome now displays the location of a parsing error for its configuration file ([#1627](https://github.com/biomejs/biome/issues/1627)).

--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -231,7 +231,6 @@ impl StableReactHookConfiguration {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum StableHookResult {
     /// Used to indicate the hook does not have a stable result.
     #[default]
@@ -250,6 +249,55 @@ pub enum StableHookResult {
     /// For example, React's `useState()` hook returns a stable function at
     /// index 1.
     Indices(Vec<u8>),
+}
+
+#[cfg(feature = "schemars")]
+impl JsonSchema for StableHookResult {
+    fn schema_name() -> String {
+        "StableHookResult".to_owned()
+    }
+
+    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        use schemars::schema::*;
+        Schema::Object(SchemaObject {
+            subschemas: Some(Box::new(SubschemaValidation {
+                one_of: Some(vec![
+                    Schema::Object(SchemaObject {
+                        instance_type: Some(InstanceType::Boolean.into()),
+                        metadata: Some(Box::new(Metadata {
+                            description: Some("Whether the hook has a stable result.".to_owned()),
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    }),
+                    Schema::Object(SchemaObject {
+                        instance_type: Some(InstanceType::Array.into()),
+                        array: Some(Box::new(ArrayValidation {
+                            items: Some(SingleOrVec::Single(Box::new(Schema::Object(SchemaObject {
+                                instance_type: Some(InstanceType::Integer.into()),
+                                format: Some("uint8".to_owned()),
+                                number: Some(Box::new(NumberValidation {
+                                    minimum: Some(0.),
+                                    maximum: Some(255.),
+                                    ..Default::default()
+                                })),
+                                ..Default::default()
+                            })))),
+                            min_items: Some(1),
+                            ..Default::default()
+                        })),
+                        metadata: Some(Box::new(Metadata {
+                            description: Some("Used to indicate the hook returns an array and some of its indices have stable identities.".to_owned()),
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    })
+                ]),
+                ..Default::default()
+            })),
+            ..Default::default()
+        })
+    }
 }
 
 impl biome_deserialize::Deserializable for StableHookResult {

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1681,7 +1681,7 @@ export type FilenameCases = FilenameCase[];
  * Supported cases for TypeScript `enum` member names.
  */
 export type EnumMemberCase = "PascalCase" | "CONSTANT_CASE" | "camelCase";
-export type StableHookResult = "None" | "Identity" | { Indices: number[] };
+export type StableHookResult = boolean | number[];
 /**
  * Supported cases for file names.
  */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1983,26 +1983,19 @@
 		"StableHookResult": {
 			"oneOf": [
 				{
-					"description": "Used to indicate the hook does not have a stable result.",
-					"type": "string",
-					"enum": ["None"]
+					"description": "Whether the hook has a stable result.",
+					"type": "boolean"
 				},
 				{
-					"description": "Used to indicate the identity of the result value is stable.\n\nNote this does not imply internal stability. For instance, the ref objects returned by React's `useRef()` always have a stable identity, but their internal value may be mutable.",
-					"type": "string",
-					"enum": ["Identity"]
-				},
-				{
-					"description": "Used to indicate the hook returns an array and some of its indices have stable identities.\n\nFor example, React's `useState()` hook returns a stable function at index 1.",
-					"type": "object",
-					"required": ["Indices"],
-					"properties": {
-						"Indices": {
-							"type": "array",
-							"items": { "type": "integer", "format": "uint8", "minimum": 0.0 }
-						}
+					"description": "Used to indicate the hook returns an array and some of its indices have stable identities.",
+					"type": "array",
+					"items": {
+						"type": "integer",
+						"format": "uint8",
+						"maximum": 255.0,
+						"minimum": 0.0
 					},
-					"additionalProperties": false
+					"minItems": 1
 				}
 			]
 		},

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -150,6 +150,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Biome configuration files can correctly extends `.jsonc` configuration files now ([#2279](https://github.com/biomejs/biome/issues/2279)). Contributed by @Sec-ant
 
+- Fixed the JSON schema for React hooks configuration ([#2396](https://github.com/biomejs/biome/issues/2396)). Contributed by @arendjr
+
 #### Enhancements
 
 - Biome now displays the location of a parsing error for its configuration file ([#1627](https://github.com/biomejs/biome/issues/1627)).


### PR DESCRIPTION
## Summary

Derived schema wasn't correct for enum, so I made a manual implementation.

Fixes https://github.com/biomejs/biome/issues/2396

## Test Plan

Manually tested.
