### PR TITLE
feat(lint): add new js lint: `useTopLevelRegex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Add [nursery/useThrowNewError](https://biomejs.dev/linter/rules/use-throw-new-error/).
   Contributed by @minht11
+- Add [nursery/useTopLevelRegex](https://biomejs.dev/linter/rules/use-top-level-regex), which enforces defining regular expressions at the top level of a module. [#2148](https://github.com/biomejs/biome/issues/2148) Contributed by @dyc3.
 
 #### Bug fixes
 

--- a/crates/biome_configuration/src/linter/rules.rs
+++ b/crates/biome_configuration/src/linter/rules.rs
@@ -2760,6 +2760,9 @@ pub struct Nursery {
     #[doc = "Require new when throwing an error."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_throw_new_error: Option<RuleConfiguration<UseThrowNewError>>,
+    #[doc = "Require all regex literals to be declared at the top level."]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_top_level_regex: Option<RuleConfiguration<UseTopLevelRegex>>,
 }
 impl DeserializableValidator for Nursery {
     fn validate(
@@ -2814,6 +2817,7 @@ impl Nursery {
         "useImportRestrictions",
         "useSortedClasses",
         "useThrowNewError",
+        "useTopLevelRegex",
     ];
     const RECOMMENDED_RULES: &'static [&'static str] = &[
         "noCssEmptyBlock",
@@ -2890,6 +2894,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended_true(&self) -> bool {
@@ -3086,6 +3091,11 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
+        if let Some(rule) = self.use_top_level_regex.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
+            }
+        }
         index_set
     }
     pub(crate) fn get_disabled_rules(&self) -> IndexSet<RuleFilter> {
@@ -3270,6 +3280,11 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
+        if let Some(rule) = self.use_top_level_regex.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
+            }
+        }
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
@@ -3448,6 +3463,10 @@ impl Nursery {
                 .map(|conf| (conf.level(), conf.get_options())),
             "useThrowNewError" => self
                 .use_throw_new_error
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useTopLevelRegex" => self
+                .use_top_level_regex
                 .as_ref()
                 .map(|conf| (conf.level(), conf.get_options())),
             _ => None,

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -149,6 +149,7 @@ define_categories! {
     "lint/nursery/useImportRestrictions": "https://biomejs.dev/linter/rules/use-import-restrictions",
     "lint/nursery/useSortedClasses": "https://biomejs.dev/linter/rules/use-sorted-classes",
     "lint/nursery/useThrowNewError": "https://biomejs.dev/linter/rules/use-throw-new-error",
+    "lint/nursery/useTopLevelRegex": "https://biomejs.dev/linter/rules/use-top-level-regex",
     "lint/performance/noAccumulatingSpread": "https://biomejs.dev/linter/rules/no-accumulating-spread",
     "lint/performance/noBarrelFile": "https://biomejs.dev/linter/rules/no-barrel-file",
     "lint/performance/noDelete": "https://biomejs.dev/linter/rules/no-delete",

--- a/crates/biome_js_analyze/src/lint/nursery.rs
+++ b/crates/biome_js_analyze/src/lint/nursery.rs
@@ -23,6 +23,7 @@ pub mod use_focusable_interactive;
 pub mod use_import_restrictions;
 pub mod use_sorted_classes;
 pub mod use_throw_new_error;
+pub mod use_top_level_regex;
 
 declare_group! {
     pub Nursery {
@@ -49,6 +50,7 @@ declare_group! {
             self :: use_import_restrictions :: UseImportRestrictions ,
             self :: use_sorted_classes :: UseSortedClasses ,
             self :: use_throw_new_error :: UseThrowNewError ,
+            self :: use_top_level_regex :: UseTopLevelRegex ,
         ]
      }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/use_top_level_regex.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_top_level_regex.rs
@@ -1,0 +1,90 @@
+use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
+use biome_console::markup;
+use biome_js_syntax::{AnyJsPropertyModifier, JsPropertyClassMember, JsRegexLiteralExpression};
+use biome_rowan::{AstNode, AstNodeList};
+
+use crate::services::control_flow::AnyJsControlFlowRoot;
+
+declare_rule! {
+    /// Require all regex literals to be declared at the top level.
+    ///
+    /// This rule is useful to avoid performance issues when using regex literals inside functions called many times (hot paths). Regex literals create a new RegExp object when they are evaluated. (See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) By declaring them at the top level, this overhead can be avoided.
+    ///
+    /// It's important to note that this rule is not recommended for all cases. Placing regex literals at the top level can hurt startup times. In browser contexts, this can result in longer page loads.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// function foo(someString) {
+    ///     return /[a-Z]*/.test(someString)
+    /// }
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// const REGEX = /[a-Z]*/;
+    ///
+    /// function foo(someString) {
+    ///     return REGEX.test(someString)
+    /// }
+    /// ```
+    ///
+    pub UseTopLevelRegex {
+        version: "next",
+        name: "useTopLevelRegex",
+        language: "js",
+        recommended: false,
+    }
+}
+
+impl Rule for UseTopLevelRegex {
+    type Query = Ast<JsRegexLiteralExpression>;
+    type State = ();
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let regex = ctx.query();
+        let found_all_allowed = regex.syntax().ancestors().all(|node| {
+            if let Some(node) = AnyJsControlFlowRoot::cast_ref(&node) {
+                matches!(
+                    node,
+                    AnyJsControlFlowRoot::JsStaticInitializationBlockClassMember(_)
+                        | AnyJsControlFlowRoot::TsModuleDeclaration(_)
+                        | AnyJsControlFlowRoot::JsModule(_)
+                        | AnyJsControlFlowRoot::JsScript(_)
+                )
+            } else if let Some(node) = JsPropertyClassMember::cast_ref(&node) {
+                node.modifiers()
+                    .iter()
+                    .any(|modifier| matches!(modifier, AnyJsPropertyModifier::JsStaticModifier(_)))
+            } else {
+                true
+            }
+        });
+        if found_all_allowed {
+            None
+        } else {
+            Some(())
+        }
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
+        let node = ctx.query();
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                node.range(),
+                markup! {
+                    "This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently."
+                },
+            )
+            .note(markup! {
+                "Move the regex literal outside of this scope, and place it at the top level of this module, as a constant."
+            }),
+        )
+    }
+}

