### PR TITLE
refactor: use TriviaPiece factory functions in more places

### DIFF
--- a/crates/biome_analyze/src/matcher.rs
+++ b/crates/biome_analyze/src/matcher.rs
@@ -207,7 +207,7 @@ mod tests {
     use biome_diagnostics::{Diagnostic, Severity};
     use biome_rowan::{
         raw_language::{RawLanguage, RawLanguageKind, RawLanguageRoot, RawSyntaxTreeBuilder},
-        AstNode, SyntaxNode, TextRange, TextSize, TriviaPiece, TriviaPieceKind,
+        AstNode, SyntaxNode, TextRange, TextSize, TriviaPiece,
     };
     use std::convert::Infallible;
 
@@ -250,10 +250,7 @@ mod tests {
             builder.token_with_trivia(
                 RawLanguageKind::STRING_TOKEN,
                 "//group\n\"warn_here\"",
-                &[
-                    TriviaPiece::new(TriviaPieceKind::SingleLineComment, 7),
-                    TriviaPiece::new(TriviaPieceKind::Newline, 1),
-                ],
+                &[TriviaPiece::single_line_comment(7), TriviaPiece::newline(1)],
                 &[],
             );
             builder.finish_node();
@@ -262,7 +259,7 @@ mod tests {
                 RawLanguageKind::SEMICOLON_TOKEN,
                 ";\n",
                 &[],
-                &[TriviaPiece::new(TriviaPieceKind::Newline, 1)],
+                &[TriviaPiece::newline(1)],
             );
 
             builder.start_node(RawLanguageKind::LITERAL_EXPRESSION);
@@ -270,8 +267,8 @@ mod tests {
                 RawLanguageKind::STRING_TOKEN,
                 "//group/rule\n\"warn_here\"",
                 &[
-                    TriviaPiece::new(TriviaPieceKind::SingleLineComment, 12),
-                    TriviaPiece::new(TriviaPieceKind::Newline, 1),
+                    TriviaPiece::single_line_comment(12),
+                    TriviaPiece::newline(1),
                 ],
                 &[],
             );
@@ -281,7 +278,7 @@ mod tests {
                 RawLanguageKind::SEMICOLON_TOKEN,
                 ";\n",
                 &[],
-                &[TriviaPiece::new(TriviaPieceKind::Newline, 1)],
+                &[TriviaPiece::newline(1)],
             );
 
             builder.start_node(RawLanguageKind::LITERAL_EXPRESSION);
@@ -289,8 +286,8 @@ mod tests {
                 RawLanguageKind::STRING_TOKEN,
                 "//unknown_group\n\"warn_here\"",
                 &[
-                    TriviaPiece::new(TriviaPieceKind::SingleLineComment, 15),
-                    TriviaPiece::new(TriviaPieceKind::Newline, 1),
+                    TriviaPiece::single_line_comment(15),
+                    TriviaPiece::newline(1),
                 ],
                 &[],
             );
@@ -300,7 +297,7 @@ mod tests {
                 RawLanguageKind::SEMICOLON_TOKEN,
                 ";\n",
                 &[],
-                &[TriviaPiece::new(TriviaPieceKind::Newline, 1)],
+                &[TriviaPiece::newline(1)],
             );
 
             builder.start_node(RawLanguageKind::LITERAL_EXPRESSION);
@@ -308,8 +305,8 @@ mod tests {
                 RawLanguageKind::STRING_TOKEN,
                 "//group/unknown_rule\n\"warn_here\"",
                 &[
-                    TriviaPiece::new(TriviaPieceKind::SingleLineComment, 20),
-                    TriviaPiece::new(TriviaPieceKind::Newline, 1),
+                    TriviaPiece::single_line_comment(20),
+                    TriviaPiece::newline(1),
                 ],
                 &[],
             );
@@ -319,17 +316,17 @@ mod tests {
                 RawLanguageKind::SEMICOLON_TOKEN,
                 ";\n",
                 &[],
-                &[TriviaPiece::new(TriviaPieceKind::Newline, 1)],
+                &[TriviaPiece::newline(1)],
             );
 
             builder.token_with_trivia(
                 RawLanguageKind::SEMICOLON_TOKEN,
                 "//group/rule\n;\n",
                 &[
-                    TriviaPiece::new(TriviaPieceKind::SingleLineComment, 12),
-                    TriviaPiece::new(TriviaPieceKind::Newline, 1),
+                    TriviaPiece::single_line_comment(12),
+                    TriviaPiece::newline(1),
                 ],
-                &[TriviaPiece::new(TriviaPieceKind::Newline, 1)],
+                &[TriviaPiece::newline(1)],
             );
 
             builder.finish_node();

--- a/crates/biome_js_analyze/src/ast_utils.rs
+++ b/crates/biome_js_analyze/src/ast_utils.rs
@@ -1,4 +1,4 @@
-use biome_js_syntax::{JsLanguage, JsSyntaxNode, JsSyntaxToken, TriviaPieceKind};
+use biome_js_syntax::{JsLanguage, JsSyntaxNode, JsSyntaxToken};
 use biome_rowan::{AstNode, TriviaPiece};
 
 /// Add any leading and trailing trivia from given source node to the token.
@@ -36,7 +36,7 @@ fn add_leading_trivia(trivia: &mut Vec<TriviaPiece>, text: &mut String, node: &J
     };
     if !token.kind().is_punct() && token.trailing_trivia().pieces().next().is_none() {
         text.push(' ');
-        trivia.push(TriviaPiece::new(TriviaPieceKind::Whitespace, 1));
+        trivia.push(TriviaPiece::whitespace(1));
     }
 }
 
@@ -56,6 +56,6 @@ fn add_trailing_trivia(trivia: &mut Vec<TriviaPiece>, text: &mut String, node: &
     };
     if !token.kind().is_punct() && token.leading_trivia().pieces().next().is_none() {
         text.push(' ');
-        trivia.push(TriviaPiece::new(TriviaPieceKind::Whitespace, 1));
+        trivia.push(TriviaPiece::whitespace(1));
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_consistent_array_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_consistent_array_type.rs
@@ -336,7 +336,7 @@ fn transform_array_element_type(param: AnyTsType, array_kind: TsArrayKind) -> Op
                 JsSyntaxKind::TS_READONLY_MODIFIER,
                 "readonly ",
                 [],
-                [TriviaPiece::new(TriviaPieceKind::Whitespace, 1)],
+                [TriviaPiece::whitespace(1)],
             );
 
             // Modify `ReadonlyArray<ReadonlyArray<T>>` to `readonly (readonly T[])[]`

--- a/crates/biome_js_analyze/src/lint/style/use_shorthand_array_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_shorthand_array_type.rs
@@ -5,7 +5,7 @@ use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make;
 use biome_js_syntax::{
-    AnyTsType, JsSyntaxKind, JsSyntaxToken, TriviaPieceKind, TsReferenceType, TsTypeArguments, T,
+    AnyTsType, JsSyntaxKind, JsSyntaxToken, TsReferenceType, TsTypeArguments, T,
 };
 use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, TriviaPiece};
 
