### PR TITLE
build(deps): update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,9 +1649,9 @@ checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1664,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1674,15 +1674,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1691,38 +1691,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.59",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2059,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2913,9 +2913,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.4.5"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
 dependencies = [
  "js-sys",
  "serde",
@@ -2978,9 +2978,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.153"
+version = "1.0.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cbe7389defd07773865f045d13c1070a9afdf1bc8736a06412ef98e2e7f8b38"
+checksum = "5a2f49ace1498612d14f7e0b8245519584db8299541dfe31a06374a828d620ab"
 dependencies = [
  "serde",
 ]
@@ -3424,11 +3424,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
+ "thiserror",
  "time",
  "tracing-subscriber",
 ]
@@ -3683,9 +3684,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "serde",
@@ -3695,24 +3696,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.59",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3720,22 +3721,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.59",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,11 +65,12 @@ float_cmp_const                 = "warn"
 get_unwrap                      = "warn"
 infinite_loop                   = "warn"
 lossy_float_literal             = "warn"
-mem_forget                      = "warn"
 rc_buffer                       = "warn"
 rc_mutex                        = "warn"
 rest_pat_in_fully_bound_structs = "warn"
 verbose_file_reads              = "warn"
+# https://github.com/rustwasm/wasm-bindgen/issues/3944
+#mem_forget                      = "warn"
 
 [workspace.package]
 authors    = ["Biome Developers and Contributors"]
@@ -149,6 +150,7 @@ biome_ungrammar      = { path = "./crates/biome_ungrammar" }
 tests_macros         = { path = "./crates/tests_macros" }
 
 # Crates needed in the workspace
+anyhow             = "1.0.82"
 bitflags           = "2.5.0"
 bpaf               = { version = "0.9.9", features = ["derive"] }
 countme            = "3.0.1"

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -18,7 +18,7 @@ name = "biome"
 path = "src/main.rs"
 
 [dependencies]
-anyhow                   = "1.0.52"
+anyhow                   = { workspace = true }
 biome_analyze            = { workspace = true }
 biome_configuration      = { workspace = true }
 biome_console            = { workspace = true }
@@ -50,7 +50,7 @@ serde_json               = { workspace = true }
 smallvec                 = { workspace = true }
 tokio                    = { workspace = true, features = ["io-std", "io-util", "net", "time", "rt", "sync", "rt-multi-thread", "macros"] }
 tracing                  = { workspace = true }
-tracing-appender         = "0.2"
+tracing-appender         = "0.2.3"
 tracing-subscriber       = { workspace = true, features = ["env-filter", "json"] }
 tracing-tree             = "0.3.0"
 

--- a/crates/biome_formatter_test/Cargo.toml
+++ b/crates/biome_formatter_test/Cargo.toml
@@ -24,7 +24,7 @@ biome_parser        = { workspace = true }
 biome_rowan         = { workspace = true }
 biome_service       = { workspace = true }
 insta               = { workspace = true, features = ["glob"] }
-serde               = { version = "1", features = ["derive"] }
+serde               = { workspace = true, features = ["derive"] }
 serde_json          = { workspace = true }
 similar             = { workspace = true }
 similar-asserts     = "1.5.0"

--- a/crates/biome_grit_patterns/Cargo.toml
+++ b/crates/biome_grit_patterns/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 version              = "0.0.1"
 
 [dependencies]
-anyhow               = "1.0.52"
+anyhow               = { workspace = true }
 biome_console        = { workspace = true }
 biome_diagnostics    = { workspace = true }
 grit-pattern-matcher = { version = "0.1" }

--- a/crates/biome_grit_syntax/Cargo.toml
+++ b/crates/biome_grit_syntax/Cargo.toml
@@ -13,7 +13,7 @@ version              = "0.5.7"
 [dependencies]
 biome_rowan = { workspace = true }
 schemars    = { workspace = true, optional = true }
-serde       = { version = "1.0.136", features = ["derive"], optional = true }
+serde       = { workspace = true, features = ["derive"], optional = true }
 
 [features]
 serde = ["dep:serde", "schemars", "biome_rowan/serde"]

--- a/crates/biome_js_formatter/Cargo.toml
+++ b/crates/biome_js_formatter/Cargo.toml
@@ -38,7 +38,7 @@ countme              = { workspace = true, features = ["enable"] }
 iai                  = "0.1.1"
 quickcheck           = { workspace = true }
 quickcheck_macros    = { workspace = true }
-serde                = { version = "1", features = ["derive"] }
+serde                = { workspace = true, features = ["derive"] }
 serde_json           = { workspace = true }
 tests_macros         = { path = "../tests_macros" }
 

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -14,7 +14,7 @@ version              = "0.0.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow              = "1.0.52"
+anyhow              = { workspace = true }
 biome_analyze       = { workspace = true }
 biome_configuration = { workspace = true }
 biome_console       = { workspace = true }
@@ -23,7 +23,7 @@ biome_fs            = { workspace = true }
 biome_rowan         = { workspace = true }
 biome_service       = { workspace = true }
 biome_text_edit     = { workspace = true }
-futures             = "0.3"
+futures             = "0.3.30"
 rustc-hash          = { workspace = true }
 serde               = { workspace = true, features = ["derive"] }
 serde_json          = { workspace = true }

--- a/crates/biome_text_size/Cargo.toml
+++ b/crates/biome_text_size/Cargo.toml
@@ -15,7 +15,7 @@ schemars = { workspace = true, optional = true }
 serde    = { workspace = true, optional = true }
 
 [dev-dependencies]
-serde_test        = "1.0"
+serde_test        = "1.0.176"
 static_assertions = "1.1"
 
 [[test]]

--- a/crates/biome_wasm/Cargo.toml
+++ b/crates/biome_wasm/Cargo.toml
@@ -23,16 +23,16 @@ format_css = ["biome_service/format_css"]
 biome_console      = { workspace = true }
 biome_diagnostics  = { workspace = true }
 biome_service      = { workspace = true }
-js-sys             = "0.3.59"
+js-sys             = "0.3.69"
 serde              = { workspace = true }
-serde-wasm-bindgen = "0.4.5"
-wasm-bindgen       = { version = "0.2.82", features = ["serde-serialize"] }
+serde-wasm-bindgen = "0.6.5"
+wasm-bindgen       = { version = "0.2.92", features = ["serde-serialize"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
-console_error_panic_hook = { version = "0.1.6", optional = true }
+console_error_panic_hook = { version = "0.1.7", optional = true }
 
 
 [build-dependencies]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 version = "0.0.0"
 
 [dependencies]
-anyhow = "1.0.82"
+anyhow = { workspace = true }
 
 [lints]
 workspace = true

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 version = "0.0.0"
 
 [dependencies]
-anyhow         = "1.0.82"
+anyhow         = { workspace = true }
 bpaf           = { workspace = true, features = ["derive"] }
 git2           = { version = "0.18.3", default-features = false }
 proc-macro2    = { workspace = true, features = ["span-locations"] }


### PR DESCRIPTION
## Summary

Update all deps reported by #2641, except tower-lsp that made some breaking changes.

I disabled `clippy::mem-forget` because wasm-bindgen triggers this rule. I opened an [issue about this](https://github.com/rustwasm/wasm-bindgen/issues/3944). 
.
## Test Plan

CI must pass.