### PR TITLE
feat(biome_css_analyze): keyframe-block-no-duplicate-selectors

### DIFF
--- a/crates/biome_configuration/src/linter/rules.rs
+++ b/crates/biome_configuration/src/linter/rules.rs
@@ -2671,6 +2671,10 @@ pub struct Nursery {
     #[doc = "Disallow two keys with the same name inside a JSON object."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_duplicate_json_keys: Option<RuleConfiguration<NoDuplicateJsonKeys>>,
+    #[doc = "Succinct description of the rule."]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_duplicate_selectors_keyframe_block:
+        Option<RuleConfiguration<NoDuplicateSelectorsKeyframeBlock>>,
     #[doc = "Disallow variables from evolving into any type through reassignments."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_evolving_any: Option<RuleConfiguration<NoEvolvingAny>>,
@@ -2724,6 +2728,7 @@ impl Nursery {
         "noDuplicateElseIf",
         "noDuplicateFontNames",
         "noDuplicateJsonKeys",
+        "noDuplicateSelectorsKeyframeBlock",
         "noEvolvingAny",
         "noFlatMapIdentity",
         "noMisplacedAssertion",
@@ -2749,8 +2754,8 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]),
     ];
     const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
@@ -2770,6 +2775,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended_true(&self) -> bool {
@@ -2826,49 +2832,54 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
             }
         }
-        if let Some(rule) = self.no_evolving_any.as_ref() {
+        if let Some(rule) = self.no_duplicate_selectors_keyframe_block.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
             }
         }
-        if let Some(rule) = self.no_flat_map_identity.as_ref() {
+        if let Some(rule) = self.no_evolving_any.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
             }
         }
-        if let Some(rule) = self.no_misplaced_assertion.as_ref() {
+        if let Some(rule) = self.no_flat_map_identity.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.no_nodejs_modules.as_ref() {
+        if let Some(rule) = self.no_misplaced_assertion.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.no_react_specific_props.as_ref() {
+        if let Some(rule) = self.no_nodejs_modules.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.no_restricted_imports.as_ref() {
+        if let Some(rule) = self.no_react_specific_props.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.no_undeclared_dependencies.as_ref() {
+        if let Some(rule) = self.no_restricted_imports.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.no_undeclared_dependencies.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
+            }
+        }
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
         index_set
@@ -2915,49 +2926,54 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
             }
         }
-        if let Some(rule) = self.no_evolving_any.as_ref() {
+        if let Some(rule) = self.no_duplicate_selectors_keyframe_block.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
             }
         }
-        if let Some(rule) = self.no_flat_map_identity.as_ref() {
+        if let Some(rule) = self.no_evolving_any.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
             }
         }
