### PR TITLE
fix(lint/noUselessStringConcat): add missing fix_kind

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_string_concat.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_string_concat.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic, RuleSource,
+    context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -66,6 +67,7 @@ declare_rule! {
         name: "noUselessStringConcat",
         sources: &[RuleSource::Eslint("no-useless-concat")],
         recommended: false,
+        fix_kind: FixKind::Unsafe,
     }
 }
 


### PR DESCRIPTION
## Summary

Add missing `fix_kind` property to `noUselessStringConcat` rule, as [discussed here](https://github.com/biomejs/biome/pull/2720?#issuecomment-2096080836).