### PR TITLE
docs: update useForOf to include a relevant example

### DIFF
--- a/crates/biome_js_analyze/src/lint/style/use_for_of.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_for_of.rs
@@ -29,6 +29,12 @@ declare_rule! {
     /// ### Valid
     ///
     /// ```js
+    /// for (let item of array) {
+    ///    console.log(item);
+    ///  }
+    /// ```
+    ///
+    /// ```js
     /// for (let i = 0; i < array.length; i++) {
     ///    console.log(i, array[i]);
     ///  }

--- a/website/src/content/docs/linter/rules/use-for-of.md
+++ b/website/src/content/docs/linter/rules/use-for-of.md
@@ -23,22 +23,22 @@ for (let i = 0; i < array.length; i++) {
 <pre class="language-text"><code class="language-text">style/useForOf.js:1:1 <a href="https://biomejs.dev/linter/rules/use-for-of">lint/style/useForOf</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Use </span><span style="color: Orange;"><strong>for-of</strong></span><span style="color: Orange;"> loop instead of a </span><span style="color: Orange;"><strong>for loop</strong></span><span style="color: Orange;">.</span>
-  
+
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>for (let i = 0; i &lt; array.length; i++) {
    <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>  console.log(array[i]);
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>}
    <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>4 │ </strong>
-  
+
 </code></pre>
 
 ### Valid
 
 ```jsx
-for (let i of array) {
-  console.log(i);
-}
+for (let item of array) {
+   console.log(item);
+ }
 ```
 
 ```jsx

--- a/website/src/content/docs/linter/rules/use-for-of.md
+++ b/website/src/content/docs/linter/rules/use-for-of.md
@@ -36,6 +36,12 @@ for (let i = 0; i < array.length; i++) {
 ### Valid
 
 ```jsx
+for (let i of array) {
+  console.log(i);
+}
+```
+
+```jsx
 for (let i = 0; i < array.length; i++) {
    console.log(i, array[i]);
  }
@@ -45,12 +51,6 @@ for (let i = 0; i < array.length; i++) {
 for (let i = 0, j = 0; i < array.length; i++) {
    console.log(i, array[i]);
  }
-```
-
-```jsx
-for (var i of array) {
-  console.log(i)
-}
 ```
 
 ## Related links

--- a/website/src/content/docs/linter/rules/use-for-of.md
+++ b/website/src/content/docs/linter/rules/use-for-of.md
@@ -47,6 +47,12 @@ for (let i = 0, j = 0; i < array.length; i++) {
  }
 ```
 
+```jsx
+for (var i of array) {
+  console.log(i)
+}
+```
+
 ## Related links
 
 - [Disable a rule](/linter/#disable-a-lint-rule)


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Unintuitively, the documents for useForOf do not include an *actual* forOf. While the actual rule does check for the index accession shown in the documents already, it doesn't respect [the typescript-eslint rule](https://typescript-eslint.io/rules/prefer-for-of/#examples).

## Test Plan

: )
