### PR TITLE
fix: reverts hashbrown, which causes issues when compiling to WASM

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,58 +1,60 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "timezone": "Europe/Gibraltar",
-  "schedule": [
-    "before 9am on monday"
-  ],
-  "extends": [
-    "config:best-practices"
-  ],
-  "rangeStrategy": "bump",
-  "lockFileMaintenance": {
-    "enabled": false
-  },
-  "assignees": [
-    "@biomejs/maintainers",
-    "@biomejs/core-contributors"
-  ],
-  "packageRules": [
-    {
-      "groupName": "github-actions",
-      "matchManagers": [
-        "github-actions"
-      ]
-    },
-    {
-      "groupName": "Rust crates",
-      "matchManagers": [
-        "cargo"
-      ],
-      "matchFileNames": [
-        "crates/**",
-        "xtask/**"
-      ],
-      "ignoreDeps": [
-        "syn",
-        "quote"
-      ]
-    },
-    {
-      "groupName": "Website",
-      "matchFileNames": [
-        "website/package.json"
-      ],
-      "matchManagers": [
-        "npm"
-      ]
-    },
-    {
-      "groupName": "@biomejs packages",
-      "matchFileNames": [
-        "packages/**"
-      ],
-      "matchManagers": [
-        "npm"
-      ]
-    }
-  ]
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"timezone": "Europe/Gibraltar",
+	"schedule": [
+		"before 9am on monday"
+	],
+	"extends": [
+		"config:best-practices"
+	],
+	"rangeStrategy": "bump",
+	"lockFileMaintenance": {
+		"enabled": false
+	},
+	"assignees": [
+		"@biomejs/maintainers",
+		"@biomejs/core-contributors"
+	],
+	"packageRules": [
+		{
+			"groupName": "github-actions",
+			"matchManagers": [
+				"github-actions"
+			]
+		},
+		{
+			"groupName": "Rust crates",
+			"matchManagers": [
+				"cargo"
+			],
+			"matchFileNames": [
+				"crates/**",
+				"xtask/**"
+			],
+			"ignoreDeps": [
+				"syn",
+				"quote",
+				"hashbrown",
+				"pulldown-cmark"
+			]
+		},
+		{
+			"groupName": "Website",
+			"matchFileNames": [
+				"website/package.json"
+			],
+			"matchManagers": [
+				"npm"
+			]
+		},
+		{
+			"groupName": "@biomejs packages",
+			"matchFileNames": [
+				"packages/**"
+			],
+			"matchManagers": [
+				"npm"
+			]
+		}
+	]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
  "biome_text_edit",
  "biome_text_size",
  "countme",
- "hashbrown 0.14.3",
+ "hashbrown 0.12.3",
  "iai",
  "memoffset",
  "quickcheck",

--- a/crates/biome_rowan/Cargo.toml
+++ b/crates/biome_rowan/Cargo.toml
@@ -1,37 +1,37 @@
 [package]
-authors.workspace = true
+authors.workspace    = true
 categories.workspace = true
-description = "Biome's custom Rowan definition"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
-name = "biome_rowan"
+description          = "Biome's custom Rowan definition"
+edition.workspace    = true
+homepage.workspace   = true
+keywords.workspace   = true
+license.workspace    = true
+name                 = "biome_rowan"
 repository.workspace = true
-version = "0.5.7"
+version              = "0.5.7"
 
 [dependencies]
 biome_text_edit = { workspace = true }
 biome_text_size = { workspace = true }
-countme = { workspace = true }
-hashbrown = { version = "0.12.3", features = ["inline-more"], default-features = false }
-memoffset = "0.8.0"
-rustc-hash = { workspace = true }
-serde = { workspace = true, optional = true }
-tracing = { workspace = true }
+countme         = { workspace = true }
+hashbrown       = { version = "0.12.3", features = ["inline-more"], default-features = false }
+memoffset       = "0.8.0"
+rustc-hash      = { workspace = true }
+serde           = { workspace = true, optional = true }
+tracing         = { workspace = true }
 
 [dev-dependencies]
-iai = "0.1.1"
-quickcheck = { workspace = true }
+iai               = "0.1.1"
+quickcheck        = { workspace = true }
 quickcheck_macros = { workspace = true }
-serde_json = { workspace = true }
+serde_json        = { workspace = true }
 
 [features]
 serde = ["dep:serde", "biome_text_size/serde", "biome_text_size/schemars"]
 
 [[bench]]
 harness = false
-name = "mutation"
+name    = "mutation"
 
 [lints]
 workspace = true

--- a/crates/biome_rowan/Cargo.toml
+++ b/crates/biome_rowan/Cargo.toml
@@ -1,37 +1,37 @@
 [package]
-authors.workspace    = true
+authors.workspace = true
 categories.workspace = true
-description          = "Biome's custom Rowan definition"
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
-name                 = "biome_rowan"
+description = "Biome's custom Rowan definition"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+name = "biome_rowan"
 repository.workspace = true
-version              = "0.5.7"
+version = "0.5.7"
 
 [dependencies]
 biome_text_edit = { workspace = true }
 biome_text_size = { workspace = true }
-countme         = { workspace = true }
-hashbrown       = { version = "0.14.3", features = ["inline-more"], default-features = false }
-memoffset       = "0.8.0"
-rustc-hash      = { workspace = true }
-serde           = { workspace = true, optional = true }
-tracing         = { workspace = true }
+countme = { workspace = true }
+hashbrown = { version = "0.12.3", features = ["inline-more"], default-features = false }
+memoffset = "0.8.0"
+rustc-hash = { workspace = true }
+serde = { workspace = true, optional = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-iai               = "0.1.1"
-quickcheck        = { workspace = true }
+iai = "0.1.1"
+quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
-serde_json        = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 serde = ["dep:serde", "biome_text_size/serde", "biome_text_size/schemars"]
 
 [[bench]]
 harness = false
-name    = "mutation"
+name = "mutation"
 
 [lints]
 workspace = true

--- a/crates/biome_rowan/src/green/node_cache.rs
+++ b/crates/biome_rowan/src/green/node_cache.rs
@@ -344,22 +344,15 @@ impl NodeCache {
     /// Removes nodes, tokens and trivia entries from the cache when their
     /// generation doesn't match the current generation of the whole cache
     pub(crate) fn sweep_cache(&mut self) {
-        let nodes = self
-            .nodes
-            .extract_if(|node, _| node.node.generation() != self.generation);
-        nodes.for_each(drop);
+        self.nodes
+            .drain_filter(|node, _| node.node.generation() != self.generation);
 
-        let tokens = self
-            .tokens
-            .extract_if(|token, _| token.0.generation() != self.generation);
+        self.tokens
+            .drain_filter(|token, _| token.0.generation() != self.generation);
 
-        tokens.for_each(drop);
-
-        let trivia = self
-            .trivia
+        self.trivia
             .cache
-            .extract_if(|trivia, _| trivia.0.generation() != self.generation);
-        trivia.for_each(drop);
+            .drain_filter(|trivia, _| trivia.0.generation() != self.generation);
     }
 }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR reverts `hashbrown`. The latest version is breaking the WASM distribution. 

We will look into this later, maybe by using `features`.

I also added `hashbrown` and `pulldown-cmark` to the ignored deps in renovate, because they contain breaking changes.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

CI should pass

<!-- What demonstrates that your implementation is correct? -->
