### PR TITLE
fix(configuration_schema): rename some fields to camelCase in the `configuration_schema.json`

### DIFF
--- a/crates/biome_configuration/src/javascript/mod.rs
+++ b/crates/biome_configuration/src/javascript/mod.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Deserialize, Eq, Partial, PartialEq, Serialize)]
 #[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
 #[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
-#[partial(serde(default, deny_unknown_fields))]
+#[partial(serde(rename_all = "camelCase", default, deny_unknown_fields))]
 pub struct JavascriptConfiguration {
     /// Formatting options
     #[partial(type, bpaf(external(partial_javascript_formatter), optional))]

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -166,8 +166,8 @@ If defined here, they should not emit diagnostics.
 	/**
 	 * Indicates the type of runtime or transformation used for interpreting JSX.
 	 */
-	jsx_runtime?: JsxRuntime;
-	organize_imports?: PartialJavascriptOrganizeImports;
+	jsxRuntime?: JsxRuntime;
+	organizeImports?: PartialJavascriptOrganizeImports;
 	/**
 	 * Parsing options
 	 */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1128,11 +1128,11 @@
 					"description": "A list of global bindings that should be ignored by the analyzers\n\nIf defined here, they should not emit diagnostics.",
 					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
 				},
-				"jsx_runtime": {
+				"jsxRuntime": {
 					"description": "Indicates the type of runtime or transformation used for interpreting JSX.",
 					"anyOf": [{ "$ref": "#/definitions/JsxRuntime" }, { "type": "null" }]
 				},
-				"organize_imports": {
+				"organizeImports": {
 					"anyOf": [
 						{ "$ref": "#/definitions/JavascriptOrganizeImports" },
 						{ "type": "null" }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

When I tried to enable the `useImportType` rule in the codebase I maintain at work, I found that `jsxRuntime` still uses `snake_case` in the configuration schema.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

just gen-bindings