### PR TITLE
chore: update schema definition

### DIFF
--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1128,7 +1128,7 @@
 					"description": "A list of global bindings that should be ignored by the analyzers\n\nIf defined here, they should not emit diagnostics.",
 					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
 				},
-				"jsx_runtime": {
+				"jsxRuntime": {
 					"description": "Indicates the type of runtime or transformation used for interpreting JSX.",
 					"anyOf": [{ "$ref": "#/definitions/JsxRuntime" }, { "type": "null" }]
 				},
@@ -1332,12 +1332,12 @@
 				{
 					"description": "Indicates a modern or native JSX environment, that doesn't require special handling by Biome.",
 					"type": "string",
-					"enum": ["Transparent"]
+					"enum": ["transparent"]
 				},
 				{
 					"description": "Indicates a classic React environment that requires the `React` import.\n\nCorresponds to the `react` value for the `jsx` option in TypeScript's `tsconfig.json`.\n\nThis option should only be necessary if you cannot upgrade to a React version that supports the new JSX runtime. For more information about the old vs. new JSX runtime, please see: <https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html>",
 					"type": "string",
-					"enum": ["ReactClassic"]
+					"enum": ["reactClassic"]
 				}
 			]
 		},


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

- previously MR: #2397 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

- Property `jsxRuntime` is not allowed:  ![image](https://github.com/biomejs/biome/assets/28648715/36925872-6475-4b9c-908d-88c72eceb3c0)
- But terminal output told me need to use jsxRuntime ![image](https://github.com/biomejs/biome/assets/28648715/5de0a5fd-ab0a-4779-a384-9f8ef024cff0)

The schema for `jsxRuntime` is not match on the Doc or the prompt on terminal, so I decide to update to the correct definition.🙏

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
