### PR TITLE
chore: add infrastructure for Grit engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,8 +527,13 @@ dependencies = [
 name = "biome_grit_patterns"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
  "biome_console",
  "biome_diagnostics",
+ "biome_grit_parser",
+ "grit-core-patterns",
+ "grit-util",
+ "im",
  "serde",
 ]
 
@@ -1056,6 +1061,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bpaf"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1401,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1453,37 @@ name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+
+[[package]]
+name = "derive_builder"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f59169f400d8087f238c5c0c7db6a28af18681717f3b623227d92f397e938c7"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ec317cc3e7ef0928b0ca6e4a634a4d6c001672ae210438cf114a83e56b018d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "870368c3fb35b8031abb378861d4460f573b92238ec2152c927a21f77e3e0127"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "directories"
@@ -1455,6 +1535,15 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "elsa"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98e71ae4df57d214182a2e5cb90230c0192c6ddfcaa05c36453d46a54713e10"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1728,6 +1817,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "grit-core-patterns"
+version = "0.1.0"
+source = "git+https://github.com/arendjr/gritql.git?branch=grit-core-patterns-crate#327c14897f18f339157165c69ddeba04c0285253"
+dependencies = [
+ "anyhow",
+ "elsa",
+ "grit-util",
+ "im",
+ "itertools",
+ "rand 0.8.5",
+ "regex",
+]
+
+[[package]]
+name = "grit-util"
+version = "0.1.0"
+source = "git+https://github.com/arendjr/gritql.git?branch=grit-core-patterns-crate#327c14897f18f339157165c69ddeba04c0285253"
+dependencies = [
+ "derive_builder",
+ "once_cell",
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +1906,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71a816c97c42258aa5834d07590b718b4c9a598944cd39a52dc25b351185d678"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,6 +1935,20 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.4",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2480,7 +2614,7 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
 ]
