### PR TITLE
feat: enable CSS linter and CSS formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Contributed by @Conaclos
 
 - Add new command `biome clean`. Use this command to purge all the logs emitted by the Biome daemon. This command is really useful, because the Biome daemon tends
-  log many files and contents during its lifecycle. This means that if your editor is open for hours (or even days), the `biome-logs` folder could become quite heavy. @Contributed by emaitpico
+  log many files and contents during its lifecycle. This means that if your editor is open for hours (or even days), the `biome-logs` folder could become quite heavy. Contributed by @ematipico
 
 - Add support for formatting and linting CSS files from the CLI. These operations are **opt-in** for the time being.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,20 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- Add new command `biome clean`. Use this command to purge all the logs emitted by the Biome daemon. This command is really useful, because the Biome daemon tends
+  log many files and contents during its lifecycle. This means that if your editor is open for hours (or even days), the `biome-logs` folder could become quite heavy. @Contributed by emaitpico
+
+- Add support for formatting and linting CSS files from the CLI. These operations are **opt-in** for the time being.
+
+  If you don't have a configuration file, you can enable these features with `--css-formatter-enabled` and `--css-linter-enabled`:
+
+  ```shell
+  biome check --css-formatter-enabled=true --css-linter-enabled=true ./
+  ```
+  Contributed by @ematipico
+
+- Add new CLI options to control the CSS formatting. Check the [CLI reference page](https://biomejs.dev/reference/cli/) for more details. Contributed by @ematipico
+
 #### Enhancements
 
 - Biome now executes commands (lint, format, check and ci) on the working directory by default. [#2266](https://github.com/biomejs/biome/issues/2266) Contributed by @unvalley
@@ -107,6 +121,11 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   ```
 
   Contributed by @Conaclos
+
+- Add option `javascript.linter.enabled` to control the linter for JavaScript (and its super languages) files. Contributed by @ematipico
+- Add option `json.linter.enabled` to control the linter for JSON (and its super languages) files. Contributed by @ematipico
+- Add option `css.linter.enabled` to control the linter for CSS (and its super languages) files. Contributed by @ematipico
+- Add option `css.formatter`, to control the formatter options for CSS (and its super languages) files. Contributed by @ematipico
 
 #### Enhancements
 

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -74,8 +74,7 @@ regex                = { workspace = true }
 tokio                = { workspace = true, features = ["io-util"] }
 
 [features]
-docgen     = ["bpaf/docgen"]
-format_css = ["biome_css_formatter/format_css"]
+docgen = ["bpaf/docgen"]
 
 [lints]
 workspace = true

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -51,7 +51,7 @@ pub(crate) fn format(
         files_configuration,
         write,
         mut json_formatter,
-        mut css_formatter,
+        css_formatter,
         since,
         staged,
         changed,
@@ -130,27 +130,8 @@ pub(crate) fn format(
             }
         }
     }
-    // TODO: remove in biome 2.0
-    if let Some(css_formatter) = css_formatter.as_mut() {
-        if let Some(indent_size) = css_formatter.indent_size {
-            let diagnostic = DeprecatedArgument::new(markup! {
-                "The argument "<Emphasis>"--css-formatter-indent-size"</Emphasis>" is deprecated, it will be removed in the next major release. Use "<Emphasis>"--css-formatter-indent-width"</Emphasis>" instead."
-            });
-            console.error(markup! {
-                {PrintDiagnostic::simple(&diagnostic)}
-            });
 
-            if css_formatter.indent_width.is_none() {
-                css_formatter.indent_width = Some(indent_size);
-            }
-        }
-    }
-
-    if css_formatter.is_some() {
-        let css = configuration.css.get_or_insert_with(Default::default);
-        css.formatter.merge_with(css_formatter);
-    }
-    configuration.files.merge_with(files_configuration);
+    // merge formatter options
     if !configuration
         .formatter
         .as_ref()
@@ -163,6 +144,10 @@ pub(crate) fn format(
 
         formatter.enabled = Some(true);
     }
+    if css_formatter.is_some() {
+        let css = configuration.css.get_or_insert_with(Default::default);
+        css.formatter.merge_with(css_formatter);
+    }
     if javascript_formatter.is_some() {
         let javascript = configuration
             .javascript
@@ -173,6 +158,8 @@ pub(crate) fn format(
         let json = configuration.json.get_or_insert_with(Default::default);
         json.formatter.merge_with(json_formatter);
     }
+
+    configuration.files.merge_with(files_configuration);
     configuration.vcs.merge_with(vcs_configuration);
 
     // check if support of git ignore files is enabled

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -4,14 +4,17 @@ use crate::diagnostics::DeprecatedConfigurationFile;
 use crate::execute::Stdin;
 use crate::logging::LoggingKind;
 use crate::{CliDiagnostic, CliSession, LoggingLevel, VERSION};
+use biome_configuration::css::PartialCssLinter;
+use biome_configuration::javascript::PartialJavascriptLinter;
+use biome_configuration::json::PartialJsonLinter;
 use biome_configuration::linter::RuleSelector;
 use biome_configuration::{
-    css::partial_css_formatter, javascript::partial_javascript_formatter,
-    json::partial_json_formatter, partial_configuration, partial_files_configuration,
-    partial_formatter_configuration, partial_linter_configuration, vcs::partial_vcs_configuration,
-    vcs::PartialVcsConfiguration, PartialCssFormatter, PartialFilesConfiguration,
-    PartialFormatterConfiguration, PartialJavascriptFormatter, PartialJsonFormatter,
-    PartialLinterConfiguration,
+    css::partial_css_formatter, css::partial_css_linter, javascript::partial_javascript_formatter,
+    javascript::partial_javascript_linter, json::partial_json_formatter, json::partial_json_linter,
+    partial_configuration, partial_files_configuration, partial_formatter_configuration,
+    partial_linter_configuration, vcs::partial_vcs_configuration, vcs::PartialVcsConfiguration,
+    PartialCssFormatter, PartialFilesConfiguration, PartialFormatterConfiguration,
+    PartialJavascriptFormatter, PartialJsonFormatter, PartialLinterConfiguration,
 };
 use biome_configuration::{ConfigurationDiagnostic, PartialConfiguration};
 use biome_console::{markup, Console, ConsoleExt};
@@ -149,6 +152,15 @@ pub enum BiomeCommand {
 
         #[bpaf(external(partial_files_configuration), optional, hide_usage)]
         files_configuration: Option<PartialFilesConfiguration>,
+
+        #[bpaf(external(partial_javascript_linter), optional, hide_usage)]
+        javascript_linter: Option<PartialJavascriptLinter>,
+
+        #[bpaf(external(partial_json_linter), optional, hide_usage)]
+        json_linter: Option<PartialJsonLinter>,
+
+        #[bpaf(external(partial_css_linter), optional, hide_usage, hide)]
+        css_linter: Option<PartialCssLinter>,
 
         #[bpaf(external, hide_usage)]
         cli_options: CliOptions,

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -256,6 +256,18 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("Line width", markup!({DebugDisplayOption(json_formatter_configuration.line_width.map(|lw| lw.get()))}))}
                             {KeyValuePair("Trailing Commas", markup!({DebugDisplayOption(json_formatter_configuration.trailing_commas)}))}
                         ).fmt(fmt)?;
+
+                        let css_formatter_configuration =
+                            configuration.get_css_formatter_configuration();
+                        markup! (
+                            {Section("CSS Formatter")}
+                            {KeyValuePair("Enabled", markup!({DebugDisplay(css_formatter_configuration.enabled)}))}
+                            {KeyValuePair("Indent style", markup!({DebugDisplay(css_formatter_configuration.indent_style)}))}
+                            {KeyValuePair("Indent width", markup!({DebugDisplay(css_formatter_configuration.indent_width)}))}
+                            {KeyValuePair("Line ending", markup!({DebugDisplay(css_formatter_configuration.line_ending)}))}
+                            {KeyValuePair("Line width", markup!({DebugDisplay(css_formatter_configuration.line_width)}))}
+                            {KeyValuePair("Quote style", markup!({DebugDisplay(css_formatter_configuration.quote_style)}))}
+                        ).fmt(fmt)?;
                     }
 
                     // Print linter configuration if --linter option is true
@@ -263,8 +275,8 @@ impl Display for RageConfiguration<'_, '_> {
                         let linter_configuration = configuration.get_linter_rules();
                         markup! (
                             {Section("Linter")}
-                            {KeyValuePair("Recommended", markup!({DebugDisplay(linter_configuration.recommended.unwrap_or(false))}))}
-                            {KeyValuePair("All", markup!({DebugDisplay(linter_configuration.all.unwrap_or(false))}))}
+                            {KeyValuePair("Recommended", markup!({DebugDisplay(linter_configuration.recommended.unwrap_or_default())}))}
+                            {KeyValuePair("All", markup!({DebugDisplay(linter_configuration.all.unwrap_or_default())}))}
                             {RageConfigurationLintRules("Rules",linter_configuration)}
                         ).fmt(fmt)?;
                     }

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -122,6 +122,9 @@ impl<'app> CliSession<'app> {
                 staged,
                 changed,
                 since,
+                css_linter,
+                javascript_linter,
+                json_linter,
             } => commands::lint::lint(
                 self,
                 LintCommandPayload {
@@ -137,6 +140,9 @@ impl<'app> CliSession<'app> {
                     staged,
                     changed,
                     since,
+                    css_linter,
+                    javascript_linter,
+                    json_linter,
                 },
             ),
             BiomeCommand::Ci {

--- a/crates/biome_cli/tests/cases/handle_css_files.rs
+++ b/crates/biome_cli/tests/cases/handle_css_files.rs
@@ -1,0 +1,183 @@
+use crate::run_cli;
+use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
+use biome_console::BufferConsole;
+use biome_fs::MemoryFileSystem;
+use biome_service::DynRef;
+use bpaf::Args;
+use std::path::Path;
+
+#[test]
+fn should_not_format_files_by_default() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let css_file_content = r#"html {}"#;
+    let css_file = Path::new("input.css");
+    fs.insert(css_file.into(), css_file_content.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), css_file.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    // no files processed error
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_not_format_files_by_default",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_format_files_by_when_opt_in() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let css_file_content = r#"html {}"#;
+    let css_file = Path::new("input.css");
+    fs.insert(css_file.into(), css_file_content.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                "format",
+                "--css-formatter-enabled=true",
+                css_file.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    // not formatted error
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_format_files_by_when_opt_in",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_format_write_files_by_when_opt_in() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let css_file_content = r#"html {}"#;
+    let css_file = Path::new("input.css");
+    fs.insert(css_file.into(), css_file_content.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                "format",
+                "--write",
+                "--css-formatter-enabled=true",
+                css_file.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_format_write_files_by_when_opt_in",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_not_lint_files_by_default() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("biome.json");
+    fs.insert(
+        file_path.into(),
+        r#"{
+  "linter": { "rules": { "all": true } }
+}
+"#
+        .as_bytes(),
+    );
+
+    let css_file_content = r#"html {}"#;
+    let css_file = Path::new("input.css");
+    fs.insert(css_file.into(), css_file_content.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(["lint", css_file.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    // no files processed error
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_not_lint_files_by_default",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_lint_files_by_when_enabled() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("biome.json");
+    fs.insert(
+        file_path.into(),
+        r#"{
+  "linter": { "rules": { "all": true } }
+}
+"#
+        .as_bytes(),
+    );
+
+    let css_file_content = r#"html {}"#;
+    let css_file = Path::new("input.css");
+    fs.insert(css_file.into(), css_file_content.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                "lint",
+                "--css-linter-enabled=true",
+                css_file.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    // diagnostic
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_lint_files_by_when_enabled",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/cases/mod.rs
+++ b/crates/biome_cli/tests/cases/mod.rs
@@ -7,6 +7,7 @@ mod config_path;
 mod cts_files;
 mod diagnostics;
 mod handle_astro_files;
+mod handle_css_files;
 mod handle_svelte_files;
 mod handle_vue_files;
 mod included_files;

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -2631,8 +2631,9 @@ fn should_apply_different_formatting() {
         },
         "css": {
             "formatter": {
+                "enabled": true,
                 "lineWidth": 40,
-                "indentSize": 6
+                "indentWidth": 6
             }
         }
     }"#,
@@ -2730,7 +2731,8 @@ const a = {
                 "--json-formatter-line-width=20",
                 "--json-formatter-indent-size=2",
                 "--css-formatter-line-width=40",
-                "--css-formatter-indent-size=6",
+                "--css-formatter-indent-width=6",
+                "--css-formatter-enabled=true",
                 json_file.as_os_str().to_str().unwrap(),
                 js_file.as_os_str().to_str().unwrap(),
                 css_file.as_os_str().to_str().unwrap(),

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_format_files_by_when_opt_in.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_format_files_by_when_opt_in.snap
@@ -1,0 +1,40 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `input.css`
+
+```css
+html {}
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+input.css format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - html·{}
+      1 │ + html·{
+      2 │ + }
+      3 │ + 
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_format_write_files_by_when_opt_in.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_format_write_files_by_when_opt_in.snap
@@ -1,0 +1,17 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `input.css`
+
+```css
+html {
+}
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_lint_files_by_when_enabled.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_lint_files_by_when_enabled.snap
@@ -1,0 +1,48 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": { "rules": { "all": true } }
+}
+```
+
+## `input.css`
+
+```css
+html {}
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+input.css:1:6 lint/nursery/noCssEmptyBlock ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Empty blocks aren't allowed.
+  
+  > 1 │ html {}
+      │      ^^
+  
+  i Consider removing the empty block or adding styles inside it.
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_not_format_files_by_default.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_not_format_files_by_default.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `input.css`
+
+```css
+html {}
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × No files were processed in the specified paths.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Checked 0 files in <TIME>. No fixes needed.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_not_lint_files_by_default.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_not_lint_files_by_default.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": { "rules": { "all": true } }
+}
+```
+
+## `input.css`
+
+```css
+html {}
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × No files were processed in the specified paths.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Checked 0 files in <TIME>. No fixes needed.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -78,6 +78,19 @@ The configuration that is contained inside the file `biome.json`
         --json-formatter-trailing-commas=<none|all>  Print trailing commas wherever possible in multi-line
                               comma-separated syntactic structures. Defaults to "none".
         --json-linter-enabled=<true|false>  Control the linter for JSON (and its super languages) files.
+        --css-formatter-enabled=<true|false>  Control the formatter for CSS (and its super languages)
+                              files.
+        --css-formatter-indent-style=<tab|space>  The indent style applied to CSS (and its super languages)
+                              files.
+        --css-formatter-indent-width=NUMBER  The size of the indentation applied to CSS (and its super
+                              languages) files. Default to 2.
+        --css-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to CSS (and its super
+                              languages) files.
+        --css-formatter-line-width=NUMBER  What's the max width of a line applied to CSS (and its super
+                              languages) files. Defaults to 80.
+        --css-formatter-quote-style=<double|single>  The type of quotes used in CSS code. Defaults to
+                              double.
+        --css-linter-enabled=<true|false>  Control the linter for CSS (and its super languages) files.
 
 Global options applied to all commands
         --colors=<off|force>  Set the formatting mode for markup: "off" prints everything as plain text,

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -61,6 +61,8 @@ The configuration that is contained inside the file `biome.json`
         --quote-style=<double|single>  The type of quotes used in JavaScript code. Defaults to double.
         --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx elements.
                               Defaults to auto.
