### PR TITLE
fix(lsp): forward workspace errors to client console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Editors
 
+#### Bug fixes
+
+- Fix [#2403](https://github.com/biomejs/biome/issues/2403) by printing the errors in the client console. Contributed by @ematipico
+
 ### Formatter
 
 #### Bug fixes
@@ -1142,7 +1146,7 @@ Additionally, the following rules are now recommended:
 - Add rule [noExcessiveNestedTestSuites](https://biomejs.dev/linter/rules/no-excessive-nested-test-suites/).
   Contributed by @vasucp1207
 
-- Add rule [useJsxKeyInIterable](https://biomejs.dev/linter/rules/use-jsx-key-in-iterable/). 
+- Add rule [useJsxKeyInIterable](https://biomejs.dev/linter/rules/use-jsx-key-in-iterable/).
   Contributed by @vohoanglong0107
 
 #### Enhancements

--- a/crates/biome_formatter/src/diagnostics.rs
+++ b/crates/biome_formatter/src/diagnostics.rs
@@ -31,10 +31,10 @@ pub enum FormatError {
 impl std::fmt::Display for FormatError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FormatError::SyntaxError => fmt.write_str("syntax error"),
+            FormatError::SyntaxError => fmt.write_str("Can't format code because it contains syntax errors"),
             FormatError::RangeError { input, tree } => std::write!(
                 fmt,
-                "formatting range {input:?} is larger than syntax tree {tree:?}"
+                "Formatting range {input:?} is larger than syntax tree {tree:?}"
             ),
             FormatError::InvalidDocument(error) => std::write!(fmt, "Invalid document: {error}\n\n This is an internal Biome error. Please report if necessary."),
             FormatError::PoorLayout => {

--- a/crates/biome_lsp/src/diagnostics.rs
+++ b/crates/biome_lsp/src/diagnostics.rs
@@ -53,7 +53,11 @@ pub(crate) async fn handle_lsp_error<T>(
                 Ok(None)
             }
 
-            _ => Err(into_lsp_error(err)),
+            _ => {
+                let message = format!("{}", err);
+                client.log_message(MessageType::ERROR, message).await;
+                Ok(None)
+            }
         },
         LspError::Anyhow(err) => Err(into_lsp_error(err)),
     }

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -393,7 +393,6 @@ impl LanguageServer for LSPServer {
         let result = biome_diagnostics::panic::catch_unwind(move || {
             handlers::formatting::format_range(&self.session, params)
         });
-
         self.map_op_error(result).await
     }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR makes sure that all `WorkspaceError` are forwarded to the client, instead passing it to the main LSP handler, which ends up showing a bothering pop-up

Closes https://github.com/biomejs/biome/issues/2403

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Manually tested that the pop-up doesn't appear anymore

<img width="793" alt="Screenshot 2024-04-18 at 10 26 38" src="https://github.com/biomejs/biome/assets/602478/90ea9319-347b-49f2-bd87-4eb8725f132c">


<!-- What demonstrates that your implementation is correct? -->
