### PR TITLE
fix(js_formatter): correctly handle placement of comments inside named import clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Formatter
 
+#### Bug fixes
+
+- Correctly handle placement of comments inside named import clauses. [#2566](https://github.com/biomejs/biome/pull/2566). Contributed by @ah-yu
+
 ### JavaScript APIs
 
 ### Linter

--- a/crates/biome_js_formatter/src/comments.rs
+++ b/crates/biome_js_formatter/src/comments.rs
@@ -1331,14 +1331,16 @@ fn handle_import_named_clause_comments(
                 // import { a } from // comment
                 // "foo"
                 // ```
-                if specifier_list.len() != 0 && comment.text_position() == CommentTextPosition::EndOfLine{
+                if specifier_list.len() != 0
+                    && comment.text_position() == CommentTextPosition::EndOfLine
+                {
                     if let Some(Ok(last_specifier)) = specifier_list.last() {
                         return CommentPlacement::trailing(last_specifier.into_syntax(), comment);
                     }
                 } else {
                     // attach comments to the import specifier as leading comments if comments are placed after the from keyword
                     // ```javascript
-                    // import {} from // comment 
+                    // import {} from // comment
                     // "foo"
                     // ```
                     let is_after_from_keyword = comment

--- a/crates/biome_js_formatter/tests/specs/js/module/import/named_import_clause.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/named_import_clause.js
@@ -1,0 +1,7 @@
+import {} from /* comment*/ 'foo'
+import {} from // comment
+'foo'
+
+import {a} from /* comment */'foo'
+import {a} from // comment
+'foo'

--- a/crates/biome_js_formatter/tests/specs/js/module/import/named_import_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/named_import_clause.js.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/import/named_import_clause.js
+---
+# Input
+
+```js
+import {} from /* comment*/ 'foo'
+import {} from // comment
+'foo'
+
+import {a} from /* comment */'foo'
+import {a} from // comment
+'foo'
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+-----
+
+```js
+import {} from /* comment*/ "foo";
+import {} from // comment
+"foo";
+
+import { a } from /* comment */ "foo";
+import {
+	a, // comment
+} from "foo";
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
FIx formatting of following case. It's strange that the export declaration doesn't have such an issue.
```js
// input
import {} from /* comment*/ 'foo'
import {} from // comment
'foo'
import {a} from /* comment */'foo'
import {a} from // comment
'foo'

// before
import {} from /* comment*/ "foo";
import {} from "foo"; // comment
import { a } from /* comment */ "foo";
import { a } from "foo";

// after
import {} from /* comment*/ "foo";
import {} from // comment
"foo";
import { a } from /* comment */ "foo";
import {
  a, // comment
} from "foo";
```

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

Add new test cases