+        --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super languages)
+                              files.
         --json-formatter-enabled=<true|false>  Control the formatter for JSON (and its super languages)
                               files.
         --json-formatter-indent-style=<tab|space>  The indent style applied to JSON (and its super languages)
@@ -75,6 +77,7 @@ The configuration that is contained inside the file `biome.json`
                               languages) files. Defaults to 80.
         --json-formatter-trailing-commas=<none|all>  Print trailing commas wherever possible in multi-line
                               comma-separated syntactic structures. Defaults to "none".
+        --json-linter-enabled=<true|false>  Control the linter for JSON (and its super languages) files.
 
 Global options applied to all commands
         --colors=<off|force>  Set the formatting mode for markup: "off" prints everything as plain text,

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -63,6 +63,8 @@ The configuration that is contained inside the file `biome.json`
         --quote-style=<double|single>  The type of quotes used in JavaScript code. Defaults to double.
         --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx elements.
                               Defaults to auto.
+        --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super languages)
+                              files.
         --json-formatter-enabled=<true|false>  Control the formatter for JSON (and its super languages)
                               files.
         --json-formatter-indent-style=<tab|space>  The indent style applied to JSON (and its super languages)
@@ -77,6 +79,7 @@ The configuration that is contained inside the file `biome.json`
                               languages) files. Defaults to 80.
         --json-formatter-trailing-commas=<none|all>  Print trailing commas wherever possible in multi-line
                               comma-separated syntactic structures. Defaults to "none".
