### PR TITLE
refactor(useLiteralKeys): ignore __proto__ computed property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,17 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [complexity/useLiteralKeys](https://biomejs.dev/linter/rules/use-literal-keys/) no longer report computed properties named `__proto__` ([#2430](https://github.com/biomejs/biome/issues/2430)).
+
+  In JavaScript, `{["__proto__"]: null}` and `{__proto__: null}` have not the same semantic.
+  The first code set a regular property to `null`.
+  The second one set the prototype of the object to `null`.
+  See the [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) for more details.
+
+  The rule now ignores computed properties named `__proto__`.
+
+  Contributed by @Conaclos
+
 #### Bug fixes
 
 - Lint rules `useNodejsImportProtocol`, `useNodeAssertStrict`, `noRestrictedImports`, `noNodejsModules` will no longer check `declare module` statements anymore. Contributed by @Sec-ant

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js
@@ -36,6 +36,9 @@ a = {
 a = {
 	[""]: 2
 }
+a = {
+	"__proto__": null,
+}
 
 // optional chain
 a?.["b"]?.['c']?.d?.e?.["f"]

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js.snap
@@ -42,6 +42,9 @@ a = {
 a = {
 	[""]: 2
 }
+a = {
+	"__proto__": null,
+}
 
 // optional chain
 a?.["b"]?.['c']?.d?.e?.["f"]
@@ -641,7 +644,7 @@ invalid.js:37:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
   > 37 │ 	[""]: 2
        │ 	 ^^
     38 │ }
-    39 │ 
+    39 │ a = {
   
   i Unsafe fix: Use a literal key instead.
   
@@ -651,54 +654,71 @@ invalid.js:37:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 
 ```
-invalid.js:41:5 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:40:2 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    40 │ // optional chain
-  > 41 │ a?.["b"]?.['c']?.d?.e?.["f"]
-       │     ^^^
+    38 │ }
+    39 │ a = {
+  > 40 │ 	"__proto__": null,
+       │ 	^^^^^^^^^^^
+    41 │ }
     42 │ 
   
   i Unsafe fix: Use a literal key instead.
   
-    41 │ a?.["b"]?.['c']?.d?.e?.["f"]
+    40 │ → "__proto__":·null,
+       │   -         -       
+
+```
+
+```
+invalid.js:44:5 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The computed expression can be simplified without the use of a string literal.
+  
+    43 │ // optional chain
+  > 44 │ a?.["b"]?.['c']?.d?.e?.["f"]
+       │     ^^^
+    45 │ 
+  
+  i Unsafe fix: Use a literal key instead.
+  
+    44 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │    -- --                    
 
 ```
 
 ```
-invalid.js:41:12 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:44:12 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    40 │ // optional chain
-  > 41 │ a?.["b"]?.['c']?.d?.e?.["f"]
+    43 │ // optional chain
+  > 44 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │            ^^^
-    42 │ 
+    45 │ 
   
   i Unsafe fix: Use a literal key instead.
   
-    41 │ a?.["b"]?.['c']?.d?.e?.["f"]
+    44 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │           -- --             
 
 ```
 
 ```
-invalid.js:41:25 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:44:25 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    40 │ // optional chain
-  > 41 │ a?.["b"]?.['c']?.d?.e?.["f"]
+    43 │ // optional chain
+  > 44 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │                         ^^^
-    42 │ 
+    45 │ 
   
   i Unsafe fix: Use a literal key instead.
   
-    41 │ a?.["b"]?.['c']?.d?.e?.["f"]
+    44 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │                        -- --
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js
@@ -18,3 +18,6 @@ class C { a = 0 }
 class C { a(){} }
 class C { get a(){} }
 class C { set a(x){} }
+a = {
+	["__proto__"]: null,
+}

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js.snap
@@ -24,7 +24,7 @@ class C { a = 0 }
 class C { a(){} }
 class C { get a(){} }
 class C { set a(x){} }
-
+a = {
+	["__proto__"]: null,
+}
 ```
-
-

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -301,6 +301,17 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [complexity/useLiteralKeys](https://biomejs.dev/linter/rules/use-literal-keys/) no longer report computed properties named `__proto__` ([#2430](https://github.com/biomejs/biome/issues/2430)).
+
+  In JavaScript, `{["__proto__"]: null}` and `{__proto__: null}` have not the same semantic.
+  The first code set a regular property to `null`.
+  The second one set the prototype of the object to `null`.
+  See the [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) for more details.
+
+  The rule now ignores computed properties named `__proto__`.
+
+  Contributed by @Conaclos
+
 #### Bug fixes
 
 - Lint rules `useNodejsImportProtocol`, `useNodeAssertStrict`, `noRestrictedImports`, `noNodejsModules` will no longer check `declare module` statements anymore. Contributed by @Sec-ant


### PR DESCRIPTION
## Summary

Fix #2430

I took the opportunity of refactoring the implementation to use the utility `as_static_value`.

## Test Plan

I added some tests.
