### PR TITLE
chore: prepare knope

### DIFF
--- a/.changeset/add_crate.md
+++ b/.changeset/add_crate.md
@@ -1,7 +1,0 @@
----
-biome_html_factory: minor
-biome_html_syntax: minor
-biome_html_parser: minor
----
-
-# Add crate and started to create basic parsing of lists

--- a/.changeset/add_crate.md
+++ b/.changeset/add_crate.md
@@ -1,0 +1,7 @@
+---
+biome_html_factory: minor
+biome_html_syntax: minor
+biome_html_parser: minor
+---
+
+# Add crate and started to create basic parsing of lists

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches: [ main ]
+name: Create Release PR
+jobs:
+  prepare-release:
+    if: "!contains(github.event.head_commit.message, 'chore: prepare release')" # Skip merges from releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config --global user.name GitHub Actions
+          git config user.email github-actions@github.com
+      - uses: knope-dev/action@v2.1.0
+        with:
+          version: 0.16.2
+      - run: knope prepare-release --verbose
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "biome_html_parser"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "biome_console",
  "biome_diagnostics",

--- a/crates/biome_html_parser/Cargo.toml
+++ b/crates/biome_html_parser/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
-authors.workspace = true
+authors.workspace    = true
 categories.workspace = true
-description = "<DESCRIPTION>"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
-name = "biome_html_parser"
+description          = "<DESCRIPTION>"
+edition.workspace    = true
+homepage.workspace   = true
+keywords.workspace   = true
+license.workspace    = true
+name                 = "biome_html_parser"
 repository.workspace = true
-version = "0.0.1"
+version              = "0.0.1"
 
 [lints]
 workspace = true
 
 [dependencies]
-biome_console = { workspace = true }
-biome_diagnostics = { workspace = true }
-biome_html_factory = { workspace = true }
-biome_html_syntax = { workspace = true }
-biome_parser = { workspace = true }
-biome_rowan = { workspace = true }
+biome_console       = { workspace = true }
+biome_diagnostics   = { workspace = true }
+biome_html_factory  = { workspace = true }
+biome_html_syntax   = { workspace = true }
+biome_parser        = { workspace = true }
+biome_rowan         = { workspace = true }
 biome_unicode_table = { workspace = true }
-tracing = { workspace = true }
+tracing             = { workspace = true }
 
 
 [dev-dependencies]
-biome_test_utils = { path = "../biome_test_utils" }
-insta = { workspace = true }
-quickcheck = { workspace = true }
+biome_test_utils  = { path = "../biome_test_utils" }
+insta             = { workspace = true }
+quickcheck        = { workspace = true }
 quickcheck_macros = { workspace = true }
-tests_macros = { path = "../tests_macros" }
+tests_macros      = { path = "../tests_macros" }

--- a/crates/biome_html_parser/Cargo.toml
+++ b/crates/biome_html_parser/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
-authors.workspace    = true
+authors.workspace = true
 categories.workspace = true
-description          = "<DESCRIPTION>"
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
-name                 = "biome_html_parser"
+description = "<DESCRIPTION>"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+name = "biome_html_parser"
 repository.workspace = true
-version              = "0.0.0"
+version = "0.0.1"
 
 [lints]
 workspace = true
 
 [dependencies]
-biome_console       = { workspace = true }
-biome_diagnostics   = { workspace = true }
-biome_html_factory  = { workspace = true }
-biome_html_syntax   = { workspace = true }
-biome_parser        = { workspace = true }
-biome_rowan         = { workspace = true }
+biome_console = { workspace = true }
+biome_diagnostics = { workspace = true }
+biome_html_factory = { workspace = true }
+biome_html_syntax = { workspace = true }
+biome_parser = { workspace = true }
+biome_rowan = { workspace = true }
 biome_unicode_table = { workspace = true }
-tracing             = { workspace = true }
+tracing = { workspace = true }
 
 
 [dev-dependencies]
-biome_test_utils  = { path = "../biome_test_utils" }
-insta             = { workspace = true }
-quickcheck        = { workspace = true }
+biome_test_utils = { path = "../biome_test_utils" }
+insta = { workspace = true }
+quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
-tests_macros      = { path = "../tests_macros" }
+tests_macros = { path = "../tests_macros" }

--- a/justfile
+++ b/justfile
@@ -152,6 +152,7 @@ new-crate name:
 new-changeset:
     knope document-change
 
