### PR TITLE
refactor: foundations for LSP workspaces support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,6 +931,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "slotmap",
  "tests_macros",
  "tracing",
 ]
@@ -2900,6 +2901,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "serde",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,191 +1,191 @@
 [workspace]
 # Use the newer version of the cargo resolver
 # https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
-members = ["crates/*", "xtask/bench", "xtask/codegen", "xtask/coverage", "xtask/libs_bench", "xtask/contributors"]
+members  = ["crates/*", "xtask/bench", "xtask/codegen", "xtask/coverage", "xtask/libs_bench", "xtask/contributors"]
 resolver = "2"
 
 [workspace.lints.rust]
 absolute_paths_not_starting_with_crate = "warn"
-dead_code = "warn"
-trivial_numeric_casts = "warn"
-unused_import_braces = "warn"
-unused_lifetimes = "warn"
-unused_macro_rules = "warn"
+dead_code                              = "warn"
+trivial_numeric_casts                  = "warn"
+unused_import_braces                   = "warn"
+unused_lifetimes                       = "warn"
+unused_macro_rules                     = "warn"
 
 [workspace.lints.clippy]
-cargo_common_metadata = "allow"
+cargo_common_metadata   = "allow"
 multiple_crate_versions = "allow"
 
 # pedantic
-checked_conversions = "warn"
-cloned_instead_of_copied = "warn"
-copy_iterator = "warn"
-dbg_macro = "warn"
-doc_link_with_quotes = "warn"
-empty_enum = "warn"
-expl_impl_clone_on_copy = "warn"
-explicit_into_iter_loop = "warn"
-filter_map_next = "warn"
-flat_map_option = "warn"
-fn_params_excessive_bools = "warn"
+checked_conversions          = "warn"
+cloned_instead_of_copied     = "warn"
+copy_iterator                = "warn"
+dbg_macro                    = "warn"
+doc_link_with_quotes         = "warn"
+empty_enum                   = "warn"
+expl_impl_clone_on_copy      = "warn"
+explicit_into_iter_loop      = "warn"
+filter_map_next              = "warn"
+flat_map_option              = "warn"
+fn_params_excessive_bools    = "warn"
 from_iter_instead_of_collect = "warn"
-implicit_clone = "warn"
-implicit_hasher = "warn"
-index_refutable_slice = "warn"
-inefficient_to_string = "warn"
-invalid_upcast_comparisons = "warn"
-iter_not_returning_iterator = "warn"
-large_stack_arrays = "warn"
-large_types_passed_by_value = "warn"
-macro_use_imports = "warn"
-manual_ok_or = "warn"
-manual_string_new = "warn"
-map_flatten = "warn"
-map_unwrap_or = "warn"
+implicit_clone               = "warn"
+implicit_hasher              = "warn"
+index_refutable_slice        = "warn"
+inefficient_to_string        = "warn"
+invalid_upcast_comparisons   = "warn"
+iter_not_returning_iterator  = "warn"
+large_stack_arrays           = "warn"
+large_types_passed_by_value  = "warn"
+macro_use_imports            = "warn"
+manual_ok_or                 = "warn"
+manual_string_new            = "warn"
+map_flatten                  = "warn"
+map_unwrap_or                = "warn"
 mismatching_type_param_order = "warn"
-mut_mut = "warn"
-naive_bytecount = "warn"
-needless_bitwise_bool = "warn"
-needless_continue = "warn"
-needless_for_each = "warn"
+mut_mut                      = "warn"
+naive_bytecount              = "warn"
+needless_bitwise_bool        = "warn"
+needless_continue            = "warn"
+needless_for_each            = "warn"
 no_effect_underscore_binding = "warn"
-ref_binding_to_reference = "warn"
-ref_option_ref = "warn"
-stable_sort_primitive = "warn"
-unnecessary_box_returns = "warn"
-unnecessary_join = "warn"
-unnested_or_patterns = "warn"
-unreadable_literal = "warn"
-verbose_bit_mask = "warn"
-zero_sized_map_values = "warn"
+ref_binding_to_reference     = "warn"
+ref_option_ref               = "warn"
+stable_sort_primitive        = "warn"
+unnecessary_box_returns      = "warn"
+unnecessary_join             = "warn"
+unnested_or_patterns         = "warn"
+unreadable_literal           = "warn"
+verbose_bit_mask             = "warn"
+zero_sized_map_values        = "warn"
 
 # restriction
-empty_drop = "warn"
-float_cmp_const = "warn"
-get_unwrap = "warn"
-infinite_loop = "warn"
-lossy_float_literal = "warn"
-mem_forget = "warn"
-rc_buffer = "warn"
-rc_mutex = "warn"
+empty_drop                      = "warn"
+float_cmp_const                 = "warn"
+get_unwrap                      = "warn"
+infinite_loop                   = "warn"
+lossy_float_literal             = "warn"
+mem_forget                      = "warn"
+rc_buffer                       = "warn"
+rc_mutex                        = "warn"
 rest_pat_in_fully_bound_structs = "warn"
-verbose_file_reads = "warn"
+verbose_file_reads              = "warn"
 
 [workspace.package]
-authors = ["Biome Developers and Contributors"]
+authors    = ["Biome Developers and Contributors"]
 categories = ["development-tools", "web-programming"]
-edition = "2021"
-homepage = "https://biomejs.dev/"
-keywords = ["parser", "linter", "formatter"]
-license = "MIT OR Apache-2.0"
+edition    = "2021"
+homepage   = "https://biomejs.dev/"
+keywords   = ["parser", "linter", "formatter"]
+license    = "MIT OR Apache-2.0"
 repository = "https://github.com/biomejs/biome"
 
 [profile.release-with-debug]
-debug = true
+debug    = true
 inherits = "release"
 
 [workspace.dependencies]
 # publish
-biome_analyze = { version = "0.5.7", path = "./crates/biome_analyze" }
-biome_aria = { version = "0.5.7", path = "./crates/biome_aria" }
-biome_aria_metadata = { version = "0.5.7", path = "./crates/biome_aria_metadata" }
-biome_console = { version = "0.5.7", path = "./crates/biome_console" }
-biome_control_flow = { version = "0.5.7", path = "./crates/biome_control_flow" }
-biome_css_analyze = { version = "0.5.7", path = "./crates/biome_css_analyze" }
-biome_css_factory = { version = "0.5.7", path = "./crates/biome_css_factory" }
-biome_css_formatter = { version = "0.5.7", path = "./crates/biome_css_formatter" }
-biome_css_parser = { version = "0.5.7", path = "./crates/biome_css_parser" }
-biome_css_syntax = { version = "0.5.7", path = "./crates/biome_css_syntax" }
-biome_deserialize = { version = "0.5.7", path = "./crates/biome_deserialize" }
-biome_deserialize_macros = { version = "0.5.7", path = "./crates/biome_deserialize_macros" }
-biome_diagnostics = { version = "0.5.7", path = "./crates/biome_diagnostics" }
+biome_analyze                = { version = "0.5.7", path = "./crates/biome_analyze" }
+biome_aria                   = { version = "0.5.7", path = "./crates/biome_aria" }
+biome_aria_metadata          = { version = "0.5.7", path = "./crates/biome_aria_metadata" }
+biome_console                = { version = "0.5.7", path = "./crates/biome_console" }
+biome_control_flow           = { version = "0.5.7", path = "./crates/biome_control_flow" }
+biome_css_analyze            = { version = "0.5.7", path = "./crates/biome_css_analyze" }
+biome_css_factory            = { version = "0.5.7", path = "./crates/biome_css_factory" }
+biome_css_formatter          = { version = "0.5.7", path = "./crates/biome_css_formatter" }
+biome_css_parser             = { version = "0.5.7", path = "./crates/biome_css_parser" }
+biome_css_syntax             = { version = "0.5.7", path = "./crates/biome_css_syntax" }
+biome_deserialize            = { version = "0.5.7", path = "./crates/biome_deserialize" }
+biome_deserialize_macros     = { version = "0.5.7", path = "./crates/biome_deserialize_macros" }
+biome_diagnostics            = { version = "0.5.7", path = "./crates/biome_diagnostics" }
 biome_diagnostics_categories = { version = "0.5.7", path = "./crates/biome_diagnostics_categories" }