+        --json-linter-enabled=<true|false>  Control the linter for JSON (and its super languages) files.
 
 Global options applied to all commands
         --colors=<off|force>  Set the formatting mode for markup: "off" prints everything as plain text,

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -80,6 +80,19 @@ The configuration that is contained inside the file `biome.json`
         --json-formatter-trailing-commas=<none|all>  Print trailing commas wherever possible in multi-line
                               comma-separated syntactic structures. Defaults to "none".
         --json-linter-enabled=<true|false>  Control the linter for JSON (and its super languages) files.
+        --css-formatter-enabled=<true|false>  Control the formatter for CSS (and its super languages)
+                              files.
+        --css-formatter-indent-style=<tab|space>  The indent style applied to CSS (and its super languages)
+                              files.
+        --css-formatter-indent-width=NUMBER  The size of the indentation applied to CSS (and its super
+                              languages) files. Default to 2.
+        --css-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to CSS (and its super
+                              languages) files.
+        --css-formatter-line-width=NUMBER  What's the max width of a line applied to CSS (and its super
+                              languages) files. Defaults to 80.
+        --css-formatter-quote-style=<double|single>  The type of quotes used in CSS code. Defaults to
+                              double.
+        --css-linter-enabled=<true|false>  Control the linter for CSS (and its super languages) files.
 
 Global options applied to all commands
         --colors=<off|force>  Set the formatting mode for markup: "off" prints everything as plain text,

--- a/crates/biome_cli/tests/snapshots/main_commands_format/should_apply_different_formatting.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/should_apply_different_formatting.snap
@@ -23,8 +23,9 @@ expression: content
   },
   "css": {
     "formatter": {
+      "enabled": true,
       "lineWidth": 40,
-      "indentSize": 6
+      "indentWidth": 6
     }
   }
 }
@@ -92,21 +93,6 @@ biome.json:14:17 deserialize  DEPRECATED  ━━━━━━━━━━━━�
        │                 ^^^^^^^^^^^^
     15 │             }
     16 │         },
-  
-
-```
-
-```block
-biome.json:20:17 deserialize  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The property indentSize is deprecated. Use css.formatter.indentWidth instead.
-  
-    18 │             "formatter": {
-    19 │                 "lineWidth": 40,
-  > 20 │                 "indentSize": 6
-       │                 ^^^^^^^^^^^^
-    21 │             }
-    22 │         }
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/should_apply_different_formatting_with_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/should_apply_different_formatting_with_cli.snap
@@ -65,13 +65,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The argument --css-formatter-indent-size is deprecated, it will be removed in the next major release. Use --css-formatter-indent-width instead.
-  
-
-```
-
-```block
 Formatted 3 files in <TIME>. Fixed 3 files.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -28,6 +28,13 @@ The configuration of the filesystem
         --files-ignore-unknown=<true|false>  Tells Biome to not emit diagnostics when handling files
                               that doesn't know
 
+Linter options specific to the JavaScript linter
+        --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super languages)
+                              files.
+
+Linter options specific to the JSON linter
+        --json-linter-enabled=<true|false>  Control the linter for JSON (and its super languages) files.
+
 Global options applied to all commands
         --colors=<off|force>  Set the formatting mode for markup: "off" prints everything as plain text,
                               "force" forces the formatting of markup using ANSI even if the console

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
@@ -109,6 +109,14 @@ JSON Formatter:
   Line width:                   100
   Trailing Commas:              unset
 
+CSS Formatter:
+  Enabled:                      false
+  Indent style:                 Tab
+  Indent width:                 0
+  Line ending:                  Lf
+  Line width:                   LineWidth(80)
+  Quote style:                  Double
+
 Server:
   Version:                      0.0.0
   Name:                         biome_lsp

--- a/crates/biome_configuration/src/css.rs
+++ b/crates/biome_configuration/src/css.rs
@@ -34,6 +34,7 @@ pub struct CssParser {
     pub allow_wrong_line_comments: bool,
 }
 
+/// Options that changes how the CSS formatter behaves
 #[derive(Clone, Debug, Default, Deserialize, Eq, Partial, PartialEq, Serialize)]
 #[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
 #[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
@@ -77,6 +78,7 @@ impl PartialCssFormatter {
     }
 }
 
+/// Options that changes how the CSS linter behaves
 #[derive(Clone, Debug, Deserialize, Eq, Partial, PartialEq, Default, Serialize)]
 #[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
 #[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]

--- a/crates/biome_configuration/src/css.rs
+++ b/crates/biome_configuration/src/css.rs
@@ -8,15 +8,19 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Default, Debug, Deserialize, Eq, Partial, PartialEq, Serialize)]
 #[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
 #[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
-#[partial(serde(default, deny_unknown_fields))]
+#[partial(serde(rename_all = "camelCase", default, deny_unknown_fields))]
 pub struct CssConfiguration {
-    /// Parsing options
+    /// CSS parsing options
     #[partial(type, bpaf(external(partial_css_parser), optional))]
     pub parser: CssParser,
 
-    /// Formatting options
+    /// CSS formatter options
     #[partial(type, bpaf(external(partial_css_formatter), optional))]
     pub formatter: CssFormatter,
+
+    /// CSS linter options
+    #[partial(type, bpaf(external(partial_css_linter), optional))]
+    pub linter: CssLinter,
 }
 
 /// Options that changes how the CSS parser behaves
@@ -30,7 +34,7 @@ pub struct CssParser {
     pub allow_wrong_line_comments: bool,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Partial, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, Partial, PartialEq, Serialize)]
 #[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
 #[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
 #[partial(serde(rename_all = "camelCase", default, deny_unknown_fields))]
@@ -41,39 +45,44 @@ pub struct CssFormatter {
 
     /// The indent style applied to CSS (and its super languages) files.
     #[partial(bpaf(long("css-formatter-indent-style"), argument("tab|space"), optional))]
-    pub indent_style: Option<PlainIndentStyle>,
+    pub indent_style: PlainIndentStyle,
 
     /// The size of the indentation applied to CSS (and its super languages) files. Default to 2.
     #[partial(bpaf(long("css-formatter-indent-width"), argument("NUMBER"), optional))]
-    pub indent_width: Option<u8>,
-
-    /// The size of the indentation applied to CSS (and its super languages) files. Default to 2.
-    #[partial(bpaf(long("css-formatter-indent-size"), argument("NUMBER"), optional))]
-    #[partial(deserializable(deprecated(use_instead = "css.formatter.indentWidth")))]
-    pub indent_size: Option<u8>,
+    pub indent_width: u8,
 
     /// The type of line ending applied to CSS (and its super languages) files.
     #[partial(bpaf(long("css-formatter-line-ending"), argument("lf|crlf|cr"), optional))]
-    pub line_ending: Option<LineEnding>,
+    pub line_ending: LineEnding,
 
     /// What's the max width of a line applied to CSS (and its super languages) files. Defaults to 80.
     #[partial(bpaf(long("css-formatter-line-width"), argument("NUMBER"), optional))]
-    pub line_width: Option<LineWidth>,
+    pub line_width: LineWidth,
 
+    /// The type of quotes used in CSS code. Defaults to double.
     #[partial(bpaf(long("css-formatter-quote-style"), argument("double|single"), optional))]
     pub quote_style: QuoteStyle,
 }
 