-dry-run:
-    knope release --dry-run > out.txt
+# Dry-run of the release
+new-release *args='':
+    knope release --dry-run {{args}}
 

--- a/justfile
+++ b/justfile
@@ -148,11 +148,11 @@ new-crate name:
   cargo new --lib crates/{{snakecase(name)}}
   cargo run -p xtask_codegen -- new-crate --name={{snakecase(name)}}
 
-# Creates a new changeset for the final changelog. ONLY FOR CRATES, FOR NOW
+# Creates a new changeset for the final changelog
 new-changeset:
     knope document-change
 
 # Dry-run of the release
-new-release *args='':
+new-dry-run-release *args='':
     knope release --dry-run {{args}}
 

--- a/knope.toml
+++ b/knope.toml
@@ -1,176 +1,178 @@
 ## npm packages
-[packages.biome]
+[packages."@biomejs/biome"]
+changelog       = "CHANGELOG.md"
 versioned_files = ["packages/@biomejs/biome/package.json"]
-changelog = "CHANGELOG.md"
 
+# Special crate. This is the main binary that we are going to release.
+[packages.biome_cli]
+versioned_files = ["crates/biome_cli/Cargo.toml"]
+# Artifact names
+[[packages.biome_cli.assets]]
+name = "biome-win32-x64.tgz"
+path = "dist/biome-win32-x64.tgz"
+[[packages.biome_cli.assets]]
+name = "biome-win32-arm64.tgz"
+path = "dist/biome-win32-arm64.tgz"
+[[packages.biome_cli.assets]]
+name = "biome-linux-x64.tgz"
+path = "dist/biome-linux-x64.tgz"
+[[packages.biome_cli.assets]]
+name = "biome-linux-arm64.tgz"
+path = "dist/biome-linux-arm64.tgz"
+[[packages.biome_cli.assets]]
+name = "biome-linux-x64-musl.tgz"
+path = "dist/biome-linux-x64-musl.tgz"
+[[packages.biome_cli.assets]]
+name = "biome-linux-arm64-musl.tgz"
+path = "dist/biome-linux-arm64-musl.tgz"
+[[packages.biome_cli.assets]]
+name = "biome-darwin-x64.tgz"
+path = "dist/biome-darwin-x64.tgz"
+[[packages.biome_cli.assets]]
+name = "biome-darwin-arm64.tgz"
+path = "dist/biome-darwin-arm64.tgz"
 
 ## Rust crates. DO NOT CHANGE!
 [packages.biome_analyze]
+changelog       = "crates/biome_analyze/CHANGELOG.md"
 versioned_files = ["crates/biome_analyze/Cargo.toml"]
-changelog = "crates/biome_analyze/CHANGELOG.md"
 [packages.biome_aria]
+changelog       = "crates/biome_aria/CHANGELOG.md"
 versioned_files = ["crates/biome_aria/Cargo.toml"]
-changelog = "crates/biome_aria/CHANGELOG.md"
 [packages.biome_aria_metadata]
+changelog       = "crates/biome_aria_metadata/CHANGELOG.md"
 versioned_files = ["crates/biome_aria_metadata/Cargo.toml"]
-changelog = "crates/biome_aria_metadata/CHANGELOG.md"
 [packages.biome_console]
+changelog       = "crates/biome_console/CHANGELOG.md"
 versioned_files = ["crates/biome_console/Cargo.toml"]
-changelog = "crates/biome_console/CHANGELOG.md"
 [packages.biome_control_flow]
+changelog       = "crates/biome_control_flow/CHANGELOG.md"
 versioned_files = ["crates/biome_control_flow/Cargo.toml"]
-changelog = "crates/biome_control_flow/CHANGELOG.md"
 [packages.biome_css_factory]
+changelog       = "crates/biome_css_factory/CHANGELOG.md"
 versioned_files = ["crates/biome_css_factory/Cargo.toml"]
-changelog = "crates/biome_css_factory/CHANGELOG.md"
 [packages.biome_css_formatter]
+changelog       = "crates/biome_css_formatter/CHANGELOG.md"
 versioned_files = ["crates/biome_css_formatter/Cargo.toml"]
-changelog = "crates/biome_css_formatter/CHANGELOG.md"
 [packages.biome_css_parser]
+changelog       = "crates/biome_css_parser/CHANGELOG.md"
 versioned_files = ["crates/biome_css_parser/Cargo.toml"]
-changelog = "crates/biome_css_parser/CHANGELOG.md"
 [packages.biome_css_syntax]
