### PR TITLE
refactor(deserialize): don't handle Option specifically

### DIFF
--- a/crates/biome_deserialize/src/impls.rs
+++ b/crates/biome_deserialize/src/impls.rs
@@ -493,6 +493,16 @@ impl<T: Deserializable> Deserializable for Box<T> {
     }
 }
 
+impl<T: Deserializable> Deserializable for Option<T> {
+    fn deserialize(
+        value: &impl DeserializableValue,
+        name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self> {
+        T::deserialize(value, name, diagnostics).map(Option::Some)
+    }
+}
+
 impl<T: Deserializable> Deserializable for Vec<T> {
     fn deserialize(
         value: &impl DeserializableValue,

--- a/crates/biome_deserialize/src/merge.rs
+++ b/crates/biome_deserialize/src/merge.rs
@@ -10,10 +10,7 @@ pub trait Merge {
     fn merge_with(&mut self, other: Self);
 }
 
-impl<T> Merge for Option<T>
-where
-    T: Merge,
-{
+impl<T: Merge> Merge for Option<T> {
     fn merge_with(&mut self, other: Self) {
         if let Some(other) = other {
             match self.as_mut() {

--- a/crates/biome_deserialize_macros/src/merge_derive.rs
+++ b/crates/biome_deserialize_macros/src/merge_derive.rs
@@ -64,27 +64,11 @@ fn generate_merge_newtype(ident: Ident) -> TokenStream {
 }
 
 fn generate_merge_struct(ident: Ident, fields: Fields) -> TokenStream {
-    let merge_fields: Vec<_> = fields
-        .iter()
-        .filter_map(|field| field.ident.as_ref())
-        .map(|field_ident| {
-            quote! {
-                if let Some(other_value) = other.#field_ident {
-                    match self.#field_ident.as_mut() {
-                        Some(own_value) => biome_deserialize::Merge::merge_with(own_value, other_value),
-                        None => {
-                            self.#field_ident = Some(other_value);
-                        }
-                    }
-                }
-            }
-        })
-        .collect();
-
+    let field_idents = fields.into_iter().filter_map(|field| field.ident);
     quote! {
         impl biome_deserialize::Merge for #ident {
             fn merge_with(&mut self, other: Self) {
-                #( #merge_fields )*
+                #( biome_deserialize::Merge::merge_with(&mut self.#field_idents, other.#field_idents); )*
             }
         }
     }

--- a/crates/biome_deserialize_macros/src/partial_derive.rs
+++ b/crates/biome_deserialize_macros/src/partial_derive.rs
@@ -156,25 +156,6 @@ pub(crate) fn generate_partial(input: DeriveInput) -> TokenStream {
         },
     );
 
-    let to_partial_fields = input.fields.iter().map(
-        |FieldData {
-             ident,
-             ty,
-             should_wrap,
-             ..
-         }| {
-            if *should_wrap {
-                quote! {
-                    #ident: (other.#ident != default.#ident).then_some(other.#ident).map(#ty::into)
-                }
-            } else {
-                quote! {
-                    #ident: other.#ident.map(#ty::into)
-                }
-            }
-        },
-    );
-
     quote! {
         #( #doc_lines )*
         #[derive(#(#derives),*)]
@@ -188,15 +169,6 @@ pub(crate) fn generate_partial(input: DeriveInput) -> TokenStream {
                 let default = Self::default();
                 Self {
                     #( #from_partial_fields ),*
-                }
-            }
-        }
-
-        impl From<#ident> for #partial_ident {
-            fn from(other: #ident) -> Self {
-                let default = #ident::default();
-                Self {
-                    #( #to_partial_fields ),*
                 }
             }
         }


### PR DESCRIPTION
## Summary

A few days ago, while working on #1859, I found some possible simplification.
Because, I am no longer sure that #1859 is a good idea, I decided to extract the main simplifications in this PR.

The idea is to implement `Deserializable` for `Option`.
This allows to remove specific handling of `Option` in the `Deserializable` derive macro.

I also simplified the `Merge` derive macro, which was more complex than it needed to be.

I also removed the implementations that allow an instance to be converted to a partial instance.
It is never used and has a conceptual flaw: it assumes that a field is unset with its default value.

## Test Plan

CI should pass.
