### PR TITLE
fix(lint/useJsxKeyInIterable): don't trigger `useJsxKeyInIterable` when iterating on non-jsx things

### DIFF
--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx.snap
@@ -523,44 +523,6 @@ invalid.jsx:33:8 lint/correctness/useJsxKeyInIterable ━━━━━━━━�
 ```
 
 ```
-invalid.jsx:33:19 lint/correctness/useJsxKeyInIterable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Cannot determine whether this child has the required key prop.
-  
-    31 │ (<h1>{[<h1></h1>, <h1></h1>, <h1></h1>]}</h1>)
-    32 │ 
-  > 33 │ (<h1>{[<h1></h1>, xyz, abc? <h2></h2>: bcd]}</h1>)
-       │                   ^^^
-    34 │ 
-    35 │ (<h1>{data.map(c => <h1></h1>)}</h1>)
-  
-  i Either return a JSX expression, or suppress this instance if you determine it is safe.
-  
-  i Check the React documentation for why a key prop is required. 
-  
-
-```
-
-```
-invalid.jsx:33:24 lint/correctness/useJsxKeyInIterable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Cannot determine whether this child has the required key prop.
-  
-    31 │ (<h1>{[<h1></h1>, <h1></h1>, <h1></h1>]}</h1>)
-    32 │ 
-  > 33 │ (<h1>{[<h1></h1>, xyz, abc? <h2></h2>: bcd]}</h1>)
-       │                        ^^^^^^^^^^^^^^^^^^^
-    34 │ 
-    35 │ (<h1>{data.map(c => <h1></h1>)}</h1>)
-  
-  i Either return a JSX expression, or suppress this instance if you determine it is safe.
-  
-  i Check the React documentation for why a key prop is required. 
-  
-
-```
-
-```
 invalid.jsx:35:21 lint/correctness/useJsxKeyInIterable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Missing key property for this element in iterable.
@@ -575,25 +537,6 @@ invalid.jsx:35:21 lint/correctness/useJsxKeyInIterable ━━━━━━━━�
   i The order of the items may change, and having a key can help React identify which item was moved.
   
   i Check the React documentation. 
-  
-
-```
-
-```
-invalid.jsx:37:21 lint/correctness/useJsxKeyInIterable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Cannot determine whether this child has the required key prop.
-  
-    35 │ (<h1>{data.map(c => <h1></h1>)}</h1>)
-    36 │ 
-  > 37 │ (<h1>{data.map(c => xyz)}</h1>)
-       │                     ^^^
-    38 │ 
-    39 │ (<h1>{data.map(c => (<h1></h1>))}</h1>)
-  
-  i Either return a JSX expression, or suppress this instance if you determine it is safe.
-  
-  i Check the React documentation for why a key prop is required. 
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx
@@ -46,3 +46,9 @@ React.Children.map(c => React.cloneElement(c, {key: c}));
 (<h1>{data.map(c => (<h1 key={c}></h1>))}</h1>)
 
 (<h1>{data.map(c => {return (<h1 key={c}></h1>)})}</h1>)
+
+<>{data.reduce((total, next) => total + next, 0)}</>
+
+<>{data.reduce((a, b) => Math.max(a, b), 0)}</>
+
+<>{data.reduce((a, b) => a > b ? a : b, 0)}</>

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx.snap
@@ -52,4 +52,11 @@ React.Children.map(c => React.cloneElement(c, {key: c}));
 (<h1>{data.map(c => (<h1 key={c}></h1>))}</h1>)
 
 (<h1>{data.map(c => {return (<h1 key={c}></h1>)})}</h1>)
+
+<>{data.reduce((total, next) => total + next, 0)}</>
+
+<>{data.reduce((a, b) => Math.max(a, b), 0)}</>
+
+<>{data.reduce((a, b) => a > b ? a : b, 0)}</>
+
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

This aims to resolve some of the bugs in #2590. It's intentionally small in scope since this is my first PR here, so hopefully it will be easier to review.

It fixes cases where expressions like this would erroneously trigger the `useJsxKeyInIterable` lint:
```jsx
<>{data.reduce((total, next) => total + next, 0)}</>
```

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

related to: #2590

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
I added tests.

```bash
cargo test -p biome_js_analyze use_jsx_key_in_iterable
```
