### PR TITLE
chore(ci): add repository dispatch workflow

### DIFF
--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -1,0 +1,33 @@
+name: Repository dispatch on main
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+env:
+  BIOME_WEBSITE_REPO: biomejs/website
+  BIOME_PUSH_ON_MAIN_EVENT_TYPE: biome-push-on-main-event
+
+jobs:
+  repository-dispatch:
+    name: Repository dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch event on push
+        if: ${{ github.event_name == 'push' }}
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.BIOME_REPOSITORY_DISPATCH }}
+          repository: ${{ env.BIOME_WEBSITE_REPO }}
+          event-type: ${{ env.BIOME_PUSH_ON_MAIN_EVENT_TYPE }}
+          client-payload: '{"event": ${{ toJson(github.event) }}}'
+      # For testing only, the payload is mocked
+      - name: Dispatch event on workflow dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.BIOME_REPOSITORY_DISPATCH }}
+          repository: ${{ env.BIOME_WEBSITE_REPO }}
+          event-type: ${{ env.BIOME_PUSH_ON_MAIN_EVENT_TYPE }}
+          client-payload: '{"event": {"head_commit": {"id": "${{ env.GITHUB_SHA }}"}}}'


### PR DESCRIPTION
## Summary

Add repository dispatch workflow. This workflow is meant to trigger the [Pin submodule and run codegen workflow](https://github.com/biomejs/website/actions/workflows/pin-submodule-and-run-codegen.yaml) in [biomejs/website](https://github.com/biomejs/website) whenever a push event is issued from the main branch.

To trigger the workflow in another repository, this workflow needs a PAT ([Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)) and stores it as a repository secret. I used the secrete name `BIOME_REPOSITORY_DISPATCH` in this workflow. Further details about the token permissions can be found here: https://github.com/peter-evans/repository-dispatch?tab=readme-ov-file#token

I suggest that we create a dedicated account under the organization (maybe with the name `biomecookie` or something like that) for token management. So personal access tokens won't be associated with any personal accounts. We should also only grant the minimal permissions for the tokens we need.

A dedicated account for tokens will also let us to use it instead of `github-actions[bot]` to trigger other workflows:

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, **will not create a new workflow run**. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow **will not run even when the repository contains a workflow configured to run when push events occur**.
> 
> Commits pushed by a GitHub Actions workflow that uses the `GITHUB_TOKEN` **do not trigger a GitHub Pages build**.

A bit of info on creating a machine user:

- https://docs.github.com/en/get-started/learning-about-github/types-of-github-accounts#personal-accounts
- https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#machine-users

## Test Plan