-        if let Some(rule) = self.no_misplaced_assertion.as_ref() {
+        if let Some(rule) = self.no_flat_map_identity.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.no_nodejs_modules.as_ref() {
+        if let Some(rule) = self.no_misplaced_assertion.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.no_react_specific_props.as_ref() {
+        if let Some(rule) = self.no_nodejs_modules.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.no_restricted_imports.as_ref() {
+        if let Some(rule) = self.no_react_specific_props.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.no_undeclared_dependencies.as_ref() {
+        if let Some(rule) = self.no_restricted_imports.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.no_undeclared_dependencies.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
+            }
+        }
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
         index_set
@@ -3026,6 +3042,10 @@ impl Nursery {
                 .map(|conf| (conf.level(), conf.get_options())),
             "noDuplicateJsonKeys" => self
                 .no_duplicate_json_keys
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDuplicateSelectorsKeyframeBlock" => self
+                .no_duplicate_selectors_keyframe_block
                 .as_ref()
                 .map(|conf| (conf.level(), conf.get_options())),
             "noEvolvingAny" => self

--- a/crates/biome_configuration/src/linter/rules.rs
+++ b/crates/biome_configuration/src/linter/rules.rs
@@ -2671,7 +2671,7 @@ pub struct Nursery {
     #[doc = "Disallow two keys with the same name inside a JSON object."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_duplicate_json_keys: Option<RuleConfiguration<NoDuplicateJsonKeys>>,
-    #[doc = "Succinct description of the rule."]
+    #[doc = "Disallow duplicate selectors within keyframe blocks."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_duplicate_selectors_keyframe_block:
         Option<RuleConfiguration<NoDuplicateSelectorsKeyframeBlock>>,
@@ -2745,6 +2745,7 @@ impl Nursery {
         "noDuplicateElseIf",
         "noDuplicateFontNames",
         "noDuplicateJsonKeys",
+        "noDuplicateSelectorsKeyframeBlock",
         "noEvolvingAny",
         "noFlatMapIdentity",
     ];
@@ -2754,6 +2755,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]),
     ];

--- a/crates/biome_css_analyze/src/lint/nursery.rs
+++ b/crates/biome_css_analyze/src/lint/nursery.rs
@@ -5,6 +5,7 @@ use biome_analyze::declare_group;
 pub mod no_color_invalid_hex;
 pub mod no_css_empty_block;
 pub mod no_duplicate_font_names;
+pub mod no_duplicate_selectors_keyframe_block;
 
 declare_group! {
     pub Nursery {
@@ -13,6 +14,7 @@ declare_group! {
             self :: no_color_invalid_hex :: NoColorInvalidHex ,
             self :: no_css_empty_block :: NoCssEmptyBlock ,
             self :: no_duplicate_font_names :: NoDuplicateFontNames ,
+            self :: no_duplicate_selectors_keyframe_block :: NoDuplicateSelectorsKeyframeBlock ,
         ]
      }
 }

--- a/crates/biome_css_analyze/src/lint/nursery/no_duplicate_selectors_keyframe_block.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_duplicate_selectors_keyframe_block.rs
@@ -1,0 +1,84 @@
+use std::collections::HashSet;
+
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
+use biome_console::markup;
+use biome_css_syntax::{AnyCssKeyframesItem, CssKeyframesBlock};
+use biome_rowan::AstNode;
+
+declare_rule! {
+    /// Disallow duplicate selectors within keyframe blocks.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```css,expect_diagnostic
+    /// @keyframes foo { from {} from {} }
+    /// ```
+    ///
+    /// ```css,expect_diagnostic
+    /// @keyframes foo { from {} FROM {} }
+    /// ```
+    ///
+    /// ```css,expect_diagnostic
+    /// @keyframes foo { 0% {} 0% {} }
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```css
+    /// @keyframes foo { 0% {} 100% {} }
+    /// ```
+    ///
+    /// ```css
+    /// @keyframes foo { from {} to {} }
+    /// ```
+    ///
+    pub NoDuplicateSelectorsKeyframeBlock {
+        version: "next",
+        name: "noDuplicateSelectorsKeyframeBlock",
+        recommended: true,
+        sources:&[RuleSource::Stylelint("keyframe-block-no-duplicate-selectors")],
+    }
+}
+
+impl Rule for NoDuplicateSelectorsKeyframeBlock {
+    type Query = Ast<CssKeyframesBlock>;
+    type State = ();
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
+        let node = ctx.query();
+        let mut selector_list = HashSet::new();
+        for keyframe_item in node.items().into_iter() {
+            match keyframe_item {
+                AnyCssKeyframesItem::CssKeyframesItem(item) => {
+                    let keyframe_selector = item.selectors().into_iter().next()?;
+                    let keyframe_selector = keyframe_selector.ok()?;
+                    if !selector_list.insert(keyframe_selector.text().to_lowercase()) {
+                        return Some(());
+                    }
+                }
+                _ => return None,
+            }
+        }
+        None
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, _node: &Self::State) -> Option<RuleDiagnostic> {
+        let node = ctx.query();
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                node.range(),
+                markup! {
+                    "Unexpected duplicate selector"
+                },
+            )
+            .note(markup! {
+                    "Consider using different selector here!"
+            }),
+        )
+    }
+}

