### PR TITLE
build(xstask): remove deps `fs_extra` and `filetime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,18 +1528,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d7e9bc68be4cdabbb8938140b01a8b5bc1191937f2c7e7ecc2fcebbe2d749df"
 
 [[package]]
-name = "filetime"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,12 +1560,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fst"
@@ -3868,8 +3850,6 @@ dependencies = [
  "biome_string_case",
  "biome_ungrammar",
  "bpaf",
- "filetime",
- "fs_extra",
  "git2",
  "proc-macro2",
  "pulldown-cmark",

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -7,8 +7,6 @@ version = "0.0.0"
 [dependencies]
 anyhow         = "1.0.82"
 bpaf           = { workspace = true, features = ["derive"] }
-filetime       = "0.2.23"
-fs_extra       = "1.3.0"
 git2           = { version = "0.18.3", default-features = false }
 proc-macro2    = { workspace = true, features = ["span-locations"] }
 pulldown-cmark = { version = "0.9", default-features = false, optional = true }

--- a/xtask/codegen/src/parser_tests.rs
+++ b/xtask/codegen/src/parser_tests.rs
@@ -5,6 +5,7 @@ use std::{
     collections::HashMap,
     fs, mem,
     path::{Path, PathBuf},
+    time::SystemTime,
 };
 
 use crate::{update, Mode};
@@ -94,10 +95,7 @@ pub fn generate_parser_tests(mode: Mode) -> Result<()> {
     )?;
 
     if some_file_was_updated {
-        let _ = filetime::set_file_mtime(
-            "crates/biome_js_parser/src/tests.rs",
-            filetime::FileTime::now(),
-        );
+        fs::File::open("crates/biome_js_parser/src/tests.rs")?.set_modified(SystemTime::now())?;
     }
 
     Ok(())

--- a/xtask/codegen/src/promote_rule.rs
+++ b/xtask/codegen/src/promote_rule.rs
@@ -1,8 +1,6 @@
 use biome_string_case::Case;
-use fs_extra::dir::{create, move_dir, CopyOptions};
-use fs_extra::file;
-use fs_extra::file::move_file;
 use std::env;
+use std::fs;
 use std::path::PathBuf;
 
 const KNOWN_GROUPS: [&str; 7] = [
@@ -75,14 +73,9 @@ pub fn promote_rule(rule_name: &str, new_group: &str) {
         categories.replace_range(lint_start_index..lint_end_index, &new_lint_rule_text);
 
         if !new_group_path.exists() {
-            create(new_rule_path.clone(), false).expect("To create the group folder");
+            fs::create_dir(new_rule_path.clone()).expect("To create the group folder");
         }
-        move_file(
-            rule_path.clone(),
-            new_rule_path.clone(),
-            &file::CopyOptions::default(),
-        )
-        .unwrap_or_else(|_| {
+        fs::rename(rule_path.clone(), new_rule_path.clone()).unwrap_or_else(|_| {
             panic!(
                 "To copy {} to {}",
                 rule_path.display(),
@@ -98,18 +91,7 @@ pub fn promote_rule(rule_name: &str, new_group: &str) {
             .join("crates/biome_js_analyze/tests/specs")
             .join(new_group)
             .join(rule_name);
-
-        std::fs::create_dir(new_test_path).unwrap();
-        move_dir(
-            old_test_path.display().to_string(),
-            current_dir
-                .join("crates/biome_js_analyze/tests/specs")
-                .join(new_group)
-                .display()
-                .to_string(),
-            &CopyOptions::new(),
-        )
-        .unwrap();
+        fs::rename(old_test_path, new_test_path).unwrap();
     } else {
         panic!("Couldn't find the rule {}", rule_name);
     }


### PR DESCRIPTION


## Summary

- Since Rust `.75, standard functions are available to update file times making `filetime` optional.

- `fs_extra` can easily be replaced with the standard library

## Test Plan

I manually tested the codegen.
