### PR TITLE
fix(lint): rule `noMisplacedAssertion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,21 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @printfn
 
+- [noMisplacedAssertion](https://biomejs.dev/linter/rules/no-misplaced-assertion/) now allow these matchers
+  
+  - `expect.any()`
+  - `expect.anything()`
+  - `expect.closeTo`
+  - `expect.arrayContaining`
+  - `expect.objectContaining`
+  - `expect.stringContaining`
+  - `expect.stringMatching`
+  - `expect.extend`
+  - `expect.addEqualityTesters`
+  - `expect.addSnapshotSerializer`
+
+  Contributed by @fujiyamaorange
+
 ### Parser
 
 - The language parsers no longer panic on unterminated strings followed by a newline and a space ([#2606](https://github.com/biomejs/biome/issues/2606), [#2410](https://github.com/biomejs/biome/issues/2410)).

--- a/crates/biome_js_analyze/src/lint/nursery/no_misplaced_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misplaced_assertion.rs
@@ -176,7 +176,7 @@ impl Rule for NoMisplacedAssertion {
                 return None;
             }
 
-            let is_exeption = is_exception_for_expect(&node);
+            let is_exeption = is_exception_for_expect(node);
             let binding = model.binding(&assertion_call);
             if let Some(binding) = binding {
                 let ident = JsIdentifierBinding::cast_ref(binding.syntax())?;

--- a/crates/biome_js_analyze/src/lint/nursery/no_misplaced_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misplaced_assertion.rs
@@ -17,6 +17,18 @@ declare_rule! {
     /// - `assert`
     /// - `assertEquals`
     ///
+    /// However, the rule will ignore the following assertion calls:
+    /// - `expect.any`
+    /// - `expect.anything`
+    /// - `expect.closeTo`
+    /// - `expect.arrayContaining`
+    /// - `expect.objectContaining`
+    /// - `expect.stringContaining`
+    /// - `expect.stringMatching`
+    /// - `expect.extend`
+    /// - `expect.addEqualityTesters`
+    /// - `expect.addSnapshotSerializer`
+    ///
     /// If the assertion function is imported, the rule will check if they are imported from:
     /// - `"chai"`
     /// - `"node:assert"`
@@ -91,7 +103,7 @@ declare_rule! {
     /// ```
     ///
     pub NoMisplacedAssertion {
-        version: "1.6.4",
+        version: "next",
         name: "noMisplacedAssertion",
         recommended: false,
         sources: &[RuleSource::EslintJest("no-standalone-expect")],
@@ -107,6 +119,18 @@ const SPECIFIERS: [&str; 6] = [
     "bun:test",
     "vitest",
     "/assert/mod.ts",
+];
+const EXCEPTION_MEMBERS_FOR_EXPECT: [&str; 10] = [
+    "any",
+    "anything",
+    "closeTo",
+    "arrayContaining",
+    "objectContaining",
+    "stringContaining",
+    "stringMatching",
+    "extend",
+    "addEqualityTesters",
+    "addSnapshotSerializer",
 ];
 
 impl Rule for NoMisplacedAssertion {
@@ -152,6 +176,7 @@ impl Rule for NoMisplacedAssertion {
                 return None;
             }
 
+            let is_exeption = is_exception_for_expect(&node);
             let binding = model.binding(&assertion_call);
             if let Some(binding) = binding {
                 let ident = JsIdentifierBinding::cast_ref(binding.syntax())?;
@@ -167,10 +192,11 @@ impl Rule for NoMisplacedAssertion {
                             *specifier == source_text.text()
                         }
                     }))
+                    && !is_exeption
                 {
                     return Some(assertion_call.range());
                 }
-            } else if ASSERTION_FUNCTION_NAMES.contains(&call_text.text()) {
+            } else if ASSERTION_FUNCTION_NAMES.contains(&call_text.text()) && !is_exeption {
                 return Some(assertion_call.range());
             }
         }
