### PR TITLE
fix(glob): correctly handle relative patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,17 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- Relative glob patterns are now correctly handled ([#2421](https://github.com/biomejs/biome/issues/2421)).
+
+  Biome relies on an internal fork of the [glob crate](https://crates.io/crates/glob).
+  This crate converts relative glob patterns into recursive glob patterns.
+  This means that `./file' is equivalent to `./**/file'.
+
+  This is surprising behavior and has been reported as a bug by our users.
+  Biome no longer converts relative glob patterns to recursive glob patterns.
+
+  Contributed by @Conaclos
+
 ### Configuration
 
 ### Editors

--- a/crates/biome_service/src/matcher/pattern.rs
+++ b/crates/biome_service/src/matcher/pattern.rs
@@ -126,10 +126,8 @@ impl Pattern {
         // eg. "./test" or ".\test"
         let is_relative = matches!(chars.get(..2), Some(['.', sep]) if path::is_separator(*sep));
         if is_relative {
-            // If a pattern starts with a relative prefix, strip it from the
-            // pattern and replace it with a "**" sequence
+            // If a pattern starts with a relative prefix, strip it from the pattern
             i += 2;
-            tokens.push(AnyRecursiveSequence);
         } else {
             // A pattern is absolute if it starts with a path separator, eg. "/home" or "\\?\C:\Users"
             let mut is_absolute = chars.first().map_or(false, |c| path::is_separator(*c));
@@ -862,11 +860,11 @@ mod test {
 
     #[test]
     fn test_pattern_relative() {
-        assert!(Pattern::new("./b").unwrap().matches_path(Path::new("a/b")));
+        assert!(!Pattern::new("./b").unwrap().matches_path(Path::new("a/b")));
         assert!(Pattern::new("b").unwrap().matches_path(Path::new("a/b")));
 
         if cfg!(windows) {
-            assert!(Pattern::new(".\\b")
+            assert!(!Pattern::new(".\\b")
                 .unwrap()
                 .matches_path(Path::new("a\\b")));
             assert!(Pattern::new("b").unwrap().matches_path(Path::new("a\\b")));


### PR DESCRIPTION
## Summary

Fix #2421

Biome relies on an internal fork of the [glob crate](https://crates.io/crates/glob).
This crate converts relative glob patterns into recursive glob patterns.
This means that `./file' is equivalent to `./**/file'.

This is surprising behavior and has been reported as a bug by our users.
Biome no longer converts relative glob patterns to recursive glob patterns.

EDIT: see [the next comment](https://github.com/biomejs/biome/pull/2620#issuecomment-2080473204).

## Test Plan

I updated the unit tests of the glob pattern utility.
