### PR TITLE
fix(cli): workspace deadlock

### DIFF
--- a/crates/biome_service/src/file_handlers/astro.rs
+++ b/crates/biome_service/src/file_handlers/astro.rs
@@ -3,7 +3,7 @@ use crate::file_handlers::{
     ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults, ParseResult,
     ParserCapabilities,
 };
-use crate::settings::SettingsHandle;
+use crate::settings::WorkspaceSettingsHandle;
 use crate::workspace::{
     DocumentFileSource, FixFileResult, OrganizeImportsResult, PullActionsResult,
 };
@@ -94,7 +94,7 @@ fn parse(
     _rome_path: &BiomePath,
     file_source: DocumentFileSource,
     text: &str,
-    _settings: SettingsHandle,
+    _settings: WorkspaceSettingsHandle,
     cache: &mut NodeCache,
 ) -> ParseResult {
     let frontmatter = AstroFileHandler::input(text);
@@ -124,7 +124,7 @@ fn format(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format(biome_path, document_file_source, parse, settings)
 }
@@ -132,7 +132,7 @@ pub(crate) fn format_range(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
     range: TextRange,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format_range(biome_path, document_file_source, parse, settings, range)
@@ -142,7 +142,7 @@ pub(crate) fn format_on_type(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
     offset: TextSize,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format_on_type(biome_path, document_file_source, parse, settings, offset)

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -5,7 +5,7 @@ use crate::file_handlers::{
 };
 use crate::settings::{
     FormatSettings, LanguageListSettings, LanguageSettings, OverrideSettings, ServiceLanguage,
-    SettingsHandle,
+    WorkspaceSettingsHandle,
 };
 use crate::workspace::{DocumentFileSource, GetSyntaxTreeResult, OrganizeImportsResult};
 use crate::WorkspaceError;
@@ -133,11 +133,11 @@ fn parse(
     biome_path: &BiomePath,
     _file_source: DocumentFileSource,
     text: &str,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
     cache: &mut NodeCache,
 ) -> ParseResult {
-    let parser = &settings.as_ref().languages.css.parser;
-    let overrides = &settings.as_ref().override_settings;
+    let parser = &settings.settings().languages.css.parser;
+    let overrides = &settings.settings().override_settings;
     let options: CssParserOptions =
         overrides
             .as_css_parser_options(biome_path)
@@ -170,7 +170,7 @@ fn debug_formatter_ir(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
 ) -> Result<String, WorkspaceError> {
     let options = settings.format_options::<CssLanguage>(biome_path, document_file_source);
 
@@ -186,7 +186,7 @@ fn format(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<CssLanguage>(biome_path, document_file_source);
 
@@ -205,7 +205,7 @@ fn format_range(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
     range: TextRange,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<CssLanguage>(biome_path, document_file_source);
@@ -219,7 +219,7 @@ fn format_on_type(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
     offset: TextSize,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<CssLanguage>(biome_path, document_file_source);

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -7,7 +7,7 @@ pub use crate::file_handlers::svelte::{SvelteFileHandler, SVELTE_FENCE};
 pub use crate::file_handlers::vue::{VueFileHandler, VUE_FENCE};
 use crate::workspace::{FixFileMode, OrganizeImportsResult};
 use crate::{
-    settings::SettingsHandle,
+    settings::WorkspaceSettingsHandle,
     workspace::{FixFileResult, GetSyntaxTreeResult, PullActionsResult, RenameResult},
     WorkspaceError,
 };
@@ -304,7 +304,7 @@ pub struct FixAllParams<'a> {
     pub(crate) rules: Option<&'a Rules>,
     pub(crate) filter: AnalysisFilter<'a>,
     pub(crate) fix_file_mode: FixFileMode,
-    pub(crate) settings: SettingsHandle<'a>,
+    pub(crate) settings: WorkspaceSettingsHandle<'a>,
     /// Whether it should format the code action
     pub(crate) should_format: bool,
     pub(crate) biome_path: &'a BiomePath,
@@ -327,8 +327,13 @@ pub struct ParseResult {
     pub(crate) language: Option<DocumentFileSource>,
 }
 
-type Parse =
-    fn(&BiomePath, DocumentFileSource, &str, SettingsHandle, &mut NodeCache) -> ParseResult;
+type Parse = fn(
+    &BiomePath,
+    DocumentFileSource,
+    &str,
+    WorkspaceSettingsHandle,
+    &mut NodeCache,
+) -> ParseResult;
 
 #[derive(Default)]
 pub struct ParserCapabilities {
@@ -338,8 +343,12 @@ pub struct ParserCapabilities {
 
 type DebugSyntaxTree = fn(&BiomePath, AnyParse) -> GetSyntaxTreeResult;
 type DebugControlFlow = fn(AnyParse, TextSize) -> String;
-type DebugFormatterIR =
-    fn(&BiomePath, &DocumentFileSource, AnyParse, SettingsHandle) -> Result<String, WorkspaceError>;
+type DebugFormatterIR = fn(
+    &BiomePath,
+    &DocumentFileSource,
+    AnyParse,
+    WorkspaceSettingsHandle,
+) -> Result<String, WorkspaceError>;
 
 #[derive(Default)]
 pub struct DebugCapabilities {
@@ -353,7 +362,7 @@ pub struct DebugCapabilities {
 
 pub(crate) struct LintParams<'a> {
     pub(crate) parse: AnyParse,
-    pub(crate) settings: SettingsHandle<'a>,
+    pub(crate) settings: WorkspaceSettingsHandle<'a>,
     pub(crate) language: DocumentFileSource,
     pub(crate) max_diagnostics: u32,
     pub(crate) path: &'a BiomePath,
@@ -370,8 +379,7 @@ pub(crate) struct LintResults {
 pub(crate) struct CodeActionsParams<'a> {
     pub(crate) parse: AnyParse,
     pub(crate) range: TextRange,
-    pub(crate) rules: Option<&'a Rules>,
-    pub(crate) settings: SettingsHandle<'a>,
+    pub(crate) workspace: WorkspaceSettingsHandle<'a>,
     pub(crate) path: &'a BiomePath,
     pub(crate) manifest: Option<PackageJson>,
     pub(crate) language: DocumentFileSource,
@@ -401,20 +409,20 @@ type Format = fn(
     &BiomePath,
     &DocumentFileSource,
     AnyParse,
-    SettingsHandle,
+    WorkspaceSettingsHandle,
 ) -> Result<Printed, WorkspaceError>;
 type FormatRange = fn(
     &BiomePath,
     &DocumentFileSource,
     AnyParse,
-    SettingsHandle,
+    WorkspaceSettingsHandle,
     TextRange,
 ) -> Result<Printed, WorkspaceError>;
 type FormatOnType = fn(
     &BiomePath,
     &DocumentFileSource,
     AnyParse,
-    SettingsHandle,
+    WorkspaceSettingsHandle,
     TextSize,
 ) -> Result<Printed, WorkspaceError>;
 

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -3,7 +3,7 @@ use crate::file_handlers::{
     ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults, ParseResult,
     ParserCapabilities,
 };
-use crate::settings::SettingsHandle;
+use crate::settings::WorkspaceSettingsHandle;
 use crate::workspace::{
     DocumentFileSource, FixFileResult, OrganizeImportsResult, PullActionsResult,
 };
@@ -114,7 +114,7 @@ fn parse(
     _rome_path: &BiomePath,
     _file_source: DocumentFileSource,
     text: &str,
-    _settings: SettingsHandle,
+    _settings: WorkspaceSettingsHandle,
     cache: &mut NodeCache,
 ) -> ParseResult {
     let script = SvelteFileHandler::input(text);
@@ -141,7 +141,7 @@ fn format(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format(biome_path, document_file_source, parse, settings)
 }
@@ -149,7 +149,7 @@ pub(crate) fn format_range(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
     range: TextRange,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format_range(biome_path, document_file_source, parse, settings, range)
@@ -159,7 +159,7 @@ pub(crate) fn format_on_type(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
     offset: TextSize,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format_on_type(biome_path, document_file_source, parse, settings, offset)

--- a/crates/biome_service/src/file_handlers/vue.rs
+++ b/crates/biome_service/src/file_handlers/vue.rs
@@ -3,7 +3,7 @@ use crate::file_handlers::{
     ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults, ParseResult,
     ParserCapabilities,
 };
-use crate::settings::SettingsHandle;
+use crate::settings::WorkspaceSettingsHandle;
 use crate::workspace::{
     DocumentFileSource, FixFileResult, OrganizeImportsResult, PullActionsResult,
 };
@@ -114,7 +114,7 @@ fn parse(
     _rome_path: &BiomePath,
     _file_source: DocumentFileSource,
     text: &str,
-    _settings: SettingsHandle,
+    _settings: WorkspaceSettingsHandle,
     cache: &mut NodeCache,
 ) -> ParseResult {
     let script = VueFileHandler::input(text);
@@ -141,7 +141,7 @@ fn format(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format(biome_path, document_file_source, parse, settings)
 }
@@ -150,7 +150,7 @@ pub(crate) fn format_range(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
     range: TextRange,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format_range(biome_path, document_file_source, parse, settings, range)
@@ -160,7 +160,7 @@ pub(crate) fn format_on_type(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: SettingsHandle,
+    settings: WorkspaceSettingsHandle,
     offset: TextSize,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format_on_type(biome_path, document_file_source, parse, settings, offset)

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -10,12 +10,14 @@ use super::{
 use crate::file_handlers::{
     Capabilities, CodeActionsParams, DocumentFileSource, FixAllParams, LintParams, ParseResult,
 };
-use crate::settings::{SettingsHandleMut, WorkspaceSettings, WorkspacesHandleMut};
+use crate::settings::{WorkspaceSettings, WorkspaceSettingsHandleMut};
 use crate::workspace::{
     FileFeaturesResult, GetFileContentParams, IsPathIgnoredParams, OrganizeImportsParams,
     OrganizeImportsResult, RageEntry, RageParams, RageResult, ServerInfo,
 };
-use crate::{file_handlers::Features, settings::SettingsHandle, Workspace, WorkspaceError};
+use crate::{
+    file_handlers::Features, settings::WorkspaceSettingsHandle, Workspace, WorkspaceError,
+};
 use biome_analyze::AnalysisFilter;
 use biome_diagnostics::{
     serde::Diagnostic as SerdeDiagnostic, Diagnostic, DiagnosticExt, Severity,
@@ -97,17 +99,12 @@ impl WorkspaceServer {
     }
 
     /// Provides a reference to the current settings
-    fn settings(&self) -> SettingsHandle {
-        SettingsHandle::new(&self.settings)
+    fn workspace(&self) -> WorkspaceSettingsHandle {
+        WorkspaceSettingsHandle::new(&self.settings)
     }
 
-    /// Provides a mutable reference to the current settings
-    fn settings_mut(&self) -> SettingsHandleMut {
-        SettingsHandleMut::new(&self.settings)
-    }
-
-    fn workspaces_mut(&self) -> WorkspacesHandleMut {
-        WorkspacesHandleMut::new(&self.settings)
+    fn workspaces_mut(&self) -> WorkspaceSettingsHandleMut {
+        WorkspaceSettingsHandleMut::new(&self.settings)
     }
 
     /// Get the supported capabilities for a given file path
@@ -193,6 +190,19 @@ impl WorkspaceServer {
         index
     }
 
+    /// Updates the current project of the current workspace
+    fn update_current_project(&self, project_key: ProjectKey) {
+        let mut workspace = self.workspaces_mut();
+        let workspace_mut = workspace.as_mut();
+        workspace_mut.set_current_project(project_key);
+    }
+
+    /// Checks whether, if the current path belongs to the current project
+    fn path_belongs_to_current_workspace(&self, path: &BiomePath) -> Option<ProjectKey> {
+        let workspace = self.workspace();
+        workspace.as_ref().path_belongs_to_current_workspace(path)
+    }
+
     /// Get the parser result for a given file
     ///
     /// Returns and error if no file exists in the workspace with this path or
@@ -215,8 +225,8 @@ impl WorkspaceServer {
                     .ok_or_else(self.build_capability_error(biome_path))?;
 
                 let size_limit = {
-                    let settings = self.settings();
-                    let settings = settings.as_ref();
+                    let settings = self.workspace();
+                    let settings = settings.settings();
                     let limit = settings.files.max_size.get();
                     usize::try_from(limit).unwrap_or(usize::MAX)
                 };
@@ -231,7 +241,7 @@ impl WorkspaceServer {
                     ));
                 }
 
-                let settings = self.settings();
+                let settings = self.workspace();
                 let Some(file_source) = self.get_source(document.file_source_index) else {
                     return Err(WorkspaceError::not_found());
                 };
@@ -276,14 +286,14 @@ impl WorkspaceServer {
 
     /// Check whether a file is ignored in the top-level config `files.ignore`/`files.include`
     fn is_ignored_by_top_level_config(&self, path: &Path) -> bool {
-        let settings = self.settings();
-        let is_included = settings.as_ref().files.included_files.is_empty()
+        let settings = self.workspace();
+        let settings = settings.settings();
+        let is_included = settings.files.included_files.is_empty()
             || is_dir(path)
-            || settings.as_ref().files.included_files.matches_path(path);
+            || settings.files.included_files.matches_path(path);
         !is_included
-            || settings.as_ref().files.ignored_files.matches_path(path)
+            || settings.files.ignored_files.matches_path(path)
             || settings
-                .as_ref()
                 .files
                 .git_ignore
                 .as_ref()
@@ -305,18 +315,19 @@ impl WorkspaceServer {
 
     /// Check whether a file is ignored in the feature `ignore`/`include`
     fn is_ignored_by_feature_config(&self, path: &Path, feature: FeatureName) -> bool {
-        let settings = self.settings();
+        let settings = self.workspace();
+        let settings = settings.settings();
         let (feature_included_files, feature_ignored_files) = match feature {
             FeatureName::Format => {
-                let formatter = &settings.as_ref().formatter;
+                let formatter = &settings.formatter;
                 (&formatter.included_files, &formatter.ignored_files)
             }
             FeatureName::Lint => {
-                let linter = &settings.as_ref().linter;
+                let linter = &settings.linter;
                 (&linter.included_files, &linter.ignored_files)
             }
             FeatureName::OrganizeImports => {
-                let organize_imports = &settings.as_ref().organize_imports;
+                let organize_imports = &settings.organize_imports;
                 (
                     &organize_imports.included_files,
                     &organize_imports.ignored_files,
@@ -346,14 +357,15 @@ impl Workspace for WorkspaceServer {
                 let capabilities = self.get_file_capabilities(&params.path);
                 let language = DocumentFileSource::from_path(&params.path);
                 let path = params.path.as_path();
-                let settings = self.settings();
+                let settings = self.workspace();
+                let settings = settings.settings();
                 let mut file_features = FileFeaturesResult::new();
                 let file_name = path.file_name().and_then(|s| s.to_str());
                 file_features = file_features
                     .with_capabilities(&capabilities)
-                    .with_settings_and_language(settings.as_ref(), &language, path);
+                    .with_settings_and_language(settings, &language, path);
 
-                if settings.as_ref().files.ignore_unknown
+                if settings.files.ignore_unknown
                     && language == DocumentFileSource::Unknown
                     && self.get_file_source(&params.path) == DocumentFileSource::Unknown
                 {
@@ -394,13 +406,16 @@ impl Workspace for WorkspaceServer {
     /// by another thread having previously panicked while holding the lock
     #[tracing::instrument(level = "trace", skip(self))]
     fn update_settings(&self, params: UpdateSettingsParams) -> Result<(), WorkspaceError> {
-        let mut settings = self.settings_mut();
-        settings.as_mut().merge_with_configuration(
-            params.configuration,
-            params.workspace_directory,
-            params.vcs_base_path,
-            params.gitignore_matches.as_slice(),
-        )?;
+        let mut workspace = self.workspaces_mut();
+        workspace
+            .as_mut()
+            .get_current_settings_mut()
+            .merge_with_configuration(
+                params.configuration,
+                params.workspace_directory,
+                params.vcs_base_path,
+                params.gitignore_matches.as_slice(),
+            )?;
 
         // settings changed, hence everything that is computed from the settings needs to be purged
         self.file_features.clear();
@@ -423,9 +438,9 @@ impl Workspace for WorkspaceServer {
                 file_source_index: index,
             },
         );
-        let mut workspace = self.workspaces_mut();
-
-        workspace.as_mut().set_current_project(&params.path);
+        if let Some(project_key) = self.path_belongs_to_current_workspace(&params.path) {
+            self.update_current_project(project_key);
+        }
 
         Ok(())
     }
@@ -449,11 +464,10 @@ impl Workspace for WorkspaceServer {
         params: RegisterProjectFolderParams,
     ) -> Result<ProjectKey, WorkspaceError> {
         let mut workspace = self.workspaces_mut();
-        let key = workspace
-            .as_mut()
-            .insert_project(params.path.unwrap_or_default());
+        let workspace_mut = workspace.as_mut();
+        let key = workspace_mut.insert_project(params.path.unwrap_or_default());
         if params.set_as_current_workspace {
-            workspace.as_mut().register_current_project(key);
+            workspace_mut.register_current_project(key);
         }
         Ok(key)
     }
@@ -512,15 +526,16 @@ impl Workspace for WorkspaceServer {
             .debug
             .debug_formatter_ir
             .ok_or_else(self.build_capability_error(&params.path))?;
-        let settings = self.settings();
+        let workspace = self.workspace();
+        let settings = workspace.settings();
         let parse = self.get_parse(params.path.clone())?;
 
-        if !settings.as_ref().formatter().format_with_errors && parse.has_errors() {
+        if !settings.formatter().format_with_errors && parse.has_errors() {
             return Err(WorkspaceError::format_with_errors_disabled());
         }
         let document_file_source = self.get_file_source(&params.path);
 
-        debug_formatter_ir(&params.path, &document_file_source, parse, settings)
+        debug_formatter_ir(&params.path, &document_file_source, parse, workspace)
     }
 
     fn get_file_content(&self, params: GetFileContentParams) -> Result<String, WorkspaceError> {
@@ -569,7 +584,7 @@ impl Workspace for WorkspaceServer {
                 info_span!("Pulling diagnostics", categories =? params.categories).in_scope(|| {
                     let results = lint(LintParams {
                         parse,
-                        settings: self.settings(),
+                        settings: self.workspace(),
                         max_diagnostics: params.max_diagnostics as u32,
                         path: &params.path,
                         language: self.get_file_source(&params.path),
@@ -618,15 +633,13 @@ impl Workspace for WorkspaceServer {
             .ok_or_else(self.build_capability_error(&params.path))?;
 
         let parse = self.get_parse(params.path.clone())?;
-        let settings = self.settings();
-        let rules = settings.as_ref().linter().rules.as_ref();
+        let workspace = self.workspace();
         let manifest = self.get_current_project()?.map(|pr| pr.manifest);
         let language = self.get_file_source(&params.path);
         Ok(code_actions(CodeActionsParams {
             parse,
             range: params.range,
-            rules,
-            settings: self.settings(),
+            workspace,
             path: &params.path,
             manifest,
             language,
@@ -641,14 +654,15 @@ impl Workspace for WorkspaceServer {
             .formatter
             .format
             .ok_or_else(self.build_capability_error(&params.path))?;
-        let settings = self.settings();
+        let workspace = self.workspace();
+        let settings = workspace.settings();
         let parse = self.get_parse(params.path.clone())?;
 
-        if !settings.as_ref().formatter().format_with_errors && parse.has_errors() {
+        if !settings.formatter().format_with_errors && parse.has_errors() {
             return Err(WorkspaceError::format_with_errors_disabled());
         }
         let document_file_source = self.get_file_source(&params.path);
-        format(&params.path, &document_file_source, parse, settings)
+        format(&params.path, &document_file_source, parse, workspace)
     }
 
     fn format_range(&self, params: FormatRangeParams) -> Result<Printed, WorkspaceError> {
@@ -657,10 +671,11 @@ impl Workspace for WorkspaceServer {
             .formatter
             .format_range
             .ok_or_else(self.build_capability_error(&params.path))?;
-        let settings = self.settings();
+        let workspace = self.workspace();
+        let settings = workspace.settings();
         let parse = self.get_parse(params.path.clone())?;
 
-        if !settings.as_ref().formatter().format_with_errors && parse.has_errors() {
+        if !settings.formatter().format_with_errors && parse.has_errors() {
             return Err(WorkspaceError::format_with_errors_disabled());
         }
         let document_file_source = self.get_file_source(&params.path);
@@ -668,7 +683,7 @@ impl Workspace for WorkspaceServer {
             &params.path,
             &document_file_source,
             parse,
-            settings,
+            workspace,
             params.range,
         )
     }
@@ -680,9 +695,10 @@ impl Workspace for WorkspaceServer {
             .format_on_type
             .ok_or_else(self.build_capability_error(&params.path))?;
 
-        let settings = self.settings();
+        let workspace = self.workspace();
+        let settings = workspace.settings();
         let parse = self.get_parse(params.path.clone())?;
-        if !settings.as_ref().formatter().format_with_errors && parse.has_errors() {
+        if !settings.formatter().format_with_errors && parse.has_errors() {
             return Err(WorkspaceError::format_with_errors_disabled());
         }
         let document_file_source = self.get_file_source(&params.path);
@@ -691,7 +707,7 @@ impl Workspace for WorkspaceServer {
             &params.path,
             &document_file_source,
             parse,
-            settings,
+            workspace,
             params.offset,
         )
     }
@@ -703,10 +719,11 @@ impl Workspace for WorkspaceServer {
             .analyzer
             .fix_all
             .ok_or_else(self.build_capability_error(&params.path))?;
-        let settings = self.settings();
+        let workspace = self.workspace();
+        let settings = workspace.settings();
         let parse = self.get_parse(params.path.clone())?;
         // Compute final rules (taking `overrides` into account)
-        let rules = settings.as_ref().as_rules(params.path.as_path());
+        let rules = settings.as_rules(params.path.as_path());
         let rule_filter_list = rules
             .as_ref()
             .map(|rules| rules.as_enabled_rules())
@@ -721,7 +738,7 @@ impl Workspace for WorkspaceServer {
             rules: rules.as_ref().map(|x| x.borrow()),
             fix_file_mode: params.fix_file_mode,
             filter,
-            settings: self.settings(),
+            settings: self.workspace(),
             should_format: params.should_format,
             biome_path: &params.path,
             manifest,

--- a/packages/@biomejs/js-api/package.json
+++ b/packages/@biomejs/js-api/package.json
@@ -30,12 +30,7 @@
 	],
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
-	"keywords": [
-		"JavaScript",
-		"bindings",
-		"APIs",
-		"biome"
-	],
+	"keywords": ["JavaScript", "bindings", "APIs", "biome"],
 	"license": "MIT OR Apache-2.0",
 	"homepage": "https://biomejs.dev",
 	"repository": {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

There was some issue when running the CLI, when executing the internal `pnpm check` command, the biome CLI couldn't finish the work.

In this PR, I attempted to fix the issue by reducing the scope of when the write locks and the read locks are held. Plus, I changed the `set_current_project` method in two. That method was causing the issue, because we were holding a writing lock over the `WorkspaceSettings`, but there were instances where the type was never modified. I created two methods now: one that returns the `ProjectKey` if the opened file belongs to another project (this goes in read mode), and we update the current project is `ProjectKey` is actually returned, and in this case we use a write lock, which works every time.


BTW, the CLI is still trying read files inside folders that aren't inside the `files.include` option, that's why it's taking a massive amount of time to finish.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I tested locally, and now I don't see any more deadlocks.

<!-- What demonstrates that your implementation is correct? -->
