### PR TITLE
fix(lint/noRedeclare): don't panic on conditional types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
+- [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare/) no longer panics on conditional type ([#2659](https://github.com/biomejs/biome/issues/2659)).
+
+  This is a regression introduced by [#2394](https://github.com/biomejs/biome/issues/2394).
+  This regression makes `noRedeclare` panics on every conditional types with `infer` bindings.
+
+  Contributed by @Conaclos
+
 - Fix typo by renaming `useConsistentBuiltinInstatiation` to `useConsistentBuiltinInstantiation`
   Contributed by @minht11
 
@@ -108,7 +115,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare/) now reports redeclarations of parameters in a functions body ([#2394](https://github.com/biomejs/biome/issues/2394)).
 
-  The rule was unable to detect redeclarations of a parameter or type parameter in the function body.
+  The rule was unable to detect redeclarations of a parameter or a type parameter in the function body.
   The following two redeclarations are now reported:
 
   ```ts
@@ -147,7 +154,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - [noUndeclaredVariables](https://biomejs.dev/linter/rules/no-undeclared-variables/) no longer reports variable-only and type-only exports ([#2637](https://github.com/biomejs/biome/issues/2637)).
   Contributed by @Conaclos
 
-- [noUnusedVariables] no longer crash Biome when encountering a malformed conditional type ([#1695](https://github.com/biomejs/biome/issues/1695)).
+- [noUnusedVariables](https://biomejs.dev/linter/rules/no-unused-variables/) no longer crash Biome when encountering a malformed conditional type ([#1695](https://github.com/biomejs/biome/issues/1695)).
   Contributed by @Conaclos
 
 - [useConst](https://biomejs.dev/linter/rules/use-const/) now ignores a variable that is read before its assignment.

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-conditional-type.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-conditional-type.ts
@@ -1,0 +1,2 @@
+// Issue https://github.com/biomejs/biome/issues/2659
+type Test<T> = T extends Array<infer U> ? true : false

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-conditional-type.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-conditional-type.ts.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-conditional-type.ts
+---
+# Input
+```ts
+// Issue https://github.com/biomejs/biome/issues/2659
+type Test<T> = T extends Array<infer U> ? true : false
+```

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -1,5 +1,5 @@
 use super::*;
-use biome_js_syntax::{AnyJsRoot, JsSyntaxNode, TextRange};
+use biome_js_syntax::{AnyJsRoot, JsSyntaxNode, TextRange, TsConditionalType};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::hash_map::Entry;
 
@@ -99,7 +99,14 @@ impl SemanticModelBuilder {
             | TS_MAPPED_TYPE => {
                 self.node_by_range.insert(node.text_range(), node.clone());
             }
-            _ => {}
+            _ => {
+                if let Some(conditional_type) = TsConditionalType::cast_ref(node) {
+                    if let Ok(conditional_true_type) = conditional_type.true_type() {
+                        let syntax = conditional_true_type.into_syntax();
+                        self.node_by_range.insert(syntax.text_range(), syntax);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fix #2394

This is a regression introduced by #2394.
This regression makes `noRedeclare` panics on every conditional types with `infer` bindings.

`noRedeclare` checks the node type of every scope.
Prior to #2615, it was unlikely to retrieve the syntax node of a scope.
The semantic model builder missed many associations. I thought I added all missing associations in #2615.
However, I forgot a case: syntax node of the scope of a conditional true type.
This led to #2394.

## Test Plan

I added a test.
