### PR TITLE
feat(migrate-prettier): support shorthand for overrides.files

### DIFF
--- a/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
@@ -97,10 +97,10 @@ pub(crate) struct EslintPackageJson {
 #[derive(Debug, Default, Deserializable)]
 #[deserializable(unknown_fields = "allow")]
 pub(crate) struct LegacyConfigData {
-    pub(crate) extends: Shorthand<String>,
+    pub(crate) extends: ShorthandVec<String>,
     pub(crate) globals: Globals,
     /// The glob patterns that ignore to lint.
-    pub(crate) ignore_patterns: Shorthand<String>,
+    pub(crate) ignore_patterns: ShorthandVec<String>,
     /// The parser options.
     pub(crate) rules: Rules,
     pub(crate) overrides: Vec<OverrideConfigData>,
@@ -183,52 +183,52 @@ pub(crate) enum GlobalConfQualifier {
 #[derive(Debug, Default, Deserializable)]
 #[deserializable(unknown_fields = "allow")]
 pub(crate) struct OverrideConfigData {
-    pub(crate) extends: Shorthand<String>,
+    pub(crate) extends: ShorthandVec<String>,
     pub(crate) globals: Globals,
     /// The glob patterns for excluded files.
-    pub(crate) excluded_files: Shorthand<String>,
+    pub(crate) excluded_files: ShorthandVec<String>,
     /// The glob patterns for target files.
-    pub(crate) files: Shorthand<String>,
+    pub(crate) files: ShorthandVec<String>,
     pub(crate) rules: Rules,
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct Shorthand<T>(Vec<T>);
-impl<T> Merge for Shorthand<T> {
+pub(crate) struct ShorthandVec<T>(Vec<T>);
+impl<T> Merge for ShorthandVec<T> {
     fn merge_with(&mut self, mut other: Self) {
         self.0.append(&mut other.0);
     }
 }
-impl<T> From<T> for Shorthand<T> {
+impl<T> From<T> for ShorthandVec<T> {
     fn from(value: T) -> Self {
         Self(vec![value])
     }
 }
-impl<T> Deref for Shorthand<T> {
+impl<T> Deref for ShorthandVec<T> {
     type Target = Vec<T>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
-impl<T> DerefMut for Shorthand<T> {
+impl<T> DerefMut for ShorthandVec<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
-impl<T> IntoIterator for Shorthand<T> {
+impl<T> IntoIterator for ShorthandVec<T> {
     type Item = T;
     type IntoIter = vec::IntoIter<T>;
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
 }
-impl<T: Deserializable> Deserializable for Shorthand<T> {
+impl<T: Deserializable> Deserializable for ShorthandVec<T> {
     fn deserialize(
         value: &impl DeserializableValue,
         name: &str,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<Self> {
-        Some(Shorthand(
+        Some(ShorthandVec(
             if value.visitable_type()? == VisitableType::ARRAY {
                 Deserializable::deserialize(value, name, diagnostics)?
             } else {

--- a/crates/biome_cli/src/execute/migrate/eslint_typescript.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_typescript.rs
@@ -127,7 +127,7 @@ impl From<NamingConventionOptions> for use_naming_convention::NamingConventionOp
 #[derive(Debug, Default, Deserializable)]
 #[deserializable(unknown_fields = "allow")]
 pub(crate) struct NamingConventionSelection {
-    pub(crate) selector: eslint_eslint::Shorthand<Selector>,
+    pub(crate) selector: eslint_eslint::ShorthandVec<Selector>,
     pub(crate) modifiers: Option<Vec<Modifier>>,
     pub(crate) types: Option<Vec<Type>>,
     //pub(crate) custom: Option<Custom>,

--- a/crates/biome_cli/tests/commands/migrate_eslint.rs
+++ b/crates/biome_cli/tests/commands/migrate_eslint.rs
@@ -215,7 +215,7 @@ fn migrate_eslintrcjson_rule_options() {
             }]
         },
         "overrides": [{
-            "files": ["default.js"],
+            "files": "default.js",
             "rules": {
                 "no-restricted-globals": "error",
                 "jsx-a11y/aria-role": "error",

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrcjson_rule_options.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrcjson_rule_options.snap
@@ -33,7 +33,7 @@ expression: content
             }]
         },
         "overrides": [{
-            "files": ["default.js"],
+            "files": "default.js",
             "rules": {
                 "no-restricted-globals": "error",
                 "jsx-a11y/aria-role": "error",


### PR DESCRIPTION
## Summary

This PR adds the support for settings directly a string in `overrides.files`.

Also, I renamed `Shothand` to `ShothandVec` for clarity.

## Test Plan

I changed a test to cover this case.
