### PR TITLE
fix(lint/noExcessiveNestedTestSuites): don't alert if describe call is a member of some other object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,17 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 	return <>{item.condition ? <div /> : <div>foo</div>}</>;
 });
 ```
+- `noExcessiveNestedTestSuites` no longer erroneously alerts on `describe` calls that are not invoking the global `describe` function. [#2599](https://github.com/biomejs/biome/issues/2599) Contributed by @dyc3
+```js
+// now valid
+z.object({})
+  .describe('')
+  .describe('')
+  .describe('')
+  .describe('')
+  .describe('')
+  .describe('');
+```
 
 ### Parser
 

--- a/crates/biome_js_analyze/src/lint/complexity/no_excessive_nested_test_suites.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_excessive_nested_test_suites.rs
@@ -3,8 +3,8 @@ use biome_analyze::{
     RuleDiagnostic, RuleSource, RuleSourceKind, ServiceBag, Visitor, VisitorContext,
 };
 use biome_console::markup;
-use biome_js_syntax::{JsCallExpression, JsLanguage};
-use biome_rowan::{AstNode, Language, SyntaxNode, TextRange, WalkEvent};
+use biome_js_syntax::{JsCallExpression, JsLanguage, JsStaticMemberExpression};
+use biome_rowan::{AstNode, Language, SyntaxNode, SyntaxNodeOptionExt, TextRange, WalkEvent};
 
 declare_rule! {
     /// This rule enforces a maximum depth to nested `describe()` in test files.
@@ -116,7 +116,7 @@ impl Visitor for NestedTestVisitor {
             WalkEvent::Enter(node) => {
                 if let Some(node) = JsCallExpression::cast_ref(node) {
                     if let Ok(callee) = node.callee() {
-                        if callee.contains_describe_call() {
+                        if callee.contains_describe_call() && !is_member(&node) {
                             self.curr_count += 1;
                             if self.curr_count == self.max_count + 1 {
                                 ctx.match_query(NestedTest(node.clone()));
@@ -128,7 +128,7 @@ impl Visitor for NestedTestVisitor {
             WalkEvent::Leave(node) => {
                 if let Some(node) = JsCallExpression::cast_ref(node) {
                     if let Ok(callee) = node.callee() {
-                        if callee.contains_describe_call() {
+                        if callee.contains_describe_call() && !is_member(&node) {
                             self.curr_count -= 1;
                         }
                     }
@@ -136,6 +136,21 @@ impl Visitor for NestedTestVisitor {
             }
         }
     }
+}
+
+/// Determines whether or not the call expression is for a function that is a member of another object.
+///
+/// ```js
+/// const foo = {
+///   bar() {}
+/// }
+/// foo.bar(); // bar is a member of foo
+/// ```
+fn is_member(call: &JsCallExpression) -> bool {
+    call.syntax()
+        .parent()
+        .kind()
+        .map_or(false, JsStaticMemberExpression::can_cast)
 }
 
 // Declare a query match struct type containing a JavaScript function node

--- a/crates/biome_js_analyze/tests/specs/complexity/noExcessiveNestedTestSuites/valid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExcessiveNestedTestSuites/valid.js
@@ -51,3 +51,11 @@ xdescribe("foo", function () {
 describe("foo", () => {
 	describe.each(["hello", "world"])("%s", (a) => {});
 });
+
+z.object({})
+  .describe('')
+  .describe('')
+  .describe('')
+  .describe('')
+  .describe('')
+  .describe('');

--- a/crates/biome_js_analyze/tests/specs/complexity/noExcessiveNestedTestSuites/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExcessiveNestedTestSuites/valid.js.snap
@@ -58,6 +58,12 @@ describe("foo", () => {
 	describe.each(["hello", "world"])("%s", (a) => {});
 });
 
+z.object({})
+  .describe('')
+  .describe('')
+  .describe('')
+  .describe('')
+  .describe('')
+  .describe('');
+
 ```
-
-


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Zod has a `describe` method for describing the fields of a zod schema. Now, this rule will no longer alert when presented with snippets like this:
```js
z.object({})
  .describe('')
  .describe('')
  .describe('')
  .describe('')
  .describe('')
  .describe('');
```

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #2599


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added snippet to snapshot tests

```bash
cargo test -p biome_js_analyze no_excessive_nested_test_suites
```
