### PR TITLE
fix(js_formatter): correctly format dangling comments of continue statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Add parentheses for the return expression that has leading multiline comments. [#2504](https://github.com/biomejs/biome/pull/2504). Contributed by @ah-yu
 
+- Correctly format dangling comments of continue statements. [#2555](https://github.com/biomejs/biome/pull/2555). Contributed by @ah-yu
+
 ### JavaScript APIs
 
 ### Linter

--- a/crates/biome_js_formatter/src/js/statements/continue_statement.rs
+++ b/crates/biome_js_formatter/src/js/statements/continue_statement.rs
@@ -25,4 +25,17 @@ impl FormatNodeRule<JsContinueStatement> for FormatJsContinueStatement {
 
         write!(f, [FormatStatementSemicolon::new(semicolon_token.as_ref())])
     }
+
+    fn fmt_dangling_comments(
+        &self,
+        node: &JsContinueStatement,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        if !f.comments().has_dangling_comments(node.syntax()) {
+            return Ok(());
+        }
+        let content =
+            format_with(|f| write!(f, [space(), format_dangling_comments(node.syntax())]));
+        write!(f, [line_suffix(&content), expand_parent()])
+    }
 }

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/continue_stmt.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/continue_stmt.js
@@ -1,0 +1,4 @@
+for (const f of fs) {
+    if (condition) continue; //commment
+    else continue; // comment
+}

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/continue_stmt.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/continue_stmt.js.snap
@@ -1,0 +1,43 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/statement/continue_stmt.js
+---
+# Input
+
+```js
+for (const f of fs) {
+    if (condition) continue; //commment
+    else continue; // comment
+}
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+-----
+
+```js
+for (const f of fs) {
+	if (condition)
+		continue; //commment
+	else continue; // comment
+}
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
```js
// input
for (const f of fs) {
    if (condition) continue; //commment
    else continue; // comment
}

// before
for (const f of fs) {
  if (condition)
    continue;
      //commment
  else continue; // comment
}
// above code will be reformatted as 
for (const f of fs) {
  if (condition) continue;
  //commment
  else continue; // comment
}


// after
for (const f of fs) {
  if (condition)
    continue; // commment
  else continue; // comment
}
```


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Add new test cases