### PR TITLE
fix: `noUndeclaredVariables` no longer errors on `this` in JSX tags (attempt 2)

### DIFF
--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -187,7 +187,9 @@ impl Rule for NoUselessFragments {
                     AnyJsxElementName::JsxReferenceIdentifier(identifier) => {
                         jsx_reference_identifier_is_fragment(&identifier, model)?
                     }
-                    AnyJsxElementName::JsxName(_) | AnyJsxElementName::JsxNamespaceName(_) => false,
+                    AnyJsxElementName::JsThisExpression(_)
+                    | AnyJsxElementName::JsxName(_)
+                    | AnyJsxElementName::JsxNamespaceName(_) => false,
                 };
 
                 if is_valid_react_fragment {

--- a/crates/biome_js_analyze/src/lint/style/use_fragment_syntax.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_fragment_syntax.rs
@@ -55,7 +55,9 @@ impl Rule for UseFragmentSyntax {
             AnyJsxElementName::JsxReferenceIdentifier(identifier) => {
                 jsx_reference_identifier_is_fragment(&identifier, model)?
             }
-            AnyJsxElementName::JsxName(_) | AnyJsxElementName::JsxNamespaceName(_) => false,
+            AnyJsxElementName::JsThisExpression(_)
+            | AnyJsxElementName::JsxName(_)
+            | AnyJsxElementName::JsxNamespaceName(_) => false,
         };
 
         if maybe_invalid && opening_element.attributes().is_empty() {

--- a/crates/biome_js_formatter/src/jsx/any/element_name.rs
+++ b/crates/biome_js_formatter/src/jsx/any/element_name.rs
@@ -8,6 +8,7 @@ impl FormatRule<AnyJsxElementName> for FormatAnyJsxElementName {
     type Context = JsFormatContext;
     fn fmt(&self, node: &AnyJsxElementName, f: &mut JsFormatter) -> FormatResult<()> {
         match node {
+            AnyJsxElementName::JsThisExpression(node) => node.format().fmt(f),
             AnyJsxElementName::JsxMemberName(node) => node.format().fmt(f),
             AnyJsxElementName::JsxName(node) => node.format().fmt(f),
             AnyJsxElementName::JsxNamespaceName(node) => node.format().fmt(f),

--- a/crates/biome_js_formatter/src/jsx/any/object_name.rs
+++ b/crates/biome_js_formatter/src/jsx/any/object_name.rs
@@ -8,6 +8,7 @@ impl FormatRule<AnyJsxObjectName> for FormatAnyJsxObjectName {
     type Context = JsFormatContext;
     fn fmt(&self, node: &AnyJsxObjectName, f: &mut JsFormatter) -> FormatResult<()> {
         match node {
+            AnyJsxObjectName::JsThisExpression(node) => node.format().fmt(f),
             AnyJsxObjectName::JsxMemberName(node) => node.format().fmt(f),
             AnyJsxObjectName::JsxNamespaceName(node) => node.format().fmt(f),
             AnyJsxObjectName::JsxReferenceIdentifier(node) => node.format().fmt(f),

--- a/crates/biome_js_parser/test_data/inline/ok/jsx_member_element_name.jsx
+++ b/crates/biome_js_parser/test_data/inline/ok/jsx_member_element_name.jsx
@@ -1,3 +1,4 @@
 <a.b.c.d></a.b.c.d>;
 <a-b.c></a-b.c>;
 <Abcd></Abcd>;
+<this.foo></this.foo>;

--- a/crates/biome_js_parser/test_data/inline/ok/jsx_member_element_name.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/jsx_member_element_name.rast
@@ -126,15 +126,52 @@ JsModule {
             },
             semicolon_token: SEMICOLON@51..52 ";" [] [],
         },
+        JsExpressionStatement {
+            expression: JsxTagExpression {
+                tag: JsxElement {
+                    opening_element: JsxOpeningElement {
+                        l_angle_token: L_ANGLE@52..54 "<" [Newline("\n")] [],
+                        name: JsxMemberName {
+                            object: JsThisExpression {
+                                this_token: THIS_KW@54..58 "this" [] [],
+                            },
+                            dot_token: DOT@58..59 "." [] [],
+                            member: JsName {
+                                value_token: IDENT@59..62 "foo" [] [],
+                            },
+                        },
+                        type_arguments: missing (optional),
+                        attributes: JsxAttributeList [],
+                        r_angle_token: R_ANGLE@62..63 ">" [] [],
+                    },
+                    children: JsxChildList [],
+                    closing_element: JsxClosingElement {
+                        l_angle_token: L_ANGLE@63..64 "<" [] [],
+                        slash_token: SLASH@64..65 "/" [] [],
+                        name: JsxMemberName {
+                            object: JsThisExpression {
+                                this_token: THIS_KW@65..69 "this" [] [],
+                            },
+                            dot_token: DOT@69..70 "." [] [],
+                            member: JsName {
+                                value_token: IDENT@70..73 "foo" [] [],
+                            },
+                        },
+                        r_angle_token: R_ANGLE@73..74 ">" [] [],
+                    },
+                },
+            },
+            semicolon_token: SEMICOLON@74..75 ";" [] [],
+        },
     ],
-    eof_token: EOF@52..53 "" [Newline("\n")] [],
+    eof_token: EOF@75..76 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..53
+0: JS_MODULE@0..76
   0: (empty)
   1: (empty)
   2: JS_DIRECTIVE_LIST@0..0
-  3: JS_MODULE_ITEM_LIST@0..52
+  3: JS_MODULE_ITEM_LIST@0..75
     0: JS_EXPRESSION_STATEMENT@0..20
       0: JSX_TAG_EXPRESSION@0..19
         0: JSX_ELEMENT@0..19
@@ -221,4 +258,30 @@ JsModule {
               0: JSX_IDENT@46..50 "Abcd" [] []
             3: R_ANGLE@50..51 ">" [] []
       1: SEMICOLON@51..52 ";" [] []
-  4: EOF@52..53 "" [Newline("\n")] []
+    3: JS_EXPRESSION_STATEMENT@52..75
+      0: JSX_TAG_EXPRESSION@52..74
+        0: JSX_ELEMENT@52..74
+          0: JSX_OPENING_ELEMENT@52..63
+            0: L_ANGLE@52..54 "<" [Newline("\n")] []
+            1: JSX_MEMBER_NAME@54..62
+              0: JS_THIS_EXPRESSION@54..58
+                0: THIS_KW@54..58 "this" [] []
+              1: DOT@58..59 "." [] []
+              2: JS_NAME@59..62
+                0: IDENT@59..62 "foo" [] []
+            2: (empty)
+            3: JSX_ATTRIBUTE_LIST@62..62
+            4: R_ANGLE@62..63 ">" [] []
+          1: JSX_CHILD_LIST@63..63
+          2: JSX_CLOSING_ELEMENT@63..74
+            0: L_ANGLE@63..64 "<" [] []
+            1: SLASH@64..65 "/" [] []
+            2: JSX_MEMBER_NAME@65..73
+              0: JS_THIS_EXPRESSION@65..69
+                0: THIS_KW@65..69 "this" [] []
+              1: DOT@69..70 "." [] []
+              2: JS_NAME@70..73
+                0: IDENT@70..73 "foo" [] []
+            3: R_ANGLE@73..74 ">" [] []
+      1: SEMICOLON@74..75 ";" [] []
+  4: EOF@75..76 "" [Newline("\n")] []

--- a/crates/biome_js_syntax/src/generated/nodes.rs
+++ b/crates/biome_js_syntax/src/generated/nodes.rs
@@ -15504,12 +15504,19 @@ impl AnyJsxChild {
 #[derive(Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum AnyJsxElementName {
+    JsThisExpression(JsThisExpression),
     JsxMemberName(JsxMemberName),
     JsxName(JsxName),
     JsxNamespaceName(JsxNamespaceName),
     JsxReferenceIdentifier(JsxReferenceIdentifier),
 }
 impl AnyJsxElementName {
+    pub fn as_js_this_expression(&self) -> Option<&JsThisExpression> {
+        match &self {
+            AnyJsxElementName::JsThisExpression(item) => Some(item),
+            _ => None,
+        }
+    }
     pub fn as_jsx_member_name(&self) -> Option<&JsxMemberName> {
         match &self {
             AnyJsxElementName::JsxMemberName(item) => Some(item),
@@ -15558,11 +15565,18 @@ impl AnyJsxName {
 #[derive(Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum AnyJsxObjectName {
+    JsThisExpression(JsThisExpression),
     JsxMemberName(JsxMemberName),
     JsxNamespaceName(JsxNamespaceName),
     JsxReferenceIdentifier(JsxReferenceIdentifier),
 }
 impl AnyJsxObjectName {
+    pub fn as_js_this_expression(&self) -> Option<&JsThisExpression> {
+        match &self {
+            AnyJsxObjectName::JsThisExpression(item) => Some(item),
+            _ => None,
+        }
+    }
     pub fn as_jsx_member_name(&self) -> Option<&JsxMemberName> {
         match &self {
             AnyJsxObjectName::JsxMemberName(item) => Some(item),
@@ -34747,6 +34761,11 @@ impl From<AnyJsxChild> for SyntaxElement {
         node.into()
     }
 }
+impl From<JsThisExpression> for AnyJsxElementName {
+    fn from(node: JsThisExpression) -> AnyJsxElementName {
+        AnyJsxElementName::JsThisExpression(node)
+    }
+}
 impl From<JsxMemberName> for AnyJsxElementName {
     fn from(node: JsxMemberName) -> AnyJsxElementName {
         AnyJsxElementName::JsxMemberName(node)
@@ -34769,18 +34788,24 @@ impl From<JsxReferenceIdentifier> for AnyJsxElementName {
 }
 impl AstNode for AnyJsxElementName {
     type Language = Language;
-    const KIND_SET: SyntaxKindSet<Language> = JsxMemberName::KIND_SET
+    const KIND_SET: SyntaxKindSet<Language> = JsThisExpression::KIND_SET
+        .union(JsxMemberName::KIND_SET)
         .union(JsxName::KIND_SET)
         .union(JsxNamespaceName::KIND_SET)
         .union(JsxReferenceIdentifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
-            JSX_MEMBER_NAME | JSX_NAME | JSX_NAMESPACE_NAME | JSX_REFERENCE_IDENTIFIER
+            JS_THIS_EXPRESSION
+                | JSX_MEMBER_NAME
+                | JSX_NAME
+                | JSX_NAMESPACE_NAME
+                | JSX_REFERENCE_IDENTIFIER
         )
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
+            JS_THIS_EXPRESSION => AnyJsxElementName::JsThisExpression(JsThisExpression { syntax }),
             JSX_MEMBER_NAME => AnyJsxElementName::JsxMemberName(JsxMemberName { syntax }),
             JSX_NAME => AnyJsxElementName::JsxName(JsxName { syntax }),
             JSX_NAMESPACE_NAME => AnyJsxElementName::JsxNamespaceName(JsxNamespaceName { syntax }),
@@ -34793,6 +34818,7 @@ impl AstNode for AnyJsxElementName {
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
+            AnyJsxElementName::JsThisExpression(it) => &it.syntax,
             AnyJsxElementName::JsxMemberName(it) => &it.syntax,
             AnyJsxElementName::JsxName(it) => &it.syntax,
             AnyJsxElementName::JsxNamespaceName(it) => &it.syntax,
@@ -34801,6 +34827,7 @@ impl AstNode for AnyJsxElementName {
     }
     fn into_syntax(self) -> SyntaxNode {
         match self {
+            AnyJsxElementName::JsThisExpression(it) => it.syntax,
             AnyJsxElementName::JsxMemberName(it) => it.syntax,
             AnyJsxElementName::JsxName(it) => it.syntax,
             AnyJsxElementName::JsxNamespaceName(it) => it.syntax,
@@ -34811,6 +34838,7 @@ impl AstNode for AnyJsxElementName {
 impl std::fmt::Debug for AnyJsxElementName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            AnyJsxElementName::JsThisExpression(it) => std::fmt::Debug::fmt(it, f),
             AnyJsxElementName::JsxMemberName(it) => std::fmt::Debug::fmt(it, f),
             AnyJsxElementName::JsxName(it) => std::fmt::Debug::fmt(it, f),
             AnyJsxElementName::JsxNamespaceName(it) => std::fmt::Debug::fmt(it, f),
@@ -34821,6 +34849,7 @@ impl std::fmt::Debug for AnyJsxElementName {
 impl From<AnyJsxElementName> for SyntaxNode {
     fn from(n: AnyJsxElementName) -> SyntaxNode {
         match n {
+            AnyJsxElementName::JsThisExpression(it) => it.into(),
             AnyJsxElementName::JsxMemberName(it) => it.into(),
             AnyJsxElementName::JsxName(it) => it.into(),
             AnyJsxElementName::JsxNamespaceName(it) => it.into(),
@@ -34893,6 +34922,11 @@ impl From<AnyJsxName> for SyntaxElement {
         node.into()
     }
 }
+impl From<JsThisExpression> for AnyJsxObjectName {
+    fn from(node: JsThisExpression) -> AnyJsxObjectName {
+        AnyJsxObjectName::JsThisExpression(node)
+    }
+}
 impl From<JsxMemberName> for AnyJsxObjectName {
     fn from(node: JsxMemberName) -> AnyJsxObjectName {
         AnyJsxObjectName::JsxMemberName(node)
@@ -34910,17 +34944,19 @@ impl From<JsxReferenceIdentifier> for AnyJsxObjectName {
 }
 impl AstNode for AnyJsxObjectName {
     type Language = Language;
-    const KIND_SET: SyntaxKindSet<Language> = JsxMemberName::KIND_SET
+    const KIND_SET: SyntaxKindSet<Language> = JsThisExpression::KIND_SET
+        .union(JsxMemberName::KIND_SET)
         .union(JsxNamespaceName::KIND_SET)
         .union(JsxReferenceIdentifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
-            JSX_MEMBER_NAME | JSX_NAMESPACE_NAME | JSX_REFERENCE_IDENTIFIER
+            JS_THIS_EXPRESSION | JSX_MEMBER_NAME | JSX_NAMESPACE_NAME | JSX_REFERENCE_IDENTIFIER
         )
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
+            JS_THIS_EXPRESSION => AnyJsxObjectName::JsThisExpression(JsThisExpression { syntax }),
             JSX_MEMBER_NAME => AnyJsxObjectName::JsxMemberName(JsxMemberName { syntax }),
             JSX_NAMESPACE_NAME => AnyJsxObjectName::JsxNamespaceName(JsxNamespaceName { syntax }),
             JSX_REFERENCE_IDENTIFIER => {
@@ -34932,6 +34968,7 @@ impl AstNode for AnyJsxObjectName {
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
+            AnyJsxObjectName::JsThisExpression(it) => &it.syntax,
             AnyJsxObjectName::JsxMemberName(it) => &it.syntax,
             AnyJsxObjectName::JsxNamespaceName(it) => &it.syntax,
             AnyJsxObjectName::JsxReferenceIdentifier(it) => &it.syntax,
@@ -34939,6 +34976,7 @@ impl AstNode for AnyJsxObjectName {
     }
     fn into_syntax(self) -> SyntaxNode {
         match self {
+            AnyJsxObjectName::JsThisExpression(it) => it.syntax,
             AnyJsxObjectName::JsxMemberName(it) => it.syntax,
             AnyJsxObjectName::JsxNamespaceName(it) => it.syntax,
             AnyJsxObjectName::JsxReferenceIdentifier(it) => it.syntax,
@@ -34948,6 +34986,7 @@ impl AstNode for AnyJsxObjectName {
 impl std::fmt::Debug for AnyJsxObjectName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            AnyJsxObjectName::JsThisExpression(it) => std::fmt::Debug::fmt(it, f),
             AnyJsxObjectName::JsxMemberName(it) => std::fmt::Debug::fmt(it, f),
             AnyJsxObjectName::JsxNamespaceName(it) => std::fmt::Debug::fmt(it, f),
             AnyJsxObjectName::JsxReferenceIdentifier(it) => std::fmt::Debug::fmt(it, f),
@@ -34957,6 +34996,7 @@ impl std::fmt::Debug for AnyJsxObjectName {
 impl From<AnyJsxObjectName> for SyntaxNode {
     fn from(n: AnyJsxObjectName) -> SyntaxNode {
         match n {
+            AnyJsxObjectName::JsThisExpression(it) => it.into(),
             AnyJsxObjectName::JsxMemberName(it) => it.into(),
             AnyJsxObjectName::JsxNamespaceName(it) => it.into(),
             AnyJsxObjectName::JsxReferenceIdentifier(it) => it.into(),

--- a/crates/biome_js_syntax/src/jsx_ext.rs
+++ b/crates/biome_js_syntax/src/jsx_ext.rs
@@ -319,6 +319,7 @@ impl AnyJsxElementName {
             AnyJsxElementName::JsxName(name) => name.value_token().ok(),
             AnyJsxElementName::JsxNamespaceName(name) => name.name().ok()?.value_token().ok(),
             AnyJsxElementName::JsxReferenceIdentifier(name) => name.value_token().ok(),
+            AnyJsxElementName::JsThisExpression(name) => name.this_token().ok(),
         }
     }
 }

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -2294,12 +2294,14 @@ JsxNamespaceName =
 
 AnyJsxElementName =
 	JsxName
+	| JsThisExpression
 	| JsxReferenceIdentifier
 	| JsxMemberName
 	| JsxNamespaceName
 
 AnyJsxObjectName =
 	JsxReferenceIdentifier
+	| JsThisExpression
 	| JsxMemberName
 	| JsxNamespaceName
 


### PR DESCRIPTION
## Summary

Attempt 2 at fixing #2636. Relates to #2647.

I've added `JsThisExpression` as a new child node of `AnyJsxElementName`/`AnyJsxObjectName`, and changed the parser to no longer call `p.re_lex(JsReLexContext::JsxIdentifier);` when encountering a `THIS_KW`.

@Conaclos 

## Test Plan

I've added additional tests. It now seems to be correctly turning `<this.foo />` into:

```
                        name: JsxMemberName {
                            object: JsThisExpression {
                                this_token: THIS_KW@65..69 "this" [] [],
                            },
                            dot_token: DOT@69..70 "." [] [],
                            member: JsName {
                                value_token: IDENT@70..73 "foo" [] [],
                            },
                        },
```
