### PR TITLE
fix(lint/useJsxKeyInIterable): flag jsx in variable declarations

### DIFF
--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx
@@ -51,3 +51,15 @@ React.Children.map(c => React.cloneElement(c));
 [].map((item) => {
 	return <>{item.condition ? <div /> : <div>foo</div>}</>;
 });
+
+[].map((item) => {
+	const x = 5;
+	const div = <div>{x}</div>;
+	return div;
+});
+
+[].map(function(item) {
+	const x = 5;
+	const div = <div>{x}</div>;
+	return div;
+});

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx.snap
@@ -58,6 +58,18 @@ React.Children.map(c => React.cloneElement(c));
 	return <>{item.condition ? <div /> : <div>foo</div>}</>;
 });
 
+[].map((item) => {
+	const x = 5;
+	const div = <div>{x}</div>;
+	return div;
+});
+
+[].map(function(item) {
+	const x = 5;
+	const div = <div>{x}</div>;
+	return div;
+});
+
 ```
 
 # Diagnostics
@@ -749,6 +761,44 @@ invalid.jsx:52:39 lint/correctness/useJsxKeyInIterable ━━━━━━━━�
        │ 	                                     ^^^^^
     53 │ });
     54 │ 
+  
+  i The order of the items may change, and having a key can help React identify which item was moved.
+  
+  i Check the React documentation. 
+  
+
+```
+
+```
+invalid.jsx:57:14 lint/correctness/useJsxKeyInIterable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing key property for this element in iterable.
+  
+    55 │ [].map((item) => {
+    56 │ 	const x = 5;
+  > 57 │ 	const div = <div>{x}</div>;
+       │ 	            ^^^^^
+    58 │ 	return div;
+    59 │ });
+  
+  i The order of the items may change, and having a key can help React identify which item was moved.
+  
+  i Check the React documentation. 
+  
+
+```
+
+```
+invalid.jsx:63:14 lint/correctness/useJsxKeyInIterable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing key property for this element in iterable.
+  
+    61 │ [].map(function(item) {
+    62 │ 	const x = 5;
+  > 63 │ 	const div = <div>{x}</div>;
+       │ 	            ^^^^^
+    64 │ 	return div;
+    65 │ });
   
   i The order of the items may change, and having a key can help React identify which item was moved.
   

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx
@@ -69,10 +69,25 @@ React.Children.map(c => React.cloneElement(c, {key: c}));
 });
 
 [].map((item) => {
+	return item.condition ? <div key={item.id} /> : <div key={item.id}>foo</div>;
+});
+
+[].map((item) => {
 	return <>{item.condition ? <div key={item.id} /> : <div key={item.id}>foo</div>}</>;
 });
 
 [].map((item) => {
 	const div = <div key={item.id} />;
 	return <>{item.condition ? div : <div key={item.id}>{div}</div>}</>;
+});
+
+[].map(function(item) {
+	const x = 5;
+	return <div key={item.id}>{x}</div>;
+});
+
+[].map(function(item) {
+	const x = 5;
+	const div = <div key={item.id}>{x}</div>;
+	return div;
 });

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx.snap
@@ -75,12 +75,27 @@ React.Children.map(c => React.cloneElement(c, {key: c}));
 });
 
 [].map((item) => {
+	return item.condition ? <div key={item.id} /> : <div key={item.id}>foo</div>;
+});
+
+[].map((item) => {
 	return <>{item.condition ? <div key={item.id} /> : <div key={item.id}>foo</div>}</>;
 });
 
 [].map((item) => {
 	const div = <div key={item.id} />;
 	return <>{item.condition ? div : <div key={item.id}>{div}</div>}</>;
+});
+
+[].map(function(item) {
+	const x = 5;
+	return <div key={item.id}>{x}</div>;
+});
+
+[].map(function(item) {
+	const x = 5;
+	const div = <div key={item.id}>{x}</div>;
+	return div;
 });
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
The rule will now catch snippets like below:
```jsx
// invalid
[].map((item) => {
	const div = <div>{item}</div>;
	return div;
});
```

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fully resolves #2590

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added more snapshot tests
```bash
cargo test -p biome_js_analyze use_jsx_key_in_iterable
```

