### PR TITLE
fix(analyzer): script block detection in `vue` and `svelte` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Biome now can handle `.svelte` and `.vue` files with `CRLF` as the end-of-line sequence. Contributed by @Sec-ant
 
+- Biome now can handle `.vue` files with [generic components](https://vuejs.org/api/sfc-script-setup#generics) ([#2456](https://github.com/biomejs/biome/issues/2456)).
+  ```vue
+  <script generic="T extends Record<string, any>" lang="ts" setup>
+  //...
+  </script>
+  ```
+  Contributed by @Sec-ant
+
 #### Enhancements
 
 - Complete the well-known file lists for JSON-like files. Trailing commas are allowed in `.jsonc` files by default. Some well-known files like `tsconfig.json` and `.babelrc` don't use the `.jsonc` extension but still allow comments and trailing commas. While others, such as `.eslintrc.json`, only allow comments. Biome is able to identify these files and adjusts the `json.parser.allowTrailingCommas` option accordingly to ensure they are correctly parsed. Contributed by @Sec-ant

--- a/crates/biome_cli/tests/cases/handle_vue_files.rs
+++ b/crates/biome_cli/tests/cases/handle_vue_files.rs
@@ -73,6 +73,10 @@ import Button from "./components/Button.vue";
 const VUE_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED: &str =
     "<script>\r\n  const a    = \"b\";\r\n</script>\r\n<template></template>";
 
+const VUE_GENERIC_COMPONENT_FILE_UNFORMATTED: &str = r#"<script generic="T extends Record<string, any>" lang="ts" setup>
+const a     =     "a";
+</script>"#;
+
 #[test]
 fn format_vue_implicit_js_files() {
     let mut fs = MemoryFileSystem::default();
@@ -364,6 +368,40 @@ fn format_vue_carriage_return_line_feed_files() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "format_vue_carriage_return_line_feed_files",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_vue_generic_component_files() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let vue_file_path = Path::new("file.vue");
+    fs.insert(
+        vue_file_path.into(),
+        VUE_GENERIC_COMPONENT_FILE_UNFORMATTED.as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_file_contents(
+        &fs,
+        vue_file_path,
+        VUE_GENERIC_COMPONENT_FILE_UNFORMATTED,
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_vue_generic_component_files",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/cases/handle_vue_files.rs
+++ b/crates/biome_cli/tests/cases/handle_vue_files.rs
@@ -393,11 +393,7 @@ fn format_vue_generic_component_files() {
 
     assert!(result.is_err(), "run_cli returned {result:?}");
 
-    assert_file_contents(
-        &fs,
-        vue_file_path,
-        VUE_GENERIC_COMPONENT_FILE_UNFORMATTED,
-    );
+    assert_file_contents(&fs, vue_file_path, VUE_GENERIC_COMPONENT_FILE_UNFORMATTED);
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_generic_component_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_generic_component_files.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.vue`
+
+```vue
+<script generic="T extends Record<string, any>" lang="ts" setup>
+const a     =     "a";
+</script>
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.vue format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1 1 │   <script generic="T extends Record<string, any>" lang="ts" setup>
+    2   │ - const·a·····=·····"a";
+      2 │ + const·a·=·"a";
+    3 3 │   </script>
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 1 error.
+```

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -24,9 +24,9 @@ use super::parse_lang_from_script_opening_tag;
 pub struct SvelteFileHandler;
 
 lazy_static! {
-    // https://regex101.com/r/E4n4hh/4
+    // https://regex101.com/r/E4n4hh/6
     pub static ref SVELTE_FENCE: Regex = Regex::new(
-        r#"(?ixs)(?<opening><script[^>]*>)\r?\n(?<script>(?U:.*))</script>"#
+        r#"(?ixs)(?<opening><script(?:\s.*?)?>)\r?\n(?<script>(?U:.*))</script>"#
     )
     .unwrap();
 }

--- a/crates/biome_service/src/file_handlers/vue.rs
+++ b/crates/biome_service/src/file_handlers/vue.rs
@@ -24,9 +24,9 @@ use super::parse_lang_from_script_opening_tag;
 pub struct VueFileHandler;
 
 lazy_static! {
-    // https://regex101.com/r/E4n4hh/4
+    // https://regex101.com/r/E4n4hh/6
     pub static ref VUE_FENCE: Regex = Regex::new(
-        r#"(?ixs)(?<opening><script[^>]*>)\r?\n(?<script>(?U:.*))</script>"#
+        r#"(?ixs)(?<opening><script(?:\s.*?)?>)\r?\n(?<script>(?U:.*))</script>"#
     )
     .unwrap();
 }

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -33,6 +33,14 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Biome now can handle `.svelte` and `.vue` files with `CRLF` as the end-of-line sequence. Contributed by @Sec-ant
 
+- Biome now can handle `.vue` files with [generic components](https://vuejs.org/api/sfc-script-setup#generics) ([#2456](https://github.com/biomejs/biome/issues/2456)).
+  ```vue
+  <script generic="T extends Record<string, any>" lang="ts" setup>
+  //...
+  </script>
+  ```
+  Contributed by @Sec-ant
+
 #### Enhancements
 
 - Complete the well-known file lists for JSON-like files. Trailing commas are allowed in `.jsonc` files by default. Some well-known files like `tsconfig.json` and `.babelrc` don't use the `.jsonc` extension but still allow comments and trailing commas. While others, such as `.eslintrc.json`, only allow comments. Biome is able to identify these files and adjusts the `json.parser.allowTrailingCommas` option accordingly to ensure they are correctly parsed. Contributed by @Sec-ant


### PR DESCRIPTION
## Summary

Fix the regexes we use for script block detection in `.vue` and `.svelte` files to support generic components in `.vue` files.

Closes #2456.

## Test Plan

Added a test case borrowed from #2456.
