### PR TITLE
ci: add a workflow for linting pr titles

### DIFF
--- a/.github/workflows/pull_request_title_lint.yaml
+++ b/.github/workflows/pull_request_title_lint.yaml
@@ -1,0 +1,60 @@
+name: "Lint Pull Request Titles"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed (newline-delimited).
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            fix
+            feat
+            chore
+            ci
+            docs
+            refactor
+            release
+            test
+            revert
+          # Configure that a scope must always be provided.
+          requireScope: false
+          # Configure which scopes are disallowed in PR titles (newline-delimited).
+          # For instance by setting the value below, `chore(release): ...` (lowercase)
+          # and `ci(e2e,release): ...` (unknown scope) will be rejected.
+          # These are regex patterns auto-wrapped in `^ $`.
+          disallowScopes: |
+            release
+            [A-Z]+
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject doesn't start with an uppercase character.
+          subjectPattern: ^(?![A-Z]).+$
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          # If the PR contains one of these newline-delimited labels, the
+          # validation is skipped. If you want to rerun the validation when
+          # labels change, you might want to use the `labeled` and `unlabeled`
+          # event triggers in your workflow.
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request

--- a/.github/workflows/pull_request_title_lint.yaml
+++ b/.github/workflows/pull_request_title_lint.yaml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # Configure which types are allowed (newline-delimited).
-          # Default: https://github.com/commitizen/conventional-commit-types
+          # ref: CONTRIBUTING.md
           types: |
             feat
             fix

--- a/.github/workflows/pull_request_title_lint.yaml
+++ b/.github/workflows/pull_request_title_lint.yaml
@@ -49,9 +49,3 @@ jobs:
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
             doesn't start with an uppercase character.
-          # If the PR contains one of these newline-delimited labels, the
-          # validation is skipped. If you want to rerun the validation when
-          # labels change, you might want to use the `labeled` and `unlabeled`
-          # event triggers in your workflow.
-          ignoreLabels: |
-            bot

--- a/.github/workflows/pull_request_title_lint.yaml
+++ b/.github/workflows/pull_request_title_lint.yaml
@@ -23,15 +23,13 @@ jobs:
           # Configure which types are allowed (newline-delimited).
           # Default: https://github.com/commitizen/conventional-commit-types
           types: |
-            fix
             feat
-            chore
-            ci
+            fix
             docs
-            refactor
-            release
             test
-            revert
+            chore
+            perf
+            refactor
           # Configure that a scope must always be provided.
           requireScope: false
           # Configure which scopes are disallowed in PR titles (newline-delimited).
@@ -57,4 +55,3 @@ jobs:
           # event triggers in your workflow.
           ignoreLabels: |
             bot
-            ignore-semantic-pull-request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,6 +293,8 @@ docs: fix link to website page
 test(lint): add more cases to handle invalid rules
 ```
 
+We are using [action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) to lint the titles of pull requests. If the 'Lint Pull Request Titles' workflow fails, please correct the title.
+
 ## Creating pull requests
 
 When creating a new pull request, it's preferable to use a conventional commit-formatted title, as this title will be used as the default commit message on the squashed commit after merging.


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a workflow for linting pr titles. It uses [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request), used by some repositories ([Electron](https://github.com/electron/electron) · [Vite](https://github.com/vitejs/vite) · [Excalidraw](https://github.com/excalidraw/excalidraw) · [Apache](https://github.com/apache/pulsar) · [Vercel](https://github.com/vercel/ncc) · [Microsoft](https://github.com/microsoft/SynapseML) · [Firebase](https://github.com/firebase/flutterfire) · [AWS](https://github.com/aws-ia/terraform-aws-eks-blueprints)).

This is definition of each part (from [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request)).
```
feat(ui): Add `Button` component
^    ^    ^
|    |    |__ Subject
|    |_______ Scope
|____________ Type
```

I only added some types.
- fix
- feat
- chore
- ci
- docs
- refactor
- release
- test
- revert (we don't need this?)

No scope and subject pattern for now, but we can define scopes for consistency. In lint area, we have some random scopes for example `lint`, `lint/ruleName`, `analyzer`.

### Valid title
```txt
fix: Correct typo
feat: Add support for Node.js 18
refactor!: Drop support for Node.js 12
feat(ui): Add Button component
```

### Invalid title
```
Correct typo
wip: Add support for Node.js 18
```
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Tested on my forked repository : https://github.com/unvalley/biome/pull/2