### PR TITLE
feat(lsp): workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Editors
 
+#### New features
+
+- Add support for LSP Workspaces
+
 ### Formatter
 
 ### JavaScript APIs
@@ -216,7 +220,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Contributed by @Conaclos
 
 - [noMisplacedAssertion](https://biomejs.dev/linter/rules/no-misplaced-assertion/) now allow these matchers
-  
+
   - `expect.any()`
   - `expect.anything()`
   - `expect.closeTo`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,9 +3375,9 @@ checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-lsp"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b38fb0e6ce037835174256518aace3ca621c4f96383c56bb846cfc11b341910"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -3398,13 +3398,13 @@ dependencies = [
 
 [[package]]
 name = "tower-lsp-macros"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34723c06344244474fdde365b76aebef8050bf6be61a935b91ee9ff7c4e91157"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.59",
 ]
 
 [[package]]

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -244,7 +244,10 @@ pub enum ConfigurationPathHint {
     #[default]
     None,
 
-    Workspace(PathBuf),
+    /// Very similar to [ConfigurationPathHint::None]. However, the path provided by this variant
+    /// will be used as **working directory**, which means that all globs defined in the configuration
+    /// will use **this path** as base path.
+    FromWorkspace(PathBuf),
 
     /// The configuration path provided by the LSP, not having a configuration file is not an error.
     /// The path will always be a directory path.

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -237,12 +237,15 @@ pub struct ConfigurationPayload {
     pub external_resolution_base_path: PathBuf,
 }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, Clone)]
 pub enum ConfigurationPathHint {
     /// The default mode, not having a configuration file is not an error.
     /// The path will be filled with the working directory if it is not filled at the time of usage.
     #[default]
     None,
+
+    Workspace(PathBuf),
+
     /// The configuration path provided by the LSP, not having a configuration file is not an error.
     /// The path will always be a directory path.
     FromLsp(PathBuf),

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -28,7 +28,7 @@ rustc-hash          = { workspace = true }
 serde               = { workspace = true, features = ["derive"] }
 serde_json          = { workspace = true }
 tokio               = { workspace = true, features = ["rt", "io-std"] }
-tower-lsp           = { version = "0.19.0" }
+tower-lsp           = { version = "0.20.0" }
 tracing             = { workspace = true, features = ["attributes"] }
 
 [dev-dependencies]

--- a/crates/biome_lsp/src/handlers/text_document.rs
+++ b/crates/biome_lsp/src/handlers/text_document.rs
@@ -9,7 +9,14 @@ use crate::utils::apply_document_changes;
 use crate::{documents::Document, session::Session};
 
 /// Handler for `textDocument/didOpen` LSP notification
-#[tracing::instrument(level = "debug", skip(session), err)]
+#[tracing::instrument(
+    level = "debug",
+    skip_all,
+    fields(
+        text_document_uri = display(params.text_document.uri.as_ref()),
+        text_document_language_id = display(&params.text_document.language_id),
+    )
+)]
 pub(crate) async fn did_open(
     session: &Session,
     params: lsp_types::DidOpenTextDocumentParams,

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -233,7 +233,7 @@ impl LanguageServer for LSPServer {
     // The `root_path` field is deprecated, but we still read it so we can print a warning about it
     #[allow(deprecated)]
     #[tracing::instrument(
-        level = "debug",
+        level = "trace",
         skip_all,
         fields(
             root_uri = params.root_uri.as_ref().map(display),
@@ -250,10 +250,6 @@ impl LanguageServer for LSPServer {
         let server_capabilities = server_capabilities(&params.capabilities);
         if params.root_path.is_some() {
             warn!("The Biome Server was initialized with the deprecated `root_path` parameter: this is not supported, use `root_uri` instead");
-        }
-
-        if let Some(_folders) = &params.workspace_folders {
-            warn!("The Biome Server was initialized with the `workspace_folders` parameter: this is unsupported at the moment, use `root_uri` instead");
         }
 
         self.session.initialize(

--- a/crates/biome_lsp/src/utils.rs
+++ b/crates/biome_lsp/src/utils.rs
@@ -13,6 +13,7 @@ use biome_rowan::{TextRange, TextSize};
 use biome_service::workspace::CodeAction;
 use biome_text_edit::{CompressedOp, DiffOp, TextEdit};
 use std::any::Any;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::ops::{Add, Range};
@@ -309,7 +310,7 @@ fn print_markup(markup: &MarkupBuf) -> String {
 pub(crate) fn into_lsp_error(msg: impl Display + Debug) -> LspError {
     let mut error = LspError::internal_error();
     error!("Error: {}", msg);
-    error.message = msg.to_string();
+    error.message = Cow::Owned(msg.to_string());
     error.data = Some(format!("{msg:?}").into());
     error
 }
@@ -319,14 +320,14 @@ pub(crate) fn panic_to_lsp_error(err: Box<dyn Any + Send>) -> LspError {
 
     match err.downcast::<String>() {
         Ok(msg) => {
-            error.message = *msg;
+            error.message = Cow::Owned(msg.to_string());
         }
         Err(err) => match err.downcast::<&str>() {
             Ok(msg) => {
-                error.message = msg.to_string();
+                error.message = Cow::Owned(msg.to_string());
             }
             Err(_) => {
-                error.message = String::from("Biome encountered an unknown error");
+                error.message = Cow::Owned(String::from("Biome encountered an unknown error"));
             }
         },
     }

--- a/crates/biome_lsp/tests/server.rs
+++ b/crates/biome_lsp/tests/server.rs
@@ -2289,6 +2289,8 @@ async fn multiple_projects() -> Result<()> {
         .open_named_document(file_lint_only, url!("test_two/file.js"), "javascript")
         .await?;
 
+    let _ = sleep(Duration::from_secs(1));
+
     let res: Option<Vec<TextEdit>> = server
         .request(
             "textDocument/formatting",

--- a/crates/biome_lsp/tests/server.rs
+++ b/crates/biome_lsp/tests/server.rs
@@ -63,7 +63,6 @@ macro_rules! url {
     };
 }
 
-
 struct Server {
     service: Timeout<LspService<LSPServer>>,
 }

--- a/crates/biome_lsp/tests/server.rs
+++ b/crates/biome_lsp/tests/server.rs
@@ -20,6 +20,7 @@ use serde_json::{from_value, to_value};
 use std::any::type_name;
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::path::PathBuf;
 use std::slice;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -472,7 +473,7 @@ async fn document_lifecycle() -> Result<()> {
             "biome/get_syntax_tree",
             "get_syntax_tree",
             GetSyntaxTreeParams {
-                path: BiomePath::new("/workspace/document.js"),
+                path: BiomePath::new(PathBuf::from("/").join("workspace").join("document.js")),
             },
         )
         .await?
@@ -1909,7 +1910,7 @@ isSpreadAssignment;
             "biome/get_file_content",
             "get_file_content",
             GetFileContentParams {
-                path: BiomePath::new("/workspace/document.js"),
+                path: BiomePath::new(PathBuf::from("/").join("workspace").join("document.js")),
             },
         )
         .await?

--- a/crates/biome_lsp/tests/server.rs
+++ b/crates/biome_lsp/tests/server.rs
@@ -20,7 +20,6 @@ use serde_json::{from_value, to_value};
 use std::any::type_name;
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::path::PathBuf;
 use std::slice;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -2289,8 +2288,6 @@ async fn multiple_projects() -> Result<()> {
     server
         .open_named_document(file_lint_only, url!("test_two/file.js"), "javascript")
         .await?;
-
-    let _ = sleep(Duration::from_secs(1));
 
     let res: Option<Vec<TextEdit>> = server
         .request(

--- a/crates/biome_lsp/tests/server.rs
+++ b/crates/biome_lsp/tests/server.rs
@@ -63,16 +63,6 @@ macro_rules! url {
     };
 }
 
-/// Creates an absolute [PathBuf] by prefixing them with `/workspace` depending on the OS
-macro_rules! absolute_path {
-    ($path:literal) => {
-        if cfg!(windows) {
-            PathBuf::from(concat!("z%3A/workspace/", $path))
-        } else {
-            PathBuf::from(concat!("/workspace/", $path))
-        }
-    };
-}
 
 struct Server {
     service: Timeout<LspService<LSPServer>>,
@@ -484,7 +474,7 @@ async fn document_lifecycle() -> Result<()> {
             "biome/get_syntax_tree",
             "get_syntax_tree",
             GetSyntaxTreeParams {
-                path: BiomePath::new(absolute_path!("document.js")),
+                path: BiomePath::new(url!("document.js").to_file_path().unwrap()),
             },
         )
         .await?
@@ -1921,7 +1911,7 @@ isSpreadAssignment;
             "biome/get_file_content",
             "get_file_content",
             GetFileContentParams {
-                path: BiomePath::new(absolute_path!("document.js")),
+                path: BiomePath::new(url!("document.js").to_file_path().unwrap()),
             },
         )
         .await?

--- a/crates/biome_lsp/tests/server.rs
+++ b/crates/biome_lsp/tests/server.rs
@@ -63,6 +63,17 @@ macro_rules! url {
     };
 }
 
+/// Creates an absolute [PathBuf] by prefixing them with `/workspace` depending on the OS
+macro_rules! absolute_path {
+    ($path:literal) => {
+        if cfg!(windows) {
+            PathBuf::from(concat!("z%3A/workspace/", $path))
+        } else {
+            PathBuf::from(concat!("/workspace/", $path))
+        }
+    };
+}
+
 struct Server {
     service: Timeout<LspService<LSPServer>>,
 }
@@ -473,7 +484,7 @@ async fn document_lifecycle() -> Result<()> {
             "biome/get_syntax_tree",
             "get_syntax_tree",
             GetSyntaxTreeParams {
-                path: BiomePath::new(PathBuf::from("/").join("workspace").join("document.js")),
+                path: BiomePath::new(absolute_path!("document.js")),
             },
         )
         .await?
@@ -1910,7 +1921,7 @@ isSpreadAssignment;
             "biome/get_file_content",
             "get_file_content",
             GetFileContentParams {
-                path: BiomePath::new(PathBuf::from("/").join("workspace").join("document.js")),
+                path: BiomePath::new(absolute_path!("document.js")),
             },
         )
         .await?

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -172,7 +172,7 @@ fn load_config(
         // Path hint from LSP is always the workspace root
         // we use it as the resolution base path.
         ConfigurationPathHint::FromLsp(ref path) => path.clone(),
-        ConfigurationPathHint::Workspace(ref path) => path.clone(),
+        ConfigurationPathHint::FromWorkspace(ref path) => path.clone(),
         // Path hint from user means the command is invoked from the CLI
         // So we use the working directory (CWD) as the resolution base path
         ConfigurationPathHint::FromUser(_) | ConfigurationPathHint::None => file_system
@@ -207,10 +207,8 @@ fn load_config(
     let configuration_directory = match base_path {
         ConfigurationPathHint::FromLsp(path) => path,
         ConfigurationPathHint::FromUser(path) => path,
-        ConfigurationPathHint::Workspace(path) => path,
-        ConfigurationPathHint::None => file_system
-            .working_directory()
-            .unwrap_or_else(|| PathBuf::new()),
+        ConfigurationPathHint::FromWorkspace(path) => path,
+        ConfigurationPathHint::None => file_system.working_directory().unwrap_or_default(),
     };
 
     // We first search for `biome.json` or `biome.jsonc` files

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -172,6 +172,7 @@ fn load_config(
         // Path hint from LSP is always the workspace root
         // we use it as the resolution base path.
         ConfigurationPathHint::FromLsp(ref path) => path.clone(),
+        ConfigurationPathHint::Workspace(ref path) => path.clone(),
         // Path hint from user means the command is invoked from the CLI
         // So we use the working directory (CWD) as the resolution base path
         ConfigurationPathHint::FromUser(_) | ConfigurationPathHint::None => file_system
@@ -206,11 +207,10 @@ fn load_config(
     let configuration_directory = match base_path {
         ConfigurationPathHint::FromLsp(path) => path,
         ConfigurationPathHint::FromUser(path) => path,
-        // working directory will only work in
-        _ => match file_system.working_directory() {
-            Some(working_directory) => working_directory,
-            None => PathBuf::new(),
-        },
+        ConfigurationPathHint::Workspace(path) => path,
+        ConfigurationPathHint::None => file_system
+            .working_directory()
+            .unwrap_or_else(|| PathBuf::new()),
     };
 
     // We first search for `biome.json` or `biome.jsonc` files

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -116,10 +116,6 @@ impl WorkspaceSettings {
     /// If there's a match, and the match **isn't** the current project, the function will mark the match as the current project.
     pub fn set_current_project(&mut self, path: &BiomePath) {
         debug_assert!(
-            path.is_absolute(),
-            "Workspaces paths must be absolutes {path:?}."
-        );
-        debug_assert!(
             !self.data.is_empty(),
             "You must have at least one workspace."
         );

--- a/crates/biome_service/src/workspace/client.rs
+++ b/crates/biome_service/src/workspace/client.rs
@@ -1,7 +1,7 @@
 use crate::workspace::{
     FileFeaturesResult, GetFileContentParams, IsPathIgnoredParams, OpenProjectParams,
     OrganizeImportsParams, OrganizeImportsResult, ProjectKey, RageParams, RageResult,
-    RegisterProjectFolderParams, ServerInfo, UpdateProjectParams,
+    RegisterProjectFolderParams, ServerInfo, UnregisterProjectFolderParams, UpdateProjectParams,
 };
 use crate::{TransportError, Workspace, WorkspaceError};
 use biome_formatter::Printed;
@@ -127,6 +127,13 @@ where
         params: RegisterProjectFolderParams,
     ) -> Result<ProjectKey, WorkspaceError> {
         self.request("biome/register_project_folder", params)
+    }
+
+    fn unregister_project_folder(
+        &self,
+        params: UnregisterProjectFolderParams,
+    ) -> Result<(), WorkspaceError> {
+        self.request("biome/unregister_project_folder", params)
     }
 
     fn update_current_project(&self, params: UpdateProjectParams) -> Result<(), WorkspaceError> {

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -4,8 +4,8 @@ use super::{
     GetSyntaxTreeParams, GetSyntaxTreeResult, OpenFileParams, OpenProjectParams,
     ParsePatternParams, ParsePatternResult, PatternId, ProjectKey, PullActionsParams,
     PullActionsResult, PullDiagnosticsParams, PullDiagnosticsResult, RegisterProjectFolderParams,
-    RenameResult, SearchPatternParams, SearchResults, SupportsFeatureParams, UpdateProjectParams,
-    UpdateSettingsParams,
+    RenameResult, SearchPatternParams, SearchResults, SupportsFeatureParams,
+    UnregisterProjectFolderParams, UpdateProjectParams, UpdateSettingsParams,
 };
 use crate::file_handlers::{
     Capabilities, CodeActionsParams, DocumentFileSource, FixAllParams, LintParams, ParseResult,
@@ -425,7 +425,7 @@ impl Workspace for WorkspaceServer {
         );
         let mut workspace = self.workspaces_mut();
 
-        workspace.as_mut().update_current_project(&params.path);
+        workspace.as_mut().set_current_project(&params.path);
 
         Ok(())
     }
@@ -456,6 +456,15 @@ impl Workspace for WorkspaceServer {
             workspace.as_mut().register_current_project(key);
         }
         Ok(key)
+    }
+
+    fn unregister_project_folder(
+        &self,
+        params: UnregisterProjectFolderParams,
+    ) -> Result<(), WorkspaceError> {
+        let mut workspace = self.workspaces_mut();
+        workspace.as_mut().remove_project(params.path.as_path());
+        Ok(())
     }
 
     fn update_current_project(&self, params: UpdateProjectParams) -> Result<(), WorkspaceError> {
@@ -555,11 +564,6 @@ impl Workspace for WorkspaceServer {
     ) -> Result<PullDiagnosticsResult, WorkspaceError> {
         let parse = self.get_parse(params.path.clone())?;
         let manifest = self.get_current_project()?.map(|pr| pr.manifest);
-        debug!(
-            "Current settings: formatter {:?} and linter {:?}",
-            self.settings().as_ref().formatter.enabled,
-            self.settings().as_ref().linter.enabled,
-        );
         let (diagnostics, errors, skipped_diagnostics) =
             if let Some(lint) = self.get_file_capabilities(&params.path).analyzer.lint {
                 info_span!("Pulling diagnostics", categories =? params.categories).in_scope(|| {

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -524,7 +524,6 @@ impl Workspace for WorkspaceServer {
     }
 
     fn get_file_content(&self, params: GetFileContentParams) -> Result<String, WorkspaceError> {
-        dbg!("FILE CONTENT", &params, &self.documents);
         let document = self
             .documents
             .get(&params.path)

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -524,6 +524,10 @@ impl Workspace for WorkspaceServer {
     }
 
     fn get_file_content(&self, params: GetFileContentParams) -> Result<String, WorkspaceError> {
+        dbg!(&params);
+        self.documents.iter().for_each(|key| {
+            dbg!(&key.key());
+        });
         let document = self
             .documents
             .get(&params.path)

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -524,6 +524,7 @@ impl Workspace for WorkspaceServer {
     }
 
     fn get_file_content(&self, params: GetFileContentParams) -> Result<String, WorkspaceError> {
+        dbg!("FILE CONTENT", &params, &self.documents);
         let document = self
             .documents
             .get(&params.path)

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -524,10 +524,6 @@ impl Workspace for WorkspaceServer {
     }
 
     fn get_file_content(&self, params: GetFileContentParams) -> Result<String, WorkspaceError> {
-        dbg!(&params);
-        self.documents.iter().for_each(|key| {
-            dbg!(&key.key());
-        });
         let document = self
             .documents
             .get(&params.path)


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #1573 

This PR adds support for LSP workspaces to Biome LSP. Our internal implementation of `ServerWorkspace` will keep track of the different workspaces registered by the user. 

The Biome LSP now listens to `did_change_workspace_folders`, which is triggered when a user changes (adds and/or removes) workspace folders.

We will need to update our documentation, and explain that providing a `--config-path` will remove the support of that via LSP. Essentially, users can't have both.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added a new test and tested manually

<!-- What demonstrates that your implementation is correct? -->
