### PR TITLE
fix(js_formatter): add parentheses for the return expression that has leading multiline comments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
+- Add parentheses for the return expression that has leading multiline comments. [#2504](https://github.com/biomejs/biome/pull/2504). Contributed by @ah-yu
+
 ### JavaScript APIs
 
 ### Linter

--- a/crates/biome_js_formatter/src/js/statements/return_statement.rs
+++ b/crates/biome_js_formatter/src/js/statements/return_statement.rs
@@ -138,6 +138,14 @@ fn has_argument_leading_comments(argument: &AnyJsExpression, comments: &JsCommen
             return true;
         }
 
+        if comments
+            .leading_comments(argument.syntax())
+            .iter()
+            .any(|comment| comment.piece().has_newline())
+        {
+            return true;
+        };
+
         current = get_expression_left_side(&expression);
     }
 

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/return.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/return.js
@@ -5,3 +5,22 @@ function f1() {
 function f2() {
     return 1,3,4
 }
+
+function f3() {
+    return /* commment */'1'
+}
+
+function f4() {
+    return (
+        /* comment */
+        '1'
+    )
+}
+
+function f5() {
+    return (
+        /*
+         * multiline comment 
+         */ '1'
+    )
+}

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/return.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/return.js.snap
@@ -10,7 +10,7 @@ function f1() {
 }
 
 function f2() {
-    return 1, 3, 4
+    return 1,3,4
 }
 
 function f3() {

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/return.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/return.js.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/return.js
 ---
-
 # Input
 
 ```js
@@ -11,7 +10,26 @@ function f1() {
 }
 
 function f2() {
-    return 1,3,4
+    return 1, 3, 4
+}
+
+function f3() {
+    return /* commment */'1'
+}
+
+function f4() {
+    return (
+        /* comment */
+        '1'
+    )
+}
+
+function f5() {
+    return (
+        /*
+         * multiline comment 
+         */ '1'
+    )
 }
 ```
 
@@ -46,6 +64,23 @@ function f1() {
 function f2() {
 	return 1, 3, 4;
 }
+
+function f3() {
+	return /* commment */ "1";
+}
+
+function f4() {
+	return (
+		/* comment */
+		"1"
+	);
+}
+
+function f5() {
+	return (
+		/*
+		 * multiline comment
+		 */ "1"
+	);
+}
 ```
-
-

--- a/crates/biome_js_formatter/tests/specs/prettier/js/comments/return-statement.js
+++ b/crates/biome_js_formatter/tests/specs/prettier/js/comments/return-statement.js
@@ -120,14 +120,14 @@ function inlineComment() {
   ) || 42
 }
 
-// TODO: fix idempotency issue
-// function multilineBlockSameLine() {
-//   return (
-//     /**
-//     * @type {string}
-//     */ 'result'
-//   )
-// }
+
+function multilineBlockSameLine() {
+  return (
+    /**
+    * @type {string}
+    */ 'result'
+  )
+}
 
 function multilineBlockNextLine() {
   return (

--- a/crates/biome_js_formatter/tests/specs/prettier/js/comments/return-statement.js.snap
+++ b/crates/biome_js_formatter/tests/specs/prettier/js/comments/return-statement.js.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/comments/return-statement.js
 ---
-
 # Input
 
 ```js
@@ -128,14 +127,14 @@ function inlineComment() {
   ) || 42
 }
 
-// TODO: fix idempotency issue
-// function multilineBlockSameLine() {
-//   return (
-//     /**
-//     * @type {string}
-//     */ 'result'
-//   )
-// }
+
+function multilineBlockSameLine() {
+  return (
+    /**
+    * @type {string}
+    */ 'result'
+  )
+}
 
 function multilineBlockNextLine() {
   return (
@@ -201,28 +200,6 @@ function singleLineBlockNextLine() {
  }
  
  function excessiveEverything() {
-@@ -119,13 +121,14 @@
-   return /* hi */ 42 || 42;
- }
- 
--function multilineBlockSameLine() {
--  return (
--    /**
--     * @type {string}
--     */ "result"
--  );
--}
-+// TODO: fix idempotency issue
-+// function multilineBlockSameLine() {
-+//   return (
-+//     /**
-+//     * @type {string}
-+//     */ 'result'
-+//   )
-+// }
- 
- function multilineBlockNextLine() {
-   return (
 ```
 
 # Output
@@ -351,14 +328,13 @@ function inlineComment() {
   return /* hi */ 42 || 42;
 }
 
-// TODO: fix idempotency issue
-// function multilineBlockSameLine() {
-//   return (
-//     /**
-//     * @type {string}
-//     */ 'result'
-//   )
-// }
+function multilineBlockSameLine() {
+  return (
+    /**
+     * @type {string}
+     */ "result"
+  );
+}
 
 function multilineBlockNextLine() {
   return (
@@ -397,5 +373,3 @@ function singleLineBlockNextLine() {
   );
 }
 ```
-
-

--- a/website/src/content/docs/internals/changelog.md
+++ b/website/src/content/docs/internals/changelog.md
@@ -29,6 +29,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
+- Add parentheses for the return expression that has leading multiline comments. [#2504](https://github.com/biomejs/biome/pull/2504). Contributed by @ah-yu
+
 ### JavaScript APIs
 
 ### Linter


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fix the following case

```js
// input
function f() {
    return (
        /*
         * multiline comment 
         */ '1'
    )
}

// before
function f() {
  return /*
   * multiline comment
   */ "1";
}

// after
// add parentheses for the return expression that has multiline leading comments
function f5() {
  return (
    /*
     * multiline comment
     */ "1"
  );
}
```

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

Add new test cases and enable the prettier test case that disabled before due to reformatting issue
