### PR TITLE
fix(lint/useSingleCaseStatement): ignore `break` statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Fix typo by renaming `useConsistentBuiltinInstatiation` to `useConsistentBuiltinInstantiation`
   Contributed by @minht11
+- Fix the rule `useSingleCaseStatement` including `break` statements when counting the number of statements in a `switch` statement (#2696)
 
 ### Parser
 
@@ -183,7 +184,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Contributed by @Conaclos
 
 - [noMisplacedAssertion](https://biomejs.dev/linter/rules/no-misplaced-assertion/) now allow these matchers
-  
+
   - `expect.any()`
   - `expect.anything()`
   - `expect.closeTo`

--- a/crates/biome_js_analyze/src/lint/style/use_single_case_statement.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_single_case_statement.rs
@@ -52,7 +52,12 @@ impl Rule for UseSingleCaseStatement {
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let switch_clause = ctx.query();
-        if switch_clause.consequent().len() > 1 {
+        let count = switch_clause
+            .consequent()
+            .iter()
+            .filter(|stmt| !matches!(stmt, AnyJsStatement::JsBreakStatement(_)))
+            .count();
+        if count > 1 {
             Some(())
         } else {
             None

--- a/crates/biome_js_analyze/tests/specs/style/useSingleCaseStatement/valid.js
+++ b/crates/biome_js_analyze/tests/specs/style/useSingleCaseStatement/valid.js
@@ -29,3 +29,34 @@ switch (foo) {
 switch (foo) {
     default:
 }
+
+switch (foo) {
+	case true:
+		x = 1;
+		break;
+}
+
+switch (foo) {
+	case 1:
+		x = 2;
+		break;
+	case 2:
+		x = 1;
+		break;
+}
+
+switch (foo) {
+	case true:
+		// comment
+		x = 1;
+		break;
+}
+
+switch (foo) {
+	case 1:
+	case 2:
+		x = 1;
+		break;
+	default:
+		break;
+}

--- a/crates/biome_js_analyze/tests/specs/style/useSingleCaseStatement/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useSingleCaseStatement/valid.js.snap
@@ -36,6 +36,35 @@ switch (foo) {
     default:
 }
 
+switch (foo) {
+	case true:
+		x = 1;
+		break;
+}
+
+switch (foo) {
+	case 1:
+		x = 2;
+		break;
+	case 2:
+		x = 1;
+		break;
+}
+
+switch (foo) {
+	case true:
+		// comment
+		x = 1;
+		break;
+}
+
+switch (foo) {
+	case 1:
+	case 2:
+		x = 1;
+		break;
+	default:
+		break;
+}
+
 ```
-
-


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

The intent behind the `useSingleCaseStatement` lint is that it's supposed to enforce performing only one action or operation per switch clause. `break` statements don't really fall into this category, and they are commonly used in switch statements to prevent fallthroughs.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

fixes #2696

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added snapshot tests
```bash
cargo test -p biome_js_analyze use_single_case_statement
```
