### PR TITLE
fix(noUnusedLabels,noConfusingLabels): ignore Svelte reactive statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [noUnusedLabels](https://biomejs.dev/linter/rules/no-unused-labels/) and [noConfusingLabels](https://biomejs.dev/linter/rules/no-confusing-labels/) now ignore svelte reactive statements ([#2571](https://github.com/biomejs/biome/issues/2571)).
+
+  The rules now ignore reactive Svelte blocks in Svelte components.
+
+  ```svelte
+  <script>
+  $: { /* reactive block */ }
+  </script>
+  ```
+
+  Contributed by @Conaclos
+
 - [useExportType](https://biomejs.dev/linter/rules/use-export-type/) no longer removes leading comments ([#2685](https://github.com/biomejs/biome/issues/2685)).
 
   Previously, `useExportType` removed leading comments when it factorized the `type` qualifier.

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_labels.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_labels.rs
@@ -6,8 +6,8 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_diagnostics::Applicability;
 use biome_js_syntax::{
-    AnyJsStatement, JsBreakStatement, JsContinueStatement, JsLabeledStatement, JsLanguage,
-    TextRange, WalkEvent,
+    AnyJsStatement, JsBreakStatement, JsContinueStatement, JsFileSource, JsLabeledStatement,
+    JsLanguage, TextRange, WalkEvent,
 };
 
 use biome_rowan::{AstNode, BatchMutationExt, Language, SyntaxNode, SyntaxResult, TokenText};
@@ -20,6 +20,8 @@ declare_rule! {
     /// Disallow unused labels.
     ///
     /// Labels that are declared and never used are most likely an error due to incomplete refactoring.
+    ///
+    /// The rule ignores reactive Svelte statements in Svelte components.
     ///
     /// ## Examples
     ///
@@ -50,6 +52,12 @@ declare_rule! {
     ///     DEV: assert(n >= 0);
     ///     return n;
     /// }
+    /// ```
+    ///
+    /// ```svelte
+    /// <script>
+    /// $: { /* reactive block */ }
+    /// </script>
     /// ```
     pub NoUnusedLabels {
         version: "1.0.0",
@@ -155,7 +163,17 @@ impl Rule for NoUnusedLabels {
     type Signals = Option<Self::State>;
     type Options = ();
 
-    fn run(_: &RuleContext<Self>) -> Option<Self::State> {
+    fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
+        let label = ctx.query().label_token().ok()?;
+        let label = label.text_trimmed();
+        if label == "$"
+            && ctx
+                .source_type::<JsFileSource>()
+                .as_embedding_kind()
+                .is_svelte()
+        {
+            return None;
+        }
         Some(())
     }
 

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -11,8 +11,8 @@ use biome_test_utils::{
 };
 use std::{ffi::OsStr, fs::read_to_string, path::Path, slice};
 
-tests_macros::gen_tests! {"tests/specs/**/*.{cjs,js,jsx,tsx,ts,json,jsonc}", crate::run_test, "module"}
-tests_macros::gen_tests! {"tests/suppression/**/*.{cjs,js,jsx,tsx,ts,json,jsonc}", crate::run_suppression_test, "module"}
+tests_macros::gen_tests! {"tests/specs/**/*.{cjs,js,jsx,tsx,ts,json,jsonc,svelte}", crate::run_test, "module"}
+tests_macros::gen_tests! {"tests/suppression/**/*.{cjs,js,jsx,tsx,ts,json,jsonc,svelte}", crate::run_suppression_test, "module"}
 
 fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
     register_leak_checker();

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/invalid.js
@@ -65,3 +65,6 @@ A: {
  * "A: class Foo { foo() { break A; } }",
  * "A: { A: { break A; } }"
  */
+
+// We are not in a Svelte component
+$: {}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/invalid.js.snap
@@ -72,6 +72,8 @@ A: {
  * "A: { A: { break A; } }"
  */
 
+// We are not in a Svelte component
+$: {}
 ```
 
 # Diagnostics
@@ -262,4 +264,20 @@ invalid.js:45:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━�
 
 ```
 
+```
+invalid.js:70:1 lint/correctness/noUnusedLabels  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Unused label.
+  
+    69 │ // We are not in a Svelte component
+  > 70 │ $: {}
+       │ ^
+  
+  i The label is not used by any break statement and continue statement.
+  
+  i Safe fix: Remove the unused label.
+  
+    70 │ $:·{}
+       │ ---  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/valid.svelte
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/valid.svelte
@@ -1,0 +1,19 @@
+<script>
+	export let title;
+	export let person;
+
+	// this will update `document.title` whenever
+	// the `title` prop changes
+	$: document.title = title;
+
+	$: {
+		console.log(`multiple statements can be combined`);
+		console.log(`the current title is ${title}`);
+	}
+
+	// this will update `name` when 'person' changes
+	$: ({ name } = person);
+
+	// don't do this. it will run before the previous line
+	let name2 = name;
+</script>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/valid.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedLabels/valid.svelte.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.svelte
+---
+# Input
+```js
+<script>
+	export let title;
+	export let person;
+
+	// this will update `document.title` whenever
+	// the `title` prop changes
+	$: document.title = title;
+
+	$: {
+		console.log(`multiple statements can be combined`);
+		console.log(`the current title is ${title}`);
+	}
+
+	// this will update `name` when 'person' changes
+	$: ({ name } = person);
+
+	// don't do this. it will run before the previous line
+	let name2 = name;
+</script>
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingLabels/invalid.jsonc
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingLabels/invalid.jsonc
@@ -14,5 +14,8 @@
 
 	// switches
 	"A: switch (a) { case 0: break A; default: break; };",
-	"A: switch (a) { case 0: break A; default: break; };"
+	"A: switch (a) { case 0: break A; default: break; };",
+
+	// We are not in a Svelte component
+	"$: {}"
 ]

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingLabels/invalid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingLabels/invalid.jsonc.snap
@@ -202,4 +202,22 @@ invalid.jsonc:1:1 lint/suspicious/noConfusingLabels ━━━━━━━━━�
 
 ```
 
+# Input
+```cjs
+$: {}
+```
 
+# Diagnostics
+```
+invalid.jsonc:1:1 lint/suspicious/noConfusingLabels ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Unexpected label.
+  
+  > 1 │ $: {}
+      │ ^
+  
+  i Only loops should be labeled.
+    The use of labels for other statements is suspicious and unfamiliar.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingLabels/valid.svelte
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingLabels/valid.svelte
@@ -1,0 +1,19 @@
+<script>
+	export let title;
+	export let person;
+
+	// this will update `document.title` whenever
+	// the `title` prop changes
+	$: document.title = title;
+
+	$: {
+		console.log(`multiple statements can be combined`);
+		console.log(`the current title is ${title}`);
+	}
+
+	// this will update `name` when 'person' changes
+	$: ({ name } = person);
+
+	// don't do this. it will run before the previous line
+	let name2 = name;
+</script>

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConfusingLabels/valid.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConfusingLabels/valid.svelte.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.svelte
+---
+# Input
+```js
+<script>
+	export let title;
+	export let person;
+
+	// this will update `document.title` whenever
+	// the `title` prop changes
+	$: document.title = title;
+
+	$: {
+		console.log(`multiple statements can be combined`);
+		console.log(`the current title is ${title}`);
+	}
+
+	// this will update `name` when 'person' changes
+	$: ({ name } = person);
+
+	// don't do this. it will run before the previous line
+	let name2 = name;
+</script>
+```


### PR DESCRIPTION
## Summary

Fix #2571

We now ignore the use of labels named `$` in Svelte components for the `noUnusedLabels` and `noCOnfusingLabels` rules.

## Test Plan

I added tests for each rule.