--- a/crates/biome_css_analyze/src/lint/nursery/no_duplicate_selectors_keyframe_block.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_duplicate_selectors_keyframe_block.rs
@@ -54,8 +54,7 @@ impl Rule for NoDuplicateSelectorsKeyframeBlock {
         for keyframe_item in node.items() {
             match keyframe_item {
                 AnyCssKeyframesItem::CssKeyframesItem(item) => {
-                    let keyframe_selector = item.selectors().into_iter().next()?;
-                    let keyframe_selector = keyframe_selector.ok()?;
+                    let keyframe_selector = item.selectors().into_iter().next()?.ok()?;
                     if !selector_list.insert(keyframe_selector.text().to_lowercase()) {
                         return Some(keyframe_selector);
                     }
@@ -76,7 +75,7 @@ impl Rule for NoDuplicateSelectorsKeyframeBlock {
                 },
             )
             .note(markup! {
-                    "Consider using different selector here!"
+                    "Consider using a different percentage value or keyword to avoid duplication"
             }),
         )
     }

--- a/crates/biome_css_analyze/src/options.rs
+++ b/crates/biome_css_analyze/src/options.rs
@@ -8,3 +8,4 @@ pub type NoCssEmptyBlock =
     <lint::nursery::no_css_empty_block::NoCssEmptyBlock as biome_analyze::Rule>::Options;
 pub type NoDuplicateFontNames =
     <lint::nursery::no_duplicate_font_names::NoDuplicateFontNames as biome_analyze::Rule>::Options;
+pub type NoDuplicateSelectorsKeyframeBlock = < lint :: nursery :: no_duplicate_selectors_keyframe_block :: NoDuplicateSelectorsKeyframeBlock as biome_analyze :: Rule > :: Options ;

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/invalid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/invalid.css
@@ -1,0 +1,5 @@
+@keyframes foo { from {} from {}}
+
+@keyframes foo { from {} FROM {}}
+
+@keyframes foo { 0% {} 0% {}}

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/invalid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/invalid.css
@@ -3,3 +3,11 @@
 @keyframes foo { from {} FROM {}}
 
 @keyframes foo { 0% {} 0% {}}
+
+@keyframes foo { from {} to {} to {} }
+
+@keyframes foo { 0% {} 0% {} 100% {} }
+
+@-webkit-keyframes foo { 0% {} 0% {} 100% {} }
+
+@-moz-keyframes foo { 0% {} 0% {} 100% {} }

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/invalid.css.snap
@@ -9,6 +9,14 @@ expression: invalid.css
 @keyframes foo { from {} FROM {}}
 
 @keyframes foo { 0% {} 0% {}}
+
+@keyframes foo { from {} to {} to {} }
+
+@keyframes foo { 0% {} 0% {} 100% {} }
+
+@-webkit-keyframes foo { 0% {} 0% {} 100% {} }
+
+@-moz-keyframes foo { 0% {} 0% {} 100% {} }
 ```
 
 # Diagnostics
@@ -22,7 +30,7 @@ invalid.css:1:26 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━�
     2 │ 
     3 │ @keyframes foo { from {} FROM {}}
   
-  i Consider using different selector here!
+  i Consider using a different percentage value or keyword to avoid duplication
   
 
 ```
@@ -39,7 +47,7 @@ invalid.css:3:26 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━�
     4 │ 
     5 │ @keyframes foo { 0% {} 0% {}}
   
-  i Consider using different selector here!
+  i Consider using a different percentage value or keyword to avoid duplication
   
 
 ```
@@ -53,8 +61,76 @@ invalid.css:5:24 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━�
     4 │ 
   > 5 │ @keyframes foo { 0% {} 0% {}}
       │                        ^^
+    6 │ 
+    7 │ @keyframes foo { from {} to {} to {} }
   
-  i Consider using different selector here!
+  i Consider using a different percentage value or keyword to avoid duplication
+  
+
+```
+
+```
+invalid.css:7:32 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Unexpected duplicate selector: to
+  
+    5 │ @keyframes foo { 0% {} 0% {}}
+    6 │ 
+  > 7 │ @keyframes foo { from {} to {} to {} }
+      │                                ^^
+    8 │ 
+    9 │ @keyframes foo { 0% {} 0% {} 100% {} }
+  
+  i Consider using a different percentage value or keyword to avoid duplication
+  
+
+```
+
+```
+invalid.css:9:24 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Unexpected duplicate selector: 0%
+  
+     7 │ @keyframes foo { from {} to {} to {} }
+     8 │ 
+   > 9 │ @keyframes foo { 0% {} 0% {} 100% {} }
+       │                        ^^
+    10 │ 
+    11 │ @-webkit-keyframes foo { 0% {} 0% {} 100% {} }
+  
+  i Consider using a different percentage value or keyword to avoid duplication
+  
+
+```
+
+```
+invalid.css:11:32 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Unexpected duplicate selector: 0%
+  
+     9 │ @keyframes foo { 0% {} 0% {} 100% {} }
+    10 │ 
+  > 11 │ @-webkit-keyframes foo { 0% {} 0% {} 100% {} }
+       │                                ^^
+    12 │ 
+    13 │ @-moz-keyframes foo { 0% {} 0% {} 100% {} }
+  
+  i Consider using a different percentage value or keyword to avoid duplication
+  
+
+```
+
+```
+invalid.css:13:29 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Unexpected duplicate selector: 0%
+  
+    11 │ @-webkit-keyframes foo { 0% {} 0% {} 100% {} }
+    12 │ 
+  > 13 │ @-moz-keyframes foo { 0% {} 0% {} 100% {} }
+       │                             ^^
+  
+  i Consider using a different percentage value or keyword to avoid duplication
   
 
 ```

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/invalid.css.snap
@@ -13,12 +13,12 @@ expression: invalid.css
 
 # Diagnostics
 ```
-invalid.css:1:16 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.css:1:26 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Unexpected duplicate selector
+  ! Unexpected duplicate selector: from
   
   > 1 │ @keyframes foo { from {} from {}}
-      │                ^^^^^^^^^^^^^^^^^^
+      │                          ^^^^
     2 │ 
     3 │ @keyframes foo { from {} FROM {}}
   
@@ -28,14 +28,14 @@ invalid.css:1:16 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━�
 ```
 
 ```
-invalid.css:3:16 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.css:3:26 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Unexpected duplicate selector
+  ! Unexpected duplicate selector: FROM
   
     1 │ @keyframes foo { from {} from {}}
     2 │ 
   > 3 │ @keyframes foo { from {} FROM {}}
-      │                ^^^^^^^^^^^^^^^^^^
+      │                          ^^^^
     4 │ 
     5 │ @keyframes foo { 0% {} 0% {}}
   
@@ -45,14 +45,14 @@ invalid.css:3:16 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━�
 ```
 
 ```
-invalid.css:5:16 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.css:5:24 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Unexpected duplicate selector
+  ! Unexpected duplicate selector: 0%
   
     3 │ @keyframes foo { from {} FROM {}}
     4 │ 
   > 5 │ @keyframes foo { 0% {} 0% {}}
-      │                ^^^^^^^^^^^^^^
+      │                        ^^
   
   i Consider using different selector here!
   

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/invalid.css.snap
@@ -1,0 +1,60 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: invalid.css
+---
+# Input
+```css
+@keyframes foo { from {} from {}}
+
+@keyframes foo { from {} FROM {}}
+
+@keyframes foo { 0% {} 0% {}}
+```
+
+# Diagnostics
+```
+invalid.css:1:16 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Unexpected duplicate selector
+  
+  > 1 │ @keyframes foo { from {} from {}}
+      │                ^^^^^^^^^^^^^^^^^^
+    2 │ 
+    3 │ @keyframes foo { from {} FROM {}}
+  
+  i Consider using different selector here!
+  
+
+```
+
+```
+invalid.css:3:16 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Unexpected duplicate selector
+  
+    1 │ @keyframes foo { from {} from {}}
+    2 │ 
+  > 3 │ @keyframes foo { from {} FROM {}}
+      │                ^^^^^^^^^^^^^^^^^^
+    4 │ 
+    5 │ @keyframes foo { 0% {} 0% {}}
+  
+  i Consider using different selector here!
+  
+
+```
+
+```
+invalid.css:5:16 lint/nursery/noDuplicateSelectorsKeyframeBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Unexpected duplicate selector
+  
+    3 │ @keyframes foo { from {} FROM {}}
+    4 │ 
+  > 5 │ @keyframes foo { 0% {} 0% {}}
+      │                ^^^^^^^^^^^^^^
+  
+  i Consider using different selector here!
+  
+
+```

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/valid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/valid.css
@@ -1,3 +1,3 @@
-@keyframes foo { from {} to {}}
+@keyframes foo { from {} to {} }
 
-@keyframes foo { 0% {} 100% {}}
+@keyframes foo { 0% {} 100% {} }

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/valid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/valid.css
@@ -1,0 +1,3 @@
+@keyframes foo { from {} to {}}
+
+@keyframes foo { 0% {} 100% {}}

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/valid.css.snap
@@ -4,7 +4,7 @@ expression: valid.css
 ---
 # Input
 ```css
-@keyframes foo { from {} to {}}
+@keyframes foo { from {} to {} }
 
-@keyframes foo { 0% {} 100% {}}
+@keyframes foo { 0% {} 100% {} }
 ```

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectorsKeyframeBlock/valid.css.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: valid.css
+---
+# Input
+```css
+@keyframes foo { from {} to {}}
+
+@keyframes foo { 0% {} 100% {}}
+```

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -118,6 +118,7 @@ define_categories! {
     "lint/nursery/noDuplicateElseIf": "https://biomejs.dev/linter/rules/no-duplicate-else-if",
     "lint/nursery/noDuplicateFontNames": "https://biomejs.dev/linter/rules/no-font-family-duplicate-names",
     "lint/nursery/noDuplicateJsonKeys": "https://biomejs.dev/linter/rules/no-duplicate-json-keys",
+    "lint/nursery/noDuplicateSelectorsKeyframeBlock": "https://biomejs.dev/linter/rules/no-duplicate-selectors-keyframe-block",
     "lint/nursery/noEvolvingAny": "https://biomejs.dev/linter/rules/no-evolving-any",
     "lint/nursery/noFlatMapIdentity": "https://biomejs.dev/linter/rules/no-flat-map-identity",
     "lint/nursery/noMisplacedAssertion": "https://biomejs.dev/linter/rules/no-misplaced-assertion",

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -941,7 +941,7 @@ export interface Nursery {
 	 */
 	noDuplicateJsonKeys?: RuleConfiguration_for_Null;
 	/**
-	 * Succinct description of the rule.
+	 * Disallow duplicate selectors within keyframe blocks.
 	 */
 	noDuplicateSelectorsKeyframeBlock?: RuleConfiguration_for_Null;
 	/**

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -941,6 +941,10 @@ export interface Nursery {
 	 */
 	noDuplicateJsonKeys?: RuleConfiguration_for_Null;
 	/**
+	 * Succinct description of the rule.
+	 */
+	noDuplicateSelectorsKeyframeBlock?: RuleConfiguration_for_Null;
+	/**
 	 * Disallow variables from evolving into any type through reassignments.
 	 */
 	noEvolvingAny?: RuleConfiguration_for_Null;
@@ -1948,6 +1952,7 @@ export type Category =
 	| "lint/nursery/noDuplicateElseIf"
 	| "lint/nursery/noDuplicateFontNames"
 	| "lint/nursery/noDuplicateJsonKeys"
+	| "lint/nursery/noDuplicateSelectorsKeyframeBlock"
 	| "lint/nursery/noEvolvingAny"
 	| "lint/nursery/noFlatMapIdentity"
 	| "lint/nursery/noMisplacedAssertion"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1490,7 +1490,7 @@
 					]
 				},
 				"noDuplicateSelectorsKeyframeBlock": {
-					"description": "Succinct description of the rule.",
+					"description": "Disallow duplicate selectors within keyframe blocks.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1489,6 +1489,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noDuplicateSelectorsKeyframeBlock": {
+					"description": "Succinct description of the rule.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noEvolvingAny": {
 					"description": "Disallow variables from evolving into any type through reassignments.",
 					"anyOf": [


### PR DESCRIPTION
## Summary

this PR adds lint support to remove duplicate selector in keyframes block #2523

## Test Plan

spec test
