### PR TITLE
refactor(noReExportAll): don't report type re-export

### DIFF
--- a/crates/biome_js_analyze/tests/specs/nursery/noReExportAll/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noReExportAll/valid.ts
@@ -1,0 +1,2 @@
+export type * from 'foo';
+export type * as foo from 'foo';

--- a/crates/biome_js_analyze/tests/specs/nursery/noReExportAll/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noReExportAll/valid.ts.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```ts
+export type * from 'foo';
+export type * as foo from 'foo';
+```

--- a/website/src/content/docs/linter/rules/no-re-export-all.md
+++ b/website/src/content/docs/linter/rules/no-re-export-all.md
@@ -21,14 +21,14 @@ Additionally, it complicates the codebase, making it difficult to navigate and u
 ### Invalid
 
 ```jsx
-export * from 'foo';
+export * from "foo";
 ```
 
 <pre class="language-text"><code class="language-text">nursery/noReExportAll.js:1:1 <a href="https://biomejs.dev/linter/rules/no-re-export-all">lint/nursery/noReExportAll</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Do not use export all ( </span><span style="color: Orange;"><strong>export * from ...</strong></span><span style="color: Orange;"> ).</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>export * from 'foo';
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>export * from &quot;foo&quot;;
    <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
   
@@ -37,14 +37,14 @@ export * from 'foo';
 </code></pre>
 
 ```jsx
-export * as foo from 'foo';
+export * as foo from "foo";
 ```
 
 <pre class="language-text"><code class="language-text">nursery/noReExportAll.js:1:1 <a href="https://biomejs.dev/linter/rules/no-re-export-all">lint/nursery/noReExportAll</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Do not use export all ( </span><span style="color: Orange;"><strong>export * from ...</strong></span><span style="color: Orange;"> ).</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>export * as foo from 'foo';
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>export * as foo from &quot;foo&quot;;
    <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
   
@@ -56,6 +56,11 @@ export * as foo from 'foo';
 
 ```jsx
 export { foo } from "foo";
+```
+
+```ts
+export type * from "foo";
+export type * as bar from "bar";
 ```
 
 ## Related links


### PR DESCRIPTION
## Summary

Don't report type re-export such as `export type * from "foo";`.
This aligns the behavior of `noReExportAll` to `noBarrelFile`.

## Test Plan

I added a test.