--- a/crates/biome_js_analyze/src/options.rs
+++ b/crates/biome_js_analyze/src/options.rs
@@ -336,6 +336,8 @@ pub type UseSortedClasses =
 pub type UseTemplate = <lint::style::use_template::UseTemplate as biome_analyze::Rule>::Options;
 pub type UseThrowNewError =
     <lint::nursery::use_throw_new_error::UseThrowNewError as biome_analyze::Rule>::Options;
+pub type UseTopLevelRegex =
+    <lint::nursery::use_top_level_regex::UseTopLevelRegex as biome_analyze::Rule>::Options;
 pub type UseValidAnchor =
     <lint::a11y::use_valid_anchor::UseValidAnchor as biome_analyze::Rule>::Options;
 pub type UseValidAriaProps =

--- a/crates/biome_js_analyze/tests/specs/nursery/useTopLevelRegex/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useTopLevelRegex/invalid.js
@@ -1,0 +1,52 @@
+function foo(someString) {
+	return /[a-Z]*/.test(someString)
+}
+
+function foo(someString) {
+	const r = /[a-Z]*/;
+	return r.test(someString)
+}
+
+const foo = (someString) => {
+	return /[a-Z]*/.test(someString)
+}
+
+class Foo {
+	constructor() {
+		this.regex = /[a-Z]*/;
+	}
+}
+
+class Foo {
+	regex = /[a-Z]*/;
+}
+
+class Foo {
+	get regex() {
+		return /[a-Z]*/;
+	}
+}
+
+class Foo {
+	set apply(s) {
+		this.value = /[a-Z]*/.test(s);
+	}
+}
+
+const foo = {
+	regex() {
+		return /[a-Z]*/;
+	}
+}
+
+const foo = {
+	get regex() {
+		return /[a-Z]*/;
+	}
+}
+
+const foo = {
+	set apply(s) {
+		this.value = /[a-Z]*/.test(s);
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useTopLevelRegex/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useTopLevelRegex/invalid.js.snap
@@ -1,0 +1,227 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.js
+---
+# Input
+```jsx
+function foo(someString) {
+	return /[a-Z]*/.test(someString)
+}
+
+function foo(someString) {
+	const r = /[a-Z]*/;
+	return r.test(someString)
+}
+
+const foo = (someString) => {
+	return /[a-Z]*/.test(someString)
+}
+
+class Foo {
+	constructor() {
+		this.regex = /[a-Z]*/;
+	}
+}
+
+class Foo {
+	regex = /[a-Z]*/;
+}
+
+class Foo {
+	get regex() {
+		return /[a-Z]*/;
+	}
+}
+
+class Foo {
+	set apply(s) {
+		this.value = /[a-Z]*/.test(s);
+	}
+}
+
+const foo = {
+	regex() {
+		return /[a-Z]*/;
+	}
+}
+
+const foo = {
+	get regex() {
+		return /[a-Z]*/;
+	}
+}
+
+const foo = {
+	set apply(s) {
+		this.value = /[a-Z]*/.test(s);
+	}
+}
+
+```
+
+# Diagnostics
+```
+invalid.js:2:9 lint/nursery/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    1 │ function foo(someString) {
+  > 2 │ 	return /[a-Z]*/.test(someString)
+      │ 	       ^^^^^^^^
+    3 │ }
+    4 │ 
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+
+```
+
+```
+invalid.js:6:12 lint/nursery/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    5 │ function foo(someString) {
+  > 6 │ 	const r = /[a-Z]*/;
+      │ 	          ^^^^^^^^
+    7 │ 	return r.test(someString)
+    8 │ }
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+
+```
+
+```
+invalid.js:11:9 lint/nursery/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    10 │ const foo = (someString) => {
+  > 11 │ 	return /[a-Z]*/.test(someString)
+       │ 	       ^^^^^^^^
+    12 │ }
+    13 │ 
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+
+```
+
+```
+invalid.js:16:16 lint/nursery/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    14 │ class Foo {
+    15 │ 	constructor() {
+  > 16 │ 		this.regex = /[a-Z]*/;
+       │ 		             ^^^^^^^^
+    17 │ 	}
+    18 │ }
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+
+```
+
+```
+invalid.js:21:10 lint/nursery/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    20 │ class Foo {
+  > 21 │ 	regex = /[a-Z]*/;
+       │ 	        ^^^^^^^^
+    22 │ }
+    23 │ 
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+
+```
+
+```
+invalid.js:26:10 lint/nursery/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    24 │ class Foo {
+    25 │ 	get regex() {
+  > 26 │ 		return /[a-Z]*/;
+       │ 		       ^^^^^^^^
+    27 │ 	}
+    28 │ }
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+
+```
+
+```
+invalid.js:32:16 lint/nursery/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    30 │ class Foo {
+    31 │ 	set apply(s) {
+  > 32 │ 		this.value = /[a-Z]*/.test(s);
+       │ 		             ^^^^^^^^
+    33 │ 	}
+    34 │ }
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+
+```
+
+```
+invalid.js:38:10 lint/nursery/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    36 │ const foo = {
+    37 │ 	regex() {
+  > 38 │ 		return /[a-Z]*/;
+       │ 		       ^^^^^^^^
+    39 │ 	}
+    40 │ }
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+
+```
+
+```
+invalid.js:44:10 lint/nursery/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    42 │ const foo = {
+    43 │ 	get regex() {
+  > 44 │ 		return /[a-Z]*/;
+       │ 		       ^^^^^^^^
+    45 │ 	}
+    46 │ }
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+
+```
+
+```
+invalid.js:50:16 lint/nursery/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    48 │ const foo = {
+    49 │ 	set apply(s) {
+  > 50 │ 		this.value = /[a-Z]*/.test(s);
+       │ 		             ^^^^^^^^
+    51 │ 	}
+    52 │ }
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useTopLevelRegex/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useTopLevelRegex/valid.js
@@ -1,0 +1,17 @@
+/* should not generate diagnostics */
+
+/[a-Z]*/.test("foo");
+
+const REGEX = /[a-Z]*/;
+
+function foo(someString) {
+	return REGEX.test(someString)
+}
+
+const foo = {
+	regex: /[a-Z]*/
+}
+
+class Foo {
+	static regex = /[a-Z]*/;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useTopLevelRegex/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useTopLevelRegex/valid.js.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+
+/[a-Z]*/.test("foo");
+
+const REGEX = /[a-Z]*/;
+
+function foo(someString) {
+	return REGEX.test(someString)
+}
+
+const foo = {
+	regex: /[a-Z]*/
+}
+
+class Foo {
+	static regex = /[a-Z]*/;
+}
+
+```

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1060,6 +1060,10 @@ export interface Nursery {
 	 * Require new when throwing an error.
 	 */
 	useThrowNewError?: RuleConfiguration_for_Null;
+	/**
+	 * Require all regex literals to be declared at the top level.
+	 */
+	useTopLevelRegex?: RuleConfiguration_for_Null;
 }
 /**
  * A list of rules that belong to this group
@@ -2149,6 +2153,7 @@ export type Category =
 	| "lint/nursery/useImportRestrictions"
 	| "lint/nursery/useSortedClasses"
 	| "lint/nursery/useThrowNewError"
+	| "lint/nursery/useTopLevelRegex"
 	| "lint/performance/noAccumulatingSpread"
 	| "lint/performance/noBarrelFile"
 	| "lint/performance/noDelete"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1820,6 +1820,13 @@
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }
 					]
+				},
+				"useTopLevelRegex": {
+					"description": "Require all regex literals to be declared at the top level.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

This rule detects regex literals that are defined inside functions. This can result in performance problems if a function like this is called often:

```js
function foo(someString) {
	return /[a-Z]*/.test(someString)
}
```

Instead, biome will now encourage users to place regex literals at the top level of a module.

```js
const REGEX = /[a-Z]*/;

function foo(someString) {
	return REGEX.test(someString)
}
```

It's a little unclear to me if it would be preferable to implement this using a Visitor instead.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
closes #2148

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added snapshot tests
```bash
cargo test -p biome_js_analyze use_top_level_regex
```