+changelog       = "crates/biome_css_syntax/CHANGELOG.md"
 versioned_files = ["crates/biome_css_syntax/Cargo.toml"]
-changelog = "crates/biome_css_syntax/CHANGELOG.md"
 [packages.biome_deserialize]
+changelog       = "crates/biome_deserialize/CHANGELOG.md"
 versioned_files = ["crates/biome_deserialize/Cargo.toml"]
-changelog = "crates/biome_deserialize/CHANGELOG.md"
 [packages.biome_deserialize_macros]
+changelog       = "crates/biome_deserialize_macros/CHANGELOG.md"
 versioned_files = ["crates/biome_deserialize_macros/Cargo.toml"]
-changelog = "crates/biome_deserialize_macros/CHANGELOG.md"
 [packages.biome_diagnostics]
+changelog       = "crates/biome_diagnostics/CHANGELOG.md"
 versioned_files = ["crates/biome_diagnostics/Cargo.toml"]
-changelog = "crates/biome_diagnostics/CHANGELOG.md"
 [packages.biome_diagnostics_categories]
+changelog       = "crates/biome_diagnostics_categories/CHANGELOG.md"
 versioned_files = ["crates/biome_diagnostics_categories/Cargo.toml"]
-changelog = "crates/biome_diagnostics_categories/CHANGELOG.md"
 [packages.biome_diagnostics_macros]
+changelog       = "crates/biome_diagnostics_macros/CHANGELOG.md"
 versioned_files = ["crates/biome_diagnostics_macros/Cargo.toml"]
-changelog = "crates/biome_diagnostics_macros/CHANGELOG.md"
 [packages.biome_formatter]
+changelog       = "crates/biome_formatter/CHANGELOG.md"
 versioned_files = ["crates/biome_formatter/Cargo.toml"]
-changelog = "crates/biome_formatter/CHANGELOG.md"
 [packages.biome_fs]
+changelog       = "crates/biome_fs/CHANGELOG.md"
 versioned_files = ["crates/biome_fs/Cargo.toml"]
-changelog = "crates/biome_fs/CHANGELOG.md"
 [packages.biome_grit_factory]
+changelog       = "crates/biome_grit_factory/CHANGELOG.md"
 versioned_files = ["crates/biome_grit_factory/Cargo.toml"]
-changelog = "crates/biome_grit_factory/CHANGELOG.md"
 [packages.biome_grit_parser]
+changelog       = "crates/biome_grit_parser/CHANGELOG.md"
 versioned_files = ["crates/biome_grit_parser/Cargo.toml"]
-changelog = "crates/biome_grit_parser/CHANGELOG.md"
 [packages.biome_grit_syntax]
+changelog       = "crates/biome_grit_syntax/CHANGELOG.md"
 versioned_files = ["crates/biome_grit_syntax/Cargo.toml"]
-changelog = "crates/biome_grit_syntax/CHANGELOG.md"
 [packages.biome_html_factory]
+changelog       = "crates/biome_html_factory/CHANGELOG.md"
 versioned_files = ["crates/biome_html_factory/Cargo.toml"]
-changelog = "crates/biome_html_factory/CHANGELOG.md"
 [packages.biome_html_syntax]
+changelog       = "crates/biome_html_syntax/CHANGELOG.md"
 versioned_files = ["crates/biome_html_syntax/Cargo.toml"]
-changelog = "crates/biome_html_syntax/CHANGELOG.md"
 [packages.biome_js_analyze]
+changelog       = "crates/biome_js_analyze/CHANGELOG.md"
 versioned_files = ["crates/biome_js_analyze/Cargo.toml"]
-changelog = "crates/biome_js_analyze/CHANGELOG.md"
 [packages.biome_js_factory]
+changelog       = "crates/biome_js_factory/CHANGELOG.md"
 versioned_files = ["crates/biome_js_factory/Cargo.toml"]
-changelog = "crates/biome_js_factory/CHANGELOG.md"
 [packages.biome_js_formatter]
+changelog       = "crates/biome_js_formatter/CHANGELOG.md"
 versioned_files = ["crates/biome_js_formatter/Cargo.toml"]
-changelog = "crates/biome_js_formatter/CHANGELOG.md"
 [packages.biome_js_parser]
+changelog       = "crates/biome_js_parser/CHANGELOG.md"
 versioned_files = ["crates/biome_js_parser/Cargo.toml"]