@@ -2491,6 +2625,8 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2502,6 +2638,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2529,6 +2675,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2894,6 +3049,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2928,10 +3093,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -3313,6 +3490,12 @@ dependencies = [
  "serde_json",
  "termcolor",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
  "biome_text_edit",
  "bpaf",
  "dashmap",
+ "getrandom 0.2.14",
  "ignore",
  "indexmap 1.9.3",
  "insta",
@@ -1763,8 +1764,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,6 @@ dependencies = [
  "anyhow",
  "biome_console",
  "biome_diagnostics",
- "biome_grit_parser",
  "grit-pattern-matcher",
  "grit-util",
  "im",
@@ -1822,7 +1821,8 @@ dependencies = [
 [[package]]
 name = "grit-pattern-matcher"
 version = "0.1.0"
-source = "git+https://github.com/arendjr/gritql.git?branch=trimmed-submodules#1bd04b1e8f57faea0b5cfd413a6847e40a8eeb6e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c0574d27418acbda6c6c10b85d496100e82eebc46b9533bf15f204792f11b8"
 dependencies = [
  "anyhow",
  "elsa",
@@ -1836,7 +1836,8 @@ dependencies = [
 [[package]]
 name = "grit-util"
 version = "0.1.0"
-source = "git+https://github.com/arendjr/gritql.git?branch=trimmed-submodules#1bd04b1e8f57faea0b5cfd413a6847e40a8eeb6e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbccf24e380ffb524304fa7b1fbeaa0d021e281dcc931a098e1876f37adb4ef"
 dependencies = [
  "derive_builder",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
  "biome_console",
  "biome_diagnostics",
  "biome_grit_parser",
- "grit-core-patterns",
+ "grit-pattern-matcher",
  "grit-util",
  "im",
  "serde",
@@ -1817,9 +1817,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "grit-core-patterns"
+name = "grit-pattern-matcher"
 version = "0.1.0"
-source = "git+https://github.com/arendjr/gritql.git?branch=grit-core-patterns-crate#327c14897f18f339157165c69ddeba04c0285253"
+source = "git+https://github.com/arendjr/gritql.git?branch=trimmed-submodules#1bd04b1e8f57faea0b5cfd413a6847e40a8eeb6e"
 dependencies = [
  "anyhow",
  "elsa",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "grit-util"
 version = "0.1.0"
-source = "git+https://github.com/arendjr/gritql.git?branch=grit-core-patterns-crate#327c14897f18f339157165c69ddeba04c0285253"
+source = "git+https://github.com/arendjr/gritql.git?branch=trimmed-submodules#1bd04b1e8f57faea0b5cfd413a6847e40a8eeb6e"
 dependencies = [
  "derive_builder",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ bpaf               = { version = "0.9.9", features = ["derive"] }
 countme            = "3.0.1"
 crossbeam          = "0.8.4"
 dashmap            = "5.4.0"
+getrandom          = "0.2.14"
 ignore             = "0.4.21"
 indexmap           = "1.9.3"
 insta              = "1.38.0"

--- a/crates/biome_grit_patterns/Cargo.toml
+++ b/crates/biome_grit_patterns/Cargo.toml
@@ -12,15 +12,14 @@ repository.workspace = true
 version              = "0.0.1"
 
 [dependencies]
-biome_console     = { workspace = true }
-biome_diagnostics = { workspace = true }
-#biome_grit_parser = { workspace = true } TODO: will be used in a future PR
-#marzano-core      = { git = "https://github.com/getgrit/gritql.git", optional = true }
-serde = { workspace = true, features = ["derive"] }
-
-[features]
-default = [] # add "grit" to enable linking to Grit's Marzano engine
-#grit    = ["dep:marzano-core"]
+anyhow             = "1.0.52"
+biome_console      = { workspace = true }
+biome_diagnostics  = { workspace = true }
+biome_grit_parser  = { workspace = true }
+grit-core-patterns = { git = "https://github.com/arendjr/gritql.git", branch = "grit-core-patterns-crate" }
+grit-util          = { git = "https://github.com/arendjr/gritql.git", branch = "grit-core-patterns-crate" }
+im                 = { version = "15.1.0" }
+serde              = { workspace = true, features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/biome_grit_patterns/Cargo.toml
+++ b/crates/biome_grit_patterns/Cargo.toml
@@ -15,9 +15,8 @@ version              = "0.0.1"
 anyhow               = "1.0.52"
 biome_console        = { workspace = true }
 biome_diagnostics    = { workspace = true }
-biome_grit_parser    = { workspace = true }
-grit-pattern-matcher = { git = "https://github.com/arendjr/gritql.git", branch = "trimmed-submodules" }
-grit-util            = { git = "https://github.com/arendjr/gritql.git", branch = "trimmed-submodules" }
+grit-pattern-matcher = { version = "0.1" }
+grit-util            = { version = "0.1" }
 im                   = { version = "15.1.0" }
 serde                = { workspace = true, features = ["derive"] }
 

--- a/crates/biome_grit_patterns/Cargo.toml
+++ b/crates/biome_grit_patterns/Cargo.toml
@@ -12,14 +12,14 @@ repository.workspace = true
 version              = "0.0.1"
 
 [dependencies]
-anyhow             = "1.0.52"
-biome_console      = { workspace = true }
-biome_diagnostics  = { workspace = true }
-biome_grit_parser  = { workspace = true }
-grit-core-patterns = { git = "https://github.com/arendjr/gritql.git", branch = "grit-core-patterns-crate" }
-grit-util          = { git = "https://github.com/arendjr/gritql.git", branch = "grit-core-patterns-crate" }
-im                 = { version = "15.1.0" }
-serde              = { workspace = true, features = ["derive"] }
+anyhow               = "1.0.52"
+biome_console        = { workspace = true }
+biome_diagnostics    = { workspace = true }
+biome_grit_parser    = { workspace = true }
+grit-pattern-matcher = { git = "https://github.com/arendjr/gritql.git", branch = "trimmed-submodules" }
+grit-util            = { git = "https://github.com/arendjr/gritql.git", branch = "trimmed-submodules" }
+im                   = { version = "15.1.0" }
+serde                = { workspace = true, features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/biome_grit_patterns/src/grit_binding.rs
+++ b/crates/biome_grit_patterns/src/grit_binding.rs
@@ -1,0 +1,125 @@
+use crate::{grit_context::GritQueryContext, grit_language::GritLanguage, grit_node::GritNode};
+use grit_core_patterns::{binding::Binding, constant::Constant};
+use grit_util::{CodeRange, Range};
+use std::path::Path;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct GritBinding;
+
+impl<'a> Binding<'a, GritQueryContext> for GritBinding {
+    fn from_constant(_constant: &'a Constant) -> Self {
+        todo!()
+    }
+
+    fn from_node(_node: GritNode) -> Self {
+        todo!()
+    }
+
+    fn from_path(_path: &'a Path) -> Self {
+        todo!()
+    }
+
+    fn from_range(_range: Range, _source: &'a str) -> Self {
+        todo!()
+    }
+
+    fn singleton(&self) -> Option<GritNode> {
+        todo!()
+    }
+
+    fn get_sexp(&self) -> Option<String> {
+        todo!()
+    }
+
+    fn position(&self, _language: &GritLanguage) -> Option<Range> {
+        todo!()
+    }
+
+    fn code_range(&self, _language: &GritLanguage) -> Option<CodeRange> {
+        todo!()
+    }
+
+    fn is_equivalent_to(&self, _other: &Self, _language: &GritLanguage) -> bool {
+        todo!()
+    }
+
+    fn is_suppressed(&self, _language: &GritLanguage, _current_name: Option<&str>) -> bool {
+        todo!()
+    }
+
+    fn get_insertion_padding(
+        &self,
+        _text: &str,
+        _is_first: bool,
+        _language: &GritLanguage,
+    ) -> Option<String> {
+        todo!()
+    }
+
+    fn linearized_text(
+        &self,
+        _language: &GritLanguage,
+        _effects: &[grit_core_patterns::effects::Effect<'a, GritQueryContext>],
+        _files: &grit_core_patterns::pattern::state::FileRegistry<'a, GritQueryContext>,
+        _memo: &mut std::collections::HashMap<grit_util::CodeRange, Option<String>>,
+        _distributed_indent: Option<usize>,
+        _logs: &mut grit_util::AnalysisLogs,
+    ) -> anyhow::Result<std::borrow::Cow<'a, str>> {
+        todo!()
+    }
+
+    fn text(&self, _language: &GritLanguage) -> anyhow::Result<std::borrow::Cow<str>> {
+        todo!()
+    }
+
+    fn source(&self) -> Option<&'a str> {
+        todo!()
+    }
+
+    fn as_constant(&self) -> Option<&grit_core_patterns::constant::Constant> {
+        todo!()
+    }
+
+    fn as_filename(&self) -> Option<&std::path::Path> {
+        todo!()
+    }
+
+    fn as_node(&self) -> Option<GritNode> {
+        todo!()
+    }
+
+    fn is_list(&self) -> bool {
+        todo!()
+    }
+
+    fn list_items(&self) -> Option<impl Iterator<Item = GritNode> + Clone> {
+        None::<TodoIterator>
+    }
+
+    fn parent_node(&self) -> Option<GritNode> {
+        todo!()
+    }
+
+    fn is_truthy(&self) -> bool {
+        todo!()
+    }
+
+    fn log_empty_field_rewrite_error(
+        &self,
+        _language: &GritLanguage,
+        _logs: &mut grit_util::AnalysisLogs,
+    ) -> anyhow::Result<()> {
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+struct TodoIterator;
+
+impl Iterator for TodoIterator {
+    type Item = GritNode;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}

--- a/crates/biome_grit_patterns/src/grit_binding.rs
+++ b/crates/biome_grit_patterns/src/grit_binding.rs
@@ -1,5 +1,5 @@
 use crate::{grit_context::GritQueryContext, grit_language::GritLanguage, grit_node::GritNode};
-use grit_core_patterns::{binding::Binding, constant::Constant};
+use grit_pattern_matcher::{binding::Binding, constant::Constant};
 use grit_util::{CodeRange, Range};
 use std::path::Path;
 
@@ -59,8 +59,8 @@ impl<'a> Binding<'a, GritQueryContext> for GritBinding {
     fn linearized_text(
         &self,
         _language: &GritLanguage,
-        _effects: &[grit_core_patterns::effects::Effect<'a, GritQueryContext>],
-        _files: &grit_core_patterns::pattern::state::FileRegistry<'a, GritQueryContext>,
+        _effects: &[grit_pattern_matcher::effects::Effect<'a, GritQueryContext>],
+        _files: &grit_pattern_matcher::pattern::FileRegistry<'a, GritQueryContext>,
         _memo: &mut std::collections::HashMap<grit_util::CodeRange, Option<String>>,
         _distributed_indent: Option<usize>,
         _logs: &mut grit_util::AnalysisLogs,
@@ -76,7 +76,7 @@ impl<'a> Binding<'a, GritQueryContext> for GritBinding {
         todo!()
     }
 
-    fn as_constant(&self) -> Option<&grit_core_patterns::constant::Constant> {
+    fn as_constant(&self) -> Option<&grit_pattern_matcher::constant::Constant> {
         todo!()
     }
 

--- a/crates/biome_grit_patterns/src/grit_code_snippet.rs
+++ b/crates/biome_grit_patterns/src/grit_code_snippet.rs
@@ -1,0 +1,51 @@
+use crate::grit_context::{GritExecContext, GritQueryContext};
+use crate::resolved_pattern::GritResolvedPattern;
+use anyhow::Result;
+use grit_core_patterns::pattern::dynamic_snippet::DynamicPattern;
+use grit_core_patterns::pattern::patterns::{CodeSnippet, Matcher, Pattern, PatternName};
+use grit_core_patterns::pattern::state::State;
+use grit_util::AnalysisLogs;
+
+#[derive(Clone, Debug)]
+pub(crate) struct GritCodeSnippet;
+
+impl CodeSnippet<GritQueryContext> for GritCodeSnippet {
+    fn patterns(&self) -> impl Iterator<Item = &Pattern<GritQueryContext>> {
+        TodoIterator { _snippet: self }
+    }
+
+    fn dynamic_snippet(&self) -> Option<&DynamicPattern<GritQueryContext>> {
+        todo!()
+    }
+}
+
+impl Matcher<GritQueryContext> for GritCodeSnippet {
+    fn execute<'a>(
+        &'a self,
+        _binding: &GritResolvedPattern,
+        _state: &mut State<'a, GritQueryContext>,
+        _context: &'a GritExecContext,
+        _logs: &mut AnalysisLogs,
+    ) -> Result<bool> {
+        todo!()
+    }
+}
+
+impl PatternName for GritCodeSnippet {
+    fn name(&self) -> &'static str {
+        "CodeSnippet"
+    }
+}
+
+#[derive(Clone)]
+struct TodoIterator<'a> {
+    _snippet: &'a GritCodeSnippet,
+}
+
+impl<'a> Iterator for TodoIterator<'a> {
+    type Item = &'a Pattern<GritQueryContext>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}

--- a/crates/biome_grit_patterns/src/grit_code_snippet.rs
+++ b/crates/biome_grit_patterns/src/grit_code_snippet.rs
@@ -1,9 +1,9 @@
 use crate::grit_context::{GritExecContext, GritQueryContext};
 use crate::resolved_pattern::GritResolvedPattern;
 use anyhow::Result;
-use grit_core_patterns::pattern::dynamic_snippet::DynamicPattern;
-use grit_core_patterns::pattern::patterns::{CodeSnippet, Matcher, Pattern, PatternName};
-use grit_core_patterns::pattern::state::State;
+use grit_pattern_matcher::pattern::{
+    CodeSnippet, DynamicPattern, Matcher, Pattern, PatternName, State,
+};
 use grit_util::AnalysisLogs;
 
 #[derive(Clone, Debug)]

--- a/crates/biome_grit_patterns/src/grit_context.rs
+++ b/crates/biome_grit_patterns/src/grit_context.rs
@@ -7,12 +7,10 @@ use crate::grit_node_patterns::{GritLeafNodePattern, GritNodePattern};
 use crate::grit_tree::GritTree;
 use crate::resolved_pattern::GritResolvedPattern;
 use anyhow::Result;
-use grit_core_patterns::context::{ExecContext, QueryContext};
-use grit_core_patterns::file_owners::FileOwners;
-use grit_core_patterns::pattern::{
-    call_built_in::CallBuiltIn, function_definition::GritFunctionDefinition,
-    pattern_definition::PatternDefinition, patterns::Pattern,
-    predicate_definition::PredicateDefinition, state::State,
+use grit_pattern_matcher::context::{ExecContext, QueryContext};
+use grit_pattern_matcher::file_owners::FileOwners;
+use grit_pattern_matcher::pattern::{
+    CallBuiltIn, GritFunctionDefinition, Pattern, PatternDefinition, PredicateDefinition, State,
 };
 use grit_util::AnalysisLogs;
 

--- a/crates/biome_grit_patterns/src/grit_context.rs
+++ b/crates/biome_grit_patterns/src/grit_context.rs
@@ -1,0 +1,86 @@
+use crate::grit_binding::GritBinding;
+use crate::grit_code_snippet::GritCodeSnippet;
+use crate::grit_file::GritFile;
+use crate::grit_language::GritLanguage;
+use crate::grit_node::GritNode;
+use crate::grit_node_patterns::{GritLeafNodePattern, GritNodePattern};
+use crate::grit_tree::GritTree;
+use crate::resolved_pattern::GritResolvedPattern;
+use anyhow::Result;
+use grit_core_patterns::context::{ExecContext, QueryContext};
+use grit_core_patterns::file_owners::FileOwners;
+use grit_core_patterns::pattern::{
+    call_built_in::CallBuiltIn, function_definition::GritFunctionDefinition,
+    pattern_definition::PatternDefinition, patterns::Pattern,
+    predicate_definition::PredicateDefinition, state::State,
+};
+use grit_util::AnalysisLogs;
+
+#[derive(Clone, Debug)]
+pub(crate) struct GritQueryContext;
+
+impl QueryContext for GritQueryContext {
+    type Node<'a> = GritNode;
+    type NodePattern = GritNodePattern;
+    type LeafNodePattern = GritLeafNodePattern;
+    type ExecContext<'a> = GritExecContext;
+    type Binding<'a> = GritBinding;
+    type CodeSnippet = GritCodeSnippet;
+    type ResolvedPattern<'a> = GritResolvedPattern;
+    type Language<'a> = GritLanguage;
+    type File<'a> = GritFile;
+    type Tree = GritTree;
+}
+
+#[derive(Debug)]
+pub(crate) struct GritExecContext;
+
+impl<'a> ExecContext<'a, GritQueryContext> for GritExecContext {
+    fn pattern_definitions(&self) -> &[PatternDefinition<GritQueryContext>] {
+        todo!()
+    }
+
+    fn predicate_definitions(&self) -> &[PredicateDefinition<GritQueryContext>] {
+        todo!()
+    }
+
+    fn function_definitions(&self) -> &[GritFunctionDefinition<GritQueryContext>] {
+        todo!()
+    }
+
+    fn ignore_limit_pattern(&self) -> bool {
+        todo!()
+    }
+
+    fn call_built_in(
+        &self,
+        _call: &'a CallBuiltIn<GritQueryContext>,
+        _context: &'a Self,
+        _state: &mut State<'a, GritQueryContext>,
+        _logs: &mut AnalysisLogs,
+    ) -> Result<GritResolvedPattern> {
+        todo!()
+    }
+
+    fn files(&self) -> &FileOwners<GritTree> {
+        todo!()
+    }
+
+    fn language(&self) -> &GritLanguage {
+        todo!()
+    }
+
+    fn exec_step(
+        &'a self,
+        _step: &'a Pattern<GritQueryContext>,
+        _binding: &GritResolvedPattern,
+        _state: &mut State<'a, GritQueryContext>,
+        _logs: &mut AnalysisLogs,
+    ) -> Result<bool> {
+        todo!()
+    }
+
+    fn name(&self) -> Option<&str> {
+        todo!()
+    }
+}

--- a/crates/biome_grit_patterns/src/grit_file.rs
+++ b/crates/biome_grit_patterns/src/grit_file.rs
@@ -1,0 +1,28 @@
+use crate::grit_context::GritQueryContext;
+use crate::grit_language::GritLanguage;
+use crate::resolved_pattern::GritResolvedPattern;
+use grit_core_patterns::pattern::{resolved_pattern::File, state::FileRegistry};
+
+pub(crate) struct GritFile;
+
+impl<'a> File<'a, GritQueryContext> for GritFile {
+    fn name(&self, _files: &FileRegistry<'a, GritQueryContext>) -> GritResolvedPattern {
+        todo!()
+    }
+
+    fn absolute_path(
+        &self,
+        _files: &FileRegistry<'a, GritQueryContext>,
+        _language: &GritLanguage,
+    ) -> anyhow::Result<GritResolvedPattern> {
+        todo!()
+    }
+
+    fn body(&self, _files: &FileRegistry<'a, GritQueryContext>) -> GritResolvedPattern {
+        todo!()
+    }
+
+    fn binding(&self, _files: &FileRegistry<'a, GritQueryContext>) -> GritResolvedPattern {
+        todo!()
+    }
+}

--- a/crates/biome_grit_patterns/src/grit_file.rs
+++ b/crates/biome_grit_patterns/src/grit_file.rs
@@ -1,7 +1,7 @@
 use crate::grit_context::GritQueryContext;
 use crate::grit_language::GritLanguage;
 use crate::resolved_pattern::GritResolvedPattern;
-use grit_core_patterns::pattern::{resolved_pattern::File, state::FileRegistry};
+use grit_pattern_matcher::pattern::{File, FileRegistry};
 
 pub(crate) struct GritFile;
 

--- a/crates/biome_grit_patterns/src/grit_language.rs
+++ b/crates/biome_grit_patterns/src/grit_language.rs
@@ -1,0 +1,24 @@
+use crate::grit_node::GritNode;
+use grit_util::Language;
+
+pub(crate) struct GritLanguage;
+
+impl Language for GritLanguage {
+    type Node<'a> = GritNode;
+
+    fn language_name(&self) -> &'static str {
+        todo!()
+    }
+
+    fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
+        todo!()
+    }
+
+    fn is_comment(&self, _node: &Self::Node<'_>) -> bool {
+        todo!()
+    }
+
+    fn is_metavariable(&self, _node: &Self::Node<'_>) -> bool {
+        todo!()
+    }
+}

--- a/crates/biome_grit_patterns/src/grit_node.rs
+++ b/crates/biome_grit_patterns/src/grit_node.rs
@@ -1,0 +1,97 @@
+use grit_util::{AstCursor, AstNode as GritAstNode, CodeRange, Range};
+use std::{borrow::Cow, str::Utf8Error};
+
+#[derive(Clone, Debug)]
+pub(crate) struct GritNode;
+
+impl GritAstNode for GritNode {
+    fn kind_id(&self) -> u16 {
+        todo!()
+    }
+
+    fn kind(&self) -> Cow<str> {
+        todo!()
+    }
+
+    fn ancestors(&self) -> impl Iterator<Item = Self> {
+        TodoIterator
+    }
+
+    fn children(&self) -> impl Iterator<Item = Self> {
+        TodoIterator
+    }
+
+    fn parent(&self) -> Option<Self> {
+        todo!()
+    }
+
+    fn next_named_node(&self) -> Option<Self> {
+        todo!()
+    }
+
+    fn previous_named_node(&self) -> Option<Self> {
+        todo!()
+    }
+
+    fn next_sibling(&self) -> Option<Self> {
+        todo!()
+    }
+
+    fn previous_sibling(&self) -> Option<Self> {
+        todo!()
+    }
+
+    fn text(&self) -> Result<Cow<str>, Utf8Error> {
+        todo!()
+    }
+
+    fn range(&self) -> Range {
+        todo!()
+    }
+
+    fn code_range(&self) -> CodeRange {
+        todo!()
+    }
+
+    fn full_source(&self) -> &str {
+        todo!()
+    }
+
+    fn walk(&self) -> impl AstCursor<Node = Self> {
+        TodoCursor
+    }
+}
+
+#[derive(Clone)]
+struct TodoIterator;
+
+impl Iterator for TodoIterator {
+    type Item = GritNode;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+struct TodoCursor;
+
+impl AstCursor for TodoCursor {
+    type Node = GritNode;
+
+    fn goto_first_child(&mut self) -> bool {
+        todo!()
+    }
+
+    fn goto_parent(&mut self) -> bool {
+        todo!()
+    }
+
+    fn goto_next_sibling(&mut self) -> bool {
+        todo!()
+    }
+
+    fn node(&self) -> Self::Node {
+        todo!()
+    }
+}

--- a/crates/biome_grit_patterns/src/grit_node.rs
+++ b/crates/biome_grit_patterns/src/grit_node.rs
@@ -5,14 +5,6 @@ use std::{borrow::Cow, str::Utf8Error};
 pub(crate) struct GritNode;
 
 impl GritAstNode for GritNode {
-    fn kind_id(&self) -> u16 {
-        todo!()
-    }
-
-    fn kind(&self) -> Cow<str> {
-        todo!()
-    }
-
     fn ancestors(&self) -> impl Iterator<Item = Self> {
         TodoIterator
     }

--- a/crates/biome_grit_patterns/src/grit_node_patterns.rs
+++ b/crates/biome_grit_patterns/src/grit_node_patterns.rs
@@ -2,10 +2,9 @@ use crate::grit_context::{GritExecContext, GritQueryContext};
 use crate::grit_node::GritNode;
 use crate::resolved_pattern::GritResolvedPattern;
 use anyhow::Result;
-use grit_core_patterns::pattern::ast_node_pattern::{AstLeafNodePattern, AstNodePattern};
-use grit_core_patterns::pattern::iter_pattern::PatternOrPredicate;
-use grit_core_patterns::pattern::patterns::{Matcher, PatternName};
-use grit_core_patterns::pattern::state::State;
+use grit_pattern_matcher::pattern::{
+    AstLeafNodePattern, AstNodePattern, Matcher, PatternName, PatternOrPredicate, State,
+};
 use grit_util::AnalysisLogs;
 
 #[derive(Clone, Debug)]

--- a/crates/biome_grit_patterns/src/grit_node_patterns.rs
+++ b/crates/biome_grit_patterns/src/grit_node_patterns.rs
@@ -1,0 +1,63 @@
+use crate::grit_context::{GritExecContext, GritQueryContext};
+use crate::grit_node::GritNode;
+use crate::resolved_pattern::GritResolvedPattern;
+use anyhow::Result;
+use grit_core_patterns::pattern::ast_node_pattern::{AstLeafNodePattern, AstNodePattern};
+use grit_core_patterns::pattern::iter_pattern::PatternOrPredicate;
+use grit_core_patterns::pattern::patterns::{Matcher, PatternName};
+use grit_core_patterns::pattern::state::State;
+use grit_util::AnalysisLogs;
+
+#[derive(Clone, Debug)]
+pub(crate) struct GritNodePattern;
+
+impl AstNodePattern<GritQueryContext> for GritNodePattern {
+    fn children(&self) -> Vec<PatternOrPredicate<GritQueryContext>> {
+        todo!()
+    }
+
+    fn matches_kind_of(&self, _node: &GritNode) -> bool {
+        todo!()
+    }
+}
+
+impl Matcher<GritQueryContext> for GritNodePattern {
+    fn execute<'a>(
+        &'a self,
+        _binding: &GritResolvedPattern,
+        _state: &mut State<'a, GritQueryContext>,
+        _context: &'a GritExecContext,
+        _logs: &mut AnalysisLogs,
+    ) -> Result<bool> {
+        todo!()
+    }
+}
+
+impl PatternName for GritNodePattern {
+    fn name(&self) -> &'static str {
+        "GritNode"
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct GritLeafNodePattern;
+
+impl AstLeafNodePattern<GritQueryContext> for GritLeafNodePattern {}
+
+impl Matcher<GritQueryContext> for GritLeafNodePattern {
+    fn execute<'a>(
+        &'a self,
+        _binding: &GritResolvedPattern,
+        _state: &mut State<'a, GritQueryContext>,
+        _context: &'a GritExecContext,
+        _logs: &mut AnalysisLogs,
+    ) -> Result<bool> {
+        todo!()
+    }
+}
+
+impl PatternName for GritLeafNodePattern {
+    fn name(&self) -> &'static str {
+        "GritLeafNode"
+    }
+}

--- a/crates/biome_grit_patterns/src/grit_tree.rs
+++ b/crates/biome_grit_patterns/src/grit_tree.rs
@@ -1,0 +1,15 @@
+use crate::grit_node::GritNode;
+use grit_util::Ast;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct GritTree;
+
+impl Ast for GritTree {
+    type Node<'a> = GritNode
+    where
+        Self: 'a;
+
+    fn root_node(&self) -> GritNode {
+        todo!()
+    }
+}

--- a/crates/biome_grit_patterns/src/lib.rs
+++ b/crates/biome_grit_patterns/src/lib.rs
@@ -1,6 +1,15 @@
 mod errors;
+mod grit_binding;
+mod grit_code_snippet;
+mod grit_context;
+mod grit_file;
+mod grit_language;
+mod grit_node;
+mod grit_node_patterns;
+mod grit_tree;
 mod parse;
 mod pattern;
+mod resolved_pattern;
 
 pub use errors::*;
 pub use parse::parse_pattern;

--- a/crates/biome_grit_patterns/src/parse.rs
+++ b/crates/biome_grit_patterns/src/parse.rs
@@ -1,5 +1,5 @@
 use crate::{GritPattern, ParseError};
-use grit_core_patterns::pattern::patterns::Pattern;
+use grit_pattern_matcher::pattern::Pattern;
 
 pub fn parse_pattern(source: String) -> Result<GritPattern, ParseError> {
     Ok(GritPattern {

--- a/crates/biome_grit_patterns/src/parse.rs
+++ b/crates/biome_grit_patterns/src/parse.rs
@@ -1,12 +1,9 @@
 use crate::{GritPattern, ParseError};
-#[cfg(feature = "grit")]
-use marzano_core::pattern::patterns::Pattern;
+use grit_core_patterns::pattern::patterns::Pattern;
 
 pub fn parse_pattern(source: String) -> Result<GritPattern, ParseError> {
     Ok(GritPattern {
-        // FIXME: Do some real parsing here.
-        #[cfg(feature = "grit")]
-        pattern: Pattern::Undefined,
+        _pattern: Pattern::Undefined,
 
         source,
     })

--- a/crates/biome_grit_patterns/src/pattern.rs
+++ b/crates/biome_grit_patterns/src/pattern.rs
@@ -1,10 +1,8 @@
-#[cfg(feature = "grit")]
-use marzano_core::pattern::patterns::Pattern;
+use crate::grit_context::GritQueryContext;
+use grit_core_patterns::pattern::patterns::Pattern;
 
 pub struct GritPattern {
-    #[allow(dead_code)]
-    #[cfg(feature = "grit")]
-    pub(crate) pattern: Pattern,
+    pub(crate) _pattern: Pattern<GritQueryContext>,
 
     pub source: String,
 }

--- a/crates/biome_grit_patterns/src/pattern.rs
+++ b/crates/biome_grit_patterns/src/pattern.rs
@@ -1,5 +1,5 @@
 use crate::grit_context::GritQueryContext;
-use grit_core_patterns::pattern::patterns::Pattern;
+use grit_pattern_matcher::pattern::Pattern;
 
 pub struct GritPattern {
     pub(crate) _pattern: Pattern<GritQueryContext>,

--- a/crates/biome_grit_patterns/src/resolved_pattern.rs
+++ b/crates/biome_grit_patterns/src/resolved_pattern.rs
@@ -1,0 +1,275 @@
+use crate::grit_context::GritExecContext;
+use crate::{grit_binding::GritBinding, grit_context::GritQueryContext};
+use anyhow::Result;
+use grit_core_patterns::constant::Constant;
+use grit_core_patterns::effects::Effect;
+use grit_core_patterns::pattern::accessor::Accessor;
+use grit_core_patterns::pattern::dynamic_snippet::{DynamicPattern, DynamicSnippet};
+use grit_core_patterns::pattern::list_index::ListIndex;
+use grit_core_patterns::pattern::patterns::Pattern;
+use grit_core_patterns::pattern::resolved_pattern::{ResolvedPattern, ResolvedSnippet};
+use grit_core_patterns::pattern::state::{FilePtr, FileRegistry, State};
+use grit_util::{AnalysisLogs, CodeRange, Range};
+use im::Vector;
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct GritResolvedPattern;
+
+impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern {
+    fn from_binding(_binding: GritBinding) -> Self {
+        todo!()
+    }
+
+    fn from_constant(_constant: Constant) -> Self {
+        todo!()
+    }
+
+    fn from_file_pointer(_file: FilePtr) -> Self {
+        todo!()
+    }
+
+    fn from_files(_files: Self) -> Self {
+        todo!()
+    }
+
+    fn from_list_parts(_parts: impl Iterator<Item = Self>) -> Self {
+        todo!()
+    }
+
+    fn from_string(_string: String) -> Self {
+        todo!()
+    }
+
+    fn from_resolved_snippet(_snippet: ResolvedSnippet<'a, GritQueryContext>) -> Self {
+        todo!()
+    }
+
+    fn from_dynamic_snippet(
+        _snippet: &'a DynamicSnippet,
+        _state: &mut State<'a, GritQueryContext>,
+        _context: &'a GritExecContext,
+        _logs: &mut grit_util::AnalysisLogs,
+    ) -> anyhow::Result<Self> {
+        todo!()
+    }
+
+    fn from_dynamic_pattern(
+        _pattern: &'a DynamicPattern<GritQueryContext>,
+        _state: &mut State<'a, GritQueryContext>,
+        _context: &'a GritExecContext,
+        _logs: &mut grit_util::AnalysisLogs,
+    ) -> anyhow::Result<Self> {
+        todo!()
+    }
+
+    fn from_accessor(
+        _accessor: &'a Accessor<GritQueryContext>,
+        _state: &mut State<'a, GritQueryContext>,
+        _context: &'a GritExecContext,
+        _logs: &mut grit_util::AnalysisLogs,
+    ) -> anyhow::Result<Self> {
+        todo!()
+    }
+
+    fn from_list_index(
+        _index: &'a ListIndex<GritQueryContext>,
+        _state: &mut State<'a, GritQueryContext>,
+        _context: &'a GritExecContext,
+        _logs: &mut grit_util::AnalysisLogs,
+    ) -> anyhow::Result<Self> {
+        todo!()
+    }
+
+    fn from_pattern(
+        _pattern: &'a Pattern<GritQueryContext>,
+        _state: &mut State<'a, GritQueryContext>,
+        _context: &'a GritExecContext,
+        _logs: &mut grit_util::AnalysisLogs,
+    ) -> anyhow::Result<Self> {
+        todo!()
+    }
+
+    fn extend(
+        &mut self,
+        _with: Self,
+        _effects: &mut Vector<Effect<'a, GritQueryContext>>,
+        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+    ) -> anyhow::Result<()> {
+        todo!()
+    }
+
+    fn float(
+        &self,
+        _state: &FileRegistry<'a, GritQueryContext>,
+        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+    ) -> anyhow::Result<f64> {
+        todo!()
+    }
+
+    fn get_bindings(&self) -> Option<impl Iterator<Item = GritBinding>> {
+        None::<TodoBindingIterator>
+    }
+
+    fn get_file(
+        &self,
+    ) -> Option<&<GritQueryContext as grit_core_patterns::context::QueryContext>::File<'a>> {
+        todo!()
+    }
+
+    fn get_file_pointers(&self) -> Option<Vec<FilePtr>> {
+        todo!()
+    }
+
+    fn get_files(&self) -> Option<&Self> {
+        todo!()
+    }
+
+    fn get_last_binding(&self) -> Option<&GritBinding> {
+        todo!()
+    }
+
+    fn get_list_item_at(&self, _index: isize) -> Option<&Self> {
+        todo!()
+    }
+
+    fn get_list_item_at_mut(&mut self, _index: isize) -> Option<&mut Self> {
+        todo!()
+    }
+
+    fn get_list_items(&self) -> Option<impl Iterator<Item = &Self>> {
+        None::<TodoSelfRefIterator>
+    }
+
+    fn get_list_binding_items(&self) -> Option<impl Iterator<Item = Self> + Clone> {
+        None::<TodoSelfIterator>
+    }
+
+    fn get_map(&self) -> Option<&std::collections::BTreeMap<String, Self>> {
+        todo!()
+    }
+
+    fn get_map_mut(&mut self) -> Option<&mut std::collections::BTreeMap<String, Self>> {
+        todo!()
+    }
+
+    fn get_snippets(&self) -> Option<impl Iterator<Item = ResolvedSnippet<'a, GritQueryContext>>> {
+        None::<TodoSnippetIterator>
+    }
+
+    fn is_binding(&self) -> bool {
+        todo!()
+    }
+
+    fn is_list(&self) -> bool {
+        todo!()
+    }
+
+    fn is_truthy(
+        &self,
+        _state: &mut State<'a, GritQueryContext>,
+        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+    ) -> Result<bool> {
+        todo!()
+    }
+
+    fn linearized_text(
+        &self,
+        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+        _effects: &[Effect<'a, GritQueryContext>],
+        _files: &FileRegistry<'a, GritQueryContext>,
+        _memo: &mut HashMap<CodeRange, Option<String>>,
+        _should_pad_snippet: bool,
+        _logs: &mut AnalysisLogs,
+    ) -> Result<std::borrow::Cow<'a, str>> {
+        todo!()
+    }
+
+    fn matches_undefined(&self) -> bool {
+        todo!()
+    }
+
+    fn matches_false_or_undefined(&self) -> bool {
+        todo!()
+    }
+
+    fn normalize_insert(
+        &mut self,
+        _binding: &GritBinding,
+        _is_first: bool,
+        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    fn position(
+        &self,
+        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+    ) -> Option<Range> {
+        todo!()
+    }
+
+    fn push_binding(&mut self, _binding: GritBinding) -> Result<()> {
+        todo!()
+    }
+
+    fn set_list_item_at_mut(&mut self, _index: isize, _value: Self) -> anyhow::Result<bool> {
+        todo!()
+    }
+
+    fn text(
+        &self,
+        _state: &grit_core_patterns::pattern::state::FileRegistry<'a, GritQueryContext>,
+        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+    ) -> Result<Cow<'a, str>> {
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+struct TodoBindingIterator;
+
+impl Iterator for TodoBindingIterator {
+    type Item = GritBinding;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+struct TodoSelfIterator;
+
+impl Iterator for TodoSelfIterator {
+    type Item = GritResolvedPattern;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
+struct TodoSelfRefIterator<'a> {
+    _pattern: &'a GritResolvedPattern,
+}
+
+impl<'a> Iterator for TodoSelfRefIterator<'a> {
+    type Item = &'a GritResolvedPattern;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+struct TodoSnippetIterator<'a> {
+    _pattern: &'a GritResolvedPattern,
+}
+
+impl<'a> Iterator for TodoSnippetIterator<'a> {
+    type Item = ResolvedSnippet<'a, GritQueryContext>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}

--- a/crates/biome_grit_patterns/src/resolved_pattern.rs
+++ b/crates/biome_grit_patterns/src/resolved_pattern.rs
@@ -1,14 +1,12 @@
 use crate::grit_context::GritExecContext;
 use crate::{grit_binding::GritBinding, grit_context::GritQueryContext};
 use anyhow::Result;
-use grit_core_patterns::constant::Constant;
-use grit_core_patterns::effects::Effect;
-use grit_core_patterns::pattern::accessor::Accessor;
-use grit_core_patterns::pattern::dynamic_snippet::{DynamicPattern, DynamicSnippet};
-use grit_core_patterns::pattern::list_index::ListIndex;
-use grit_core_patterns::pattern::patterns::Pattern;
-use grit_core_patterns::pattern::resolved_pattern::{ResolvedPattern, ResolvedSnippet};
-use grit_core_patterns::pattern::state::{FilePtr, FileRegistry, State};
+use grit_pattern_matcher::constant::Constant;
+use grit_pattern_matcher::effects::Effect;
+use grit_pattern_matcher::pattern::{
+    Accessor, DynamicPattern, DynamicSnippet, FilePtr, FileRegistry, ListIndex, Pattern,
+    ResolvedPattern, ResolvedSnippet, State,
+};
 use grit_util::{AnalysisLogs, CodeRange, Range};
 use im::Vector;
 use std::borrow::Cow;
@@ -95,7 +93,7 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern {
         &mut self,
         _with: Self,
         _effects: &mut Vector<Effect<'a, GritQueryContext>>,
-        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+        _language: &<GritQueryContext as grit_pattern_matcher::context::QueryContext>::Language<'a>,
     ) -> anyhow::Result<()> {
         todo!()
     }
@@ -103,7 +101,7 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern {
     fn float(
         &self,
         _state: &FileRegistry<'a, GritQueryContext>,
-        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+        _language: &<GritQueryContext as grit_pattern_matcher::context::QueryContext>::Language<'a>,
     ) -> anyhow::Result<f64> {
         todo!()
     }
@@ -114,7 +112,7 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern {
 
     fn get_file(
         &self,
-    ) -> Option<&<GritQueryContext as grit_core_patterns::context::QueryContext>::File<'a>> {
+    ) -> Option<&<GritQueryContext as grit_pattern_matcher::context::QueryContext>::File<'a>> {
         todo!()
     }
 
@@ -169,14 +167,14 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern {
     fn is_truthy(
         &self,
         _state: &mut State<'a, GritQueryContext>,
-        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+        _language: &<GritQueryContext as grit_pattern_matcher::context::QueryContext>::Language<'a>,
     ) -> Result<bool> {
         todo!()
     }
 
     fn linearized_text(
         &self,
-        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+        _language: &<GritQueryContext as grit_pattern_matcher::context::QueryContext>::Language<'a>,
         _effects: &[Effect<'a, GritQueryContext>],
         _files: &FileRegistry<'a, GritQueryContext>,
         _memo: &mut HashMap<CodeRange, Option<String>>,
@@ -198,14 +196,14 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern {
         &mut self,
         _binding: &GritBinding,
         _is_first: bool,
-        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+        _language: &<GritQueryContext as grit_pattern_matcher::context::QueryContext>::Language<'a>,
     ) -> Result<()> {
         todo!()
     }
 
     fn position(
         &self,
-        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+        _language: &<GritQueryContext as grit_pattern_matcher::context::QueryContext>::Language<'a>,
     ) -> Option<Range> {
         todo!()
     }
@@ -220,8 +218,8 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern {
 
     fn text(
         &self,
-        _state: &grit_core_patterns::pattern::state::FileRegistry<'a, GritQueryContext>,
-        _language: &<GritQueryContext as grit_core_patterns::context::QueryContext>::Language<'a>,
+        _state: &grit_pattern_matcher::pattern::FileRegistry<'a, GritQueryContext>,
+        _language: &<GritQueryContext as grit_pattern_matcher::context::QueryContext>::Language<'a>,
     ) -> Result<Cow<'a, str>> {
         todo!()
     }

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -44,6 +44,7 @@ biome_rowan              = { workspace = true, features = ["serde"] }
 biome_text_edit          = { workspace = true }
 bpaf                     = { workspace = true }
 dashmap                  = { workspace = true }
+getrandom                = { workspace = true, features = ["js"] }
 ignore                   = { workspace = true }
 indexmap                 = { workspace = true, features = ["serde"] }
 lazy_static              = { workspace = true }


### PR DESCRIPTION
## Summary

This PR implements the basic infrastructure on top of which to implement the bindings for the Grit engine. All implementations are merely `todo!()` so far, so this doesn't really do anything, but it gives an idea where the work will happen :)

Lays the foundation for work on https://github.com/biomejs/biome/issues/2582.

Note the Grit crate dependencies still point to my own fork, since the PR hasn't been merged yet. I'll wait with merging this one until the upstream PR is merged first.

## Test Plan

Everything should stay green.
