### PR TITLE
fix(snippet): should emit only one diagnostic

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_undefined_initialization.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_undefined_initialization.rs
@@ -25,7 +25,7 @@ declare_rule! {
     /// var a = undefined;
     /// ```
     /// ```js,expect_diagnostic
-    /// let b = undefined, c = 1, d = undefined;
+    /// let b = undefined, c = 1, d = 2;
     /// ```
     /// ```js,expect_diagnostic
     /// for (let i = 0; i < 100; i++) {


### PR DESCRIPTION
## Summary

[A snippet must emit **only ONE** diagnostic.](https://github.com/biomejs/biome/blob/main/crates/biome_analyze/CONTRIBUTING.md#:~:text=A%20snippet%20must%20emit%20only%20ONE%20diagnostic.)

https://github.com/biomejs/biome/blob/8f9c14a275d712c3f8a7de384c00bf507f410acf/crates/biome_analyze/CONTRIBUTING.md?plain=1#L183

## Test Plan

-
