### PR TITLE
fix(lint/noUndeclaredVariables): don't report variable-only/type-only exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,9 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [noUndeclaredVariables](https://biomejs.dev/linter/rules/no-undeclared-variables/) no longer reports variable-only and type-only exports ([#2637](https://github.com/biomejs/biome/issues/2637)).
+  Contributed by @Conaclos
+
 - [noUnusedVariables] no longer crash Biome when encountering a malformed conditional type ([#1695](https://github.com/biomejs/biome/issues/1695)).
   Contributed by @Conaclos
 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validExportDefaultInAmbientModule.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validExportDefaultInAmbientModule.ts
@@ -1,0 +1,5 @@
+// Issue https://github.com/biomejs/biome/issues/2637
+declare module 'test-module' {
+    const foo: any;
+    export { foo };
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validExportDefaultInAmbientModule.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validExportDefaultInAmbientModule.ts.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validExportDefaultInAmbientModule.ts
+---
+# Input
+```ts
+// Issue https://github.com/biomejs/biome/issues/2637
+declare module 'test-module' {
+    const foo: any;
+    export { foo };
+}
+```


### PR DESCRIPTION
## Summary

Fix #2637

When the semantic model finds an export it issues two references: a value reference and a type reference.
Only one reference get resolved when the referenced entity is only a variable (value) or only a type.
The remaining reference is forwarded to the parent scope and eventually marked as unresolved.
This is an erroneous behavior for two reasons:
1. An `export` cannot export a variable/type declared in a parent scope.
2. An `export` doesn't need to export both a variable and a type.

When we discover an `export` that exports a type or a variable, we no longer forward and mark as unresolved the dual variable/type.

## Test Plan

I added a test.