-biome_diagnostics_macros = { version = "0.5.7", path = "./crates/biome_diagnostics_macros" }
-biome_formatter = { version = "0.5.7", path = "./crates/biome_formatter" }
-biome_fs = { version = "0.5.7", path = "./crates/biome_fs" }
-biome_graphql_factory = { version = "0.1.0", path = "./crates/biome_graphql_factory" }
-biome_graphql_syntax = { version = "0.1.0", path = "./crates/biome_graphql_syntax" }
-biome_grit_factory = { version = "0.5.7", path = "./crates/biome_grit_factory" }
-biome_grit_parser = { version = "0.1.0", path = "./crates/biome_grit_parser" }
-biome_grit_patterns = { version = "0.0.1", path = "./crates/biome_grit_patterns" }
-biome_grit_syntax = { version = "0.5.7", path = "./crates/biome_grit_syntax" }
-biome_html_factory = { version = "0.5.7", path = "./crates/biome_html_factory" }
-biome_html_syntax = { version = "0.5.7", path = "./crates/biome_html_syntax" }
-biome_js_analyze = { version = "0.5.7", path = "./crates/biome_js_analyze" }
-biome_js_factory = { version = "0.5.7", path = "./crates/biome_js_factory" }
-biome_js_formatter = { version = "0.5.7", path = "./crates/biome_js_formatter" }
-biome_js_parser = { version = "0.5.7", path = "./crates/biome_js_parser" }
-biome_js_semantic = { version = "0.5.7", path = "./crates/biome_js_semantic" }
-biome_js_syntax = { version = "0.5.7", path = "./crates/biome_js_syntax" }
-biome_json_analyze = { version = "0.5.7", path = "./crates/biome_json_analyze" }
-biome_json_factory = { version = "0.5.7", path = "./crates/biome_json_factory" }
-biome_json_formatter = { version = "0.5.7", path = "./crates/biome_json_formatter" }
-biome_json_parser = { version = "0.5.7", path = "./crates/biome_json_parser" }
-biome_json_syntax = { version = "0.5.7", path = "./crates/biome_json_syntax" }
-biome_yaml_factory = { version = "0.0.1", path = "./crates/biome_yaml_factory" }
-biome_yaml_parser = { version = "0.0.1", path = "./crates/biome_yaml_parser" }
-biome_yaml_syntax = { version = "0.0.1", path = "./crates/biome_yaml_syntax" }
+biome_diagnostics_macros     = { version = "0.5.7", path = "./crates/biome_diagnostics_macros" }
+biome_formatter              = { version = "0.5.7", path = "./crates/biome_formatter" }
+biome_fs                     = { version = "0.5.7", path = "./crates/biome_fs" }
+biome_graphql_factory        = { version = "0.1.0", path = "./crates/biome_graphql_factory" }
+biome_graphql_syntax         = { version = "0.1.0", path = "./crates/biome_graphql_syntax" }
+biome_grit_factory           = { version = "0.5.7", path = "./crates/biome_grit_factory" }
+biome_grit_parser            = { version = "0.1.0", path = "./crates/biome_grit_parser" }
+biome_grit_patterns          = { version = "0.0.1", path = "./crates/biome_grit_patterns" }
+biome_grit_syntax            = { version = "0.5.7", path = "./crates/biome_grit_syntax" }
+biome_html_factory           = { version = "0.5.7", path = "./crates/biome_html_factory" }
+biome_html_syntax            = { version = "0.5.7", path = "./crates/biome_html_syntax" }
+biome_js_analyze             = { version = "0.5.7", path = "./crates/biome_js_analyze" }
+biome_js_factory             = { version = "0.5.7", path = "./crates/biome_js_factory" }
+biome_js_formatter           = { version = "0.5.7", path = "./crates/biome_js_formatter" }
+biome_js_parser              = { version = "0.5.7", path = "./crates/biome_js_parser" }
+biome_js_semantic            = { version = "0.5.7", path = "./crates/biome_js_semantic" }
+biome_js_syntax              = { version = "0.5.7", path = "./crates/biome_js_syntax" }
+biome_json_analyze           = { version = "0.5.7", path = "./crates/biome_json_analyze" }
+biome_json_factory           = { version = "0.5.7", path = "./crates/biome_json_factory" }
+biome_json_formatter         = { version = "0.5.7", path = "./crates/biome_json_formatter" }
+biome_json_parser            = { version = "0.5.7", path = "./crates/biome_json_parser" }
+biome_json_syntax            = { version = "0.5.7", path = "./crates/biome_json_syntax" }
+biome_yaml_factory           = { version = "0.0.1", path = "./crates/biome_yaml_factory" }
+biome_yaml_parser            = { version = "0.0.1", path = "./crates/biome_yaml_parser" }
+biome_yaml_syntax            = { version = "0.0.1", path = "./crates/biome_yaml_syntax" }
 
-biome_markup = { version = "0.5.7", path = "./crates/biome_markup" }
-biome_parser = { version = "0.5.7", path = "./crates/biome_parser" }
-biome_project = { version = "0.5.7", path = "./crates/biome_project" }
-biome_rowan = { version = "0.5.7", path = "./crates/biome_rowan" }
-biome_string_case = { version = "0.5.7", path = "./crates/biome_string_case" }
-biome_suppression = { version = "0.5.7", path = "./crates/biome_suppression" }
-biome_text_edit = { version = "0.5.7", path = "./crates/biome_text_edit" }
-biome_text_size = { version = "0.5.7", path = "./crates/biome_text_size" }
+biome_markup        = { version = "0.5.7", path = "./crates/biome_markup" }
+biome_parser        = { version = "0.5.7", path = "./crates/biome_parser" }
+biome_project       = { version = "0.5.7", path = "./crates/biome_project" }
+biome_rowan         = { version = "0.5.7", path = "./crates/biome_rowan" }
+biome_string_case   = { version = "0.5.7", path = "./crates/biome_string_case" }
+biome_suppression   = { version = "0.5.7", path = "./crates/biome_suppression" }
+biome_text_edit     = { version = "0.5.7", path = "./crates/biome_text_edit" }
+biome_text_size     = { version = "0.5.7", path = "./crates/biome_text_size" }
 biome_unicode_table = { version = "0.5.7", path = "./crates/biome_unicode_table" }
 
 # not publish
-biome_cli = { path = "./crates/biome_cli" }
-biome_configuration = { path = "./crates/biome_configuration" }
-biome_flags = { path = "./crates/biome_flags" }
+biome_cli            = { path = "./crates/biome_cli" }
+biome_configuration  = { path = "./crates/biome_configuration" }
+biome_flags          = { path = "./crates/biome_flags" }
 biome_formatter_test = { path = "./crates/biome_formatter_test" }
-biome_lsp = { path = "./crates/biome_lsp" }
-biome_migrate = { path = "./crates/biome_migrate" }
-biome_service = { path = "./crates/biome_service" }
-biome_test_utils = { path = "./crates/biome_test_utils" }
-biome_ungrammar = { path = "./crates/biome_ungrammar" }
-tests_macros = { path = "./crates/tests_macros" }
+biome_lsp            = { path = "./crates/biome_lsp" }
+biome_migrate        = { path = "./crates/biome_migrate" }
+biome_service        = { path = "./crates/biome_service" }
+biome_test_utils     = { path = "./crates/biome_test_utils" }
+biome_ungrammar      = { path = "./crates/biome_ungrammar" }
+tests_macros         = { path = "./crates/tests_macros" }
 
 # Crates needed in the workspace
-bitflags = "2.5.0"
-bpaf = { version = "0.9.9", features = ["derive"] }
-countme = "3.0.1"
-crossbeam = "0.8.4"
-dashmap = "5.4.0"
-ignore = "0.4.21"
-indexmap = "1.9.3"
-insta = "1.38.0"
-lazy_static = "1.4.0"
-oxc_resolver = "1.4.0"
-proc-macro2 = "1.0.81"
-quickcheck = "1.0.3"
-quickcheck_macros = "1.0.0"
-quote = "1.0.36"
-rayon = "1.8.1"
-regex = "1.10.4"
-rustc-hash = "1.1.0"
-schemars = { version = "0.8.12" }
-serde = { version = "1.0.198", features = ["derive"] }
-serde_json = "1.0.116"
-similar = "2.5.0"
-smallvec = { version = "1.10.0", features = ["union", "const_new"] }
-syn = "1.0.109"
-tokio = { version = "1.36.0" }
-tracing = { version = "0.1.37", default-features = false, features = ["std"] }
+bitflags           = "2.5.0"
+bpaf               = { version = "0.9.9", features = ["derive"] }
+countme            = "3.0.1"
+crossbeam          = "0.8.4"
+dashmap            = "5.4.0"
+ignore             = "0.4.21"
+indexmap           = "1.9.3"
+insta              = "1.38.0"
+lazy_static        = "1.4.0"
+oxc_resolver       = "1.4.0"
+proc-macro2        = "1.0.81"
+quickcheck         = "1.0.3"
+quickcheck_macros  = "1.0.0"
+quote              = "1.0.36"
+rayon              = "1.8.1"
+regex              = "1.10.4"
+rustc-hash         = "1.1.0"
+schemars           = { version = "0.8.12" }
+serde              = { version = "1.0.198", features = ["derive"] }
+serde_json         = "1.0.116"
+similar            = "2.5.0"
+slotmap            = "1.0.7"
+smallvec           = { version = "1.10.0", features = ["union", "const_new"] }
+syn                = "1.0.109"
+tokio              = { version = "1.36.0" }
+tracing            = { version = "0.1.37", default-features = false, features = ["std"] }
 tracing-subscriber = "0.3.18"
-unicode-bom = "2.0.3"
-slotmap = "1.0.7"
+unicode-bom        = "2.0.3"
 
 [profile.dev.package.biome_wasm]
-debug = true
+debug     = true
 opt-level = "s"
 
 [profile.test.package.biome_wasm]
-debug = true
+debug     = true
 opt-level = "s"
 
 [profile.release.package.biome_wasm]
-debug = false
+debug     = false
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,190 +1,191 @@
 [workspace]
 # Use the newer version of the cargo resolver
 # https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
-members  = ["crates/*", "xtask/bench", "xtask/codegen", "xtask/coverage", "xtask/libs_bench", "xtask/contributors"]
+members = ["crates/*", "xtask/bench", "xtask/codegen", "xtask/coverage", "xtask/libs_bench", "xtask/contributors"]
 resolver = "2"
 
 [workspace.lints.rust]
 absolute_paths_not_starting_with_crate = "warn"
-dead_code                              = "warn"
-trivial_numeric_casts                  = "warn"
-unused_import_braces                   = "warn"
-unused_lifetimes                       = "warn"
-unused_macro_rules                     = "warn"
+dead_code = "warn"
+trivial_numeric_casts = "warn"
+unused_import_braces = "warn"
+unused_lifetimes = "warn"
+unused_macro_rules = "warn"
 
 [workspace.lints.clippy]
-cargo_common_metadata   = "allow"
+cargo_common_metadata = "allow"
 multiple_crate_versions = "allow"
 
 # pedantic