-changelog = "crates/biome_js_parser/CHANGELOG.md"
 [packages.biome_js_semantic]
+changelog       = "crates/biome_js_semantic/CHANGELOG.md"
 versioned_files = ["crates/biome_js_semantic/Cargo.toml"]
-changelog = "crates/biome_js_semantic/CHANGELOG.md"
 [packages.biome_js_syntax]
+changelog       = "crates/biome_js_syntax/CHANGELOG.md"
 versioned_files = ["crates/biome_js_syntax/Cargo.toml"]
-changelog = "crates/biome_js_syntax/CHANGELOG.md"
 [packages.biome_js_transform]
+changelog       = "crates/biome_js_transform/CHANGELOG.md"
 versioned_files = ["crates/biome_js_transform/Cargo.toml"]
-changelog = "crates/biome_js_transform/CHANGELOG.md"
 [packages.biome_json_analyze]
+changelog       = "crates/biome_json_analyze/CHANGELOG.md"
 versioned_files = ["crates/biome_json_analyze/Cargo.toml"]
-changelog = "crates/biome_json_analyze/CHANGELOG.md"
 [packages.biome_json_factory]
+changelog       = "crates/biome_json_factory/CHANGELOG.md"
 versioned_files = ["crates/biome_json_factory/Cargo.toml"]
-changelog = "crates/biome_json_factory/CHANGELOG.md"
 [packages.biome_json_formatter]
+changelog       = "crates/biome_json_formatter/CHANGELOG.md"
 versioned_files = ["crates/biome_json_formatter/Cargo.toml"]
-changelog = "crates/biome_json_formatter/CHANGELOG.md"
 [packages.biome_json_parser]
+changelog       = "crates/biome_json_parser/CHANGELOG.md"
 versioned_files = ["crates/biome_json_parser/Cargo.toml"]
-changelog = "crates/biome_json_parser/CHANGELOG.md"
 [packages.biome_json_syntax]
+changelog       = "crates/biome_json_syntax/CHANGELOG.md"
 versioned_files = ["crates/biome_json_syntax/Cargo.toml"]
-changelog = "crates/biome_json_syntax/CHANGELOG.md"
 [packages.biome_markup]
+changelog       = "crates/biome_markup/CHANGELOG.md"
 versioned_files = ["crates/biome_markup/Cargo.toml"]
-changelog = "crates/biome_markup/CHANGELOG.md"
 [packages.biome_parser]
+changelog       = "crates/biome_parser/CHANGELOG.md"
 versioned_files = ["crates/biome_parser/Cargo.toml"]
-changelog = "crates/biome_parser/CHANGELOG.md"
 [packages.biome_project]
+changelog       = "crates/biome_project/CHANGELOG.md"
 versioned_files = ["crates/biome_project/Cargo.toml"]
-changelog = "crates/biome_project/CHANGELOG.md"
 [packages.biome_rowan]
+changelog       = "crates/biome_rowan/CHANGELOG.md"
 versioned_files = ["crates/biome_rowan/Cargo.toml"]
-changelog = "crates/biome_rowan/CHANGELOG.md"
 [packages.biome_suppression]
+changelog       = "crates/biome_suppression/CHANGELOG.md"
 versioned_files = ["crates/biome_suppression/Cargo.toml"]
-changelog = "crates/biome_suppression/CHANGELOG.md"
 [packages.biome_text_edit]
+changelog       = "crates/biome_text_edit/CHANGELOG.md"
 versioned_files = ["crates/biome_text_edit/Cargo.toml"]
-changelog = "crates/biome_text_edit/CHANGELOG.md"
 [packages.biome_text_size]
+changelog       = "crates/biome_text_size/CHANGELOG.md"
 versioned_files = ["crates/biome_text_size/Cargo.toml"]
-changelog = "crates/biome_text_size/CHANGELOG.md"
 [packages.biome_unicode_table]
+changelog       = "crates/biome_unicode_table/CHANGELOG.md"
 versioned_files = ["crates/biome_unicode_table/Cargo.toml"]
-changelog = "crates/biome_unicode_table/CHANGELOG.md"
 [packages.biome_string_case]
+changelog       = "crates/biome_string_case/CHANGELOG.md"
 versioned_files = ["crates/biome_string_case/Cargo.toml"]
-changelog = "crates/biome_string_case/CHANGELOG.md"
 [packages.biome_graphql_syntax]
