### PR TITLE
feat(biome_deserialize_derive): adding a rest attribute

### DIFF
--- a/crates/biome_deserialize_macros/src/deserializable_derive.rs
+++ b/crates/biome_deserialize_macros/src/deserializable_derive.rs
@@ -444,8 +444,9 @@ fn generate_deserializable_struct(
         quote! {
             unknown_key => {
                 let key_text = Text::deserialize(&key, "", diagnostics)?;
-                let value = Deserializable::deserialize(&value, key_text.text(), diagnostics)?;
-                std::iter::Extend::extend(&mut result.#rest_field, [(key_text, value)]);
+                if let Some(value) = Deserializable::deserialize(&value, key_text.text(), diagnostics) {
+                    std::iter::Extend::extend(&mut result.#rest_field, [(key_text, value)]);
+                }
             }
         }
     } else {

--- a/crates/biome_deserialize_macros/src/deserializable_derive/struct_field_attrs.rs
+++ b/crates/biome_deserialize_macros/src/deserializable_derive/struct_field_attrs.rs
@@ -35,6 +35,9 @@ pub struct StructFieldAttrs {
 
     /// Optional validation function to be called on the field value.
     pub validate: Option<Path>,
+
+    /// Flattens the field into the parent object.
+    pub flatten: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -62,6 +65,8 @@ impl TryFrom<&Vec<Attribute>> for StructFieldAttrs {
                                 opts.passthrough_name = true;
                             } else if path.is_ident("bail_on_error") {
                                 opts.bail_on_error = true;
+                            } else if path.is_ident("flatten") {
+                                opts.flatten = true;
                             } else {
                                 let path_str = path.to_token_stream().to_string();
                                 return Err(Error::new(

--- a/crates/biome_deserialize_macros/src/deserializable_derive/struct_field_attrs.rs
+++ b/crates/biome_deserialize_macros/src/deserializable_derive/struct_field_attrs.rs
@@ -36,8 +36,8 @@ pub struct StructFieldAttrs {
     /// Optional validation function to be called on the field value.
     pub validate: Option<Path>,
 
-    /// Flattens the field into the parent object.
-    pub flatten: bool,
+    /// Uses the field as a catch-all for unknown entries in the map
+    pub rest: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -65,8 +65,8 @@ impl TryFrom<&Vec<Attribute>> for StructFieldAttrs {
                                 opts.passthrough_name = true;
                             } else if path.is_ident("bail_on_error") {
                                 opts.bail_on_error = true;
-                            } else if path.is_ident("flatten") {
-                                opts.flatten = true;
+                            } else if path.is_ident("rest") {
+                                opts.rest = true;
                             } else {
                                 let path_str = path.to_token_stream().to_string();
                                 return Err(Error::new(

--- a/crates/biome_deserialize_macros/src/lib.rs
+++ b/crates/biome_deserialize_macros/src/lib.rs
@@ -294,6 +294,22 @@ use syn::{parse_macro_input, DeriveInput};
 ///     pub name: String,
 /// }
 /// ```
+/// ### `rest`
+///
+/// If present, puts the remaining fields found in the serialized representation
+/// into this field. The field must implement `Extend<K, V>` where `K` is the
+/// `Text` type and `V` implements `Deserializable`.
+///
+/// Cannot be used with the container attribute `#[deserializable(unknown_fields = deny)]`
+///
+/// ```no_test
+/// #[derive(Default, Deserializable)]
+/// pub struct StructWithRest {
+///     pub foo: String,
+///     #[deserializable(rest)]
+///     pub extra: HashMap<Text, serde_json::Value>,
+/// }
+/// ```
 ///
 /// ### `validate`
 ///


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

We want the ability to put any unknown fields into a catch-all field, like [serde's flatten attribute](https://serde.rs/attr-flatten.html#capture-additional-fields). This allows for parsing a package.json file while preserving the unknown fields.

[Discussion here](https://github.com/biomejs/biome/discussions/2698)
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This is a first draft, I'd love some guidance on the correct naming/API. Perhaps we could add a new option to the `unknown_fields` container attribute?

## Test Plan

Would love some guidance here!
