### PR TITLE
fix(lint/useTemplate): correctly escape characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- Fix [useTemplate](https://biomejs.dev/linter/rules/use-template/) that wrongly escaped strings in some edge cases ([#2580](https://github.com/biomejs/biome/issues/2580)).
+
+  Previously, the rule didn't correctly escaped characters preceded by an escaped character.
+
+  Contributed by @Conaclos
+
 ### Parser
 
 ## 1.7.1 (2024-04-22)

--- a/crates/biome_js_analyze/tests/specs/style/useTemplate/invalidIssue2580.js
+++ b/crates/biome_js_analyze/tests/specs/style/useTemplate/invalidIssue2580.js
@@ -1,0 +1,2 @@
+// Issue https://github.com/biomejs/biome/issues/2580
+'```ts\n' + x + '\n```';

--- a/crates/biome_js_analyze/tests/specs/style/useTemplate/invalidIssue2580.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useTemplate/invalidIssue2580.js.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidIssue2580.js
+---
+# Input
+```jsx
+// Issue https://github.com/biomejs/biome/issues/2580
+'```ts\n' + x + '\n```';
+```
+
+# Diagnostics
+```
+invalidIssue2580.js:2:1 lint/style/useTemplate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Template literals are preferred over string concatenation.
+  
+    1 │ // Issue https://github.com/biomejs/biome/issues/2580
+  > 2 │ '```ts\n' + x + '\n```';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^
+  
+  i Unsafe fix: Use a template literal.
+  
+    1 1 │   // Issue https://github.com/biomejs/biome/issues/2580
+    2   │ - '```ts\n'·+·x·+·'\n```';
+      2 │ + `\`\`\`ts\n${x}\n\`\`\``;
+  
+
+```


### PR DESCRIPTION
## Summary

Fix #2580

I fixed the escape utility and improved its implementation. 

## Test Plan

I added a test.