+changelog       = "crates/biome_graphql_syntax/CHANGELOG.md"
 versioned_files = ["crates/biome_graphql_syntax/Cargo.toml"]
-changelog = "crates/biome_graphql_syntax/CHANGELOG.md"
 [packages.biome_graphql_factory]
+changelog       = "crates/biome_graphql_factory/CHANGELOG.md"
 versioned_files = ["crates/biome_graphql_factory/Cargo.toml"]
-changelog = "crates/biome_graphql_factory/CHANGELOG.md"
 [packages.biome_html_parser]
+changelog       = "crates/biome_html_parser/CHANGELOG.md"
 versioned_files = ["crates/biome_html_parser/Cargo.toml"]
-changelog = "crates/biome_html_parser/CHANGELOG.md"
 [packages.biome_configuration]
+changelog       = "crates/biome_configuration/CHANGELOG.md"
 versioned_files = ["crates/biome_configuration/Cargo.toml"]
-changelog = "crates/biome_configuration/CHANGELOG.md"
 
 ## End of crates. DO NOT CHANGE!
-
-# Artifact names
-[[package.assets]]
-path = "dist/biome-win32-x64.tgz"
-name = "biome-win32-x64.tgz"
-[[package.assets]]
-path = "dist/biome-win32-arm64.tgz"
-name = "biome-win32-arm64.tgz"
-[[package.assets]]
-path = "dist/biome-linux-x64.tgz"
-name = "biome-linux-x64.tgz"
-[[package.assets]]
-path = "dist/biome-linux-arm64.tgz"
-name = "biome-linux-arm64.tgz"
-[[package.assets]]
-path = "dist/biome-linux-x64-musl.tgz"
-name = "biome-linux-x64-musl.tgz"
-[[package.assets]]
-path = "dist/biome-linux-arm64-musl.tgz"
-name = "biome-linux-arm64-musl.tgz"
-[[package.assets]]
-path = "dist/biome-darwin-x64.tgz"
-name = "biome-darwin-x64.tgz"
-[[package.assets]]
-path = "dist/biome-darwin-arm64.tgz"
-name = "biome-darwin-arm64.tgz"
 
 # Workflow to create a changeset
 [[workflows]]
@@ -180,37 +182,51 @@ name = "document-change"
 type = "CreateChangeFile"
 
 
-# Workflow that creates a PR via github actions and create a release
+# Workflow that creates a PR via GitHub actions. This PR will contain all the changes for a release: changelogs, version numbers, etc.
+# Refernce: https://knope.tech/recipes/1-preview-releases-with-pull-requests/#prepare-release-workflow
 [[workflows]]
 name = "preprare-release"
 [[workflows.steps]]
-type = "Command"
 command = "git switch -c release"
+type    = "Command"
 
 [[workflows.steps]]
 type = "PrepareRelease"
+# we have been following conventional commits, although inside the monorepo it's difficult to define scopes
+ignore_conventional_commits = true
 
 [[workflows.steps]]
 type = "Command"
+# WARNING: if you change this message, remember to update the `prepare_release.yml` too, because it uses this message
 command = "git commit -m \"chore: prepare release $version\""
 
 [[workflows.steps]]
-type = "Command"
 command = "git push --force --set-upstream origin release"
+type    = "Command"
 
 [workflows.steps.variables]
 "$version" = "Version"
 
 [[workflows.steps]]
-type = "CreatePullRequest"
 base = "main"
+type = "CreatePullRequest"
 
 [workflows.steps.title]
-template = "chore: prepare release $version"
+template  = "chore: prepare release $version"
 variables = { "$version" = "Version" }
 
 [workflows.steps.body]
-template = "This PR was created by Knope. Merging it will create a new release\n\n$changelog"
+template  = "This PR was created by Knope. Merging it will create a new release\n\n$changelog"
 variables = { "$changelog" = "ChangelogEntry" }
 
+# The release workflow that will run in CI. It is triggered when the prepare-release PR is merged
+[[workflows]]
+name = "release"
 
+[[workflows.steps]]
+type = "Release"
+
+# GitHub related information. `owner` is the name of the org, `repo` is the name of the repository where the actions run
+[github]
+owner = "biomejs"
+repo  = "biome"

--- a/knope.toml
+++ b/knope.toml
@@ -1,8 +1,10 @@
 ## npm packages
