### PR TITLE
chore(ci): renovate pin GA to semver

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,8 @@
 		"before 9am on monday"
 	],
 	"extends": [
-		"config:best-practices"
+		"config:best-practices",
+		"helpers:pinGitHubActionDigestsToSemver"
 	],
 	"rangeStrategy": "bump",
 	"lockFileMaintenance": {


### PR DESCRIPTION
## Summary

Update the renovate configuration to pin third-party github actions to commit digests corresponding to their semantic versions.

This addresses https://github.com/biomejs/biome/pull/2634#issuecomment-2082536510

## Test Plan

N/A

