### PR TITLE
ci: accept prefix 'revert:' in PR titles

### DIFF
--- a/.github/workflows/pull_request_title_lint.yaml
+++ b/.github/workflows/pull_request_title_lint.yaml
@@ -32,6 +32,7 @@ jobs:
             perf
             refactor
             release
+            revert
             test
           # Configure that a scope must always be provided.
           requireScope: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -278,6 +278,7 @@ The following commit prefixes are supported:
 - `perf:`, project performance
 - `refactor:`, refactor of the code without change in functionality
 - `release:`, release of a new version
+- `revert:`, revert a previous change
 - `test:`, a test update
 
 Below are examples of well-formatted commits:


### PR DESCRIPTION
## Summary

Accept `revert:` as PR type.

## Test Plan

CI must pass