-# Empty for now
+[packages.biome]
+versioned_files = ["packages/@biomejs/biome/package.json"]
+changelog = "CHANGELOG.md"
 
 
-## Rust crates
+## Rust crates. DO NOT CHANGE!
 [packages.biome_analyze]
 versioned_files = ["crates/biome_analyze/Cargo.toml"]
 changelog = "crates/biome_analyze/CHANGELOG.md"
@@ -135,11 +137,80 @@ changelog = "crates/biome_graphql_syntax/CHANGELOG.md"
 [packages.biome_graphql_factory]
 versioned_files = ["crates/biome_graphql_factory/Cargo.toml"]
 changelog = "crates/biome_graphql_factory/CHANGELOG.md"
-
-[package."biome_html_parser"]
-versioned_files = ["creates/biome_html_parser/Cargo.toml"]
+[packages.biome_html_parser]
+versioned_files = ["crates/biome_html_parser/Cargo.toml"]
 changelog = "crates/biome_html_parser/CHANGELOG.md"
-
-[package."biome_configuration"]
-versioned_files = ["creates/biome_configuration/Cargo.toml"]
+[packages.biome_configuration]
+versioned_files = ["crates/biome_configuration/Cargo.toml"]
 changelog = "crates/biome_configuration/CHANGELOG.md"
+
+## End of crates. DO NOT CHANGE!
+
+# Artifact names
+[[package.assets]]
+path = "dist/biome-win32-x64.tgz"
+name = "biome-win32-x64.tgz"
+[[package.assets]]
+path = "dist/biome-win32-arm64.tgz"
+name = "biome-win32-arm64.tgz"
+[[package.assets]]
+path = "dist/biome-linux-x64.tgz"
+name = "biome-linux-x64.tgz"
+[[package.assets]]
+path = "dist/biome-linux-arm64.tgz"
+name = "biome-linux-arm64.tgz"
+[[package.assets]]
+path = "dist/biome-linux-x64-musl.tgz"
+name = "biome-linux-x64-musl.tgz"
+[[package.assets]]
+path = "dist/biome-linux-arm64-musl.tgz"
+name = "biome-linux-arm64-musl.tgz"
+[[package.assets]]
+path = "dist/biome-darwin-x64.tgz"
+name = "biome-darwin-x64.tgz"
+[[package.assets]]
+path = "dist/biome-darwin-arm64.tgz"
+name = "biome-darwin-arm64.tgz"
+
+# Workflow to create a changeset
+[[workflows]]
+name = "document-change"
+
+[[workflows.steps]]
+type = "CreateChangeFile"
+
+
+# Workflow that creates a PR via github actions and create a release
+[[workflows]]
+name = "preprare-release"
+[[workflows.steps]]
+type = "Command"
+command = "git switch -c release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+
+[[workflows.steps]]
+type = "Command"
+command = "git commit -m \"chore: prepare release $version\""
+
+[[workflows.steps]]
+type = "Command"
+command = "git push --force --set-upstream origin release"
+
+[workflows.steps.variables]
+"$version" = "Version"
+
+[[workflows.steps]]
+type = "CreatePullRequest"
+base = "main"
+
+[workflows.steps.title]
+template = "chore: prepare release $version"
+variables = { "$version" = "Version" }
+
+[workflows.steps.body]
+template = "This PR was created by Knope. Merging it will create a new release\n\n$changelog"
+variables = { "$changelog" = "ChangelogEntry" }
+
+

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,4 +1,4 @@
-include = ["Cargo.toml", "crates/**/Cargo.toml", ".cargo/config.toml", "xtask/**/*.toml"]
+include = ["Cargo.toml", "crates/**/Cargo.toml", ".cargo/config.toml", "xtask/**/*.toml", "knope.toml"]
 exclude = ["./benchmark/**/*.toml"]
 
 [formatting]


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR does two things:
- it creates a knope workflow to **create a changeset** via the script `just new-changeset`. It present a prompt where users need choose the packages to update
  ![Screenshot 2024-04-16 at 15 33 20](https://github.com/biomejs/biome/assets/602478/84f43dac-3f2f-45a4-bf74-40c9601236a9)
- it creates a knope workflow **meant to be run in CI**. This workflow will create a PR that will prepare the release. If this PR is merged, then the real release will be triggered. 
- It adds a GitHub `prepare_release.yml` workflow that run the knope workflow `prepare-release`

> [!IMPORTANT]
> The release workflow isn't hooked with knope yet, so that PR won't do anything.

I will follow up with another PR to update our current release workflow only after we reach a stable stage where we can hold off on bug fixes. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
