### PR TITLE
fix(lint/useShorthandFunctionType): add parens when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,9 +79,21 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- Fix [useShorthandFunctionType](https://biomejs.dev/linter/rules/use-shorthand-function-type/) that suggested invalid code fixes when parentheses are required ([#2595](https://github.com/biomejs/biome/issues/2595)).
+
+  Previously, the rule didn't add parentheses when they were needed.
+  It now adds parentheses when the function signature is inside an array, a union, or an intersection.
+
+  ```diff
+  - type Union = { (): number } | string;
+  + type Union = (() => number) | string;
+  ```
+
+  Contributed by @Conaclos
+
 - Fix [useTemplate](https://biomejs.dev/linter/rules/use-template/) that wrongly escaped strings in some edge cases ([#2580](https://github.com/biomejs/biome/issues/2580)).
 
-  Previously, the rule didn't correctly escaped characters preceded by an escaped character.
+  Previously, the rule didn't correctly escape characters preceded by an escaped character.
 
   Contributed by @Conaclos
 

--- a/crates/biome_js_analyze/tests/specs/style/useShorthandFunctionType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useShorthandFunctionType/invalid.ts
@@ -26,6 +26,12 @@ let nestedObj: { inner: { (): boolean } };
 // Object type with call signature as a type union member
 type UnionWithCallSignature = { (): string } | string;
 
+// Object type with call signature as a type intersection member
+export type IntersectionCallSignature = { (): string } & string;
+
+// Object type with call signature as a type array
+export type ArrayCallSignature = readonly { (): string }[];
+
 // Generic object type with a call signature
 type GenericCallSignature<T> = { (arg: T): T };
 

--- a/crates/biome_js_analyze/tests/specs/style/useShorthandFunctionType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useShorthandFunctionType/invalid.ts.snap
@@ -32,6 +32,12 @@ let nestedObj: { inner: { (): boolean } };
 // Object type with call signature as a type union member
 type UnionWithCallSignature = { (): string } | string;
 
+// Object type with call signature as a type intersection member
+export type IntersectionCallSignature = { (): string } & string;
+
+// Object type with call signature as a type array
+export type ArrayCallSignature = readonly { (): string }[];
+
 // Generic object type with a call signature
 type GenericCallSignature<T> = { (arg: T): T };
 
@@ -42,7 +48,6 @@ let optionalCall: { (): number | undefined };
 interface GenericInterface<T> {
 	(value: T): boolean;
 }
-
 ```
 
 # Diagnostics
@@ -184,7 +189,7 @@ invalid.ts:27:33 lint/style/useShorthandFunctionType  FIXABLE  ━━━━━�
   > 27 │ type UnionWithCallSignature = { (): string } | string;
        │                                 ^^^^^^^^^^
     28 │ 
-    29 │ // Generic object type with a call signature
+    29 │ // Object type with call signature as a type intersection member
   
   i Types containing only a call signature can be shortened to a function type.
   
@@ -193,86 +198,134 @@ invalid.ts:27:33 lint/style/useShorthandFunctionType  FIXABLE  ━━━━━�
     25 25 │   
     26 26 │   // Object type with call signature as a type union member
     27    │ - type·UnionWithCallSignature·=·{·():·string·}·|·string;
-       27 │ + type·UnionWithCallSignature·=·()·=>·string·|·string;
+       27 │ + type·UnionWithCallSignature·=·(()·=>·string)·|·string;
     28 28 │   
-    29 29 │   // Generic object type with a call signature
+    29 29 │   // Object type with call signature as a type intersection member
   
 
 ```
 
 ```
-invalid.ts:30:34 lint/style/useShorthandFunctionType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:30:43 lint/style/useShorthandFunctionType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use a function type instead of a call signature.
   
-    29 │ // Generic object type with a call signature
-  > 30 │ type GenericCallSignature<T> = { (arg: T): T };
-       │                                  ^^^^^^^^^^^
+    29 │ // Object type with call signature as a type intersection member
+  > 30 │ export type IntersectionCallSignature = { (): string } & string;
+       │                                           ^^^^^^^^^^
     31 │ 
-    32 │ // Object type with optional call signature
+    32 │ // Object type with call signature as a type array
   
   i Types containing only a call signature can be shortened to a function type.
   
   i Safe fix: Use a function type instead of an object type with a call signature.
   
     28 28 │   
-    29 29 │   // Generic object type with a call signature
-    30    │ - type·GenericCallSignature<T>·=·{·(arg:·T):·T·};
-       30 │ + type·GenericCallSignature<T>·=·(arg:·T)·=>·T;
+    29 29 │   // Object type with call signature as a type intersection member
+    30    │ - export·type·IntersectionCallSignature·=·{·():·string·}·&·string;
+       30 │ + export·type·IntersectionCallSignature·=·(()·=>·string)·&·string;
     31 31 │   
-    32 32 │   // Object type with optional call signature
+    32 32 │   // Object type with call signature as a type array
   
 
 ```
 
 ```
-invalid.ts:33:21 lint/style/useShorthandFunctionType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:33:45 lint/style/useShorthandFunctionType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use a function type instead of a call signature.
   
-    32 │ // Object type with optional call signature
-  > 33 │ let optionalCall: { (): number | undefined };
-       │                     ^^^^^^^^^^^^^^^^^^^^^^
+    32 │ // Object type with call signature as a type array
+  > 33 │ export type ArrayCallSignature = readonly { (): string }[];
+       │                                             ^^^^^^^^^^
     34 │ 
-    35 │ // Generic interface with a call signature
+    35 │ // Generic object type with a call signature
   
   i Types containing only a call signature can be shortened to a function type.
   
   i Safe fix: Use a function type instead of an object type with a call signature.
   
     31 31 │   
-    32 32 │   // Object type with optional call signature
-    33    │ - let·optionalCall:·{·():·number·|·undefined·};
-       33 │ + let·optionalCall:·()·=>·number·|·undefined;
+    32 32 │   // Object type with call signature as a type array
+    33    │ - export·type·ArrayCallSignature·=·readonly·{·():·string·}[];
+       33 │ + export·type·ArrayCallSignature·=·readonly·(()·=>·string)[];
     34 34 │   
-    35 35 │   // Generic interface with a call signature
+    35 35 │   // Generic object type with a call signature
   
 
 ```
 
 ```
-invalid.ts:37:2 lint/style/useShorthandFunctionType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:36:34 lint/style/useShorthandFunctionType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use a function type instead of a call signature.
   
-    35 │ // Generic interface with a call signature
-    36 │ interface GenericInterface<T> {
-  > 37 │ 	(value: T): boolean;
+    35 │ // Generic object type with a call signature
+  > 36 │ type GenericCallSignature<T> = { (arg: T): T };
+       │                                  ^^^^^^^^^^^
+    37 │ 
+    38 │ // Object type with optional call signature
+  
+  i Types containing only a call signature can be shortened to a function type.
+  
+  i Safe fix: Use a function type instead of an object type with a call signature.
+  
+    34 34 │   
+    35 35 │   // Generic object type with a call signature
+    36    │ - type·GenericCallSignature<T>·=·{·(arg:·T):·T·};
+       36 │ + type·GenericCallSignature<T>·=·(arg:·T)·=>·T;
+    37 37 │   
+    38 38 │   // Object type with optional call signature
+  
+
+```
+
+```
+invalid.ts:39:21 lint/style/useShorthandFunctionType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use a function type instead of a call signature.
+  
+    38 │ // Object type with optional call signature
+  > 39 │ let optionalCall: { (): number | undefined };
+       │                     ^^^^^^^^^^^^^^^^^^^^^^
+    40 │ 
+    41 │ // Generic interface with a call signature
+  
+  i Types containing only a call signature can be shortened to a function type.
+  
+  i Safe fix: Use a function type instead of an object type with a call signature.
+  
+    37 37 │   
+    38 38 │   // Object type with optional call signature
+    39    │ - let·optionalCall:·{·():·number·|·undefined·};
+       39 │ + let·optionalCall:·()·=>·number·|·undefined;
+    40 40 │   
+    41 41 │   // Generic interface with a call signature
+  
+
+```
+
+```
+invalid.ts:43:2 lint/style/useShorthandFunctionType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use a function type instead of a call signature.
+  
+    41 │ // Generic interface with a call signature
+    42 │ interface GenericInterface<T> {
+  > 43 │ 	(value: T): boolean;
        │ 	^^^^^^^^^^^^^^^^^^^^
-    38 │ }
-    39 │ 
+    44 │ }
   
   i Types containing only a call signature can be shortened to a function type.
   
   i Safe fix: Alias a function type instead of using an interface with a call signature.
   
-    34 34 │   
-    35 35 │   // Generic interface with a call signature
-    36    │ - interface·GenericInterface<T>·{
-    37    │ - → (value:·T):·boolean;
-    38    │ - }
-       36 │ + type·GenericInterface<T>·=·(value:·T)·=>·boolean
-    39 37 │   
+    40 40 │   
+    41 41 │   // Generic interface with a call signature
+    42    │ - interface·GenericInterface<T>·{
+    43    │ - → (value:·T):·boolean;
+    44    │ - }
+       42 │ + type·GenericInterface<T>·=·(value:·T)·=>·boolean
   
 
 ```


### PR DESCRIPTION
## Summary

Fix #2595

Previously, the rule didn't add parentheses when they were needed.
It now adds parentheses when the function signature is inside an array, a union, or an intersection.

```diff
- type Union = { (): number } | string;
+ type Union = (() => number) | string;
```

Note: we should move the needs_parens utility from `biome_js_formatter` to `biome_js_syntax`.
It is not the first time we encounter this need.
Another possibility is to format the code fix with the formatter.
However, it is not actually possible?

## Test Plan

I added non-regression tests.
