### PR TITLE
feat(cli): support passing file path to `--config-path` and `BIOME_CONFIG_PATH`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,7 +200,11 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Now you can pass a `.json`/`.jsonc` file path with any filename to the `--config-path` flag or the
   `BIOME_CONFIG_PATH` environment variable. This will disable the configuration auto-resolution and Biome
   will try to read the configuration from the said file path ([#2265](https://github.com/biomejs/biome/issues/2265)).
-  
+
+  ```shell
+  biome format --config-path=../biome.json ./src
+  ```
+
   Contributed by @Sec-ant
 
 #### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,14 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Support `overrides` field in Prettier configuration files when migrating from Prettier.
   Contributed by @Conaclos
 
+- Support passing a file path to the `--config-path` flag or the `BIOME_CONFIG_PATH` environment variable.
+
+  Now you can pass a `.json`/`.jsonc` file path with any filename to the `--config-path` flag or the
+  `BIOME_CONFIG_PATH` environment variable. This will disable the configuration auto-resolution and Biome
+  will try to read the configuration from the said file path ([#2265](https://github.com/biomejs/biome/issues/2265)).
+  
+  Contributed by @Sec-ant
+
 #### Bug fixes
 
 - Biome now tags the diagnostics emitted by `organizeImports` and `formatter` with correct severity levels, so they will be properly filtered by the flag `--diagnositic-level` ([#2288](https://github.com/biomejs/biome/issues/2288)). Contributed by @Sec-ant
@@ -202,6 +210,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Biome now correctly filters out files that are not present in the current directory when using the `--changed` flag [#1996](https://github.com/biomejs/biome/issues/1996). Contributed by @castarco
 
 - Biome now skips traversing `fifo` or `socket` files ([#2311](https://github.com/biomejs/biome/issues/2311)). Contributed by @Sec-ant
+
+- Biome now resolves configuration files exported from external libraries in `extends` from the working directory (CLI) or project root (LSP). This is the documented behavior and previous resolution behavior is considered as a bug ([#2231](https://github.com/biomejs/biome/issues/2231)). Contributed by @Sec-ant
 
 ### Configuration
 

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -1,6 +1,6 @@
 use crate::logging::LoggingKind;
 use crate::LoggingLevel;
-use biome_configuration::ConfigurationBasePath;
+use biome_configuration::ConfigurationPathHint;
 use biome_diagnostics::Severity;
 use bpaf::Bpaf;
 use std::fmt::{Display, Formatter};
@@ -22,7 +22,7 @@ pub struct CliOptions {
     #[bpaf(long("verbose"), switch, fallback(false))]
     pub verbose: bool,
 
-    /// Set the directory of the biome.json or biome.jsonc configuration file and disable default configuration file resolution.
+    /// Set the file path to the configuration file, or the directory path to find `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
     #[bpaf(long("config-path"), argument("PATH"), optional)]
     pub config_path: Option<String>,
 
@@ -86,11 +86,11 @@ pub struct CliOptions {
 }
 
 impl CliOptions {
-    /// Computes the [ConfigurationBasePath] based on the options passed by the user
-    pub(crate) fn as_configuration_base_path(&self) -> ConfigurationBasePath {
+    /// Computes the [ConfigurationPathHint] based on the options passed by the user
+    pub(crate) fn as_configuration_path_hint(&self) -> ConfigurationPathHint {
         match self.config_path.as_ref() {
-            None => ConfigurationBasePath::default(),
-            Some(path) => ConfigurationBasePath::FromUser(PathBuf::from(path)),
+            None => ConfigurationPathHint::default(),
+            Some(path) => ConfigurationPathHint::FromUser(PathBuf::from(path)),
         }
     }
 }

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -22,7 +22,8 @@ pub struct CliOptions {
     #[bpaf(long("verbose"), switch, fallback(false))]
     pub verbose: bool,
 
-    /// Set the file path to the configuration file, or the directory path to find `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
+    /// Set the file path to the configuration file, or the directory path to find `biome.json` or `biome.jsonc`.
+    /// If used, it disables the default configuration file resolution.
     #[bpaf(long("config-path"), argument("PATH"), optional)]
     pub config_path: Option<String>,
 

--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -67,7 +67,7 @@ pub(crate) fn check(
     };
 
     let loaded_configuration =
-        load_configuration(&session.app.fs, cli_options.as_configuration_base_path())?;
+        load_configuration(&session.app.fs, cli_options.as_configuration_path_hint())?;
     validate_configuration_diagnostics(
         &loaded_configuration,
         session.app.console,

--- a/crates/biome_cli/src/commands/ci.rs
+++ b/crates/biome_cli/src/commands/ci.rs
@@ -37,7 +37,7 @@ pub(crate) fn ci(session: CliSession, payload: CiCommandPayload) -> Result<(), C
     setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
 
     let loaded_configuration =
-        load_configuration(&session.app.fs, cli_options.as_configuration_base_path())?;
+        load_configuration(&session.app.fs, cli_options.as_configuration_path_hint())?;
 
     validate_configuration_diagnostics(
         &loaded_configuration,

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -59,7 +59,7 @@ pub(crate) fn format(
     setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
 
     let loaded_configuration =
-        load_configuration(&session.app.fs, cli_options.as_configuration_base_path())?;
+        load_configuration(&session.app.fs, cli_options.as_configuration_path_hint())?;
     validate_configuration_diagnostics(
         &loaded_configuration,
         session.app.console,

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -61,7 +61,7 @@ pub(crate) fn lint(session: CliSession, payload: LintCommandPayload) -> Result<(
     };
 
     let loaded_configuration =
-        load_configuration(&session.app.fs, cli_options.as_configuration_base_path())?;
+        load_configuration(&session.app.fs, cli_options.as_configuration_path_hint())?;
     validate_configuration_diagnostics(
         &loaded_configuration,
         session.app.console,

--- a/crates/biome_cli/src/commands/migrate.rs
+++ b/crates/biome_cli/src/commands/migrate.rs
@@ -14,7 +14,7 @@ pub(crate) fn migrate(
     write: bool,
     sub_command: Option<MigrateSubCommand>,
 ) -> Result<(), CliDiagnostic> {
-    let base_path = cli_options.as_configuration_base_path();
+    let base_path = cli_options.as_configuration_path_hint();
     let LoadedConfiguration {
         configuration: _,
         diagnostics: _,

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -61,7 +61,8 @@ pub enum BiomeCommand {
     /// Start the Biome daemon server process
     #[bpaf(command)]
     Start(
-        /// Allows to set a custom path when discovering the configuration file `biome.json`
+        /// Allows to set a custom file path to the configuration file,
+        /// or a custom directory path to find `biome.json` or `biome.jsonc`
         #[bpaf(env("BIOME_CONFIG_PATH"), long("config-path"), argument("PATH"))]
         Option<PathBuf>,
     ),
@@ -271,7 +272,8 @@ pub enum BiomeCommand {
     /// Acts as a server for the Language Server Protocol over stdin/stdout
     #[bpaf(command("lsp-proxy"))]
     LspProxy(
-        /// Allows to set a custom path when discovering the configuration file `biome.json`
+        /// Allows to set a custom file path to the configuration file,
+        /// or a custom directory path to find `biome.json` or `biome.jsonc`
         #[bpaf(env("BIOME_CONFIG_PATH"), long("config-path"), argument("PATH"))]
         Option<PathBuf>,
         /// Bogus argument to make the command work with vscode-languageclient
@@ -348,7 +350,8 @@ pub enum BiomeCommand {
     RunServer {
         #[bpaf(long("stop-on-disconnect"), hide_usage)]
         stop_on_disconnect: bool,
-        /// Allows to set a custom path when discovering the configuration file `biome.json`
+        /// Allows to set a custom file path to the configuration file,
+        /// or a custom directory path to find `biome.json` or `biome.jsonc`
         #[bpaf(env("BIOME_CONFIG_PATH"), long("config-path"), argument("PATH"))]
         config_path: Option<PathBuf>,
     },
@@ -482,7 +485,7 @@ fn resolve_manifest(cli_session: &CliSession) -> Result<(), WorkspaceError> {
     let workspace = &*cli_session.app.workspace;
 
     let result = fs.auto_search(
-        fs.working_directory().unwrap_or_default(),
+        &fs.working_directory().unwrap_or_default(),
         &["package.json"],
         false,
     )?;

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -1,4 +1,4 @@
-use biome_configuration::ConfigurationBasePath;
+use biome_configuration::ConfigurationPathHint;
 use biome_console::fmt::{Display, Formatter};
 use biome_console::{fmt, markup, ConsoleExt, HorizontalLine, Markup};
 use biome_diagnostics::termcolor::{ColorChoice, WriteColor};
@@ -184,7 +184,7 @@ impl Display for RageConfiguration<'_, '_> {
     fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
         Section("Biome Configuration").fmt(fmt)?;
 
-        match load_configuration(self.fs, ConfigurationBasePath::default()) {
+        match load_configuration(self.fs, ConfigurationPathHint::default()) {
             Ok(loaded_configuration) => {
                 if loaded_configuration.directory_path.is_none() {
                     KeyValuePair("Status", markup!(<Dim>"unset"</Dim>)).fmt(fmt)?;

--- a/crates/biome_cli/src/commands/search.rs
+++ b/crates/biome_cli/src/commands/search.rs
@@ -36,7 +36,7 @@ pub(crate) fn search(
     setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
 
     let loaded_configuration =
-        load_configuration(&session.app.fs, cli_options.as_configuration_base_path())?;
+        load_configuration(&session.app.fs, cli_options.as_configuration_path_hint())?;
     validate_configuration_diagnostics(
         &loaded_configuration,
         session.app.console,

--- a/crates/biome_cli/src/logging.rs
+++ b/crates/biome_cli/src/logging.rs
@@ -167,7 +167,7 @@ impl FromStr for LoggingKind {
             "compact" => Ok(Self::Compact),
             "pretty" => Ok(Self::Pretty),
             "json" => Ok(Self::Json),
-            _ => Err("This log kind doesn't exists".to_string()),
+            _ => Err("This log kind doesn't exist".to_string()),
         }
     }
 }

--- a/crates/biome_cli/tests/cases/config_path.rs
+++ b/crates/biome_cli/tests/cases/config_path.rs
@@ -17,23 +17,22 @@ fn set_config_path_to_directory() {
     let config_path = Path::new("config/biome.jsonc");
     fs.insert(
         config_path.into(),
-        r#"
-        {
-          "organizeImports": {
-            "enabled": true
-          },
-          "linter": {
-            "enabled": false
-          },
-          "formatter": {
-            "enabled": true,
-          },
-          "javascript": {
-            "formatter": {
-              "quoteStyle": "single", // comment
-            }
-          }
-        }"#
+        r#"{
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": false
+  },
+  "formatter": {
+    "enabled": true,
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single", // comment
+    }
+  }
+}"#
         .as_bytes(),
     );
 
@@ -65,23 +64,22 @@ fn set_config_path_to_file() {
     let config_path = Path::new("config/a.jsonc");
     fs.insert(
         config_path.into(),
-        r#"
-        {
-          "organizeImports": {
-            "enabled": true
-          },
-          "linter": {
-            "enabled": false
-          },
-          "formatter": {
-            "enabled": true,
-          },
-          "javascript": {
-            "formatter": {
-              "quoteStyle": "single", // comment
-            }
-          }
-        }"#
+        r#"{
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": false
+  },
+  "formatter": {
+    "enabled": true,
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single", // comment
+    }
+  }
+}"#
         .as_bytes(),
     );
 

--- a/crates/biome_cli/tests/cases/config_path.rs
+++ b/crates/biome_cli/tests/cases/config_path.rs
@@ -7,7 +7,7 @@ use bpaf::Args;
 use std::path::Path;
 
 #[test]
-fn set_config_path() {
+fn set_config_path_to_directory() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
@@ -30,7 +30,7 @@ fn set_config_path() {
           },
           "javascript": {
             "formatter": {
-              "quoteStyle": "single"
+              "quoteStyle": "single", // comment
             }
           }
         }"#
@@ -47,7 +47,55 @@ fn set_config_path() {
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
-        "set_config_path",
+        "set_config_path_to_directory",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn set_config_path_to_file() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("src/index.js");
+    fs.insert(file_path.into(), "a['b']  =  42;".as_bytes());
+
+    let config_path = Path::new("config/a.jsonc");
+    fs.insert(
+        config_path.into(),
+        r#"
+        {
+          "organizeImports": {
+            "enabled": true
+          },
+          "linter": {
+            "enabled": false
+          },
+          "formatter": {
+            "enabled": true,
+          },
+          "javascript": {
+            "formatter": {
+              "quoteStyle": "single", // comment
+            }
+          }
+        }"#
+        .as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("check"), ("--config-path=config/a.jsonc"), ("src")].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "set_config_path_to_file",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snap_test.rs
+++ b/crates/biome_cli/tests/snap_test.rs
@@ -59,7 +59,12 @@ impl CliSnapshot {
         if let Some((configuration, file_name)) = &self.configuration {
             let redacted = redact_snapshot(configuration).unwrap_or(String::new().into());
 
-            let parsed = parse_json(&redacted, JsonParserOptions::default());
+            let parsed = parse_json(
+                &redacted,
+                JsonParserOptions::default()
+                    .with_allow_comments()
+                    .with_allow_trailing_commas(),
+            );
             let formatted = format_node(
                 JsonFormatOptions::default()
                     .with_indent_style(IndentStyle::Space)

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration.snap
@@ -35,10 +35,8 @@ formatTYPO.json configuration ━━━━━━━━━━━━━━━━�
   
   Verbose advice
   
-    i Biome tried to load the configuration file  using formatTYPO.json as base path.
+    i Biome tried to load the extend configuration file "formatTYPO.json" using "" as the base path.
     
 
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration.snap
@@ -35,7 +35,7 @@ formatTYPO.json configuration ━━━━━━━━━━━━━━━━�
   
   Verbose advice
   
-    i Biome tried to load the extend configuration file "formatTYPO.json" using "" as the base path.
+    i Biome tried to load the configuration file "formatTYPO.json" in "extends" using "" as the base path.
     
 
 

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration_and_show_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration_and_show_verbose.snap
@@ -35,10 +35,8 @@ formatTYPO.json configuration ━━━━━━━━━━━━━━━━�
   
   Verbose advice
   
-    i Biome tried to load the configuration file  using formatTYPO.json as base path.
+    i Biome tried to load the extend configuration file "formatTYPO.json" using "" as the base path.
     
 
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration_and_show_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration_and_show_verbose.snap
@@ -35,7 +35,7 @@ formatTYPO.json configuration ━━━━━━━━━━━━━━━━�
   
   Verbose advice
   
-    i Biome tried to load the extend configuration file "formatTYPO.json" using "" as the base path.
+    i Biome tried to load the configuration file "formatTYPO.json" in "extends" using "" as the base path.
     
 
 

--- a/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_directory.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_directory.snap
@@ -5,23 +5,22 @@ expression: content
 ## `config/biome.jsonc`
 
 ```jsonc
-
-        {
-          "organizeImports": {
-            "enabled": true
-          },
-          "linter": {
-            "enabled": false
-          },
-          "formatter": {
-            "enabled": true,
-          },
-          "javascript": {
-            "formatter": {
-              "quoteStyle": "single", // comment
-            }
-          }
-        }
+{
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": false
+  },
+  "formatter": {
+    "enabled": true,
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single", // comment
+    }
+  }
+}
 ```
 
 ## `src/index.js`

--- a/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_directory.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_directory.snap
@@ -1,0 +1,61 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `config/biome.jsonc`
+
+```jsonc
+
+        {
+          "organizeImports": {
+            "enabled": true
+          },
+          "linter": {
+            "enabled": false
+          },
+          "formatter": {
+            "enabled": true,
+          },
+          "javascript": {
+            "formatter": {
+              "quoteStyle": "single", // comment
+            }
+          }
+        }
+```
+
+## `src/index.js`
+
+```js
+a['b']  =  42;
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+src/index.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - a['b']··=··42;
+      1 │ + a['b']·=·42;
+      2 │ + 
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_file.snap
@@ -5,23 +5,22 @@ expression: content
 ## `config/a.jsonc`
 
 ```jsonc
-
-        {
-          "organizeImports": {
-            "enabled": true
-          },
-          "linter": {
-            "enabled": false
-          },
-          "formatter": {
-            "enabled": true,
-          },
-          "javascript": {
-            "formatter": {
-              "quoteStyle": "single", // comment
-            }
-          }
-        }
+{
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": false
+  },
+  "formatter": {
+    "enabled": true,
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single", // comment
+    }
+  }
+}
 ```
 
 ## `src/index.js`

--- a/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_file.snap
@@ -1,0 +1,61 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `config/a.jsonc`
+
+```jsonc
+
+        {
+          "organizeImports": {
+            "enabled": true
+          },
+          "linter": {
+            "enabled": false
+          },
+          "formatter": {
+            "enabled": true,
+          },
+          "javascript": {
+            "formatter": {
+              "quoteStyle": "single", // comment
+            }
+          }
+        }
+```
+
+## `src/index.js`
+
+```js
+a['b']  =  42;
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+src/index.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - a['b']··=··42;
+      1 │ + a['b']·=·42;
+      2 │ + 
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -81,7 +81,8 @@ Global options applied to all commands
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
         --config-path=PATH    Set the file path to the configuration file, or the directory path to find
-                              `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
+                              `biome.json` or `biome.jsonc`. If used, it disables the default configuration
+                              file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -80,8 +80,8 @@ Global options applied to all commands
                               output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
-        --config-path=PATH    Set the directory of the biome.json or biome.jsonc configuration file and
-                              disable default configuration file resolution.
+        --config-path=PATH    Set the file path to the configuration file, or the directory path to find
+                              `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_formatter_biome_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_formatter_biome_jsonc.snap
@@ -6,7 +6,7 @@ expression: content
 
 ```json
 {
- // I am a comment
+  // I am a comment
   "formatter": {
     "enabled": false
   }

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -82,8 +82,8 @@ Global options applied to all commands
                               output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
-        --config-path=PATH    Set the directory of the biome.json or biome.jsonc configuration file and
-                              disable default configuration file resolution.
+        --config-path=PATH    Set the file path to the configuration file, or the directory path to find
+                              `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -83,7 +83,8 @@ Global options applied to all commands
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
         --config-path=PATH    Set the file path to the configuration file, or the directory path to find
-                              `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
+                              `biome.json` or `biome.jsonc`. If used, it disables the default configuration
+                              file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -72,8 +72,8 @@ Global options applied to all commands
                               output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
-        --config-path=PATH    Set the directory of the biome.json or biome.jsonc configuration file and
-                              disable default configuration file resolution.
+        --config-path=PATH    Set the file path to the configuration file, or the directory path to find
+                              `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -73,7 +73,8 @@ Global options applied to all commands
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
         --config-path=PATH    Set the file path to the configuration file, or the directory path to find
-                              `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
+                              `biome.json` or `biome.jsonc`. If used, it disables the default configuration
+                              file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.

--- a/crates/biome_cli/tests/snapshots/main_commands_format/invalid_config_file_path.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/invalid_config_file_path.snap
@@ -11,14 +11,12 @@ content
 # Termination Message
 
 ```block
-test/rome.json internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+test/biome.json internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Biome couldn't read the file
+  × Cannot read file
   
-  × Biome couldn't read the following file, maybe for permissions reasons or it doesn't exists: test/rome.json
+  × Biome can't read the following file, maybe for permissions reasons or it doesn't exist: test/biome.json
   
 
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -34,7 +34,8 @@ Global options applied to all commands
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
         --config-path=PATH    Set the file path to the configuration file, or the directory path to find
-                              `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
+                              `biome.json` or `biome.jsonc`. If used, it disables the default configuration
+                              file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -33,8 +33,8 @@ Global options applied to all commands
                               output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
-        --config-path=PATH    Set the directory of the biome.json or biome.jsonc configuration file and
-                              disable default configuration file resolution.
+        --config-path=PATH    Set the file path to the configuration file, or the directory path to find
+                              `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.

--- a/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
@@ -10,10 +10,9 @@ Acts as a server for the Language Server Protocol over stdin/stdout
 Usage: lsp-proxy [--config-path=PATH]
 
 Available options:
-        --config-path=PATH  Allows to set a custom path when discovering the configuration file `biome.json`
+        --config-path=PATH  Allows to set a custom file path to the configuration file, or a custom directory
+                            path to find `biome.json` or `biome.jsonc`
                             [env:BIOME_CONFIG_PATH: N/A]
     -h, --help              Prints help information
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
@@ -16,7 +16,8 @@ Global options applied to all commands
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
         --config-path=PATH    Set the file path to the configuration file, or the directory path to find
-                              `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
+                              `biome.json` or `biome.jsonc`. If used, it disables the default configuration
+                              file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
@@ -15,8 +15,8 @@ Global options applied to all commands
                               output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
-        --config-path=PATH    Set the directory of the biome.json or biome.jsonc configuration file and
-                              disable default configuration file resolution.
+        --config-path=PATH    Set the file path to the configuration file, or the directory path to find
+                              `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -16,7 +16,8 @@ Global options applied to all commands
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
         --config-path=PATH    Set the file path to the configuration file, or the directory path to find
-                              `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
+                              `biome.json` or `biome.jsonc`. If used, it disables the default configuration
+                              file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -15,8 +15,8 @@ Global options applied to all commands
                               output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
         --verbose             Print additional diagnostics, and some diagnostics show more information.
-        --config-path=PATH    Set the directory of the biome.json or biome.jsonc configuration file and
-                              disable default configuration file resolution.
+        --config-path=PATH    Set the file path to the configuration file, or the directory path to find
+                              `biome.json` or `biome.jsonc`. Disable default configuration file resolution.
         --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_jsonc_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_jsonc_configuration.snap
@@ -8,7 +8,7 @@ expression: content
 {
   "formatter": {
     // disable formatter
-    "enabled": false,
+    "enabled": false
   }
 }
 ```

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -259,13 +259,6 @@ impl ConfigurationPathHint {
     pub const fn is_from_lsp(&self) -> bool {
         matches!(self, Self::FromLsp(_))
     }
-    pub fn is_file(&self) -> bool {
-        if let Self::FromUser(path) = self {
-            path.is_file()
-        } else {
-            false
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/biome_fs/src/fs/memory.rs
+++ b/crates/biome_fs/src/fs/memory.rs
@@ -233,7 +233,7 @@ impl FileSystem for MemoryFileSystem {
     fn resolve_configuration(
         &self,
         _specifier: &str,
-        _path: Option<&Path>,
+        _path: &Path,
     ) -> Result<Resolution, ResolveError> {
         todo!()
     }

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -94,14 +94,9 @@ impl FileSystem for OsFileSystem {
     fn resolve_configuration(
         &self,
         specifier: &str,
-        path: Option<&Path>,
+        path: &Path,
     ) -> Result<Resolution, ResolveError> {
-        if let Some(path) = path {
-            self.configuration_resolver.resolve(path, specifier)
-        } else {
-            self.configuration_resolver
-                .resolve(self.working_directory().unwrap_or_default(), specifier)
-        }
+        self.configuration_resolver.resolve(path, specifier)
     }
 
     fn get_changed_files(&self, base: &str) -> io::Result<Vec<String>> {

--- a/crates/biome_js_analyze/src/react.rs
+++ b/crates/biome_js_analyze/src/react.rs
@@ -189,7 +189,7 @@ pub(crate) fn is_react_call_api(
     api_name: &str,
 ) -> bool {
     if matches!(lib, ReactLibrary::React) {
-        // we bail straight away if the API doesn't exists in React
+        // we bail straight away if the API doesn't exist in React
         debug_assert!(VALID_REACT_API.contains(&api_name));
     }
 

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -5,7 +5,7 @@ use crate::extension_settings::CONFIGURATION_SECTION;
 use crate::utils;
 use anyhow::Result;
 use biome_analyze::RuleCategories;
-use biome_configuration::ConfigurationBasePath;
+use biome_configuration::ConfigurationPathHint;
 use biome_console::markup;
 use biome_diagnostics::PrintDescription;
 use biome_fs::{BiomePath, FileSystem};
@@ -415,11 +415,11 @@ impl Session {
     #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) async fn load_workspace_settings(&self) {
         let base_path = if let Some(config_path) = &self.config_path {
-            ConfigurationBasePath::FromUser(config_path.clone())
+            ConfigurationPathHint::FromUser(config_path.clone())
         } else {
             match self.base_path() {
-                None => ConfigurationBasePath::default(),
-                Some(path) => ConfigurationBasePath::Lsp(path),
+                None => ConfigurationPathHint::default(),
+                Some(path) => ConfigurationPathHint::FromLsp(path),
             }
         };
 
@@ -487,9 +487,7 @@ impl Session {
             .map(PathBuf::from)
             .or(self.base_path());
         if let Some(base_path) = base_path {
-            let result = self
-                .fs
-                .auto_search(base_path.clone(), &["package.json"], false);
+            let result = self.fs.auto_search(&base_path, &["package.json"], false);
             match result {
                 Ok(result) => {
                     if let Some(result) = result {

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -3,7 +3,7 @@ use crate::{DynRef, WorkspaceError, VERSION};
 use biome_analyze::AnalyzerRules;
 use biome_configuration::diagnostics::CantLoadExtendFile;
 use biome_configuration::{
-    push_to_analyzer_rules, ConfigurationBasePath, ConfigurationDiagnostic, ConfigurationPayload,
+    push_to_analyzer_rules, ConfigurationDiagnostic, ConfigurationPathHint, ConfigurationPayload,
     PartialConfiguration,
 };
 use biome_console::markup;
@@ -102,7 +102,7 @@ impl LoadedConfiguration {
         };
 
         let ConfigurationPayload {
-            configuration_directory_path,
+            external_resolution_base_path,
             configuration_file_path,
             deserialized,
         } = value;
@@ -114,7 +114,7 @@ impl LoadedConfiguration {
                     partial_configuration.apply_extends(
                         fs,
                         &configuration_file_path,
-                        &configuration_directory_path,
+                        &external_resolution_base_path,
                         &mut diagnostics,
                     )?;
                     partial_configuration.migrate_deprecated_fields();
@@ -128,7 +128,7 @@ impl LoadedConfiguration {
                     diagnostic.with_file_path(configuration_file_path.display().to_string())
                 })
                 .collect(),
-            directory_path: Some(configuration_directory_path),
+            directory_path: configuration_file_path.parent().map(PathBuf::from),
             file_path: Some(configuration_file_path),
         })
     }
@@ -137,7 +137,7 @@ impl LoadedConfiguration {
 /// Load the partial configuration for this session of the CLI.
 pub fn load_configuration(
     fs: &DynRef<'_, dyn FileSystem>,
-    config_path: ConfigurationBasePath,
+    config_path: ConfigurationPathHint,
 ) -> Result<LoadedConfiguration, WorkspaceError> {
     let config = load_config(fs, config_path)?;
     LoadedConfiguration::try_from_payload(config, fs)
@@ -150,74 +150,109 @@ type LoadConfig = Result<Option<ConfigurationPayload>, WorkspaceError>;
 
 /// Load the configuration from the file system.
 ///
-/// The configuration file will be read from the `file_system`. A [base path](ConfigurationBasePath) should be provided.
+/// The configuration file will be read from the `file_system`. A [path hint](ConfigurationPathHint) should be provided.
 ///
-/// The function will try to traverse upwards the file system until if finds a `biome.json` file, or there
-/// aren't directories anymore.
+/// - If the path hint is a path to a file that is provided by the user, the function will try to load that file or error.
+/// The name doesn't have to be `biome.json` or `biome.jsonc`. And if it doesn't end with `.json`, Biome will try to
+/// deserialize it as a `.jsonc` file.
 ///
-/// If a the configuration base path was provided by the user, the function will error. If not, Biome will use
-/// its defaults.
+/// - If the path hint is a path to a directory which is provided by the user, the function will try to find a `biome.json`
+/// or `biome.jsonc` file in order in that directory. And If it cannot find one, it will error.
+///
+/// - Otherwise, the function will try to traverse upwards the file system until it finds a `biome.json` or `biome.jsonc`
+/// file, or there aren't directories anymore. In this case, the function will not error but return an `Ok(None)`, which
+/// means Biome will use the default configuration.
 fn load_config(
     file_system: &DynRef<'_, dyn FileSystem>,
-    base_path: ConfigurationBasePath,
+    base_path: ConfigurationPathHint,
 ) -> LoadConfig {
-    let deprecated_config_name = file_system.deprecated_config_name();
-    let working_directory = file_system.working_directory();
-    let configuration_directory = match base_path {
-        ConfigurationBasePath::Lsp(ref path) | ConfigurationBasePath::FromUser(ref path) => {
-            path.clone()
+    // This path is used for configuration resolution from external packages.
+    let external_resolution_base_path = match base_path {
+        // Path hint from LSP is always the workspace root
+        // we use it as the resolution base path.
+        ConfigurationPathHint::FromLsp(ref path) => path.clone(),
+        // Path hint from user means the command is invoked from the CLI
+        // So we use the working directory (CWD) as the resolution base path
+        ConfigurationPathHint::FromUser(_) | ConfigurationPathHint::None => file_system
+            .working_directory()
+            .map_or(PathBuf::new(), |working_directory| working_directory),
+    };
+
+    // If the configuration path hint is from user and is a file path,
+    // we'll load it directly
+    if let ConfigurationPathHint::FromUser(ref configuration_file_path) = base_path {
+        if file_system.path_is_file(configuration_file_path) {
+            let content = file_system.read_file_from_path(configuration_file_path)?;
+            let parser_options = match configuration_file_path.extension().and_then(OsStr::to_str) {
+                Some("json") => JsonParserOptions::default(),
+                _ => JsonParserOptions::default()
+                    .with_allow_comments()
+                    .with_allow_trailing_commas(),
+            };
+            let deserialized =
+                deserialize_from_json_str::<PartialConfiguration>(&content, parser_options, "");
+            return Ok(Some(ConfigurationPayload {
+                deserialized,
+                configuration_file_path: PathBuf::from(configuration_file_path),
+                external_resolution_base_path,
+            }));
         }
-        _ => match working_directory {
-            Some(wd) => wd,
+    }
+
+    // If the configuration path hint is not a file path
+    // we'll auto search for the configuration file
+    let should_error = base_path.is_from_user();
+    let configuration_directory = match base_path {
+        ConfigurationPathHint::FromLsp(path) => path,
+        ConfigurationPathHint::FromUser(path) => path,
+        // working directory will only work in
+        _ => match file_system.working_directory() {
+            Some(working_directory) => working_directory,
             None => PathBuf::new(),
         },
     };
-    let should_error = base_path.is_from_user();
 
-    let auto_search_result;
-    let result = file_system.auto_search(
-        configuration_directory.clone(),
+    // We first search for `biome.json` or `biome.jsonc` files
+    if let Some(auto_search_result) = match file_system.auto_search(
+        &configuration_directory,
         ConfigName::file_names().as_slice(),
         should_error,
-    );
-    if let Ok(result) = result {
-        if result.is_none() {
-            auto_search_result = file_system.auto_search(
-                configuration_directory.clone(),
-                [deprecated_config_name].as_slice(),
-                should_error,
-            )?;
-        } else {
-            auto_search_result = result;
-        }
-    } else {
-        auto_search_result = file_system.auto_search(
-            configuration_directory.clone(),
-            [deprecated_config_name].as_slice(),
+    ) {
+        Ok(Some(auto_search_result)) => Some(auto_search_result),
+        // We then search for the deprecated `rome.json` file
+        // if neither `biome.json` nor `biome.jsonc` is found
+        // TODO: The following arms should be removed in v2.0.0
+        Ok(None) => file_system.auto_search(
+            &configuration_directory,
+            [file_system.deprecated_config_name()].as_slice(),
             should_error,
-        )?;
-    }
+        )?,
+        Err(error) => file_system
+            .auto_search(
+                &configuration_directory,
+                [file_system.deprecated_config_name()].as_slice(),
+                should_error,
+            )
+            // Map the error so users won't see error messages
+            // that contains `rome.json`
+            .map_err(|_| error)?,
+    } {
+        let AutoSearchResult { content, file_path } = auto_search_result;
 
-    if let Some(auto_search_result) = auto_search_result {
-        let AutoSearchResult {
-            content,
-            directory_path,
-            file_path,
-        } = auto_search_result;
-        let parser_options =
-            if file_path.file_name().and_then(|s| s.to_str()) == Some(ConfigName::biome_jsonc()) {
-                JsonParserOptions::default()
-                    .with_allow_comments()
-                    .with_allow_trailing_commas()
-            } else {
-                JsonParserOptions::default()
-            };
+        let parser_options = match file_path.extension().and_then(OsStr::to_str) {
+            Some("json") => JsonParserOptions::default(),
+            _ => JsonParserOptions::default()
+                .with_allow_comments()
+                .with_allow_trailing_commas(),
+        };
+
         let deserialized =
             deserialize_from_json_str::<PartialConfiguration>(&content, parser_options, "");
+
         Ok(Some(ConfigurationPayload {
             deserialized,
             configuration_file_path: file_path,
-            configuration_directory_path: directory_path,
+            external_resolution_base_path,
         }))
     } else {
         Ok(None)
@@ -297,14 +332,15 @@ pub trait PartialConfigurationExt {
         &mut self,
         fs: &DynRef<'_, dyn FileSystem>,
         file_path: &Path,
-        directory_path: &Path,
+        external_resolution_base_path: &Path,
         diagnostics: &mut Vec<Error>,
     ) -> Result<(), WorkspaceError>;
 
     fn deserialize_extends(
         &mut self,
         fs: &DynRef<'_, dyn FileSystem>,
-        directory_path: &Path,
+        relative_resolution_base_path: &Path,
+        external_resolution_base_path: &Path,
     ) -> Result<Vec<Deserialized<PartialConfiguration>>, WorkspaceError>;
 
     fn migrate_deprecated_fields(&mut self);
@@ -327,10 +363,14 @@ impl PartialConfigurationExt for PartialConfiguration {
         &mut self,
         fs: &DynRef<'_, dyn FileSystem>,
         file_path: &Path,
-        directory_path: &Path,
+        external_resolution_base_path: &Path,
         diagnostics: &mut Vec<Error>,
     ) -> Result<(), WorkspaceError> {
-        let deserialized = self.deserialize_extends(fs, directory_path)?;
+        let deserialized = self.deserialize_extends(
+            fs,
+            file_path.parent().expect("file path should have a parent"),
+            external_resolution_base_path,
+        )?;
         let (configurations, errors): (Vec<_>, Vec<_>) = deserialized
             .into_iter()
             .map(|d| d.consume())
@@ -364,30 +404,29 @@ impl PartialConfigurationExt for PartialConfiguration {
     fn deserialize_extends(
         &mut self,
         fs: &DynRef<'_, dyn FileSystem>,
-        directory_path: &Path,
+        relative_resolution_base_path: &Path,
+        external_resolution_base_path: &Path,
     ) -> Result<Vec<Deserialized<PartialConfiguration>>, WorkspaceError> {
         let Some(extends) = &self.extends else {
             return Ok(Vec::new());
         };
 
         let mut deserialized_configurations = vec![];
-        for path in extends.iter() {
-            let as_path = Path::new(path);
-            let extension = as_path.extension().and_then(|ext| ext.to_str());
-            // TODO: Remove extension in Biome 2.0
-            let config_path = if as_path.starts_with(".")
-                || extension == Some("json")
-                || extension == Some("jsonc")
-            {
-                directory_path.join(path)
+        for extend_entry in extends.iter() {
+            let extend_entry_as_path = Path::new(extend_entry);
+
+            let extend_configuration_file_path = if extend_entry_as_path.starts_with(".")
+                // TODO: Remove extension in Biome 2.0
+                || matches!(
+                    extend_entry_as_path.extension().and_then(OsStr::to_str),
+                    Some("json" | "jsonc")
+                ) {
+                relative_resolution_base_path.join(extend_entry)
             } else {
-                fs.resolve_configuration(path.as_str(), Some(directory_path))
+                fs.resolve_configuration(extend_entry.as_str(), external_resolution_base_path)
                     .map_err(|error| {
                         ConfigurationDiagnostic::cant_resolve(
-                            fs.working_directory()
-                                .unwrap_or_default()
-                                .display()
-                                .to_string(),
+                            external_resolution_base_path.display().to_string(),
                             error,
                         )
                     })?
@@ -395,17 +434,27 @@ impl PartialConfigurationExt for PartialConfiguration {
             };
 
             let mut file = fs
-                .open_with_options(config_path.as_path(), OpenOptions::default().read(true))
+                .open_with_options(
+                    extend_configuration_file_path.as_path(),
+                    OpenOptions::default().read(true),
+                )
                 .map_err(|err| {
-                    CantLoadExtendFile::new(config_path.display().to_string(), err.to_string()).with_verbose_advice(
-                        markup!{
-                            "Biome tried to load the configuration file "<Emphasis>{directory_path.display().to_string()}</Emphasis>" using "<Emphasis>{config_path.display().to_string()}</Emphasis>" as base path."
-                        }
+                    CantLoadExtendFile::new(
+                        extend_configuration_file_path.display().to_string(),
+                        err.to_string(),
                     )
+                    .with_verbose_advice(markup! {
+                        "Biome tried to load the extend configuration file \""<Emphasis>{
+                            extend_configuration_file_path.display().to_string()
+                        }</Emphasis>"\" using \""<Emphasis>{
+                            external_resolution_base_path.display().to_string()
+                        }</Emphasis>"\" as the base path."
+                    })
                 })?;
+
             let mut content = String::new();
             file.read_to_string(&mut content).map_err(|err| {
-                CantLoadExtendFile::new(config_path.display().to_string(), err.to_string()).with_verbose_advice(
+                CantLoadExtendFile::new(extend_configuration_file_path.display().to_string(), err.to_string()).with_verbose_advice(
                     markup!{
                         "It's possible that the file was created with a different user/group. Make sure you have the rights to read the file."
                     }
@@ -414,7 +463,10 @@ impl PartialConfigurationExt for PartialConfiguration {
             })?;
             let deserialized = deserialize_from_json_str::<PartialConfiguration>(
                 content.as_str(),
-                match config_path.extension().and_then(OsStr::to_str) {
+                match extend_configuration_file_path
+                    .extension()
+                    .and_then(OsStr::to_str)
+                {
                     Some("json") => JsonParserOptions::default(),
                     _ => JsonParserOptions::default()
                         .with_allow_comments()
@@ -487,12 +539,12 @@ impl PartialConfigurationExt for PartialConfiguration {
             if let Some(client_kind) = &vcs.client_kind {
                 if !vcs.ignore_file_disabled() {
                     let result = file_system
-                        .auto_search(vcs_base_path, &[client_kind.ignore_file()], false)
+                        .auto_search(&vcs_base_path, &[client_kind.ignore_file()], false)
                         .map_err(WorkspaceError::from)?;
 
                     if let Some(result) = result {
                         return Ok((
-                            Some(result.directory_path),
+                            result.file_path.parent().map(PathBuf::from),
                             result
                                 .content
                                 .lines()

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -444,9 +444,9 @@ impl PartialConfigurationExt for PartialConfiguration {
                         err.to_string(),
                     )
                     .with_verbose_advice(markup! {
-                        "Biome tried to load the extend configuration file \""<Emphasis>{
+                        "Biome tried to load the configuration file \""<Emphasis>{
                             extend_configuration_file_path.display().to_string()
-                        }</Emphasis>"\" using \""<Emphasis>{
+                        }</Emphasis>"\" in \"extends\" using \""<Emphasis>{
                             external_resolution_base_path.display().to_string()
                         }</Emphasis>"\" as the base path."
                     })

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -200,8 +200,8 @@ pub struct FormatWithErrorsDisabled;
 #[diagnostic(
     category = "internalError/fs",
     message(
-        message("Biome couldn't read the following directory, maybe for permissions reasons or it doesn't exists: "{self.path}),
-        description = "Biome couldn't read the following directory, maybe for permissions reasons or it doesn't exists: {path}"
+        message("Biome couldn't read the following directory, maybe for permissions reasons or it doesn't exist: "{self.path}),
+        description = "Biome couldn't read the following directory, maybe for permissions reasons or it doesn't exist: {path}"
     )
 )]
 pub struct CantReadDirectory {
@@ -213,8 +213,8 @@ pub struct CantReadDirectory {
 #[diagnostic(
     category = "internalError/fs",
     message(
-        message("Biome couldn't read the following file, maybe for permissions reasons or it doesn't exists: "{self.path}),
-        description = "Biome couldn't read the following file, maybe for permissions reasons or it doesn't exists: {path}"
+        message("Biome couldn't read the following file, maybe for permissions reasons or it doesn't exist: "{self.path}),
+        description = "Biome couldn't read the following file, maybe for permissions reasons or it doesn't exist: {path}"
     )
 )]
 pub struct CantReadFile {

--- a/crates/biome_service/src/snapshots/cant_read_directory.snap
+++ b/crates/biome_service/src/snapshots/cant_read_directory.snap
@@ -4,4 +4,4 @@ expression: content
 ---
 example/ internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Biome couldn't read the following directory, maybe for permissions reasons or it doesn't exists: example/
+  × Biome couldn't read the following directory, maybe for permissions reasons or it doesn't exist: example/

--- a/crates/biome_service/src/snapshots/cant_read_file.snap
+++ b/crates/biome_service/src/snapshots/cant_read_file.snap
@@ -4,4 +4,4 @@ expression: content
 ---
 example.js internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Biome couldn't read the following file, maybe for permissions reasons or it doesn't exists: example.js
+  × Biome couldn't read the following file, maybe for permissions reasons or it doesn't exist: example.js

--- a/website/src/content/docs/guides/how-biome-works.mdx
+++ b/website/src/content/docs/guides/how-biome-works.mdx
@@ -44,10 +44,10 @@ When you run `biome init`, the default configuration emitted is the following:
 
 ### Configuration file resolution
 
-Biome uses auto discovery to find the nearest `biome.json` file. It starts looking for `biome.json` in the current
+Biome uses auto discovery to find the nearest configuration file. It starts looking for one in the current
 working directory, and then it starts looking in the parent directories until:
-- it finds a `biome.json` file;
-- it applies Biome's defaults if **no `biome.json` is found**;
+- it finds a `biome.json` or a `biome.jsonc` file;
+- it applies Biome's defaults if **no configuration file is found**;
 
 Here's an example:
 
@@ -65,12 +65,14 @@ Here's an example:
 </FileTree>
 
 
-- biome commands that run in `app/backend/package.json` will use the configuration file `app/backend/biome.json`;
-- biome commands that run in `app/frontend/legacy/package.json` and `app/frontend/new/package.json`
+- Biome commands that run in `app/backend/package.json` will use the configuration file `app/backend/biome.json`;
+- Biome commands that run in `app/frontend/legacy/package.json` and `app/frontend/new/package.json`
 will use the configuration file `app/frontend/biome.json`;
 
 :::note
-Most biome commands also support the `--config-path` command line option to point to a custom directory for the `biome.json` file. In this case, the above configuration file resolution is **disabled**.
+Most Biome commands support using the `--config-path` command line option. This allows you to specify a custom configuration file or a directory where Biome can look for a `biome.json` or `biome.jsonc` file. When you use `--config-path`, the standard configuration file resolution process is **disabled**.
+
+If `--config-path` points directly to a file, you can use names other than `biome.json` or `biome.jsonc`. Biome will read a `.json` file using a standard JSON parser. For files with other extensions, Biome will treat them as `.jsonc` files, using a more flexible JSON parser that allows comments and trailing commas.
 :::
 
 :::caution
@@ -79,7 +81,9 @@ Biome doesn't support nested `biome.json` files, neither in CLI nor in LSP. [Fol
 
 ### The `extends` option
 
-The `extends` option allows to break down a configuration in multiple file and "share" common patterns among multiple projects/folders.
+The `extends` option allows you to split your configuration across multiple files. This way, you can share common settings across different projects or folders.
+
+Here's an example of how you might set up your `biome.json` to extend other configuration files:
 
 ```json title="biome.json"
 {
@@ -87,6 +91,8 @@ The `extends` option allows to break down a configuration in multiple file and "
   "extends": ["./formatter.json", "./linter.json"]
 }
 ```
+
+For instance, you could define formatter settings in `formatter.json`:
 
 ```json title="formatter.json"
 {
@@ -101,6 +107,8 @@ The `extends` option allows to break down a configuration in multiple file and "
   }
 }
 ```
+
+And linter rules in `linter.json`:
 
 ```json title="linter.json"
 {
@@ -120,15 +128,13 @@ The entries defined in this array:
 - are resolved from the path where the `biome.json` file is defined;
 - must be relative paths or [paths to library](#extends-biomejson-from-a-library)
 - must be reachable by Biome, e.g. symbolic links might not be resolved by Biome, if they are relative paths;
-- will be processed in order: from the first one to the last one;
-- can override the same properties, but ultimately only the last one will be used by Biome;
-
+- are processed in the order they are listed, with settings in later files overriding earlier ones;
 
 ### Extend `biome.json` from a library
 
-From version `v1.6.0`, Biome is able to resolve configuration files from `node_modules/`, so you can export your configuration file from a library, and import it in multiple projects.
+Starting from version `v1.6.0`, Biome is able to resolve configuration files from the `node_modules/` directory. So you can export your configuration file from a library, and import it in multiple projects.
 
-In order to do so, the first thing to do is to set up your "shared" Biome configuration in a certain way. Let's suppose that your library is called `@org/shared-configs`, and you want to import the Biome configuration using the specifier `@org/shared-configs/biome`. You have to set up the `package.json` is a specific way:
+In order to do so, the first thing to do is to set up your "shared" Biome configuration in a certain way. Let's suppose that your library is called `@org/shared-configs`, and you want to import the Biome configuration using the specifier `@org/shared-configs/biome`. You have to set up the `package.json` in a specific way:
 
 ```json title="package.json" ins={5,3}
 {
@@ -157,10 +163,10 @@ Biome will attempt to **resolve** your library `@org/shared-configs/` from your 
 - when using the LSP, the root directory of your project.
 
 :::caution
-To avoid a breaking change with how the existing resolution works, paths that start with a dot `.` or contains `.json`/`.jsonc` in their name, they **won't** be resolved from `node_modules/`.
+To avoid a breaking change with how the existing resolution works, paths starting with a dot `.` or ending with `.json` or `.jsonc` **won't** be resolved from `node_modules/`.
 :::
 
-For more information about the resolution algorithm, read the [Node.js documentation](https://nodejs.org/api/esm.html#resolution-and-loading-algorithm).
+For more information about the resolution algorithm, refer to the [Node.js documentation](https://nodejs.org/api/esm.html#resolution-and-loading-algorithm).
 
 ### Resolution of globs and paths
 

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -206,7 +206,11 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Now you can pass a `.json`/`.jsonc` file path with any filename to the `--config-path` flag or the
   `BIOME_CONFIG_PATH` environment variable. This will disable the configuration auto-resolution and Biome
   will try to read the configuration from the said file path ([#2265](https://github.com/biomejs/biome/issues/2265)).
-  
+
+  ```shell
+  biome format --config-path=../biome.json ./src
+  ```
+
   Contributed by @Sec-ant
 
 #### Bug fixes

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -201,6 +201,14 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Support `overrides` field in Prettier configuration files when migrating from Prettier.
   Contributed by @Conaclos
 
+- Support passing a file path to the `--config-path` flag or the `BIOME_CONFIG_PATH` environment variable.
+
+  Now you can pass a `.json`/`.jsonc` file path with any filename to the `--config-path` flag or the
+  `BIOME_CONFIG_PATH` environment variable. This will disable the configuration auto-resolution and Biome
+  will try to read the configuration from the said file path ([#2265](https://github.com/biomejs/biome/issues/2265)).
+  
+  Contributed by @Sec-ant
+
 #### Bug fixes
 
 - Biome now tags the diagnostics emitted by `organizeImports` and `formatter` with correct severity levels, so they will be properly filtered by the flag `--diagnositic-level` ([#2288](https://github.com/biomejs/biome/issues/2288)). Contributed by @Sec-ant
@@ -208,6 +216,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Biome now correctly filters out files that are not present in the current directory when using the `--changed` flag [#1996](https://github.com/biomejs/biome/issues/1996). Contributed by @castarco
 
 - Biome now skips traversing `fifo` or `socket` files ([#2311](https://github.com/biomejs/biome/issues/2311)). Contributed by @Sec-ant
+
+- Biome now resolves configuration files exported from external libraries in `extends` from the working directory (CLI) or project root (LSP). This is the documented behavior and previous resolution behavior is considered as a bug ([#2231](https://github.com/biomejs/biome/issues/2231)). Contributed by @Sec-ant
 
 ### Configuration
 


### PR DESCRIPTION
## Summary

- Support passing file path to `--config-path` and `BIOME_CONFIG_PATH`. Closes #2265.

- Fix external configuration resolution base path. Closes #2231.

## Test Plan

Added a test case for the 1st feat, and tested manually in VS Code for the 2nd fix.
