### PR TITLE
fix(lint/noBlankTarget): don't hang when applying the code fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
+- [noBlankTarget](https://biomejs.dev/linter/rules/no-blank-target/) no longer hangs when applying a code fix ([#2675](https://github.com/biomejs/biome/issues/2675)).
+
+  Previously, the following code made Biome hangs when applying a code fix.
+
+  ```jsx
+  <a href="https://example.com" rel="" target="_blank"></a>
+  ```
+
+  Contributed by @Conaclos
+
 - [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare/) no longer panics on conditional type ([#2659](https://github.com/biomejs/biome/issues/2659)).
 
   This is a regression introduced by [#2394](https://github.com/biomejs/biome/issues/2394).

--- a/crates/biome_js_analyze/src/lint/a11y/no_blank_target.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_blank_target.rs
@@ -112,10 +112,13 @@ impl Rule for NoBlankTarget {
             let prev_jsx_attribute = rel_attribute.initializer()?.value().ok()?;
             let prev_jsx_string = prev_jsx_attribute.as_jsx_string()?;
             let new_text = format!(
-                "\"noreferrer {}\"",
+                "noreferrer {}",
                 prev_jsx_string.inner_string_text().ok()?.text()
             );
-            mutation.replace_node(prev_jsx_string.clone(), jsx_string(jsx_ident(&new_text)));
+            mutation.replace_node(
+                prev_jsx_string.clone(),
+                jsx_string(jsx_string_literal(new_text.trim_end())),
+            );
 
             (markup! {
                 "Add the "<Emphasis>"\"noreferrer\""</Emphasis>" to the existing attribute."

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -6,8 +6,8 @@ use biome_analyze::{declare_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_factory::make::{
-    ident, js_expression_statement, js_string_literal_expression, jsx_expression_child, jsx_string,
-    jsx_tag_expression, token, JsxExpressionChildBuilder,
+    js_expression_statement, js_string_literal_expression, jsx_expression_child, jsx_string,
+    jsx_string_literal, jsx_tag_expression, token, JsxExpressionChildBuilder,
 };
 use biome_js_syntax::{
     AnyJsExpression, AnyJsxChild, AnyJsxElementName, AnyJsxTag, JsLanguage,
@@ -268,12 +268,15 @@ impl Rule for NoUselessFragments {
                         jsx_tag_expression(AnyJsxTag::JsxSelfClosingElement(node)).into_syntax(),
                     ),
                     AnyJsxChild::JsxText(text) => {
-                        let new_value =
-                            format!("\"{}\"", text.value_token().ok()?.token_text().trim());
+                        let new_value = text.value_token().ok()?.token_text();
+                        let new_value = new_value.trim();
                         if parent.kind() == JsSyntaxKind::JSX_EXPRESSION_ATTRIBUTE_VALUE {
-                            Some(jsx_string(ident(&new_value)).into_syntax())
+                            Some(jsx_string(jsx_string_literal(new_value)).into_syntax())
                         } else {
-                            Some(js_string_literal_expression(ident(&new_value)).into_syntax())
+                            Some(
+                                js_string_literal_expression(jsx_string_literal(new_value))
+                                    .into_syntax(),
+                            )
                         }
                     }
                     AnyJsxChild::JsxExpressionChild(child) => {

--- a/crates/biome_js_analyze/tests/specs/a11y/noBlankTarget/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noBlankTarget/invalid.jsx.snap
@@ -57,8 +57,8 @@ invalid.jsx:3:8 lint/a11y/noBlankTarget  FIXABLE  ━━━━━━━━━━
   
   i Safe fix: Add the "noreferrer" to the existing attribute.
   
-    3 │ ····<a·target="_blank"·rel="noreferrer·"·href="https://example.com/2"></a>
-      │                             +++++++++++                                   
+    3 │ ····<a·target="_blank"·rel="noreferrer"·href="https://example.com/2"></a>
+      │                             ++++++++++                                   
 
 ```
 
@@ -230,5 +230,3 @@ invalid.jsx:12:8 lint/a11y/noBlankTarget  FIXABLE  ━━━━━━━━━�
        │                                                 +++++++++++++++++     
 
 ```
-
-


### PR DESCRIPTION
## Summary

Fix #2675

The code fix created a JSX string with a `JSX_IDENT` token.
`inner_string_text` is called to retrieve the content of the attribute.
`inner_string_text` removes quotes only when the token is a `JSX_STRING_LITERAL`.
Thus, on first run, the quotes were well removed, while on the following run, the quotes are not removed.
This led to a never fixed lint rule and thus, an infinite loop. 

I also fixed a similar issue for `noUselessFragments` which was not observed yet.

To avoid this kind of issue we could:
- Add `debug_assert` in node factories (this should be generated by the grammar) to guarantee that every leaf node has the correct token kind.
- Avoid the infinite loop by setting a limit. We can expect to have some conflicting rules in the future.
  We should ensure that this doesn't lead to an infinite loop.

## Test Plan

I manually tested the code.
We could add a test in `biome_cli` however I think it is not worth it because this could require to add a test for every rule that create jsx/js/css strings. 