@@ -203,5 +229,25 @@ fn may_extract_nested_expr(callee: AnyJsExpression) -> Option<AnyJsExpression> {
         AnyJsExpression::JsCallExpression(call_expr) => call_expr.callee().ok(),
         AnyJsExpression::JsTemplateExpression(template_expr) => template_expr.tag(),
         _ => Some(callee),
+    }
+}
+
+/// Returns whether the assertion call is an exception for the `expect` assertion function.
+fn is_exception_for_expect(node: &AnyJsExpression) -> bool {
+    let assertion_call = node.get_callee_object_identifier().unwrap();
+    let callee_text = assertion_call.syntax().parent().unwrap().text_trimmed();
+
+    let parent = node.syntax().parent().unwrap();
+    let last_token = parent.last_token().unwrap();
+    let last_token_text = last_token.text();
+
+    let member = node.get_callee_member_name().unwrap();
+    let member_text = member.text_trimmed();
+
+    if callee_text == "expect" {
+        EXCEPTION_MEMBERS_FOR_EXPECT.contains(&member_text)
+            || EXCEPTION_MEMBERS_FOR_EXPECT.contains(&last_token_text)
+    } else {
+        false
     }
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js
@@ -15,3 +15,36 @@ Deno.test("something", () => {
 await waitFor(() => {
 	expect(111).toBe(222);
 });
+
+expect.any(Number);
+
+expect.anything()
+
+expect.closeTo(0.3, 5)
+
+expect.arrayContaining(['Alice', 'Bob'])
+
+expect.objectContaining({
+  x: expect.any(Number),
+  y: expect.any(Number),
+})
+
+expect.not.stringContaining('Hello world!')
+
+expect.stringMatching(/^Alic/)
+expect.stringMatching(/^[BR]ob/)
+
+expect.extend({
+  toBeFoo: (received, expected) => {
+	if (received !== 'foo') {
+      return {
+	    message: () => `expected ${received} to be foo`,
+		pass: false,
+	  }
+	}
+  },
+});
+
+expect.addEqualityTesters([areVolumesEqual]);
+
+expect.addSnapshotSerializer(serializer);

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js
@@ -29,7 +29,7 @@ expect.objectContaining({
   y: expect.any(Number),
 })
 
-expect.not.stringContaining('Hello world!')
+expect.stringContaining('Hello world!')
 
 expect.stringMatching(/^Alic/)
 expect.stringMatching(/^[BR]ob/)

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js.snap
@@ -35,7 +35,7 @@ expect.objectContaining({
   y: expect.any(Number),
 })
 
-expect.not.stringContaining('Hello world!')
+expect.stringContaining('Hello world!')
 
 expect.stringMatching(/^Alic/)
 expect.stringMatching(/^[BR]ob/)
@@ -54,24 +54,4 @@ expect.extend({
 expect.addEqualityTesters([areVolumesEqual]);
 
 expect.addSnapshotSerializer(serializer);
-```
-
-# Diagnostics
-```
-valid.js:32:1 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The assertion isn't inside a it(), test() or Deno.test() function call.
-  
-    30 │ })
-    31 │ 
-  > 32 │ expect.not.stringContaining('Hello world!')
-       │ ^^^^^^
-    33 │ 
-    34 │ expect.stringMatching(/^Alic/)
-  
-  i This will result in unexpected behaviours from your test suite.
-  
-  i Move the assertion inside a it(), test() or Deno.test() function call.
-  
-
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisplacedAssertion/valid.js.snap
@@ -22,4 +22,56 @@ await waitFor(() => {
 	expect(111).toBe(222);
 });
 
+expect.any(Number);
+
+expect.anything()
+
+expect.closeTo(0.3, 5)
+
+expect.arrayContaining(['Alice', 'Bob'])
+
+expect.objectContaining({
+  x: expect.any(Number),
+  y: expect.any(Number),
+})
+
+expect.not.stringContaining('Hello world!')
+
+expect.stringMatching(/^Alic/)
+expect.stringMatching(/^[BR]ob/)
+
+expect.extend({
+  toBeFoo: (received, expected) => {
+	if (received !== 'foo') {
+      return {
+	    message: () => `expected ${received} to be foo`,
+		pass: false,
+	  }
+	}
+  },
+});
+
+expect.addEqualityTesters([areVolumesEqual]);
+
+expect.addSnapshotSerializer(serializer);
+```
+
+# Diagnostics
+```
+valid.js:32:1 lint/nursery/noMisplacedAssertion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The assertion isn't inside a it(), test() or Deno.test() function call.
+  
+    30 │ })
+    31 │ 
+  > 32 │ expect.not.stringContaining('Hello world!')
+       │ ^^^^^^
+    33 │ 
+    34 │ expect.stringMatching(/^Alic/)
+  
+  i This will result in unexpected behaviours from your test suite.
+  
+  i Move the assertion inside a it(), test() or Deno.test() function call.
+  
+
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
- Close https://github.com/biomejs/biome/issues/2547

> [!NOTE]
> I have some troubles with `cargo format` in `just gen-lint`.

<details>
<summary>Occurred error</summary>

```
biome on  fix-lint-no-misplaced_assertion via  v20.12.1 via 🦀 v1.77.2 
❯ cargo format
[lib (2021)] "/path-to-biome/biome/crates/biome_analyze/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_aria/src/lib.rs"
[custom-build (2021)] "/path-to-biome/biome/crates/biome_aria_metadata/build.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_aria_metadata/src/lib.rs"
[example (2021)] "/path-to-biome/biome/crates/biome_cli/examples/text_reporter.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_cli/src/lib.rs"
[bin (2021)] "/path-to-biome/biome/crates/biome_cli/src/main.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_cli/tests/configs.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_cli/tests/main.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_cli/tests/snap_test.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_configuration/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_console/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_console/tests/macro.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_control_flow/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_css_analyze/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_css_analyze/tests/spec_tests.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_css_factory/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_css_formatter/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_css_formatter/tests/language.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_css_formatter/tests/prettier_tests.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_css_formatter/tests/quick_test.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_css_formatter/tests/spec_test.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_css_formatter/tests/spec_tests.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_css_parser/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_css_parser/tests/spec_test.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_css_parser/tests/spec_tests.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_css_syntax/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_deserialize/src/lib.rs"
[proc-macro (2021)] "/path-to-biome/biome/crates/biome_deserialize_macros/src/lib.rs"
[example (2021)] "/path-to-biome/biome/crates/biome_diagnostics/examples/cli.rs"
[example (2021)] "/path-to-biome/biome/crates/biome_diagnostics/examples/fs.rs"
[example (2021)] "/path-to-biome/biome/crates/biome_diagnostics/examples/lint.rs"
[example (2021)] "/path-to-biome/biome/crates/biome_diagnostics/examples/serde.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_diagnostics/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_diagnostics/tests/macros.rs"
[custom-build (2021)] "/path-to-biome/biome/crates/biome_diagnostics_categories/build.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_diagnostics_categories/src/lib.rs"
[proc-macro (2021)] "/path-to-biome/biome/crates/biome_diagnostics_macros/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_flags/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_formatter/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_formatter_test/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_fs/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_graphql_factory/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_graphql_parser/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_graphql_parser/tests/spec_test.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_graphql_parser/tests/spec_tests.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_graphql_syntax/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_grit_factory/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_grit_parser/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_grit_parser/tests/spec_test.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_grit_parser/tests/spec_tests.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_grit_patterns/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_grit_syntax/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_html_factory/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_html_parser/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_html_parser/tests/spec_test.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_html_parser/tests/spec_tests.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_html_syntax/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_js_analyze/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_js_analyze/tests/spec_tests.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_js_factory/src/lib.rs"
[bench (2021)] "/path-to-biome/biome/crates/biome_js_formatter/benches/iai.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_js_formatter/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_js_formatter/tests/language.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_js_formatter/tests/prettier_tests.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_js_formatter/tests/quick_test.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_js_formatter/tests/spec_test.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_js_formatter/tests/spec_tests.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_js_parser/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_js_semantic/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_js_syntax/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_js_transform/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_js_transform/tests/spec_tests.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_json_analyze/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_json_analyze/tests/spec_tests.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_json_factory/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_json_formatter/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_json_formatter/tests/language.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_json_formatter/tests/prettier_tests.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_json_formatter/tests/quick_test.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_json_formatter/tests/spec_test.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_json_formatter/tests/spec_tests.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_json_parser/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_json_parser/tests/spec_test.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_json_parser/tests/spec_tests.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_json_syntax/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_lsp/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_lsp/tests/server.rs"
[proc-macro (2021)] "/path-to-biome/biome/crates/biome_markup/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_migrate/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_migrate/tests/spec_tests.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_parser/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_project/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_project/tests/manifest_spec_tests.rs"
[bench (2021)] "/path-to-biome/biome/crates/biome_rowan/benches/mutation.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_rowan/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_service/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_service/tests/spec_tests.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_service/tests/workspace.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_string_case/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_suppression/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_test_utils/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_text_edit/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_text_size/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_text_size/tests/auto_traits.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_text_size/tests/contructors.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_text_size/tests/indexing.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_text_size/tests/main.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_text_size/tests/serde.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_ungrammar/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_unicode_table/src/lib.rs"
[custom-build (2021)] "/path-to-biome/biome/crates/biome_wasm/build.rs"
[cdylib (2021)] "/path-to-biome/biome/crates/biome_wasm/src/lib.rs"
[test (2021)] "/path-to-biome/biome/crates/biome_wasm/tests/web.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_yaml_factory/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_yaml_parser/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/crates/biome_yaml_syntax/src/lib.rs"
[proc-macro (2021)] "/path-to-biome/biome/crates/tests_macros/src/lib.rs"
[bench (2021)] "/path-to-biome/biome/xtask/bench/benches/analyzer.rs"
[bench (2021)] "/path-to-biome/biome/xtask/bench/benches/css_formatter.rs"
[bench (2021)] "/path-to-biome/biome/xtask/bench/benches/css_parser.rs"
[bench (2021)] "/path-to-biome/biome/xtask/bench/benches/js_formatter.rs"
[bench (2021)] "/path-to-biome/biome/xtask/bench/benches/js_parser.rs"
[bench (2021)] "/path-to-biome/biome/xtask/bench/benches/json_formatter.rs"
[bench (2021)] "/path-to-biome/biome/xtask/bench/benches/json_parser.rs"
[lib (2021)] "/path-to-biome/biome/xtask/bench/src/lib.rs"
[lib (2021)] "/path-to-biome/biome/xtask/codegen/src/lib.rs"
[bin (2021)] "/path-to-biome/biome/xtask/codegen/src/main.rs"
[bin (2021)] "/path-to-biome/biome/xtask/contributors/src/main.rs"
[lib (2021)] "/path-to-biome/biome/xtask/coverage/src/lib.rs"
[bin (2021)] "/path-to-biome/biome/xtask/coverage/src/main.rs"
[bench (2021)] "/path-to-biome/biome/xtask/libs_bench/benches/contains.rs"
[bench (2021)] "/path-to-biome/biome/xtask/libs_bench/benches/contains_criterion.rs"
[bench (2021)] "/path-to-biome/biome/xtask/libs_bench/benches/contains_iai.rs"
[bin (2021)] "/path-to-biome/biome/xtask/libs_bench/bins/contains_iai.rs"
[bin (2021)] "/path-to-biome/biome/xtask/libs_bench/src/main.rs"
[lib (2021)] "/path-to-biome/biome/xtask/src/lib.rs"
rustfmt --edition 2021 /path-to-biome/biome/crates/biome_analyze/src/lib.rs /path-to-biome/biome/crates/biome_aria/src/lib.rs /path-to-biome/biome/crates/biome_aria_metadata/build.rs /path-to-biome/biome/crates/biome_aria_metadata/src/lib.rs /path-to-biome/biome/crates/biome_cli/examples/text_reporter.rs /path-to-biome/biome/crates/biome_cli/src/lib.rs /path-to-biome/biome/crates/biome_cli/src/main.rs /path-to-biome/biome/crates/biome_cli/tests/configs.rs /path-to-biome/biome/crates/biome_cli/tests/main.rs /path-to-biome/biome/crates/biome_cli/tests/snap_test.rs /path-to-biome/biome/crates/biome_configuration/src/lib.rs /path-to-biome/biome/crates/biome_console/src/lib.rs /path-to-biome/biome/crates/biome_console/tests/macro.rs /path-to-biome/biome/crates/biome_control_flow/src/lib.rs /path-to-biome/biome/crates/biome_css_analyze/src/lib.rs /path-to-biome/biome/crates/biome_css_analyze/tests/spec_tests.rs /path-to-biome/biome/crates/biome_css_factory/src/lib.rs /path-to-biome/biome/crates/biome_css_formatter/src/lib.rs /path-to-biome/biome/crates/biome_css_formatter/tests/language.rs /path-to-biome/biome/crates/biome_css_formatter/tests/prettier_tests.rs /path-to-biome/biome/crates/biome_css_formatter/tests/quick_test.rs /path-to-biome/biome/crates/biome_css_formatter/tests/spec_test.rs /path-to-biome/biome/crates/biome_css_formatter/tests/spec_tests.rs /path-to-biome/biome/crates/biome_css_parser/src/lib.rs /path-to-biome/biome/crates/biome_css_parser/tests/spec_test.rs /path-to-biome/biome/crates/biome_css_parser/tests/spec_tests.rs /path-to-biome/biome/crates/biome_css_syntax/src/lib.rs /path-to-biome/biome/crates/biome_deserialize/src/lib.rs /path-to-biome/biome/crates/biome_deserialize_macros/src/lib.rs /path-to-biome/biome/crates/biome_diagnostics/examples/cli.rs /path-to-biome/biome/crates/biome_diagnostics/examples/fs.rs /path-to-biome/biome/crates/biome_diagnostics/examples/lint.rs /path-to-biome/biome/crates/biome_diagnostics/examples/serde.rs /path-to-biome/biome/crates/biome_diagnostics/src/lib.rs /path-to-biome/biome/crates/biome_diagnostics/tests/macros.rs /path-to-biome/biome/crates/biome_diagnostics_categories/build.rs /path-to-biome/biome/crates/biome_diagnostics_categories/src/lib.rs /path-to-biome/biome/crates/biome_diagnostics_macros/src/lib.rs /path-to-biome/biome/crates/biome_flags/src/lib.rs /path-to-biome/biome/crates/biome_formatter/src/lib.rs /path-to-biome/biome/crates/biome_formatter_test/src/lib.rs /path-to-biome/biome/crates/biome_fs/src/lib.rs /path-to-biome/biome/crates/biome_graphql_factory/src/lib.rs /path-to-biome/biome/crates/biome_graphql_parser/src/lib.rs /path-to-biome/biome/crates/biome_graphql_parser/tests/spec_test.rs /path-to-biome/biome/crates/biome_graphql_parser/tests/spec_tests.rs /path-to-biome/biome/crates/biome_graphql_syntax/src/lib.rs /path-to-biome/biome/crates/biome_grit_factory/src/lib.rs /path-to-biome/biome/crates/biome_grit_parser/src/lib.rs /path-to-biome/biome/crates/biome_grit_parser/tests/spec_test.rs /path-to-biome/biome/crates/biome_grit_parser/tests/spec_tests.rs /path-to-biome/biome/crates/biome_grit_patterns/src/lib.rs /path-to-biome/biome/crates/biome_grit_syntax/src/lib.rs /path-to-biome/biome/crates/biome_html_factory/src/lib.rs /path-to-biome/biome/crates/biome_html_parser/src/lib.rs /path-to-biome/biome/crates/biome_html_parser/tests/spec_test.rs /path-to-biome/biome/crates/biome_html_parser/tests/spec_tests.rs /path-to-biome/biome/crates/biome_html_syntax/src/lib.rs /path-to-biome/biome/crates/biome_js_analyze/src/lib.rs /path-to-biome/biome/crates/biome_js_analyze/tests/spec_tests.rs /path-to-biome/biome/crates/biome_js_factory/src/lib.rs /path-to-biome/biome/crates/biome_js_formatter/benches/iai.rs /path-to-biome/biome/crates/biome_js_formatter/src/lib.rs /path-to-biome/biome/crates/biome_js_formatter/tests/language.rs /path-to-biome/biome/crates/biome_js_formatter/tests/prettier_tests.rs /path-to-biome/biome/crates/biome_js_formatter/tests/quick_test.rs /path-to-biome/biome/crates/biome_js_formatter/tests/spec_test.rs /path-to-biome/biome/crates/biome_js_formatter/tests/spec_tests.rs /path-to-biome/biome/crates/biome_js_parser/src/lib.rs /path-to-biome/biome/crates/biome_js_semantic/src/lib.rs /path-to-biome/biome/crates/biome_js_syntax/src/lib.rs /path-to-biome/biome/crates/biome_js_transform/src/lib.rs /path-to-biome/biome/crates/biome_js_transform/tests/spec_tests.rs /path-to-biome/biome/crates/biome_json_analyze/src/lib.rs /path-to-biome/biome/crates/biome_json_analyze/tests/spec_tests.rs /path-to-biome/biome/crates/biome_json_factory/src/lib.rs /path-to-biome/biome/crates/biome_json_formatter/src/lib.rs /path-to-biome/biome/crates/biome_json_formatter/tests/language.rs /path-to-biome/biome/crates/biome_json_formatter/tests/prettier_tests.rs /path-to-biome/biome/crates/biome_json_formatter/tests/quick_test.rs /path-to-biome/biome/crates/biome_json_formatter/tests/spec_test.rs /path-to-biome/biome/crates/biome_json_formatter/tests/spec_tests.rs /path-to-biome/biome/crates/biome_json_parser/src/lib.rs /path-to-biome/biome/crates/biome_json_parser/tests/spec_test.rs /path-to-biome/biome/crates/biome_json_parser/tests/spec_tests.rs /path-to-biome/biome/crates/biome_json_syntax/src/lib.rs /path-to-biome/biome/crates/biome_lsp/src/lib.rs /path-to-biome/biome/crates/biome_lsp/tests/server.rs /path-to-biome/biome/crates/biome_markup/src/lib.rs /path-to-biome/biome/crates/biome_migrate/src/lib.rs /path-to-biome/biome/crates/biome_migrate/tests/spec_tests.rs /path-to-biome/biome/crates/biome_parser/src/lib.rs /path-to-biome/biome/crates/biome_project/src/lib.rs /path-to-biome/biome/crates/biome_project/tests/manifest_spec_tests.rs /path-to-biome/biome/crates/biome_rowan/benches/mutation.rs /path-to-biome/biome/crates/biome_rowan/src/lib.rs /path-to-biome/biome/crates/biome_service/src/lib.rs /path-to-biome/biome/crates/biome_service/tests/spec_tests.rs /path-to-biome/biome/crates/biome_service/tests/workspace.rs /path-to-biome/biome/crates/biome_string_case/src/lib.rs /path-to-biome/biome/crates/biome_suppression/src/lib.rs /path-to-biome/biome/crates/biome_test_utils/src/lib.rs /path-to-biome/biome/crates/biome_text_edit/src/lib.rs /path-to-biome/biome/crates/biome_text_size/src/lib.rs /path-to-biome/biome/crates/biome_text_size/tests/auto_traits.rs /path-to-biome/biome/crates/biome_text_size/tests/contructors.rs /path-to-biome/biome/crates/biome_text_size/tests/indexing.rs /path-to-biome/biome/crates/biome_text_size/tests/main.rs /path-to-biome/biome/crates/biome_text_size/tests/serde.rs /path-to-biome/biome/crates/biome_ungrammar/src/lib.rs /path-to-biome/biome/crates/biome_unicode_table/src/lib.rs /path-to-biome/biome/crates/biome_wasm/build.rs /path-to-biome/biome/crates/biome_wasm/src/lib.rs /path-to-biome/biome/crates/biome_wasm/tests/web.rs /path-to-biome/biome/crates/biome_yaml_factory/src/lib.rs /path-to-biome/biome/crates/biome_yaml_parser/src/lib.rs /path-to-biome/biome/crates/biome_yaml_syntax/src/lib.rs /path-to-biome/biome/crates/tests_macros/src/lib.rs /path-to-biome/biome/xtask/bench/benches/analyzer.rs /path-to-biome/biome/xtask/bench/benches/css_formatter.rs /path-to-biome/biome/xtask/bench/benches/css_parser.rs /path-to-biome/biome/xtask/bench/benches/js_formatter.rs /path-to-biome/biome/xtask/bench/benches/js_parser.rs /path-to-biome/biome/xtask/bench/benches/json_formatter.rs /path-to-biome/biome/xtask/bench/benches/json_parser.rs /path-to-biome/biome/xtask/bench/src/lib.rs /path-to-biome/biome/xtask/codegen/src/lib.rs /path-to-biome/biome/xtask/codegen/src/main.rs /path-to-biome/biome/xtask/contributors/src/main.rs /path-to-biome/biome/xtask/coverage/src/lib.rs /path-to-biome/biome/xtask/coverage/src/main.rs /path-to-biome/biome/xtask/libs_bench/benches/contains.rs /path-to-biome/biome/xtask/libs_bench/benches/contains_criterion.rs /path-to-biome/biome/xtask/libs_bench/benches/contains_iai.rs /path-to-biome/biome/xtask/libs_bench/bins/contains_iai.rs /path-to-biome/biome/xtask/libs_bench/src/main.rs /path-to-biome/biome/xtask/src/lib.rs
```
</details>


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
Confirm these matchers
 - `expect.any()`
  - `expect.anything()`
  - `expect.closeTo`
  - `expect.arrayContaining`
  - `expect.objectContaining`
  - `expect.stringContaining`
  - `expect.stringMatching`
  - `expect.extend`
  - `expect.addEqualityTesters`
  - `expect.addSnapshotSerializer`
<!-- What demonstrates that your implementation is correct? -->