-impl Default for CssFormatter {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            indent_style: Default::default(),
-            indent_width: Default::default(),
-            indent_size: Default::default(),
-            line_ending: Default::default(),
-            line_width: Default::default(),
-            quote_style: Default::default(),
+impl PartialCssFormatter {
+    pub fn get_formatter_configuration(&self) -> CssFormatter {
+        CssFormatter {
+            enabled: self.enabled.unwrap_or_default(),
+            indent_style: self.indent_style.unwrap_or_default(),
+            indent_width: self.indent_width.unwrap_or_default(),
+            line_ending: self.line_ending.unwrap_or_default(),
+            line_width: self.line_width.unwrap_or_default(),
+            quote_style: self.quote_style.unwrap_or_default(),
         }
     }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Partial, PartialEq, Default, Serialize)]
+#[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
+#[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
+#[partial(serde(rename_all = "camelCase", default, deny_unknown_fields))]
+pub struct CssLinter {
+    /// Control the linter for CSS (and its super languages) files.
+    #[partial(bpaf(long("css-linter-enabled"), argument("true|false"), optional))]
+    pub enabled: bool,
 }

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -146,3 +146,28 @@ impl Default for JavascriptFormatter {
         }
     }
 }
+
+/// Linter options specific to the JavaScript linter
+#[derive(Clone, Debug, Deserialize, Eq, Partial, PartialEq, Serialize)]
+#[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
+#[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
+#[partial(serde(rename_all = "camelCase", default, deny_unknown_fields))]
+pub struct JavascriptLinter {
+    /// Control the linter for JavaScript (and its super languages) files.
+    #[partial(bpaf(long("javascript-linter-enabled"), argument("true|false"), optional))]
+    pub enabled: bool,
+}
+
+impl Default for JavascriptLinter {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+impl PartialJavascriptLinter {
+    pub fn get_formatter_configuration(&self) -> JavascriptLinter {
+        JavascriptLinter {
+            enabled: self.enabled.unwrap_or_default(),
+        }
+    }
+}

--- a/crates/biome_configuration/src/javascript/mod.rs
+++ b/crates/biome_configuration/src/javascript/mod.rs
@@ -2,11 +2,13 @@ mod formatter;
 
 use std::str::FromStr;
 
+use crate::javascript::formatter::JavascriptLinter;
 use biome_deserialize::StringSet;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use bpaf::Bpaf;
 pub use formatter::{
-    partial_javascript_formatter, JavascriptFormatter, PartialJavascriptFormatter,
+    partial_javascript_formatter, partial_javascript_linter, JavascriptFormatter,
+    PartialJavascriptFormatter, PartialJavascriptLinter,
 };
 use serde::{Deserialize, Serialize};
 
@@ -19,6 +21,10 @@ pub struct JavascriptConfiguration {
     /// Formatting options
     #[partial(type, bpaf(external(partial_javascript_formatter), optional))]
     pub formatter: JavascriptFormatter,
+
+    /// Linter options
+    #[partial(type, bpaf(external(partial_javascript_linter), optional))]
+    pub linter: JavascriptLinter,
 
     /// Parsing options
     #[partial(type, bpaf(external(partial_javascript_parser), optional))]

--- a/crates/biome_configuration/src/json.rs
+++ b/crates/biome_configuration/src/json.rs
@@ -18,6 +18,10 @@ pub struct JsonConfiguration {
     /// Formatting options
     #[partial(type, bpaf(external(partial_json_formatter), optional))]
     pub formatter: JsonFormatter,
+
+    /// Linting options
+    #[partial(type, bpaf(external(partial_json_linter), optional))]
+    pub linter: JsonLinter,
 }
 
 /// Options that changes how the JSON parser behaves
@@ -95,5 +99,30 @@ impl Default for JsonFormatter {
             line_width: Default::default(),
             trailing_commas: Default::default(),
         }
+    }
+}
+
+/// Linter options specific to the JSON linter
+#[derive(Clone, Debug, Deserialize, Eq, Partial, PartialEq, Serialize)]
+#[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
+#[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
+#[partial(serde(rename_all = "camelCase", default, deny_unknown_fields))]
+pub struct JsonLinter {
+    /// Control the linter for JSON (and its super languages) files.
+    #[partial(bpaf(long("json-linter-enabled"), argument("true|false"), optional))]
+    pub enabled: bool,
+}
+
+impl PartialJsonFormatter {
+    pub fn get_linter_configuration(&self) -> JsonLinter {
+        JsonLinter {
+            enabled: self.enabled.unwrap_or_default(),
+        }
+    }
+}
+
+impl Default for JsonLinter {
+    fn default() -> Self {
+        Self { enabled: true }
     }
 }

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -166,6 +166,18 @@ impl PartialConfiguration {
             .unwrap_or_default()
     }
 
