### PR TITLE
fix(parser): fix Unicode surrogate char in escape sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Parser
 
+#### Bug fixes
+
+- Fixed an issue when Unicode surrogate pairs were encoded in JavaScript strings
+  using an escape sequence ([#2384](https://github.com/biomejs/biome/issues/2384)).
+  Contributed by @arendjr
+
 
 ## 1.6.4 (2022-04-03)
 

--- a/crates/biome_js_parser/src/lexer/tests.rs
+++ b/crates/biome_js_parser/src/lexer/tests.rs
@@ -122,6 +122,33 @@ fn identifier() {
 }
 
 #[test]
+fn unicode_identifier() {
+    assert_lex! {
+        r#"\uD83D\uDCA9"#,
+        ERROR_TOKEN:5,
+        IDENT: 1,
+        ERROR_TOKEN:5,
+        JS_NUMBER_LITERAL: 1,
+    }
+
+    assert_lex! {
+        r#"a\uD83D\uDCA9"#,
+        IDENT:1,
+        ERROR_TOKEN:5,
+        IDENT: 1,
+        ERROR_TOKEN:5,
+        JS_NUMBER_LITERAL: 1,
+    }
+
+    assert_lex! {
+        r#"a\uD83D"#,
+        IDENT:1,
+        ERROR_TOKEN:5,
+        IDENT: 1,
+    }
+}
+
+#[test]
 fn punctuators() {
     assert_lex! {
         "!%%&()*+,-.:;<=>?[]^{}|~",
@@ -299,6 +326,19 @@ fn string_unicode_escape_valid() {
     assert_lex! {
         r"'abcd\u2000a'",
         JS_STRING_LITERAL:13
+    }
+}
+
+#[test]
+fn string_unicode_escape_surrogates() {
+    assert_lex! {
+        r#""\uD83D\uDCA9""#,
+        JS_STRING_LITERAL:14
+    }
+
+    assert_lex! {
+        r#""\uD83D""#,
+        JS_STRING_LITERAL:8
     }
 }
 

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -250,6 +250,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Parser
 
+#### Bug fixes
+
+- Fixed an issue when Unicode surrogate pairs were encoded in JavaScript strings
+  using an escape sequence ([#2384](https://github.com/biomejs/biome/issues/2384)).
+  Contributed by @arendjr
+
 
 ## 1.6.4 (2022-04-03)
 


### PR DESCRIPTION
## Summary

Our parser wrongly assumed all `u32` sequences could be converted to valid Unicode characters, which led to issues as described here: https://github.com/biomejs/biome/issues/2384

This PR makes conversion from `u32` to `char` optional, since in many cases we don't care about the actual value of the escape sequence. And in situations where we do, we can bail as soon as the conversion fails.

Fixes https://github.com/biomejs/biome/issues/2384

## Test Plan

Test cases added.