@@ -236,11 +236,7 @@ fn convert_to_array_type(
             length => {
                 let ts_union_type_builder = make::ts_union_type(make::ts_union_type_variant_list(
                     types_array,
-                    (0..length - 1).map(|_| {
-                        make::token(T![|])
-                            .with_leading_trivia([(TriviaPieceKind::Whitespace, " ")])
-                            .with_trailing_trivia([(TriviaPieceKind::Whitespace, " ")])
-                    }),
+                    (0..length - 1).map(|_| make::token_decorated_with_space(T![|])),
                 ));
                 return Some(AnyTsType::TsUnionType(ts_union_type_builder.build()));
             }

--- a/crates/biome_js_analyze/src/lint/style/use_shorthand_array_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_shorthand_array_type.rs
@@ -185,7 +185,7 @@ fn convert_to_array_type(
                             JsSyntaxKind::TS_READONLY_MODIFIER,
                             "readonly ",
                             [],
-                            [TriviaPiece::new(TriviaPieceKind::Whitespace, 1)],
+                            [TriviaPiece::whitespace(1)],
                         );
 
                         // Modify `ReadonlyArray<ReadonlyArray<T>>` to `readonly (readonly T[])[]`

--- a/crates/biome_js_factory/src/make.rs
+++ b/crates/biome_js_factory/src/make.rs
@@ -1,8 +1,6 @@
 use std::fmt::Display;
 
-use biome_js_syntax::{
-    AnyJsExpression, JsParenthesizedExpression, JsSyntaxKind, JsSyntaxToken, TriviaPieceKind,
-};
+use biome_js_syntax::{AnyJsExpression, JsParenthesizedExpression, JsSyntaxKind, JsSyntaxToken};
 use biome_rowan::TriviaPiece;
 
 pub use crate::generated::node_factory::*;
@@ -92,8 +90,8 @@ pub fn token_decorated_with_space(kind: JsSyntaxKind) -> JsSyntaxToken {
         JsSyntaxToken::new_detached(
             kind,
             &format!(" {text} "),
-            [TriviaPiece::new(TriviaPieceKind::Whitespace, 1)],
-            [TriviaPiece::new(TriviaPieceKind::Whitespace, 1)],
+            [TriviaPiece::whitespace(1)],
+            [TriviaPiece::whitespace(1)],
         )
     } else {
         panic!("token kind {kind:?} cannot be transformed to text")

--- a/crates/biome_rowan/src/cursor/trivia.rs
+++ b/crates/biome_rowan/src/cursor/trivia.rs
@@ -158,7 +158,7 @@ impl ExactSizeIterator for SyntaxTriviaPiecesIterator {}
 #[cfg(test)]
 mod tests {
     use crate::raw_language::{RawLanguage, RawLanguageKind, RawSyntaxTreeBuilder};
-    use crate::{SyntaxNode, TriviaPiece, TriviaPieceKind};
+    use crate::{SyntaxNode, TriviaPiece};
 
     #[test]
     fn trivia_text() {
@@ -167,8 +167,8 @@ mod tests {
         builder.token_with_trivia(
             RawLanguageKind::WHITESPACE,
             "\t let \t\t",
-            &[TriviaPiece::new(TriviaPieceKind::Whitespace, 2)],
-            &[TriviaPiece::new(TriviaPieceKind::Whitespace, 3)],
+            &[TriviaPiece::whitespace(2)],
+            &[TriviaPiece::whitespace(3)],
         );
         builder.finish_node();
 


### PR DESCRIPTION
## Summary
Replace instances of `TriviaPiece::new(TriviaPieceKind::whitespace, 1)` with `TriviaPiece::whitespace(1)`.

Please feel free to close this PR if the changes like these are not warranted.

## Test Plan

No functionality changes