-checked_conversions          = "warn"
-cloned_instead_of_copied     = "warn"
-copy_iterator                = "warn"
-dbg_macro                    = "warn"
-doc_link_with_quotes         = "warn"
-empty_enum                   = "warn"
-expl_impl_clone_on_copy      = "warn"
-explicit_into_iter_loop      = "warn"
-filter_map_next              = "warn"
-flat_map_option              = "warn"
-fn_params_excessive_bools    = "warn"
+checked_conversions = "warn"
+cloned_instead_of_copied = "warn"
+copy_iterator = "warn"
+dbg_macro = "warn"
+doc_link_with_quotes = "warn"
+empty_enum = "warn"
+expl_impl_clone_on_copy = "warn"
+explicit_into_iter_loop = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+fn_params_excessive_bools = "warn"
 from_iter_instead_of_collect = "warn"
-implicit_clone               = "warn"
-implicit_hasher              = "warn"
-index_refutable_slice        = "warn"
-inefficient_to_string        = "warn"
-invalid_upcast_comparisons   = "warn"
-iter_not_returning_iterator  = "warn"
-large_stack_arrays           = "warn"
-large_types_passed_by_value  = "warn"
-macro_use_imports            = "warn"
-manual_ok_or                 = "warn"
-manual_string_new            = "warn"
-map_flatten                  = "warn"
-map_unwrap_or                = "warn"
+implicit_clone = "warn"
+implicit_hasher = "warn"
+index_refutable_slice = "warn"
+inefficient_to_string = "warn"
+invalid_upcast_comparisons = "warn"
+iter_not_returning_iterator = "warn"
+large_stack_arrays = "warn"
+large_types_passed_by_value = "warn"
+macro_use_imports = "warn"
+manual_ok_or = "warn"
+manual_string_new = "warn"
+map_flatten = "warn"
+map_unwrap_or = "warn"
 mismatching_type_param_order = "warn"
-mut_mut                      = "warn"
-naive_bytecount              = "warn"
-needless_bitwise_bool        = "warn"
-needless_continue            = "warn"
-needless_for_each            = "warn"
+mut_mut = "warn"
+naive_bytecount = "warn"
+needless_bitwise_bool = "warn"
+needless_continue = "warn"
+needless_for_each = "warn"
 no_effect_underscore_binding = "warn"
-ref_binding_to_reference     = "warn"
-ref_option_ref               = "warn"
-stable_sort_primitive        = "warn"
-unnecessary_box_returns      = "warn"
-unnecessary_join             = "warn"
-unnested_or_patterns         = "warn"
-unreadable_literal           = "warn"
-verbose_bit_mask             = "warn"
-zero_sized_map_values        = "warn"
+ref_binding_to_reference = "warn"
+ref_option_ref = "warn"
+stable_sort_primitive = "warn"
+unnecessary_box_returns = "warn"
+unnecessary_join = "warn"
+unnested_or_patterns = "warn"
+unreadable_literal = "warn"
+verbose_bit_mask = "warn"
+zero_sized_map_values = "warn"
 
 # restriction
-empty_drop                      = "warn"
-float_cmp_const                 = "warn"
-get_unwrap                      = "warn"
-infinite_loop                   = "warn"
-lossy_float_literal             = "warn"
-mem_forget                      = "warn"
-rc_buffer                       = "warn"
-rc_mutex                        = "warn"
+empty_drop = "warn"
+float_cmp_const = "warn"
+get_unwrap = "warn"
+infinite_loop = "warn"
+lossy_float_literal = "warn"
+mem_forget = "warn"
+rc_buffer = "warn"
+rc_mutex = "warn"
 rest_pat_in_fully_bound_structs = "warn"
-verbose_file_reads              = "warn"
+verbose_file_reads = "warn"
 
 [workspace.package]
-authors    = ["Biome Developers and Contributors"]
+authors = ["Biome Developers and Contributors"]
 categories = ["development-tools", "web-programming"]
-edition    = "2021"
-homepage   = "https://biomejs.dev/"
-keywords   = ["parser", "linter", "formatter"]
-license    = "MIT OR Apache-2.0"
+edition = "2021"
+homepage = "https://biomejs.dev/"
+keywords = ["parser", "linter", "formatter"]
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/biomejs/biome"
 
 [profile.release-with-debug]
-debug    = true
+debug = true
 inherits = "release"
 
 [workspace.dependencies]
 # publish
-biome_analyze                = { version = "0.5.7", path = "./crates/biome_analyze" }
-biome_aria                   = { version = "0.5.7", path = "./crates/biome_aria" }
-biome_aria_metadata          = { version = "0.5.7", path = "./crates/biome_aria_metadata" }
-biome_console                = { version = "0.5.7", path = "./crates/biome_console" }
-biome_control_flow           = { version = "0.5.7", path = "./crates/biome_control_flow" }
-biome_css_analyze            = { version = "0.5.7", path = "./crates/biome_css_analyze" }
-biome_css_factory            = { version = "0.5.7", path = "./crates/biome_css_factory" }
-biome_css_formatter          = { version = "0.5.7", path = "./crates/biome_css_formatter" }
-biome_css_parser             = { version = "0.5.7", path = "./crates/biome_css_parser" }
-biome_css_syntax             = { version = "0.5.7", path = "./crates/biome_css_syntax" }
-biome_deserialize            = { version = "0.5.7", path = "./crates/biome_deserialize" }
-biome_deserialize_macros     = { version = "0.5.7", path = "./crates/biome_deserialize_macros" }
-biome_diagnostics            = { version = "0.5.7", path = "./crates/biome_diagnostics" }
+biome_analyze = { version = "0.5.7", path = "./crates/biome_analyze" }
+biome_aria = { version = "0.5.7", path = "./crates/biome_aria" }
+biome_aria_metadata = { version = "0.5.7", path = "./crates/biome_aria_metadata" }
+biome_console = { version = "0.5.7", path = "./crates/biome_console" }
+biome_control_flow = { version = "0.5.7", path = "./crates/biome_control_flow" }
+biome_css_analyze = { version = "0.5.7", path = "./crates/biome_css_analyze" }
+biome_css_factory = { version = "0.5.7", path = "./crates/biome_css_factory" }
+biome_css_formatter = { version = "0.5.7", path = "./crates/biome_css_formatter" }
+biome_css_parser = { version = "0.5.7", path = "./crates/biome_css_parser" }
+biome_css_syntax = { version = "0.5.7", path = "./crates/biome_css_syntax" }
+biome_deserialize = { version = "0.5.7", path = "./crates/biome_deserialize" }
+biome_deserialize_macros = { version = "0.5.7", path = "./crates/biome_deserialize_macros" }
+biome_diagnostics = { version = "0.5.7", path = "./crates/biome_diagnostics" }
 biome_diagnostics_categories = { version = "0.5.7", path = "./crates/biome_diagnostics_categories" }
-biome_diagnostics_macros     = { version = "0.5.7", path = "./crates/biome_diagnostics_macros" }
-biome_formatter              = { version = "0.5.7", path = "./crates/biome_formatter" }
-biome_fs                     = { version = "0.5.7", path = "./crates/biome_fs" }
-biome_graphql_factory        = { version = "0.1.0", path = "./crates/biome_graphql_factory" }
-biome_graphql_syntax         = { version = "0.1.0", path = "./crates/biome_graphql_syntax" }
-biome_grit_factory           = { version = "0.5.7", path = "./crates/biome_grit_factory" }
-biome_grit_parser            = { version = "0.1.0", path = "./crates/biome_grit_parser" }
-biome_grit_patterns          = { version = "0.0.1", path = "./crates/biome_grit_patterns" }
-biome_grit_syntax            = { version = "0.5.7", path = "./crates/biome_grit_syntax" }
-biome_html_factory           = { version = "0.5.7", path = "./crates/biome_html_factory" }
-biome_html_syntax            = { version = "0.5.7", path = "./crates/biome_html_syntax" }
-biome_js_analyze             = { version = "0.5.7", path = "./crates/biome_js_analyze" }
-biome_js_factory             = { version = "0.5.7", path = "./crates/biome_js_factory" }
-biome_js_formatter           = { version = "0.5.7", path = "./crates/biome_js_formatter" }
-biome_js_parser              = { version = "0.5.7", path = "./crates/biome_js_parser" }
-biome_js_semantic            = { version = "0.5.7", path = "./crates/biome_js_semantic" }
-biome_js_syntax              = { version = "0.5.7", path = "./crates/biome_js_syntax" }
-biome_json_analyze           = { version = "0.5.7", path = "./crates/biome_json_analyze" }
-biome_json_factory           = { version = "0.5.7", path = "./crates/biome_json_factory" }
-biome_json_formatter         = { version = "0.5.7", path = "./crates/biome_json_formatter" }
-biome_json_parser            = { version = "0.5.7", path = "./crates/biome_json_parser" }
-biome_json_syntax            = { version = "0.5.7", path = "./crates/biome_json_syntax" }
-biome_yaml_factory           = { version = "0.0.1", path = "./crates/biome_yaml_factory" }
-biome_yaml_parser            = { version = "0.0.1", path = "./crates/biome_yaml_parser" }
-biome_yaml_syntax            = { version = "0.0.1", path = "./crates/biome_yaml_syntax" }
+biome_diagnostics_macros = { version = "0.5.7", path = "./crates/biome_diagnostics_macros" }
+biome_formatter = { version = "0.5.7", path = "./crates/biome_formatter" }
+biome_fs = { version = "0.5.7", path = "./crates/biome_fs" }
+biome_graphql_factory = { version = "0.1.0", path = "./crates/biome_graphql_factory" }
+biome_graphql_syntax = { version = "0.1.0", path = "./crates/biome_graphql_syntax" }
+biome_grit_factory = { version = "0.5.7", path = "./crates/biome_grit_factory" }
+biome_grit_parser = { version = "0.1.0", path = "./crates/biome_grit_parser" }
+biome_grit_patterns = { version = "0.0.1", path = "./crates/biome_grit_patterns" }
+biome_grit_syntax = { version = "0.5.7", path = "./crates/biome_grit_syntax" }
+biome_html_factory = { version = "0.5.7", path = "./crates/biome_html_factory" }
+biome_html_syntax = { version = "0.5.7", path = "./crates/biome_html_syntax" }
+biome_js_analyze = { version = "0.5.7", path = "./crates/biome_js_analyze" }
+biome_js_factory = { version = "0.5.7", path = "./crates/biome_js_factory" }
+biome_js_formatter = { version = "0.5.7", path = "./crates/biome_js_formatter" }
+biome_js_parser = { version = "0.5.7", path = "./crates/biome_js_parser" }
+biome_js_semantic = { version = "0.5.7", path = "./crates/biome_js_semantic" }
+biome_js_syntax = { version = "0.5.7", path = "./crates/biome_js_syntax" }
+biome_json_analyze = { version = "0.5.7", path = "./crates/biome_json_analyze" }
+biome_json_factory = { version = "0.5.7", path = "./crates/biome_json_factory" }
+biome_json_formatter = { version = "0.5.7", path = "./crates/biome_json_formatter" }
+biome_json_parser = { version = "0.5.7", path = "./crates/biome_json_parser" }
+biome_json_syntax = { version = "0.5.7", path = "./crates/biome_json_syntax" }
+biome_yaml_factory = { version = "0.0.1", path = "./crates/biome_yaml_factory" }
+biome_yaml_parser = { version = "0.0.1", path = "./crates/biome_yaml_parser" }
+biome_yaml_syntax = { version = "0.0.1", path = "./crates/biome_yaml_syntax" }
 
