### PR TITLE
fix(lint/useExportType): preserve leading comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,22 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [useExportType](https://biomejs.dev/linter/rules/use-export-type/) no longer removes leading comments ([#2685](https://github.com/biomejs/biome/issues/2685)).
+
+  Previously, `useExportType` removed leading comments when it factorized the `type` qualifier.
+  It now provides a code fix that preserves the leading comments:
+
+  ```diff
+  - export {
+  + export type {
+      /**leading comment*/
+  -   type T
+  +   T
+    }
+  ```
+
+  Contributed by @Conaclos
+
 - Fix typo by renaming `useConsistentBuiltinInstatiation` to `useConsistentBuiltinInstantiation`
   Contributed by @minht11
 

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts
@@ -29,3 +29,11 @@ export { Interface, TypeAlias, Enum, func as f, Class };
 export /*0*/ { /*1*/ type /*2*/ func /*3*/, /*4*/ type Class as C /*5*/ } /*6*/;
 
 export {}
+
+import { type T7, type T8 } from "./mod.ts";
+export {
+  /*1*/
+  type T7,
+  /*2*/
+  type T8,
+};

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts.snap
@@ -36,6 +36,13 @@ export /*0*/ { /*1*/ type /*2*/ func /*3*/, /*4*/ type Class as C /*5*/ } /*6*/;
 
 export {}
 
+import { type T7, type T8 } from "./mod.ts";
+export {
+  /*1*/
+  type T7,
+  /*2*/
+  type T8,
+};
 ```
 
 # Diagnostics
@@ -206,6 +213,7 @@ invalid.ts:31:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
   > 31 │ export {}
        │        ^^
     32 │ 
+    33 │ import { type T7, type T8 } from "./mod.ts";
   
   i Using export type allows transpilers to safely drop exports of types without looking for their definition.
   
@@ -216,4 +224,36 @@ invalid.ts:31:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
 
 ```
 
+```
+invalid.ts:34:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! All exports are only types and should thus use export type.
+  
+    33 │ import { type T7, type T8 } from "./mod.ts";
+  > 34 │ export {
+       │        ^
+  > 35 │   /*1*/
+  > 36 │   type T7,
+  > 37 │   /*2*/
+  > 38 │   type T8,
+  > 39 │ };
+       │ ^^
+  
+  i Using export type allows transpilers to safely drop exports of types without looking for their definition.
+  
+  i Safe fix: Use a grouped export type.
+  
+    32 32 │   
+    33 33 │   import { type T7, type T8 } from "./mod.ts";
+    34    │ - export·{
+       34 │ + export·type·{
+    35 35 │     /*1*/
+    36    │ - ··type·T7,
+       36 │ + ··T7,
+    37 37 │     /*2*/
+    38    │ - ··type·T8,
+       38 │ + ··T8,
+    39 39 │   };
+  
+
+```


### PR DESCRIPTION
## Summary

Fix #2685
I took the opportunity of renaming some types to align with `useImportType`.

## Test Plan

I added a non regression test.
