### PR TITLE
docs: fix typo in biome analyze contribution document

### DIFF
--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -281,7 +281,7 @@ We would like to set the options in the `biome.json` configuration file:
 The first step is to create the Rust data representation of the rule's options.
 
 ```rust,ignore
-use biome_deserializable_macros::Deserializable;
+use biome_deserialize_macros::Deserializable;
 
 #[derive(Clone, Debug, Default, Deserializable)]
 pub struct MyRuleOptions {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

There are no `biome_deserializable_macros`.
I think the correct one is `biome_deserialize_macros`.

https://github.com/biomejs/biome/blob/3ef48c5a8ee4b8acdbe0b2eac9a3b89068d3d76c/crates/biome_deserialize_macros/Cargo.toml#L9

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