+    pub fn get_css_formatter_configuration(&self) -> CssFormatter {
+        self.css
+            .as_ref()
+            .map(|f| {
+                f.formatter
+                    .as_ref()
+                    .map(|f| f.get_formatter_configuration())
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default()
+    }
+
     pub fn is_linter_disabled(&self) -> bool {
         self.linter.as_ref().map_or(false, |f| f.is_disabled())
     }

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -99,7 +99,7 @@ pub struct Configuration {
     pub json: JsonConfiguration,
 
     /// Specific configuration for the Css language
-    #[partial(type, bpaf(external(partial_css_configuration), optional, hide))]
+    #[partial(type, bpaf(external(partial_css_configuration), optional))]
     pub css: CssConfiguration,
 
     /// A list of paths to other JSON files, used to extends the current configuration.

--- a/crates/biome_css_analyze/src/lint/nursery/no_color_invalid_hex.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_color_invalid_hex.rs
@@ -38,11 +38,7 @@ impl Rule for NoColorInvalidHex {
     type Signals = Option<Self::State>;
     type Options = ();
 
-    fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
-        let node = ctx.query();
-        if node.items().into_iter().next().is_none() {
-            return Some(node.clone());
-        }
+    fn run(_ctx: &RuleContext<Self>) -> Option<Self::State> {
         None
     }
 

--- a/crates/biome_css_analyze/tests/spec_tests.rs
+++ b/crates/biome_css_analyze/tests/spec_tests.rs
@@ -99,7 +99,7 @@ pub(crate) fn analyze_and_snap(
     check_action_type: CheckActionType,
     parser_options: CssParserOptions,
 ) -> usize {
-    let parsed = parse_css(input_code, parser_options.clone());
+    let parsed = parse_css(input_code, parser_options);
     let root = parsed.tree();
 
     let mut diagnostics = Vec::new();
@@ -116,18 +116,12 @@ pub(crate) fn analyze_and_snap(
                             input_code,
                             source_type,
                             &action,
-                            parser_options.clone(),
+                            parser_options,
                         );
                         diag = diag.add_code_suggestion(CodeSuggestionAdvice::from(action));
                     }
                 } else if !action.is_suppression() {
-                    check_code_action(
-                        input_file,
-                        input_code,
-                        source_type,
-                        &action,
-                        parser_options.clone(),
-                    );
+                    check_code_action(input_file, input_code, source_type, &action, parser_options);
                     diag = diag.add_code_suggestion(CodeSuggestionAdvice::from(action));
                 }
             }
@@ -140,23 +134,11 @@ pub(crate) fn analyze_and_snap(
         for action in event.actions() {
             if check_action_type.is_suppression() {
                 if action.category.matches("quickfix.suppressRule") {
-                    check_code_action(
-                        input_file,
-                        input_code,
-                        source_type,
-                        &action,
-                        parser_options.clone(),
-                    );
+                    check_code_action(input_file, input_code, source_type, &action, parser_options);
                     code_fixes.push(code_fix_to_string(input_code, action));
                 }
             } else if !action.category.matches("quickfix.suppressRule") {
-                check_code_action(
-                    input_file,
-                    input_code,
-                    source_type,
-                    &action,
-                    parser_options.clone(),
-                );
+                check_code_action(input_file, input_code, source_type, &action, parser_options);
                 code_fixes.push(code_fix_to_string(input_code, action));
             }
         }

--- a/crates/biome_css_formatter/Cargo.toml
+++ b/crates/biome_css_formatter/Cargo.toml
@@ -10,9 +10,6 @@ name                 = "biome_css_formatter"
 repository.workspace = true
 version              = "0.5.7"
 
-[features]
-format_css = []
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/biome_css_formatter/src/lib.rs
+++ b/crates/biome_css_formatter/src/lib.rs
@@ -369,16 +369,6 @@ pub fn format_sub_tree(options: CssFormatOptions, root: &CssSyntaxNode) -> Forma
     biome_formatter::format_sub_tree(root, CssFormatLanguage::new(options))
 }
 
-/// Whether the CSS formatter is allowed to be used at all.
-///
-/// Until the formatter is sufficiently ready, we're disabling its use in any
-/// external projects, but we still want to be able to run test suites in the
-/// meantime. This flag controls that visibility, and only returns true for
-/// non-release builds.
-pub const fn can_format_css_yet() -> bool {
-    cfg!(debug_assertions) || cfg!(feature = "format_css")
-}
-
 #[cfg(test)]
 mod tests {
     use crate::context::CssFormatOptions;

--- a/crates/biome_css_parser/src/parser.rs
+++ b/crates/biome_css_parser/src/parser.rs
@@ -14,7 +14,7 @@ pub(crate) struct CssParser<'source> {
     state: CssParserState,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct CssParserOptions {
     pub allow_wrong_line_comments: bool,
 }

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -57,7 +57,6 @@ serde_json               = { workspace = true, features = ["raw_value"] }
 slotmap                  = { workspace = true, features = ["serde"] }
 tracing                  = { workspace = true, features = ["attributes", "log"] }
 [features]
-format_css = ["biome_css_formatter/format_css"]
 schema = [
   "dep:schemars",
   "biome_js_analyze/schema",

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -483,13 +483,6 @@ impl PartialConfigurationExt for PartialConfiguration {
     /// configuration to apply them to the new schema.
     fn migrate_deprecated_fields(&mut self) {
         // TODO: remove in biome 2.0
-        if let Some(formatter) = self.css.as_mut().and_then(|css| css.formatter.as_mut()) {
-            if formatter.indent_size.is_some() && formatter.indent_width.is_none() {
-                formatter.indent_width = formatter.indent_size;
-            }
-        }
-
-        // TODO: remove in biome 2.0
         if let Some(formatter) = self.formatter.as_mut() {
             if formatter.indent_size.is_some() && formatter.indent_width.is_none() {
                 formatter.indent_width = formatter.indent_size;

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::configuration::to_analyzer_rules;
 use crate::diagnostics::extension_error;
 use crate::file_handlers::{is_diagnostic_error, FixAllParams};
-use crate::settings::OverrideSettings;
+use crate::settings::{LinterSettings, OverrideSettings, Settings};
 use crate::workspace::{DocumentFileSource, OrganizeImportsResult};
 use crate::{
     settings::{
@@ -82,7 +82,7 @@ pub struct JsParserSettings {
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct JsLinterSettings {
-    pub globals: Vec<String>,
+    pub enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -167,6 +167,68 @@ impl ServiceLanguage for JsLanguage {
 
         overrides.override_js_format_options(path, options)
     }
+
+    fn resolve_analyzer_options(
+        global: &Settings,
+        _linter: &LinterSettings,
+        overrides: &OverrideSettings,
+        _language: &Self::LinterSettings,
+        path: &BiomePath,
+        _file_source: &DocumentFileSource,
+    ) -> AnalyzerOptions {
+        let preferred_quote = global
+            .languages
+            .javascript
+            .formatter
+            .quote_style
+            .map(|quote_style: QuoteStyle| {
+                if quote_style == QuoteStyle::Single {
+                    PreferredQuote::Single
+                } else {
+                    PreferredQuote::Double
+                }
+            })
+            .unwrap_or_default();
+
+        let jsx_runtime = match overrides
+            .override_jsx_runtime(path, global.languages.javascript.environment.jsx_runtime)
+        {
+            // In the future, we may wish to map an `Auto` variant to a concrete
+            // analyzer value for easy access by the analyzer.
+            JsxRuntime::Transparent => biome_analyze::options::JsxRuntime::Transparent,
+            JsxRuntime::ReactClassic => biome_analyze::options::JsxRuntime::ReactClassic,
+        };
+
+        let mut globals: Vec<_> = overrides
+            .override_js_globals(path, &global.languages.javascript.globals)
+            .into_iter()
+            .collect();
+        if path.extension().and_then(OsStr::to_str) == Some("vue") {
+            globals.extend(
+                [
+                    "defineEmits",
+                    "defineProps",
+                    "defineExpose",
+                    "defineModel",
+                    "defineOptions",
+                    "defineSlots",
+                ]
+                .map(ToOwned::to_owned),
+            );
+        }
+
+        let configuration = AnalyzerConfiguration {
+            rules: to_analyzer_rules(global, path),
+            globals,
+            preferred_quote,
+            jsx_runtime: Some(jsx_runtime),
+        };
+
+        AnalyzerOptions {
+            configuration,
+            file_path: path.to_path_buf(),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -206,7 +268,7 @@ fn parse(
 ) -> ParseResult {
     let parser_settings = &settings.settings().languages.javascript.parser;
     let overrides = &settings.settings().override_settings;
-    let options = overrides.override_js_parser_options(
+    let options = overrides.to_override_js_parser_options(
         biome_path,
         JsParserOptions {
             parse_class_parameter_decorators: parser_settings.parse_class_parameter_decorators,
@@ -311,8 +373,10 @@ pub(crate) fn lint(params: LintParams) -> LintResults {
             };
             let tree = params.parse.tree();
             let mut diagnostics = params.parse.into_diagnostics();
-            let analyzer_options =
-                compute_analyzer_options(&params.settings, PathBuf::from(params.path.as_path()));
+            let analyzer_options = &params
+                .settings
+                .analyzer_options::<JsLanguage>(params.path, &params.language);
+            compute_analyzer_options(&params.settings, PathBuf::from(params.path.as_path()));
 
             // Compute final rules (taking `overrides` into account)
             let mut rules = settings.as_rules(params.path.as_path());
@@ -377,7 +441,7 @@ pub(crate) fn lint(params: LintParams) -> LintResults {
             let (_, analyze_diagnostics) = analyze(
                 &tree,
                 filter,
-                &analyzer_options,
+                analyzer_options,
                 file_source,
                 params.manifest,
                 |signal| {

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -6,8 +6,8 @@ use crate::file_handlers::{
     LintResults, ParserCapabilities,
 };
 use crate::settings::{
-    FormatSettings, LanguageListSettings, LanguageSettings, OverrideSettings, ServiceLanguage,
-    WorkspaceSettingsHandle,
+    FormatSettings, LanguageListSettings, LanguageSettings, LinterSettings, OverrideSettings,
+    ServiceLanguage, Settings, WorkspaceSettingsHandle,
 };
 use crate::workspace::{
     FixFileResult, GetSyntaxTreeResult, OrganizeImportsResult, PullActionsResult,
@@ -31,7 +31,6 @@ use biome_json_syntax::{JsonLanguage, JsonRoot, JsonSyntaxNode};
 use biome_parser::AnyParse;
 use biome_rowan::{AstNode, NodeCache};
 use biome_rowan::{TextRange, TextSize, TokenAtOffset};
-use std::path::PathBuf;
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -51,9 +50,15 @@ pub struct JsonParserSettings {
     pub allow_trailing_commas: bool,
 }
 
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct JsonLinterSettings {
+    pub enabled: Option<bool>,
+}
+
 impl ServiceLanguage for JsonLanguage {
     type FormatterSettings = JsonFormatterSettings;
-    type LinterSettings = ();
+    type LinterSettings = JsonLinterSettings;
     type OrganizeImportsSettings = ();
     type FormatOptions = JsonFormatOptions;
     type ParserSettings = JsonParserSettings;
@@ -92,7 +97,7 @@ impl ServiceLanguage for JsonLanguage {
             global.line_ending.unwrap_or_default()
         };
 
-        overrides.override_json_format_options(
+        overrides.to_override_json_format_options(
             path,
             JsonFormatOptions::new()
                 .with_line_ending(line_ending)
@@ -101,6 +106,26 @@ impl ServiceLanguage for JsonLanguage {
                 .with_line_width(line_width)
                 .with_trailing_commas(language.trailing_commas.unwrap_or_default()),
         )
+    }
+
+    fn resolve_analyzer_options(
+        global: &Settings,
+        _linter: &LinterSettings,
+        _overrides: &OverrideSettings,
+        _language: &Self::LinterSettings,
+        path: &BiomePath,
+        _file_source: &DocumentFileSource,
+    ) -> AnalyzerOptions {
+        let configuration = AnalyzerConfiguration {
+            rules: to_analyzer_rules(global, path.as_path()),
+            globals: vec![],
+            preferred_quote: PreferredQuote::Double,
+            jsx_runtime: Default::default(),
+        };
+        AnalyzerOptions {
+            configuration,
+            file_path: path.to_path_buf(),
+        }
     }
 }
 
@@ -142,7 +167,7 @@ fn parse(
     let parser = &settings.settings().languages.json.parser;
     let overrides = &settings.settings().override_settings;
     let optional_json_file_source = file_source.to_json_file_source();
-    let options: JsonParserOptions = overrides.override_json_parser_options(
+    let options: JsonParserOptions = overrides.to_override_json_parser_options(
         biome_path,
         JsonParserOptions {
             allow_comments: parser.allow_comments
@@ -326,13 +351,14 @@ fn lint(params: LintParams) -> LintResults {
                 rule_filter_list
             };
 
-            let analyzer_options =
-                compute_analyzer_options(&params.settings, PathBuf::from(params.path.as_path()));
+            let analyzer_options = &params
+                .settings
+                .analyzer_options::<JsonLanguage>(params.path, &params.language);
             let mut filter = AnalysisFilter::from_enabled_rules(Some(rule_filter_list.as_slice()));
             filter.categories = params.categories;
             let has_lint = filter.categories.contains(RuleCategories::LINT);
 
-            let (_, analyze_diagnostics) = analyze(&root, filter, &analyzer_options, |signal| {
+            let (_, analyze_diagnostics) = analyze(&root, filter, analyzer_options, |signal| {
                 if let Some(mut diagnostic) = signal.diagnostic() {
                     // Do not report unused suppression comment diagnostics if this is a syntax-only analyzer pass
                     if !has_lint && diagnostic.category() == Some(category!("suppressions/unused"))
@@ -412,20 +438,4 @@ fn organize_imports(parse: AnyParse) -> Result<OrganizeImportsResult, WorkspaceE
     Ok(OrganizeImportsResult {
         code: parse.syntax::<JsonLanguage>().to_string(),
     })
-}
-
-fn compute_analyzer_options(
-    settings: &WorkspaceSettingsHandle,
-    file_path: PathBuf,
-) -> AnalyzerOptions {
-    let configuration = AnalyzerConfiguration {
-        rules: to_analyzer_rules(settings.settings(), file_path.as_path()),
-        globals: vec![],
-        preferred_quote: PreferredQuote::Double,
-        jsx_runtime: Default::default(),
-    };
-    AnalyzerOptions {
-        configuration,
-        file_path,
-    }
 }

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -16,7 +16,6 @@ use biome_configuration::linter::RuleSelector;
 use biome_configuration::Rules;
 use biome_console::fmt::Formatter;
 use biome_console::markup;
-use biome_css_formatter::can_format_css_yet;
 use biome_css_syntax::CssFileSource;
 use biome_diagnostics::{Diagnostic, Severity};
 use biome_formatter::Printed;
@@ -485,14 +484,7 @@ impl Features {
                 EmbeddingKind::None => self.js.capabilities(),
             },
             DocumentFileSource::Json(_) => self.json.capabilities(),
-            DocumentFileSource::Css(_) => {
-                // TODO: change this when we are ready to handle CSS files
-                if can_format_css_yet() {
-                    self.css.capabilities()
-                } else {
-                    self.unknown.capabilities()
-                }
-            }
+            DocumentFileSource::Css(_) => self.css.capabilities(),
             DocumentFileSource::Unknown => self.unknown.capabilities(),
         }
     }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1,6 +1,6 @@
 use crate::workspace::{DocumentFileSource, ProjectKey, WorkspaceData};
 use crate::{Matcher, WorkspaceError};
-use biome_analyze::AnalyzerRules;
+use biome_analyze::{AnalyzerOptions, AnalyzerRules};
 use biome_configuration::diagnostics::InvalidIgnorePattern;
 use biome_configuration::javascript::JsxRuntime;
 use biome_configuration::organize_imports::OrganizeImports;
@@ -250,6 +250,24 @@ impl Settings {
         enabled == Some(&false)
     }
 
+    /// Whether the linter is disabled for CSS files
+    pub fn javascript_linter_disabled(&self) -> bool {
+        let enabled = self.languages.javascript.linter.enabled.as_ref();
+        enabled == Some(&false)
+    }
+
+    /// Whether the linter is disabled for CSS files
+    pub fn json_linter_disabled(&self) -> bool {
+        let enabled = self.languages.json.linter.enabled.as_ref();
+        enabled == Some(&false)
+    }
+
+    /// Whether the linter is disabled for CSS files
+    pub fn css_linter_disabled(&self) -> bool {
+        let enabled = self.languages.css.linter.enabled.as_ref();
+        enabled == Some(&false)
+    }
+
     /// Retrieves the settings of the linter
     pub fn linter(&self) -> &LinterSettings {
         &self.linter
@@ -446,6 +464,7 @@ impl From<JavascriptConfiguration> for LanguageSettings<JsLanguage> {
 
         language_setting.globals = Some(javascript.globals.into_index_set());
         language_setting.environment = javascript.jsx_runtime.into();
+        language_setting.linter.enabled = Some(javascript.linter.enabled);
 
         language_setting
     }
@@ -462,6 +481,7 @@ impl From<JsonConfiguration> for LanguageSettings<JsonLanguage> {
         language_setting.formatter.line_width = json.formatter.line_width;
         language_setting.formatter.indent_width = json.formatter.indent_width.map(Into::into);
         language_setting.formatter.indent_style = json.formatter.indent_style.map(Into::into);
+        language_setting.linter.enabled = Some(json.linter.enabled);
 
         language_setting
     }
@@ -472,10 +492,11 @@ impl From<CssConfiguration> for LanguageSettings<CssLanguage> {
         let mut language_setting: LanguageSettings<CssLanguage> = LanguageSettings::default();
 
         language_setting.formatter.enabled = Some(css.formatter.enabled);
-        language_setting.formatter.line_width = css.formatter.line_width;
-        language_setting.formatter.indent_width = css.formatter.indent_width.map(Into::into);
-        language_setting.formatter.indent_style = css.formatter.indent_style.map(Into::into);
+        language_setting.formatter.line_width = Some(css.formatter.line_width);
+        language_setting.formatter.indent_width = Some(css.formatter.indent_width.into());
+        language_setting.formatter.indent_style = Some(css.formatter.indent_style.into());
         language_setting.formatter.quote_style = Some(css.formatter.quote_style);
+        language_setting.linter.enabled = Some(css.linter.enabled);
 
         language_setting
     }
@@ -511,6 +532,17 @@ pub trait ServiceLanguage: biome_rowan::Language {
         path: &BiomePath,
         file_source: &DocumentFileSource,
     ) -> Self::FormatOptions;
+
+    /// Resolve the linter options from the global (workspace level),
+    /// per-language and editor provided formatter settings
+    fn resolve_analyzer_options(
+        global: &Settings,
+        linter: &LinterSettings,
+        overrides: &OverrideSettings,
+        language: &Self::LinterSettings,
+        path: &BiomePath,
+        file_source: &DocumentFileSource,
+    ) -> AnalyzerOptions;
 }
 
 #[derive(Debug, Default)]
@@ -645,6 +677,25 @@ impl<'a> WorkspaceSettingsHandle<'a> {
             file_source,
         )
     }
+
+    pub(crate) fn analyzer_options<L>(
+        &self,
+        path: &BiomePath,
+        file_source: &DocumentFileSource,
+    ) -> AnalyzerOptions
+    where
+        L: ServiceLanguage,
+    {
+        let settings = self.inner.get_current_settings();
+        L::resolve_analyzer_options(
+            settings,
+            &settings.linter,
+            &settings.override_settings,
+            &L::lookup_settings(&settings.languages).linter,
+            path,
+            file_source,
+        )
+    }
 }
 
 pub struct WorkspaceSettingsHandleMut<'a> {
@@ -748,8 +799,8 @@ impl OverrideSettings {
             })
     }
 
-    /// It scans the current override rules and return the formatting options that of the first override is matched
-    pub fn override_json_format_options(
+    /// It scans the current override rules and return the json format that of the first override is matched
+    pub fn to_override_json_format_options(
         &self,
         path: &Path,
         options: JsonFormatOptions,
@@ -769,7 +820,7 @@ impl OverrideSettings {
     }
 
     /// It scans the current override rules and return the formatting options that of the first override is matched
-    pub fn override_css_format_options(
+    pub fn to_override_css_format_options(
         &self,
         path: &Path,
         options: CssFormatOptions,
@@ -788,7 +839,7 @@ impl OverrideSettings {
         })
     }
 
-    pub fn override_js_parser_options(
+    pub fn to_override_js_parser_options(
         &self,
         path: &Path,
         options: JsParserOptions,
@@ -806,7 +857,7 @@ impl OverrideSettings {
         })
     }
 
-    pub fn override_json_parser_options(
+    pub fn to_override_json_parser_options(
         &self,
         path: &Path,
         options: JsonParserOptions,
@@ -824,21 +875,22 @@ impl OverrideSettings {
         })
     }
 
-    pub fn as_css_parser_options(&self, path: &Path) -> Option<CssParserOptions> {
-        for pattern in &self.patterns {
+    /// It scans the current override rules and return the parser options that of the first override is matched
+    pub fn to_override_css_parser_options(
+        &self,
+        path: &Path,
+        options: CssParserOptions,
+    ) -> CssParserOptions {
+        self.patterns.iter().fold(options, |mut options, pattern| {
             let included = !pattern.include.is_empty() && pattern.include.matches_path(path);
             let excluded = !pattern.exclude.is_empty() && pattern.exclude.matches_path(path);
 
             if included || !excluded {
-                let css_parser = &pattern.languages.css.parser;
-
-                return Some(CssParserOptions {
-                    allow_wrong_line_comments: css_parser.allow_wrong_line_comments,
-                });
+                pattern.apply_overrides_to_css_parser_options(&mut options)
             }
-        }
 
-        None
+            options
+        })
     }
 
     /// Retrieves the options of lint rules that have been overridden
@@ -932,6 +984,7 @@ pub struct OverrideSettingPattern {
     pub(crate) cached_css_format_options: RwLock<Option<CssFormatOptions>>,
     pub(crate) cached_js_parser_options: RwLock<Option<JsParserOptions>>,
     pub(crate) cached_json_parser_options: RwLock<Option<JsonParserOptions>>,
+    pub(crate) cached_css_parser_options: RwLock<Option<CssParserOptions>>,
 }
 impl OverrideSettingPattern {
     fn apply_overrides_to_js_format_options(&self, options: &mut JsFormatOptions) {
@@ -1088,6 +1141,24 @@ impl OverrideSettingPattern {
         options.allow_comments = json_parser.allow_comments;
 
         if let Ok(mut writeonly_cache) = self.cached_json_parser_options.write() {
+            let options = *options;
+            let _ = writeonly_cache.insert(options);
+        }
+    }
+
+    fn apply_overrides_to_css_parser_options(&self, options: &mut CssParserOptions) {
+        if let Ok(readonly_cache) = self.cached_css_parser_options.read() {
+            if let Some(cached_options) = readonly_cache.as_ref() {
+                *options = *cached_options;
+                return;
+            }
+        }
+
+        let css_parser = &self.languages.css.parser;
+
+        options.allow_wrong_line_comments = css_parser.allow_wrong_line_comments;
+
+        if let Ok(mut writeonly_cache) = self.cached_css_parser_options.write() {
             let options = *options;
             let _ = writeonly_cache.insert(options);
         }
@@ -1374,7 +1445,6 @@ fn to_css_language_settings(
     language_setting.formatter.indent_width = formatter
         .indent_width
         .map(Into::into)
-        .or(formatter.indent_size.map(Into::into))
         .or(parent_formatter.indent_width);
     language_setting.formatter.indent_style = formatter
         .indent_style

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -58,7 +58,6 @@ pub use biome_analyze::RuleCategories;
 use biome_configuration::linter::RuleSelector;
 use biome_configuration::PartialConfiguration;
 use biome_console::{markup, Markup, MarkupBuf};
-use biome_css_formatter::can_format_css_yet;
 use biome_diagnostics::CodeSuggestion;
 use biome_formatter::Printed;
 use biome_fs::BiomePath;
@@ -165,9 +164,7 @@ impl FileFeaturesResult {
             } else if file_source.is_json_like() {
                 !settings.formatter().enabled || settings.json_formatter_disabled()
             } else if file_source.is_css_like() {
-                !can_format_css_yet()
-                    || !settings.formatter().enabled
-                    || settings.css_formatter_disabled()
+                !settings.formatter().enabled || settings.css_formatter_disabled()
             } else {
                 !settings.formatter().enabled
             };
@@ -176,12 +173,21 @@ impl FileFeaturesResult {
                 .insert(FeatureName::Format, SupportKind::FeatureNotEnabled);
         }
         // linter
-        if let Some(disabled) = settings.override_settings.linter_disabled(path) {
-            if disabled {
-                self.features_supported
-                    .insert(FeatureName::Lint, SupportKind::FeatureNotEnabled);
+        let linter_disabled = {
+            if let Some(disabled) = settings.override_settings.linter_disabled(path) {
+                disabled
+            } else if file_source.is_javascript_like() {
+                !settings.linter().enabled || settings.javascript_linter_disabled()
+            } else if file_source.is_json_like() {
+                !settings.linter().enabled || settings.json_linter_disabled()
+            } else if file_source.is_css_like() {
+                !settings.linter().enabled || settings.css_linter_disabled()
+            } else {
+                !settings.linter().enabled
             }
-        } else if !settings.linter().enabled {
+        };
+
+        if linter_disabled {
             self.features_supported
                 .insert(FeatureName::Lint, SupportKind::FeatureNotEnabled);
         }
@@ -766,7 +772,7 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
     /// Takes as input the path of the file that workspace is currently processing and
     /// a list of paths to match against.
     ///
-    /// If the file path matches, than `true` is returned and it should be considered ignored.
+    /// If the file path matches, then `true` is returned, and it should be considered ignored.
     fn is_path_ignored(&self, params: IsPathIgnoredParams) -> Result<bool, WorkspaceError>;
 
     /// Update the global settings for this workspace

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -391,7 +391,6 @@ impl Workspace for WorkspaceServer {
                 {
                     file_features.set_protected_for_all_features();
                 }
-
                 Ok(entry.insert(file_features).clone())
             }
         }

--- a/crates/biome_wasm/Cargo.toml
+++ b/crates/biome_wasm/Cargo.toml
@@ -16,8 +16,7 @@ version     = "1.7.3"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default    = ["console_error_panic_hook"]
-format_css = ["biome_service/format_css"]
+default = ["console_error_panic_hook"]
 
 [dependencies]
 biome_console      = { workspace = true }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -77,11 +77,15 @@ export interface PartialConfiguration {
  */
 export interface PartialCssConfiguration {
 	/**
-	 * Formatting options
+	 * CSS formatter options
 	 */
 	formatter?: PartialCssFormatter;
 	/**
-	 * Parsing options
+	 * CSS linter options
+	 */
+	linter?: PartialCssLinter;
+	/**
+	 * CSS parsing options
 	 */
 	parser?: PartialCssParser;
 }
@@ -167,6 +171,10 @@ If defined here, they should not emit diagnostics.
 	 * Indicates the type of runtime or transformation used for interpreting JSX.
 	 */
 	jsxRuntime?: JsxRuntime;
+	/**
+	 * Linter options
+	 */
+	linter?: PartialJavascriptLinter;
 	organizeImports?: PartialJavascriptOrganizeImports;
 	/**
 	 * Parsing options
@@ -181,6 +189,10 @@ export interface PartialJsonConfiguration {
 	 * Formatting options
 	 */
 	formatter?: PartialJsonFormatter;
+	/**
+	 * Linting options
+	 */
+	linter?: PartialJsonLinter;
 	/**
 	 * Parsing options
 	 */
@@ -252,10 +264,6 @@ export interface PartialCssFormatter {
 	 */
 	enabled?: boolean;
 	/**
-	 * The size of the indentation applied to CSS (and its super languages) files. Default to 2.
-	 */
-	indentSize?: number;
-	/**
 	 * The indent style applied to CSS (and its super languages) files.
 	 */
 	indentStyle?: PlainIndentStyle;
@@ -271,7 +279,16 @@ export interface PartialCssFormatter {
 	 * What's the max width of a line applied to CSS (and its super languages) files. Defaults to 80.
 	 */
 	lineWidth?: LineWidth;
+	/**
+	 * The type of quotes used in CSS code. Defaults to double.
+	 */
 	quoteStyle?: QuoteStyle;
+}
+export interface PartialCssLinter {
+	/**
+	 * Control the linter for CSS (and its super languages) files.
+	 */
+	enabled?: boolean;
 }
 /**
  * Options that changes how the CSS parser behaves
@@ -364,6 +381,15 @@ export interface PartialJavascriptFormatter {
  * Indicates the type of runtime or transformation used for interpreting JSX.
  */
 export type JsxRuntime = "transparent" | "reactClassic";
+/**
+ * Linter options specific to the JavaScript linter
+ */
+export interface PartialJavascriptLinter {
+	/**
+	 * Control the linter for JavaScript (and its super languages) files.
+	 */
+	enabled?: boolean;
+}
 export interface PartialJavascriptOrganizeImports {}
 /**
  * Options that changes how the JavaScript parser behaves
@@ -405,6 +431,15 @@ export interface PartialJsonFormatter {
 	 * Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "none".
 	 */
 	trailingCommas?: TrailingCommas2;
+}
+/**
+ * Linter options specific to the JSON linter
+ */
+export interface PartialJsonLinter {
+	/**
+	 * Control the linter for JSON (and its super languages) files.
+	 */
+	enabled?: boolean;
 }
 /**
  * Options that changes how the JSON parser behaves

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -258,6 +258,9 @@ If Biome can't find the configuration, it will attempt to use the current workin
 	 */
 	useIgnoreFile?: boolean;
 }
+/**
+ * Options that changes how the CSS formatter behaves
+ */
 export interface PartialCssFormatter {
 	/**
 	 * Control the formatter for CSS (and its super languages) files.
@@ -284,6 +287,9 @@ export interface PartialCssFormatter {
 	 */
 	quoteStyle?: QuoteStyle;
 }
+/**
+ * Options that changes how the CSS linter behaves
+ */
 export interface PartialCssLinter {
 	/**
 	 * Control the linter for CSS (and its super languages) files.

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -862,14 +862,18 @@
 			"type": "object",
 			"properties": {
 				"formatter": {
-					"description": "Formatting options",
+					"description": "CSS formatter options",
 					"anyOf": [
 						{ "$ref": "#/definitions/CssFormatter" },
 						{ "type": "null" }
 					]
 				},
+				"linter": {
+					"description": "CSS linter options",
+					"anyOf": [{ "$ref": "#/definitions/CssLinter" }, { "type": "null" }]
+				},
 				"parser": {
-					"description": "Parsing options",
+					"description": "CSS parsing options",
 					"anyOf": [{ "$ref": "#/definitions/CssParser" }, { "type": "null" }]
 				}
 			},
@@ -881,12 +885,6 @@
 				"enabled": {
 					"description": "Control the formatter for CSS (and its super languages) files.",
 					"type": ["boolean", "null"]
-				},
-				"indentSize": {
-					"description": "The size of the indentation applied to CSS (and its super languages) files. Default to 2.",
-					"type": ["integer", "null"],
-					"format": "uint8",
-					"minimum": 0.0
 				},
 				"indentStyle": {
 					"description": "The indent style applied to CSS (and its super languages) files.",
@@ -910,7 +908,18 @@
 					"anyOf": [{ "$ref": "#/definitions/LineWidth" }, { "type": "null" }]
 				},
 				"quoteStyle": {
+					"description": "The type of quotes used in CSS code. Defaults to double.",
 					"anyOf": [{ "$ref": "#/definitions/QuoteStyle" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"CssLinter": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Control the linter for CSS (and its super languages) files.",
+					"type": ["boolean", "null"]
 				}
 			},
 			"additionalProperties": false
@@ -1164,6 +1173,13 @@
 					"description": "Indicates the type of runtime or transformation used for interpreting JSX.",
 					"anyOf": [{ "$ref": "#/definitions/JsxRuntime" }, { "type": "null" }]
 				},
+				"linter": {
+					"description": "Linter options",
+					"anyOf": [
+						{ "$ref": "#/definitions/JavascriptLinter" },
+						{ "type": "null" }
+					]
+				},
 				"organizeImports": {
 					"anyOf": [
 						{ "$ref": "#/definitions/JavascriptOrganizeImports" },
@@ -1273,6 +1289,17 @@
 			},
 			"additionalProperties": false
 		},
+		"JavascriptLinter": {
+			"description": "Linter options specific to the JavaScript linter",
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Control the linter for JavaScript (and its super languages) files.",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
 		"JavascriptOrganizeImports": {
 			"type": "object",
 			"additionalProperties": false
@@ -1298,6 +1325,10 @@
 						{ "$ref": "#/definitions/JsonFormatter" },
 						{ "type": "null" }
 					]
+				},
+				"linter": {
+					"description": "Linting options",
+					"anyOf": [{ "$ref": "#/definitions/JsonLinter" }, { "type": "null" }]
 				},
 				"parser": {
 					"description": "Parsing options",
@@ -1346,6 +1377,17 @@
 						{ "$ref": "#/definitions/TrailingCommas2" },
 						{ "type": "null" }
 					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"JsonLinter": {
+			"description": "Linter options specific to the JSON linter",
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Control the linter for JSON (and its super languages) files.",
+					"type": ["boolean", "null"]
 				}
 			},
 			"additionalProperties": false

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -880,6 +880,7 @@
 			"additionalProperties": false
 		},
 		"CssFormatter": {
+			"description": "Options that changes how the CSS formatter behaves",
 			"type": "object",
 			"properties": {
 				"enabled": {
@@ -915,6 +916,7 @@
 			"additionalProperties": false
 		},
 		"CssLinter": {
+			"description": "Options that changes how the CSS linter behaves",
 			"type": "object",
 			"properties": {
 				"enabled": {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR enables CSS parsing and CSS formatting.

> [!IMPORTANT]
> Internally, we decided that linter and formatting are **opt-in** and **disabled by default**. Why? Because it's possible that parser, formatter and linter aren't quite stable yet, and it's hightly possible that there are bugs.

Enabling this in Biome comes with new options across the configuration. Mainly now, each language section can enable or disable the linter. This was required because, until now, we haven't officially had lint rules for languages other than JSON, and that single lint rule still needs some work, that's why it isn't documented yet. 

The PR adds:
- `javascript.linter.enabled`
- `css.linter.enabled`
- `json.linter.enabled`

The relative CLI options are also added.

 Also, since we are officially enabling the CSS formatter to the people with this PR, I took the chance to remove `inde_size` from the options. It doesn't make sense to expose an option that is already deprecated.

### Technical changes

Most of the changes are around configuration and overrides. It's mostly boilerplate and copying code from other implementations.

One thing of relevance though, is the creation of the type `AnalyzerOptions` when we do linting. So far, we were using a standalone function to do that, however, that's not the right way not. 

Our infrastructure allows to generate generic functions at triat level that return options for a specifict language, for example `format_options`. These are function meant to receive options from global settings (`biome.json` and CLI) and the LSP (client options). I did create a new function called `analyzer_options`, and how each language implements that. The implementation of each function is a copy-paste of their former functions, but adapted to use the proper parameters. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I created new test cases inside a new file called `handle_css_files.rs`. I find using the "cases" concept better than grouping stuff by commands. More files, sure, but they are smaller and focused on certain things.

<!-- What demonstrates that your implementation is correct? -->
