### PR TITLE
fix(lint/useJsxKeyInIterable): handle ternaries outside jsx expressions

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -205,20 +205,21 @@ fn handle_potential_react_component(
 ) -> Option<Vec<TextRange>> {
     let node = unwrap_parenthesis(node)?;
 
-    if is_inside_jsx {
-        if let AnyJsExpression::JsConditionalExpression(node) = node {
-            let consequent =
-                handle_potential_react_component(node.consequent().ok()?, model, is_inside_jsx);
-            let alternate =
-                handle_potential_react_component(node.alternate().ok()?, model, is_inside_jsx);
+    if let AnyJsExpression::JsConditionalExpression(node) = node {
+        let consequent =
+            handle_potential_react_component(node.consequent().ok()?, model, is_inside_jsx);
+        let alternate =
+            handle_potential_react_component(node.alternate().ok()?, model, is_inside_jsx);
 
-            return match (consequent, alternate) {
-                (Some(consequent), Some(alternate)) => Some([consequent, alternate].concat()),
-                (Some(consequent), None) => Some(consequent),
-                (None, Some(alternate)) => Some(alternate),
-                (None, None) => None,
-            };
-        }
+        return match (consequent, alternate) {
+            (Some(consequent), Some(alternate)) => Some([consequent, alternate].concat()),
+            (Some(consequent), None) => Some(consequent),
+            (None, Some(alternate)) => Some(alternate),
+            (None, None) => None,
+        };
+    }
+
+    if is_inside_jsx {
         if let Some(node) = ReactComponentExpression::cast_ref(node.syntax()) {
             let range = handle_react_component(node, model)?;
             Some(vec![range])

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx
@@ -39,3 +39,7 @@ React.Children.map(c => React.cloneElement(c));
 (<h1>{data.map(c => (<h1></h1>))}</h1>)
 
 (<h1>{data.map(c => {return (<h1></h1>)})}</h1>)
+
+[].map((item) => {
+	return item.condition ? <div /> : <div>foo</div>;
+});

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx.snap
@@ -45,6 +45,11 @@ React.Children.map(c => React.cloneElement(c));
 (<h1>{data.map(c => (<h1></h1>))}</h1>)
 
 (<h1>{data.map(c => {return (<h1></h1>)})}</h1>)
+
+[].map((item) => {
+	return item.condition ? <div /> : <div>foo</div>;
+});
+
 ```
 
 # Diagnostics
@@ -171,6 +176,44 @@ invalid.jsx:7:2 lint/correctness/useJsxKeyInIterable ━━━━━━━━━
     6 │ 
   > 7 │ [<Hello />, xyz ? <Hello />: <Hello />, <Hello />];
       │  ^^^^^^^^^
+    8 │ 
+    9 │ [<></>, <></>, <></>];
+  
+  i The order of the items may change, and having a key can help React identify which item was moved.
+  
+  i Check the React documentation. 
+  
+
+```
+
+```
+invalid.jsx:7:19 lint/correctness/useJsxKeyInIterable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing key property for this element in iterable.
+  
+    5 │ [...[<Hello />, <Hello />], <Hello />];
+    6 │ 
+  > 7 │ [<Hello />, xyz ? <Hello />: <Hello />, <Hello />];
+      │                   ^^^^^^^^^
+    8 │ 
+    9 │ [<></>, <></>, <></>];
+  
+  i The order of the items may change, and having a key can help React identify which item was moved.
+  
+  i Check the React documentation. 
+  
+
+```
+
+```
+invalid.jsx:7:30 lint/correctness/useJsxKeyInIterable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing key property for this element in iterable.
+  
+    5 │ [...[<Hello />, <Hello />], <Hello />];
+    6 │ 
+  > 7 │ [<Hello />, xyz ? <Hello />: <Hello />, <Hello />];
+      │                              ^^^^^^^^^
     8 │ 
     9 │ [<></>, <></>, <></>];
   
@@ -428,6 +471,42 @@ invalid.jsx:27:43 lint/correctness/useJsxKeyInIterable ━━━━━━━━�
 ```
 
 ```
+invalid.jsx:44:26 lint/correctness/useJsxKeyInIterable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing key property for this element in iterable.
+  
+    43 │ [].map((item) => {
+  > 44 │ 	return item.condition ? <div /> : <div>foo</div>;
+       │ 	                        ^^^^^^^
+    45 │ });
+    46 │ 
+  
+  i The order of the items may change, and having a key can help React identify which item was moved.
+  
+  i Check the React documentation. 
+  
+
+```
+
+```
+invalid.jsx:44:36 lint/correctness/useJsxKeyInIterable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing key property for this element in iterable.
+  
+    43 │ [].map((item) => {
+  > 44 │ 	return item.condition ? <div /> : <div>foo</div>;
+       │ 	                                  ^^^^^
+    45 │ });
+    46 │ 
+  
+  i The order of the items may change, and having a key can help React identify which item was moved.
+  
+  i Check the React documentation. 
+  
+
+```
+
+```
 invalid.jsx:29:21 lint/correctness/useJsxKeyInIterable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Missing key property for this element in iterable.
@@ -588,6 +667,8 @@ invalid.jsx:41:30 lint/correctness/useJsxKeyInIterable ━━━━━━━━�
     40 │ 
   > 41 │ (<h1>{data.map(c => {return (<h1></h1>)})}</h1>)
        │                              ^^^^
+    42 │ 
+    43 │ [].map((item) => {
   
   i The order of the items may change, and having a key can help React identify which item was moved.
   


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

This is similar to #2701, in that it now handles ternaries a bit better. Cases like this are now caught:
```jsx
[].map((item) => {
	return item.condition ? <div /> : <div>foo</div>;
});
```

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
related to: #2590

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added snapshot tests

```bash
cargo test -p biome_js_analyze use_jsx_key_in_iterable
```
