### PR TITLE
fix(migrate-eslint): handle cyclic references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### CLI
 
+#### Bug fixes
+
+- `biome migrate eslint` now handles cyclic references.
+
+  Some plugins and configurations export objects with cyclic references.
+  This causes `biome migrate eslint` to fail or ignore them.
+  These edge cases are now handled correctly.
+
 ### Configuration
 
 ### Editors


### PR DESCRIPTION
## Summary

Some plugins and configurations export objects with cyclic references.
This causes `biome migrate eslint` to fail or ignore them.
These edge cases are now handled correctly.

To do that, we detect cyclic references when we serialize the object.

## Test Plan

I manually tested using the [ESLint config of the Astro repository](https://github.com/withastro/astro/blob/main/eslint.config.js).

NOTE: We should find a way of writing tests because I am a bit uncomfortable of having so much untested code.