### PR TITLE
feat(linter): allow to call `expect` inside `waitFor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,19 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Fix case where `jsxRuntime` wasn't being respected by `useImportType` rule ([#2473](https://github.com/biomejs/biome/issues/2473)).Contributed by @arendjr
 
+#### Enhancements
+
+- The rule `noMisplacedAssertions` now considers valid calling `expect` inside `waitFor`:
+  ```js
+  import { waitFor } from '@testing-library/react';
+
+  await waitFor(() => {
+    expect(111).toBe(222);
+  });
+  ```
+  Contributed by @ematipico
+
+
 ### Parser
 
 

--- a/crates/biome_js_analyze/src/lint/nursery/no_misplaced_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misplaced_assertion.rs
@@ -83,6 +83,13 @@ declare_rule! {
     /// })
     /// ```
     ///
+    /// ```js
+    /// import { waitFor } from '@testing-library/react';
+    /// await waitFor(() => {
+    ///   expect(111).toBe(222);
+    /// });
+    /// ```
+    ///
     pub NoMisplacedAssertion {
         version: "1.6.4",
         name: "noMisplacedAssertion",

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js
@@ -1,13 +1,17 @@
 describe("msg", () => {
-    it("msg", () => {
-        expect("something").toBeTrue()
-    })
+	it("msg", () => {
+		expect("something").toBeTrue()
+	})
 })
 
 test("something", () => {
-    expect("something").toBeTrue()
+	expect("something").toBeTrue()
 })
 
 Deno.test("something", () => {
-    expect("something").toBeTrue()
+	expect("something").toBeTrue()
 })
+
+await waitFor(() => {
+	expect(111).toBe(222);
+});

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js.snap
@@ -5,16 +5,21 @@ expression: valid.js
 # Input
 ```jsx
 describe("msg", () => {
-    it("msg", () => {
-        expect("something").toBeTrue()
-    })
+	it("msg", () => {
+		expect("something").toBeTrue()
+	})
 })
 
 test("something", () => {
-    expect("something").toBeTrue()
+	expect("something").toBeTrue()
 })
 
 Deno.test("something", () => {
-    expect("something").toBeTrue()
+	expect("something").toBeTrue()
 })
+
+await waitFor(() => {
+	expect(111).toBe(222);
+});
+
 ```

--- a/crates/biome_js_syntax/src/expr_ext.rs
+++ b/crates/biome_js_syntax/src/expr_ext.rs
@@ -1086,9 +1086,10 @@ impl AnyJsExpression {
     }
 
     /// Checks whether the current function call is:
-    /// - `it`
-    /// - `test`
-    /// - `Deno.test`
+    /// - `it`: many libraries such as Node.js, Mocha, Jest, etc.
+    /// - `test`: many libraries such as Node.js, bun, etc.
+    /// - [`Deno.test`](https://docs.deno.com/runtime/manual/basics/testing/)
+    /// - [`waitFor`](https://testing-library.com/docs/dom-testing-library/api-async/#waitfor)
     pub fn contains_it_call(&self) -> bool {
         let mut members = CalleeNamesIterator::new(self.clone());
 
@@ -1100,7 +1101,7 @@ impl AnyJsExpression {
         let second = rev.next().map(|t| t.text());
 
         match first {
-            Some("test" | "it") => true,
+            Some("test" | "it" | "waitFor") => true,
             Some("Deno") => matches!(second, Some("test")),
             _ => false,
         }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/2474

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test case

<!-- What demonstrates that your implementation is correct? -->
