### PR TITLE
feat(biome_graphql_parser): parse input object definition

### DIFF
--- a/crates/biome_graphql_parser/src/parser/definitions/enum.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/enum.rs
@@ -87,9 +87,9 @@ impl ParseRecovery for EnumValueListParseRecovery {
     const RECOVERED_KIND: Self::Kind = GRAPHQL_BOGUS;
 
     fn is_at_recovered(&self, p: &mut Self::Parser<'_>) -> bool {
-        // After a union definition is a new type definition so it's safe to
-        // assume any name we see before a new type definition is a union
-        // member type
+        // After a enum definition is a new type definition so it's safe to
+        // assume any name we see before a new type definition is a enum
+        // value
         is_at_name(p) || is_at_enum_values_end(p)
     }
 }

--- a/crates/biome_graphql_parser/src/parser/definitions/field.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/field.rs
@@ -151,7 +151,7 @@ impl ParseRecovery for ArgumentDefinitionListParseRecovery {
 }
 
 #[inline]
-fn parse_input_value_definition(p: &mut GraphqlParser) -> ParsedSyntax {
+pub(super) fn parse_input_value_definition(p: &mut GraphqlParser) -> ParsedSyntax {
     if !is_at_input_value_definition(p) {
         return Absent;
     }
@@ -196,7 +196,7 @@ fn is_at_field(p: &mut GraphqlParser<'_>) -> bool {
 }
 
 #[inline]
-fn is_at_input_value_definition(p: &mut GraphqlParser<'_>) -> bool {
+pub(super) fn is_at_input_value_definition(p: &mut GraphqlParser<'_>) -> bool {
     (is_at_name(p) && p.nth_at(1, T![:]))
     || (is_at_string(p) && p.nth_at(1, GRAPHQL_NAME) && p.nth_at(2, T![:]))
     // missing name

--- a/crates/biome_graphql_parser/src/parser/definitions/input_object.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/input_object.rs
@@ -1,0 +1,108 @@
+use crate::parser::{
+    directive::DirectiveList, parse_description, parse_error::expected_name, parse_name,
+    value::is_at_string, GraphqlParser,
+};
+use biome_graphql_syntax::{
+    GraphqlSyntaxKind::{self, *},
+    T,
+};
+use biome_parser::{
+    parse_lists::ParseNodeList, parse_recovery::ParseRecovery, parsed_syntax::ParsedSyntax,
+    prelude::ParsedSyntax::*, Parser,
+};
+
+use super::{
+    field::{is_at_input_value_definition, parse_input_value_definition},
+    is_at_definition,
+};
+
+#[inline]
+pub(crate) fn parse_input_object_type_definition(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_input_object_type_definition(p) {
+        return Absent;
+    }
+    let m = p.start();
+
+    // description is optional
+    parse_description(p).ok();
+
+    p.bump(T![input]);
+
+    parse_name(p).or_add_diagnostic(p, expected_name);
+
+    DirectiveList.parse_list(p);
+
+    // input fields are optional
+    parse_input_fields_definition(p).ok();
+
+    Present(m.complete(p, GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION))
+}
+
+#[inline]
+fn parse_input_fields_definition(p: &mut GraphqlParser) -> ParsedSyntax {
+    if !is_at_input_fields_definition(p) {
+        return Absent;
+    }
+    let m = p.start();
+    p.expect(T!['{']);
+
+    InputFieldList.parse_list(p);
+    p.expect(T!['}']);
+
+    Present(m.complete(p, GRAPHQL_INPUT_FIELDS_DEFINITION))
+}
+
+#[derive(Default)]
+struct InputFieldList;
+
+impl ParseNodeList for InputFieldList {
+    type Kind = GraphqlSyntaxKind;
+    type Parser<'source> = GraphqlParser<'source>;
+
+    const LIST_KIND: Self::Kind = GRAPHQL_INPUT_FIELD_LIST;
+
+    fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
+        parse_input_value_definition(p)
+    }
+
+    fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
+        is_input_fields_end(p)
+    }
+
+    fn recover(
+        &mut self,
+        p: &mut Self::Parser<'_>,
+        parsed_element: ParsedSyntax,
+    ) -> biome_parser::parse_recovery::RecoveryResult {
+        parsed_element.or_recover(p, &InputFieldListParseRecovery, expected_name)
+    }
+}
+
+struct InputFieldListParseRecovery;
+
+impl ParseRecovery for InputFieldListParseRecovery {
+    type Kind = GraphqlSyntaxKind;
+    type Parser<'source> = GraphqlParser<'source>;
+    const RECOVERED_KIND: Self::Kind = GRAPHQL_BOGUS;
+
+    fn is_at_recovered(&self, p: &mut Self::Parser<'_>) -> bool {
+        is_at_input_value_definition(p) || is_input_fields_end(p)
+    }
+}
+
+#[inline]
+pub(crate) fn is_at_input_object_type_definition(p: &mut GraphqlParser) -> bool {
+    p.at(T![input]) || (is_at_string(p) && p.nth_at(1, T![input]))
+}
+
+#[inline]
+fn is_at_input_fields_definition(p: &mut GraphqlParser) -> bool {
+    p.at(T!['{'])
+    // missing opening brace
+    || is_at_input_value_definition(p)
+}
+
+#[inline]
+fn is_input_fields_end(p: &mut GraphqlParser) -> bool {
+    p.at(T!['}']) || is_at_definition(p)
+}

--- a/crates/biome_graphql_parser/src/parser/definitions/mod.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/mod.rs
@@ -1,6 +1,7 @@
 mod r#enum;
 mod field;
 mod fragment;
+mod input_object;
 mod interface;
 mod object;
 mod operation;
@@ -17,6 +18,7 @@ use biome_parser::{
 
 use self::{
     fragment::{is_at_fragment_definition, parse_fragment_definition},
+    input_object::{is_at_input_object_type_definition, parse_input_object_type_definition},
     interface::{is_at_interface_type_definition, parse_interface_type_definition},
     object::{is_at_object_type_definition, parse_object_type_definition},
     operation::{is_at_operation, parse_operation_definition},
@@ -67,7 +69,7 @@ impl ParseNodeList for DefinitionList {
 
 #[inline]
 fn parse_definition(p: &mut GraphqlParser) -> ParsedSyntax {
-    // TODO: parse any definition
+    // TODO: add directive definition
     if is_at_operation(p) {
         parse_operation_definition(p)
     } else if is_at_fragment_definition(p) {
@@ -84,6 +86,8 @@ fn parse_definition(p: &mut GraphqlParser) -> ParsedSyntax {
         parse_union_type_definition(p)
     } else if is_at_enum_type_definition(p) {
         parse_enum_type_definition(p)
+    } else if is_at_input_object_type_definition(p) {
+        parse_input_object_type_definition(p)
     } else {
         Absent
     }
@@ -91,7 +95,7 @@ fn parse_definition(p: &mut GraphqlParser) -> ParsedSyntax {
 
 #[inline]
 fn is_at_definition(p: &mut GraphqlParser<'_>) -> bool {
-    // TODO: recover at any definition
+    // TODO: add directive definition
     is_at_operation(p)
         || is_at_fragment_definition(p)
         || is_at_schema_definition(p)
@@ -100,4 +104,5 @@ fn is_at_definition(p: &mut GraphqlParser<'_>) -> bool {
         || is_at_interface_type_definition(p)
         || is_at_union_type_definition(p)
         || is_at_enum_type_definition(p)
+        || is_at_input_object_type_definition(p)
 }

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/input_object.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/input_object.graphql
@@ -1,0 +1,44 @@
+input Point2D
+  x: Float
+  y: Float
+}
+
+input Point2D
+  x: Float
+  y: Float
+
+input Point2D {
+
+input Point2D @deprecated {
+	x: Float
+}
+
+input Point2D {
+  x: = 0
+  y: @deprecated
+}
+
+input Point2D {
+  x = 0
+  y: @deprecated
+}
+
+input Point2D {
+  = 0
+  : @
+}
+
+input Point2D {
+  x
+  y
+}
+
+input Point2D {
+	=
+  : Float
+}
+
+iput Point2D {
+	x: Float
+	y: Float
+}

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/input_object.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/input_object.graphql.snap
@@ -1,0 +1,965 @@
+---
+source: crates/biome_graphql_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```graphql
+input Point2D
+  x: Float
+  y: Float
+}
+
+input Point2D
+  x: Float
+  y: Float
+
+input Point2D {
+
+input Point2D @deprecated {
+	x: Float
+}
+
+input Point2D {
+  x: = 0
+  y: @deprecated
+}
+
+input Point2D {
+  x = 0
+  y: @deprecated
+}
+
+input Point2D {
+  = 0
+  : @
+}
+
+input Point2D {
+  x
+  y
+}
+
+input Point2D {
+	=
+  : Float
+}
+
+iput Point2D {
+	x: Float
+	y: Float
+}
+
+```
+
+## AST
+
+```
+GraphqlRoot {
+    bom_token: missing (optional),
+    definitions: GraphqlDefinitionList [
+        GraphqlInputObjectTypeDefinition {
+            description: missing (optional),
+            input_token: INPUT_KW@0..6 "input" [] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@6..13 "Point2D" [] [],
+            },
+            directives: GraphqlDirectiveList [],
+            input_fields: GraphqlInputFieldsDefinition {
+                l_curly_token: missing (required),
+                fields: GraphqlInputFieldList [
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@13..17 "x" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@17..19 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@19..24 "Float" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@24..28 "y" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@30..35 "Float" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_curly_token: R_CURLY@35..37 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlInputObjectTypeDefinition {
+            description: missing (optional),
+            input_token: INPUT_KW@37..45 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@45..52 "Point2D" [] [],
+            },
+            directives: GraphqlDirectiveList [],
+            input_fields: GraphqlInputFieldsDefinition {
+                l_curly_token: missing (required),
+                fields: GraphqlInputFieldList [
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@52..56 "x" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@56..58 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@58..63 "Float" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@63..67 "y" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@67..69 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@69..74 "Float" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_curly_token: missing (required),
+            },
+        },
+        GraphqlInputObjectTypeDefinition {
+            description: missing (optional),
+            input_token: INPUT_KW@74..82 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@82..90 "Point2D" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [],
+            input_fields: GraphqlInputFieldsDefinition {
+                l_curly_token: L_CURLY@90..91 "{" [] [],
+                fields: GraphqlInputFieldList [],
+                r_curly_token: missing (required),
+            },
+        },
+        GraphqlInputObjectTypeDefinition {
+            description: missing (optional),
+            input_token: INPUT_KW@91..99 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@99..107 "Point2D" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [
+                GraphqlDirective {
+                    at_token: AT@107..108 "@" [] [],
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@108..119 "deprecated" [] [Whitespace(" ")],
+                    },
+                    arguments: missing (optional),
+                },
+            ],
+            input_fields: GraphqlInputFieldsDefinition {
+                l_curly_token: L_CURLY@119..120 "{" [] [],
+                fields: GraphqlInputFieldList [
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@120..123 "x" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        colon_token: COLON@123..125 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@125..130 "Float" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_curly_token: R_CURLY@130..132 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlInputObjectTypeDefinition {
+            description: missing (optional),
+            input_token: INPUT_KW@132..140 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@140..148 "Point2D" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [],
+            input_fields: GraphqlInputFieldsDefinition {
+                l_curly_token: L_CURLY@148..149 "{" [] [],
+                fields: GraphqlInputFieldList [
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@149..153 "x" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@153..155 ":" [] [Whitespace(" ")],
+                        ty: missing (required),
+                        default: GraphqlDefaultValue {
+                            eq_token: EQ@155..157 "=" [] [Whitespace(" ")],
+                            value: GraphqlIntValue {
+                                graphql_int_literal_token: GRAPHQL_INT_LITERAL@157..158 "0" [] [],
+                            },
+                        },
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@158..162 "y" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@162..164 ":" [] [Whitespace(" ")],
+                        ty: missing (required),
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [
+                            GraphqlDirective {
+                                at_token: AT@164..165 "@" [] [],
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@165..175 "deprecated" [] [],
+                                },
+                                arguments: missing (optional),
+                            },
+                        ],
+                    },
+                ],
+                r_curly_token: R_CURLY@175..177 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlBogusDefinition {
+            items: [
+                INPUT_KW@177..185 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                GraphqlName {
+                    value_token: GRAPHQL_NAME@185..193 "Point2D" [] [Whitespace(" ")],
+                },
+                GraphqlDirectiveList [],
+                GraphqlBogus {
+                    items: [
+                        L_CURLY@193..194 "{" [] [],
+                        GraphqlBogus {
+                            items: [
+                                GraphqlBogus {
+                                    items: [
+                                        GRAPHQL_NAME@194..199 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        EQ@199..201 "=" [] [Whitespace(" ")],
+                                        GRAPHQL_INT_LITERAL@201..202 "0" [] [],
+                                    ],
+                                },
+                                GraphqlInputValueDefinition {
+                                    description: missing (optional),
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@202..206 "y" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    colon_token: COLON@206..208 ":" [] [Whitespace(" ")],
+                                    ty: missing (required),
+                                    default: missing (optional),
+                                    directives: GraphqlDirectiveList [
+                                        GraphqlDirective {
+                                            at_token: AT@208..209 "@" [] [],
+                                            name: GraphqlName {
+                                                value_token: GRAPHQL_NAME@209..219 "deprecated" [] [],
+                                            },
+                                            arguments: missing (optional),
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        R_CURLY@219..221 "}" [Newline("\n")] [],
+                    ],
+                },
+            ],
+        },
+        GraphqlBogusDefinition {
+            items: [
+                INPUT_KW@221..229 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                GraphqlName {
+                    value_token: GRAPHQL_NAME@229..237 "Point2D" [] [Whitespace(" ")],
+                },
+                GraphqlDirectiveList [],
+                GraphqlBogus {
+                    items: [
+                        L_CURLY@237..238 "{" [] [],
+                        GraphqlBogus {
+                            items: [
+                                GraphqlBogus {
+                                    items: [
+                                        EQ@238..243 "=" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        GRAPHQL_INT_LITERAL@243..244 "0" [] [],
+                                    ],
+                                },
+                                GraphqlInputValueDefinition {
+                                    description: missing (optional),
+                                    name: missing (required),
+                                    colon_token: COLON@244..249 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                    ty: missing (required),
+                                    default: missing (optional),
+                                    directives: GraphqlDirectiveList [
+                                        GraphqlDirective {
+                                            at_token: AT@249..250 "@" [] [],
+                                            name: missing (required),
+                                            arguments: missing (optional),
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        R_CURLY@250..252 "}" [Newline("\n")] [],
+                    ],
+                },
+            ],
+        },
+        GraphqlInputObjectTypeDefinition {
+            description: missing (optional),
+            input_token: INPUT_KW@252..260 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@260..268 "Point2D" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [],
+            input_fields: GraphqlInputFieldsDefinition {
+                l_curly_token: L_CURLY@268..269 "{" [] [],
+                fields: GraphqlInputFieldList [
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@269..273 "x" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: missing (required),
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@273..277 "y" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_curly_token: R_CURLY@277..279 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlBogusDefinition {
+            items: [
+                INPUT_KW@279..287 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                GraphqlName {
+                    value_token: GRAPHQL_NAME@287..295 "Point2D" [] [Whitespace(" ")],
+                },
+                GraphqlDirectiveList [],
+                GraphqlBogus {
+                    items: [
+                        L_CURLY@295..296 "{" [] [],
+                        GraphqlBogus {
+                            items: [
+                                GraphqlBogus {
+                                    items: [
+                                        EQ@296..299 "=" [Newline("\n"), Whitespace("\t")] [],
+                                    ],
+                                },
+                                GraphqlInputValueDefinition {
+                                    description: missing (optional),
+                                    name: missing (required),
+                                    colon_token: COLON@299..304 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                    ty: GraphqlNamedType {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@304..309 "Float" [] [],
+                                        },
+                                    },
+                                    default: missing (optional),
+                                    directives: GraphqlDirectiveList [],
+                                },
+                            ],
+                        },
+                        R_CURLY@309..311 "}" [Newline("\n")] [],
+                    ],
+                },
+            ],
+        },
+        GraphqlBogusDefinition {
+            items: [
+                GRAPHQL_NAME@311..318 "iput" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                GRAPHQL_NAME@318..326 "Point2D" [] [Whitespace(" ")],
+            ],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@326..327 "{" [] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: GraphqlAlias {
+                        value: GraphqlName {
+                            value_token: GRAPHQL_NAME@327..330 "x" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        colon_token: COLON@330..332 ":" [] [Whitespace(" ")],
+                    },
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@332..337 "Float" [] [],
+                    },
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [],
+                    selection_set: missing (optional),
+                },
+                GraphqlField {
+                    alias: GraphqlAlias {
+                        value: GraphqlName {
+                            value_token: GRAPHQL_NAME@337..340 "y" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        colon_token: COLON@340..342 ":" [] [Whitespace(" ")],
+                    },
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@342..347 "Float" [] [],
+                    },
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@347..349 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@349..350 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: GRAPHQL_ROOT@0..350
+  0: (empty)
+  1: GRAPHQL_DEFINITION_LIST@0..349
+    0: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@0..37
+      0: (empty)
+      1: INPUT_KW@0..6 "input" [] [Whitespace(" ")]
+      2: GRAPHQL_NAME@6..13
+        0: GRAPHQL_NAME@6..13 "Point2D" [] []
+      3: GRAPHQL_DIRECTIVE_LIST@13..13
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@13..37
+        0: (empty)
+        1: GRAPHQL_INPUT_FIELD_LIST@13..35
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@13..24
+            0: (empty)
+            1: GRAPHQL_NAME@13..17
+              0: GRAPHQL_NAME@13..17 "x" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@17..19 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@19..24
+              0: GRAPHQL_NAME@19..24
+                0: GRAPHQL_NAME@19..24 "Float" [] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@24..24
+          1: GRAPHQL_INPUT_VALUE_DEFINITION@24..35
+            0: (empty)
+            1: GRAPHQL_NAME@24..28
+              0: GRAPHQL_NAME@24..28 "y" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@28..30 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@30..35
+              0: GRAPHQL_NAME@30..35
+                0: GRAPHQL_NAME@30..35 "Float" [] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@35..35
+        2: R_CURLY@35..37 "}" [Newline("\n")] []
+    1: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@37..74
+      0: (empty)
+      1: INPUT_KW@37..45 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@45..52
+        0: GRAPHQL_NAME@45..52 "Point2D" [] []
+      3: GRAPHQL_DIRECTIVE_LIST@52..52
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@52..74
+        0: (empty)
+        1: GRAPHQL_INPUT_FIELD_LIST@52..74
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@52..63
+            0: (empty)
+            1: GRAPHQL_NAME@52..56
+              0: GRAPHQL_NAME@52..56 "x" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@56..58 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@58..63
+              0: GRAPHQL_NAME@58..63
+                0: GRAPHQL_NAME@58..63 "Float" [] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@63..63
+          1: GRAPHQL_INPUT_VALUE_DEFINITION@63..74
+            0: (empty)
+            1: GRAPHQL_NAME@63..67
+              0: GRAPHQL_NAME@63..67 "y" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@67..69 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@69..74
+              0: GRAPHQL_NAME@69..74
+                0: GRAPHQL_NAME@69..74 "Float" [] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@74..74
+        2: (empty)
+    2: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@74..91
+      0: (empty)
+      1: INPUT_KW@74..82 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@82..90
+        0: GRAPHQL_NAME@82..90 "Point2D" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@90..90
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@90..91
+        0: L_CURLY@90..91 "{" [] []
+        1: GRAPHQL_INPUT_FIELD_LIST@91..91
+        2: (empty)
+    3: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@91..132
+      0: (empty)
+      1: INPUT_KW@91..99 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@99..107
+        0: GRAPHQL_NAME@99..107 "Point2D" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@107..119
+        0: GRAPHQL_DIRECTIVE@107..119
+          0: AT@107..108 "@" [] []
+          1: GRAPHQL_NAME@108..119
+            0: GRAPHQL_NAME@108..119 "deprecated" [] [Whitespace(" ")]
+          2: (empty)
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@119..132
+        0: L_CURLY@119..120 "{" [] []
+        1: GRAPHQL_INPUT_FIELD_LIST@120..130
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@120..130
+            0: (empty)
+            1: GRAPHQL_NAME@120..123
+              0: GRAPHQL_NAME@120..123 "x" [Newline("\n"), Whitespace("\t")] []
+            2: COLON@123..125 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@125..130
+              0: GRAPHQL_NAME@125..130
+                0: GRAPHQL_NAME@125..130 "Float" [] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@130..130
+        2: R_CURLY@130..132 "}" [Newline("\n")] []
+    4: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@132..177
+      0: (empty)
+      1: INPUT_KW@132..140 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@140..148
+        0: GRAPHQL_NAME@140..148 "Point2D" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@148..148
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@148..177
+        0: L_CURLY@148..149 "{" [] []
+        1: GRAPHQL_INPUT_FIELD_LIST@149..175
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@149..158
+            0: (empty)
+            1: GRAPHQL_NAME@149..153
+              0: GRAPHQL_NAME@149..153 "x" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@153..155 ":" [] [Whitespace(" ")]
+            3: (empty)
+            4: GRAPHQL_DEFAULT_VALUE@155..158
+              0: EQ@155..157 "=" [] [Whitespace(" ")]
+              1: GRAPHQL_INT_VALUE@157..158
+                0: GRAPHQL_INT_LITERAL@157..158 "0" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@158..158
+          1: GRAPHQL_INPUT_VALUE_DEFINITION@158..175
+            0: (empty)
+            1: GRAPHQL_NAME@158..162
+              0: GRAPHQL_NAME@158..162 "y" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@162..164 ":" [] [Whitespace(" ")]
+            3: (empty)
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@164..175
+              0: GRAPHQL_DIRECTIVE@164..175
+                0: AT@164..165 "@" [] []
+                1: GRAPHQL_NAME@165..175
+                  0: GRAPHQL_NAME@165..175 "deprecated" [] []
+                2: (empty)
+        2: R_CURLY@175..177 "}" [Newline("\n")] []
+    5: GRAPHQL_BOGUS_DEFINITION@177..221
+      0: INPUT_KW@177..185 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@185..193
+        0: GRAPHQL_NAME@185..193 "Point2D" [] [Whitespace(" ")]
+      2: GRAPHQL_DIRECTIVE_LIST@193..193
+      3: GRAPHQL_BOGUS@193..221
+        0: L_CURLY@193..194 "{" [] []
+        1: GRAPHQL_BOGUS@194..219
+          0: GRAPHQL_BOGUS@194..202
+            0: GRAPHQL_NAME@194..199 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            1: EQ@199..201 "=" [] [Whitespace(" ")]
+            2: GRAPHQL_INT_LITERAL@201..202 "0" [] []
+          1: GRAPHQL_INPUT_VALUE_DEFINITION@202..219
+            0: (empty)
+            1: GRAPHQL_NAME@202..206
+              0: GRAPHQL_NAME@202..206 "y" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@206..208 ":" [] [Whitespace(" ")]
+            3: (empty)
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@208..219
+              0: GRAPHQL_DIRECTIVE@208..219
+                0: AT@208..209 "@" [] []
+                1: GRAPHQL_NAME@209..219
+                  0: GRAPHQL_NAME@209..219 "deprecated" [] []
+                2: (empty)
+        2: R_CURLY@219..221 "}" [Newline("\n")] []
+    6: GRAPHQL_BOGUS_DEFINITION@221..252
+      0: INPUT_KW@221..229 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@229..237
+        0: GRAPHQL_NAME@229..237 "Point2D" [] [Whitespace(" ")]
+      2: GRAPHQL_DIRECTIVE_LIST@237..237
+      3: GRAPHQL_BOGUS@237..252
+        0: L_CURLY@237..238 "{" [] []
+        1: GRAPHQL_BOGUS@238..250
+          0: GRAPHQL_BOGUS@238..244
+            0: EQ@238..243 "=" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            1: GRAPHQL_INT_LITERAL@243..244 "0" [] []
+          1: GRAPHQL_INPUT_VALUE_DEFINITION@244..250
+            0: (empty)
+            1: (empty)
+            2: COLON@244..249 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            3: (empty)
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@249..250
+              0: GRAPHQL_DIRECTIVE@249..250
+                0: AT@249..250 "@" [] []
+                1: (empty)
+                2: (empty)
+        2: R_CURLY@250..252 "}" [Newline("\n")] []
+    7: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@252..279
+      0: (empty)
+      1: INPUT_KW@252..260 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@260..268
+        0: GRAPHQL_NAME@260..268 "Point2D" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@268..268
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@268..279
+        0: L_CURLY@268..269 "{" [] []
+        1: GRAPHQL_INPUT_FIELD_LIST@269..277
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@269..277
+            0: (empty)
+            1: GRAPHQL_NAME@269..273
+              0: GRAPHQL_NAME@269..273 "x" [Newline("\n"), Whitespace("  ")] []
+            2: (empty)
+            3: GRAPHQL_NAMED_TYPE@273..277
+              0: GRAPHQL_NAME@273..277
+                0: GRAPHQL_NAME@273..277 "y" [Newline("\n"), Whitespace("  ")] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@277..277
+        2: R_CURLY@277..279 "}" [Newline("\n")] []
+    8: GRAPHQL_BOGUS_DEFINITION@279..311
+      0: INPUT_KW@279..287 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@287..295
+        0: GRAPHQL_NAME@287..295 "Point2D" [] [Whitespace(" ")]
+      2: GRAPHQL_DIRECTIVE_LIST@295..295
+      3: GRAPHQL_BOGUS@295..311
+        0: L_CURLY@295..296 "{" [] []
+        1: GRAPHQL_BOGUS@296..309
+          0: GRAPHQL_BOGUS@296..299
+            0: EQ@296..299 "=" [Newline("\n"), Whitespace("\t")] []
+          1: GRAPHQL_INPUT_VALUE_DEFINITION@299..309
+            0: (empty)
+            1: (empty)
+            2: COLON@299..304 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@304..309
+              0: GRAPHQL_NAME@304..309
+                0: GRAPHQL_NAME@304..309 "Float" [] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@309..309
+        2: R_CURLY@309..311 "}" [Newline("\n")] []
+    9: GRAPHQL_BOGUS_DEFINITION@311..326
+      0: GRAPHQL_NAME@311..318 "iput" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@318..326 "Point2D" [] [Whitespace(" ")]
+    10: GRAPHQL_SELECTION_SET@326..349
+      0: L_CURLY@326..327 "{" [] []
+      1: GRAPHQL_SELECTION_LIST@327..347
+        0: GRAPHQL_FIELD@327..337
+          0: GRAPHQL_ALIAS@327..332
+            0: GRAPHQL_NAME@327..330
+              0: GRAPHQL_NAME@327..330 "x" [Newline("\n"), Whitespace("\t")] []
+            1: COLON@330..332 ":" [] [Whitespace(" ")]
+          1: GRAPHQL_NAME@332..337
+            0: GRAPHQL_NAME@332..337 "Float" [] []
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@337..337
+          4: (empty)
+        1: GRAPHQL_FIELD@337..347
+          0: GRAPHQL_ALIAS@337..342
+            0: GRAPHQL_NAME@337..340
+              0: GRAPHQL_NAME@337..340 "y" [Newline("\n"), Whitespace("\t")] []
+            1: COLON@340..342 ":" [] [Whitespace(" ")]
+          1: GRAPHQL_NAME@342..347
+            0: GRAPHQL_NAME@342..347 "Float" [] []
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@347..347
+          4: (empty)
+      2: R_CURLY@347..349 "}" [Newline("\n")] []
+  2: EOF@349..350 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+input_object.graphql:2:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `{` but instead found `x`
+  
+    1 │ input Point2D
+  > 2 │   x: Float
+      │   ^
+    3 │   y: Float
+    4 │ }
+  
+  i Remove x
+  
+input_object.graphql:7:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `{` but instead found `x`
+  
+    6 │ input Point2D
+  > 7 │   x: Float
+      │   ^
+    8 │   y: Float
+    9 │ 
+  
+  i Remove x
+  
+input_object.graphql:10:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `}` but instead found `input`
+  
+     8 │   y: Float
+     9 │ 
+  > 10 │ input Point2D {
+       │ ^^^^^
+    11 │ 
+    12 │ input Point2D @deprecated {
+  
+  i Remove input
+  
+input_object.graphql:12:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `}` but instead found `input`
+  
+    10 │ input Point2D {
+    11 │ 
+  > 12 │ input Point2D @deprecated {
+       │ ^^^^^
+    13 │ 	x: Float
+    14 │ }
+  
+  i Remove input
+  
+input_object.graphql:17:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a type but instead found '='.
+  
+    16 │ input Point2D {
+  > 17 │   x: = 0
+       │      ^
+    18 │   y: @deprecated
+    19 │ }
+  
+  i Expected a type here.
+  
+    16 │ input Point2D {
+  > 17 │   x: = 0
+       │      ^
+    18 │   y: @deprecated
+    19 │ }
+  
+input_object.graphql:18:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a type but instead found '@'.
+  
+    16 │ input Point2D {
+    17 │   x: = 0
+  > 18 │   y: @deprecated
+       │      ^
+    19 │ }
+    20 │ 
+  
+  i Expected a type here.
+  
+    16 │ input Point2D {
+    17 │   x: = 0
+  > 18 │   y: @deprecated
+       │      ^
+    19 │ }
+    20 │ 
+  
+input_object.graphql:22:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a name but instead found 'x = 0'.
+  
+    21 │ input Point2D {
+  > 22 │   x = 0
+       │   ^^^^^
+    23 │   y: @deprecated
+    24 │ }
+  
+  i Expected a name here.
+  
+    21 │ input Point2D {
+  > 22 │   x = 0
+       │   ^^^^^
+    23 │   y: @deprecated
+    24 │ }
+  
+input_object.graphql:23:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a type but instead found '@'.
+  
+    21 │ input Point2D {
+    22 │   x = 0
+  > 23 │   y: @deprecated
+       │      ^
+    24 │ }
+    25 │ 
+  
+  i Expected a type here.
+  
+    21 │ input Point2D {
+    22 │   x = 0
+  > 23 │   y: @deprecated
+       │      ^
+    24 │ }
+    25 │ 
+  
+input_object.graphql:27:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a name but instead found '= 0'.
+  
+    26 │ input Point2D {
+  > 27 │   = 0
+       │   ^^^
+    28 │   : @
+    29 │ }
+  
+  i Expected a name here.
+  
+    26 │ input Point2D {
+  > 27 │   = 0
+       │   ^^^
+    28 │   : @
+    29 │ }
+  
+input_object.graphql:28:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a name but instead found ':'.
+  
+    26 │ input Point2D {
+    27 │   = 0
+  > 28 │   : @
+       │   ^
+    29 │ }
+    30 │ 
+  
+  i Expected a name here.
+  
+    26 │ input Point2D {
+    27 │   = 0
+  > 28 │   : @
+       │   ^
+    29 │ }
+    30 │ 
+  
+input_object.graphql:28:5 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a type but instead found '@'.
+  
+    26 │ input Point2D {
+    27 │   = 0
+  > 28 │   : @
+       │     ^
+    29 │ }
+    30 │ 
+  
+  i Expected a type here.
+  
+    26 │ input Point2D {
+    27 │   = 0
+  > 28 │   : @
+       │     ^
+    29 │ }
+    30 │ 
+  
+input_object.graphql:29:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a name but instead found '}'.
+  
+    27 │   = 0
+    28 │   : @
+  > 29 │ }
+       │ ^
+    30 │ 
+    31 │ input Point2D {
+  
+  i Expected a name here.
+  
+    27 │   = 0
+    28 │   : @
+  > 29 │ }
+       │ ^
+    30 │ 
+    31 │ input Point2D {
+  
+input_object.graphql:33:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `:` but instead found `y`
+  
+    31 │ input Point2D {
+    32 │   x
+  > 33 │   y
+       │   ^
+    34 │ }
+    35 │ 
+  
+  i Remove y
+  
+input_object.graphql:37:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a name but instead found '='.
+  
+    36 │ input Point2D {
+  > 37 │ 	=
+       │ 	^
+    38 │   : Float
+    39 │ }
+  
+  i Expected a name here.
+  
+    36 │ input Point2D {
+  > 37 │ 	=
+       │ 	^
+    38 │   : Float
+    39 │ }
+  
+input_object.graphql:38:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a name but instead found ':'.
+  
+    36 │ input Point2D {
+    37 │ 	=
+  > 38 │   : Float
+       │   ^
+    39 │ }
+    40 │ 
+  
+  i Expected a name here.
+  
+    36 │ input Point2D {
+    37 │ 	=
+  > 38 │   : Float
+       │   ^
+    39 │ }
+    40 │ 
+  
+input_object.graphql:41:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a definition but instead found 'iput Point2D'.
+  
+    39 │ }
+    40 │ 
+  > 41 │ iput Point2D {
+       │ ^^^^^^^^^^^^
+    42 │ 	x: Float
+    43 │ 	y: Float
+  
+  i Expected a definition here.
+  
+    39 │ }
+    40 │ 
+  > 41 │ iput Point2D {
+       │ ^^^^^^^^^^^^
+    42 │ 	x: Float
+    43 │ 	y: Float
+  
+```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/input_object.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/input_object.graphql
@@ -1,0 +1,19 @@
+input Point2D {
+  x: Float
+  y: Float
+}
+
+input Point2D {}
+
+input Point2D
+
+input Point2D @deprecated {
+	x: Float
+}
+
+"This is an input object" input Point2D @deprecated
+
+input Point2D {
+  x: Float = 0
+  "this is y" y: Float @deprecated
+}

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/input_object.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/input_object.graphql.snap
@@ -1,0 +1,354 @@
+---
+source: crates/biome_graphql_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```graphql
+input Point2D {
+  x: Float
+  y: Float
+}
+
+input Point2D {}
+
+input Point2D
+
+input Point2D @deprecated {
+	x: Float
+}
+
+"This is an input object" input Point2D @deprecated
+
+input Point2D {
+  x: Float = 0
+  "this is y" y: Float @deprecated
+}
+
+```
+
+## AST
+
+```
+GraphqlRoot {
+    bom_token: missing (optional),
+    definitions: GraphqlDefinitionList [
+        GraphqlInputObjectTypeDefinition {
+            description: missing (optional),
+            input_token: INPUT_KW@0..6 "input" [] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@6..14 "Point2D" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [],
+            input_fields: GraphqlInputFieldsDefinition {
+                l_curly_token: L_CURLY@14..15 "{" [] [],
+                fields: GraphqlInputFieldList [
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@15..19 "x" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@19..21 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@21..26 "Float" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@26..30 "y" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@30..32 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@32..37 "Float" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_curly_token: R_CURLY@37..39 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlInputObjectTypeDefinition {
+            description: missing (optional),
+            input_token: INPUT_KW@39..47 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@47..55 "Point2D" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [],
+            input_fields: GraphqlInputFieldsDefinition {
+                l_curly_token: L_CURLY@55..56 "{" [] [],
+                fields: GraphqlInputFieldList [],
+                r_curly_token: R_CURLY@56..57 "}" [] [],
+            },
+        },
+        GraphqlInputObjectTypeDefinition {
+            description: missing (optional),
+            input_token: INPUT_KW@57..65 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@65..72 "Point2D" [] [],
+            },
+            directives: GraphqlDirectiveList [],
+            input_fields: missing (optional),
+        },
+        GraphqlInputObjectTypeDefinition {
+            description: missing (optional),
+            input_token: INPUT_KW@72..80 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@80..88 "Point2D" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [
+                GraphqlDirective {
+                    at_token: AT@88..89 "@" [] [],
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@89..100 "deprecated" [] [Whitespace(" ")],
+                    },
+                    arguments: missing (optional),
+                },
+            ],
+            input_fields: GraphqlInputFieldsDefinition {
+                l_curly_token: L_CURLY@100..101 "{" [] [],
+                fields: GraphqlInputFieldList [
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@101..104 "x" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        colon_token: COLON@104..106 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@106..111 "Float" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_curly_token: R_CURLY@111..113 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlInputObjectTypeDefinition {
+            description: GraphqlDescription {
+                graphql_string_value: GraphqlStringValue {
+                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@113..141 "\"This is an input object\"" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                },
+            },
+            input_token: INPUT_KW@141..147 "input" [] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@147..155 "Point2D" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [
+                GraphqlDirective {
+                    at_token: AT@155..156 "@" [] [],
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@156..166 "deprecated" [] [],
+                    },
+                    arguments: missing (optional),
+                },
+            ],
+            input_fields: missing (optional),
+        },
+        GraphqlInputObjectTypeDefinition {
+            description: missing (optional),
+            input_token: INPUT_KW@166..174 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@174..182 "Point2D" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [],
+            input_fields: GraphqlInputFieldsDefinition {
+                l_curly_token: L_CURLY@182..183 "{" [] [],
+                fields: GraphqlInputFieldList [
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@183..187 "x" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        colon_token: COLON@187..189 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@189..195 "Float" [] [Whitespace(" ")],
+                            },
+                        },
+                        default: GraphqlDefaultValue {
+                            eq_token: EQ@195..197 "=" [] [Whitespace(" ")],
+                            value: GraphqlIntValue {
+                                graphql_int_literal_token: GRAPHQL_INT_LITERAL@197..198 "0" [] [],
+                            },
+                        },
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlInputValueDefinition {
+                        description: GraphqlDescription {
+                            graphql_string_value: GraphqlStringValue {
+                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@198..213 "\"this is y\"" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                            },
+                        },
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@213..214 "y" [] [],
+                        },
+                        colon_token: COLON@214..216 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@216..222 "Float" [] [Whitespace(" ")],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [
+                            GraphqlDirective {
+                                at_token: AT@222..223 "@" [] [],
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@223..233 "deprecated" [] [],
+                                },
+                                arguments: missing (optional),
+                            },
+                        ],
+                    },
+                ],
+                r_curly_token: R_CURLY@233..235 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@235..236 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: GRAPHQL_ROOT@0..236
+  0: (empty)
+  1: GRAPHQL_DEFINITION_LIST@0..235
+    0: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@0..39
+      0: (empty)
+      1: INPUT_KW@0..6 "input" [] [Whitespace(" ")]
+      2: GRAPHQL_NAME@6..14
+        0: GRAPHQL_NAME@6..14 "Point2D" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@14..14
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@14..39
+        0: L_CURLY@14..15 "{" [] []
+        1: GRAPHQL_INPUT_FIELD_LIST@15..37
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@15..26
+            0: (empty)
+            1: GRAPHQL_NAME@15..19
+              0: GRAPHQL_NAME@15..19 "x" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@19..21 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@21..26
+              0: GRAPHQL_NAME@21..26
+                0: GRAPHQL_NAME@21..26 "Float" [] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@26..26
+          1: GRAPHQL_INPUT_VALUE_DEFINITION@26..37
+            0: (empty)
+            1: GRAPHQL_NAME@26..30
+              0: GRAPHQL_NAME@26..30 "y" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@30..32 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@32..37
+              0: GRAPHQL_NAME@32..37
+                0: GRAPHQL_NAME@32..37 "Float" [] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@37..37
+        2: R_CURLY@37..39 "}" [Newline("\n")] []
+    1: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@39..57
+      0: (empty)
+      1: INPUT_KW@39..47 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@47..55
+        0: GRAPHQL_NAME@47..55 "Point2D" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@55..55
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@55..57
+        0: L_CURLY@55..56 "{" [] []
+        1: GRAPHQL_INPUT_FIELD_LIST@56..56
+        2: R_CURLY@56..57 "}" [] []
+    2: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@57..72
+      0: (empty)
+      1: INPUT_KW@57..65 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@65..72
+        0: GRAPHQL_NAME@65..72 "Point2D" [] []
+      3: GRAPHQL_DIRECTIVE_LIST@72..72
+      4: (empty)
+    3: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@72..113
+      0: (empty)
+      1: INPUT_KW@72..80 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@80..88
+        0: GRAPHQL_NAME@80..88 "Point2D" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@88..100
+        0: GRAPHQL_DIRECTIVE@88..100
+          0: AT@88..89 "@" [] []
+          1: GRAPHQL_NAME@89..100
+            0: GRAPHQL_NAME@89..100 "deprecated" [] [Whitespace(" ")]
+          2: (empty)
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@100..113
+        0: L_CURLY@100..101 "{" [] []
+        1: GRAPHQL_INPUT_FIELD_LIST@101..111
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@101..111
+            0: (empty)
+            1: GRAPHQL_NAME@101..104
+              0: GRAPHQL_NAME@101..104 "x" [Newline("\n"), Whitespace("\t")] []
+            2: COLON@104..106 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@106..111
+              0: GRAPHQL_NAME@106..111
+                0: GRAPHQL_NAME@106..111 "Float" [] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@111..111
+        2: R_CURLY@111..113 "}" [Newline("\n")] []
+    4: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@113..166
+      0: GRAPHQL_DESCRIPTION@113..141
+        0: GRAPHQL_STRING_VALUE@113..141
+          0: GRAPHQL_STRING_LITERAL@113..141 "\"This is an input object\"" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: INPUT_KW@141..147 "input" [] [Whitespace(" ")]
+      2: GRAPHQL_NAME@147..155
+        0: GRAPHQL_NAME@147..155 "Point2D" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@155..166
+        0: GRAPHQL_DIRECTIVE@155..166
+          0: AT@155..156 "@" [] []
+          1: GRAPHQL_NAME@156..166
+            0: GRAPHQL_NAME@156..166 "deprecated" [] []
+          2: (empty)
+      4: (empty)
+    5: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@166..235
+      0: (empty)
+      1: INPUT_KW@166..174 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@174..182
+        0: GRAPHQL_NAME@174..182 "Point2D" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@182..182
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@182..235
+        0: L_CURLY@182..183 "{" [] []
+        1: GRAPHQL_INPUT_FIELD_LIST@183..233
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@183..198
+            0: (empty)
+            1: GRAPHQL_NAME@183..187
+              0: GRAPHQL_NAME@183..187 "x" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@187..189 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@189..195
+              0: GRAPHQL_NAME@189..195
+                0: GRAPHQL_NAME@189..195 "Float" [] [Whitespace(" ")]
+            4: GRAPHQL_DEFAULT_VALUE@195..198
+              0: EQ@195..197 "=" [] [Whitespace(" ")]
+              1: GRAPHQL_INT_VALUE@197..198
+                0: GRAPHQL_INT_LITERAL@197..198 "0" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@198..198
+          1: GRAPHQL_INPUT_VALUE_DEFINITION@198..233
+            0: GRAPHQL_DESCRIPTION@198..213
+              0: GRAPHQL_STRING_VALUE@198..213
+                0: GRAPHQL_STRING_LITERAL@198..213 "\"this is y\"" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            1: GRAPHQL_NAME@213..214
+              0: GRAPHQL_NAME@213..214 "y" [] []
+            2: COLON@214..216 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@216..222
+              0: GRAPHQL_NAME@216..222
+                0: GRAPHQL_NAME@216..222 "Float" [] [Whitespace(" ")]
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@222..233
+              0: GRAPHQL_DIRECTIVE@222..233
+                0: AT@222..223 "@" [] []
+                1: GRAPHQL_NAME@223..233
+                  0: GRAPHQL_NAME@223..233 "deprecated" [] []
+                2: (empty)
+        2: R_CURLY@233..235 "}" [Newline("\n")] []
+  2: EOF@235..236 "" [Newline("\n")] []
+
+```


### PR DESCRIPTION
## Summary

Parse GraphQL Input Object definition ([link](https://spec.graphql.org/October2021/#sec-Input-Objects)). This is also a small case, as almost all parsing logic was implemented in a previous PR that focused on parsing Object definition.

Once this is complete, we only have directive definitions left as the last GraphQL definitions. After handling both, we could start parsing GraphQL type extensions.

## Test Plan

All tests should pass