### PR TITLE
feat(biome_analyze): make jsx_runtime optional inside the analyzer

### DIFF
--- a/crates/biome_analyze/src/context.rs
+++ b/crates/biome_analyze/src/context.rs
@@ -19,7 +19,7 @@ where
     file_path: &'a Path,
     options: &'a R::Options,
     preferred_quote: &'a PreferredQuote,
-    jsx_runtime: JsxRuntime,
+    jsx_runtime: Option<JsxRuntime>,
 }
 
 impl<'a, R> RuleContext<'a, R>
@@ -35,7 +35,7 @@ where
         file_path: &'a Path,
         options: &'a R::Options,
         preferred_quote: &'a PreferredQuote,
-        jsx_runtime: JsxRuntime,
+        jsx_runtime: Option<JsxRuntime>,
     ) -> Result<Self, Error> {
         let rule_key = RuleKey::rule::<R>();
         Ok(Self {
@@ -103,7 +103,7 @@ where
 
     /// Returns the JSX runtime in use.
     pub fn jsx_runtime(&self) -> JsxRuntime {
-        self.jsx_runtime
+        self.jsx_runtime.expect("jsx_runtime should be provided")
     }
 
     /// Checks whether the provided text belongs to globals

--- a/crates/biome_analyze/src/options.rs
+++ b/crates/biome_analyze/src/options.rs
@@ -58,7 +58,7 @@ pub struct AnalyzerConfiguration {
     pub preferred_quote: PreferredQuote,
 
     /// Indicates the type of runtime or transformation used for interpreting JSX.
-    pub jsx_runtime: JsxRuntime,
+    pub jsx_runtime: Option<JsxRuntime>,
 }
 
 /// A set of information useful to the analyzer infrastructure
@@ -80,7 +80,7 @@ impl AnalyzerOptions {
             .collect()
     }
 
-    pub fn jsx_runtime(&self) -> JsxRuntime {
+    pub fn jsx_runtime(&self) -> Option<JsxRuntime> {
         self.configuration.jsx_runtime
     }
 

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -852,7 +852,7 @@ fn compute_analyzer_options(
             .into_iter()
             .collect(),
         preferred_quote,
-        jsx_runtime,
+        jsx_runtime: Some(jsx_runtime),
     };
 
     AnalyzerOptions {

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -42,7 +42,7 @@ pub fn create_analyzer_options(
         rules: AnalyzerRules::default(),
         globals: vec![],
         preferred_quote: PreferredQuote::Double,
-        jsx_runtime: JsxRuntime::Transparent,
+        jsx_runtime: Some(JsxRuntime::Transparent),
     };
     let options_file = input_file.with_extension("options.json");
     if let Ok(json) = std::fs::read_to_string(options_file.clone()) {
@@ -90,8 +90,8 @@ pub fn create_analyzer_options(
                 .and_then(|js| js.jsx_runtime)
                 .unwrap_or_default()
             {
-                ReactClassic => JsxRuntime::ReactClassic,
-                Transparent => JsxRuntime::Transparent,
+                ReactClassic => Some(JsxRuntime::ReactClassic),
+                Transparent => Some(JsxRuntime::Transparent),
             };
 
             settings


### PR DESCRIPTION
Close https://github.com/biomejs/biome/issues/2800

## Summary
- Make jsx_runtime optional inside the analyzer
  - It is because `AnalyzerOptions` is a type that is used across languages, and JSON/CSS languages don't need/require this option.

## Test Plan
Pass existing tests. 