### PR TITLE
fix(lint/noDuplicateAtImportRules): correctly handle both single- and double quotes

### DIFF
--- a/crates/biome_css_analyze/src/lint/nursery/no_duplicate_at_import_rules.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_duplicate_at_import_rules.rs
@@ -70,7 +70,8 @@ impl Rule for NoDuplicateAtImportRules {
                             .text()
                             .to_lowercase()
                             .replace("url(", "")
-                            .replace(')', "");
+                            .replace(')', "")
+                            .replace('"', "'");
                         if let Some(media_query_set) = import_url_map.get_mut(&import_url) {
                             // if the current import_rule has no media queries or there are no queries saved in the
                             // media_query_set, this is always a duplicate

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateAtImportRules/invalidQuotes.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateAtImportRules/invalidQuotes.css
@@ -1,0 +1,2 @@
+@import "a.css";
+@import 'a.css';

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateAtImportRules/invalidQuotes.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateAtImportRules/invalidQuotes.css.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: invalidQuotes.css
+---
+# Input
+```css
+@import "a.css";
+@import 'a.css';
+
+```
+
+# Diagnostics
+```
+invalidQuotes.css:2:2 lint/nursery/noDuplicateAtImportRules ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Each @import should be unique unless differing by media queries.
+  
+    1 │ @import "a.css";
+  > 2 │ @import 'a.css';
+      │  ^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Consider removing one of the duplicated imports.
+  
+
+```


### PR DESCRIPTION
## Summary

While checking different rules, I noticed that I forgot to check for a specific case when implementing the `noDuplicateAtImportRules` rule.

```css
@import "a.css";
@import 'a.css';
```
This should show an error, but didn't. 

This PR fixes this small bug and also adds a test for this scenario

## Test Plan

Added a new test to validate the change.
