### PR TITLE
fix(lint/useConst): handle reads before assignment and improve docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,14 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   ```diff
     import "z"
-    - import { D } from "d";
+  - import { D } from "d";
     import { C } from "c";
-    + import { D } from "d";
+  + import { D } from "d";
     import "y"
     import "x"
-    - import { B } from "b";
+  - import { B } from "b";
     import { A } from "a";
-    + import { B } from "b";
+  + import { B } from "b";
     import "w"
   ```
 
@@ -47,6 +47,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   This causes `biome migrate eslint` to fail or ignore them.
   These edge cases are now handled correctly.
 
+  Contributed by @Conaclos
+
 ### Configuration
 
 ### Editors
@@ -60,6 +62,22 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 ### JavaScript APIs
 
 ### Linter
+
+#### Bug fixes
+
+- [useConst](https://biomejs.dev/linter/rules/use-const/) now ignores a variable that is read before its assignment.
+
+  Previously, the rule reported the following example:
+
+  ```js
+  let x;
+  x; // read
+  x = 0; // write
+  ```
+
+  It is now correctly ignored.
+
+  Contributed by @Conaclos
 
 ### Parser
 

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_runs_linter_not_formatter_issue_3495.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_runs_linter_not_formatter_issue_3495.snap
@@ -34,12 +34,12 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 file.js:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This let declares a variable which is never re-assigned.
+  × This let declares a variable that is only assigned once.
   
   > 1 │ let a = !b || !c
       │ ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ let a = !b || !c
       │     ^

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/correctly_handles_ignored_and_not_ignored_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/correctly_handles_ignored_and_not_ignored_files.snap
@@ -52,12 +52,12 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 /formatter-ignored/test.js:1:19 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This let declares a variable which is never re-assigned.
+  × This let declares a variable that is only assigned once.
   
   > 1 │ statement(    ) ; let a = !b || !c;
       │                   ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ statement(    ) ; let a = !b || !c;
       │                       ^

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_subdir.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_subdir.snap
@@ -39,14 +39,14 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 ```block
 <TEMP_DIR>/include_files_in_subdir/subdir/file.js:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━
 
-  × This let declares a variable which is never re-assigned.
+  × This let declares a variable that is only assigned once.
   
   > 1 │ let a = 4;
       │ ^^^
     2 │ debugger;
     3 │ console.log(a);
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ let a = 4;
       │     ^

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_symlinked_subdir.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_symlinked_subdir.snap
@@ -39,14 +39,14 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 ```block
 <TEMP_DIR>/include_files_in_symlinked_subdir/symlinked/file.js:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━
 
-  × This let declares a variable which is never re-assigned.
+  × This let declares a variable that is only assigned once.
   
   > 1 │ let a = 4;
       │ ^^^
     2 │ debugger;
     3 │ console.log(a);
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ let a = 4;
       │     ^

--- a/crates/biome_configuration/src/linter/rules.rs
+++ b/crates/biome_configuration/src/linter/rules.rs
@@ -3556,7 +3556,7 @@ pub struct Style {
     #[doc = "Require consistently using either T\\[] or Array\\<T>"]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_consistent_array_type: Option<RuleConfiguration<UseConsistentArrayType>>,
-    #[doc = "Require const declarations for variables that are never reassigned after declared."]
+    #[doc = "Require const declarations for variables that are only assigned once."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_const: Option<RuleConfiguration<UseConst>>,
     #[doc = "Enforce default function parameters and optional function parameters to be last."]

--- a/crates/biome_js_analyze/tests/specs/style/useConst/invalid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useConst/invalid.jsonc.snap
@@ -11,12 +11,12 @@ let x = 1; foo(x);
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let x = 1; foo(x);
       │ ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is never reassigned.
   
   > 1 │ let x = 1; foo(x);
       │     ^
@@ -38,12 +38,12 @@ for (let i in [1,2,3]) { foo(i); }
 ```
 invalid.jsonc:1:6 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ for (let i in [1,2,3]) { foo(i); }
       │      ^^^
   
-  i 'i' is never re-assigned.
+  i 'i' is never reassigned.
   
   > 1 │ for (let i in [1,2,3]) { foo(i); }
       │          ^
@@ -65,12 +65,12 @@ for (let x of [1,2,3]) { foo(x); }
 ```
 invalid.jsonc:1:6 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ for (let x of [1,2,3]) { foo(x); }
       │      ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is never reassigned.
   
   > 1 │ for (let x of [1,2,3]) { foo(x); }
       │          ^
@@ -92,12 +92,12 @@ invalid.jsonc:1:6 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:15 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ (function() { let x = 1; foo(x); })();
       │               ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is never reassigned.
   
   > 1 │ (function() { let x = 1; foo(x); })();
       │                   ^
@@ -119,12 +119,12 @@ invalid.jsonc:1:15 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ (function() { for (let i in [1,2,3]) { foo(i); } })();
       │                    ^^^
   
-  i 'i' is never re-assigned.
+  i 'i' is never reassigned.
   
   > 1 │ (function() { for (let i in [1,2,3]) { foo(i); } })();
       │                        ^
@@ -146,12 +146,12 @@ invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ (function() { for (let x of [1,2,3]) { foo(x); } })();
       │                    ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is never reassigned.
   
   > 1 │ (function() { for (let x of [1,2,3]) { foo(x); } })();
       │                        ^
@@ -173,12 +173,12 @@ let f = (function() { let g = x; })(); f = 1;
 ```
 invalid.jsonc:1:23 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let f = (function() { let g = x; })(); f = 1;
       │                       ^^^
   
-  i 'g' is never re-assigned.
+  i 'g' is never reassigned.
   
   > 1 │ let f = (function() { let g = x; })(); f = 1;
       │                           ^
@@ -200,12 +200,12 @@ let x = 0; { let x = 1; foo(x); } x = 0;
 ```
 invalid.jsonc:1:14 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let x = 0; { let x = 1; foo(x); } x = 0;
       │              ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is never reassigned.
   
   > 1 │ let x = 0; { let x = 1; foo(x); } x = 0;
       │                  ^
@@ -227,12 +227,12 @@ for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }
 ```
 invalid.jsonc:1:32 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }
       │                                ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is never reassigned.
   
   > 1 │ for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }
       │                                    ^
@@ -254,12 +254,12 @@ for (let i in [1,2,3]) { let x = 1; foo(x); }
 ```
 invalid.jsonc:1:6 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ for (let i in [1,2,3]) { let x = 1; foo(x); }
       │      ^^^
   
-  i 'i' is never re-assigned.
+  i 'i' is never reassigned.
   
   > 1 │ for (let i in [1,2,3]) { let x = 1; foo(x); }
       │          ^
@@ -275,12 +275,12 @@ invalid.jsonc:1:6 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:26 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ for (let i in [1,2,3]) { let x = 1; foo(x); }
       │                          ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is never reassigned.
   
   > 1 │ for (let i in [1,2,3]) { let x = 1; foo(x); }
       │                              ^
@@ -302,15 +302,15 @@ var foo = function() { for (const b of c) { let a; a = 1; } };
 ```
 invalid.jsonc:1:45 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ var foo = function() { for (const b of c) { let a; a = 1; } };
       │                                             ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is only assigned here.
   
   > 1 │ var foo = function() { for (const b of c) { let a; a = 1; } };
-      │                                                 ^
+      │                                                    ^
   
 
 ```
@@ -324,15 +324,15 @@ var foo = function() { for (const b of c) { let a; ({a} = 1); } };
 ```
 invalid.jsonc:1:45 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ var foo = function() { for (const b of c) { let a; ({a} = 1); } };
       │                                             ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is only assigned here.
   
   > 1 │ var foo = function() { for (const b of c) { let a; ({a} = 1); } };
-      │                                                 ^
+      │                                                      ^
   
 
 ```
@@ -346,15 +346,15 @@ let x; x = 0;
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let x; x = 0;
       │ ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is only assigned here.
   
   > 1 │ let x; x = 0;
-      │     ^
+      │        ^
   
 
 ```
@@ -368,15 +368,15 @@ switch (a) { case 0: let x; x = 0; }
 ```
 invalid.jsonc:1:22 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ switch (a) { case 0: let x; x = 0; }
       │                      ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is only assigned here.
   
   > 1 │ switch (a) { case 0: let x; x = 0; }
-      │                          ^
+      │                             ^
   
 
 ```
@@ -390,15 +390,15 @@ invalid.jsonc:1:22 lint/style/useConst ━━━━━━━━━━━━━�
 ```
 invalid.jsonc:1:15 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ (function() { let x; x = 1; })();
       │               ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is only assigned here.
   
   > 1 │ (function() { let x; x = 1; })();
-      │                   ^
+      │                      ^
   
 
 ```
@@ -412,17 +412,17 @@ let {a: {b, c}} = {a: {b: 1, c: 2}}
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ let {a: {b, c}} = {a: {b: 1, c: 2}}
       │ ^^^
   
-  i 'b' is never re-assigned.
+  i 'b' is never reassigned.
   
   > 1 │ let {a: {b, c}} = {a: {b: 1, c: 2}}
       │          ^
   
-  i 'c' is never re-assigned.
+  i 'c' is never reassigned.
   
   > 1 │ let {a: {b, c}} = {a: {b: 1, c: 2}}
       │             ^
@@ -444,17 +444,17 @@ let {a = 0, b} = obj; foo(a, b);
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ let {a = 0, b} = obj; foo(a, b);
       │ ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ let {a = 0, b} = obj; foo(a, b);
       │      ^
   
-  i 'b' is never re-assigned.
+  i 'b' is never reassigned.
   
   > 1 │ let {a = 0, b} = obj; foo(a, b);
       │             ^
@@ -476,12 +476,12 @@ let [a] = [1]
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let [a] = [1]
       │ ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ let [a] = [1]
       │      ^
@@ -503,12 +503,12 @@ let {a} = obj
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let {a} = obj
       │ ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ let {a} = obj
       │      ^
@@ -530,20 +530,20 @@ let a, b; ({a = 0, b} = obj); foo(a, b);
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ let a, b; ({a = 0, b} = obj); foo(a, b);
       │ ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is only assigned here.
   
   > 1 │ let a, b; ({a = 0, b} = obj); foo(a, b);
-      │     ^
+      │             ^
   
-  i 'b' is never re-assigned.
+  i 'b' is only assigned here.
   
   > 1 │ let a, b; ({a = 0, b} = obj); foo(a, b);
-      │        ^
+      │                    ^
   
 
 ```
@@ -557,15 +557,15 @@ let x; function foo() { bar(x); } x = 0;
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let x; function foo() { bar(x); } x = 0;
       │ ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is only assigned here.
   
   > 1 │ let x; function foo() { bar(x); } x = 0;
-      │     ^
+      │                                   ^
   
 
 ```
@@ -579,12 +579,12 @@ invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━
 ```
 invalid.jsonc:1:24 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ /*eslint use-x:error*/ let x = 1
       │                        ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is never reassigned.
   
   > 1 │ /*eslint use-x:error*/ let x = 1
       │                            ^
@@ -606,12 +606,12 @@ invalid.jsonc:1:24 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:26 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ /*eslint use-x:error*/ { let x = 1 }
       │                          ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is never reassigned.
   
   > 1 │ /*eslint use-x:error*/ { let x = 1 }
       │                              ^
@@ -633,17 +633,17 @@ let { foo, bar } = baz;
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ let { foo, bar } = baz;
       │ ^^^
   
-  i 'foo' is never re-assigned.
+  i 'foo' is never reassigned.
   
   > 1 │ let { foo, bar } = baz;
       │       ^^^
   
-  i 'bar' is never re-assigned.
+  i 'bar' is never reassigned.
   
   > 1 │ let { foo, bar } = baz;
       │            ^^^
@@ -665,12 +665,12 @@ const x = [1,2]; let [,y] = x;
 ```
 invalid.jsonc:1:18 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ const x = [1,2]; let [,y] = x;
       │                  ^^^
   
-  i 'y' is never re-assigned.
+  i 'y' is never reassigned.
   
   > 1 │ const x = [1,2]; let [,y] = x;
       │                        ^
@@ -692,17 +692,17 @@ const x = [1,2,3]; let [y,,z] = x;
 ```
 invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ const x = [1,2,3]; let [y,,z] = x;
       │                    ^^^
   
-  i 'y' is never re-assigned.
+  i 'y' is never reassigned.
   
   > 1 │ const x = [1,2,3]; let [y,,z] = x;
       │                         ^
   
-  i 'z' is never re-assigned.
+  i 'z' is never reassigned.
   
   > 1 │ const x = [1,2,3]; let [y,,z] = x;
       │                            ^
@@ -724,15 +724,15 @@ let predicate; [, {foo:returnType, predicate}] = foo();
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let predicate; [, {foo:returnType, predicate}] = foo();
       │ ^^^
   
-  i 'predicate' is never re-assigned.
+  i 'predicate' is only assigned here.
   
   > 1 │ let predicate; [, {foo:returnType, predicate}] = foo();
-      │     ^^^^^^^^^
+      │                                    ^^^^^^^^^
   
 
 ```
@@ -746,15 +746,15 @@ let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();
       │ ^^^
   
-  i 'predicate' is never re-assigned.
+  i 'predicate' is only assigned here.
   
   > 1 │ let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();
-      │     ^^^^^^^^^
+      │                                    ^^^^^^^^^
   
 
 ```
@@ -768,15 +768,15 @@ let predicate; [, {foo:returnType, ...predicate} ] = foo();
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let predicate; [, {foo:returnType, ...predicate} ] = foo();
       │ ^^^
   
-  i 'predicate' is never re-assigned.
+  i 'predicate' is only assigned here.
   
   > 1 │ let predicate; [, {foo:returnType, ...predicate} ] = foo();
-      │     ^^^^^^^^^
+      │                                       ^^^^^^^^^
   
 
 ```
@@ -790,17 +790,17 @@ let x = 'x', y = 'y';
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ let x = 'x', y = 'y';
       │ ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is never reassigned.
   
   > 1 │ let x = 'x', y = 'y';
       │     ^
   
-  i 'y' is never re-assigned.
+  i 'y' is never reassigned.
   
   > 1 │ let x = 'x', y = 'y';
       │              ^
@@ -822,17 +822,17 @@ let x = 1, y = 'y'; let z = 1;
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ let x = 1, y = 'y'; let z = 1;
       │ ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is never reassigned.
   
   > 1 │ let x = 1, y = 'y'; let z = 1;
       │     ^
   
-  i 'y' is never re-assigned.
+  i 'y' is never reassigned.
   
   > 1 │ let x = 1, y = 'y'; let z = 1;
       │            ^
@@ -848,12 +848,12 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:21 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let x = 1, y = 'y'; let z = 1;
       │                     ^^^
   
-  i 'z' is never re-assigned.
+  i 'z' is never reassigned.
   
   > 1 │ let x = 1, y = 'y'; let z = 1;
       │                         ^
@@ -875,22 +875,22 @@ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
       │ ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
       │       ^
   
-  i 'b' is never re-assigned.
+  i 'b' is never reassigned.
   
   > 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
       │          ^
   
-  i 'c' is never re-assigned.
+  i 'c' is never reassigned.
   
   > 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
       │             ^
@@ -912,17 +912,17 @@ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
       │ ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is never reassigned.
   
   > 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
       │     ^
   
-  i 'y' is never re-assigned.
+  i 'y' is never reassigned.
   
   > 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
       │              ^
@@ -938,17 +938,17 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:45 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
       │                                             ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
       │                                                 ^
   
-  i 'b' is never re-assigned.
+  i 'b' is never reassigned.
   
   > 1 │ let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }
       │                                                        ^
@@ -970,12 +970,12 @@ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
       │ ^^^
   
-  i 'someFunc' is never re-assigned.
+  i 'someFunc' is never reassigned.
   
   > 1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
       │     ^^^^^^^^
@@ -991,17 +991,17 @@ invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:24 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
       │                        ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
       │                            ^
   
-  i 'b' is never re-assigned.
+  i 'b' is never reassigned.
   
   > 1 │ let someFunc = () => { let a = 1, b = 2; foo(a, b) }
       │                                   ^
@@ -1023,12 +1023,12 @@ invalid.jsonc:1:24 lint/style/useConst  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.jsonc:1:32 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ /*eslint no-undef-init:error*/ let foo = undefined;
       │                                ^^^
   
-  i 'foo' is never re-assigned.
+  i 'foo' is never reassigned.
   
   > 1 │ /*eslint no-undef-init:error*/ let foo = undefined;
       │                                    ^^^
@@ -1050,12 +1050,12 @@ let a = 1; class C { static { a; } }
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let a = 1; class C { static { a; } }
       │ ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ let a = 1; class C { static { a; } }
       │     ^
@@ -1077,12 +1077,12 @@ class C { static { a; } } let a = 1;
 ```
 invalid.jsonc:1:27 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ class C { static { a; } } let a = 1;
       │                           ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ class C { static { a; } } let a = 1;
       │                               ^
@@ -1104,12 +1104,12 @@ class C { static { let a = 1; } }
 ```
 invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ class C { static { let a = 1; } }
       │                    ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ class C { static { let a = 1; } }
       │                        ^
@@ -1131,12 +1131,12 @@ class C { static { if (foo) { let a = 1; } } }
 ```
 invalid.jsonc:1:31 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ class C { static { if (foo) { let a = 1; } } }
       │                               ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ class C { static { if (foo) { let a = 1; } } }
       │                                   ^
@@ -1158,12 +1158,12 @@ class C { static { let a = 1; if (foo) { a; } } }
 ```
 invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ class C { static { let a = 1; if (foo) { a; } } }
       │                    ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ class C { static { let a = 1; if (foo) { a; } } }
       │                        ^
@@ -1185,15 +1185,15 @@ class C { static { if (foo) { let a; a = 1; } } }
 ```
 invalid.jsonc:1:31 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ class C { static { if (foo) { let a; a = 1; } } }
       │                               ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is only assigned here.
   
   > 1 │ class C { static { if (foo) { let a; a = 1; } } }
-      │                                   ^
+      │                                      ^
   
 
 ```
@@ -1207,15 +1207,15 @@ class C { static { let a; a = 1; } }
 ```
 invalid.jsonc:1:20 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ class C { static { let a; a = 1; } }
       │                    ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is only assigned here.
   
   > 1 │ class C { static { let a; a = 1; } }
-      │                        ^
+      │                           ^
   
 
 ```
@@ -1229,17 +1229,17 @@ class C { static { let { a, b } = foo; } }
 ```
 invalid.jsonc:1:20 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ class C { static { let { a, b } = foo; } }
       │                    ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ class C { static { let { a, b } = foo; } }
       │                          ^
   
-  i 'b' is never re-assigned.
+  i 'b' is never reassigned.
   
   > 1 │ class C { static { let { a, b } = foo; } }
       │                             ^
@@ -1261,20 +1261,20 @@ class C { static { let a, b; ({ a, b } = foo); } }
 ```
 invalid.jsonc:1:20 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ class C { static { let a, b; ({ a, b } = foo); } }
       │                    ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is only assigned here.
   
   > 1 │ class C { static { let a, b; ({ a, b } = foo); } }
-      │                        ^
+      │                                 ^
   
-  i 'b' is never re-assigned.
+  i 'b' is only assigned here.
   
   > 1 │ class C { static { let a, b; ({ a, b } = foo); } }
-      │                           ^
+      │                                    ^
   
 
 ```
@@ -1288,15 +1288,15 @@ class C { static { let a; let b; ({ a, b } = foo); } }
 ```
 invalid.jsonc:1:20 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ class C { static { let a; let b; ({ a, b } = foo); } }
       │                    ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is only assigned here.
   
   > 1 │ class C { static { let a; let b; ({ a, b } = foo); } }
-      │                        ^
+      │                                     ^
   
 
 ```
@@ -1304,15 +1304,15 @@ invalid.jsonc:1:20 lint/style/useConst ━━━━━━━━━━━━━�
 ```
 invalid.jsonc:1:27 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ class C { static { let a; let b; ({ a, b } = foo); } }
       │                           ^^^
   
-  i 'b' is never re-assigned.
+  i 'b' is only assigned here.
   
   > 1 │ class C { static { let a; let b; ({ a, b } = foo); } }
-      │                               ^
+      │                                        ^
   
 
 ```
@@ -1326,15 +1326,15 @@ class C { static { let a; a = 0; console.log(a); } }
 ```
 invalid.jsonc:1:20 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ class C { static { let a; a = 0; console.log(a); } }
       │                    ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is only assigned here.
   
   > 1 │ class C { static { let a; a = 0; console.log(a); } }
-      │                        ^
+      │                           ^
   
 
 ```
@@ -1348,22 +1348,22 @@ let { itemId, list } = {}, obj = []; console.log(itemId, list, obj);
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ let { itemId, list } = {}, obj = []; console.log(itemId, list, obj);
       │ ^^^
   
-  i 'itemId' is never re-assigned.
+  i 'itemId' is never reassigned.
   
   > 1 │ let { itemId, list } = {}, obj = []; console.log(itemId, list, obj);
       │       ^^^^^^
   
-  i 'list' is never re-assigned.
+  i 'list' is never reassigned.
   
   > 1 │ let { itemId, list } = {}, obj = []; console.log(itemId, list, obj);
       │               ^^^^
   
-  i 'obj' is never re-assigned.
+  i 'obj' is never reassigned.
   
   > 1 │ let { itemId, list } = {}, obj = []; console.log(itemId, list, obj);
       │                            ^^^
@@ -1385,22 +1385,22 @@ let [ itemId, list ] = [], obj = []; console.log(itemId, list, obj);
 ```
 invalid.jsonc:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares some variables which are never re-assigned.
+  ! This let declares some variables that are only assigned once.
   
   > 1 │ let [ itemId, list ] = [], obj = []; console.log(itemId, list, obj);
       │ ^^^
   
-  i 'itemId' is never re-assigned.
+  i 'itemId' is never reassigned.
   
   > 1 │ let [ itemId, list ] = [], obj = []; console.log(itemId, list, obj);
       │       ^^^^^^
   
-  i 'list' is never re-assigned.
+  i 'list' is never reassigned.
   
   > 1 │ let [ itemId, list ] = [], obj = []; console.log(itemId, list, obj);
       │               ^^^^
   
-  i 'obj' is never re-assigned.
+  i 'obj' is never reassigned.
   
   > 1 │ let [ itemId, list ] = [], obj = []; console.log(itemId, list, obj);
       │                            ^^^
@@ -1422,12 +1422,12 @@ class C { static { () => a; let a = 1; } };
 ```
 invalid.jsonc:1:29 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ class C { static { () => a; let a = 1; } };
       │                             ^^^
   
-  i 'a' is never re-assigned.
+  i 'a' is never reassigned.
   
   > 1 │ class C { static { () => a; let a = 1; } };
       │                                 ^
@@ -1449,17 +1449,15 @@ let x; function foo() { bar(x); } x = 0;
 ```
 invalid.jsonc:1:1 lint/style/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This let declares a variable which is never re-assigned.
+  ! This let declares a variable that is only assigned once.
   
   > 1 │ let x; function foo() { bar(x); } x = 0;
       │ ^^^
   
-  i 'x' is never re-assigned.
+  i 'x' is only assigned here.
   
   > 1 │ let x; function foo() { bar(x); } x = 0;
-      │     ^
+      │                                   ^
   
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/style/useConst/valid.jsonc
+++ b/crates/biome_js_analyze/tests/specs/style/useConst/valid.jsonc
@@ -98,5 +98,10 @@
 
 	// https://github.com/eslint/eslint/issues/16266
 	"let { itemId, list } = {}, obj = [], total = 0; total = 9; console.log(itemId, list, obj, total);",
-	"let [ itemId, list ] = [], total = 0; total = 9; console.log(itemId, list, total);"
+	"let [ itemId, list ] = [], total = 0; total = 9; console.log(itemId, list, total);",
+
+	// Read before an assignement
+	"let x; x; x = 0;",
+	"let x; { x; }; x = 0;",
+	"let x; { { x; } }; x = 0;"
 ]

--- a/crates/biome_js_analyze/tests/specs/style/useConst/valid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useConst/valid.jsonc.snap
@@ -412,4 +412,17 @@ let { itemId, list } = {}, obj = [], total = 0; total = 9; console.log(itemId, l
 let [ itemId, list ] = [], total = 0; total = 9; console.log(itemId, list, total);
 ```
 
+# Input
+```cjs
+let x; x; x = 0;
+```
 
+# Input
+```cjs
+let x; { x; }; x = 0;
+```
+
+# Input
+```cjs
+let x; { { x; } }; x = 0;
+```

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ upgrade-tools:
 # Generate all files across crates and tools. You rarely want to use it locally.
 gen-all:
   cargo run -p xtask_codegen -- all
-  cargo run -p xtask_codegen -- configuration
+  cargo codegen-configuration
   cargo run -p xtask_codegen --features configuration -- migrate-eslint
   just gen-bindings
   just format

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1144,7 +1144,7 @@ export interface Style {
 	 */
 	useConsistentArrayType?: RuleConfiguration_for_ConsistentArrayTypeOptions;
 	/**
-	 * Require const declarations for variables that are never reassigned after declared.
+	 * Require const declarations for variables that are only assigned once.
 	 */
 	useConst?: RuleConfiguration_for_Null;
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2192,7 +2192,7 @@
 					]
 				},
 				"useConst": {
-					"description": "Require const declarations for variables that are never reassigned after declared.",
+					"description": "Require const declarations for variables that are only assigned once.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }


### PR DESCRIPTION
## Summary

Fix #2575

I also took the opportunity of fixing an issue I discovered when reading the code:
The rule should not report an implicitly initialized variable that is read before its assignment.
The following example was previously reported:

```js
let a;
a;
a = 0;
```

## Test Plan

I added 3 tests and updated the snapshots.