-biome_markup        = { version = "0.5.7", path = "./crates/biome_markup" }
-biome_parser        = { version = "0.5.7", path = "./crates/biome_parser" }
-biome_project       = { version = "0.5.7", path = "./crates/biome_project" }
-biome_rowan         = { version = "0.5.7", path = "./crates/biome_rowan" }
-biome_string_case   = { version = "0.5.7", path = "./crates/biome_string_case" }
-biome_suppression   = { version = "0.5.7", path = "./crates/biome_suppression" }
-biome_text_edit     = { version = "0.5.7", path = "./crates/biome_text_edit" }
-biome_text_size     = { version = "0.5.7", path = "./crates/biome_text_size" }
+biome_markup = { version = "0.5.7", path = "./crates/biome_markup" }
+biome_parser = { version = "0.5.7", path = "./crates/biome_parser" }
+biome_project = { version = "0.5.7", path = "./crates/biome_project" }
+biome_rowan = { version = "0.5.7", path = "./crates/biome_rowan" }
+biome_string_case = { version = "0.5.7", path = "./crates/biome_string_case" }
+biome_suppression = { version = "0.5.7", path = "./crates/biome_suppression" }
+biome_text_edit = { version = "0.5.7", path = "./crates/biome_text_edit" }
+biome_text_size = { version = "0.5.7", path = "./crates/biome_text_size" }
 biome_unicode_table = { version = "0.5.7", path = "./crates/biome_unicode_table" }
 
 # not publish
-biome_cli            = { path = "./crates/biome_cli" }
-biome_configuration  = { path = "./crates/biome_configuration" }
-biome_flags          = { path = "./crates/biome_flags" }
+biome_cli = { path = "./crates/biome_cli" }
+biome_configuration = { path = "./crates/biome_configuration" }
+biome_flags = { path = "./crates/biome_flags" }
 biome_formatter_test = { path = "./crates/biome_formatter_test" }
-biome_lsp            = { path = "./crates/biome_lsp" }
-biome_migrate        = { path = "./crates/biome_migrate" }
-biome_service        = { path = "./crates/biome_service" }
-biome_test_utils     = { path = "./crates/biome_test_utils" }
-biome_ungrammar      = { path = "./crates/biome_ungrammar" }
-tests_macros         = { path = "./crates/tests_macros" }
+biome_lsp = { path = "./crates/biome_lsp" }
+biome_migrate = { path = "./crates/biome_migrate" }
+biome_service = { path = "./crates/biome_service" }
+biome_test_utils = { path = "./crates/biome_test_utils" }
+biome_ungrammar = { path = "./crates/biome_ungrammar" }
+tests_macros = { path = "./crates/tests_macros" }
 
 # Crates needed in the workspace
-bitflags           = "2.5.0"
-bpaf               = { version = "0.9.9", features = ["derive"] }
-countme            = "3.0.1"
-crossbeam          = "0.8.4"
-dashmap            = "5.4.0"
-ignore             = "0.4.21"
-indexmap           = "1.9.3"
-insta              = "1.38.0"
-lazy_static        = "1.4.0"
-oxc_resolver       = "1.4.0"
-proc-macro2        = "1.0.81"
-quickcheck         = "1.0.3"
-quickcheck_macros  = "1.0.0"
-quote              = "1.0.36"
-rayon              = "1.8.1"
-regex              = "1.10.4"
-rustc-hash         = "1.1.0"
-schemars           = { version = "0.8.12" }
-serde              = { version = "1.0.198", features = ["derive"] }
-serde_json         = "1.0.116"
-similar            = "2.5.0"
-smallvec           = { version = "1.10.0", features = ["union", "const_new"] }
-syn                = "1.0.109"
-tokio              = { version = "1.36.0" }
-tracing            = { version = "0.1.37", default-features = false, features = ["std"] }
+bitflags = "2.5.0"
+bpaf = { version = "0.9.9", features = ["derive"] }
+countme = "3.0.1"
+crossbeam = "0.8.4"
+dashmap = "5.4.0"
+ignore = "0.4.21"
+indexmap = "1.9.3"
+insta = "1.38.0"
+lazy_static = "1.4.0"
+oxc_resolver = "1.4.0"
+proc-macro2 = "1.0.81"
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
+quote = "1.0.36"
+rayon = "1.8.1"
+regex = "1.10.4"
+rustc-hash = "1.1.0"
+schemars = { version = "0.8.12" }
+serde = { version = "1.0.198", features = ["derive"] }
+serde_json = "1.0.116"
+similar = "2.5.0"
+smallvec = { version = "1.10.0", features = ["union", "const_new"] }
+syn = "1.0.109"
+tokio = { version = "1.36.0" }
+tracing = { version = "0.1.37", default-features = false, features = ["std"] }
 tracing-subscriber = "0.3.18"
-unicode-bom        = "2.0.3"
+unicode-bom = "2.0.3"
+slotmap = "1.0.7"
 
 [profile.dev.package.biome_wasm]
-debug     = true
+debug = true
 opt-level = "s"
 
 [profile.test.package.biome_wasm]
-debug     = true
+debug = true
 opt-level = "s"
 
 [profile.release.package.biome_wasm]
-debug     = false
+debug = false
 opt-level = 3

--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -11,6 +11,7 @@ use biome_configuration::{
 };
 use biome_deserialize::Merge;
 use biome_service::configuration::PartialConfigurationExt;
