### PR TITLE
refactor(parser): implement NthToken for T

### DIFF
--- a/crates/biome_css_parser/src/lexer/mod.rs
+++ b/crates/biome_css_parser/src/lexer/mod.rs
@@ -8,6 +8,7 @@ use biome_parser::diagnostic::ParseDiagnostic;
 use biome_parser::lexer::{
     LexContext, Lexer, LexerCheckpoint, LexerWithCheckpoint, ReLexer, TokenFlags,
 };
+use biome_rowan::SyntaxKind;
 use biome_unicode_table::{
     is_css_id_continue, is_css_id_start, lookup_byte, Dispatch, Dispatch::*,
 };

--- a/crates/biome_css_parser/tests/spec_test.rs
+++ b/crates/biome_css_parser/tests/spec_test.rs
@@ -134,8 +134,10 @@ pub fn run(test_case: &str, _snapshot_name: &str, test_directory: &str, outcome_
 #[test]
 pub fn quick_test() {
     let code = r#"
-        @color-profile DEVICE-CMYK
-    @color-profile
+div {
+
+	background: src(var(--foo));
+}
 
     "#;
 

--- a/crates/biome_css_syntax/src/lib.rs
+++ b/crates/biome_css_syntax/src/lib.rs
@@ -12,7 +12,7 @@ pub use file_source::CssFileSource;
 pub use syntax_node::*;
 
 use crate::CssSyntaxKind::*;
-use biome_rowan::{AstNode, RawSyntaxKind};
+use biome_rowan::{AstNode, RawSyntaxKind, SyntaxKind};
 
 impl From<u16> for CssSyntaxKind {
     fn from(d: u16) -> CssSyntaxKind {
@@ -28,16 +28,6 @@ impl From<CssSyntaxKind> for u16 {
 }
 
 impl CssSyntaxKind {
-    pub fn is_trivia(self) -> bool {
-        matches!(
-            self,
-            CssSyntaxKind::NEWLINE
-                | CssSyntaxKind::WHITESPACE
-                | CssSyntaxKind::COMMENT
-                | CssSyntaxKind::MULTILINE_COMMENT
-        )
-    }
-
     /// Returns `true` for any contextual or non-contextual keyword
     #[inline]
     pub const fn is_keyword(self) -> bool {
@@ -146,6 +136,16 @@ impl biome_rowan::SyntaxKind for CssSyntaxKind {
     #[inline]
     fn is_list(&self) -> bool {
         CssSyntaxKind::is_list(*self)
+    }
+
+    fn is_trivia(self) -> bool {
+        matches!(
+            self,
+            CssSyntaxKind::NEWLINE
+                | CssSyntaxKind::WHITESPACE
+                | CssSyntaxKind::COMMENT
+                | CssSyntaxKind::MULTILINE_COMMENT
+        )
     }
 
     fn to_string(&self) -> Option<&'static str> {

--- a/crates/biome_graphql_parser/src/lexer/mod.rs
+++ b/crates/biome_graphql_parser/src/lexer/mod.rs
@@ -5,6 +5,7 @@ mod tests;
 use biome_graphql_syntax::{GraphqlSyntaxKind, GraphqlSyntaxKind::*, TextLen, TextSize, T};
 use biome_parser::diagnostic::ParseDiagnostic;
 use biome_parser::lexer::{Lexer, LexerCheckpoint, LexerWithCheckpoint, TokenFlags};
+use biome_rowan::SyntaxKind;
 use std::ops::Add;
 
 #[derive(Debug)]

--- a/crates/biome_graphql_parser/src/token_source.rs
+++ b/crates/biome_graphql_parser/src/token_source.rs
@@ -1,45 +1,22 @@
-use std::collections::VecDeque;
-
 use crate::lexer::GraphqlLexer;
 use biome_graphql_syntax::GraphqlSyntaxKind::EOF;
 use biome_graphql_syntax::{GraphqlSyntaxKind, TextRange};
 use biome_parser::diagnostic::ParseDiagnostic;
 use biome_parser::lexer::BufferedLexer;
 use biome_parser::prelude::TokenSource;
-use biome_parser::token_source::{NthToken, Trivia};
+use biome_parser::token_source::{TokenSourceWithBufferedLexer, Trivia};
 use biome_rowan::TriviaPieceKind;
 
 pub(crate) struct GraphqlTokenSource<'source> {
-    lexer: BufferedLexer<'source, GraphqlLexer<'source>>,
+    lexer: BufferedLexer<GraphqlSyntaxKind, GraphqlLexer<'source>>,
     trivia_list: Vec<Trivia>,
-
-    /// Cache for the non-trivia token lookahead. For example for the source `let a = 10;` if the
-    /// [TokenSource]'s currently positioned at the start of the file (`let`). The `nth(2)` non-trivia token,
-    /// as returned by the [TokenSource], is the `=` token but retrieving it requires skipping over the
-    /// two whitespace trivia tokens (first between `let` and `a`, second between `a` and `=`).
-    /// The [TokenSource] state then is:
-    ///
-    /// * `non_trivia_lookahead`: [IDENT: 'a', EQ]
-    /// * `lookahead_offset`: 4 (the `=` is the 4th token after the `let` keyword)
-    non_trivia_lookahead: VecDeque<Lookahead>,
-
-    /// Offset of the last cached lookahead token from the current [BufferedLexer] token.
-    lookahead_offset: usize,
-}
-
-#[derive(Debug, Copy, Clone)]
-struct Lookahead {
-    kind: GraphqlSyntaxKind,
-    after_newline: bool,
 }
 
 impl<'source> GraphqlTokenSource<'source> {
-    pub(crate) fn new(lexer: BufferedLexer<'source, GraphqlLexer<'source>>) -> Self {
+    pub(crate) fn new(lexer: BufferedLexer<GraphqlSyntaxKind, GraphqlLexer<'source>>) -> Self {
         Self {
             lexer,
             trivia_list: Vec::new(),
-            non_trivia_lookahead: VecDeque::new(),
-            lookahead_offset: 0,
         }
     }
     pub fn from_str(source: &'source str) -> Self {
@@ -52,51 +29,11 @@ impl<'source> GraphqlTokenSource<'source> {
         source
     }
 
-    #[inline(always)]
-    fn lookahead(&mut self, n: usize) -> Option<Lookahead> {
-        assert_ne!(n, 0);
-
-        // Return the cached token if any
-        if let Some(lookahead) = self.non_trivia_lookahead.get(n - 1) {
-            return Some(*lookahead);
-        }
-
-        // Jump right to where we've left of last time rather than going through all tokens again.
-        let iter = self.lexer.lookahead().skip(self.lookahead_offset);
-        let mut remaining = n - self.non_trivia_lookahead.len();
-
-        for item in iter {
-            self.lookahead_offset += 1;
-
-            if !item.kind().is_trivia() {
-                remaining -= 1;
-
-                let lookahead = Lookahead {
-                    after_newline: item.has_preceding_line_break(),
-                    kind: item.kind(),
-                };
-
-                self.non_trivia_lookahead.push_back(lookahead);
-
-                if remaining == 0 {
-                    return Some(lookahead);
-                }
-            }
-        }
-
-        None
-    }
-
     fn next_non_trivia_token(&mut self, first_token: bool) {
-        let mut processed_tokens = 0;
         let mut trailing = !first_token;
-
-        // Drop the last cached lookahead, we're now moving past it
-        self.non_trivia_lookahead.pop_front();
 
         loop {
             let kind = self.lexer.next_token(());
-            processed_tokens += 1;
 
             let trivia_kind = TriviaPieceKind::try_from(kind);
 
@@ -114,11 +51,6 @@ impl<'source> GraphqlTokenSource<'source> {
                         .push(Trivia::new(trivia_kind, self.current_range(), trailing));
                 }
             }
-        }
-
-        if self.lookahead_offset != 0 {
-            debug_assert!(self.lookahead_offset >= processed_tokens);
-            self.lookahead_offset -= processed_tokens;
         }
     }
 }
@@ -165,24 +97,8 @@ impl<'source> TokenSource for GraphqlTokenSource<'source> {
     }
 }
 
-impl<'source> NthToken for GraphqlTokenSource<'source> {
-    /// Gets the kind of the nth non-trivia token
-    fn nth(&mut self, n: usize) -> GraphqlSyntaxKind {
-        if n == 0 {
-            self.current()
-        } else {
-            self.lookahead(n).map_or(EOF, |lookahead| lookahead.kind)
-        }
-    }
-
-    /// Returns true if the nth non-trivia token is preceded by a line break
-    #[inline(always)]
-    fn has_nth_preceding_line_break(&mut self, n: usize) -> bool {
-        if n == 0 {
-            self.has_preceding_line_break()
-        } else {
-            self.lookahead(n)
-                .map_or(false, |lookahead| lookahead.after_newline)
-        }
+impl<'source> TokenSourceWithBufferedLexer<GraphqlLexer<'source>> for GraphqlTokenSource<'source> {
+    fn lexer(&mut self) -> &mut BufferedLexer<GraphqlSyntaxKind, GraphqlLexer<'source>> {
+        &mut self.lexer
     }
 }

--- a/crates/biome_graphql_syntax/src/lib.rs
+++ b/crates/biome_graphql_syntax/src/lib.rs
@@ -6,7 +6,7 @@
 mod generated;
 mod syntax_node;
 
-use biome_rowan::{AstNode, RawSyntaxKind};
+use biome_rowan::{AstNode, RawSyntaxKind, SyntaxKind};
 pub use biome_rowan::{TextLen, TextRange, TextSize, TokenAtOffset, TriviaPieceKind, WalkEvent};
 pub use generated::*;
 pub use syntax_node::*;
@@ -27,16 +27,6 @@ impl From<GraphqlSyntaxKind> for u16 {
 }
 
 impl GraphqlSyntaxKind {
-    pub fn is_trivia(self) -> bool {
-        matches!(
-            self,
-            GraphqlSyntaxKind::NEWLINE
-                | GraphqlSyntaxKind::WHITESPACE
-                | GraphqlSyntaxKind::COMMENT
-                | GraphqlSyntaxKind::COMMA
-        )
-    }
-
     /// Returns `true` for any contextual (await) or non-contextual keyword
     #[inline]
     pub const fn is_keyword(self) -> bool {
@@ -93,6 +83,16 @@ impl biome_rowan::SyntaxKind for GraphqlSyntaxKind {
 
     fn is_list(&self) -> bool {
         GraphqlSyntaxKind::is_list(*self)
+    }
+
+    fn is_trivia(self) -> bool {
+        matches!(
+            self,
+            GraphqlSyntaxKind::NEWLINE
+                | GraphqlSyntaxKind::WHITESPACE
+                | GraphqlSyntaxKind::COMMENT
+                | GraphqlSyntaxKind::COMMA
+        )
     }
 
     fn to_string(&self) -> Option<&'static str> {

--- a/crates/biome_grit_parser/src/lexer/mod.rs
+++ b/crates/biome_grit_parser/src/lexer/mod.rs
@@ -7,6 +7,7 @@ use crate::constants::SUPPORTED_LANGUAGE_SET_STR;
 use biome_grit_syntax::{GritSyntaxKind, GritSyntaxKind::*, TextLen, TextRange, TextSize, T};
 use biome_parser::diagnostic::ParseDiagnostic;
 use biome_parser::lexer::{Lexer, LexerCheckpoint};
+use biome_rowan::SyntaxKind;
 use std::ops::Add;
 
 /// An extremely fast, lookup table based, lossless Grit lexer

--- a/crates/biome_grit_syntax/src/lib.rs
+++ b/crates/biome_grit_syntax/src/lib.rs
@@ -12,7 +12,7 @@ pub use generated::*;
 pub use syntax_ext::*;
 pub use syntax_node::*;
 
-use biome_rowan::{AstNode, RawSyntaxKind};
+use biome_rowan::{AstNode, RawSyntaxKind, SyntaxKind};
 use GritSyntaxKind::*;
 
 impl From<u16> for GritSyntaxKind {
@@ -29,13 +29,6 @@ impl From<GritSyntaxKind> for u16 {
 }
 
 impl GritSyntaxKind {
-    pub fn is_trivia(self) -> bool {
-        matches!(
-            self,
-            GritSyntaxKind::NEWLINE | GritSyntaxKind::WHITESPACE | GritSyntaxKind::COMMENT
-        )
-    }
-
     /// Returns `true` for any contextual (await) or non-contextual keyword
     #[inline]
     pub const fn is_keyword(self) -> bool {
@@ -98,6 +91,13 @@ impl biome_rowan::SyntaxKind for GritSyntaxKind {
 
     fn is_list(&self) -> bool {
         GritSyntaxKind::is_list(*self)
+    }
+
+    fn is_trivia(self) -> bool {
+        matches!(
+            self,
+            GritSyntaxKind::NEWLINE | GritSyntaxKind::WHITESPACE | GritSyntaxKind::COMMENT
+        )
     }
 
     fn to_string(&self) -> Option<&'static str> {

--- a/crates/biome_html_parser/src/lexer/mod.rs
+++ b/crates/biome_html_parser/src/lexer/mod.rs
@@ -8,6 +8,7 @@ use biome_html_syntax::HtmlSyntaxKind::{
 use biome_html_syntax::{HtmlSyntaxKind, TextLen, TextSize, T};
 use biome_parser::diagnostic::ParseDiagnostic;
 use biome_parser::lexer::{Lexer, LexerCheckpoint, LexerWithCheckpoint, TokenFlags};
+use biome_rowan::SyntaxKind;
 use biome_unicode_table::lookup_byte;
 use biome_unicode_table::Dispatch::{BSL, QOT, UNI, WHS};
 use std::ops::Add;

--- a/crates/biome_html_parser/src/token_source.rs
+++ b/crates/biome_html_parser/src/token_source.rs
@@ -3,28 +3,15 @@ use biome_html_syntax::HtmlSyntaxKind::EOF;
 use biome_html_syntax::{HtmlSyntaxKind, TextRange};
 use biome_parser::diagnostic::ParseDiagnostic;
 use biome_parser::lexer::{BufferedLexer, LexContext};
-use biome_parser::prelude::{BumpWithContext, NthToken};
-use biome_parser::token_source::{TokenSource, Trivia};
+use biome_parser::prelude::BumpWithContext;
+use biome_parser::token_source::{TokenSource, TokenSourceWithBufferedLexer, Trivia};
 use biome_rowan::TriviaPieceKind;
-use std::collections::VecDeque;
 
 pub(crate) struct HtmlTokenSource<'source> {
-    lexer: BufferedLexer<'source, HtmlLexer<'source>>,
+    lexer: BufferedLexer<HtmlSyntaxKind, HtmlLexer<'source>>,
 
     /// List of the skipped trivia. Needed to construct the CST and compute the non-trivia token offsets.
     pub(super) trivia_list: Vec<Trivia>,
-    /// Cache for the non-trivia token lookahead. For example for the source `.class {};` if the
-    /// [TokenSource]'s currently positioned at the start of the file (`.`). The `nth(2)` non-trivia token,
-    /// as returned by the [TokenSource], is the `{` token but retrieving it requires skipping over the
-    /// one whitespace trivia tokens (between `class` and `{`).
-    /// The [TokenSource] state then is:
-    ///
-    /// * `non_trivia_lookahead`: [IDENT: 'class', L_CURLY]
-    /// * `lookahead_offset`: 3 (the `{` is the 3th token after the `.` keyword)
-    non_trivia_lookahead: VecDeque<Lookahead>,
-
-    /// Offset of the last cached lookahead token from the current [BufferedLexer] token.
-    lookahead_offset: usize,
 }
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -35,12 +22,6 @@ pub(crate) enum HtmlLexContext {
     #[allow(unused)]
     /// When the lexer is inside a element list, newlines, spaces and quotes are part of the text
     ElementList,
-}
-
-#[derive(Debug, Copy, Clone)]
-struct Lookahead {
-    kind: HtmlSyntaxKind,
-    after_newline: bool,
 }
 
 impl LexContext for HtmlLexContext {
@@ -62,25 +43,18 @@ impl<'source> HtmlTokenSource<'source> {
     }
 
     /// Creates a new token source.
-    pub(crate) fn new(lexer: BufferedLexer<'source, HtmlLexer<'source>>) -> Self {
+    pub(crate) fn new(lexer: BufferedLexer<HtmlSyntaxKind, HtmlLexer<'source>>) -> Self {
         Self {
             lexer,
             trivia_list: vec![],
-            lookahead_offset: 0,
-            non_trivia_lookahead: VecDeque::new(),
         }
     }
 
     fn next_non_trivia_token(&mut self, context: HtmlLexContext, first_token: bool) {
-        let mut processed_tokens = 0;
         let mut trailing = !first_token;
-
-        // Drop the last cached lookahead, we're now moving past it
-        self.non_trivia_lookahead.pop_front();
 
         loop {
             let kind = self.lexer.next_token(context);
-            processed_tokens += 1;
 
             let trivia_kind = TriviaPieceKind::try_from(kind);
 
@@ -99,51 +73,6 @@ impl<'source> HtmlTokenSource<'source> {
                 }
             }
         }
-
-        if self.lookahead_offset != 0 {
-            debug_assert!(
-                self.lookahead_offset >= processed_tokens,
-                "lookadead offeset: {}, processed tokens: {}",
-                self.lookahead_offset,
-                processed_tokens
-            );
-            self.lookahead_offset -= processed_tokens;
-        }
-    }
-
-    #[inline(always)]
-    fn lookahead(&mut self, n: usize) -> Option<Lookahead> {
-        assert_ne!(n, 0);
-
-        // Return the cached token if any
-        if let Some(lookahead) = self.non_trivia_lookahead.get(n - 1) {
-            return Some(*lookahead);
-        }
-
-        // Jump right to where we've left of last time rather than going through all tokens again.
-        let iter = self.lexer.lookahead().skip(self.lookahead_offset);
-        let mut remaining = n - self.non_trivia_lookahead.len();
-
-        for item in iter {
-            self.lookahead_offset += 1;
-
-            if !item.kind().is_trivia() {
-                remaining -= 1;
-
-                let lookahead = Lookahead {
-                    after_newline: item.has_preceding_line_break(),
-                    kind: item.kind(),
-                };
-
-                self.non_trivia_lookahead.push_back(lookahead);
-
-                if remaining == 0 {
-                    return Some(lookahead);
-                }
-            }
-        }
-
-        None
     }
 }
 
@@ -183,22 +112,12 @@ impl<'source> BumpWithContext for HtmlTokenSource<'source> {
     type Context = HtmlLexContext;
     fn bump_with_context(&mut self, context: Self::Context) {
         if self.current() != EOF {
-            if !context.is_regular() {
-                self.lookahead_offset = 0;
-                self.non_trivia_lookahead.clear();
-            }
-
             self.next_non_trivia_token(context, false);
         }
     }
 
     fn skip_as_trivia_with_context(&mut self, context: Self::Context) {
         if self.current() != EOF {
-            if !context.is_regular() {
-                self.lookahead_offset = 0;
-                self.non_trivia_lookahead.clear();
-            }
-
             self.trivia_list.push(Trivia::new(
                 TriviaPieceKind::Skipped,
                 self.current_range(),
@@ -210,23 +129,8 @@ impl<'source> BumpWithContext for HtmlTokenSource<'source> {
     }
 }
 
-impl<'source> NthToken for HtmlTokenSource<'source> {
-    #[inline(always)]
-
-    fn nth(&mut self, n: usize) -> Self::Kind {
-        if n == 0 {
-            self.current()
-        } else {
-            self.lookahead(n).map_or(EOF, |lookahead| lookahead.kind)
-        }
-    }
-    #[inline(always)]
-    fn has_nth_preceding_line_break(&mut self, n: usize) -> bool {
-        if n == 0 {
-            self.has_preceding_line_break()
-        } else {
-            self.lookahead(n)
-                .map_or(false, |lookahead| lookahead.after_newline)
-        }
+impl<'source> TokenSourceWithBufferedLexer<HtmlLexer<'source>> for HtmlTokenSource<'source> {
+    fn lexer(&mut self) -> &mut BufferedLexer<HtmlSyntaxKind, HtmlLexer<'source>> {
+        &mut self.lexer
     }
 }

--- a/crates/biome_html_syntax/src/lib.rs
+++ b/crates/biome_html_syntax/src/lib.rs
@@ -9,7 +9,7 @@ pub use file_source::HtmlFileSource;
 pub use syntax_node::*;
 
 use crate::HtmlSyntaxKind::{HTML_BOGUS, HTML_BOGUS_ATTRIBUTE};
-use biome_rowan::{AstNode, RawSyntaxKind, TokenText};
+use biome_rowan::{AstNode, RawSyntaxKind, SyntaxKind, TokenText};
 
 impl From<u16> for HtmlSyntaxKind {
     fn from(d: u16) -> HtmlSyntaxKind {
@@ -25,10 +25,6 @@ impl From<HtmlSyntaxKind> for u16 {
 }
 
 impl HtmlSyntaxKind {
-    pub fn is_trivia(self) -> bool {
-        matches!(self, HtmlSyntaxKind::NEWLINE | HtmlSyntaxKind::WHITESPACE)
-    }
-
     pub fn is_comments(self) -> bool {
         matches!(self, HtmlSyntaxKind::COMMENT)
     }
@@ -77,6 +73,10 @@ impl biome_rowan::SyntaxKind for HtmlSyntaxKind {
 
     fn is_list(&self) -> bool {
         HtmlSyntaxKind::is_list(*self)
+    }
+
+    fn is_trivia(self) -> bool {
+        matches!(self, HtmlSyntaxKind::NEWLINE | HtmlSyntaxKind::WHITESPACE)
     }
 
     fn to_string(&self) -> Option<&'static str> {

--- a/crates/biome_js_parser/src/lexer/mod.rs
+++ b/crates/biome_js_parser/src/lexer/mod.rs
@@ -25,6 +25,7 @@ use biome_parser::diagnostic::ParseDiagnostic;
 use biome_parser::lexer::{
     LexContext, Lexer, LexerCheckpoint, LexerWithCheckpoint, ReLexer, TokenFlags,
 };
+use biome_rowan::SyntaxKind;
 use biome_unicode_table::{
     is_js_id_continue, is_js_id_start, lookup_byte,
     Dispatch::{self, *},

--- a/crates/biome_js_parser/src/lexer/tests.rs
+++ b/crates/biome_js_parser/src/lexer/tests.rs
@@ -1455,7 +1455,10 @@ fn lookahead() {
     );
 
     {
-        let lookahead = buffered.lookahead().map(|l| l.kind()).collect::<Vec<_>>();
+        let lookahead = buffered
+            .lookahead_iter()
+            .map(|l| l.kind())
+            .collect::<Vec<_>>();
 
         assert_eq!(
             lookahead,
@@ -1476,7 +1479,7 @@ fn lookahead() {
     assert_eq!(buffered.next_token(JsLexContext::default()), WHITESPACE);
 
     {
-        let mut lookahead = buffered.lookahead();
+        let mut lookahead = buffered.lookahead_iter();
         let nth1 = lookahead.next().unwrap();
         let nth2 = lookahead.next().unwrap();
         let nth3 = lookahead.next().unwrap();

--- a/crates/biome_js_parser/src/token_source.rs
+++ b/crates/biome_js_parser/src/token_source.rs
@@ -2,48 +2,26 @@ use crate::lexer::{JsLexContext, JsLexer, JsReLexContext, TextRange};
 use crate::prelude::*;
 use biome_js_syntax::JsSyntaxKind;
 use biome_js_syntax::JsSyntaxKind::EOF;
-use biome_parser::lexer::{BufferedLexer, LexContext};
-use biome_parser::token_source::{TokenSourceCheckpoint, Trivia};
+use biome_parser::lexer::BufferedLexer;
+use biome_parser::token_source::{TokenSourceCheckpoint, TokenSourceWithBufferedLexer, Trivia};
 use biome_rowan::{TextSize, TriviaPieceKind};
-use std::collections::VecDeque;
 
 /// Token source for the parser that skips over any non-trivia token.
 pub struct JsTokenSource<'l> {
-    lexer: BufferedLexer<'l, JsLexer<'l>>,
+    lexer: BufferedLexer<JsSyntaxKind, JsLexer<'l>>,
 
     /// List of the skipped trivia. Needed to construct the CST and compute the non-trivia token offsets.
     pub(super) trivia_list: Vec<Trivia>,
-
-    /// Cache for the non-trivia token lookahead. For example for the source `let a = 10;` if the
-    /// [TokenSource]'s currently positioned at the start of the file (`let`). The `nth(2)` non-trivia token,
-    /// as returned by the [TokenSource], is the `=` token but retrieving it requires skipping over the
-    /// two whitespace trivia tokens (first between `let` and `a`, second between `a` and `=`).
-    /// The [TokenSource] state then is:
-    ///
-    /// * `non_trivia_lookahead`: [IDENT: 'a', EQ]
-    /// * `lookahead_offset`: 4 (the `=` is the 4th token after the `let` keyword)
-    non_trivia_lookahead: VecDeque<Lookahead>,
-
-    /// Offset of the last cached lookahead token from the current [BufferedLexer] token.
-    lookahead_offset: usize,
-}
-
-#[derive(Debug, Copy, Clone)]
-struct Lookahead {
-    kind: JsSyntaxKind,
-    after_newline: bool,
 }
 
 pub(crate) type JsTokenSourceCheckpoint = TokenSourceCheckpoint<JsSyntaxKind>;
 
 impl<'l> JsTokenSource<'l> {
     /// Creates a new token source.
-    pub(crate) fn new(lexer: BufferedLexer<'l, JsLexer<'l>>) -> JsTokenSource<'l> {
+    pub(crate) fn new(lexer: BufferedLexer<JsSyntaxKind, JsLexer<'l>>) -> JsTokenSource<'l> {
         JsTokenSource {
             lexer,
             trivia_list: vec![],
-            lookahead_offset: 0,
-            non_trivia_lookahead: VecDeque::new(),
         }
     }
 
@@ -59,15 +37,10 @@ impl<'l> JsTokenSource<'l> {
 
     #[inline]
     fn next_non_trivia_token(&mut self, context: JsLexContext, first_token: bool) {
-        let mut processed_tokens = 0;
         let mut trailing = !first_token;
-
-        // Drop the last cached lookahead, we're now moving past it
-        self.non_trivia_lookahead.pop_front();
 
         loop {
             let kind = self.lexer.next_token(context);
-            processed_tokens += 1;
 
             let trivia_kind = TriviaPieceKind::try_from(kind);
 
@@ -84,11 +57,6 @@ impl<'l> JsTokenSource<'l> {
                 }
             }
         }
-
-        if self.lookahead_offset != 0 {
-            debug_assert!(self.lookahead_offset >= processed_tokens);
-            self.lookahead_offset -= processed_tokens;
-        }
     }
 
     #[inline(always)]
@@ -101,59 +69,14 @@ impl<'l> JsTokenSource<'l> {
     pub fn has_next_preceding_trivia(&mut self) -> bool {
         let next_token_trivia = self
             .lexer
-            .lookahead()
+            .lookahead_iter()
             .next()
             .and_then(|lookahead| TriviaPieceKind::try_from(lookahead.kind()).ok());
         next_token_trivia.is_some()
     }
 
-    #[inline(always)]
-    fn lookahead(&mut self, n: usize) -> Option<Lookahead> {
-        assert_ne!(n, 0);
-
-        // Return the cached token if any
-        if let Some(lookahead) = self.non_trivia_lookahead.get(n - 1) {
-            return Some(*lookahead);
-        }
-
-        // Jump right to where we've left of last time rather than going through all tokens again.
-        let iter = self.lexer.lookahead().skip(self.lookahead_offset);
-        let mut remaining = n - self.non_trivia_lookahead.len();
-
-        for item in iter {
-            self.lookahead_offset += 1;
-
-            if !item.kind().is_trivia() {
-                remaining -= 1;
-
-                let lookahead = Lookahead {
-                    after_newline: item.has_preceding_line_break(),
-                    kind: item.kind(),
-                };
-
-                self.non_trivia_lookahead.push_back(lookahead);
-
-                if remaining == 0 {
-                    return Some(lookahead);
-                }
-            }
-        }
-
-        None
-    }
-
     pub fn re_lex(&mut self, mode: JsReLexContext) -> JsSyntaxKind {
-        let current_kind = self.current();
-
-        let new_kind = self.lexer.re_lex(mode);
-
-        // Only need to clear the lookahead cache when the token did change
-        if current_kind != new_kind {
-            self.non_trivia_lookahead.clear();
-            self.lookahead_offset = 0;
-        }
-
-        new_kind
+        self.lexer.re_lex(mode)
     }
 
     /// Creates a checkpoint to which it can later return using [Self::rewind].
@@ -169,8 +92,6 @@ impl<'l> JsTokenSource<'l> {
         assert!(self.trivia_list.len() >= checkpoint.trivia_len as usize);
         self.trivia_list.truncate(checkpoint.trivia_len as usize);
         self.lexer.rewind(checkpoint.lexer_checkpoint);
-        self.non_trivia_lookahead.clear();
-        self.lookahead_offset = 0;
     }
 }
 
@@ -225,11 +146,6 @@ impl<'source> BumpWithContext for JsTokenSource<'source> {
     #[inline(always)]
     fn bump_with_context(&mut self, context: Self::Context) {
         if self.current() != EOF {
-            if !context.is_regular() {
-                self.lookahead_offset = 0;
-                self.non_trivia_lookahead.clear();
-            }
-
             self.next_non_trivia_token(context, false);
         }
     }
@@ -237,11 +153,6 @@ impl<'source> BumpWithContext for JsTokenSource<'source> {
     /// Skips the current token as skipped token trivia
     fn skip_as_trivia_with_context(&mut self, context: JsLexContext) {
         if self.current() != EOF {
-            if !context.is_regular() {
-                self.lookahead_offset = 0;
-                self.non_trivia_lookahead.clear();
-            }
-
             self.trivia_list.push(Trivia::new(
                 TriviaPieceKind::Skipped,
                 self.current_range(),
@@ -253,25 +164,8 @@ impl<'source> BumpWithContext for JsTokenSource<'source> {
     }
 }
 
-impl<'source> NthToken for JsTokenSource<'source> {
-    /// Gets the kind of the nth non-trivia token
-    #[inline(always)]
-    fn nth(&mut self, n: usize) -> JsSyntaxKind {
-        if n == 0 {
-            self.current()
-        } else {
-            self.lookahead(n).map_or(EOF, |lookahead| lookahead.kind)
-        }
-    }
-
-    /// Returns true if the nth non-trivia token is preceded by a line break
-    #[inline(always)]
-    fn has_nth_preceding_line_break(&mut self, n: usize) -> bool {
-        if n == 0 {
-            self.has_preceding_line_break()
-        } else {
-            self.lookahead(n)
-                .map_or(false, |lookahead| lookahead.after_newline)
-        }
+impl<'source> TokenSourceWithBufferedLexer<JsLexer<'source>> for JsTokenSource<'source> {
+    fn lexer(&mut self) -> &mut BufferedLexer<JsSyntaxKind, JsLexer<'source>> {
+        &mut self.lexer
     }
 }

--- a/crates/biome_js_syntax/src/lib.rs
+++ b/crates/biome_js_syntax/src/lib.rs
@@ -39,7 +39,7 @@ pub use stmt_ext::*;
 pub use syntax_node::*;
 
 use crate::JsSyntaxKind::*;
-use biome_rowan::{AstNode, RawSyntaxKind, SyntaxResult};
+use biome_rowan::{AstNode, RawSyntaxKind, SyntaxKind, SyntaxResult};
 
 impl From<u16> for JsSyntaxKind {
     fn from(d: u16) -> JsSyntaxKind {
@@ -55,16 +55,6 @@ impl From<JsSyntaxKind> for u16 {
 }
 
 impl JsSyntaxKind {
-    pub fn is_trivia(self) -> bool {
-        matches!(
-            self,
-            JsSyntaxKind::NEWLINE
-                | JsSyntaxKind::WHITESPACE
-                | JsSyntaxKind::COMMENT
-                | JsSyntaxKind::MULTILINE_COMMENT
-        )
-    }
-
     /// Returns `true` for any contextual (await) or non-contextual keyword
     #[inline]
     pub const fn is_keyword(self) -> bool {
@@ -146,6 +136,16 @@ impl biome_rowan::SyntaxKind for JsSyntaxKind {
 
     fn is_list(&self) -> bool {
         JsSyntaxKind::is_list(*self)
+    }
+
+    fn is_trivia(self) -> bool {
+        matches!(
+            self,
+            JsSyntaxKind::NEWLINE
+                | JsSyntaxKind::WHITESPACE
+                | JsSyntaxKind::COMMENT
+                | JsSyntaxKind::MULTILINE_COMMENT
+        )
     }
 
     fn to_string(&self) -> Option<&'static str> {

--- a/crates/biome_json_syntax/src/lib.rs
+++ b/crates/biome_json_syntax/src/lib.rs
@@ -10,7 +10,7 @@ pub use biome_rowan::{TextLen, TextRange, TextSize, TokenAtOffset, TriviaPieceKi
 pub use file_source::JsonFileSource;
 pub use syntax_node::*;
 
-use biome_rowan::{RawSyntaxKind, TokenText};
+use biome_rowan::{RawSyntaxKind, SyntaxKind, TokenText};
 
 impl From<u16> for JsonSyntaxKind {
     fn from(d: u16) -> JsonSyntaxKind {
@@ -26,10 +26,6 @@ impl From<JsonSyntaxKind> for u16 {
 }
 
 impl JsonSyntaxKind {
-    pub fn is_trivia(self) -> bool {
-        matches!(self, JsonSyntaxKind::NEWLINE | JsonSyntaxKind::WHITESPACE)
-    }
-
     pub fn is_comments(self) -> bool {
         matches!(
             self,
@@ -83,6 +79,10 @@ impl biome_rowan::SyntaxKind for JsonSyntaxKind {
 
     fn is_list(&self) -> bool {
         JsonSyntaxKind::is_list(*self)
+    }
+
+    fn is_trivia(self) -> bool {
+        matches!(self, JsonSyntaxKind::NEWLINE | JsonSyntaxKind::WHITESPACE)
     }
 
     fn to_string(&self) -> Option<&'static str> {

--- a/crates/biome_parser/src/lexer.rs
+++ b/crates/biome_parser/src/lexer.rs
@@ -312,37 +312,115 @@ impl LexContext for () {
 ///   that any following token may turn out to be different as well, thus, it's necessary to clear the
 ///   lookahead cache.
 #[derive(Debug)]
-pub struct BufferedLexer<'l, Lex: Lexer<'l>> {
+pub struct BufferedLexer<Kind, Lex> {
     /// Cache storing the lookahead tokens. That are, all tokens between the `current` token and
     /// the "current" of the [Lexer]. This is because the [Lexer]'s current token points to the
     /// furthest requested lookahead token.
     ///
     /// For example for the following source `let a = 2;`. The `current` token of the inner [Lexer] and
     /// of the [BufferedLexer] after one call to `next_token` is the `let` token. However, the `current`
-    /// token diverges if the [BufferedLexer] performs lookahead. Let's say you do a lookahead of 4 (`=` token).
+    /// token diverges if the [BufferedLexer] performs lookahead. Let's say you do a non trivia lookahead of 2 (`=` token).
     /// Now, the [BufferedLexer] calls [Lexer::next_token] four times, moving the [Lexer]'s `current`
     /// token to the `=`. However, the `current` of the [BufferedLexer] still points to the `let` token.
     /// That's why the [BufferedLexer] stores the following information:
     /// * `current`: `let` (information about the `current` token from the consumer perspective)
-    /// * `lookahead`: [WHITESPACE, IDENT: 'a', WHITESPACE]. The tokens that have been lexed to
-    ///    answer the "lookahead 4" request but haven't been returned yet.
+    /// * `all_checkpoints`: [WHITESPACE, IDENT: 'a', WHITESPACE, EQ]. The checkpoints that have been lexed to
+    ///    answer the "non trivia lookahead 2" request but haven't been returned yet.
+    /// * `non_trivia_checkpoints`: [IDENT: 'a', EQ]. The checkpoints that have been lexed to
+    ///    answer the "non trivia lookahead 2" request but haven't been returned yet.
     /// * [Lexer::current]: Points to `=`
-    lookahead: VecDeque<LexerCheckpoint<Lex::Kind>>,
+    lookahead: Lookahead<Kind>,
 
     /// Stores the information of the current token in case the `lexer` is at least one token ahead.
-    current: Option<LexerCheckpoint<Lex::Kind>>,
+    current: Option<LexerCheckpoint<Kind>>,
 
     /// Underlying lexer. May be ahead if iterated with lookahead
     inner: Lex,
 }
 
-impl<'l, Lex: Lexer<'l>> BufferedLexer<'l, Lex> {
+/// A structure that maintains two collections of lexer checkpoints:
+/// one for all checkpoints and another for non-trivia checkpoints only.
+#[derive(Debug)]
+struct Lookahead<Kind> {
+    /// A buffer of all checkpoints including trivia and non-trivia types.
+    all_checkpoints: VecDeque<LexerCheckpoint<Kind>>,
+    /// A buffer of only non-trivia checkpoints.
+    non_trivia_checkpoints: VecDeque<LexerCheckpoint<Kind>>,
+}
+
+impl<K: SyntaxKind> Lookahead<K> {
+    /// Creates a new instance of `BufferedLookahead` with specified capacity for both buffers.
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            all_checkpoints: VecDeque::with_capacity(capacity),
+            non_trivia_checkpoints: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    /// Adds a checkpoint to the end of both buffers, if applicable.
+    ///
+    /// Non-trivia checkpoints are cloned and added to the `non_trivia_checkpoints` buffer
+    /// only if they are not considered trivia.
+    fn push_back(&mut self, checkpoint: LexerCheckpoint<K>) {
+        if !checkpoint.current_kind.is_trivia() {
+            self.non_trivia_checkpoints.push_back(checkpoint.clone());
+        }
+
+        self.all_checkpoints.push_back(checkpoint);
+    }
+
+    /// Removes and returns the first element from the `all_checkpoints` buffer.
+    /// Also removes the corresponding element from `non_trivia_checkpoints` if it's non-trivia.
+    fn pop_front(&mut self) -> Option<LexerCheckpoint<K>> {
+        if let Some(lookahead) = self.all_checkpoints.pop_front() {
+            if !lookahead.current_kind.is_trivia() {
+                self.non_trivia_checkpoints.pop_front();
+            }
+            Some(lookahead)
+        } else {
+            None
+        }
+    }
+
+    /// Retrieves a reference to a checkpoint by index from the `all_checkpoints` buffer.
+    fn get_checkpoint(&self, index: usize) -> Option<&LexerCheckpoint<K>> {
+        self.all_checkpoints.get(index)
+    }
+
+    /// Retrieves a reference to a non-trivia checkpoint by index from the `non_trivia_checkpoints` buffer.
+    fn get_non_trivia_checkpoint(&self, index: usize) -> Option<&LexerCheckpoint<K>> {
+        self.non_trivia_checkpoints.get(index)
+    }
+
+    /// Checks if there are no checkpoints.
+    fn is_empty(&self) -> bool {
+        self.all_checkpoints.is_empty()
+    }
+
+    /// Clears all checkpoints from both buffers.
+    fn clear(&mut self) {
+        self.all_checkpoints.clear();
+        self.non_trivia_checkpoints.clear();
+    }
+
+    /// Returns the number of checkpoints in the `all_checkpoints` buffer.
+    fn all_len(&self) -> usize {
+        self.all_checkpoints.len()
+    }
+
+    /// Returns the number of non-trivia checkpoints in the `non_trivia_checkpoints` buffer.
+    fn non_trivia_len(&self) -> usize {
+        self.non_trivia_checkpoints.len()
+    }
+}
+
+impl<'l, Lex: Lexer<'l>> BufferedLexer<Lex::Kind, Lex> {
     /// Creates a new [BufferedLexer] wrapping the passed in [Lexer].
     pub fn new(lexer: Lex) -> Self {
         Self {
             inner: lexer,
             current: None,
-            lookahead: VecDeque::new(),
+            lookahead: Lookahead::with_capacity(5),
         }
     }
 
@@ -441,7 +519,7 @@ impl<'l, Lex: Lexer<'l>> BufferedLexer<'l, Lex> {
     /// Returns an iterator over the tokens following the current token to perform lookahead.
     /// For example, what's the 3rd token after the current token?
     #[inline(always)]
-    pub fn lookahead<'s>(&'s mut self) -> LookaheadIterator<'s, 'l, Lex> {
+    pub fn lookahead_iter<'s>(&'s mut self) -> LookaheadIterator<'s, 'l, Lex> {
         LookaheadIterator::new(self)
     }
 
@@ -450,7 +528,7 @@ impl<'l, Lex: Lexer<'l>> BufferedLexer<'l, Lex> {
         self.inner.finish()
     }
 }
-impl<'l, Lex> BufferedLexer<'l, Lex>
+impl<'l, Lex> BufferedLexer<Lex::Kind, Lex>
 where
     Lex: ReLexer<'l>,
 {
@@ -479,10 +557,40 @@ where
     }
 }
 
-impl<'l, Lex> BufferedLexer<'l, Lex>
+impl<'l, Lex> BufferedLexer<Lex::Kind, Lex>
 where
     Lex: LexerWithCheckpoint<'l>,
 {
+    #[inline(always)]
+    pub fn nth_non_trivia(&mut self, n: usize) -> Option<LookaheadToken<Lex::Kind>> {
+        assert_ne!(n, 0);
+
+        if let Some(lookahead_token) = self
+            .lookahead
+            .get_non_trivia_checkpoint(n - 1)
+            .map(LookaheadToken::from)
+        {
+            return Some(lookahead_token);
+        }
+
+        // Jump right to where we've left of last time rather than going through all tokens again.
+        let mut remaining = n - self.lookahead.non_trivia_len();
+        let current_length = self.lookahead.all_len();
+        let iter = self.lookahead_iter().skip(current_length);
+
+        for item in iter {
+            if !item.kind().is_trivia() {
+                remaining -= 1;
+
+                if remaining == 0 {
+                    return Some(item);
+                }
+            }
+        }
+
+        None
+    }
+
     pub fn checkpoint(&self) -> LexerCheckpoint<Lex::Kind> {
         if let Some(current) = &self.current {
             current.clone()
@@ -494,12 +602,12 @@ where
 
 #[derive(Debug)]
 pub struct LookaheadIterator<'l, 't, Lex: Lexer<'t>> {
-    buffered: &'l mut BufferedLexer<'t, Lex>,
+    buffered: &'l mut BufferedLexer<Lex::Kind, Lex>,
     nth: usize,
 }
 
 impl<'l, 't, Lex: Lexer<'t>> LookaheadIterator<'l, 't, Lex> {
-    fn new(lexer: &'l mut BufferedLexer<'t, Lex>) -> Self {
+    fn new(lexer: &'l mut BufferedLexer<Lex::Kind, Lex>) -> Self {
         Self {
             buffered: lexer,
             nth: 0,
@@ -516,7 +624,7 @@ impl<'l, 't, Lex: LexerWithCheckpoint<'t>> Iterator for LookaheadIterator<'l, 't
         self.nth += 1;
 
         // Is the `nth` token already in the cache, then return it
-        if let Some(lookbehind) = lookbehind.get(self.nth - 1) {
+        if let Some(lookbehind) = lookbehind.get_checkpoint(self.nth - 1) {
             let lookahead = LookaheadToken::from(lookbehind);
             return Some(lookahead);
         }
@@ -537,8 +645,7 @@ impl<'l, 't, Lex: LexerWithCheckpoint<'t>> Iterator for LookaheadIterator<'l, 't
         let kind = lexer.next_token(Lex::LexContext::default());
         // Lex the next token and cache it in the lookahead cache. Needed to cache it right away
         // because of the diagnostic.
-        let checkpoint = lexer.checkpoint();
-        self.buffered.lookahead.push_back(checkpoint);
+        self.buffered.lookahead.push_back(lexer.checkpoint());
 
         Some(LookaheadToken {
             kind,
@@ -550,7 +657,7 @@ impl<'l, 't, Lex: LexerWithCheckpoint<'t>> Iterator for LookaheadIterator<'l, 't
 impl<'l, 't, Lex: LexerWithCheckpoint<'t>> FusedIterator for LookaheadIterator<'l, 't, Lex> {}
 
 #[derive(Debug)]
-pub struct LookaheadToken<Kind: SyntaxKind> {
+pub struct LookaheadToken<Kind> {
     kind: Kind,
     flags: TokenFlags,
 }

--- a/crates/biome_parser/src/lexer.rs
+++ b/crates/biome_parser/src/lexer.rs
@@ -350,10 +350,10 @@ struct Lookahead<Kind> {
 
 impl<K: SyntaxKind> Lookahead<K> {
     /// Creates a new instance of `BufferedLookahead` with specified capacity for both buffers.
-    fn with_capacity(capacity: usize) -> Self {
+    fn new() -> Self {
         Self {
-            all_checkpoints: VecDeque::with_capacity(capacity),
-            non_trivia_checkpoints: VecDeque::with_capacity(capacity),
+            all_checkpoints: VecDeque::new(),
+            non_trivia_checkpoints: VecDeque::new(),
         }
     }
 
@@ -420,7 +420,7 @@ impl<'l, Lex: Lexer<'l>> BufferedLexer<Lex::Kind, Lex> {
         Self {
             inner: lexer,
             current: None,
-            lookahead: Lookahead::with_capacity(5),
+            lookahead: Lookahead::new(),
         }
     }
 

--- a/crates/biome_rowan/src/raw_language.rs
+++ b/crates/biome_rowan/src/raw_language.rs
@@ -75,6 +75,10 @@ impl SyntaxKind for RawLanguageKind {
         )
     }
 
+    fn is_trivia(self) -> bool {
+        self == RawLanguageKind::WHITESPACE
+    }
+
     fn to_string(&self) -> Option<&'static str> {
         let str = match self {
             COMMA_TOKEN => ",",

--- a/crates/biome_rowan/src/syntax.rs
+++ b/crates/biome_rowan/src/syntax.rs
@@ -45,6 +45,9 @@ pub trait SyntaxKind: fmt::Debug + PartialEq + Copy {
     /// Returns `true` if this kind is a list node.
     fn is_list(&self) -> bool;
 
+    /// Returns `true` if this kind is a trivia.
+    fn is_trivia(self) -> bool;
+
     /// Returns a string for keywords and punctuation tokens or `None` otherwise.
     fn to_string(&self) -> Option<&'static str>;
 }

--- a/crates/biome_yaml_syntax/src/lib.rs
+++ b/crates/biome_yaml_syntax/src/lib.rs
@@ -56,6 +56,13 @@ impl biome_rowan::SyntaxKind for YamlSyntaxKind {
         YamlSyntaxKind::is_list(*self)
     }
 
+    fn is_trivia(self) -> bool {
+        matches!(
+            self,
+            YamlSyntaxKind::NEWLINE | YamlSyntaxKind::WHITESPACE | YamlSyntaxKind::COMMENT
+        )
+    }
+
     fn to_string(&self) -> Option<&'static str> {
         YamlSyntaxKind::to_string(self)
     }


### PR DESCRIPTION
## Summary

We have code duplication around the non-trivia lookahead in our parser. The MR attempts to extract the common parts into the parser crate. Basically, we have a `non_trivia_lookahead` vector for each token source. We can try to move them inside the current lookahead in the buffered lexer, because we are interested only in non-trivia lookahead.

## Test Plan

`cargo test`
