### PR TITLE
build(deps): update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,9 +1215,9 @@ checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "codspeed"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "735f16ee0fc63cb90596cd7b57ce481522adfe1714f95bc04a94d4f4b0a06a6d"
+checksum = "3a104ac948e0188b921eb3fcbdd55dcf62e542df4c7ab7e660623f6288302089"
 dependencies = [
  "colored",
  "libc",
@@ -1226,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-criterion-compat"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572ca9c8ad460591b40aad63c99d6746aa3c532f979175344eb015389499860c"
+checksum = "722c36bdc62d9436d027256ce2627af81ac7a596dfc7d13d849d0d212448d7fe"
 dependencies = [
  "codspeed",
  "colored",
@@ -1800,11 +1800,11 @@ dependencies = [
 
 [[package]]
 name = "globwalk"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "ignore",
  "walkdir",
 ]
@@ -2086,9 +2086,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libgit2-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,18 +105,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
-
-[[package]]
-name = "basic-toml"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0de75129aa8d0cceaf750b89013f0e08804d6ec61416da787b35ad0d7cddf1"
-dependencies = [
- "serde",
-]
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "biome_analyze"
@@ -1127,15 +1118,15 @@ checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "bytemuck"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1591,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "expect-test"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d9eafeadd538e68fb28016364c9732d78e420b9ff8853fa5e4058861e9f8d3"
+checksum = "9e0be0a561335815e06dab7c62e50353134c796e7a6155402a64bcff66b6a5e0"
 dependencies = [
  "dissimilar",
  "once_cell",
@@ -1866,9 +1857,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.2"
+version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
  "byteorder",
  "num-traits",
@@ -2084,9 +2075,9 @@ checksum = "c3d129799327c8f80861e467c59b825ba24c277dba6ad0d71a141dc98f9e04ee"
 
 [[package]]
 name = "json_comments"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ee439ee368ba4a77ac70d04f14015415af8600d6c894dc1f11bd79758c57d5"
+checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
 
 [[package]]
 name = "lazy_static"
@@ -2114,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.35"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+checksum = "81eb4061c0582dedea1cbc7aff2240300dd6982e0239d1c99e65c1dbf4a30ba7"
 dependencies = [
  "cc",
  "libc",
@@ -2203,9 +2194,9 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -2235,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.39"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+checksum = "9f41a2280ded0da56c8cf898babb86e8f10651a34adcfff190ae9a1159c6908d"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -2415,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2776,12 +2767,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
-name = "retain_mut"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c31b5c4033f8fdde8700e4657be2c497e7288f01515be52168c631e2e4d4086"
-
-[[package]]
 name = "rgb"
 version = "0.8.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,13 +2792,12 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0fb5e826a8bde011ecae6a8539dd333884335c57ff0f003fbe27c25bbe8f71"
+checksum = "b26f4c25a604fcb3a1bcd96dd6ba37c93840de95de8198d94c0d571a74a804d1"
 dependencies = [
  "bytemuck",
  "byteorder",
- "retain_mut",
 ]
 
 [[package]]
@@ -2994,6 +2978,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_test"
 version = "1.0.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3165,9 +3158,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
@@ -3328,6 +3321,40 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+dependencies = [
+ "indexmap 2.2.3",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3493,17 +3520,17 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.80"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501dbdbb99861e4ab6b60eb6a7493956a9defb644fd034bc4a5ef27c693c8a3a"
+checksum = "8ad7eb6319ebadebca3dacf1f85a93bc54b73dd81b9036795f73de7ddfe27d5a"
 dependencies = [
- "basic-toml",
  "glob",
  "once_cell",
  "serde",
  "serde_derive",
  "serde_json",
  "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -3550,15 +3577,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unreachable"
@@ -3583,9 +3610,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.6"
+version = "2.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
+checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
 dependencies = [
  "base64",
  "flate2",
@@ -3982,6 +4009,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "winnow"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "xorfilter-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,6 @@ dependencies = [
  "countme",
  "hashbrown 0.12.3",
  "iai",
- "memoffset",
  "quickcheck",
  "quickcheck_macros",
  "rustc-hash",
@@ -2191,15 +2190,6 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "miette"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,9 +2165,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lsp-types"
-version = "0.94.0"
+version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b63735a13a1f9cd4f4835223d828ed9c2e35c8c5e61837774399f558b6a1237"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
 dependencies = [
  "bitflags 1.3.2",
  "serde",
@@ -3028,9 +3028,9 @@ dependencies = [
 
 [[package]]
 name = "similar-asserts"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf644ad016b75129f01a34a355dcb8d66a5bc803e417c7a77cc5d5ee9fa0f18"
+checksum = "e041bb827d1bfca18f213411d51b665309f1afb37a04a5d1464530e13779fc0f"
 dependencies = [
  "console",
  "similar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,10 +174,12 @@ similar            = "2.5.0"
 slotmap            = "1.0.7"
 smallvec           = { version = "1.10.0", features = ["union", "const_new"] }
 syn                = "1.0.109"
+termcolor          = "1.4.1"
 tokio              = { version = "1.36.0" }
 tracing            = { version = "0.1.37", default-features = false, features = ["std"] }
 tracing-subscriber = "0.3.18"
 unicode-bom        = "2.0.3"
+unicode-width      = "0.1.12"
 
 [profile.dev.package.biome_wasm]
 debug     = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ quote              = "1.0.36"
 rayon              = "1.8.1"
 regex              = "1.10.4"
 rustc-hash         = "1.1.0"
-schemars           = { version = "0.8.17" }
+schemars           = "0.8.17"
 serde              = { version = "1.0.199", features = ["derive"] }
 serde_json         = "1.0.116"
 similar            = "2.5.0"
@@ -175,7 +175,7 @@ slotmap            = "1.0.7"
 smallvec           = { version = "1.10.0", features = ["union", "const_new"] }
 syn                = "1.0.109"
 termcolor          = "1.4.1"
-tokio              = { version = "1.36.0" }
+tokio              = "1.36.0"
 tracing            = { version = "0.1.37", default-features = false, features = ["std"] }
 tracing-subscriber = "0.3.18"
 unicode-bom        = "2.0.3"

--- a/crates/biome_aria_metadata/Cargo.toml
+++ b/crates/biome_aria_metadata/Cargo.toml
@@ -17,7 +17,7 @@ version              = "0.5.7"
 
 [build-dependencies]
 biome_string_case = { workspace = true }
-proc-macro2       = { version = "1.0.63", features = ["span-locations"] }
+proc-macro2       = { workspace = true, features = ["span-locations"] }
 quote             = { workspace = true }
 
 [lints]

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -55,7 +55,7 @@ tracing-subscriber       = { workspace = true, features = ["env-filter", "json"]
 tracing-tree             = "0.3.0"
 
 [target.'cfg(unix)'.dependencies]
-libc  = "0.2.127"
+libc  = "0.2.154"
 tokio = { workspace = true, features = ["process"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -40,7 +40,7 @@ biome_text_edit          = { workspace = true }
 bpaf                     = { workspace = true, features = ["bright-color"] }
 crossbeam                = { workspace = true }
 dashmap                  = { workspace = true }
-hdrhistogram             = { version = "7.5.0", default-features = false }
+hdrhistogram             = { version = "7.5.4", default-features = false }
 indexmap                 = { workspace = true }
 lazy_static              = { workspace = true }
 rayon                    = { workspace = true }
@@ -59,7 +59,7 @@ libc  = "0.2.127"
 tokio = { workspace = true, features = ["process"] }
 
 [target.'cfg(windows)'.dependencies]
-mimalloc = "0.1.29"
+mimalloc = "0.1.41"
 
 [target.'cfg(all(target_family="unix", not(all(target_arch = "aarch64", target_env = "musl"))))'.dependencies]
 tikv-jemallocator = "0.5.1"

--- a/crates/biome_console/Cargo.toml
+++ b/crates/biome_console/Cargo.toml
@@ -17,12 +17,12 @@ biome_markup         = { workspace = true }
 biome_text_size      = { workspace = true }
 schemars             = { workspace = true, optional = true }
 serde                = { workspace = true, optional = true, features = ["derive"] }
-termcolor            = "1.1.2"
-unicode-segmentation = "1.10.1"
-unicode-width        = "0.1.9"
+termcolor            = { workspace = true }
+unicode-segmentation = "1.11.0"
+unicode-width        = { workspace = true }
 
 [dev-dependencies]
-trybuild = "1.0"
+trybuild = "1.0.91"
 
 [features]
 serde_markup = ["serde", "schemars"]

--- a/crates/biome_diagnostics/Cargo.toml
+++ b/crates/biome_diagnostics/Cargo.toml
@@ -27,7 +27,7 @@ name = "serde"
 test = true
 
 [dependencies]
-backtrace                    = "0.3.66"
+backtrace                    = "0.3.71"
 biome_console                = { workspace = true, features = ["serde_markup"] }
 biome_diagnostics_categories = { workspace = true, features = ["serde"] }
 biome_diagnostics_macros     = { workspace = true }
@@ -40,15 +40,15 @@ oxc_resolver                 = { workspace = true }
 schemars                     = { workspace = true, optional = true }
 serde                        = { workspace = true, features = ["derive"] }
 serde_json                   = { workspace = true }
-termcolor                    = "1.1.2"
-unicode-width                = "0.1.9"
+termcolor                    = { workspace = true }
+unicode-width                = { workspace = true }
 
 [features]
 schema = ["schemars", "biome_text_edit/schemars", "biome_diagnostics_categories/schemars"]
 
 [dev-dependencies]
 serde_json = { workspace = true }
-trybuild   = "1.0.80"
+trybuild   = "1.0.91"
 
 [lints]
 workspace = true

--- a/crates/biome_formatter/Cargo.toml
+++ b/crates/biome_formatter/Cargo.toml
@@ -27,7 +27,7 @@ rustc-hash               = { workspace = true }
 schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true, features = ["derive"], optional = true }
 tracing                  = { workspace = true }
-unicode-width            = "0.1.9"
+unicode-width            = { workspace = true }
 
 [dev-dependencies]
 biome_js_parser = { path = "../biome_js_parser" }

--- a/crates/biome_formatter_test/Cargo.toml
+++ b/crates/biome_formatter_test/Cargo.toml
@@ -27,7 +27,7 @@ insta               = { workspace = true, features = ["glob"] }
 serde               = { version = "1", features = ["derive"] }
 serde_json          = { workspace = true }
 similar             = { workspace = true }
-similar-asserts     = "1.2.0"
+similar-asserts     = "1.5.0"
 
 [dev-dependencies]
 

--- a/crates/biome_fs/Cargo.toml
+++ b/crates/biome_fs/Cargo.toml
@@ -18,7 +18,7 @@ crossbeam         = { workspace = true }
 directories       = "5.0.1"
 indexmap          = { workspace = true }
 oxc_resolver      = { workspace = true }
-parking_lot       = { version = "0.12.0", features = ["arc_lock"] }
+parking_lot       = { version = "0.12.2", features = ["arc_lock"] }
 rayon             = { workspace = true }
 rustc-hash        = { workspace = true }
 schemars          = { workspace = true, optional = true }

--- a/crates/biome_grit_syntax/Cargo.toml
+++ b/crates/biome_grit_syntax/Cargo.toml
@@ -12,7 +12,7 @@ version              = "0.5.7"
 
 [dependencies]
 biome_rowan = { workspace = true }
-schemars    = { version = "0.8.10", optional = true }
+schemars    = { workspace = true, optional = true }
 serde       = { version = "1.0.136", features = ["derive"], optional = true }
 
 [features]

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -28,7 +28,7 @@ biome_suppression        = { workspace = true }
 biome_unicode_table      = { workspace = true }
 lazy_static              = { workspace = true }
 natord                   = "1.0.9"
-roaring                  = "0.10.1"
+roaring                  = "0.10.4"
 rustc-hash               = { workspace = true }
 schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true, features = ["derive"] }

--- a/crates/biome_js_formatter/Cargo.toml
+++ b/crates/biome_js_formatter/Cargo.toml
@@ -26,7 +26,7 @@ biome_unicode_table          = { workspace = true }
 schemars                     = { workspace = true, optional = true }
 serde                        = { workspace = true, features = ["derive"], optional = true }
 smallvec                     = { workspace = true }
-unicode-width                = "0.1.9"
+unicode-width                = { workspace = true }
 
 [dev-dependencies]
 biome_formatter_test = { path = "../biome_formatter_test" }

--- a/crates/biome_js_parser/Cargo.toml
+++ b/crates/biome_js_parser/Cargo.toml
@@ -29,7 +29,7 @@ smallvec            = { workspace = true }
 tracing             = { workspace = true }
 
 [dev-dependencies]
-expect-test       = "1.2.2"
+expect-test       = "1.5.0"
 quickcheck        = { workspace = true }
 quickcheck_macros = { workspace = true }
 tests_macros      = { workspace = true }

--- a/crates/biome_js_semantic/Cargo.toml
+++ b/crates/biome_js_semantic/Cargo.toml
@@ -13,7 +13,7 @@ version              = "0.5.7"
 [dependencies]
 biome_js_syntax = { workspace = true }
 biome_rowan     = { workspace = true }
-rust-lapper     = "1.0.1"
+rust-lapper     = "1.1.0"
 rustc-hash      = { workspace = true }
 
 [dev-dependencies]

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -33,7 +33,7 @@ tracing             = { workspace = true, features = ["attributes"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
-tower = { version = "0.4.12", features = ["timeout"] }
+tower = { version = "0.4.13", features = ["timeout"] }
 
 [lints]
 workspace = true

--- a/crates/biome_rowan/Cargo.toml
+++ b/crates/biome_rowan/Cargo.toml
@@ -15,7 +15,6 @@ biome_text_edit = { workspace = true }
 biome_text_size = { workspace = true }
 countme         = { workspace = true }
 hashbrown       = { version = "0.12.3", features = ["inline-more"], default-features = false }
-memoffset       = "0.9.1"
 rustc-hash      = { workspace = true }
 serde           = { workspace = true, optional = true }
 tracing         = { workspace = true }

--- a/crates/biome_rowan/Cargo.toml
+++ b/crates/biome_rowan/Cargo.toml
@@ -15,7 +15,7 @@ biome_text_edit = { workspace = true }
 biome_text_size = { workspace = true }
 countme         = { workspace = true }
 hashbrown       = { version = "0.12.3", features = ["inline-more"], default-features = false }
-memoffset       = "0.8.0"
+memoffset       = "0.9.1"
 rustc-hash      = { workspace = true }
 serde           = { workspace = true, optional = true }
 tracing         = { workspace = true }

--- a/crates/biome_rowan/src/arc.rs
+++ b/crates/biome_rowan/src/arc.rs
@@ -4,7 +4,7 @@ use std::{
     cmp::Ordering,
     hash::{Hash, Hasher},
     marker::PhantomData,
-    mem::{self, ManuallyDrop},
+    mem::{self, offset_of, ManuallyDrop},
     ops::Deref,
     ptr::{self, NonNull},
     sync::atomic::{
@@ -12,8 +12,6 @@ use std::{
         Ordering::{Acquire, Relaxed, Release},
     },
 };
-
-use memoffset::offset_of;
 
 /// A soft limit on the amount of references that may be made to an `Arc`.
 ///

--- a/crates/biome_test_utils/Cargo.toml
+++ b/crates/biome_test_utils/Cargo.toml
@@ -24,7 +24,7 @@ biome_project       = { workspace = true }
 biome_rowan         = { workspace = true }
 biome_service       = { workspace = true }
 countme             = { workspace = true, features = ["enable"] }
-json_comments       = "0.2.1"
+json_comments       = "0.2.2"
 serde_json          = { workspace = true }
 similar             = { workspace = true }
 

--- a/crates/tests_macros/Cargo.toml
+++ b/crates/tests_macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 
 [dependencies]
 case             = "1.0.0"
-globwalk         = "0.8.1"
+globwalk         = "0.9.1"
 proc-macro-error = "1.0.4"
 proc-macro2      = { workspace = true }
 quote            = "1.0.14"

--- a/xtask/bench/Cargo.toml
+++ b/xtask/bench/Cargo.toml
@@ -22,7 +22,7 @@ biome_rowan          = { workspace = true }
 
 
 ansi_rgb                  = "0.2.0"
-codspeed-criterion-compat = { version = "2.5.0", optional = true }
+codspeed-criterion-compat = { version = "2.6.0", optional = true }
 criterion                 = "0.5.1"
 ureq                      = "2.9.7"
 url                       = "2.5.0"

--- a/xtask/bench/Cargo.toml
+++ b/xtask/bench/Cargo.toml
@@ -24,11 +24,11 @@ biome_rowan          = { workspace = true }
 ansi_rgb                  = "0.2.0"
 codspeed-criterion-compat = { version = "2.5.0", optional = true }
 criterion                 = "0.5.1"
-ureq                      = "2.9.6"
+ureq                      = "2.9.7"
 url                       = "2.5.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mimalloc = "0.1.39"
+mimalloc = "0.1.41"
 
 [target.'cfg(all(target_family="unix", not(all(target_arch = "aarch64", target_env = "musl"))))'.dependencies]
 tikv-jemallocator = "0.5.4"

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -12,7 +12,7 @@ proc-macro2    = { workspace = true, features = ["span-locations"] }
 pulldown-cmark = { version = "0.9", default-features = false, optional = true }
 quote          = "1.0.36"
 serde          = { workspace = true, optional = true }
-ureq           = "2.9.6"
+ureq           = "2.9.7"
 walkdir        = "2.5.0"
 xtask          = { path = '../', version = "0.0" }
 

--- a/xtask/contributors/Cargo.toml
+++ b/xtask/contributors/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.0.0"
 html-escape = "0.2.13"
 pico-args   = "0.5.0"
 serde       = { workspace = true, features = ["derive"] }
-ureq        = { version = "2.9.6", features = ["json"] }
+ureq        = { version = "2.9.7", features = ["json"] }
 xtask       = { path = '../', version = "0.0" }
 
 [lints]

--- a/xtask/coverage/Cargo.toml
+++ b/xtask/coverage/Cargo.toml
@@ -21,7 +21,7 @@ pico-args          = { version = "0.5.0", features = ["eq-separator"] }
 regex              = { workspace = true }
 serde              = { workspace = true, features = ["derive"] }
 serde_json         = { workspace = true }
-serde_yaml         = "0.9.33"
+serde_yaml         = "0.9.34"
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "std"] }
 walkdir            = "2.5.0"

--- a/xtask/coverage/Cargo.toml
+++ b/xtask/coverage/Cargo.toml
@@ -18,7 +18,7 @@ colored            = "2.1.0"
 indicatif          = { version = "0.17.8", features = ["improved_unicode"] }
 once_cell          = "1.19.0"
 pico-args          = { version = "0.5.0", features = ["eq-separator"] }
-regex              = "1.10.4"
+regex              = { workspace = true }
 serde              = { workspace = true, features = ["derive"] }
 serde_json         = { workspace = true }
 serde_yaml         = "0.9.33"

--- a/xtask/libs_bench/Cargo.toml
+++ b/xtask/libs_bench/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 version = "0.0.0"
 
 [dependencies]
-regex = { version = "1.6.0" }
+regex = { workspace = true }
 
 [dev-dependencies]
 criterion    = "0.5.1"


### PR DESCRIPTION
## Summary

Attempt of extracting the deps update from #2641 that don't make Ci fail.

I also removed `memoffset` because `offset_of!` is now stable since Rust 1.77.
And I factorized some deps at workspace level.

## Test Plan

CI must pass.