+use biome_service::workspace::RegisterWorkspaceFoldersParams;
 use biome_service::{
     configuration::{load_configuration, LoadedConfiguration},
     workspace::{FixFileMode, UpdateSettingsParams},
@@ -132,8 +133,16 @@ pub(crate) fn check(
     session
         .app
         .workspace
+        .register_workspace_folder(RegisterWorkspaceFoldersParams {
+            path: session.app.fs.working_directory(),
+            set_as_current_workspace: true,
+        })?;
+
+    session
+        .app
+        .workspace
         .update_settings(UpdateSettingsParams {
-            working_directory: session.app.fs.working_directory(),
+            workspace_directory: session.app.fs.working_directory(),
             configuration: fs_configuration,
             vcs_base_path,
             gitignore_matches,

--- a/crates/biome_cli/src/commands/ci.rs
+++ b/crates/biome_cli/src/commands/ci.rs
@@ -8,7 +8,7 @@ use biome_deserialize::Merge;
 use biome_service::configuration::{
     load_configuration, LoadedConfiguration, PartialConfigurationExt,
 };
-use biome_service::workspace::UpdateSettingsParams;
+use biome_service::workspace::{RegisterWorkspaceFoldersParams, UpdateSettingsParams};
 use std::ffi::OsString;
 
 pub(crate) struct CiCommandPayload {
@@ -109,9 +109,17 @@ pub(crate) fn ci(session: CliSession, payload: CiCommandPayload) -> Result<(), C
     session
         .app
         .workspace
+        .register_workspace_folder(RegisterWorkspaceFoldersParams {
+            path: session.app.fs.working_directory(),
+            set_as_current_workspace: true,
+        })?;
+
+    session
+        .app
+        .workspace
         .update_settings(UpdateSettingsParams {
             configuration: fs_configuration,
-            working_directory: session.app.fs.working_directory(),
+            workspace_directory: session.app.fs.working_directory(),
             vcs_base_path,
             gitignore_matches,
         })?;

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -17,7 +17,7 @@ use biome_diagnostics::PrintDiagnostic;
 use biome_service::configuration::{
     load_configuration, LoadedConfiguration, PartialConfigurationExt,
 };
-use biome_service::workspace::UpdateSettingsParams;
+use biome_service::workspace::{RegisterWorkspaceFoldersParams, UpdateSettingsParams};
 use std::ffi::OsString;
 
 pub(crate) struct FormatCommandPayload {
@@ -168,8 +168,16 @@ pub(crate) fn format(
     session
         .app
         .workspace
+        .register_workspace_folder(RegisterWorkspaceFoldersParams {
+            path: session.app.fs.working_directory(),
+            set_as_current_workspace: true,
+        })?;
+
+    session
+        .app
+        .workspace
         .update_settings(UpdateSettingsParams {
-            working_directory: session.app.fs.working_directory(),
+            workspace_directory: session.app.fs.working_directory(),
             configuration,
             vcs_base_path,
             gitignore_matches,

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -13,7 +13,7 @@ use biome_deserialize::Merge;
 use biome_service::configuration::{
     load_configuration, LoadedConfiguration, PartialConfigurationExt,
 };
-use biome_service::workspace::{FixFileMode, UpdateSettingsParams};
+use biome_service::workspace::{FixFileMode, RegisterWorkspaceFoldersParams, UpdateSettingsParams};
 use std::ffi::OsString;
 
 pub(crate) struct LintCommandPayload {
@@ -109,8 +109,16 @@ pub(crate) fn lint(session: CliSession, payload: LintCommandPayload) -> Result<(
     session
         .app
         .workspace
+        .register_workspace_folder(RegisterWorkspaceFoldersParams {
+            path: session.app.fs.working_directory(),
+            set_as_current_workspace: true,
+        })?;
+
+    session
+        .app
+        .workspace
         .update_settings(UpdateSettingsParams {
-            working_directory: session.app.fs.working_directory(),
+            workspace_directory: session.app.fs.working_directory(),
             configuration: fs_configuration,
             vcs_base_path,
             gitignore_matches,

--- a/crates/biome_cli/src/commands/search.rs
+++ b/crates/biome_cli/src/commands/search.rs
@@ -8,7 +8,9 @@ use biome_deserialize::Merge;
 use biome_service::configuration::{
     load_configuration, LoadedConfiguration, PartialConfigurationExt,
 };
-use biome_service::workspace::{ParsePatternParams, UpdateSettingsParams};
+use biome_service::workspace::{
+    ParsePatternParams, RegisterWorkspaceFoldersParams, UpdateSettingsParams,
+};
 use std::ffi::OsString;
 
 pub(crate) struct SearchCommandPayload {
@@ -59,8 +61,15 @@ pub(crate) fn search(
         configuration.retrieve_gitignore_matches(&session.app.fs, vcs_base_path.as_deref())?;
 
     let workspace = &session.app.workspace;
+    session
+        .app
+        .workspace
+        .register_workspace_folder(RegisterWorkspaceFoldersParams {
+            path: session.app.fs.working_directory(),
+            set_as_current_workspace: true,
+        })?;
     workspace.update_settings(UpdateSettingsParams {
-        working_directory: session.app.fs.working_directory(),
+        workspace_directory: session.app.fs.working_directory(),
         configuration,
         vcs_base_path,
         gitignore_matches,

--- a/crates/biome_css_formatter/tests/language.rs
+++ b/crates/biome_css_formatter/tests/language.rs
@@ -6,7 +6,7 @@ use biome_formatter::{FormatResult, Formatted, Printed};
 use biome_formatter_test::TestFormatLanguage;
 use biome_parser::AnyParse;
 use biome_rowan::{SyntaxNode, TextRange};
-use biome_service::settings::{ServiceLanguage, WorkspaceSettings};
+use biome_service::settings::{ServiceLanguage, Settings};
 
 #[derive(Default)]
 pub struct CssTestFormatLanguage {
@@ -26,7 +26,7 @@ impl TestFormatLanguage for CssTestFormatLanguage {
 
     fn to_language_settings<'a>(
         &self,
-        settings: &'a WorkspaceSettings,
+        settings: &'a Settings,
     ) -> &'a <Self::ServiceLanguage as ServiceLanguage>::FormatterSettings {
         &settings.languages.css.formatter
     }

--- a/crates/biome_formatter_test/src/lib.rs
+++ b/crates/biome_formatter_test/src/lib.rs
@@ -4,7 +4,7 @@ use biome_parser::AnyParse;
 use biome_rowan::{SyntaxNode, TextRange};
 use biome_service::file_handlers::DocumentFileSource;
 use biome_service::settings::ServiceLanguage;
-use biome_service::settings::WorkspaceSettings;
+use biome_service::settings::Settings;
 
 pub mod check_reformat;
 pub mod diff_report;
@@ -25,7 +25,7 @@ pub trait TestFormatLanguage {
 
     fn to_language_settings<'a>(
         &self,
-        settings: &'a WorkspaceSettings,
+        settings: &'a Settings,
     ) -> &'a <Self::ServiceLanguage as ServiceLanguage>::FormatterSettings;
 
     fn format_node(
@@ -45,7 +45,7 @@ pub trait TestFormatLanguage {
 
     fn to_options(
         &self,
-        settings: &WorkspaceSettings,
+        settings: &Settings,
         file_source: &DocumentFileSource,
     ) -> <Self::ServiceLanguage as ServiceLanguage>::FormatOptions {
         let language_settings = self.to_language_settings(settings);

--- a/crates/biome_formatter_test/src/spec.rs
+++ b/crates/biome_formatter_test/src/spec.rs
@@ -10,7 +10,7 @@ use biome_formatter::{FormatOptions, Printed};
 use biome_fs::BiomePath;
 use biome_parser::AnyParse;
 use biome_rowan::{TextRange, TextSize};
-use biome_service::settings::{ServiceLanguage, WorkspaceSettings};
+use biome_service::settings::{ServiceLanguage, Settings};
 use biome_service::workspace::{DocumentFileSource, FeaturesBuilder, SupportsFeatureParams};
 use biome_service::App;
 use std::ops::Range;
@@ -222,7 +222,7 @@ where
         if options_path.exists() {
             let mut options_path = BiomePath::new(&options_path);
 
-            let mut settings = WorkspaceSettings::default();
+            let mut settings = Settings::default();
             // SAFETY: we checked its existence already, we assume we have rights to read it
             let (test_options, diagnostics) = deserialize_from_str::<PartialConfiguration>(
                 options_path.get_buffer_from_file().as_str(),

--- a/crates/biome_fs/Cargo.toml
+++ b/crates/biome_fs/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
-authors.workspace = true
+authors.workspace    = true
 categories.workspace = true
-description = "A small wrapper around std::path::PathBuf contains additional information and convenient methods"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
-name = "biome_fs"
+description          = "A small wrapper around std::path::PathBuf contains additional information and convenient methods"
+edition.workspace    = true
+homepage.workspace   = true
+keywords.workspace   = true
+license.workspace    = true
+name                 = "biome_fs"
 repository.workspace = true
-version = "0.5.7"
+version              = "0.5.7"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 biome_diagnostics = { workspace = true }
-crossbeam = { workspace = true }
-directories = "5.0.1"
-indexmap = { workspace = true }
-oxc_resolver = { workspace = true }
-parking_lot = { version = "0.12.0", features = ["arc_lock"] }
-rayon = { workspace = true }
-rustc-hash = { workspace = true }
-schemars = { workspace = true, optional = true }
-serde = { workspace = true }
-tracing = { workspace = true }
+crossbeam         = { workspace = true }
+directories       = "5.0.1"
+indexmap          = { workspace = true }
+oxc_resolver      = { workspace = true }
+parking_lot       = { version = "0.12.0", features = ["arc_lock"] }
+rayon             = { workspace = true }
+rustc-hash        = { workspace = true }
+schemars          = { workspace = true, optional = true }
+serde             = { workspace = true }
+tracing           = { workspace = true }
 
 [features]
 serde = ["schemars", "biome_diagnostics/schema"]

--- a/crates/biome_fs/Cargo.toml
+++ b/crates/biome_fs/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
-authors.workspace    = true
+authors.workspace = true
 categories.workspace = true
-description          = "A small wrapper around std::path::PathBuf contains additional information and convenient methods"
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
-name                 = "biome_fs"
+description = "A small wrapper around std::path::PathBuf contains additional information and convenient methods"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+name = "biome_fs"
 repository.workspace = true
-version              = "0.5.7"
+version = "0.5.7"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 biome_diagnostics = { workspace = true }
-crossbeam         = { workspace = true }
-directories       = "5.0.1"
-indexmap          = { workspace = true }
-oxc_resolver      = { workspace = true }
-parking_lot       = { version = "0.12.0", features = ["arc_lock"] }
-rayon             = { workspace = true }
-rustc-hash        = { workspace = true }
-schemars          = { workspace = true, optional = true }
-serde             = { workspace = true }
-tracing           = { workspace = true }
+crossbeam = { workspace = true }
+directories = "5.0.1"
+indexmap = { workspace = true }
+oxc_resolver = { workspace = true }
+parking_lot = { version = "0.12.0", features = ["arc_lock"] }
+rayon = { workspace = true }
+rustc-hash = { workspace = true }
+schemars = { workspace = true, optional = true }
+serde = { workspace = true }
+tracing = { workspace = true }
 
 [features]
 serde = ["schemars", "biome_diagnostics/schema"]

--- a/crates/biome_fs/src/path.rs
+++ b/crates/biome_fs/src/path.rs
@@ -6,7 +6,7 @@
 use std::fs::{self, read_to_string};
 use std::{fs::File, io, io::Write, ops::Deref, path::PathBuf};
 
-#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Default)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)

--- a/crates/biome_js_formatter/tests/language.rs
+++ b/crates/biome_js_formatter/tests/language.rs
@@ -6,7 +6,7 @@ use biome_js_parser::{parse, JsParserOptions};
 use biome_js_syntax::{JsFileSource, JsLanguage};
 use biome_parser::AnyParse;
 use biome_rowan::SyntaxNode;
-use biome_service::settings::{ServiceLanguage, WorkspaceSettings};
+use biome_service::settings::{ServiceLanguage, Settings};
 use biome_text_size::TextRange;
 
 pub struct JsTestFormatLanguage {
@@ -36,7 +36,7 @@ impl TestFormatLanguage for JsTestFormatLanguage {
 
     fn to_language_settings<'a>(
         &self,
-        settings: &'a WorkspaceSettings,
+        settings: &'a Settings,
     ) -> &'a <Self::ServiceLanguage as ServiceLanguage>::FormatterSettings {
         &settings.languages.javascript.formatter
     }

--- a/crates/biome_json_formatter/tests/language.rs
+++ b/crates/biome_json_formatter/tests/language.rs
@@ -6,7 +6,7 @@ use biome_json_parser::{parse_json, JsonParserOptions};
 use biome_json_syntax::{JsonFileSource, JsonLanguage};
 use biome_parser::AnyParse;
 use biome_rowan::{SyntaxNode, TextRange};
-use biome_service::settings::{ServiceLanguage, WorkspaceSettings};
+use biome_service::settings::{ServiceLanguage, Settings};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default)]
@@ -27,7 +27,7 @@ impl TestFormatLanguage for JsonTestFormatLanguage {
 
     fn to_language_settings<'a>(
         &self,
-        settings: &'a WorkspaceSettings,
+        settings: &'a Settings,
     ) -> &'a <Self::ServiceLanguage as ServiceLanguage>::FormatterSettings {
         &settings.languages.json.formatter
     }

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -248,6 +248,14 @@ impl LanguageServer for LSPServer {
         self.is_initialized.store(true, Ordering::Relaxed);
 
         let server_capabilities = server_capabilities(&params.capabilities);
+        if params.root_path.is_some() {
+            warn!("The Biome Server was initialized with the deprecated `root_path` parameter: this is not supported, use `root_uri` instead");
+        }
+
+        if let Some(_folders) = &params.workspace_folders {
+            warn!("The Biome Server was initialized with the `workspace_folders` parameter: this is unsupported at the moment, use `root_uri` instead");
+        }
+
         self.session.initialize(
             params.capabilities,
             params.client_info.map(|client_info| ClientInformation {
@@ -255,15 +263,8 @@ impl LanguageServer for LSPServer {
                 version: client_info.version,
             }),
             params.root_uri,
+            params.workspace_folders,
         );
-
-        if params.root_path.is_some() {
-            warn!("The Biome Server was initialized with the deprecated `root_path` parameter: this is not supported, use `root_uri` instead");
-        }
-
-        if params.workspace_folders.is_some() {
-            warn!("The Biome Server was initialized with the `workspace_folders` parameter: this is unsupported at the moment, use `root_uri` instead");
-        }
 
         //
         let init = InitializeResult {
@@ -574,6 +575,7 @@ impl ServerFactory {
         workspace_method!(builder, file_features);
         workspace_method!(builder, is_path_ignored);
         workspace_method!(builder, update_settings);
+        workspace_method!(builder, register_workspace_folder);
         workspace_method!(builder, open_file);
         workspace_method!(builder, open_project);
         workspace_method!(builder, update_current_project);

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -15,7 +15,7 @@ use biome_service::configuration::{
 use biome_service::file_handlers::{AstroFileHandler, SvelteFileHandler, VueFileHandler};
 use biome_service::workspace::{
     FeaturesBuilder, GetFileContentParams, OpenProjectParams, PullDiagnosticsParams,
-    SupportsFeatureParams, UpdateProjectParams,
+    RegisterWorkspaceFoldersParams, SupportsFeatureParams, UpdateProjectParams,
 };
 use biome_service::workspace::{RageEntry, RageParams, RageResult, UpdateSettingsParams};
 use biome_service::Workspace;
@@ -32,9 +32,9 @@ use std::sync::RwLock;
 use tokio::sync::Notify;
 use tokio::sync::OnceCell;
 use tower_lsp::lsp_types;
-use tower_lsp::lsp_types::Unregistration;
 use tower_lsp::lsp_types::Url;
 use tower_lsp::lsp_types::{MessageType, Registration};
+use tower_lsp::lsp_types::{Unregistration, WorkspaceFolder};
 use tracing::{debug, error, info};
 
 pub(crate) struct ClientInformation {
@@ -83,6 +83,8 @@ struct InitializeParams {
     client_capabilities: lsp_types::ClientCapabilities,
     client_information: Option<ClientInformation>,
     root_uri: Option<Url>,
+    #[allow(unused)]
+    workspace_folders: Option<Vec<WorkspaceFolder>>,
 }
 
 #[repr(u8)]
@@ -171,11 +173,13 @@ impl Session {
         client_capabilities: lsp_types::ClientCapabilities,
         client_information: Option<ClientInformation>,
         root_uri: Option<Url>,
+        workspace_folders: Option<Vec<WorkspaceFolder>>,
     ) {
         let result = self.initialize_params.set(InitializeParams {
             client_capabilities,
             client_information,
             root_uri,
+            workspace_folders,
         });
 
         if let Err(err) = result {
@@ -236,7 +240,7 @@ impl Session {
 
     /// Get a [`Document`] matching the provided [`lsp_types::Url`]
     ///
-    /// If document does not exist, result is [SessionError::DocumentNotFound]
+    /// If document does not exist, result is [WorkspaceError::NotFound]
     pub(crate) fn document(&self, url: &lsp_types::Url) -> Result<Document, WorkspaceError> {
         self.documents
             .read()
@@ -447,8 +451,15 @@ impl Session {
 
                     match result {
                         Ok((vcs_base_path, gitignore_matches)) => {
+                            // We don't need the key for now, but will soon
+                            let _ = self.workspace.register_workspace_folder(
+                                RegisterWorkspaceFoldersParams {
+                                    path: fs.working_directory(),
+                                    set_as_current_workspace: true,
+                                },
+                            );
                             let result = self.workspace.update_settings(UpdateSettingsParams {
-                                working_directory: fs.working_directory(),
+                                workspace_directory: fs.working_directory(),
                                 configuration,
                                 vcs_base_path,
                                 gitignore_matches,

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -1,74 +1,74 @@
 [package]
-authors.workspace = true
+authors.workspace    = true
 categories.workspace = true
-description = "Biome's core functionality"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
-name = "biome_service"
-publish = false
+description          = "Biome's core functionality"
+edition.workspace    = true
+homepage.workspace   = true
+keywords.workspace   = true
+license.workspace    = true
+name                 = "biome_service"
+publish              = false
 repository.workspace = true
-version = "0.0.0"
+version              = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-biome_analyze = { workspace = true, features = ["serde"] }
-biome_configuration = { workspace = true, features = ["schema"] }
-biome_console = { workspace = true }
-biome_css_analyze = { workspace = true }
-biome_css_formatter = { workspace = true }
-biome_css_parser = { workspace = true }
-biome_css_syntax = { workspace = true }
-biome_deserialize = { workspace = true }
+biome_analyze            = { workspace = true, features = ["serde"] }
+biome_configuration      = { workspace = true, features = ["schema"] }
+biome_console            = { workspace = true }
+biome_css_analyze        = { workspace = true }
+biome_css_formatter      = { workspace = true }
+biome_css_parser         = { workspace = true }
+biome_css_syntax         = { workspace = true }
+biome_deserialize        = { workspace = true }
 biome_deserialize_macros = { workspace = true }
-biome_diagnostics = { workspace = true }
-biome_flags = { workspace = true }
-biome_formatter = { workspace = true, features = ["serde"] }
-biome_fs = { workspace = true, features = ["serde"] }
-biome_grit_patterns = { workspace = true }
-biome_js_analyze = { workspace = true }
-biome_js_factory = { workspace = true, optional = true }
-biome_js_formatter = { workspace = true, features = ["serde"] }
-biome_js_parser = { workspace = true }
-biome_js_semantic = { workspace = true }
-biome_js_syntax = { workspace = true, features = ["schema"] }
-biome_json_analyze = { workspace = true }
-biome_json_formatter = { workspace = true, features = ["serde"] }
-biome_json_parser = { workspace = true }
-biome_json_syntax = { workspace = true }
-biome_parser = { workspace = true }
-biome_project = { workspace = true }
-biome_rowan = { workspace = true, features = ["serde"] }
-biome_text_edit = { workspace = true }
-bpaf = { workspace = true }
-dashmap = { workspace = true }
-ignore = { workspace = true }
-indexmap = { workspace = true, features = ["serde"] }
-lazy_static = { workspace = true }
-oxc_resolver = { workspace = true }
-regex = { workspace = true }
-rustc-hash = { workspace = true }
-schemars = { workspace = true, features = ["indexmap1"], optional = true }
-serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, features = ["raw_value"] }
-tracing = { workspace = true, features = ["attributes", "log"] }
-slotmap = { workspace = true, features = ["serde"] }
+biome_diagnostics        = { workspace = true }
+biome_flags              = { workspace = true }
+biome_formatter          = { workspace = true, features = ["serde"] }
+biome_fs                 = { workspace = true, features = ["serde"] }
+biome_grit_patterns      = { workspace = true }
+biome_js_analyze         = { workspace = true }
+biome_js_factory         = { workspace = true, optional = true }
+biome_js_formatter       = { workspace = true, features = ["serde"] }
+biome_js_parser          = { workspace = true }
+biome_js_semantic        = { workspace = true }
+biome_js_syntax          = { workspace = true, features = ["schema"] }
+biome_json_analyze       = { workspace = true }
+biome_json_formatter     = { workspace = true, features = ["serde"] }
+biome_json_parser        = { workspace = true }
+biome_json_syntax        = { workspace = true }
+biome_parser             = { workspace = true }
+biome_project            = { workspace = true }
+biome_rowan              = { workspace = true, features = ["serde"] }
+biome_text_edit          = { workspace = true }
+bpaf                     = { workspace = true }
+dashmap                  = { workspace = true }
+ignore                   = { workspace = true }
+indexmap                 = { workspace = true, features = ["serde"] }
+lazy_static              = { workspace = true }
+oxc_resolver             = { workspace = true }
+regex                    = { workspace = true }
+rustc-hash               = { workspace = true }
+schemars                 = { workspace = true, features = ["indexmap1"], optional = true }
+serde                    = { workspace = true, features = ["derive"] }
+serde_json               = { workspace = true, features = ["raw_value"] }
+slotmap                  = { workspace = true, features = ["serde"] }
+tracing                  = { workspace = true, features = ["attributes", "log"] }
 [features]
 format_css = ["biome_css_formatter/format_css"]
 schema = [
-	"dep:schemars",
-	"biome_js_analyze/schema",
-	"biome_formatter/serde",
-	"biome_js_factory",
-	"biome_text_edit/schemars",
-	"biome_json_syntax/schema",
-	"biome_css_syntax/schema",
+  "dep:schemars",
+  "biome_js_analyze/schema",
+  "biome_formatter/serde",
+  "biome_js_factory",
+  "biome_text_edit/schemars",
+  "biome_json_syntax/schema",
+  "biome_css_syntax/schema",
 ]
 
 [dev-dependencies]
-insta = { workspace = true }
+insta        = { workspace = true }
 tests_macros = { workspace = true }
 
 [lints]

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -1,74 +1,74 @@
 [package]
-authors.workspace    = true
+authors.workspace = true
 categories.workspace = true
-description          = "Biome's core functionality"
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
-name                 = "biome_service"
-publish              = false
+description = "Biome's core functionality"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+name = "biome_service"
+publish = false
 repository.workspace = true
-version              = "0.0.0"
+version = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-biome_analyze            = { workspace = true, features = ["serde"] }
-biome_configuration      = { workspace = true, features = ["schema"] }
-biome_console            = { workspace = true }
-biome_css_analyze        = { workspace = true }
-biome_css_formatter      = { workspace = true }
-biome_css_parser         = { workspace = true }
-biome_css_syntax         = { workspace = true }
-biome_deserialize        = { workspace = true }
+biome_analyze = { workspace = true, features = ["serde"] }
+biome_configuration = { workspace = true, features = ["schema"] }
+biome_console = { workspace = true }
+biome_css_analyze = { workspace = true }
+biome_css_formatter = { workspace = true }
+biome_css_parser = { workspace = true }
+biome_css_syntax = { workspace = true }
+biome_deserialize = { workspace = true }
 biome_deserialize_macros = { workspace = true }
-biome_diagnostics        = { workspace = true }
-biome_flags              = { workspace = true }
-biome_formatter          = { workspace = true, features = ["serde"] }
-biome_fs                 = { workspace = true, features = ["serde"] }
-biome_grit_patterns      = { workspace = true }
-biome_js_analyze         = { workspace = true }
-biome_js_factory         = { workspace = true, optional = true }
-biome_js_formatter       = { workspace = true, features = ["serde"] }
-biome_js_parser          = { workspace = true }
-biome_js_semantic        = { workspace = true }
-biome_js_syntax          = { workspace = true, features = ["schema"] }
-biome_json_analyze       = { workspace = true }
-biome_json_formatter     = { workspace = true, features = ["serde"] }
-biome_json_parser        = { workspace = true }
-biome_json_syntax        = { workspace = true }
-biome_parser             = { workspace = true }
-biome_project            = { workspace = true }
-biome_rowan              = { workspace = true, features = ["serde"] }
-biome_text_edit          = { workspace = true }
-bpaf                     = { workspace = true }
-dashmap                  = { workspace = true }
-ignore                   = { workspace = true }
-indexmap                 = { workspace = true, features = ["serde"] }
-lazy_static              = { workspace = true }
-oxc_resolver             = { workspace = true }
-regex                    = { workspace = true }
-rustc-hash               = { workspace = true }
-schemars                 = { workspace = true, features = ["indexmap1"], optional = true }
-serde                    = { workspace = true, features = ["derive"] }
-serde_json               = { workspace = true, features = ["raw_value"] }
-tracing                  = { workspace = true, features = ["attributes", "log"] }
-
+biome_diagnostics = { workspace = true }
+biome_flags = { workspace = true }
+biome_formatter = { workspace = true, features = ["serde"] }
+biome_fs = { workspace = true, features = ["serde"] }
+biome_grit_patterns = { workspace = true }
+biome_js_analyze = { workspace = true }
+biome_js_factory = { workspace = true, optional = true }
+biome_js_formatter = { workspace = true, features = ["serde"] }
+biome_js_parser = { workspace = true }
+biome_js_semantic = { workspace = true }
+biome_js_syntax = { workspace = true, features = ["schema"] }
+biome_json_analyze = { workspace = true }
+biome_json_formatter = { workspace = true, features = ["serde"] }
+biome_json_parser = { workspace = true }
+biome_json_syntax = { workspace = true }
+biome_parser = { workspace = true }
+biome_project = { workspace = true }
+biome_rowan = { workspace = true, features = ["serde"] }
+biome_text_edit = { workspace = true }
+bpaf = { workspace = true }
+dashmap = { workspace = true }
+ignore = { workspace = true }
+indexmap = { workspace = true, features = ["serde"] }
+lazy_static = { workspace = true }
+oxc_resolver = { workspace = true }
+regex = { workspace = true }
+rustc-hash = { workspace = true }
+schemars = { workspace = true, features = ["indexmap1"], optional = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
+tracing = { workspace = true, features = ["attributes", "log"] }
+slotmap = { workspace = true, features = ["serde"] }
 [features]
 format_css = ["biome_css_formatter/format_css"]
 schema = [
-  "dep:schemars",
-  "biome_js_analyze/schema",
-  "biome_formatter/serde",
-  "biome_js_factory",
-  "biome_text_edit/schemars",
-  "biome_json_syntax/schema",
-  "biome_css_syntax/schema",
+	"dep:schemars",
+	"biome_js_analyze/schema",
+	"biome_formatter/serde",
+	"biome_js_factory",
+	"biome_text_edit/schemars",
+	"biome_json_syntax/schema",
+	"biome_css_syntax/schema",
 ]
 
 [dev-dependencies]
-insta        = { workspace = true }
+insta = { workspace = true }
 tests_macros = { workspace = true }
 
 [lints]

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -1,4 +1,4 @@
-use crate::settings::WorkspaceSettings;
+use crate::settings::Settings;
 use crate::{DynRef, WorkspaceError, VERSION};
 use biome_analyze::AnalyzerRules;
 use biome_configuration::diagnostics::CantLoadExtendFile;
@@ -316,8 +316,8 @@ pub fn create_config(
     Ok(())
 }
 
-/// Returns the rules applied to a specific [Path], given the [WorkspaceSettings]
-pub fn to_analyzer_rules(settings: &WorkspaceSettings, path: &Path) -> AnalyzerRules {
+/// Returns the rules applied to a specific [Path], given the [Settings]
+pub fn to_analyzer_rules(settings: &Settings, path: &Path) -> AnalyzerRules {
     let linter_settings = &settings.linter;
     let overrides = &settings.override_settings;
     let mut analyzer_rules = AnalyzerRules::default();

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -36,19 +36,10 @@ use std::{
     sync::{RwLock, RwLockReadGuard},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PathToSettings {
     path: BiomePath,
     settings: Settings,
-}
-
-impl Default for PathToSettings {
-    fn default() -> Self {
-        Self {
-            path: BiomePath::default(),
-            settings: Settings::default(),
-        }
-    }
 }
 
 #[derive(Debug, Default)]
@@ -60,7 +51,7 @@ pub struct WorkspaceSettings {
 impl WorkspaceSettings {
     pub fn current_settings(&self) -> &Settings {
         debug_assert!(
-            self.data.paths.len() > 0,
+            !self.data.paths.is_empty(),
             "You must have at least one workspace."
         );
         let data = self.data.paths.get(self.current_workspace).unwrap();
@@ -73,7 +64,7 @@ impl WorkspaceSettings {
 
     pub fn current_settings_mut(&mut self) -> &mut Settings {
         debug_assert!(
-            self.data.paths.len() > 0,
+            !self.data.paths.is_empty(),
             "You must have at least one workspace."
         );
         &mut self.data.get_mut(self.current_workspace).unwrap().settings
@@ -90,11 +81,11 @@ impl WorkspaceSettings {
     pub fn current_workspace_path(&self, path: &BiomePath) -> (WorkspaceKey, &BiomePath) {
         debug_assert!(path.is_absolute(), "Workspaces paths must be absolutes.");
         debug_assert!(
-            self.data.paths.len() > 0,
+            !self.data.paths.is_empty(),
             "You must have at least one workspace."
         );
         for (key, path_to_settings) in &self.data.paths {
-            if let Ok(_) = path.strip_prefix(path_to_settings.path.as_path()) {
+            if path.strip_prefix(path_to_settings.path.as_path()).is_ok() {
                 return (key, &path_to_settings.path);
             }
         }
@@ -104,11 +95,11 @@ impl WorkspaceSettings {
     pub fn get_settings_by_path(&self, path: &BiomePath) -> &Settings {
         debug_assert!(path.is_absolute(), "Workspaces paths must be absolutes.");
         debug_assert!(
-            self.data.paths.len() > 0,
+            !self.data.paths.is_empty(),
             "You must have at least one workspace."
         );
         for (_, path_to_settings) in &self.data.paths {
-            if let Ok(_) = path.strip_prefix(path_to_settings.path.as_path()) {
+            if path.strip_prefix(path_to_settings.path.as_path()).is_ok() {
                 return &path_to_settings.settings;
             }
         }
@@ -118,11 +109,11 @@ impl WorkspaceSettings {
     pub fn get_settings_by_path_mut(&mut self, path: &Path) -> &mut Settings {
         debug_assert!(path.is_absolute(), "Workspaces paths must be absolutes.");
         debug_assert!(
-            self.data.paths.len() > 0,
+            !self.data.paths.is_empty(),
             "You must have at least one workspace."
         );
         for (_, path_to_settings) in &mut self.data.paths {
-            if let Ok(_) = path.strip_prefix(path_to_settings.path.as_path()) {
+            if path.strip_prefix(path_to_settings.path.as_path()).is_ok() {
                 return &mut path_to_settings.settings;
             }
         }
@@ -601,7 +592,7 @@ impl<'a> SettingsHandle<'a> {
 
 impl<'a> AsRef<Settings> for SettingsHandle<'a> {
     fn as_ref(&self) -> &Settings {
-        &self.inner.current_settings()
+        self.inner.current_settings()
     }
 }
 

--- a/crates/biome_service/src/workspace/client.rs
+++ b/crates/biome_service/src/workspace/client.rs
@@ -1,7 +1,7 @@
 use crate::workspace::{
     FileFeaturesResult, GetFileContentParams, IsPathIgnoredParams, OpenProjectParams,
-    OrganizeImportsParams, OrganizeImportsResult, RageParams, RageResult, ServerInfo,
-    UpdateProjectParams,
+    OrganizeImportsParams, OrganizeImportsResult, RageParams, RageResult,
+    RegisterWorkspaceFoldersParams, ServerInfo, UpdateProjectParams, WorkspaceKey,
 };
 use crate::{TransportError, Workspace, WorkspaceError};
 use biome_formatter::Printed;
@@ -110,7 +110,6 @@ where
     fn is_path_ignored(&self, params: IsPathIgnoredParams) -> Result<bool, WorkspaceError> {
         self.request("biome/is_path_ignored", params)
     }
-
     fn update_settings(&self, params: UpdateSettingsParams) -> Result<(), WorkspaceError> {
         self.request("biome/update_settings", params)
     }
@@ -121,6 +120,13 @@ where
 
     fn open_project(&self, params: OpenProjectParams) -> Result<(), WorkspaceError> {
         self.request("biome/open_project", params)
+    }
+
+    fn register_workspace_folder(
+        &self,
+        params: RegisterWorkspaceFoldersParams,
+    ) -> Result<WorkspaceKey, WorkspaceError> {
+        self.request("biome/register_workspace_folder", params)
     }
 
     fn update_current_project(&self, params: UpdateProjectParams) -> Result<(), WorkspaceError> {

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -3,21 +3,19 @@ use super::{
     FormatOnTypeParams, FormatRangeParams, GetControlFlowGraphParams, GetFormatterIRParams,
     GetSyntaxTreeParams, GetSyntaxTreeResult, OpenFileParams, OpenProjectParams,
     ParsePatternParams, ParsePatternResult, PatternId, PullActionsParams, PullActionsResult,
-    PullDiagnosticsParams, PullDiagnosticsResult, RenameResult, SearchPatternParams, SearchResults,
-    SupportsFeatureParams, UpdateProjectParams, UpdateSettingsParams,
+    PullDiagnosticsParams, PullDiagnosticsResult, RegisterWorkspaceFoldersParams, RenameResult,
+    SearchPatternParams, SearchResults, SupportsFeatureParams, UpdateProjectParams,
+    UpdateSettingsParams, WorkspaceKey,
 };
 use crate::file_handlers::{
     Capabilities, CodeActionsParams, DocumentFileSource, FixAllParams, LintParams, ParseResult,
 };
+use crate::settings::{SettingsHandleMut, WorkspaceSettings, WorkspacesHandleMut};
 use crate::workspace::{
     FileFeaturesResult, GetFileContentParams, IsPathIgnoredParams, OrganizeImportsParams,
     OrganizeImportsResult, RageEntry, RageParams, RageResult, ServerInfo,
 };
-use crate::{
-    file_handlers::Features,
-    settings::{SettingsHandle, WorkspaceSettings},
-    Workspace, WorkspaceError,
-};
+use crate::{file_handlers::Features, settings::SettingsHandle, Workspace, WorkspaceError};
 use biome_analyze::AnalysisFilter;
 use biome_diagnostics::{
     serde::Diagnostic as SerdeDiagnostic, Diagnostic, DiagnosticExt, Severity,
@@ -98,8 +96,18 @@ impl WorkspaceServer {
         }
     }
 
+    /// Provides a reference to the current settings
     fn settings(&self) -> SettingsHandle {
         SettingsHandle::new(&self.settings)
+    }
+
+    /// Provides a mutable reference to the current settings
+    fn settings_mut(&self) -> SettingsHandleMut {
+        SettingsHandleMut::new(&self.settings)
+    }
+
+    fn workspaces_mut(&self) -> WorkspacesHandleMut {
+        WorkspacesHandleMut::new(&self.settings)
     }
 
     /// Get the supported capabilities for a given file path
@@ -338,14 +346,14 @@ impl Workspace for WorkspaceServer {
                 let capabilities = self.get_file_capabilities(&params.path);
                 let language = DocumentFileSource::from_path(&params.path);
                 let path = params.path.as_path();
-                let settings = self.settings.read().unwrap();
+                let settings = self.settings();
                 let mut file_features = FileFeaturesResult::new();
                 let file_name = path.file_name().and_then(|s| s.to_str());
                 file_features = file_features
                     .with_capabilities(&capabilities)
-                    .with_settings_and_language(&settings, &language, path);
+                    .with_settings_and_language(settings.as_ref(), &language, path);
 
-                if settings.files.ignore_unknown
+                if settings.as_ref().files.ignore_unknown
                     && language == DocumentFileSource::Unknown
                     && self.get_file_source(&params.path) == DocumentFileSource::Unknown
                 {
@@ -386,11 +394,11 @@ impl Workspace for WorkspaceServer {
     /// by another thread having previously panicked while holding the lock
     #[tracing::instrument(level = "trace", skip(self))]
     fn update_settings(&self, params: UpdateSettingsParams) -> Result<(), WorkspaceError> {
-        let mut settings = self.settings.write().unwrap();
+        let mut settings = self.settings_mut();
 
-        settings.merge_with_configuration(
+        settings.as_mut().merge_with_configuration(
             params.configuration,
-            params.working_directory,
+            params.workspace_directory,
             params.vcs_base_path,
             params.gitignore_matches.as_slice(),
         )?;
@@ -399,7 +407,6 @@ impl Workspace for WorkspaceServer {
         self.file_features.clear();
         Ok(())
     }
-
     /// Add a new file to the workspace
     fn open_file(&self, params: OpenFileParams) -> Result<(), WorkspaceError> {
         let index = self.set_source(
@@ -419,7 +426,6 @@ impl Workspace for WorkspaceServer {
         );
         Ok(())
     }
-
     fn open_project(&self, params: OpenProjectParams) -> Result<(), WorkspaceError> {
         let index = self.set_source(JsonFileSource::json().into());
         self.syntax.remove(&params.path);
@@ -433,6 +439,20 @@ impl Workspace for WorkspaceServer {
             },
         );
         Ok(())
+    }
+
+    fn register_workspace_folder(
+        &self,
+        params: RegisterWorkspaceFoldersParams,
+    ) -> Result<WorkspaceKey, WorkspaceError> {
+        let mut workspace = self.workspaces_mut();
+        let key = workspace
+            .as_mut()
+            .insert_workspace(params.path.unwrap_or_default());
+        if params.set_as_current_workspace {
+            workspace.as_mut().register_current_workspace(key);
+        }
+        Ok(key)
     }
 
     fn update_current_project(&self, params: UpdateProjectParams) -> Result<(), WorkspaceError> {
@@ -586,8 +606,8 @@ impl Workspace for WorkspaceServer {
             .ok_or_else(self.build_capability_error(&params.path))?;
 
         let parse = self.get_parse(params.path.clone())?;
-        let settings = self.settings.read().unwrap();
-        let rules = settings.linter().rules.as_ref();
+        let settings = self.settings();
+        let rules = settings.as_ref().linter().rules.as_ref();
         let manifest = self.get_current_project()?.map(|pr| pr.manifest);
         let language = self.get_file_source(&params.path);
         Ok(code_actions(CodeActionsParams {
@@ -671,10 +691,10 @@ impl Workspace for WorkspaceServer {
             .analyzer
             .fix_all
             .ok_or_else(self.build_capability_error(&params.path))?;
-        let settings = self.settings.read().unwrap();
+        let settings = self.settings();
         let parse = self.get_parse(params.path.clone())?;
         // Compute final rules (taking `overrides` into account)
-        let rules = settings.as_rules(params.path.as_path());
+        let rules = settings.as_ref().as_rules(params.path.as_path());
         let rule_filter_list = rules
             .as_ref()
             .map(|rules| rules.as_enabled_rules())

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -9,7 +9,7 @@ use biome_json_parser::{JsonParserOptions, ParseDiagnostic};
 use biome_project::PackageJson;
 use biome_rowan::{SyntaxKind, SyntaxNode, SyntaxSlot};
 use biome_service::configuration::to_analyzer_rules;
-use biome_service::settings::{ServiceLanguage, WorkspaceSettings};
+use biome_service::settings::{ServiceLanguage, Settings};
 use json_comments::StripComments;
 use similar::TextDiff;
 use std::ffi::{c_int, OsStr};
@@ -67,7 +67,7 @@ pub fn create_analyzer_options(
             );
         } else {
             let configuration = deserialized.into_deserialized().unwrap_or_default();
-            let mut settings = WorkspaceSettings::default();
+            let mut settings = Settings::default();
             analyzer_configuration.preferred_quote = configuration
                 .javascript
                 .as_ref()


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Related to #1573 

This refactoring doesn't change any logic, but it does some internal refactoring to prepare the LSP to support multiple workspaces. 

I created some data structures to help to query/mutate the workspaces. 

To save the workspaces data, I used `slotmap::DenseSlotmap`. [You can read more in the documentation](https://docs.rs/slotmap/latest/slotmap/#choosing-slotmap-hopslotmap-or-denseslotmap). 

The good about `slotmap` is that it emits a unique key every time we insert something; that key can be used later on to access the stored data. Those keys are always unique. Also, upon deletion, the slot that was used stays free, and it gets reused when a new element is inserted.

I chose `DeseSlotmap` because it's the fast during iteration, and slowest upon insertion. Inserting workspace folders will be a one-time operation or a rare operation. How many times does a user add a new project to a workspace? However, choosing the correct workspace will be an operation that we will have to do often. The LSP isn't able to signal if a file belongs to a certain workspace, so we have to guess it based on its path. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

The current tests should pass

<!-- What demonstrates that your implementation is correct? -->
