### PR TITLE
chore: speed up `wasm-pack` profiling build

### DIFF
--- a/crates/biome_wasm/Cargo.toml
+++ b/crates/biome_wasm/Cargo.toml
@@ -44,3 +44,6 @@ quote              = "1.0.14"
 
 [lints]
 workspace = true
+
+[package.metadata.wasm-pack.profile.profiling]
+wasm-opt = false


### PR DESCRIPTION
## Summary

Disable `wasm-opt` when running `pnpm build:wasm-dev`.

Context: https://github.com/biomejs/website/pull/22#discussion_r1559508351

## Test Plan

`wasm-opt` is skipped for wasm dev builds.
