### PR TITLE
fix(biome_graphql_parser): allow keyword to be used as identifier

### DIFF
--- a/crates/biome_graphql_parser/src/parser/argument.rs
+++ b/crates/biome_graphql_parser/src/parser/argument.rs
@@ -9,7 +9,6 @@ use biome_parser::{
 };
 
 use super::{
-    definitions::is_at_selection_set_end,
     directive::is_at_directive,
     is_nth_at_name,
     parse_error::{expected_argument, expected_value},
@@ -90,8 +89,13 @@ fn parse_argument(p: &mut GraphqlParser) -> ParsedSyntax {
 #[inline]
 pub(crate) fn is_at_argument_list_end(p: &mut GraphqlParser<'_>) -> bool {
     p.at(T![')'])
-    // also handle the start of a selection set
-    || is_at_selection_set_end(p)
+    // at the start af a new arguments list
+    || p.at(T!['('])
+    // at a selection set or body of a definition
+    || p.at(T!['{'])
+    || p.at(T!['}'])
     // at the start of a new directive
     || is_at_directive(p)
+    // if we can't find any of the above, we can't be sure if we're outside of
+    // an argument list
 }

--- a/crates/biome_graphql_parser/src/parser/definitions/fragment.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/fragment.rs
@@ -1,6 +1,6 @@
 use crate::parser::{
     directive::DirectiveList,
-    parse_error::{expected_name, expected_named_type},
+    parse_error::{expected_name, expected_named_type, fragment_name_must_not_be_on},
     parse_name,
     r#type::parse_named_type,
     GraphqlParser,
@@ -22,6 +22,9 @@ pub(crate) fn parse_fragment_definition(p: &mut GraphqlParser) -> ParsedSyntax {
     let m = p.start();
     p.bump(T![fragment]);
 
+    if p.at(T![on]) {
+        p.error(fragment_name_must_not_be_on(p, p.cur_range()));
+    }
     parse_name(p).or_add_diagnostic(p, expected_name);
     parse_type_condition(p);
 

--- a/crates/biome_graphql_parser/src/parser/definitions/input_object.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/input_object.rs
@@ -11,10 +11,7 @@ use biome_parser::{
     prelude::ParsedSyntax::*, Parser,
 };
 
-use super::{
-    field::{is_at_input_value_definition, parse_input_value_definition},
-    is_at_definition,
-};
+use super::field::{is_at_input_value_definition, parse_input_value_definition};
 
 #[inline]
 pub(crate) fn parse_input_object_type_definition(p: &mut GraphqlParser) -> ParsedSyntax {
@@ -104,5 +101,7 @@ fn is_at_input_fields_definition(p: &mut GraphqlParser) -> bool {
 
 #[inline]
 fn is_input_fields_end(p: &mut GraphqlParser) -> bool {
-    p.at(T!['}']) || is_at_definition(p)
+    p.at(T!['}'])
+    // start of next definition body, since input fields can't be nested
+    || p.at(T!['{'])
 }

--- a/crates/biome_graphql_parser/src/parser/definitions/interface.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/interface.rs
@@ -11,14 +11,15 @@ use biome_graphql_syntax::{
     GraphqlSyntaxKind::{self, *},
     T,
 };
-use biome_parser::parse_lists::ParseNodeList;
-use biome_parser::prelude::TokenSource;
+use biome_parser::parse_lists::{ParseNodeList, ParseSeparatedList};
 use biome_parser::{
-    parse_lists::ParseSeparatedList, parse_recovery::ParseRecovery, parsed_syntax::ParsedSyntax,
-    prelude::ParsedSyntax::*, Parser,
+    parse_recovery::ParseRecovery, parsed_syntax::ParsedSyntax, prelude::ParsedSyntax::*, Parser,
 };
 
-use super::field::{is_at_fields, is_at_fields_end, parse_fields_definition};
+use super::{
+    field::{is_at_fields, is_at_fields_end, parse_fields_definition},
+    is_at_definition,
+};
 
 #[inline]
 pub(super) fn parse_interface_type_definition(p: &mut GraphqlParser) -> ParsedSyntax {
@@ -54,15 +55,7 @@ pub(super) fn parse_implements_interface(p: &mut GraphqlParser) -> ParsedSyntax 
 
     p.bump(T![implements]);
 
-    // & is optional
-    p.eat(T![&]);
-
-    let position = p.source().position();
     ImplementsInterfaceList.parse_list(p);
-
-    if position == p.source().position() {
-        p.error(expected_named_type(p, p.cur_range()));
-    }
 
     Present(m.complete(p, GRAPHQL_IMPLEMENTS_INTERFACES))
 }
@@ -103,6 +96,14 @@ impl ParseSeparatedList for ImplementsInterfaceList {
     fn allow_trailing_separating_element(&self) -> bool {
         false
     }
+
+    fn allow_empty(&self) -> bool {
+        false
+    }
+
+    fn allow_leading_seperating_element(&self) -> bool {
+        true
+    }
 }
 
 struct ImplementsInterfaceListParseRecovery;
@@ -129,5 +130,5 @@ fn is_at_implements_interface(p: &mut GraphqlParser<'_>) -> bool {
 
 #[inline]
 fn is_at_implements_interface_end(p: &mut GraphqlParser<'_>) -> bool {
-    is_at_directive(p) || is_at_fields(p) || is_at_fields_end(p)
+    is_at_directive(p) || is_at_fields(p) || is_at_fields_end(p) || is_at_definition(p)
 }

--- a/crates/biome_graphql_parser/src/parser/definitions/mod.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/mod.rs
@@ -29,7 +29,6 @@ use self::{
     schema::{is_at_schema_definition, parse_schema_definition},
     union::{is_at_union_type_definition, parse_union_type_definition},
 };
-pub(crate) use operation::is_at_selection_set_end;
 
 struct DefinitionListParseRecovery;
 

--- a/crates/biome_graphql_parser/src/parser/mod.rs
+++ b/crates/biome_graphql_parser/src/parser/mod.rs
@@ -17,6 +17,49 @@ use definitions::DefinitionList;
 
 use self::value::{is_at_string, parse_string};
 
+/// Graphql allow keywords to be used as names
+const GRAPHQL_POTENTIAL_NAME_SET: TokenSet<GraphqlSyntaxKind> = token_set![
+    GRAPHQL_NAME,
+    TRUE_KW,
+    FALSE_KW,
+    QUERY_KW,
+    MUTATION_KW,
+    SUBSCRIPTION_KW,
+    FRAGMENT_KW,
+    ON_KW,
+    NULL_KW,
+    SCHEMA_KW,
+    EXTEND_KW,
+    SCALAR_KW,
+    TYPE_KW,
+    IMPLEMENTS_KW,
+    INTERFACE_KW,
+    UNION_KW,
+    ENUM_KW,
+    INPUT_KW,
+    DIRECTIVE_KW,
+    REPEATABLE_KW,
+    UPPER_QUERY_KW,
+    UPPER_MUTATION_KW,
+    UPPER_SUBSCRIPTION_KW,
+    UPPER_FIELD_KW,
+    FRAGMENT_DEFINITION_KW,
+    FRAGMENT_SPREAD_KW,
+    INLINE_FRAGMENT_KW,
+    VARIABLE_DEFINITION_KW,
+    UPPER_SCHEMA_KW,
+    UPPER_SCALAR_KW,
+    UPPER_OBJECT_KW,
+    FIELD_DEFINITION_KW,
+    ARGUMENT_DEFINITION_KW,
+    UPPER_INTERFACE_KW,
+    UPPER_UNION_KW,
+    UPPER_ENUM_KW,
+    ENUM_VALUE_KW,
+    INPUT_OBJECT_KW,
+    INPUT_FIELD_DEFINITION_KW,
+];
+
 pub(crate) struct GraphqlParser<'source> {
     context: ParserContext<GraphqlSyntaxKind>,
     source: GraphqlTokenSource<'source>,
@@ -81,12 +124,12 @@ pub(crate) fn parse_root(p: &mut GraphqlParser) -> CompletedMarker {
 
 #[inline]
 fn parse_name(p: &mut GraphqlParser) -> ParsedSyntax {
-    if !p.at(GRAPHQL_NAME) {
+    if !is_nth_at_name(p, 0) {
         return Absent;
     }
 
     let m = p.start();
-    p.bump(GRAPHQL_NAME);
+    p.bump_remap(GRAPHQL_NAME);
     Present(m.complete(p, GRAPHQL_NAME))
 }
 
@@ -105,5 +148,10 @@ fn parse_description(p: &mut GraphqlParser) -> ParsedSyntax {
 
 #[inline]
 fn is_nth_at_name(p: &mut GraphqlParser, n: usize) -> bool {
+    p.nth_at_ts(n, GRAPHQL_POTENTIAL_NAME_SET)
+}
+
+#[inline]
+fn is_nth_at_non_kw_name(p: &mut GraphqlParser, n: usize) -> bool {
     p.nth_at(n, GRAPHQL_NAME)
 }

--- a/crates/biome_graphql_parser/src/parser/parse_error.rs
+++ b/crates/biome_graphql_parser/src/parser/parse_error.rs
@@ -95,3 +95,7 @@ pub(crate) fn expected_directive_location(p: &GraphqlParser, range: TextRange) -
             ],
         )
 }
+
+pub(crate) fn fragment_name_must_not_be_on(p: &GraphqlParser, range: TextRange) -> ParseDiagnostic {
+    p.err_builder("Fragment name must not be 'on'", range)
+}

--- a/crates/biome_graphql_parser/src/parser/value.rs
+++ b/crates/biome_graphql_parser/src/parser/value.rs
@@ -270,9 +270,10 @@ fn is_at_null(p: &GraphqlParser) -> bool {
     p.at(T![null])
 }
 
+/// https://spec.graphql.org/October2021/#EnumValue
 #[inline]
 fn is_at_enum(p: &mut GraphqlParser) -> bool {
-    is_nth_at_name(p, 0)
+    is_nth_at_name(p, 0) && !p.at(TRUE_KW) && !p.at(FALSE_KW) && !p.at(T![null])
 }
 
 #[inline]

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/directive_definition.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/directive_definition.graphql.snap
@@ -50,10 +50,12 @@ GraphqlRoot {
             description: missing (optional),
             directive_token: DIRECTIVE_KW@23..35 "directive" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             at_token: AT@35..37 "@" [] [Whitespace(" ")],
-            name: missing (required),
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@37..40 "on" [] [Whitespace(" ")],
+            },
             arguments: missing (optional),
             repeatable_token: missing (optional),
-            on_token: ON_KW@37..40 "on" [] [Whitespace(" ")],
+            on_token: missing (required),
             bitwise_or_token: PIPE@40..42 "|" [] [Whitespace(" ")],
             locations: GraphqlDirectiveLocationList [
                 GraphqlDirectiveLocation {
@@ -214,10 +216,11 @@ GraphqlRoot {
       0: (empty)
       1: DIRECTIVE_KW@23..35 "directive" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: AT@35..37 "@" [] [Whitespace(" ")]
-      3: (empty)
+      3: GRAPHQL_NAME@37..40
+        0: GRAPHQL_NAME@37..40 "on" [] [Whitespace(" ")]
       4: (empty)
       5: (empty)
-      6: ON_KW@37..40 "on" [] [Whitespace(" ")]
+      6: (empty)
       7: PIPE@40..42 "|" [] [Whitespace(" ")]
       8: GRAPHQL_DIRECTIVE_LOCATION_LIST@42..61
         0: GRAPHQL_DIRECTIVE_LOCATION@42..61
@@ -350,25 +353,18 @@ directive_definition.graphql:3:1 parse ━━━━━━━━━━━━━�
   - INPUT_OBJECT
   - INPUT_FIELD_DEFINITION
   
-directive_definition.graphql:3:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+directive_definition.graphql:3:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a name but instead found 'on'.
+  × expected `on` but instead found `|`
   
     1 │ directive @example on |
     2 │ 
   > 3 │ directive @ on | ARGUMENT_DEFINITION
-      │             ^^
+      │                ^
     4 │ 
     5 │ directive example on | ARGUMENT_DEFINITION
   
-  i Expected a name here.
-  
-    1 │ directive @example on |
-    2 │ 
-  > 3 │ directive @ on | ARGUMENT_DEFINITION
-      │             ^^
-    4 │ 
-    5 │ directive example on | ARGUMENT_DEFINITION
+  i Remove |
   
 directive_definition.graphql:5:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/enum.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/enum.graphql
@@ -5,10 +5,10 @@ enum Direction
   WEST
 }
 
-enum Direction
-  NORTH
-
+# the following 2 invalid enum definitions form a valid enum definition
 enum Direction {
+
+enum Direction }
 
 enum Direction {
 	@deprecated
@@ -19,3 +19,7 @@ enu Direction
 enum Direction @
   NORTH
 }
+
+enum Direction
+  NORTH
+

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/enum.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/enum.graphql.snap
@@ -11,10 +11,10 @@ enum Direction
   WEST
 }
 
-enum Direction
-  NORTH
-
+# the following 2 invalid enum definitions form a valid enum definition
 enum Direction {
+
+enum Direction }
 
 enum Direction {
 	@deprecated
@@ -25,6 +25,10 @@ enu Direction
 enum Direction @
   NORTH
 }
+
+enum Direction
+  NORTH
+
 
 ```
 
@@ -86,9 +90,96 @@ GraphqlRoot {
         },
         GraphqlEnumTypeDefinition {
             description: missing (optional),
-            enum_token: ENUM_KW@46..53 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            enum_token: ENUM_KW@46..125 "enum" [Newline("\n"), Newline("\n"), Comments("# the following 2 inv ..."), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@53..62 "Direction" [] [],
+                value_token: GRAPHQL_NAME@125..135 "Direction" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [],
+            enum_values: GraphqlEnumValuesDefinition {
+                l_curly_token: L_CURLY@135..136 "{" [] [],
+                values: GraphqlEnumValueList [
+                    GraphqlEnumValueDefinition {
+                        description: missing (optional),
+                        value: GraphqlEnumValue {
+                            graphql_name: GraphqlName {
+                                value_token: GRAPHQL_NAME@136..143 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                            },
+                        },
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlEnumValueDefinition {
+                        description: missing (optional),
+                        value: GraphqlEnumValue {
+                            graphql_name: GraphqlName {
+                                value_token: GRAPHQL_NAME@143..153 "Direction" [] [Whitespace(" ")],
+                            },
+                        },
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_curly_token: R_CURLY@153..154 "}" [] [],
+            },
+        },
+        GraphqlEnumTypeDefinition {
+            description: missing (optional),
+            enum_token: ENUM_KW@154..161 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@161..171 "Direction" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [],
+            enum_values: GraphqlEnumValuesDefinition {
+                l_curly_token: L_CURLY@171..172 "{" [] [],
+                values: GraphqlEnumValueList [
+                    GraphqlEnumValueDefinition {
+                        description: missing (optional),
+                        value: missing (required),
+                        directives: GraphqlDirectiveList [
+                            GraphqlDirective {
+                                at_token: AT@172..175 "@" [Newline("\n"), Whitespace("\t")] [],
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@175..185 "deprecated" [] [],
+                                },
+                                arguments: missing (optional),
+                            },
+                        ],
+                    },
+                ],
+                r_curly_token: R_CURLY@185..187 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlBogusDefinition {
+            items: [
+                GRAPHQL_NAME@187..193 "enu" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                GRAPHQL_NAME@193..202 "Direction" [] [],
+            ],
+        },
+        GraphqlEnumTypeDefinition {
+            description: missing (optional),
+            enum_token: ENUM_KW@202..209 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@209..219 "Direction" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [
+                GraphqlDirective {
+                    at_token: AT@219..220 "@" [] [],
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@220..228 "NORTH" [Newline("\n"), Whitespace("  ")] [],
+                    },
+                    arguments: missing (optional),
+                },
+            ],
+            enum_values: missing (optional),
+        },
+        GraphqlBogusDefinition {
+            items: [
+                R_CURLY@228..230 "}" [Newline("\n")] [],
+            ],
+        },
+        GraphqlEnumTypeDefinition {
+            description: missing (optional),
+            enum_token: ENUM_KW@230..237 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@237..246 "Direction" [] [],
             },
             directives: GraphqlDirectiveList [],
             enum_values: GraphqlEnumValuesDefinition {
@@ -98,7 +189,7 @@ GraphqlRoot {
                         description: missing (optional),
                         value: GraphqlEnumValue {
                             graphql_name: GraphqlName {
-                                value_token: GRAPHQL_NAME@62..70 "NORTH" [Newline("\n"), Whitespace("  ")] [],
+                                value_token: GRAPHQL_NAME@246..254 "NORTH" [Newline("\n"), Whitespace("  ")] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
@@ -107,85 +198,17 @@ GraphqlRoot {
                 r_curly_token: missing (required),
             },
         },
-        GraphqlEnumTypeDefinition {
-            description: missing (optional),
-            enum_token: ENUM_KW@70..77 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@77..87 "Direction" [] [Whitespace(" ")],
-            },
-            directives: GraphqlDirectiveList [],
-            enum_values: GraphqlEnumValuesDefinition {
-                l_curly_token: L_CURLY@87..88 "{" [] [],
-                values: GraphqlEnumValueList [],
-                r_curly_token: missing (required),
-            },
-        },
-        GraphqlEnumTypeDefinition {
-            description: missing (optional),
-            enum_token: ENUM_KW@88..95 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@95..105 "Direction" [] [Whitespace(" ")],
-            },
-            directives: GraphqlDirectiveList [],
-            enum_values: GraphqlEnumValuesDefinition {
-                l_curly_token: L_CURLY@105..106 "{" [] [],
-                values: GraphqlEnumValueList [
-                    GraphqlEnumValueDefinition {
-                        description: missing (optional),
-                        value: missing (required),
-                        directives: GraphqlDirectiveList [
-                            GraphqlDirective {
-                                at_token: AT@106..109 "@" [Newline("\n"), Whitespace("\t")] [],
-                                name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@109..119 "deprecated" [] [],
-                                },
-                                arguments: missing (optional),
-                            },
-                        ],
-                    },
-                ],
-                r_curly_token: R_CURLY@119..121 "}" [Newline("\n")] [],
-            },
-        },
-        GraphqlBogusDefinition {
-            items: [
-                GRAPHQL_NAME@121..127 "enu" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-                GRAPHQL_NAME@127..136 "Direction" [] [],
-            ],
-        },
-        GraphqlEnumTypeDefinition {
-            description: missing (optional),
-            enum_token: ENUM_KW@136..143 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@143..153 "Direction" [] [Whitespace(" ")],
-            },
-            directives: GraphqlDirectiveList [
-                GraphqlDirective {
-                    at_token: AT@153..154 "@" [] [],
-                    name: GraphqlName {
-                        value_token: GRAPHQL_NAME@154..162 "NORTH" [Newline("\n"), Whitespace("  ")] [],
-                    },
-                    arguments: missing (optional),
-                },
-            ],
-            enum_values: missing (optional),
-        },
-        GraphqlBogusDefinition {
-            items: [
-                R_CURLY@162..164 "}" [Newline("\n")] [],
-            ],
-        },
     ],
-    eof_token: EOF@164..165 "" [Newline("\n")] [],
+    eof_token: EOF@254..256 "" [Newline("\n"), Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..165
+0: GRAPHQL_ROOT@0..256
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..164
+  1: GRAPHQL_DEFINITION_LIST@0..254
     0: GRAPHQL_ENUM_TYPE_DEFINITION@0..46
       0: (empty)
       1: ENUM_KW@0..5 "enum" [] [Whitespace(" ")]
@@ -220,69 +243,81 @@ GraphqlRoot {
                 0: GRAPHQL_NAME@37..44 "WEST" [Newline("\n"), Whitespace("  ")] []
             2: GRAPHQL_DIRECTIVE_LIST@44..44
         2: R_CURLY@44..46 "}" [Newline("\n")] []
-    1: GRAPHQL_ENUM_TYPE_DEFINITION@46..70
+    1: GRAPHQL_ENUM_TYPE_DEFINITION@46..154
       0: (empty)
-      1: ENUM_KW@46..53 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@53..62
-        0: GRAPHQL_NAME@53..62 "Direction" [] []
-      3: GRAPHQL_DIRECTIVE_LIST@62..62
-      4: GRAPHQL_ENUM_VALUES_DEFINITION@62..70
-        0: (empty)
-        1: GRAPHQL_ENUM_VALUE_LIST@62..70
-          0: GRAPHQL_ENUM_VALUE_DEFINITION@62..70
+      1: ENUM_KW@46..125 "enum" [Newline("\n"), Newline("\n"), Comments("# the following 2 inv ..."), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@125..135
+        0: GRAPHQL_NAME@125..135 "Direction" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@135..135
+      4: GRAPHQL_ENUM_VALUES_DEFINITION@135..154
+        0: L_CURLY@135..136 "{" [] []
+        1: GRAPHQL_ENUM_VALUE_LIST@136..153
+          0: GRAPHQL_ENUM_VALUE_DEFINITION@136..143
             0: (empty)
-            1: GRAPHQL_ENUM_VALUE@62..70
-              0: GRAPHQL_NAME@62..70
-                0: GRAPHQL_NAME@62..70 "NORTH" [Newline("\n"), Whitespace("  ")] []
-            2: GRAPHQL_DIRECTIVE_LIST@70..70
-        2: (empty)
-    2: GRAPHQL_ENUM_TYPE_DEFINITION@70..88
+            1: GRAPHQL_ENUM_VALUE@136..143
+              0: GRAPHQL_NAME@136..143
+                0: GRAPHQL_NAME@136..143 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+            2: GRAPHQL_DIRECTIVE_LIST@143..143
+          1: GRAPHQL_ENUM_VALUE_DEFINITION@143..153
+            0: (empty)
+            1: GRAPHQL_ENUM_VALUE@143..153
+              0: GRAPHQL_NAME@143..153
+                0: GRAPHQL_NAME@143..153 "Direction" [] [Whitespace(" ")]
+            2: GRAPHQL_DIRECTIVE_LIST@153..153
+        2: R_CURLY@153..154 "}" [] []
+    2: GRAPHQL_ENUM_TYPE_DEFINITION@154..187
       0: (empty)
-      1: ENUM_KW@70..77 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@77..87
-        0: GRAPHQL_NAME@77..87 "Direction" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@87..87
-      4: GRAPHQL_ENUM_VALUES_DEFINITION@87..88
-        0: L_CURLY@87..88 "{" [] []
-        1: GRAPHQL_ENUM_VALUE_LIST@88..88
-        2: (empty)
-    3: GRAPHQL_ENUM_TYPE_DEFINITION@88..121
-      0: (empty)
-      1: ENUM_KW@88..95 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@95..105
-        0: GRAPHQL_NAME@95..105 "Direction" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@105..105
-      4: GRAPHQL_ENUM_VALUES_DEFINITION@105..121
-        0: L_CURLY@105..106 "{" [] []
-        1: GRAPHQL_ENUM_VALUE_LIST@106..119
-          0: GRAPHQL_ENUM_VALUE_DEFINITION@106..119
+      1: ENUM_KW@154..161 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@161..171
+        0: GRAPHQL_NAME@161..171 "Direction" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@171..171
+      4: GRAPHQL_ENUM_VALUES_DEFINITION@171..187
+        0: L_CURLY@171..172 "{" [] []
+        1: GRAPHQL_ENUM_VALUE_LIST@172..185
+          0: GRAPHQL_ENUM_VALUE_DEFINITION@172..185
             0: (empty)
             1: (empty)
-            2: GRAPHQL_DIRECTIVE_LIST@106..119
-              0: GRAPHQL_DIRECTIVE@106..119
-                0: AT@106..109 "@" [Newline("\n"), Whitespace("\t")] []
-                1: GRAPHQL_NAME@109..119
-                  0: GRAPHQL_NAME@109..119 "deprecated" [] []
+            2: GRAPHQL_DIRECTIVE_LIST@172..185
+              0: GRAPHQL_DIRECTIVE@172..185
+                0: AT@172..175 "@" [Newline("\n"), Whitespace("\t")] []
+                1: GRAPHQL_NAME@175..185
+                  0: GRAPHQL_NAME@175..185 "deprecated" [] []
                 2: (empty)
-        2: R_CURLY@119..121 "}" [Newline("\n")] []
-    4: GRAPHQL_BOGUS_DEFINITION@121..136
-      0: GRAPHQL_NAME@121..127 "enu" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      1: GRAPHQL_NAME@127..136 "Direction" [] []
-    5: GRAPHQL_ENUM_TYPE_DEFINITION@136..162
+        2: R_CURLY@185..187 "}" [Newline("\n")] []
+    3: GRAPHQL_BOGUS_DEFINITION@187..202
+      0: GRAPHQL_NAME@187..193 "enu" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@193..202 "Direction" [] []
+    4: GRAPHQL_ENUM_TYPE_DEFINITION@202..228
       0: (empty)
-      1: ENUM_KW@136..143 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@143..153
-        0: GRAPHQL_NAME@143..153 "Direction" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@153..162
-        0: GRAPHQL_DIRECTIVE@153..162
-          0: AT@153..154 "@" [] []
-          1: GRAPHQL_NAME@154..162
-            0: GRAPHQL_NAME@154..162 "NORTH" [Newline("\n"), Whitespace("  ")] []
+      1: ENUM_KW@202..209 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@209..219
+        0: GRAPHQL_NAME@209..219 "Direction" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@219..228
+        0: GRAPHQL_DIRECTIVE@219..228
+          0: AT@219..220 "@" [] []
+          1: GRAPHQL_NAME@220..228
+            0: GRAPHQL_NAME@220..228 "NORTH" [Newline("\n"), Whitespace("  ")] []
           2: (empty)
       4: (empty)
-    6: GRAPHQL_BOGUS_DEFINITION@162..164
-      0: R_CURLY@162..164 "}" [Newline("\n")] []
-  2: EOF@164..165 "" [Newline("\n")] []
+    5: GRAPHQL_BOGUS_DEFINITION@228..230
+      0: R_CURLY@228..230 "}" [Newline("\n")] []
+    6: GRAPHQL_ENUM_TYPE_DEFINITION@230..254
+      0: (empty)
+      1: ENUM_KW@230..237 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@237..246
+        0: GRAPHQL_NAME@237..246 "Direction" [] []
+      3: GRAPHQL_DIRECTIVE_LIST@246..246
+      4: GRAPHQL_ENUM_VALUES_DEFINITION@246..254
+        0: (empty)
+        1: GRAPHQL_ENUM_VALUE_LIST@246..254
+          0: GRAPHQL_ENUM_VALUE_DEFINITION@246..254
+            0: (empty)
+            1: GRAPHQL_ENUM_VALUE@246..254
+              0: GRAPHQL_NAME@246..254
+                0: GRAPHQL_NAME@246..254 "NORTH" [Newline("\n"), Whitespace("  ")] []
+            2: GRAPHQL_DIRECTIVE_LIST@254..254
+        2: (empty)
+  2: EOF@254..256 "" [Newline("\n"), Newline("\n")] []
 
 ```
 
@@ -300,44 +335,6 @@ enum.graphql:2:3 parse ━━━━━━━━━━━━━━━━━━━
     4 │   SOUTH
   
   i Remove NORTH
-  
-enum.graphql:9:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `{` but instead found `NORTH`
-  
-     8 │ enum Direction
-   > 9 │   NORTH
-       │   ^^^^^
-    10 │ 
-    11 │ enum Direction {
-  
-  i Remove NORTH
-  
-enum.graphql:11:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `}` but instead found `enum`
-  
-     9 │   NORTH
-    10 │ 
-  > 11 │ enum Direction {
-       │ ^^^^
-    12 │ 
-    13 │ enum Direction {
-  
-  i Remove enum
-  
-enum.graphql:13:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `}` but instead found `enum`
-  
-    11 │ enum Direction {
-    12 │ 
-  > 13 │ enum Direction {
-       │ ^^^^
-    14 │ 	@deprecated
-    15 │ }
-  
-  i Remove enum
   
 enum.graphql:14:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -386,6 +383,7 @@ enum.graphql:21:1 parse ━━━━━━━━━━━━━━━━━━�
   > 21 │ }
        │ ^
     22 │ 
+    23 │ enum Direction
   
   i Expected a definition here.
   
@@ -394,5 +392,33 @@ enum.graphql:21:1 parse ━━━━━━━━━━━━━━━━━━�
   > 21 │ }
        │ ^
     22 │ 
+    23 │ enum Direction
+  
+enum.graphql:24:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `{` but instead found `NORTH`
+  
+    23 │ enum Direction
+  > 24 │   NORTH
+       │   ^^^^^
+    25 │ 
+  
+  i Remove NORTH
+  
+enum.graphql:26:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `}` but instead the file ends
+  
+    24 │   NORTH
+    25 │ 
+  > 26 │ 
+       │ 
+  
+  i the file ends here
+  
+    24 │   NORTH
+    25 │ 
+  > 26 │ 
+       │ 
   
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/fragment.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/fragment.graphql
@@ -1,3 +1,8 @@
+fragment on on User {
+  id
+  name
+}
+
 fragmen friendFields on User {
   id
   name

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/fragment.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/fragment.graphql.snap
@@ -4,6 +4,11 @@ expression: snapshot
 ---
 ## Input
 ```graphql
+fragment on on User {
+  id
+  name
+}
+
 fragmen friendFields on User {
   id
   name
@@ -27,67 +32,27 @@ fragment friendFields o User @deprecated {
 GraphqlRoot {
     bom_token: missing (optional),
     definitions: GraphqlDefinitionList [
-        GraphqlBogusDefinition {
-            items: [
-                GRAPHQL_NAME@0..8 "fragmen" [] [Whitespace(" ")],
-                GRAPHQL_NAME@8..21 "friendFields" [] [Whitespace(" ")],
-                ON_KW@21..24 "on" [] [Whitespace(" ")],
-                GRAPHQL_NAME@24..29 "User" [] [Whitespace(" ")],
-            ],
-        },
-        GraphqlSelectionSet {
-            l_curly_token: L_CURLY@29..30 "{" [] [],
-            selections: GraphqlSelectionList [
-                GraphqlField {
-                    alias: missing (optional),
-                    name: GraphqlName {
-                        value_token: GRAPHQL_NAME@30..35 "id" [Newline("\n"), Whitespace("  ")] [],
-                    },
-                    arguments: missing (optional),
-                    directives: GraphqlDirectiveList [],
-                    selection_set: missing (optional),
-                },
-                GraphqlField {
-                    alias: missing (optional),
-                    name: GraphqlName {
-                        value_token: GRAPHQL_NAME@35..42 "name" [Newline("\n"), Whitespace("  ")] [],
-                    },
-                    arguments: missing (optional),
-                    directives: GraphqlDirectiveList [],
-                    selection_set: missing (optional),
-                },
-            ],
-            r_curly_token: R_CURLY@42..44 "}" [Newline("\n")] [],
-        },
         GraphqlFragmentDefinition {
-            fragment_token: FRAGMENT_KW@44..55 "fragment" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            fragment_token: FRAGMENT_KW@0..9 "fragment" [] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@55..68 "friendFields" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@9..12 "on" [] [Whitespace(" ")],
             },
             type_condition: GraphqlTypeCondition {
-                on_token: missing (required),
+                on_token: ON_KW@12..15 "on" [] [Whitespace(" ")],
                 ty: GraphqlNamedType {
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@68..73 "User" [] [Whitespace(" ")],
+                        value_token: GRAPHQL_NAME@15..20 "User" [] [Whitespace(" ")],
                     },
                 },
             },
-            directives: GraphqlDirectiveList [
-                GraphqlDirective {
-                    at_token: AT@73..74 "@" [] [],
-                    name: GraphqlName {
-                        value_token: GRAPHQL_NAME@74..85 "deprecated" [] [Whitespace(" ")],
-                    },
-                    arguments: missing (optional),
-                },
-            ],
+            directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@85..86 "{" [] [],
+                l_curly_token: L_CURLY@20..21 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@86..91 "id" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@21..26 "id" [Newline("\n"), Whitespace("  ")] [],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
@@ -96,26 +61,105 @@ GraphqlRoot {
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@91..98 "name" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@26..33 "name" [Newline("\n"), Whitespace("  ")] [],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@98..100 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@33..35 "}" [Newline("\n")] [],
             },
         },
+        GraphqlBogusDefinition {
+            items: [
+                GRAPHQL_NAME@35..45 "fragmen" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                GRAPHQL_NAME@45..58 "friendFields" [] [Whitespace(" ")],
+                ON_KW@58..61 "on" [] [Whitespace(" ")],
+                GRAPHQL_NAME@61..66 "User" [] [Whitespace(" ")],
+            ],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@66..67 "{" [] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@67..72 "id" [Newline("\n"), Whitespace("  ")] [],
+                    },
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [],
+                    selection_set: missing (optional),
+                },
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@72..79 "name" [Newline("\n"), Whitespace("  ")] [],
+                    },
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@79..81 "}" [Newline("\n")] [],
+        },
         GraphqlFragmentDefinition {
-            fragment_token: FRAGMENT_KW@100..111 "fragment" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            fragment_token: FRAGMENT_KW@81..92 "fragment" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@111..124 "friendFields" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@92..105 "friendFields" [] [Whitespace(" ")],
             },
             type_condition: GraphqlTypeCondition {
                 on_token: missing (required),
                 ty: GraphqlNamedType {
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@124..126 "o" [] [Whitespace(" ")],
+                        value_token: GRAPHQL_NAME@105..110 "User" [] [Whitespace(" ")],
+                    },
+                },
+            },
+            directives: GraphqlDirectiveList [
+                GraphqlDirective {
+                    at_token: AT@110..111 "@" [] [],
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@111..122 "deprecated" [] [Whitespace(" ")],
+                    },
+                    arguments: missing (optional),
+                },
+            ],
+            selection_set: GraphqlSelectionSet {
+                l_curly_token: L_CURLY@122..123 "{" [] [],
+                selections: GraphqlSelectionList [
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@123..128 "id" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        arguments: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@128..135 "name" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        arguments: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@135..137 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlFragmentDefinition {
+            fragment_token: FRAGMENT_KW@137..148 "fragment" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@148..161 "friendFields" [] [Whitespace(" ")],
+            },
+            type_condition: GraphqlTypeCondition {
+                on_token: missing (required),
+                ty: GraphqlNamedType {
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@161..163 "o" [] [Whitespace(" ")],
                     },
                 },
             },
@@ -126,25 +170,25 @@ GraphqlRoot {
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@126..131 "User" [] [Whitespace(" ")],
+                            value_token: GRAPHQL_NAME@163..168 "User" [] [Whitespace(" ")],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [
                             GraphqlDirective {
-                                at_token: AT@131..132 "@" [] [],
+                                at_token: AT@168..169 "@" [] [],
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@132..143 "deprecated" [] [Whitespace(" ")],
+                                    value_token: GRAPHQL_NAME@169..180 "deprecated" [] [Whitespace(" ")],
                                 },
                                 arguments: missing (optional),
                             },
                         ],
                         selection_set: GraphqlSelectionSet {
-                            l_curly_token: L_CURLY@143..144 "{" [] [],
+                            l_curly_token: L_CURLY@180..181 "{" [] [],
                             selections: GraphqlSelectionList [
                                 GraphqlField {
                                     alias: missing (optional),
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@144..149 "id" [Newline("\n"), Whitespace("  ")] [],
+                                        value_token: GRAPHQL_NAME@181..186 "id" [Newline("\n"), Whitespace("  ")] [],
                                     },
                                     arguments: missing (optional),
                                     directives: GraphqlDirectiveList [],
@@ -153,14 +197,14 @@ GraphqlRoot {
                                 GraphqlField {
                                     alias: missing (optional),
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@149..156 "name" [Newline("\n"), Whitespace("  ")] [],
+                                        value_token: GRAPHQL_NAME@186..193 "name" [Newline("\n"), Whitespace("  ")] [],
                                     },
                                     arguments: missing (optional),
                                     directives: GraphqlDirectiveList [],
                                     selection_set: missing (optional),
                                 },
                             ],
-                            r_curly_token: R_CURLY@156..158 "}" [Newline("\n")] [],
+                            r_curly_token: R_CURLY@193..195 "}" [Newline("\n")] [],
                         },
                     },
                 ],
@@ -168,191 +212,232 @@ GraphqlRoot {
             },
         },
     ],
-    eof_token: EOF@158..159 "" [Newline("\n")] [],
+    eof_token: EOF@195..196 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..159
+0: GRAPHQL_ROOT@0..196
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..158
-    0: GRAPHQL_BOGUS_DEFINITION@0..29
-      0: GRAPHQL_NAME@0..8 "fragmen" [] [Whitespace(" ")]
-      1: GRAPHQL_NAME@8..21 "friendFields" [] [Whitespace(" ")]
-      2: ON_KW@21..24 "on" [] [Whitespace(" ")]
-      3: GRAPHQL_NAME@24..29 "User" [] [Whitespace(" ")]
-    1: GRAPHQL_SELECTION_SET@29..44
-      0: L_CURLY@29..30 "{" [] []
-      1: GRAPHQL_SELECTION_LIST@30..42
-        0: GRAPHQL_FIELD@30..35
-          0: (empty)
-          1: GRAPHQL_NAME@30..35
-            0: GRAPHQL_NAME@30..35 "id" [Newline("\n"), Whitespace("  ")] []
-          2: (empty)
-          3: GRAPHQL_DIRECTIVE_LIST@35..35
-          4: (empty)
-        1: GRAPHQL_FIELD@35..42
-          0: (empty)
-          1: GRAPHQL_NAME@35..42
-            0: GRAPHQL_NAME@35..42 "name" [Newline("\n"), Whitespace("  ")] []
-          2: (empty)
-          3: GRAPHQL_DIRECTIVE_LIST@42..42
-          4: (empty)
-      2: R_CURLY@42..44 "}" [Newline("\n")] []
-    2: GRAPHQL_FRAGMENT_DEFINITION@44..100
-      0: FRAGMENT_KW@44..55 "fragment" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      1: GRAPHQL_NAME@55..68
-        0: GRAPHQL_NAME@55..68 "friendFields" [] [Whitespace(" ")]
-      2: GRAPHQL_TYPE_CONDITION@68..73
-        0: (empty)
-        1: GRAPHQL_NAMED_TYPE@68..73
-          0: GRAPHQL_NAME@68..73
-            0: GRAPHQL_NAME@68..73 "User" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@73..85
-        0: GRAPHQL_DIRECTIVE@73..85
-          0: AT@73..74 "@" [] []
-          1: GRAPHQL_NAME@74..85
-            0: GRAPHQL_NAME@74..85 "deprecated" [] [Whitespace(" ")]
-          2: (empty)
-      4: GRAPHQL_SELECTION_SET@85..100
-        0: L_CURLY@85..86 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@86..98
-          0: GRAPHQL_FIELD@86..91
+  1: GRAPHQL_DEFINITION_LIST@0..195
+    0: GRAPHQL_FRAGMENT_DEFINITION@0..35
+      0: FRAGMENT_KW@0..9 "fragment" [] [Whitespace(" ")]
+      1: GRAPHQL_NAME@9..12
+        0: GRAPHQL_NAME@9..12 "on" [] [Whitespace(" ")]
+      2: GRAPHQL_TYPE_CONDITION@12..20
+        0: ON_KW@12..15 "on" [] [Whitespace(" ")]
+        1: GRAPHQL_NAMED_TYPE@15..20
+          0: GRAPHQL_NAME@15..20
+            0: GRAPHQL_NAME@15..20 "User" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@20..20
+      4: GRAPHQL_SELECTION_SET@20..35
+        0: L_CURLY@20..21 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@21..33
+          0: GRAPHQL_FIELD@21..26
             0: (empty)
-            1: GRAPHQL_NAME@86..91
-              0: GRAPHQL_NAME@86..91 "id" [Newline("\n"), Whitespace("  ")] []
+            1: GRAPHQL_NAME@21..26
+              0: GRAPHQL_NAME@21..26 "id" [Newline("\n"), Whitespace("  ")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@91..91
+            3: GRAPHQL_DIRECTIVE_LIST@26..26
             4: (empty)
-          1: GRAPHQL_FIELD@91..98
+          1: GRAPHQL_FIELD@26..33
             0: (empty)
-            1: GRAPHQL_NAME@91..98
-              0: GRAPHQL_NAME@91..98 "name" [Newline("\n"), Whitespace("  ")] []
+            1: GRAPHQL_NAME@26..33
+              0: GRAPHQL_NAME@26..33 "name" [Newline("\n"), Whitespace("  ")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@98..98
+            3: GRAPHQL_DIRECTIVE_LIST@33..33
             4: (empty)
-        2: R_CURLY@98..100 "}" [Newline("\n")] []
-    3: GRAPHQL_FRAGMENT_DEFINITION@100..158
-      0: FRAGMENT_KW@100..111 "fragment" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      1: GRAPHQL_NAME@111..124
-        0: GRAPHQL_NAME@111..124 "friendFields" [] [Whitespace(" ")]
-      2: GRAPHQL_TYPE_CONDITION@124..126
+        2: R_CURLY@33..35 "}" [Newline("\n")] []
+    1: GRAPHQL_BOGUS_DEFINITION@35..66
+      0: GRAPHQL_NAME@35..45 "fragmen" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@45..58 "friendFields" [] [Whitespace(" ")]
+      2: ON_KW@58..61 "on" [] [Whitespace(" ")]
+      3: GRAPHQL_NAME@61..66 "User" [] [Whitespace(" ")]
+    2: GRAPHQL_SELECTION_SET@66..81
+      0: L_CURLY@66..67 "{" [] []
+      1: GRAPHQL_SELECTION_LIST@67..79
+        0: GRAPHQL_FIELD@67..72
+          0: (empty)
+          1: GRAPHQL_NAME@67..72
+            0: GRAPHQL_NAME@67..72 "id" [Newline("\n"), Whitespace("  ")] []
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@72..72
+          4: (empty)
+        1: GRAPHQL_FIELD@72..79
+          0: (empty)
+          1: GRAPHQL_NAME@72..79
+            0: GRAPHQL_NAME@72..79 "name" [Newline("\n"), Whitespace("  ")] []
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@79..79
+          4: (empty)
+      2: R_CURLY@79..81 "}" [Newline("\n")] []
+    3: GRAPHQL_FRAGMENT_DEFINITION@81..137
+      0: FRAGMENT_KW@81..92 "fragment" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@92..105
+        0: GRAPHQL_NAME@92..105 "friendFields" [] [Whitespace(" ")]
+      2: GRAPHQL_TYPE_CONDITION@105..110
         0: (empty)
-        1: GRAPHQL_NAMED_TYPE@124..126
-          0: GRAPHQL_NAME@124..126
-            0: GRAPHQL_NAME@124..126 "o" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@126..126
-      4: GRAPHQL_SELECTION_SET@126..158
-        0: (empty)
-        1: GRAPHQL_SELECTION_LIST@126..158
-          0: GRAPHQL_FIELD@126..158
+        1: GRAPHQL_NAMED_TYPE@105..110
+          0: GRAPHQL_NAME@105..110
+            0: GRAPHQL_NAME@105..110 "User" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@110..122
+        0: GRAPHQL_DIRECTIVE@110..122
+          0: AT@110..111 "@" [] []
+          1: GRAPHQL_NAME@111..122
+            0: GRAPHQL_NAME@111..122 "deprecated" [] [Whitespace(" ")]
+          2: (empty)
+      4: GRAPHQL_SELECTION_SET@122..137
+        0: L_CURLY@122..123 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@123..135
+          0: GRAPHQL_FIELD@123..128
             0: (empty)
-            1: GRAPHQL_NAME@126..131
-              0: GRAPHQL_NAME@126..131 "User" [] [Whitespace(" ")]
+            1: GRAPHQL_NAME@123..128
+              0: GRAPHQL_NAME@123..128 "id" [Newline("\n"), Whitespace("  ")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@131..143
-              0: GRAPHQL_DIRECTIVE@131..143
-                0: AT@131..132 "@" [] []
-                1: GRAPHQL_NAME@132..143
-                  0: GRAPHQL_NAME@132..143 "deprecated" [] [Whitespace(" ")]
+            3: GRAPHQL_DIRECTIVE_LIST@128..128
+            4: (empty)
+          1: GRAPHQL_FIELD@128..135
+            0: (empty)
+            1: GRAPHQL_NAME@128..135
+              0: GRAPHQL_NAME@128..135 "name" [Newline("\n"), Whitespace("  ")] []
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@135..135
+            4: (empty)
+        2: R_CURLY@135..137 "}" [Newline("\n")] []
+    4: GRAPHQL_FRAGMENT_DEFINITION@137..195
+      0: FRAGMENT_KW@137..148 "fragment" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@148..161
+        0: GRAPHQL_NAME@148..161 "friendFields" [] [Whitespace(" ")]
+      2: GRAPHQL_TYPE_CONDITION@161..163
+        0: (empty)
+        1: GRAPHQL_NAMED_TYPE@161..163
+          0: GRAPHQL_NAME@161..163
+            0: GRAPHQL_NAME@161..163 "o" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@163..163
+      4: GRAPHQL_SELECTION_SET@163..195
+        0: (empty)
+        1: GRAPHQL_SELECTION_LIST@163..195
+          0: GRAPHQL_FIELD@163..195
+            0: (empty)
+            1: GRAPHQL_NAME@163..168
+              0: GRAPHQL_NAME@163..168 "User" [] [Whitespace(" ")]
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@168..180
+              0: GRAPHQL_DIRECTIVE@168..180
+                0: AT@168..169 "@" [] []
+                1: GRAPHQL_NAME@169..180
+                  0: GRAPHQL_NAME@169..180 "deprecated" [] [Whitespace(" ")]
                 2: (empty)
-            4: GRAPHQL_SELECTION_SET@143..158
-              0: L_CURLY@143..144 "{" [] []
-              1: GRAPHQL_SELECTION_LIST@144..156
-                0: GRAPHQL_FIELD@144..149
+            4: GRAPHQL_SELECTION_SET@180..195
+              0: L_CURLY@180..181 "{" [] []
+              1: GRAPHQL_SELECTION_LIST@181..193
+                0: GRAPHQL_FIELD@181..186
                   0: (empty)
-                  1: GRAPHQL_NAME@144..149
-                    0: GRAPHQL_NAME@144..149 "id" [Newline("\n"), Whitespace("  ")] []
+                  1: GRAPHQL_NAME@181..186
+                    0: GRAPHQL_NAME@181..186 "id" [Newline("\n"), Whitespace("  ")] []
                   2: (empty)
-                  3: GRAPHQL_DIRECTIVE_LIST@149..149
+                  3: GRAPHQL_DIRECTIVE_LIST@186..186
                   4: (empty)
-                1: GRAPHQL_FIELD@149..156
+                1: GRAPHQL_FIELD@186..193
                   0: (empty)
-                  1: GRAPHQL_NAME@149..156
-                    0: GRAPHQL_NAME@149..156 "name" [Newline("\n"), Whitespace("  ")] []
+                  1: GRAPHQL_NAME@186..193
+                    0: GRAPHQL_NAME@186..193 "name" [Newline("\n"), Whitespace("  ")] []
                   2: (empty)
-                  3: GRAPHQL_DIRECTIVE_LIST@156..156
+                  3: GRAPHQL_DIRECTIVE_LIST@193..193
                   4: (empty)
-              2: R_CURLY@156..158 "}" [Newline("\n")] []
+              2: R_CURLY@193..195 "}" [Newline("\n")] []
         2: (empty)
-  2: EOF@158..159 "" [Newline("\n")] []
+  2: EOF@195..196 "" [Newline("\n")] []
 
 ```
 
 ## Diagnostics
 
 ```
-fragment.graphql:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+fragment.graphql:1:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Fragment name must not be 'on'
+  
+  > 1 │ fragment on on User {
+      │          ^^
+    2 │   id
+    3 │   name
+  
+fragment.graphql:6:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a definition but instead found 'fragmen friendFields on User'.
   
-  > 1 │ fragmen friendFields on User {
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │   id
-    3 │   name
-  
-  i Expected a definition here.
-  
-  > 1 │ fragmen friendFields on User {
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │   id
-    3 │   name
-  
-fragment.graphql:6:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `on` but instead found `User`
-  
     4 │ }
     5 │ 
-  > 6 │ fragment friendFields User @deprecated {
-      │                       ^^^^
+  > 6 │ fragmen friendFields on User {
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     7 │   id
     8 │   name
   
-  i Remove User
+  i Expected a definition here.
+  
+    4 │ }
+    5 │ 
+  > 6 │ fragmen friendFields on User {
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │   id
+    8 │   name
   
 fragment.graphql:11:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × expected `on` but instead found `o`
+  × expected `on` but instead found `User`
   
      9 │ }
     10 │ 
-  > 11 │ fragment friendFields o User @deprecated {
-       │                       ^
-    12 │   id
-    13 │   name
-  
-  i Remove o
-  
-fragment.graphql:11:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `{` but instead found `User`
-  
-     9 │ }
-    10 │ 
-  > 11 │ fragment friendFields o User @deprecated {
-       │                         ^^^^
+  > 11 │ fragment friendFields User @deprecated {
+       │                       ^^^^
     12 │   id
     13 │   name
   
   i Remove User
   
-fragment.graphql:15:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+fragment.graphql:16:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `on` but instead found `o`
+  
+    14 │ }
+    15 │ 
+  > 16 │ fragment friendFields o User @deprecated {
+       │                       ^
+    17 │   id
+    18 │   name
+  
+  i Remove o
+  
+fragment.graphql:16:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `{` but instead found `User`
+  
+    14 │ }
+    15 │ 
+  > 16 │ fragment friendFields o User @deprecated {
+       │                         ^^^^
+    17 │   id
+    18 │   name
+  
+  i Remove User
+  
+fragment.graphql:20:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `}` but instead the file ends
   
-    13 │   name
-    14 │ }
-  > 15 │ 
+    18 │   name
+    19 │ }
+  > 20 │ 
        │ 
   
   i the file ends here
   
-    13 │   name
-    14 │ }
-  > 15 │ 
+    18 │   name
+    19 │ }
+  > 20 │ 
        │ 
   
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/input_object.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/input_object.graphql
@@ -3,12 +3,6 @@ input Point2D
   y: Float
 }
 
-input Point2D
-  x: Float
-  y: Float
-
-input Point2D {
-
 input Point2D @deprecated {
 	x: Float
 }
@@ -42,3 +36,10 @@ iput Point2D {
 	x: Float
 	y: Float
 }
+
+input Point2D
+  x: Float
+  y: Float
+
+input Point2D {
+

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/input_object.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/input_object.graphql.snap
@@ -9,12 +9,6 @@ input Point2D
   y: Float
 }
 
-input Point2D
-  x: Float
-  y: Float
-
-input Point2D {
-
 input Point2D @deprecated {
 	x: Float
 }
@@ -48,6 +42,13 @@ iput Point2D {
 	x: Float
 	y: Float
 }
+
+input Point2D
+  x: Float
+  y: Float
+
+input Point2D {
+
 
 ```
 
@@ -103,114 +104,59 @@ GraphqlRoot {
             description: missing (optional),
             input_token: INPUT_KW@37..45 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@45..52 "Point2D" [] [],
-            },
-            directives: GraphqlDirectiveList [],
-            input_fields: GraphqlInputFieldsDefinition {
-                l_curly_token: missing (required),
-                fields: GraphqlInputFieldList [
-                    GraphqlInputValueDefinition {
-                        description: missing (optional),
-                        name: GraphqlName {
-                            value_token: GRAPHQL_NAME@52..56 "x" [Newline("\n"), Whitespace("  ")] [],
-                        },
-                        colon_token: COLON@56..58 ":" [] [Whitespace(" ")],
-                        ty: GraphqlNamedType {
-                            name: GraphqlName {
-                                value_token: GRAPHQL_NAME@58..63 "Float" [] [],
-                            },
-                        },
-                        default: missing (optional),
-                        directives: GraphqlDirectiveList [],
-                    },
-                    GraphqlInputValueDefinition {
-                        description: missing (optional),
-                        name: GraphqlName {
-                            value_token: GRAPHQL_NAME@63..67 "y" [Newline("\n"), Whitespace("  ")] [],
-                        },
-                        colon_token: COLON@67..69 ":" [] [Whitespace(" ")],
-                        ty: GraphqlNamedType {
-                            name: GraphqlName {
-                                value_token: GRAPHQL_NAME@69..74 "Float" [] [],
-                            },
-                        },
-                        default: missing (optional),
-                        directives: GraphqlDirectiveList [],
-                    },
-                ],
-                r_curly_token: missing (required),
-            },
-        },
-        GraphqlInputObjectTypeDefinition {
-            description: missing (optional),
-            input_token: INPUT_KW@74..82 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@82..90 "Point2D" [] [Whitespace(" ")],
-            },
-            directives: GraphqlDirectiveList [],
-            input_fields: GraphqlInputFieldsDefinition {
-                l_curly_token: L_CURLY@90..91 "{" [] [],
-                fields: GraphqlInputFieldList [],
-                r_curly_token: missing (required),
-            },
-        },
-        GraphqlInputObjectTypeDefinition {
-            description: missing (optional),
-            input_token: INPUT_KW@91..99 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@99..107 "Point2D" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@45..53 "Point2D" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
-                    at_token: AT@107..108 "@" [] [],
+                    at_token: AT@53..54 "@" [] [],
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@108..119 "deprecated" [] [Whitespace(" ")],
+                        value_token: GRAPHQL_NAME@54..65 "deprecated" [] [Whitespace(" ")],
                     },
                     arguments: missing (optional),
                 },
             ],
             input_fields: GraphqlInputFieldsDefinition {
-                l_curly_token: L_CURLY@119..120 "{" [] [],
+                l_curly_token: L_CURLY@65..66 "{" [] [],
                 fields: GraphqlInputFieldList [
                     GraphqlInputValueDefinition {
                         description: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@120..123 "x" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@66..69 "x" [Newline("\n"), Whitespace("\t")] [],
                         },
-                        colon_token: COLON@123..125 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@69..71 ":" [] [Whitespace(" ")],
                         ty: GraphqlNamedType {
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@125..130 "Float" [] [],
+                                value_token: GRAPHQL_NAME@71..76 "Float" [] [],
                             },
                         },
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_curly_token: R_CURLY@130..132 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@76..78 "}" [Newline("\n")] [],
             },
         },
         GraphqlInputObjectTypeDefinition {
             description: missing (optional),
-            input_token: INPUT_KW@132..140 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            input_token: INPUT_KW@78..86 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@140..148 "Point2D" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@86..94 "Point2D" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
             input_fields: GraphqlInputFieldsDefinition {
-                l_curly_token: L_CURLY@148..149 "{" [] [],
+                l_curly_token: L_CURLY@94..95 "{" [] [],
                 fields: GraphqlInputFieldList [
                     GraphqlInputValueDefinition {
                         description: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@149..153 "x" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@95..99 "x" [Newline("\n"), Whitespace("  ")] [],
                         },
-                        colon_token: COLON@153..155 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@99..101 ":" [] [Whitespace(" ")],
                         ty: missing (required),
                         default: GraphqlDefaultValue {
-                            eq_token: EQ@155..157 "=" [] [Whitespace(" ")],
+                            eq_token: EQ@101..103 "=" [] [Whitespace(" ")],
                             value: GraphqlIntValue {
-                                graphql_int_literal_token: GRAPHQL_INT_LITERAL@157..158 "0" [] [],
+                                graphql_int_literal_token: GRAPHQL_INT_LITERAL@103..104 "0" [] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
@@ -218,57 +164,57 @@ GraphqlRoot {
                     GraphqlInputValueDefinition {
                         description: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@158..162 "y" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@104..108 "y" [Newline("\n"), Whitespace("  ")] [],
                         },
-                        colon_token: COLON@162..164 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@108..110 ":" [] [Whitespace(" ")],
                         ty: missing (required),
                         default: missing (optional),
                         directives: GraphqlDirectiveList [
                             GraphqlDirective {
-                                at_token: AT@164..165 "@" [] [],
+                                at_token: AT@110..111 "@" [] [],
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@165..175 "deprecated" [] [],
+                                    value_token: GRAPHQL_NAME@111..121 "deprecated" [] [],
                                 },
                                 arguments: missing (optional),
                             },
                         ],
                     },
                 ],
-                r_curly_token: R_CURLY@175..177 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@121..123 "}" [Newline("\n")] [],
             },
         },
         GraphqlBogusDefinition {
             items: [
-                INPUT_KW@177..185 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                INPUT_KW@123..131 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
                 GraphqlName {
-                    value_token: GRAPHQL_NAME@185..193 "Point2D" [] [Whitespace(" ")],
+                    value_token: GRAPHQL_NAME@131..139 "Point2D" [] [Whitespace(" ")],
                 },
                 GraphqlDirectiveList [],
                 GraphqlBogus {
                     items: [
-                        L_CURLY@193..194 "{" [] [],
+                        L_CURLY@139..140 "{" [] [],
                         GraphqlBogus {
                             items: [
                                 GraphqlBogus {
                                     items: [
-                                        GRAPHQL_NAME@194..199 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
-                                        EQ@199..201 "=" [] [Whitespace(" ")],
-                                        GRAPHQL_INT_LITERAL@201..202 "0" [] [],
+                                        GRAPHQL_NAME@140..145 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        EQ@145..147 "=" [] [Whitespace(" ")],
+                                        GRAPHQL_INT_LITERAL@147..148 "0" [] [],
                                     ],
                                 },
                                 GraphqlInputValueDefinition {
                                     description: missing (optional),
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@202..206 "y" [Newline("\n"), Whitespace("  ")] [],
+                                        value_token: GRAPHQL_NAME@148..152 "y" [Newline("\n"), Whitespace("  ")] [],
                                     },
-                                    colon_token: COLON@206..208 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@152..154 ":" [] [Whitespace(" ")],
                                     ty: missing (required),
                                     default: missing (optional),
                                     directives: GraphqlDirectiveList [
                                         GraphqlDirective {
-                                            at_token: AT@208..209 "@" [] [],
+                                            at_token: AT@154..155 "@" [] [],
                                             name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@209..219 "deprecated" [] [],
+                                                value_token: GRAPHQL_NAME@155..165 "deprecated" [] [],
                                             },
                                             arguments: missing (optional),
                                         },
@@ -276,38 +222,38 @@ GraphqlRoot {
                                 },
                             ],
                         },
-                        R_CURLY@219..221 "}" [Newline("\n")] [],
+                        R_CURLY@165..167 "}" [Newline("\n")] [],
                     ],
                 },
             ],
         },
         GraphqlBogusDefinition {
             items: [
-                INPUT_KW@221..229 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                INPUT_KW@167..175 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
                 GraphqlName {
-                    value_token: GRAPHQL_NAME@229..237 "Point2D" [] [Whitespace(" ")],
+                    value_token: GRAPHQL_NAME@175..183 "Point2D" [] [Whitespace(" ")],
                 },
                 GraphqlDirectiveList [],
                 GraphqlBogus {
                     items: [
-                        L_CURLY@237..238 "{" [] [],
+                        L_CURLY@183..184 "{" [] [],
                         GraphqlBogus {
                             items: [
                                 GraphqlBogus {
                                     items: [
-                                        EQ@238..243 "=" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
-                                        GRAPHQL_INT_LITERAL@243..244 "0" [] [],
+                                        EQ@184..189 "=" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        GRAPHQL_INT_LITERAL@189..190 "0" [] [],
                                     ],
                                 },
                                 GraphqlInputValueDefinition {
                                     description: missing (optional),
                                     name: missing (required),
-                                    colon_token: COLON@244..249 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                    colon_token: COLON@190..195 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                                     ty: missing (required),
                                     default: missing (optional),
                                     directives: GraphqlDirectiveList [
                                         GraphqlDirective {
-                                            at_token: AT@249..250 "@" [] [],
+                                            at_token: AT@195..196 "@" [] [],
                                             name: missing (required),
                                             arguments: missing (optional),
                                         },
@@ -315,63 +261,63 @@ GraphqlRoot {
                                 },
                             ],
                         },
-                        R_CURLY@250..252 "}" [Newline("\n")] [],
+                        R_CURLY@196..198 "}" [Newline("\n")] [],
                     ],
                 },
             ],
         },
         GraphqlInputObjectTypeDefinition {
             description: missing (optional),
-            input_token: INPUT_KW@252..260 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            input_token: INPUT_KW@198..206 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@260..268 "Point2D" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@206..214 "Point2D" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
             input_fields: GraphqlInputFieldsDefinition {
-                l_curly_token: L_CURLY@268..269 "{" [] [],
+                l_curly_token: L_CURLY@214..215 "{" [] [],
                 fields: GraphqlInputFieldList [
                     GraphqlInputValueDefinition {
                         description: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@269..273 "x" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@215..219 "x" [Newline("\n"), Whitespace("  ")] [],
                         },
                         colon_token: missing (required),
                         ty: GraphqlNamedType {
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@273..277 "y" [Newline("\n"), Whitespace("  ")] [],
+                                value_token: GRAPHQL_NAME@219..223 "y" [Newline("\n"), Whitespace("  ")] [],
                             },
                         },
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_curly_token: R_CURLY@277..279 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@223..225 "}" [Newline("\n")] [],
             },
         },
         GraphqlBogusDefinition {
             items: [
-                INPUT_KW@279..287 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                INPUT_KW@225..233 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
                 GraphqlName {
-                    value_token: GRAPHQL_NAME@287..295 "Point2D" [] [Whitespace(" ")],
+                    value_token: GRAPHQL_NAME@233..241 "Point2D" [] [Whitespace(" ")],
                 },
                 GraphqlDirectiveList [],
                 GraphqlBogus {
                     items: [
-                        L_CURLY@295..296 "{" [] [],
+                        L_CURLY@241..242 "{" [] [],
                         GraphqlBogus {
                             items: [
                                 GraphqlBogus {
                                     items: [
-                                        EQ@296..299 "=" [Newline("\n"), Whitespace("\t")] [],
+                                        EQ@242..245 "=" [Newline("\n"), Whitespace("\t")] [],
                                     ],
                                 },
                                 GraphqlInputValueDefinition {
                                     description: missing (optional),
                                     name: missing (required),
-                                    colon_token: COLON@299..304 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                    colon_token: COLON@245..250 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                                     ty: GraphqlNamedType {
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@304..309 "Float" [] [],
+                                            value_token: GRAPHQL_NAME@250..255 "Float" [] [],
                                         },
                                     },
                                     default: missing (optional),
@@ -379,29 +325,29 @@ GraphqlRoot {
                                 },
                             ],
                         },
-                        R_CURLY@309..311 "}" [Newline("\n")] [],
+                        R_CURLY@255..257 "}" [Newline("\n")] [],
                     ],
                 },
             ],
         },
         GraphqlBogusDefinition {
             items: [
-                GRAPHQL_NAME@311..318 "iput" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-                GRAPHQL_NAME@318..326 "Point2D" [] [Whitespace(" ")],
+                GRAPHQL_NAME@257..264 "iput" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                GRAPHQL_NAME@264..272 "Point2D" [] [Whitespace(" ")],
             ],
         },
         GraphqlSelectionSet {
-            l_curly_token: L_CURLY@326..327 "{" [] [],
+            l_curly_token: L_CURLY@272..273 "{" [] [],
             selections: GraphqlSelectionList [
                 GraphqlField {
                     alias: GraphqlAlias {
                         value: GraphqlName {
-                            value_token: GRAPHQL_NAME@327..330 "x" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@273..276 "x" [Newline("\n"), Whitespace("\t")] [],
                         },
-                        colon_token: COLON@330..332 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@276..278 ":" [] [Whitespace(" ")],
                     },
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@332..337 "Float" [] [],
+                        value_token: GRAPHQL_NAME@278..283 "Float" [] [],
                     },
                     arguments: missing (optional),
                     directives: GraphqlDirectiveList [],
@@ -410,29 +356,85 @@ GraphqlRoot {
                 GraphqlField {
                     alias: GraphqlAlias {
                         value: GraphqlName {
-                            value_token: GRAPHQL_NAME@337..340 "y" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@283..286 "y" [Newline("\n"), Whitespace("\t")] [],
                         },
-                        colon_token: COLON@340..342 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@286..288 ":" [] [Whitespace(" ")],
                     },
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@342..347 "Float" [] [],
+                        value_token: GRAPHQL_NAME@288..293 "Float" [] [],
                     },
                     arguments: missing (optional),
                     directives: GraphqlDirectiveList [],
                     selection_set: missing (optional),
                 },
             ],
-            r_curly_token: R_CURLY@347..349 "}" [Newline("\n")] [],
+            r_curly_token: R_CURLY@293..295 "}" [Newline("\n")] [],
+        },
+        GraphqlBogusDefinition {
+            items: [
+                INPUT_KW@295..303 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                GraphqlName {
+                    value_token: GRAPHQL_NAME@303..310 "Point2D" [] [],
+                },
+                GraphqlDirectiveList [],
+                GraphqlBogus {
+                    items: [
+                        GraphqlBogus {
+                            items: [
+                                GraphqlInputValueDefinition {
+                                    description: missing (optional),
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@310..314 "x" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    colon_token: COLON@314..316 ":" [] [Whitespace(" ")],
+                                    ty: GraphqlNamedType {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@316..321 "Float" [] [],
+                                        },
+                                    },
+                                    default: missing (optional),
+                                    directives: GraphqlDirectiveList [],
+                                },
+                                GraphqlInputValueDefinition {
+                                    description: missing (optional),
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@321..325 "y" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    colon_token: COLON@325..327 ":" [] [Whitespace(" ")],
+                                    ty: GraphqlNamedType {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@327..332 "Float" [] [],
+                                        },
+                                    },
+                                    default: missing (optional),
+                                    directives: GraphqlDirectiveList [],
+                                },
+                                GraphqlBogus {
+                                    items: [
+                                        INPUT_KW@332..340 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                                        GRAPHQL_NAME@340..348 "Point2D" [] [Whitespace(" ")],
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@348..349 "{" [] [],
+            selections: GraphqlSelectionList [],
+            r_curly_token: missing (required),
         },
     ],
-    eof_token: EOF@349..350 "" [Newline("\n")] [],
+    eof_token: EOF@349..351 "" [Newline("\n"), Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..350
+0: GRAPHQL_ROOT@0..351
   0: (empty)
   1: GRAPHQL_DEFINITION_LIST@0..349
     0: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@0..37
@@ -465,222 +467,216 @@ GraphqlRoot {
             4: (empty)
             5: GRAPHQL_DIRECTIVE_LIST@35..35
         2: R_CURLY@35..37 "}" [Newline("\n")] []
-    1: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@37..74
+    1: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@37..78
       0: (empty)
       1: INPUT_KW@37..45 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@45..52
-        0: GRAPHQL_NAME@45..52 "Point2D" [] []
-      3: GRAPHQL_DIRECTIVE_LIST@52..52
-      4: GRAPHQL_INPUT_FIELDS_DEFINITION@52..74
-        0: (empty)
-        1: GRAPHQL_INPUT_FIELD_LIST@52..74
-          0: GRAPHQL_INPUT_VALUE_DEFINITION@52..63
-            0: (empty)
-            1: GRAPHQL_NAME@52..56
-              0: GRAPHQL_NAME@52..56 "x" [Newline("\n"), Whitespace("  ")] []
-            2: COLON@56..58 ":" [] [Whitespace(" ")]
-            3: GRAPHQL_NAMED_TYPE@58..63
-              0: GRAPHQL_NAME@58..63
-                0: GRAPHQL_NAME@58..63 "Float" [] []
-            4: (empty)
-            5: GRAPHQL_DIRECTIVE_LIST@63..63
-          1: GRAPHQL_INPUT_VALUE_DEFINITION@63..74
-            0: (empty)
-            1: GRAPHQL_NAME@63..67
-              0: GRAPHQL_NAME@63..67 "y" [Newline("\n"), Whitespace("  ")] []
-            2: COLON@67..69 ":" [] [Whitespace(" ")]
-            3: GRAPHQL_NAMED_TYPE@69..74
-              0: GRAPHQL_NAME@69..74
-                0: GRAPHQL_NAME@69..74 "Float" [] []
-            4: (empty)
-            5: GRAPHQL_DIRECTIVE_LIST@74..74
-        2: (empty)
-    2: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@74..91
-      0: (empty)
-      1: INPUT_KW@74..82 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@82..90
-        0: GRAPHQL_NAME@82..90 "Point2D" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@90..90
-      4: GRAPHQL_INPUT_FIELDS_DEFINITION@90..91
-        0: L_CURLY@90..91 "{" [] []
-        1: GRAPHQL_INPUT_FIELD_LIST@91..91
-        2: (empty)
-    3: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@91..132
-      0: (empty)
-      1: INPUT_KW@91..99 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@99..107
-        0: GRAPHQL_NAME@99..107 "Point2D" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@107..119
-        0: GRAPHQL_DIRECTIVE@107..119
-          0: AT@107..108 "@" [] []
-          1: GRAPHQL_NAME@108..119
-            0: GRAPHQL_NAME@108..119 "deprecated" [] [Whitespace(" ")]
+      2: GRAPHQL_NAME@45..53
+        0: GRAPHQL_NAME@45..53 "Point2D" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@53..65
+        0: GRAPHQL_DIRECTIVE@53..65
+          0: AT@53..54 "@" [] []
+          1: GRAPHQL_NAME@54..65
+            0: GRAPHQL_NAME@54..65 "deprecated" [] [Whitespace(" ")]
           2: (empty)
-      4: GRAPHQL_INPUT_FIELDS_DEFINITION@119..132
-        0: L_CURLY@119..120 "{" [] []
-        1: GRAPHQL_INPUT_FIELD_LIST@120..130
-          0: GRAPHQL_INPUT_VALUE_DEFINITION@120..130
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@65..78
+        0: L_CURLY@65..66 "{" [] []
+        1: GRAPHQL_INPUT_FIELD_LIST@66..76
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@66..76
             0: (empty)
-            1: GRAPHQL_NAME@120..123
-              0: GRAPHQL_NAME@120..123 "x" [Newline("\n"), Whitespace("\t")] []
-            2: COLON@123..125 ":" [] [Whitespace(" ")]
-            3: GRAPHQL_NAMED_TYPE@125..130
-              0: GRAPHQL_NAME@125..130
-                0: GRAPHQL_NAME@125..130 "Float" [] []
+            1: GRAPHQL_NAME@66..69
+              0: GRAPHQL_NAME@66..69 "x" [Newline("\n"), Whitespace("\t")] []
+            2: COLON@69..71 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@71..76
+              0: GRAPHQL_NAME@71..76
+                0: GRAPHQL_NAME@71..76 "Float" [] []
             4: (empty)
-            5: GRAPHQL_DIRECTIVE_LIST@130..130
-        2: R_CURLY@130..132 "}" [Newline("\n")] []
-    4: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@132..177
+            5: GRAPHQL_DIRECTIVE_LIST@76..76
+        2: R_CURLY@76..78 "}" [Newline("\n")] []
+    2: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@78..123
       0: (empty)
-      1: INPUT_KW@132..140 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@140..148
-        0: GRAPHQL_NAME@140..148 "Point2D" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@148..148
-      4: GRAPHQL_INPUT_FIELDS_DEFINITION@148..177
-        0: L_CURLY@148..149 "{" [] []
-        1: GRAPHQL_INPUT_FIELD_LIST@149..175
-          0: GRAPHQL_INPUT_VALUE_DEFINITION@149..158
+      1: INPUT_KW@78..86 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@86..94
+        0: GRAPHQL_NAME@86..94 "Point2D" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@94..94
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@94..123
+        0: L_CURLY@94..95 "{" [] []
+        1: GRAPHQL_INPUT_FIELD_LIST@95..121
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@95..104
             0: (empty)
-            1: GRAPHQL_NAME@149..153
-              0: GRAPHQL_NAME@149..153 "x" [Newline("\n"), Whitespace("  ")] []
-            2: COLON@153..155 ":" [] [Whitespace(" ")]
+            1: GRAPHQL_NAME@95..99
+              0: GRAPHQL_NAME@95..99 "x" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@99..101 ":" [] [Whitespace(" ")]
             3: (empty)
-            4: GRAPHQL_DEFAULT_VALUE@155..158
-              0: EQ@155..157 "=" [] [Whitespace(" ")]
-              1: GRAPHQL_INT_VALUE@157..158
-                0: GRAPHQL_INT_LITERAL@157..158 "0" [] []
-            5: GRAPHQL_DIRECTIVE_LIST@158..158
-          1: GRAPHQL_INPUT_VALUE_DEFINITION@158..175
+            4: GRAPHQL_DEFAULT_VALUE@101..104
+              0: EQ@101..103 "=" [] [Whitespace(" ")]
+              1: GRAPHQL_INT_VALUE@103..104
+                0: GRAPHQL_INT_LITERAL@103..104 "0" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@104..104
+          1: GRAPHQL_INPUT_VALUE_DEFINITION@104..121
             0: (empty)
-            1: GRAPHQL_NAME@158..162
-              0: GRAPHQL_NAME@158..162 "y" [Newline("\n"), Whitespace("  ")] []
-            2: COLON@162..164 ":" [] [Whitespace(" ")]
-            3: (empty)
-            4: (empty)
-            5: GRAPHQL_DIRECTIVE_LIST@164..175
-              0: GRAPHQL_DIRECTIVE@164..175
-                0: AT@164..165 "@" [] []
-                1: GRAPHQL_NAME@165..175
-                  0: GRAPHQL_NAME@165..175 "deprecated" [] []
-                2: (empty)
-        2: R_CURLY@175..177 "}" [Newline("\n")] []
-    5: GRAPHQL_BOGUS_DEFINITION@177..221
-      0: INPUT_KW@177..185 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      1: GRAPHQL_NAME@185..193
-        0: GRAPHQL_NAME@185..193 "Point2D" [] [Whitespace(" ")]
-      2: GRAPHQL_DIRECTIVE_LIST@193..193
-      3: GRAPHQL_BOGUS@193..221
-        0: L_CURLY@193..194 "{" [] []
-        1: GRAPHQL_BOGUS@194..219
-          0: GRAPHQL_BOGUS@194..202
-            0: GRAPHQL_NAME@194..199 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-            1: EQ@199..201 "=" [] [Whitespace(" ")]
-            2: GRAPHQL_INT_LITERAL@201..202 "0" [] []
-          1: GRAPHQL_INPUT_VALUE_DEFINITION@202..219
-            0: (empty)
-            1: GRAPHQL_NAME@202..206
-              0: GRAPHQL_NAME@202..206 "y" [Newline("\n"), Whitespace("  ")] []
-            2: COLON@206..208 ":" [] [Whitespace(" ")]
+            1: GRAPHQL_NAME@104..108
+              0: GRAPHQL_NAME@104..108 "y" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@108..110 ":" [] [Whitespace(" ")]
             3: (empty)
             4: (empty)
-            5: GRAPHQL_DIRECTIVE_LIST@208..219
-              0: GRAPHQL_DIRECTIVE@208..219
-                0: AT@208..209 "@" [] []
-                1: GRAPHQL_NAME@209..219
-                  0: GRAPHQL_NAME@209..219 "deprecated" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@110..121
+              0: GRAPHQL_DIRECTIVE@110..121
+                0: AT@110..111 "@" [] []
+                1: GRAPHQL_NAME@111..121
+                  0: GRAPHQL_NAME@111..121 "deprecated" [] []
                 2: (empty)
-        2: R_CURLY@219..221 "}" [Newline("\n")] []
-    6: GRAPHQL_BOGUS_DEFINITION@221..252
-      0: INPUT_KW@221..229 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      1: GRAPHQL_NAME@229..237
-        0: GRAPHQL_NAME@229..237 "Point2D" [] [Whitespace(" ")]
-      2: GRAPHQL_DIRECTIVE_LIST@237..237
-      3: GRAPHQL_BOGUS@237..252
-        0: L_CURLY@237..238 "{" [] []
-        1: GRAPHQL_BOGUS@238..250
-          0: GRAPHQL_BOGUS@238..244
-            0: EQ@238..243 "=" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-            1: GRAPHQL_INT_LITERAL@243..244 "0" [] []
-          1: GRAPHQL_INPUT_VALUE_DEFINITION@244..250
+        2: R_CURLY@121..123 "}" [Newline("\n")] []
+    3: GRAPHQL_BOGUS_DEFINITION@123..167
+      0: INPUT_KW@123..131 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@131..139
+        0: GRAPHQL_NAME@131..139 "Point2D" [] [Whitespace(" ")]
+      2: GRAPHQL_DIRECTIVE_LIST@139..139
+      3: GRAPHQL_BOGUS@139..167
+        0: L_CURLY@139..140 "{" [] []
+        1: GRAPHQL_BOGUS@140..165
+          0: GRAPHQL_BOGUS@140..148
+            0: GRAPHQL_NAME@140..145 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            1: EQ@145..147 "=" [] [Whitespace(" ")]
+            2: GRAPHQL_INT_LITERAL@147..148 "0" [] []
+          1: GRAPHQL_INPUT_VALUE_DEFINITION@148..165
+            0: (empty)
+            1: GRAPHQL_NAME@148..152
+              0: GRAPHQL_NAME@148..152 "y" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@152..154 ":" [] [Whitespace(" ")]
+            3: (empty)
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@154..165
+              0: GRAPHQL_DIRECTIVE@154..165
+                0: AT@154..155 "@" [] []
+                1: GRAPHQL_NAME@155..165
+                  0: GRAPHQL_NAME@155..165 "deprecated" [] []
+                2: (empty)
+        2: R_CURLY@165..167 "}" [Newline("\n")] []
+    4: GRAPHQL_BOGUS_DEFINITION@167..198
+      0: INPUT_KW@167..175 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@175..183
+        0: GRAPHQL_NAME@175..183 "Point2D" [] [Whitespace(" ")]
+      2: GRAPHQL_DIRECTIVE_LIST@183..183
+      3: GRAPHQL_BOGUS@183..198
+        0: L_CURLY@183..184 "{" [] []
+        1: GRAPHQL_BOGUS@184..196
+          0: GRAPHQL_BOGUS@184..190
+            0: EQ@184..189 "=" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            1: GRAPHQL_INT_LITERAL@189..190 "0" [] []
+          1: GRAPHQL_INPUT_VALUE_DEFINITION@190..196
             0: (empty)
             1: (empty)
-            2: COLON@244..249 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            2: COLON@190..195 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
             3: (empty)
             4: (empty)
-            5: GRAPHQL_DIRECTIVE_LIST@249..250
-              0: GRAPHQL_DIRECTIVE@249..250
-                0: AT@249..250 "@" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@195..196
+              0: GRAPHQL_DIRECTIVE@195..196
+                0: AT@195..196 "@" [] []
                 1: (empty)
                 2: (empty)
-        2: R_CURLY@250..252 "}" [Newline("\n")] []
-    7: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@252..279
+        2: R_CURLY@196..198 "}" [Newline("\n")] []
+    5: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@198..225
       0: (empty)
-      1: INPUT_KW@252..260 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@260..268
-        0: GRAPHQL_NAME@260..268 "Point2D" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@268..268
-      4: GRAPHQL_INPUT_FIELDS_DEFINITION@268..279
-        0: L_CURLY@268..269 "{" [] []
-        1: GRAPHQL_INPUT_FIELD_LIST@269..277
-          0: GRAPHQL_INPUT_VALUE_DEFINITION@269..277
+      1: INPUT_KW@198..206 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@206..214
+        0: GRAPHQL_NAME@206..214 "Point2D" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@214..214
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@214..225
+        0: L_CURLY@214..215 "{" [] []
+        1: GRAPHQL_INPUT_FIELD_LIST@215..223
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@215..223
             0: (empty)
-            1: GRAPHQL_NAME@269..273
-              0: GRAPHQL_NAME@269..273 "x" [Newline("\n"), Whitespace("  ")] []
+            1: GRAPHQL_NAME@215..219
+              0: GRAPHQL_NAME@215..219 "x" [Newline("\n"), Whitespace("  ")] []
             2: (empty)
-            3: GRAPHQL_NAMED_TYPE@273..277
-              0: GRAPHQL_NAME@273..277
-                0: GRAPHQL_NAME@273..277 "y" [Newline("\n"), Whitespace("  ")] []
+            3: GRAPHQL_NAMED_TYPE@219..223
+              0: GRAPHQL_NAME@219..223
+                0: GRAPHQL_NAME@219..223 "y" [Newline("\n"), Whitespace("  ")] []
             4: (empty)
-            5: GRAPHQL_DIRECTIVE_LIST@277..277
-        2: R_CURLY@277..279 "}" [Newline("\n")] []
-    8: GRAPHQL_BOGUS_DEFINITION@279..311
-      0: INPUT_KW@279..287 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      1: GRAPHQL_NAME@287..295
-        0: GRAPHQL_NAME@287..295 "Point2D" [] [Whitespace(" ")]
-      2: GRAPHQL_DIRECTIVE_LIST@295..295
-      3: GRAPHQL_BOGUS@295..311
-        0: L_CURLY@295..296 "{" [] []
-        1: GRAPHQL_BOGUS@296..309
-          0: GRAPHQL_BOGUS@296..299
-            0: EQ@296..299 "=" [Newline("\n"), Whitespace("\t")] []
-          1: GRAPHQL_INPUT_VALUE_DEFINITION@299..309
+            5: GRAPHQL_DIRECTIVE_LIST@223..223
+        2: R_CURLY@223..225 "}" [Newline("\n")] []
+    6: GRAPHQL_BOGUS_DEFINITION@225..257
+      0: INPUT_KW@225..233 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@233..241
+        0: GRAPHQL_NAME@233..241 "Point2D" [] [Whitespace(" ")]
+      2: GRAPHQL_DIRECTIVE_LIST@241..241
+      3: GRAPHQL_BOGUS@241..257
+        0: L_CURLY@241..242 "{" [] []
+        1: GRAPHQL_BOGUS@242..255
+          0: GRAPHQL_BOGUS@242..245
+            0: EQ@242..245 "=" [Newline("\n"), Whitespace("\t")] []
+          1: GRAPHQL_INPUT_VALUE_DEFINITION@245..255
             0: (empty)
             1: (empty)
-            2: COLON@299..304 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-            3: GRAPHQL_NAMED_TYPE@304..309
-              0: GRAPHQL_NAME@304..309
-                0: GRAPHQL_NAME@304..309 "Float" [] []
+            2: COLON@245..250 ":" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@250..255
+              0: GRAPHQL_NAME@250..255
+                0: GRAPHQL_NAME@250..255 "Float" [] []
             4: (empty)
-            5: GRAPHQL_DIRECTIVE_LIST@309..309
-        2: R_CURLY@309..311 "}" [Newline("\n")] []
-    9: GRAPHQL_BOGUS_DEFINITION@311..326
-      0: GRAPHQL_NAME@311..318 "iput" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      1: GRAPHQL_NAME@318..326 "Point2D" [] [Whitespace(" ")]
-    10: GRAPHQL_SELECTION_SET@326..349
-      0: L_CURLY@326..327 "{" [] []
-      1: GRAPHQL_SELECTION_LIST@327..347
-        0: GRAPHQL_FIELD@327..337
-          0: GRAPHQL_ALIAS@327..332
-            0: GRAPHQL_NAME@327..330
-              0: GRAPHQL_NAME@327..330 "x" [Newline("\n"), Whitespace("\t")] []
-            1: COLON@330..332 ":" [] [Whitespace(" ")]
-          1: GRAPHQL_NAME@332..337
-            0: GRAPHQL_NAME@332..337 "Float" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@255..255
+        2: R_CURLY@255..257 "}" [Newline("\n")] []
+    7: GRAPHQL_BOGUS_DEFINITION@257..272
+      0: GRAPHQL_NAME@257..264 "iput" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@264..272 "Point2D" [] [Whitespace(" ")]
+    8: GRAPHQL_SELECTION_SET@272..295
+      0: L_CURLY@272..273 "{" [] []
+      1: GRAPHQL_SELECTION_LIST@273..293
+        0: GRAPHQL_FIELD@273..283
+          0: GRAPHQL_ALIAS@273..278
+            0: GRAPHQL_NAME@273..276
+              0: GRAPHQL_NAME@273..276 "x" [Newline("\n"), Whitespace("\t")] []
+            1: COLON@276..278 ":" [] [Whitespace(" ")]
+          1: GRAPHQL_NAME@278..283
+            0: GRAPHQL_NAME@278..283 "Float" [] []
           2: (empty)
-          3: GRAPHQL_DIRECTIVE_LIST@337..337
+          3: GRAPHQL_DIRECTIVE_LIST@283..283
           4: (empty)
-        1: GRAPHQL_FIELD@337..347
-          0: GRAPHQL_ALIAS@337..342
-            0: GRAPHQL_NAME@337..340
-              0: GRAPHQL_NAME@337..340 "y" [Newline("\n"), Whitespace("\t")] []
-            1: COLON@340..342 ":" [] [Whitespace(" ")]
-          1: GRAPHQL_NAME@342..347
-            0: GRAPHQL_NAME@342..347 "Float" [] []
+        1: GRAPHQL_FIELD@283..293
+          0: GRAPHQL_ALIAS@283..288
+            0: GRAPHQL_NAME@283..286
+              0: GRAPHQL_NAME@283..286 "y" [Newline("\n"), Whitespace("\t")] []
+            1: COLON@286..288 ":" [] [Whitespace(" ")]
+          1: GRAPHQL_NAME@288..293
+            0: GRAPHQL_NAME@288..293 "Float" [] []
           2: (empty)
-          3: GRAPHQL_DIRECTIVE_LIST@347..347
+          3: GRAPHQL_DIRECTIVE_LIST@293..293
           4: (empty)
-      2: R_CURLY@347..349 "}" [Newline("\n")] []
-  2: EOF@349..350 "" [Newline("\n")] []
+      2: R_CURLY@293..295 "}" [Newline("\n")] []
+    9: GRAPHQL_BOGUS_DEFINITION@295..348
+      0: INPUT_KW@295..303 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@303..310
+        0: GRAPHQL_NAME@303..310 "Point2D" [] []
+      2: GRAPHQL_DIRECTIVE_LIST@310..310
+      3: GRAPHQL_BOGUS@310..348
+        0: GRAPHQL_BOGUS@310..348
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@310..321
+            0: (empty)
+            1: GRAPHQL_NAME@310..314
+              0: GRAPHQL_NAME@310..314 "x" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@314..316 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@316..321
+              0: GRAPHQL_NAME@316..321
+                0: GRAPHQL_NAME@316..321 "Float" [] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@321..321
+          1: GRAPHQL_INPUT_VALUE_DEFINITION@321..332
+            0: (empty)
+            1: GRAPHQL_NAME@321..325
+              0: GRAPHQL_NAME@321..325 "y" [Newline("\n"), Whitespace("  ")] []
+            2: COLON@325..327 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@327..332
+              0: GRAPHQL_NAME@327..332
+                0: GRAPHQL_NAME@327..332 "Float" [] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@332..332
+          2: GRAPHQL_BOGUS@332..348
+            0: INPUT_KW@332..340 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+            1: GRAPHQL_NAME@340..348 "Point2D" [] [Whitespace(" ")]
+    10: GRAPHQL_SELECTION_SET@348..349
+      0: L_CURLY@348..349 "{" [] []
+      1: GRAPHQL_SELECTION_LIST@349..349
+      2: (empty)
+  2: EOF@349..351 "" [Newline("\n"), Newline("\n")] []
 
 ```
 
@@ -699,267 +695,287 @@ input_object.graphql:2:3 parse ━━━━━━━━━━━━━━━━�
   
   i Remove x
   
-input_object.graphql:7:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `{` but instead found `x`
-  
-    6 │ input Point2D
-  > 7 │   x: Float
-      │   ^
-    8 │   y: Float
-    9 │ 
-  
-  i Remove x
-  
-input_object.graphql:10:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `}` but instead found `input`
-  
-     8 │   y: Float
-     9 │ 
-  > 10 │ input Point2D {
-       │ ^^^^^
-    11 │ 
-    12 │ input Point2D @deprecated {
-  
-  i Remove input
-  
-input_object.graphql:12:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `}` but instead found `input`
-  
-    10 │ input Point2D {
-    11 │ 
-  > 12 │ input Point2D @deprecated {
-       │ ^^^^^
-    13 │ 	x: Float
-    14 │ }
-  
-  i Remove input
-  
-input_object.graphql:17:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+input_object.graphql:11:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a type but instead found '='.
   
-    16 │ input Point2D {
-  > 17 │   x: = 0
+    10 │ input Point2D {
+  > 11 │   x: = 0
        │      ^
-    18 │   y: @deprecated
-    19 │ }
+    12 │   y: @deprecated
+    13 │ }
   
   i Expected a type here.
   
-    16 │ input Point2D {
-  > 17 │   x: = 0
+    10 │ input Point2D {
+  > 11 │   x: = 0
        │      ^
-    18 │   y: @deprecated
-    19 │ }
+    12 │   y: @deprecated
+    13 │ }
   
-input_object.graphql:18:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+input_object.graphql:12:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a type but instead found '@'.
   
-    16 │ input Point2D {
-    17 │   x: = 0
-  > 18 │   y: @deprecated
+    10 │ input Point2D {
+    11 │   x: = 0
+  > 12 │   y: @deprecated
        │      ^
-    19 │ }
-    20 │ 
+    13 │ }
+    14 │ 
   
   i Expected a type here.
   
-    16 │ input Point2D {
-    17 │   x: = 0
-  > 18 │   y: @deprecated
+    10 │ input Point2D {
+    11 │   x: = 0
+  > 12 │   y: @deprecated
        │      ^
-    19 │ }
-    20 │ 
+    13 │ }
+    14 │ 
   
-input_object.graphql:22:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+input_object.graphql:16:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a name but instead found 'x = 0'.
   
-    21 │ input Point2D {
-  > 22 │   x = 0
+    15 │ input Point2D {
+  > 16 │   x = 0
        │   ^^^^^
-    23 │   y: @deprecated
-    24 │ }
+    17 │   y: @deprecated
+    18 │ }
   
   i Expected a name here.
   
-    21 │ input Point2D {
-  > 22 │   x = 0
+    15 │ input Point2D {
+  > 16 │   x = 0
        │   ^^^^^
-    23 │   y: @deprecated
-    24 │ }
+    17 │   y: @deprecated
+    18 │ }
   
-input_object.graphql:23:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+input_object.graphql:17:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a type but instead found '@'.
   
-    21 │ input Point2D {
-    22 │   x = 0
-  > 23 │   y: @deprecated
+    15 │ input Point2D {
+    16 │   x = 0
+  > 17 │   y: @deprecated
        │      ^
-    24 │ }
-    25 │ 
+    18 │ }
+    19 │ 
   
   i Expected a type here.
   
-    21 │ input Point2D {
-    22 │   x = 0
-  > 23 │   y: @deprecated
+    15 │ input Point2D {
+    16 │   x = 0
+  > 17 │   y: @deprecated
        │      ^
-    24 │ }
-    25 │ 
+    18 │ }
+    19 │ 
   
-input_object.graphql:27:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+input_object.graphql:21:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a name but instead found '= 0'.
   
-    26 │ input Point2D {
-  > 27 │   = 0
+    20 │ input Point2D {
+  > 21 │   = 0
        │   ^^^
-    28 │   : @
-    29 │ }
+    22 │   : @
+    23 │ }
   
   i Expected a name here.
   
-    26 │ input Point2D {
-  > 27 │   = 0
+    20 │ input Point2D {
+  > 21 │   = 0
        │   ^^^
-    28 │   : @
-    29 │ }
+    22 │   : @
+    23 │ }
   
-input_object.graphql:28:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+input_object.graphql:22:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a name but instead found ':'.
   
-    26 │ input Point2D {
-    27 │   = 0
-  > 28 │   : @
+    20 │ input Point2D {
+    21 │   = 0
+  > 22 │   : @
        │   ^
-    29 │ }
-    30 │ 
+    23 │ }
+    24 │ 
   
   i Expected a name here.
   
-    26 │ input Point2D {
-    27 │   = 0
-  > 28 │   : @
+    20 │ input Point2D {
+    21 │   = 0
+  > 22 │   : @
        │   ^
-    29 │ }
-    30 │ 
+    23 │ }
+    24 │ 
   
-input_object.graphql:28:5 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+input_object.graphql:22:5 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a type but instead found '@'.
   
-    26 │ input Point2D {
-    27 │   = 0
-  > 28 │   : @
+    20 │ input Point2D {
+    21 │   = 0
+  > 22 │   : @
        │     ^
-    29 │ }
-    30 │ 
+    23 │ }
+    24 │ 
   
   i Expected a type here.
   
-    26 │ input Point2D {
-    27 │   = 0
-  > 28 │   : @
+    20 │ input Point2D {
+    21 │   = 0
+  > 22 │   : @
        │     ^
-    29 │ }
-    30 │ 
+    23 │ }
+    24 │ 
   
-input_object.graphql:29:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+input_object.graphql:23:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a name but instead found '}'.
   
-    27 │   = 0
-    28 │   : @
-  > 29 │ }
+    21 │   = 0
+    22 │   : @
+  > 23 │ }
        │ ^
-    30 │ 
-    31 │ input Point2D {
+    24 │ 
+    25 │ input Point2D {
   
   i Expected a name here.
   
-    27 │   = 0
-    28 │   : @
-  > 29 │ }
+    21 │   = 0
+    22 │   : @
+  > 23 │ }
        │ ^
-    30 │ 
-    31 │ input Point2D {
+    24 │ 
+    25 │ input Point2D {
   
-input_object.graphql:33:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+input_object.graphql:27:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `:` but instead found `y`
   
-    31 │ input Point2D {
-    32 │   x
-  > 33 │   y
+    25 │ input Point2D {
+    26 │   x
+  > 27 │   y
        │   ^
-    34 │ }
-    35 │ 
+    28 │ }
+    29 │ 
   
   i Remove y
   
-input_object.graphql:37:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+input_object.graphql:31:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a name but instead found '='.
   
-    36 │ input Point2D {
-  > 37 │ 	=
+    30 │ input Point2D {
+  > 31 │ 	=
        │ 	^
-    38 │   : Float
-    39 │ }
+    32 │   : Float
+    33 │ }
   
   i Expected a name here.
   
-    36 │ input Point2D {
-  > 37 │ 	=
+    30 │ input Point2D {
+  > 31 │ 	=
        │ 	^
-    38 │   : Float
-    39 │ }
+    32 │   : Float
+    33 │ }
   
-input_object.graphql:38:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+input_object.graphql:32:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a name but instead found ':'.
   
-    36 │ input Point2D {
-    37 │ 	=
-  > 38 │   : Float
+    30 │ input Point2D {
+    31 │ 	=
+  > 32 │   : Float
        │   ^
-    39 │ }
-    40 │ 
+    33 │ }
+    34 │ 
   
   i Expected a name here.
   
-    36 │ input Point2D {
-    37 │ 	=
-  > 38 │   : Float
+    30 │ input Point2D {
+    31 │ 	=
+  > 32 │   : Float
        │   ^
-    39 │ }
-    40 │ 
+    33 │ }
+    34 │ 
   
-input_object.graphql:41:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+input_object.graphql:35:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a definition but instead found 'iput Point2D'.
   
-    39 │ }
-    40 │ 
-  > 41 │ iput Point2D {
+    33 │ }
+    34 │ 
+  > 35 │ iput Point2D {
        │ ^^^^^^^^^^^^
-    42 │ 	x: Float
-    43 │ 	y: Float
+    36 │ 	x: Float
+    37 │ 	y: Float
   
   i Expected a definition here.
   
-    39 │ }
-    40 │ 
-  > 41 │ iput Point2D {
+    33 │ }
+    34 │ 
+  > 35 │ iput Point2D {
        │ ^^^^^^^^^^^^
-    42 │ 	x: Float
-    43 │ 	y: Float
+    36 │ 	x: Float
+    37 │ 	y: Float
+  
+input_object.graphql:41:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `{` but instead found `x`
+  
+    40 │ input Point2D
+  > 41 │   x: Float
+       │   ^
+    42 │   y: Float
+    43 │ 
+  
+  i Remove x
+  
+input_object.graphql:44:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a name but instead found 'input Point2D'.
+  
+    42 │   y: Float
+    43 │ 
+  > 44 │ input Point2D {
+       │ ^^^^^^^^^^^^^
+    45 │ 
+  
+  i Expected a name here.
+  
+    42 │   y: Float
+    43 │ 
+  > 44 │ input Point2D {
+       │ ^^^^^^^^^^^^^
+    45 │ 
+  
+input_object.graphql:44:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `}` but instead found `{`
+  
+    42 │   y: Float
+    43 │ 
+  > 44 │ input Point2D {
+       │               ^
+    45 │ 
+  
+  i Remove {
+  
+input_object.graphql:46:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `}` but instead the file ends
+  
+    44 │ input Point2D {
+    45 │ 
+  > 46 │ 
+       │ 
+  
+  i the file ends here
+  
+    44 │ input Point2D {
+    45 │ 
+  > 46 │ 
+       │ 
   
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/interface.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/interface.graphql.snap
@@ -105,88 +105,81 @@ GraphqlRoot {
                 r_curly_token: R_CURLY@31..33 "}" [Newline("\n")] [],
             },
         },
-        GraphqlInterfaceTypeDefinition {
-            description: missing (optional),
-            interface_token: INTERFACE_KW@33..45 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@45..52 "Person" [] [Whitespace(" ")],
-            },
-            implements: missing (optional),
-            directives: GraphqlDirectiveList [],
-            fields: GraphqlFieldsDefinition {
-                l_curly_token: L_CURLY@52..53 "{" [] [],
-                fields: GraphqlFieldDefinitionList [
-                    GraphqlFieldDefinition {
-                        description: missing (optional),
-                        name: GraphqlName {
-                            value_token: GRAPHQL_NAME@53..60 "name" [Newline("\n"), Whitespace("  ")] [],
+        GraphqlBogusDefinition {
+            items: [
+                INTERFACE_KW@33..45 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                GraphqlName {
+                    value_token: GRAPHQL_NAME@45..52 "Person" [] [Whitespace(" ")],
+                },
+                GraphqlDirectiveList [],
+                GraphqlBogus {
+                    items: [
+                        L_CURLY@52..53 "{" [] [],
+                        GraphqlBogus {
+                            items: [
+                                GraphqlFieldDefinition {
+                                    description: missing (optional),
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@53..60 "name" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    arguments: missing (optional),
+                                    colon_token: COLON@60..62 ":" [] [Whitespace(" ")],
+                                    ty: GraphqlNamedType {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@62..68 "String" [] [],
+                                        },
+                                    },
+                                    directives: GraphqlDirectiveList [],
+                                },
+                                GraphqlBogus {
+                                    items: [
+                                        INTERFACE_KW@68..80 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                                        GRAPHQL_NAME@80..86 "Person" [] [],
+                                    ],
+                                },
+                                GraphqlFieldDefinition {
+                                    description: missing (optional),
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@86..93 "name" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    arguments: missing (optional),
+                                    colon_token: COLON@93..95 ":" [] [Whitespace(" ")],
+                                    ty: GraphqlNamedType {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@95..101 "String" [] [],
+                                        },
+                                    },
+                                    directives: GraphqlDirectiveList [],
+                                },
+                                GraphqlBogus {
+                                    items: [
+                                        INTERFACE_KW@101..113 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                                        GRAPHQL_NAME@113..120 "Person" [] [Whitespace(" ")],
+                                    ],
+                                },
+                            ],
                         },
-                        arguments: missing (optional),
-                        colon_token: COLON@60..62 ":" [] [Whitespace(" ")],
-                        ty: GraphqlNamedType {
-                            name: GraphqlName {
-                                value_token: GRAPHQL_NAME@62..68 "String" [] [],
-                            },
-                        },
-                        directives: GraphqlDirectiveList [],
-                    },
-                ],
-                r_curly_token: missing (required),
-            },
+                    ],
+                },
+            ],
         },
-        GraphqlInterfaceTypeDefinition {
-            description: missing (optional),
-            interface_token: INTERFACE_KW@68..80 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@80..86 "Person" [] [],
-            },
-            implements: missing (optional),
-            directives: GraphqlDirectiveList [],
-            fields: GraphqlFieldsDefinition {
-                l_curly_token: missing (required),
-                fields: GraphqlFieldDefinitionList [
-                    GraphqlFieldDefinition {
-                        description: missing (optional),
-                        name: GraphqlName {
-                            value_token: GRAPHQL_NAME@86..93 "name" [Newline("\n"), Whitespace("  ")] [],
-                        },
-                        arguments: missing (optional),
-                        colon_token: COLON@93..95 ":" [] [Whitespace(" ")],
-                        ty: GraphqlNamedType {
-                            name: GraphqlName {
-                                value_token: GRAPHQL_NAME@95..101 "String" [] [],
-                            },
-                        },
-                        directives: GraphqlDirectiveList [],
-                    },
-                ],
-                r_curly_token: missing (required),
-            },
-        },
-        GraphqlInterfaceTypeDefinition {
-            description: missing (optional),
-            interface_token: INTERFACE_KW@101..113 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@113..120 "Person" [] [Whitespace(" ")],
-            },
-            implements: missing (optional),
-            directives: GraphqlDirectiveList [],
-            fields: GraphqlFieldsDefinition {
-                l_curly_token: L_CURLY@120..121 "{" [] [],
-                fields: GraphqlFieldDefinitionList [
-                    GraphqlFieldDefinition {
-                        description: missing (optional),
-                        name: GraphqlName {
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@120..121 "{" [] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: GraphqlAlias {
+                        value: GraphqlName {
                             value_token: GRAPHQL_NAME@121..128 "name" [Newline("\n"), Whitespace("  ")] [],
                         },
-                        arguments: missing (optional),
                         colon_token: COLON@128..129 ":" [] [],
-                        ty: missing (required),
-                        directives: GraphqlDirectiveList [],
                     },
-                ],
-                r_curly_token: R_CURLY@129..131 "}" [Newline("\n")] [],
-            },
+                    name: missing (required),
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@129..131 "}" [Newline("\n")] [],
         },
         GraphqlInterfaceTypeDefinition {
             description: missing (optional),
@@ -435,40 +428,37 @@ GraphqlRoot {
             },
             implements: GraphqlImplementsInterfaces {
                 implements_token: IMPLEMENTS_KW@480..491 "implements" [] [Whitespace(" ")],
-                amp_token: AMP@491..492 "&" [] [],
-                interfaces: GraphqlImplementsInterfaceList [],
+                amp_token: missing (optional),
+                interfaces: GraphqlImplementsInterfaceList [
+                    missing element,
+                    AMP@491..492 "&" [] [],
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@492..504 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                        },
+                    },
+                    missing separator,
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@504..511 "Person" [] [Whitespace(" ")],
+                        },
+                    },
+                ],
             },
-            directives: GraphqlDirectiveList [],
-            fields: missing (optional),
-        },
-        GraphqlInterfaceTypeDefinition {
-            description: missing (optional),
-            interface_token: INTERFACE_KW@492..504 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@504..511 "Person" [] [Whitespace(" ")],
-            },
-            implements: missing (optional),
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
                     at_token: AT@511..512 "@" [] [],
-                    name: missing (required),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@512..524 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                    },
                     arguments: missing (optional),
                 },
             ],
             fields: missing (optional),
         },
-        GraphqlInterfaceTypeDefinition {
-            description: missing (optional),
-            interface_token: INTERFACE_KW@512..524 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@524..531 "Person" [] [Whitespace(" ")],
-            },
-            implements: missing (optional),
-            directives: GraphqlDirectiveList [],
-            fields: missing (optional),
-        },
         GraphqlBogusDefinition {
             items: [
+                GRAPHQL_NAME@524..531 "Person" [] [Whitespace(" ")],
                 GRAPHQL_NAME@531..540 "implents" [] [Whitespace(" ")],
                 GRAPHQL_NAME@540..550 "Character" [] [Whitespace(" ")],
                 AT@550..551 "@" [] [],
@@ -753,16 +743,14 @@ GraphqlRoot {
                 0: GRAPHQL_NAME@25..31 "String" [] []
             5: GRAPHQL_DIRECTIVE_LIST@31..31
         2: R_CURLY@31..33 "}" [Newline("\n")] []
-    1: GRAPHQL_INTERFACE_TYPE_DEFINITION@33..68
-      0: (empty)
-      1: INTERFACE_KW@33..45 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@45..52
+    1: GRAPHQL_BOGUS_DEFINITION@33..120
+      0: INTERFACE_KW@33..45 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@45..52
         0: GRAPHQL_NAME@45..52 "Person" [] [Whitespace(" ")]
-      3: (empty)
-      4: GRAPHQL_DIRECTIVE_LIST@52..52
-      5: GRAPHQL_FIELDS_DEFINITION@52..68
+      2: GRAPHQL_DIRECTIVE_LIST@52..52
+      3: GRAPHQL_BOGUS@52..120
         0: L_CURLY@52..53 "{" [] []
-        1: GRAPHQL_FIELD_DEFINITION_LIST@53..68
+        1: GRAPHQL_BOGUS@53..120
           0: GRAPHQL_FIELD_DEFINITION@53..68
             0: (empty)
             1: GRAPHQL_NAME@53..60
@@ -773,18 +761,10 @@ GraphqlRoot {
               0: GRAPHQL_NAME@62..68
                 0: GRAPHQL_NAME@62..68 "String" [] []
             5: GRAPHQL_DIRECTIVE_LIST@68..68
-        2: (empty)
-    2: GRAPHQL_INTERFACE_TYPE_DEFINITION@68..101
-      0: (empty)
-      1: INTERFACE_KW@68..80 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@80..86
-        0: GRAPHQL_NAME@80..86 "Person" [] []
-      3: (empty)
-      4: GRAPHQL_DIRECTIVE_LIST@86..86
-      5: GRAPHQL_FIELDS_DEFINITION@86..101
-        0: (empty)
-        1: GRAPHQL_FIELD_DEFINITION_LIST@86..101
-          0: GRAPHQL_FIELD_DEFINITION@86..101
+          1: GRAPHQL_BOGUS@68..86
+            0: INTERFACE_KW@68..80 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+            1: GRAPHQL_NAME@80..86 "Person" [] []
+          2: GRAPHQL_FIELD_DEFINITION@86..101
             0: (empty)
             1: GRAPHQL_NAME@86..93
               0: GRAPHQL_NAME@86..93 "name" [Newline("\n"), Whitespace("  ")] []
@@ -794,27 +774,23 @@ GraphqlRoot {
               0: GRAPHQL_NAME@95..101
                 0: GRAPHQL_NAME@95..101 "String" [] []
             5: GRAPHQL_DIRECTIVE_LIST@101..101
-        2: (empty)
-    3: GRAPHQL_INTERFACE_TYPE_DEFINITION@101..131
-      0: (empty)
-      1: INTERFACE_KW@101..113 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@113..120
-        0: GRAPHQL_NAME@113..120 "Person" [] [Whitespace(" ")]
-      3: (empty)
-      4: GRAPHQL_DIRECTIVE_LIST@120..120
-      5: GRAPHQL_FIELDS_DEFINITION@120..131
-        0: L_CURLY@120..121 "{" [] []
-        1: GRAPHQL_FIELD_DEFINITION_LIST@121..129
-          0: GRAPHQL_FIELD_DEFINITION@121..129
-            0: (empty)
-            1: GRAPHQL_NAME@121..128
+          3: GRAPHQL_BOGUS@101..120
+            0: INTERFACE_KW@101..113 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+            1: GRAPHQL_NAME@113..120 "Person" [] [Whitespace(" ")]
+    2: GRAPHQL_SELECTION_SET@120..131
+      0: L_CURLY@120..121 "{" [] []
+      1: GRAPHQL_SELECTION_LIST@121..129
+        0: GRAPHQL_FIELD@121..129
+          0: GRAPHQL_ALIAS@121..129
+            0: GRAPHQL_NAME@121..128
               0: GRAPHQL_NAME@121..128 "name" [Newline("\n"), Whitespace("  ")] []
-            2: (empty)
-            3: COLON@128..129 ":" [] []
-            4: (empty)
-            5: GRAPHQL_DIRECTIVE_LIST@129..129
-        2: R_CURLY@129..131 "}" [Newline("\n")] []
-    4: GRAPHQL_INTERFACE_TYPE_DEFINITION@131..164
+            1: COLON@128..129 ":" [] []
+          1: (empty)
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@129..129
+          4: (empty)
+      2: R_CURLY@129..131 "}" [Newline("\n")] []
+    3: GRAPHQL_INTERFACE_TYPE_DEFINITION@131..164
       0: (empty)
       1: INTERFACE_KW@131..143 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@143..150
@@ -834,7 +810,7 @@ GraphqlRoot {
                 0: GRAPHQL_NAME@156..162 "String" [] []
             5: GRAPHQL_DIRECTIVE_LIST@162..162
         2: R_CURLY@162..164 "}" [Newline("\n")] []
-    5: GRAPHQL_INTERFACE_TYPE_DEFINITION@164..190
+    4: GRAPHQL_INTERFACE_TYPE_DEFINITION@164..190
       0: (empty)
       1: INTERFACE_KW@164..176 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@176..183
@@ -852,7 +828,7 @@ GraphqlRoot {
             4: (empty)
             5: GRAPHQL_DIRECTIVE_LIST@188..188
         2: R_CURLY@188..190 "}" [Newline("\n")] []
-    6: GRAPHQL_BOGUS_DEFINITION@190..226
+    5: GRAPHQL_BOGUS_DEFINITION@190..226
       0: INTERFACE_KW@190..202 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: GRAPHQL_NAME@202..209
         0: GRAPHQL_NAME@202..209 "Person" [] [Whitespace(" ")]
@@ -864,7 +840,7 @@ GraphqlRoot {
             0: GRAPHQL_NAME@210..218 "name" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
             1: GRAPHQL_NAME@218..224 "String" [] []
         2: R_CURLY@224..226 "}" [Newline("\n")] []
-    7: GRAPHQL_INTERFACE_TYPE_DEFINITION@226..245
+    6: GRAPHQL_INTERFACE_TYPE_DEFINITION@226..245
       0: (empty)
       1: INTERFACE_KW@226..238 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@238..245
@@ -872,9 +848,9 @@ GraphqlRoot {
       3: (empty)
       4: GRAPHQL_DIRECTIVE_LIST@245..245
       5: (empty)
-    8: GRAPHQL_BOGUS_DEFINITION@245..256
+    7: GRAPHQL_BOGUS_DEFINITION@245..256
       0: GRAPHQL_NAME@245..256 "deprecated" [] [Whitespace(" ")]
-    9: GRAPHQL_SELECTION_SET@256..274
+    8: GRAPHQL_SELECTION_SET@256..274
       0: L_CURLY@256..257 "{" [] []
       1: GRAPHQL_SELECTION_LIST@257..272
         0: GRAPHQL_FIELD@257..272
@@ -888,7 +864,7 @@ GraphqlRoot {
           3: GRAPHQL_DIRECTIVE_LIST@272..272
           4: (empty)
       2: R_CURLY@272..274 "}" [Newline("\n")] []
-    10: GRAPHQL_INTERFACE_TYPE_DEFINITION@274..313
+    9: GRAPHQL_INTERFACE_TYPE_DEFINITION@274..313
       0: (empty)
       1: INTERFACE_KW@274..286 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@286..293
@@ -913,7 +889,7 @@ GraphqlRoot {
                 0: GRAPHQL_NAME@305..311 "String" [] []
             5: GRAPHQL_DIRECTIVE_LIST@311..311
         2: R_CURLY@311..313 "}" [Newline("\n")] []
-    11: GRAPHQL_INTERFACE_TYPE_DEFINITION@313..350
+    10: GRAPHQL_INTERFACE_TYPE_DEFINITION@313..350
       0: (empty)
       1: INTERFACE_KW@313..325 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@325..332
@@ -938,7 +914,7 @@ GraphqlRoot {
                 0: GRAPHQL_NAME@342..348 "String" [] []
             5: GRAPHQL_DIRECTIVE_LIST@348..348
         2: R_CURLY@348..350 "}" [Newline("\n")] []
-    12: GRAPHQL_INTERFACE_TYPE_DEFINITION@350..369
+    11: GRAPHQL_INTERFACE_TYPE_DEFINITION@350..369
       0: (empty)
       1: INTERFACE_KW@350..362 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@362..369
@@ -946,11 +922,11 @@ GraphqlRoot {
       3: (empty)
       4: GRAPHQL_DIRECTIVE_LIST@369..369
       5: (empty)
-    13: GRAPHQL_BOGUS_DEFINITION@369..391
+    12: GRAPHQL_BOGUS_DEFINITION@369..391
       0: GRAPHQL_NAME@369..379 "implement" [] [Whitespace(" ")]
       1: GRAPHQL_NAME@379..389 "Character" [] [Whitespace(" ")]
       2: AT@389..391 "@" [] [Whitespace(" ")]
-    14: GRAPHQL_SELECTION_SET@391..409
+    13: GRAPHQL_SELECTION_SET@391..409
       0: L_CURLY@391..392 "{" [] []
       1: GRAPHQL_SELECTION_LIST@392..407
         0: GRAPHQL_FIELD@392..407
@@ -964,10 +940,10 @@ GraphqlRoot {
           3: GRAPHQL_DIRECTIVE_LIST@407..407
           4: (empty)
       2: R_CURLY@407..409 "}" [Newline("\n")] []
-    15: GRAPHQL_BOGUS_DEFINITION@409..423
+    14: GRAPHQL_BOGUS_DEFINITION@409..423
       0: GRAPHQL_NAME@409..417 "inter" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: GRAPHQL_NAME@417..423 "Person" [] []
-    16: GRAPHQL_INTERFACE_TYPE_DEFINITION@423..442
+    15: GRAPHQL_INTERFACE_TYPE_DEFINITION@423..442
       0: (empty)
       1: INTERFACE_KW@423..435 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@435..442
@@ -975,45 +951,40 @@ GraphqlRoot {
       3: (empty)
       4: GRAPHQL_DIRECTIVE_LIST@442..442
       5: (empty)
-    17: GRAPHQL_BOGUS_DEFINITION@442..461
+    16: GRAPHQL_BOGUS_DEFINITION@442..461
       0: GRAPHQL_NAME@442..452 "implemets" [] [Whitespace(" ")]
       1: GRAPHQL_NAME@452..461 "Character" [] []
-    18: GRAPHQL_INTERFACE_TYPE_DEFINITION@461..492
+    17: GRAPHQL_INTERFACE_TYPE_DEFINITION@461..524
       0: (empty)
       1: INTERFACE_KW@461..473 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@473..480
         0: GRAPHQL_NAME@473..480 "Person" [] [Whitespace(" ")]
-      3: GRAPHQL_IMPLEMENTS_INTERFACES@480..492
+      3: GRAPHQL_IMPLEMENTS_INTERFACES@480..511
         0: IMPLEMENTS_KW@480..491 "implements" [] [Whitespace(" ")]
-        1: AMP@491..492 "&" [] []
-        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@492..492
-      4: GRAPHQL_DIRECTIVE_LIST@492..492
-      5: (empty)
-    19: GRAPHQL_INTERFACE_TYPE_DEFINITION@492..512
-      0: (empty)
-      1: INTERFACE_KW@492..504 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@504..511
-        0: GRAPHQL_NAME@504..511 "Person" [] [Whitespace(" ")]
-      3: (empty)
-      4: GRAPHQL_DIRECTIVE_LIST@511..512
-        0: GRAPHQL_DIRECTIVE@511..512
+        1: (empty)
+        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@491..511
+          0: (empty)
+          1: AMP@491..492 "&" [] []
+          2: GRAPHQL_NAMED_TYPE@492..504
+            0: GRAPHQL_NAME@492..504
+              0: GRAPHQL_NAME@492..504 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+          3: (empty)
+          4: GRAPHQL_NAMED_TYPE@504..511
+            0: GRAPHQL_NAME@504..511
+              0: GRAPHQL_NAME@504..511 "Person" [] [Whitespace(" ")]
+      4: GRAPHQL_DIRECTIVE_LIST@511..524
+        0: GRAPHQL_DIRECTIVE@511..524
           0: AT@511..512 "@" [] []
-          1: (empty)
+          1: GRAPHQL_NAME@512..524
+            0: GRAPHQL_NAME@512..524 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
           2: (empty)
       5: (empty)
-    20: GRAPHQL_INTERFACE_TYPE_DEFINITION@512..531
-      0: (empty)
-      1: INTERFACE_KW@512..524 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@524..531
-        0: GRAPHQL_NAME@524..531 "Person" [] [Whitespace(" ")]
-      3: (empty)
-      4: GRAPHQL_DIRECTIVE_LIST@531..531
-      5: (empty)
-    21: GRAPHQL_BOGUS_DEFINITION@531..551
-      0: GRAPHQL_NAME@531..540 "implents" [] [Whitespace(" ")]
-      1: GRAPHQL_NAME@540..550 "Character" [] [Whitespace(" ")]
-      2: AT@550..551 "@" [] []
-    22: GRAPHQL_INTERFACE_TYPE_DEFINITION@551..617
+    18: GRAPHQL_BOGUS_DEFINITION@524..551
+      0: GRAPHQL_NAME@524..531 "Person" [] [Whitespace(" ")]
+      1: GRAPHQL_NAME@531..540 "implents" [] [Whitespace(" ")]
+      2: GRAPHQL_NAME@540..550 "Character" [] [Whitespace(" ")]
+      3: AT@550..551 "@" [] []
+    19: GRAPHQL_INTERFACE_TYPE_DEFINITION@551..617
       0: (empty)
       1: INTERFACE_KW@551..563 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@563..570
@@ -1038,7 +1009,7 @@ GraphqlRoot {
             0: GRAPHQL_NAME@607..617 "deprecated" [] []
           2: (empty)
       5: (empty)
-    23: GRAPHQL_BOGUS_DEFINITION@617..891
+    20: GRAPHQL_BOGUS_DEFINITION@617..891
       0: INTERFACE_KW@617..629 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: GRAPHQL_NAME@629..636
         0: GRAPHQL_NAME@629..636 "Person" [] [Whitespace(" ")]
@@ -1199,45 +1170,60 @@ interface.graphql:2:3 parse ━━━━━━━━━━━━━━━━━�
   
 interface.graphql:8:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × expected `}` but instead found `interface`
+  × Expected a field definition but instead found 'interface Person'.
   
      6 │   name: String
      7 │ 
    > 8 │ interface Person
-       │ ^^^^^^^^^
+       │ ^^^^^^^^^^^^^^^^
      9 │   name: String
     10 │ 
   
-  i Remove interface
+  i Expected a field definition here.
   
-interface.graphql:9:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `{` but instead found `name`
-  
-     8 │ interface Person
-   > 9 │   name: String
-       │   ^^^^
+     6 │   name: String
+     7 │ 
+   > 8 │ interface Person
+       │ ^^^^^^^^^^^^^^^^
+     9 │   name: String
     10 │ 
-    11 │ interface Person {
-  
-  i Remove name
   
 interface.graphql:11:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × expected `}` but instead found `interface`
+  × Expected a field definition but instead found 'interface Person'.
   
      9 │   name: String
     10 │ 
   > 11 │ interface Person {
-       │ ^^^^^^^^^
+       │ ^^^^^^^^^^^^^^^^
     12 │   name:
     13 │ }
   
-  i Remove interface
+  i Expected a field definition here.
+  
+     9 │   name: String
+    10 │ 
+  > 11 │ interface Person {
+       │ ^^^^^^^^^^^^^^^^
+    12 │   name:
+    13 │ }
+  
+interface.graphql:11:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `}` but instead found `{`
+  
+     9 │   name: String
+    10 │ 
+  > 11 │ interface Person {
+       │                  ^
+    12 │   name:
+    13 │ }
+  
+  i Remove {
   
 interface.graphql:13:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a type but instead found '}'.
+  × Expected a name but instead found '}'.
   
     11 │ interface Person {
     12 │   name:
@@ -1246,7 +1232,7 @@ interface.graphql:13:1 parse ━━━━━━━━━━━━━━━━━
     14 │ 
     15 │ interface Person {
   
-  i Expected a type here.
+  i Expected a name here.
   
     11 │ interface Person {
     12 │   name:
@@ -1441,54 +1427,27 @@ interface.graphql:45:18 parse ━━━━━━━━━━━━━━━━�
     46 │ 
     47 │ interface Person implements &
   
-interface.graphql:49:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+interface.graphql:49:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a named type but instead found 'interface'.
+  × expected `&` but instead found `Person`
   
     47 │ interface Person implements &
     48 │ 
   > 49 │ interface Person @
-       │ ^^^^^^^^^
+       │           ^^^^^^
     50 │ 
     51 │ interface Person implents Character @
   
-  i Expected a named type here.
+  i Remove Person
   
-    47 │ interface Person implements &
-    48 │ 
-  > 49 │ interface Person @
-       │ ^^^^^^^^^
-    50 │ 
-    51 │ interface Person implents Character @
-  
-interface.graphql:51:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+interface.graphql:51:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a name but instead found 'interface'.
+  × Expected a definition but instead found 'Person implents Character @'.
   
     49 │ interface Person @
     50 │ 
   > 51 │ interface Person implents Character @
-       │ ^^^^^^^^^
-    52 │ 
-    53 │ interface Person implements Character & Character1 & @deprecated
-  
-  i Expected a name here.
-  
-    49 │ interface Person @
-    50 │ 
-  > 51 │ interface Person implents Character @
-       │ ^^^^^^^^^
-    52 │ 
-    53 │ interface Person implements Character & Character1 & @deprecated
-  
-interface.graphql:51:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected a definition but instead found 'implents Character @'.
-  
-    49 │ interface Person @
-    50 │ 
-  > 51 │ interface Person implents Character @
-       │                  ^^^^^^^^^^^^^^^^^^^^
+       │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     52 │ 
     53 │ interface Person implements Character & Character1 & @deprecated
   
@@ -1497,7 +1456,7 @@ interface.graphql:51:18 parse ━━━━━━━━━━━━━━━━�
     49 │ interface Person @
     50 │ 
   > 51 │ interface Person implents Character @
-       │                  ^^^^^^^^^^^^^^^^^^^^
+       │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     52 │ 
     53 │ interface Person implements Character & Character1 & @deprecated
   

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/object.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/object.graphql.snap
@@ -105,88 +105,81 @@ GraphqlRoot {
                 r_curly_token: R_CURLY@26..28 "}" [Newline("\n")] [],
             },
         },
-        GraphqlObjectTypeDefinition {
-            description: missing (optional),
-            type_token: TYPE_KW@28..35 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@35..42 "Person" [] [Whitespace(" ")],
-            },
-            implements: missing (optional),
-            directives: GraphqlDirectiveList [],
-            fields: GraphqlFieldsDefinition {
-                l_curly_token: L_CURLY@42..43 "{" [] [],
-                fields: GraphqlFieldDefinitionList [
-                    GraphqlFieldDefinition {
-                        description: missing (optional),
-                        name: GraphqlName {
-                            value_token: GRAPHQL_NAME@43..50 "name" [Newline("\n"), Whitespace("  ")] [],
+        GraphqlBogusDefinition {
+            items: [
+                TYPE_KW@28..35 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                GraphqlName {
+                    value_token: GRAPHQL_NAME@35..42 "Person" [] [Whitespace(" ")],
+                },
+                GraphqlDirectiveList [],
+                GraphqlBogus {
+                    items: [
+                        L_CURLY@42..43 "{" [] [],
+                        GraphqlBogus {
+                            items: [
+                                GraphqlFieldDefinition {
+                                    description: missing (optional),
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@43..50 "name" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    arguments: missing (optional),
+                                    colon_token: COLON@50..52 ":" [] [Whitespace(" ")],
+                                    ty: GraphqlNamedType {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@52..58 "String" [] [],
+                                        },
+                                    },
+                                    directives: GraphqlDirectiveList [],
+                                },
+                                GraphqlBogus {
+                                    items: [
+                                        TYPE_KW@58..65 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                                        GRAPHQL_NAME@65..71 "Person" [] [],
+                                    ],
+                                },
+                                GraphqlFieldDefinition {
+                                    description: missing (optional),
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@71..78 "name" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    arguments: missing (optional),
+                                    colon_token: COLON@78..80 ":" [] [Whitespace(" ")],
+                                    ty: GraphqlNamedType {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@80..86 "String" [] [],
+                                        },
+                                    },
+                                    directives: GraphqlDirectiveList [],
+                                },
+                                GraphqlBogus {
+                                    items: [
+                                        TYPE_KW@86..93 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                                        GRAPHQL_NAME@93..100 "Person" [] [Whitespace(" ")],
+                                    ],
+                                },
+                            ],
                         },
-                        arguments: missing (optional),
-                        colon_token: COLON@50..52 ":" [] [Whitespace(" ")],
-                        ty: GraphqlNamedType {
-                            name: GraphqlName {
-                                value_token: GRAPHQL_NAME@52..58 "String" [] [],
-                            },
-                        },
-                        directives: GraphqlDirectiveList [],
-                    },
-                ],
-                r_curly_token: missing (required),
-            },
+                    ],
+                },
+            ],
         },
-        GraphqlObjectTypeDefinition {
-            description: missing (optional),
-            type_token: TYPE_KW@58..65 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@65..71 "Person" [] [],
-            },
-            implements: missing (optional),
-            directives: GraphqlDirectiveList [],
-            fields: GraphqlFieldsDefinition {
-                l_curly_token: missing (required),
-                fields: GraphqlFieldDefinitionList [
-                    GraphqlFieldDefinition {
-                        description: missing (optional),
-                        name: GraphqlName {
-                            value_token: GRAPHQL_NAME@71..78 "name" [Newline("\n"), Whitespace("  ")] [],
-                        },
-                        arguments: missing (optional),
-                        colon_token: COLON@78..80 ":" [] [Whitespace(" ")],
-                        ty: GraphqlNamedType {
-                            name: GraphqlName {
-                                value_token: GRAPHQL_NAME@80..86 "String" [] [],
-                            },
-                        },
-                        directives: GraphqlDirectiveList [],
-                    },
-                ],
-                r_curly_token: missing (required),
-            },
-        },
-        GraphqlObjectTypeDefinition {
-            description: missing (optional),
-            type_token: TYPE_KW@86..93 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@93..100 "Person" [] [Whitespace(" ")],
-            },
-            implements: missing (optional),
-            directives: GraphqlDirectiveList [],
-            fields: GraphqlFieldsDefinition {
-                l_curly_token: L_CURLY@100..101 "{" [] [],
-                fields: GraphqlFieldDefinitionList [
-                    GraphqlFieldDefinition {
-                        description: missing (optional),
-                        name: GraphqlName {
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@100..101 "{" [] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: GraphqlAlias {
+                        value: GraphqlName {
                             value_token: GRAPHQL_NAME@101..108 "name" [Newline("\n"), Whitespace("  ")] [],
                         },
-                        arguments: missing (optional),
                         colon_token: COLON@108..109 ":" [] [],
-                        ty: missing (required),
-                        directives: GraphqlDirectiveList [],
                     },
-                ],
-                r_curly_token: R_CURLY@109..111 "}" [Newline("\n")] [],
-            },
+                    name: missing (required),
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@109..111 "}" [Newline("\n")] [],
         },
         GraphqlObjectTypeDefinition {
             description: missing (optional),
@@ -435,40 +428,37 @@ GraphqlRoot {
             },
             implements: GraphqlImplementsInterfaces {
                 implements_token: IMPLEMENTS_KW@413..424 "implements" [] [Whitespace(" ")],
-                amp_token: AMP@424..425 "&" [] [],
-                interfaces: GraphqlImplementsInterfaceList [],
+                amp_token: missing (optional),
+                interfaces: GraphqlImplementsInterfaceList [
+                    missing element,
+                    AMP@424..425 "&" [] [],
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@425..432 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                        },
+                    },
+                    missing separator,
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@432..439 "Person" [] [Whitespace(" ")],
+                        },
+                    },
+                ],
             },
-            directives: GraphqlDirectiveList [],
-            fields: missing (optional),
-        },
-        GraphqlObjectTypeDefinition {
-            description: missing (optional),
-            type_token: TYPE_KW@425..432 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@432..439 "Person" [] [Whitespace(" ")],
-            },
-            implements: missing (optional),
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
                     at_token: AT@439..440 "@" [] [],
-                    name: missing (required),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@440..447 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                    },
                     arguments: missing (optional),
                 },
             ],
             fields: missing (optional),
         },
-        GraphqlObjectTypeDefinition {
-            description: missing (optional),
-            type_token: TYPE_KW@440..447 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@447..454 "Person" [] [Whitespace(" ")],
-            },
-            implements: missing (optional),
-            directives: GraphqlDirectiveList [],
-            fields: missing (optional),
-        },
         GraphqlBogusDefinition {
             items: [
+                GRAPHQL_NAME@447..454 "Person" [] [Whitespace(" ")],
                 GRAPHQL_NAME@454..463 "implents" [] [Whitespace(" ")],
                 GRAPHQL_NAME@463..473 "Character" [] [Whitespace(" ")],
                 AT@473..474 "@" [] [],
@@ -753,16 +743,14 @@ GraphqlRoot {
                 0: GRAPHQL_NAME@20..26 "String" [] []
             5: GRAPHQL_DIRECTIVE_LIST@26..26
         2: R_CURLY@26..28 "}" [Newline("\n")] []
-    1: GRAPHQL_OBJECT_TYPE_DEFINITION@28..58
-      0: (empty)
-      1: TYPE_KW@28..35 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@35..42
+    1: GRAPHQL_BOGUS_DEFINITION@28..100
+      0: TYPE_KW@28..35 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@35..42
         0: GRAPHQL_NAME@35..42 "Person" [] [Whitespace(" ")]
-      3: (empty)
-      4: GRAPHQL_DIRECTIVE_LIST@42..42
-      5: GRAPHQL_FIELDS_DEFINITION@42..58
+      2: GRAPHQL_DIRECTIVE_LIST@42..42
+      3: GRAPHQL_BOGUS@42..100
         0: L_CURLY@42..43 "{" [] []
-        1: GRAPHQL_FIELD_DEFINITION_LIST@43..58
+        1: GRAPHQL_BOGUS@43..100
           0: GRAPHQL_FIELD_DEFINITION@43..58
             0: (empty)
             1: GRAPHQL_NAME@43..50
@@ -773,18 +761,10 @@ GraphqlRoot {
               0: GRAPHQL_NAME@52..58
                 0: GRAPHQL_NAME@52..58 "String" [] []
             5: GRAPHQL_DIRECTIVE_LIST@58..58
-        2: (empty)
-    2: GRAPHQL_OBJECT_TYPE_DEFINITION@58..86
-      0: (empty)
-      1: TYPE_KW@58..65 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@65..71
-        0: GRAPHQL_NAME@65..71 "Person" [] []
-      3: (empty)
-      4: GRAPHQL_DIRECTIVE_LIST@71..71
-      5: GRAPHQL_FIELDS_DEFINITION@71..86
-        0: (empty)
-        1: GRAPHQL_FIELD_DEFINITION_LIST@71..86
-          0: GRAPHQL_FIELD_DEFINITION@71..86
+          1: GRAPHQL_BOGUS@58..71
+            0: TYPE_KW@58..65 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+            1: GRAPHQL_NAME@65..71 "Person" [] []
+          2: GRAPHQL_FIELD_DEFINITION@71..86
             0: (empty)
             1: GRAPHQL_NAME@71..78
               0: GRAPHQL_NAME@71..78 "name" [Newline("\n"), Whitespace("  ")] []
@@ -794,27 +774,23 @@ GraphqlRoot {
               0: GRAPHQL_NAME@80..86
                 0: GRAPHQL_NAME@80..86 "String" [] []
             5: GRAPHQL_DIRECTIVE_LIST@86..86
-        2: (empty)
-    3: GRAPHQL_OBJECT_TYPE_DEFINITION@86..111
-      0: (empty)
-      1: TYPE_KW@86..93 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@93..100
-        0: GRAPHQL_NAME@93..100 "Person" [] [Whitespace(" ")]
-      3: (empty)
-      4: GRAPHQL_DIRECTIVE_LIST@100..100
-      5: GRAPHQL_FIELDS_DEFINITION@100..111
-        0: L_CURLY@100..101 "{" [] []
-        1: GRAPHQL_FIELD_DEFINITION_LIST@101..109
-          0: GRAPHQL_FIELD_DEFINITION@101..109
-            0: (empty)
-            1: GRAPHQL_NAME@101..108
+          3: GRAPHQL_BOGUS@86..100
+            0: TYPE_KW@86..93 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+            1: GRAPHQL_NAME@93..100 "Person" [] [Whitespace(" ")]
+    2: GRAPHQL_SELECTION_SET@100..111
+      0: L_CURLY@100..101 "{" [] []
+      1: GRAPHQL_SELECTION_LIST@101..109
+        0: GRAPHQL_FIELD@101..109
+          0: GRAPHQL_ALIAS@101..109
+            0: GRAPHQL_NAME@101..108
               0: GRAPHQL_NAME@101..108 "name" [Newline("\n"), Whitespace("  ")] []
-            2: (empty)
-            3: COLON@108..109 ":" [] []
-            4: (empty)
-            5: GRAPHQL_DIRECTIVE_LIST@109..109
-        2: R_CURLY@109..111 "}" [Newline("\n")] []
-    4: GRAPHQL_OBJECT_TYPE_DEFINITION@111..139
+            1: COLON@108..109 ":" [] []
+          1: (empty)
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@109..109
+          4: (empty)
+      2: R_CURLY@109..111 "}" [Newline("\n")] []
+    3: GRAPHQL_OBJECT_TYPE_DEFINITION@111..139
       0: (empty)
       1: TYPE_KW@111..118 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@118..125
@@ -834,7 +810,7 @@ GraphqlRoot {
                 0: GRAPHQL_NAME@131..137 "String" [] []
             5: GRAPHQL_DIRECTIVE_LIST@137..137
         2: R_CURLY@137..139 "}" [Newline("\n")] []
-    5: GRAPHQL_OBJECT_TYPE_DEFINITION@139..160
+    4: GRAPHQL_OBJECT_TYPE_DEFINITION@139..160
       0: (empty)
       1: TYPE_KW@139..146 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@146..153
@@ -852,7 +828,7 @@ GraphqlRoot {
             4: (empty)
             5: GRAPHQL_DIRECTIVE_LIST@158..158
         2: R_CURLY@158..160 "}" [Newline("\n")] []
-    6: GRAPHQL_BOGUS_DEFINITION@160..191
+    5: GRAPHQL_BOGUS_DEFINITION@160..191
       0: TYPE_KW@160..167 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: GRAPHQL_NAME@167..174
         0: GRAPHQL_NAME@167..174 "Person" [] [Whitespace(" ")]
@@ -864,7 +840,7 @@ GraphqlRoot {
             0: GRAPHQL_NAME@175..183 "name" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
             1: GRAPHQL_NAME@183..189 "String" [] []
         2: R_CURLY@189..191 "}" [Newline("\n")] []
-    7: GRAPHQL_OBJECT_TYPE_DEFINITION@191..205
+    6: GRAPHQL_OBJECT_TYPE_DEFINITION@191..205
       0: (empty)
       1: TYPE_KW@191..198 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@198..205
@@ -872,9 +848,9 @@ GraphqlRoot {
       3: (empty)
       4: GRAPHQL_DIRECTIVE_LIST@205..205
       5: (empty)
-    8: GRAPHQL_BOGUS_DEFINITION@205..216
+    7: GRAPHQL_BOGUS_DEFINITION@205..216
       0: GRAPHQL_NAME@205..216 "deprecated" [] [Whitespace(" ")]
-    9: GRAPHQL_SELECTION_SET@216..234
+    8: GRAPHQL_SELECTION_SET@216..234
       0: L_CURLY@216..217 "{" [] []
       1: GRAPHQL_SELECTION_LIST@217..232
         0: GRAPHQL_FIELD@217..232
@@ -888,7 +864,7 @@ GraphqlRoot {
           3: GRAPHQL_DIRECTIVE_LIST@232..232
           4: (empty)
       2: R_CURLY@232..234 "}" [Newline("\n")] []
-    10: GRAPHQL_OBJECT_TYPE_DEFINITION@234..268
+    9: GRAPHQL_OBJECT_TYPE_DEFINITION@234..268
       0: (empty)
       1: TYPE_KW@234..241 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@241..248
@@ -913,7 +889,7 @@ GraphqlRoot {
                 0: GRAPHQL_NAME@260..266 "String" [] []
             5: GRAPHQL_DIRECTIVE_LIST@266..266
         2: R_CURLY@266..268 "}" [Newline("\n")] []
-    11: GRAPHQL_OBJECT_TYPE_DEFINITION@268..300
+    10: GRAPHQL_OBJECT_TYPE_DEFINITION@268..300
       0: (empty)
       1: TYPE_KW@268..275 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@275..282
@@ -938,7 +914,7 @@ GraphqlRoot {
                 0: GRAPHQL_NAME@292..298 "String" [] []
             5: GRAPHQL_DIRECTIVE_LIST@298..298
         2: R_CURLY@298..300 "}" [Newline("\n")] []
-    12: GRAPHQL_OBJECT_TYPE_DEFINITION@300..314
+    11: GRAPHQL_OBJECT_TYPE_DEFINITION@300..314
       0: (empty)
       1: TYPE_KW@300..307 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@307..314
@@ -946,11 +922,11 @@ GraphqlRoot {
       3: (empty)
       4: GRAPHQL_DIRECTIVE_LIST@314..314
       5: (empty)
-    13: GRAPHQL_BOGUS_DEFINITION@314..336
+    12: GRAPHQL_BOGUS_DEFINITION@314..336
       0: GRAPHQL_NAME@314..324 "implement" [] [Whitespace(" ")]
       1: GRAPHQL_NAME@324..334 "Character" [] [Whitespace(" ")]
       2: AT@334..336 "@" [] [Whitespace(" ")]
-    14: GRAPHQL_SELECTION_SET@336..354
+    13: GRAPHQL_SELECTION_SET@336..354
       0: L_CURLY@336..337 "{" [] []
       1: GRAPHQL_SELECTION_LIST@337..352
         0: GRAPHQL_FIELD@337..352
@@ -964,10 +940,10 @@ GraphqlRoot {
           3: GRAPHQL_DIRECTIVE_LIST@352..352
           4: (empty)
       2: R_CURLY@352..354 "}" [Newline("\n")] []
-    15: GRAPHQL_BOGUS_DEFINITION@354..366
+    14: GRAPHQL_BOGUS_DEFINITION@354..366
       0: GRAPHQL_NAME@354..360 "typ" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: GRAPHQL_NAME@360..366 "Person" [] []
-    16: GRAPHQL_OBJECT_TYPE_DEFINITION@366..380
+    15: GRAPHQL_OBJECT_TYPE_DEFINITION@366..380
       0: (empty)
       1: TYPE_KW@366..373 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@373..380
@@ -975,45 +951,40 @@ GraphqlRoot {
       3: (empty)
       4: GRAPHQL_DIRECTIVE_LIST@380..380
       5: (empty)
-    17: GRAPHQL_BOGUS_DEFINITION@380..399
+    16: GRAPHQL_BOGUS_DEFINITION@380..399
       0: GRAPHQL_NAME@380..390 "implemets" [] [Whitespace(" ")]
       1: GRAPHQL_NAME@390..399 "Character" [] []
-    18: GRAPHQL_OBJECT_TYPE_DEFINITION@399..425
+    17: GRAPHQL_OBJECT_TYPE_DEFINITION@399..447
       0: (empty)
       1: TYPE_KW@399..406 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@406..413
         0: GRAPHQL_NAME@406..413 "Person" [] [Whitespace(" ")]
-      3: GRAPHQL_IMPLEMENTS_INTERFACES@413..425
+      3: GRAPHQL_IMPLEMENTS_INTERFACES@413..439
         0: IMPLEMENTS_KW@413..424 "implements" [] [Whitespace(" ")]
-        1: AMP@424..425 "&" [] []
-        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@425..425
-      4: GRAPHQL_DIRECTIVE_LIST@425..425
-      5: (empty)
-    19: GRAPHQL_OBJECT_TYPE_DEFINITION@425..440
-      0: (empty)
-      1: TYPE_KW@425..432 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@432..439
-        0: GRAPHQL_NAME@432..439 "Person" [] [Whitespace(" ")]
-      3: (empty)
-      4: GRAPHQL_DIRECTIVE_LIST@439..440
-        0: GRAPHQL_DIRECTIVE@439..440
+        1: (empty)
+        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@424..439
+          0: (empty)
+          1: AMP@424..425 "&" [] []
+          2: GRAPHQL_NAMED_TYPE@425..432
+            0: GRAPHQL_NAME@425..432
+              0: GRAPHQL_NAME@425..432 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+          3: (empty)
+          4: GRAPHQL_NAMED_TYPE@432..439
+            0: GRAPHQL_NAME@432..439
+              0: GRAPHQL_NAME@432..439 "Person" [] [Whitespace(" ")]
+      4: GRAPHQL_DIRECTIVE_LIST@439..447
+        0: GRAPHQL_DIRECTIVE@439..447
           0: AT@439..440 "@" [] []
-          1: (empty)
+          1: GRAPHQL_NAME@440..447
+            0: GRAPHQL_NAME@440..447 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
           2: (empty)
       5: (empty)
-    20: GRAPHQL_OBJECT_TYPE_DEFINITION@440..454
-      0: (empty)
-      1: TYPE_KW@440..447 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@447..454
-        0: GRAPHQL_NAME@447..454 "Person" [] [Whitespace(" ")]
-      3: (empty)
-      4: GRAPHQL_DIRECTIVE_LIST@454..454
-      5: (empty)
-    21: GRAPHQL_BOGUS_DEFINITION@454..474
-      0: GRAPHQL_NAME@454..463 "implents" [] [Whitespace(" ")]
-      1: GRAPHQL_NAME@463..473 "Character" [] [Whitespace(" ")]
-      2: AT@473..474 "@" [] []
-    22: GRAPHQL_OBJECT_TYPE_DEFINITION@474..535
+    18: GRAPHQL_BOGUS_DEFINITION@447..474
+      0: GRAPHQL_NAME@447..454 "Person" [] [Whitespace(" ")]
+      1: GRAPHQL_NAME@454..463 "implents" [] [Whitespace(" ")]
+      2: GRAPHQL_NAME@463..473 "Character" [] [Whitespace(" ")]
+      3: AT@473..474 "@" [] []
+    19: GRAPHQL_OBJECT_TYPE_DEFINITION@474..535
       0: (empty)
       1: TYPE_KW@474..481 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@481..488
@@ -1038,7 +1009,7 @@ GraphqlRoot {
             0: GRAPHQL_NAME@525..535 "deprecated" [] []
           2: (empty)
       5: (empty)
-    23: GRAPHQL_BOGUS_DEFINITION@535..804
+    20: GRAPHQL_BOGUS_DEFINITION@535..804
       0: TYPE_KW@535..542 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: GRAPHQL_NAME@542..549
         0: GRAPHQL_NAME@542..549 "Person" [] [Whitespace(" ")]
@@ -1199,45 +1170,60 @@ object.graphql:2:3 parse ━━━━━━━━━━━━━━━━━━�
   
 object.graphql:8:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × expected `}` but instead found `type`
+  × Expected a field definition but instead found 'type Person'.
   
      6 │   name: String
      7 │ 
    > 8 │ type Person
-       │ ^^^^
+       │ ^^^^^^^^^^^
      9 │   name: String
     10 │ 
   
-  i Remove type
+  i Expected a field definition here.
   
-object.graphql:9:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `{` but instead found `name`
-  
-     8 │ type Person
-   > 9 │   name: String
-       │   ^^^^
+     6 │   name: String
+     7 │ 
+   > 8 │ type Person
+       │ ^^^^^^^^^^^
+     9 │   name: String
     10 │ 
-    11 │ type Person {
-  
-  i Remove name
   
 object.graphql:11:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × expected `}` but instead found `type`
+  × Expected a field definition but instead found 'type Person'.
   
      9 │   name: String
     10 │ 
   > 11 │ type Person {
-       │ ^^^^
+       │ ^^^^^^^^^^^
     12 │   name:
     13 │ }
   
-  i Remove type
+  i Expected a field definition here.
+  
+     9 │   name: String
+    10 │ 
+  > 11 │ type Person {
+       │ ^^^^^^^^^^^
+    12 │   name:
+    13 │ }
+  
+object.graphql:11:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `}` but instead found `{`
+  
+     9 │   name: String
+    10 │ 
+  > 11 │ type Person {
+       │             ^
+    12 │   name:
+    13 │ }
+  
+  i Remove {
   
 object.graphql:13:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a type but instead found '}'.
+  × Expected a name but instead found '}'.
   
     11 │ type Person {
     12 │   name:
@@ -1246,7 +1232,7 @@ object.graphql:13:1 parse ━━━━━━━━━━━━━━━━━━
     14 │ 
     15 │ type Person {
   
-  i Expected a type here.
+  i Expected a name here.
   
     11 │ type Person {
     12 │   name:
@@ -1441,54 +1427,27 @@ object.graphql:45:13 parse ━━━━━━━━━━━━━━━━━�
     46 │ 
     47 │ type Person implements &
   
-object.graphql:49:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+object.graphql:49:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a named type but instead found 'type'.
+  × expected `&` but instead found `Person`
   
     47 │ type Person implements &
     48 │ 
   > 49 │ type Person @
-       │ ^^^^
+       │      ^^^^^^
     50 │ 
     51 │ type Person implents Character @
   
-  i Expected a named type here.
+  i Remove Person
   
-    47 │ type Person implements &
-    48 │ 
-  > 49 │ type Person @
-       │ ^^^^
-    50 │ 
-    51 │ type Person implents Character @
-  
-object.graphql:51:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+object.graphql:51:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a name but instead found 'type'.
+  × Expected a definition but instead found 'Person implents Character @'.
   
     49 │ type Person @
     50 │ 
   > 51 │ type Person implents Character @
-       │ ^^^^
-    52 │ 
-    53 │ type Person implements Character & Character1 & @deprecated
-  
-  i Expected a name here.
-  
-    49 │ type Person @
-    50 │ 
-  > 51 │ type Person implents Character @
-       │ ^^^^
-    52 │ 
-    53 │ type Person implements Character & Character1 & @deprecated
-  
-object.graphql:51:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected a definition but instead found 'implents Character @'.
-  
-    49 │ type Person @
-    50 │ 
-  > 51 │ type Person implents Character @
-       │             ^^^^^^^^^^^^^^^^^^^^
+       │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     52 │ 
     53 │ type Person implements Character & Character1 & @deprecated
   
@@ -1497,7 +1456,7 @@ object.graphql:51:13 parse ━━━━━━━━━━━━━━━━━�
     49 │ type Person @
     50 │ 
   > 51 │ type Person implents Character @
-       │             ^^^^^^^^^^^^^^^^^^^^
+       │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     52 │ 
     53 │ type Person implements Character & Character1 & @deprecated
   

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/union.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/union.graphql
@@ -10,7 +10,8 @@ union SearchResult =
 
 union SearchResult =
 	| Photo
-	|
+	  Person
+	| union
 
 union SearchResult @
 

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/union.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/union.graphql.snap
@@ -16,7 +16,8 @@ union SearchResult =
 
 union SearchResult =
 	| Photo
-	|
+	  Person
+	| union
 
 union SearchResult @
 
@@ -66,8 +67,10 @@ GraphqlRoot {
             directives: GraphqlDirectiveList [],
             union_members: GraphqlUnionMemberTypes {
                 eq_token: missing (required),
-                bitwise_or_token: PIPE@48..52 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                bitwise_or_token: missing (optional),
                 members: GraphqlUnionMemberTypeList [
+                    missing element,
+                    PIPE@48..52 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     GraphqlNamedType {
                         name: GraphqlName {
                             value_token: GRAPHQL_NAME@52..57 "Photo" [] [],
@@ -91,8 +94,10 @@ GraphqlRoot {
             directives: GraphqlDirectiveList [],
             union_members: GraphqlUnionMemberTypes {
                 eq_token: EQ@88..89 "=" [] [],
-                bitwise_or_token: PIPE@89..92 "|" [Newline("\n"), Whitespace("\t")] [],
+                bitwise_or_token: missing (optional),
                 members: GraphqlUnionMemberTypeList [
+                    missing element,
+                    PIPE@89..92 "|" [Newline("\n"), Whitespace("\t")] [],
                     missing element,
                     PIPE@92..96 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     GraphqlNamedType {
@@ -112,102 +117,119 @@ GraphqlRoot {
             directives: GraphqlDirectiveList [],
             union_members: GraphqlUnionMemberTypes {
                 eq_token: EQ@123..124 "=" [] [],
-                bitwise_or_token: PIPE@124..128 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                bitwise_or_token: missing (optional),
                 members: GraphqlUnionMemberTypeList [
+                    missing element,
+                    PIPE@124..128 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     GraphqlNamedType {
                         name: GraphqlName {
                             value_token: GRAPHQL_NAME@128..133 "Photo" [] [],
                         },
                     },
-                    PIPE@133..136 "|" [Newline("\n"), Whitespace("\t")] [],
+                    missing separator,
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@133..143 "Person" [Newline("\n"), Whitespace("\t  ")] [],
+                        },
+                    },
+                    PIPE@143..147 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@147..152 "union" [] [],
+                        },
+                    },
+                ],
+            },
+        },
+        GraphqlUnionTypeDefinition {
+            description: missing (optional),
+            union_token: UNION_KW@152..160 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@160..173 "SearchResult" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [
+                GraphqlDirective {
+                    at_token: AT@173..174 "@" [] [],
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@174..182 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                    },
+                    arguments: missing (optional),
+                },
+            ],
+            union_members: GraphqlUnionMemberTypes {
+                eq_token: missing (required),
+                bitwise_or_token: missing (optional),
+                members: GraphqlUnionMemberTypeList [
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@182..195 "SearchResult" [] [Whitespace(" ")],
+                        },
+                    },
+                    PIPE@195..196 "|" [] [],
                     missing element,
                 ],
             },
         },
         GraphqlUnionTypeDefinition {
             description: missing (optional),
-            union_token: UNION_KW@136..144 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            union_token: UNION_KW@196..204 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@144..157 "SearchResult" [] [Whitespace(" ")],
-            },
-            directives: GraphqlDirectiveList [
-                GraphqlDirective {
-                    at_token: AT@157..158 "@" [] [],
-                    name: missing (required),
-                    arguments: missing (optional),
-                },
-            ],
-            union_members: missing (optional),
-        },
-        GraphqlUnionTypeDefinition {
-            description: missing (optional),
-            union_token: UNION_KW@158..166 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@166..179 "SearchResult" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@204..217 "SearchResult" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
             union_members: GraphqlUnionMemberTypes {
-                eq_token: missing (required),
-                bitwise_or_token: PIPE@179..180 "|" [] [],
-                members: GraphqlUnionMemberTypeList [],
-            },
-        },
-        GraphqlUnionTypeDefinition {
-            description: missing (optional),
-            union_token: UNION_KW@180..188 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-            name: GraphqlName {
-                value_token: GRAPHQL_NAME@188..201 "SearchResult" [] [Whitespace(" ")],
-            },
-            directives: GraphqlDirectiveList [],
-            union_members: GraphqlUnionMemberTypes {
-                eq_token: EQ@201..202 "=" [] [],
+                eq_token: EQ@217..218 "=" [] [],
                 bitwise_or_token: missing (optional),
                 members: GraphqlUnionMemberTypeList [],
             },
         },
         GraphqlUnionTypeDefinition {
             description: missing (optional),
-            union_token: UNION_KW@202..210 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            union_token: UNION_KW@218..226 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@210..223 "SearchResult" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@226..239 "SearchResult" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
             union_members: GraphqlUnionMemberTypes {
-                eq_token: EQ@223..225 "=" [] [Whitespace(" ")],
-                bitwise_or_token: PIPE@225..226 "|" [] [],
-                members: GraphqlUnionMemberTypeList [],
+                eq_token: EQ@239..241 "=" [] [Whitespace(" ")],
+                bitwise_or_token: missing (optional),
+                members: GraphqlUnionMemberTypeList [
+                    missing element,
+                    PIPE@241..242 "|" [] [],
+                    missing element,
+                ],
             },
         },
         GraphqlUnionTypeDefinition {
             description: missing (optional),
-            union_token: UNION_KW@226..234 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            union_token: UNION_KW@242..250 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@234..247 "SearchResult" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@250..263 "SearchResult" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
-                    at_token: AT@247..249 "@" [] [Whitespace(" ")],
+                    at_token: AT@263..265 "@" [] [Whitespace(" ")],
                     name: missing (required),
                     arguments: missing (optional),
                 },
             ],
             union_members: GraphqlUnionMemberTypes {
-                eq_token: EQ@249..250 "=" [] [],
+                eq_token: EQ@265..266 "=" [] [],
                 bitwise_or_token: missing (optional),
                 members: GraphqlUnionMemberTypeList [],
             },
         },
     ],
-    eof_token: EOF@250..251 "" [Newline("\n")] [],
+    eof_token: EOF@266..267 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..251
+0: GRAPHQL_ROOT@0..267
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..250
+  1: GRAPHQL_DEFINITION_LIST@0..266
     0: GRAPHQL_UNION_TYPE_DEFINITION@0..28
       0: (empty)
       1: UNION_KW@0..6 "union" [] [Whitespace(" ")]
@@ -231,13 +253,15 @@ GraphqlRoot {
       3: GRAPHQL_DIRECTIVE_LIST@48..48
       4: GRAPHQL_UNION_MEMBER_TYPES@48..67
         0: (empty)
-        1: PIPE@48..52 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
-        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@52..67
-          0: GRAPHQL_NAMED_TYPE@52..57
+        1: (empty)
+        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@48..67
+          0: (empty)
+          1: PIPE@48..52 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+          2: GRAPHQL_NAMED_TYPE@52..57
             0: GRAPHQL_NAME@52..57
               0: GRAPHQL_NAME@52..57 "Photo" [] []
-          1: PIPE@57..61 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
-          2: GRAPHQL_NAMED_TYPE@61..67
+          3: PIPE@57..61 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+          4: GRAPHQL_NAMED_TYPE@61..67
             0: GRAPHQL_NAME@61..67
               0: GRAPHQL_NAME@61..67 "Person" [] []
     2: GRAPHQL_UNION_TYPE_DEFINITION@67..102
@@ -248,84 +272,96 @@ GraphqlRoot {
       3: GRAPHQL_DIRECTIVE_LIST@88..88
       4: GRAPHQL_UNION_MEMBER_TYPES@88..102
         0: EQ@88..89 "=" [] []
-        1: PIPE@89..92 "|" [Newline("\n"), Whitespace("\t")] []
-        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@92..102
+        1: (empty)
+        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@89..102
           0: (empty)
-          1: PIPE@92..96 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
-          2: GRAPHQL_NAMED_TYPE@96..102
+          1: PIPE@89..92 "|" [Newline("\n"), Whitespace("\t")] []
+          2: (empty)
+          3: PIPE@92..96 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+          4: GRAPHQL_NAMED_TYPE@96..102
             0: GRAPHQL_NAME@96..102
               0: GRAPHQL_NAME@96..102 "Person" [] []
-    3: GRAPHQL_UNION_TYPE_DEFINITION@102..136
+    3: GRAPHQL_UNION_TYPE_DEFINITION@102..152
       0: (empty)
       1: UNION_KW@102..110 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@110..123
         0: GRAPHQL_NAME@110..123 "SearchResult" [] [Whitespace(" ")]
       3: GRAPHQL_DIRECTIVE_LIST@123..123
-      4: GRAPHQL_UNION_MEMBER_TYPES@123..136
+      4: GRAPHQL_UNION_MEMBER_TYPES@123..152
         0: EQ@123..124 "=" [] []
-        1: PIPE@124..128 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
-        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@128..136
-          0: GRAPHQL_NAMED_TYPE@128..133
+        1: (empty)
+        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@124..152
+          0: (empty)
+          1: PIPE@124..128 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+          2: GRAPHQL_NAMED_TYPE@128..133
             0: GRAPHQL_NAME@128..133
               0: GRAPHQL_NAME@128..133 "Photo" [] []
-          1: PIPE@133..136 "|" [Newline("\n"), Whitespace("\t")] []
-          2: (empty)
-    4: GRAPHQL_UNION_TYPE_DEFINITION@136..158
+          3: (empty)
+          4: GRAPHQL_NAMED_TYPE@133..143
+            0: GRAPHQL_NAME@133..143
+              0: GRAPHQL_NAME@133..143 "Person" [Newline("\n"), Whitespace("\t  ")] []
+          5: PIPE@143..147 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+          6: GRAPHQL_NAMED_TYPE@147..152
+            0: GRAPHQL_NAME@147..152
+              0: GRAPHQL_NAME@147..152 "union" [] []
+    4: GRAPHQL_UNION_TYPE_DEFINITION@152..196
       0: (empty)
-      1: UNION_KW@136..144 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@144..157
-        0: GRAPHQL_NAME@144..157 "SearchResult" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@157..158
-        0: GRAPHQL_DIRECTIVE@157..158
-          0: AT@157..158 "@" [] []
-          1: (empty)
+      1: UNION_KW@152..160 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@160..173
+        0: GRAPHQL_NAME@160..173 "SearchResult" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@173..182
+        0: GRAPHQL_DIRECTIVE@173..182
+          0: AT@173..174 "@" [] []
+          1: GRAPHQL_NAME@174..182
+            0: GRAPHQL_NAME@174..182 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
           2: (empty)
-      4: (empty)
-    5: GRAPHQL_UNION_TYPE_DEFINITION@158..180
-      0: (empty)
-      1: UNION_KW@158..166 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@166..179
-        0: GRAPHQL_NAME@166..179 "SearchResult" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@179..179
-      4: GRAPHQL_UNION_MEMBER_TYPES@179..180
+      4: GRAPHQL_UNION_MEMBER_TYPES@182..196
         0: (empty)
-        1: PIPE@179..180 "|" [] []
-        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@180..180
-    6: GRAPHQL_UNION_TYPE_DEFINITION@180..202
-      0: (empty)
-      1: UNION_KW@180..188 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@188..201
-        0: GRAPHQL_NAME@188..201 "SearchResult" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@201..201
-      4: GRAPHQL_UNION_MEMBER_TYPES@201..202
-        0: EQ@201..202 "=" [] []
         1: (empty)
-        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@202..202
-    7: GRAPHQL_UNION_TYPE_DEFINITION@202..226
+        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@182..196
+          0: GRAPHQL_NAMED_TYPE@182..195
+            0: GRAPHQL_NAME@182..195
+              0: GRAPHQL_NAME@182..195 "SearchResult" [] [Whitespace(" ")]
+          1: PIPE@195..196 "|" [] []
+          2: (empty)
+    5: GRAPHQL_UNION_TYPE_DEFINITION@196..218
       0: (empty)
-      1: UNION_KW@202..210 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@210..223
-        0: GRAPHQL_NAME@210..223 "SearchResult" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@223..223
-      4: GRAPHQL_UNION_MEMBER_TYPES@223..226
-        0: EQ@223..225 "=" [] [Whitespace(" ")]
-        1: PIPE@225..226 "|" [] []
-        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@226..226
-    8: GRAPHQL_UNION_TYPE_DEFINITION@226..250
+      1: UNION_KW@196..204 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@204..217
+        0: GRAPHQL_NAME@204..217 "SearchResult" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@217..217
+      4: GRAPHQL_UNION_MEMBER_TYPES@217..218
+        0: EQ@217..218 "=" [] []
+        1: (empty)
+        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@218..218
+    6: GRAPHQL_UNION_TYPE_DEFINITION@218..242
       0: (empty)
-      1: UNION_KW@226..234 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@234..247
-        0: GRAPHQL_NAME@234..247 "SearchResult" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@247..249
-        0: GRAPHQL_DIRECTIVE@247..249
-          0: AT@247..249 "@" [] [Whitespace(" ")]
+      1: UNION_KW@218..226 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@226..239
+        0: GRAPHQL_NAME@226..239 "SearchResult" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@239..239
+      4: GRAPHQL_UNION_MEMBER_TYPES@239..242
+        0: EQ@239..241 "=" [] [Whitespace(" ")]
+        1: (empty)
+        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@241..242
+          0: (empty)
+          1: PIPE@241..242 "|" [] []
+          2: (empty)
+    7: GRAPHQL_UNION_TYPE_DEFINITION@242..266
+      0: (empty)
+      1: UNION_KW@242..250 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@250..263
+        0: GRAPHQL_NAME@250..263 "SearchResult" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@263..265
+        0: GRAPHQL_DIRECTIVE@263..265
+          0: AT@263..265 "@" [] [Whitespace(" ")]
           1: (empty)
           2: (empty)
-      4: GRAPHQL_UNION_MEMBER_TYPES@249..250
-        0: EQ@249..250 "=" [] []
+      4: GRAPHQL_UNION_MEMBER_TYPES@265..266
+        0: EQ@265..266 "=" [] []
         1: (empty)
-        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@250..250
-  2: EOF@250..251 "" [Newline("\n")] []
+        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@266..266
+  2: EOF@266..267 "" [Newline("\n")] []
 
 ```
 
@@ -364,147 +400,120 @@ union.graphql:4:2 parse ━━━━━━━━━━━━━━━━━━�
   
   i Remove |
   
-union.graphql:15:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+union.graphql:13:4 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `|` but instead found `Person`
+  
+    11 │ union SearchResult =
+    12 │ 	| Photo
+  > 13 │ 	  Person
+       │ 	  ^^^^^^
+    14 │ 	| union
+    15 │ 
+  
+  i Remove Person
+  
+union.graphql:18:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `=` but instead found `SearchResult`
+  
+    16 │ union SearchResult @
+    17 │ 
+  > 18 │ union SearchResult |
+       │       ^^^^^^^^^^^^
+    19 │ 
+    20 │ union SearchResult =
+  
+  i Remove SearchResult
+  
+union.graphql:20:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a named type but instead found 'union'.
   
-    13 │ 	|
-    14 │ 
-  > 15 │ union SearchResult @
+    18 │ union SearchResult |
+    19 │ 
+  > 20 │ union SearchResult =
        │ ^^^^^
-    16 │ 
-    17 │ union SearchResult |
+    21 │ 
+    22 │ union SearchResult = |
   
   i Expected a named type here.
   
-    13 │ 	|
-    14 │ 
-  > 15 │ union SearchResult @
+    18 │ union SearchResult |
+    19 │ 
+  > 20 │ union SearchResult =
        │ ^^^^^
-    16 │ 
-    17 │ union SearchResult |
+    21 │ 
+    22 │ union SearchResult = |
   
-union.graphql:17:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected a name but instead found 'union'.
-  
-    15 │ union SearchResult @
-    16 │ 
-  > 17 │ union SearchResult |
-       │ ^^^^^
-    18 │ 
-    19 │ union SearchResult =
-  
-  i Expected a name here.
-  
-    15 │ union SearchResult @
-    16 │ 
-  > 17 │ union SearchResult |
-       │ ^^^^^
-    18 │ 
-    19 │ union SearchResult =
-  
-union.graphql:17:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `=` but instead found `|`
-  
-    15 │ union SearchResult @
-    16 │ 
-  > 17 │ union SearchResult |
-       │                    ^
-    18 │ 
-    19 │ union SearchResult =
-  
-  i Remove |
-  
-union.graphql:19:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+union.graphql:22:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a named type but instead found 'union'.
   
-    17 │ union SearchResult |
-    18 │ 
-  > 19 │ union SearchResult =
+    20 │ union SearchResult =
+    21 │ 
+  > 22 │ union SearchResult = |
        │ ^^^^^
-    20 │ 
-    21 │ union SearchResult = |
+    23 │ 
+    24 │ union SearchResult @ =
   
   i Expected a named type here.
   
-    17 │ union SearchResult |
-    18 │ 
-  > 19 │ union SearchResult =
+    20 │ union SearchResult =
+    21 │ 
+  > 22 │ union SearchResult = |
        │ ^^^^^
-    20 │ 
-    21 │ union SearchResult = |
-  
-union.graphql:21:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected a named type but instead found 'union'.
-  
-    19 │ union SearchResult =
-    20 │ 
-  > 21 │ union SearchResult = |
-       │ ^^^^^
-    22 │ 
-    23 │ union SearchResult @ =
-  
-  i Expected a named type here.
-  
-    19 │ union SearchResult =
-    20 │ 
-  > 21 │ union SearchResult = |
-       │ ^^^^^
-    22 │ 
-    23 │ union SearchResult @ =
-  
-union.graphql:23:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected a named type but instead found 'union'.
-  
-    21 │ union SearchResult = |
-    22 │ 
-  > 23 │ union SearchResult @ =
-       │ ^^^^^
-    24 │ 
-  
-  i Expected a named type here.
-  
-    21 │ union SearchResult = |
-    22 │ 
-  > 23 │ union SearchResult @ =
-       │ ^^^^^
-    24 │ 
-  
-union.graphql:23:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected a name but instead found '='.
-  
-    21 │ union SearchResult = |
-    22 │ 
-  > 23 │ union SearchResult @ =
-       │                      ^
-    24 │ 
-  
-  i Expected a name here.
-  
-    21 │ union SearchResult = |
-    22 │ 
-  > 23 │ union SearchResult @ =
-       │                      ^
-    24 │ 
+    23 │ 
+    24 │ union SearchResult @ =
   
 union.graphql:24:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  × Expected a named type but instead found 'union'.
+  
+    22 │ union SearchResult = |
+    23 │ 
+  > 24 │ union SearchResult @ =
+       │ ^^^^^
+    25 │ 
+  
+  i Expected a named type here.
+  
+    22 │ union SearchResult = |
+    23 │ 
+  > 24 │ union SearchResult @ =
+       │ ^^^^^
+    25 │ 
+  
+union.graphql:24:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a name but instead found '='.
+  
+    22 │ union SearchResult = |
+    23 │ 
+  > 24 │ union SearchResult @ =
+       │                      ^
+    25 │ 
+  
+  i Expected a name here.
+  
+    22 │ union SearchResult = |
+    23 │ 
+  > 24 │ union SearchResult @ =
+       │                      ^
+    25 │ 
+  
+union.graphql:25:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
   × Expected a named type but instead found the end of the file.
   
-    23 │ union SearchResult @ =
-  > 24 │ 
+    24 │ union SearchResult @ =
+  > 25 │ 
        │ 
   
   i Expected a named type here.
   
-    23 │ union SearchResult @ =
-  > 24 │ 
+    24 │ union SearchResult @ =
+  > 25 │ 
        │ 
   
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/operation.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/operation.graphql
@@ -2,7 +2,7 @@ query likeStory }
 
 query likeStory
 
-query like$Story
+query }
 
 # malformed variables
 query ($storyId: ID! {

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/operation.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/operation.graphql.snap
@@ -8,7 +8,7 @@ query likeStory }
 
 query likeStory
 
-query like$Story
+query }
 
 # malformed variables
 query ($storyId: ID! {
@@ -120,121 +120,43 @@ GraphqlRoot {
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
                 l_curly_token: missing (required),
-                selections: GraphqlSelectionList [],
-                r_curly_token: missing (required),
+                selections: GraphqlSelectionList [
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@34..42 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                        },
+                        arguments: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@42..43 "}" [] [],
             },
-        },
-        GraphqlBogusDefinition {
-            items: [
-                GraphqlOperationType {
-                    value_token: QUERY_KW@34..42 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
-                },
-                GraphqlName {
-                    value_token: GRAPHQL_NAME@42..46 "like" [] [],
-                },
-                GraphqlBogus {
-                    items: [
-                        GraphqlBogus {
-                            items: [
-                                GraphqlVariableDefinition {
-                                    variable: GraphqlVariable {
-                                        dollar_token: DOLLAR@46..47 "$" [] [],
-                                        name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@47..52 "Story" [] [],
-                                        },
-                                    },
-                                    colon_token: missing (required),
-                                    ty: missing (required),
-                                    default: missing (optional),
-                                    directives: GraphqlDirectiveList [],
-                                },
-                                GraphqlBogus {
-                                    items: [
-                                        QUERY_KW@52..82 "query" [Newline("\n"), Newline("\n"), Comments("# malformed variables"), Newline("\n")] [Whitespace(" ")],
-                                        L_PAREN@82..83 "(" [] [],
-                                    ],
-                                },
-                                GraphqlVariableDefinition {
-                                    variable: GraphqlVariable {
-                                        dollar_token: DOLLAR@83..84 "$" [] [],
-                                        name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@84..91 "storyId" [] [],
-                                        },
-                                    },
-                                    colon_token: COLON@91..93 ":" [] [Whitespace(" ")],
-                                    ty: GraphqlNonNullType {
-                                        base: GraphqlNamedType {
-                                            name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@93..95 "ID" [] [],
-                                            },
-                                        },
-                                        excl_token: BANG@95..97 "!" [] [Whitespace(" ")],
-                                    },
-                                    default: missing (optional),
-                                    directives: GraphqlDirectiveList [],
-                                },
-                            ],
-                        },
-                    ],
-                },
-                GraphqlDirectiveList [],
-                GraphqlSelectionSet {
-                    l_curly_token: L_CURLY@97..98 "{" [] [],
-                    selections: GraphqlSelectionList [
-                        GraphqlField {
-                            alias: missing (optional),
-                            name: GraphqlName {
-                                value_token: GRAPHQL_NAME@98..109 "likeStory" [Newline("\n"), Whitespace("\t")] [],
-                            },
-                            arguments: GraphqlArguments {
-                                l_paren_token: L_PAREN@109..110 "(" [] [],
-                                arguments: GraphqlArgumentList [
-                                    GraphqlArgument {
-                                        name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@110..117 "storyId" [] [],
-                                        },
-                                        colon_token: COLON@117..119 ":" [] [Whitespace(" ")],
-                                        value: GraphqlVariable {
-                                            dollar_token: DOLLAR@119..120 "$" [] [],
-                                            name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@120..127 "storyId" [] [],
-                                            },
-                                        },
-                                    },
-                                ],
-                                r_paren_token: R_PAREN@127..128 ")" [] [],
-                            },
-                            directives: GraphqlDirectiveList [],
-                            selection_set: missing (optional),
-                        },
-                    ],
-                    r_curly_token: R_CURLY@128..130 "}" [Newline("\n")] [],
-                },
-            ],
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@130..138 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@43..73 "query" [Newline("\n"), Newline("\n"), Comments("# malformed variables"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
-                l_paren_token: missing (required),
+                l_paren_token: L_PAREN@73..74 "(" [] [],
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: GraphqlVariable {
-                            dollar_token: DOLLAR@138..139 "$" [] [],
+                            dollar_token: DOLLAR@74..75 "$" [] [],
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@139..146 "storyId" [] [],
+                                value_token: GRAPHQL_NAME@75..82 "storyId" [] [],
                             },
                         },
-                        colon_token: COLON@146..148 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@82..84 ":" [] [Whitespace(" ")],
                         ty: GraphqlNonNullType {
                             base: GraphqlNamedType {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@148..150 "ID" [] [],
+                                    value_token: GRAPHQL_NAME@84..86 "ID" [] [],
                                 },
                             },
-                            excl_token: BANG@150..152 "!" [] [Whitespace(" ")],
+                            excl_token: BANG@86..88 "!" [] [Whitespace(" ")],
                         },
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
@@ -244,41 +166,41 @@ GraphqlRoot {
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@152..153 "{" [] [],
+                l_curly_token: L_CURLY@88..89 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@153..164 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@89..100 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: GraphqlArguments {
-                            l_paren_token: L_PAREN@164..165 "(" [] [],
+                            l_paren_token: L_PAREN@100..101 "(" [] [],
                             arguments: GraphqlArgumentList [
                                 GraphqlArgument {
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@165..172 "storyId" [] [],
+                                        value_token: GRAPHQL_NAME@101..108 "storyId" [] [],
                                     },
-                                    colon_token: COLON@172..174 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@108..110 ":" [] [Whitespace(" ")],
                                     value: GraphqlVariable {
-                                        dollar_token: DOLLAR@174..175 "$" [] [],
+                                        dollar_token: DOLLAR@110..111 "$" [] [],
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@175..182 "storyId" [] [],
+                                            value_token: GRAPHQL_NAME@111..118 "storyId" [] [],
                                         },
                                     },
                                 },
                             ],
-                            r_paren_token: R_PAREN@182..183 ")" [] [],
+                            r_paren_token: R_PAREN@118..119 ")" [] [],
                         },
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@183..185 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@119..121 "}" [Newline("\n")] [],
             },
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@185..193 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@121..129 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
@@ -286,167 +208,231 @@ GraphqlRoot {
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: GraphqlVariable {
-                            dollar_token: DOLLAR@193..194 "$" [] [],
+                            dollar_token: DOLLAR@129..130 "$" [] [],
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@194..201 "storyId" [] [],
+                                value_token: GRAPHQL_NAME@130..137 "storyId" [] [],
                             },
                         },
-                        colon_token: COLON@201..203 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@137..139 ":" [] [Whitespace(" ")],
                         ty: GraphqlNonNullType {
                             base: GraphqlNamedType {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@203..205 "ID" [] [],
+                                    value_token: GRAPHQL_NAME@139..141 "ID" [] [],
                                 },
                             },
-                            excl_token: BANG@205..206 "!" [] [],
+                            excl_token: BANG@141..143 "!" [] [Whitespace(" ")],
                         },
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_paren_token: R_PAREN@206..208 ")" [] [Whitespace(" ")],
+                r_paren_token: missing (required),
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@208..209 "{" [] [],
+                l_curly_token: L_CURLY@143..144 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@209..220 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@144..155 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: GraphqlArguments {
-                            l_paren_token: L_PAREN@220..221 "(" [] [],
+                            l_paren_token: L_PAREN@155..156 "(" [] [],
                             arguments: GraphqlArgumentList [
                                 GraphqlArgument {
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@221..228 "storyId" [] [],
+                                        value_token: GRAPHQL_NAME@156..163 "storyId" [] [],
                                     },
-                                    colon_token: COLON@228..230 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@163..165 ":" [] [Whitespace(" ")],
                                     value: GraphqlVariable {
-                                        dollar_token: DOLLAR@230..231 "$" [] [],
+                                        dollar_token: DOLLAR@165..166 "$" [] [],
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@231..238 "storyId" [] [],
+                                            value_token: GRAPHQL_NAME@166..173 "storyId" [] [],
                                         },
                                     },
                                 },
                             ],
-                            r_paren_token: R_PAREN@238..239 ")" [] [],
+                            r_paren_token: R_PAREN@173..174 ")" [] [],
                         },
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@239..241 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@174..176 "}" [Newline("\n")] [],
             },
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@241..249 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@176..184 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
-                l_paren_token: L_PAREN@249..250 "(" [] [],
+                l_paren_token: missing (required),
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: GraphqlVariable {
-                            dollar_token: DOLLAR@250..251 "$" [] [],
+                            dollar_token: DOLLAR@184..185 "$" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@185..192 "storyId" [] [],
+                            },
+                        },
+                        colon_token: COLON@192..194 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNonNullType {
+                            base: GraphqlNamedType {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@194..196 "ID" [] [],
+                                },
+                            },
+                            excl_token: BANG@196..197 "!" [] [],
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_paren_token: R_PAREN@197..199 ")" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [],
+            selection_set: GraphqlSelectionSet {
+                l_curly_token: L_CURLY@199..200 "{" [] [],
+                selections: GraphqlSelectionList [
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@200..211 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        arguments: GraphqlArguments {
+                            l_paren_token: L_PAREN@211..212 "(" [] [],
+                            arguments: GraphqlArgumentList [
+                                GraphqlArgument {
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@212..219 "storyId" [] [],
+                                    },
+                                    colon_token: COLON@219..221 ":" [] [Whitespace(" ")],
+                                    value: GraphqlVariable {
+                                        dollar_token: DOLLAR@221..222 "$" [] [],
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@222..229 "storyId" [] [],
+                                        },
+                                    },
+                                },
+                            ],
+                            r_paren_token: R_PAREN@229..230 ")" [] [],
+                        },
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@230..232 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlOperationDefinition {
+            ty: GraphqlOperationType {
+                value_token: QUERY_KW@232..240 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            },
+            name: missing (optional),
+            variables: GraphqlVariableDefinitions {
+                l_paren_token: L_PAREN@240..241 "(" [] [],
+                elements: GraphqlVariableDefinitionList [
+                    GraphqlVariableDefinition {
+                        variable: GraphqlVariable {
+                            dollar_token: DOLLAR@241..242 "$" [] [],
                             name: missing (required),
                         },
-                        colon_token: COLON@251..253 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@242..244 ":" [] [Whitespace(" ")],
                         ty: missing (required),
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_paren_token: R_PAREN@253..255 ")" [] [Whitespace(" ")],
+                r_paren_token: R_PAREN@244..246 ")" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@255..256 "{" [] [],
+                l_curly_token: L_CURLY@246..247 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@256..267 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@247..258 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: GraphqlArguments {
-                            l_paren_token: L_PAREN@267..268 "(" [] [],
+                            l_paren_token: L_PAREN@258..259 "(" [] [],
                             arguments: GraphqlArgumentList [
                                 GraphqlArgument {
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@268..275 "storyId" [] [],
+                                        value_token: GRAPHQL_NAME@259..266 "storyId" [] [],
                                     },
-                                    colon_token: COLON@275..277 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@266..268 ":" [] [Whitespace(" ")],
                                     value: GraphqlVariable {
-                                        dollar_token: DOLLAR@277..278 "$" [] [],
+                                        dollar_token: DOLLAR@268..269 "$" [] [],
                                         name: missing (required),
                                     },
                                 },
                             ],
-                            r_paren_token: R_PAREN@278..279 ")" [] [],
+                            r_paren_token: R_PAREN@269..270 ")" [] [],
                         },
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@279..281 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@270..272 "}" [Newline("\n")] [],
             },
         },
         GraphqlBogusDefinition {
             items: [
                 GraphqlOperationType {
-                    value_token: QUERY_KW@281..289 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                    value_token: QUERY_KW@272..280 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
                 },
                 GraphqlBogus {
                     items: [
-                        L_PAREN@289..290 "(" [] [],
+                        L_PAREN@280..281 "(" [] [],
                         GraphqlBogus {
                             items: [
                                 GraphqlBogus {
                                     items: [
-                                        GRAPHQL_NAME@290..291 "a" [] [],
-                                        COLON@291..293 ":" [] [Whitespace(" ")],
+                                        GRAPHQL_NAME@281..282 "a" [] [],
+                                        COLON@282..284 ":" [] [Whitespace(" ")],
                                         GraphqlDirectiveList [],
                                     ],
                                 },
                             ],
                         },
-                        R_PAREN@293..295 ")" [] [Whitespace(" ")],
+                        R_PAREN@284..286 ")" [] [Whitespace(" ")],
                     ],
                 },
                 GraphqlDirectiveList [],
                 GraphqlSelectionSet {
-                    l_curly_token: L_CURLY@295..296 "{" [] [],
+                    l_curly_token: L_CURLY@286..287 "{" [] [],
                     selections: GraphqlSelectionList [
                         GraphqlField {
                             alias: missing (optional),
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@296..307 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                                value_token: GRAPHQL_NAME@287..298 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                             },
                             arguments: missing (optional),
                             directives: GraphqlDirectiveList [],
                             selection_set: missing (optional),
                         },
                     ],
-                    r_curly_token: R_CURLY@307..309 "}" [Newline("\n")] [],
+                    r_curly_token: R_CURLY@298..300 "}" [Newline("\n")] [],
                 },
             ],
         },
         GraphqlBogusDefinition {
             items: [
                 GraphqlOperationType {
-                    value_token: QUERY_KW@309..317 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                    value_token: QUERY_KW@300..308 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
                 },
                 GraphqlBogus {
                     items: [
-                        L_PAREN@317..318 "(" [] [],
+                        L_PAREN@308..309 "(" [] [],
                         GraphqlBogus {
                             items: [
                                 GraphqlBogus {
                                     items: [
-                                        GRAPHQL_NAME@318..319 "a" [] [],
-                                        COLON@319..322 ":" [] [Whitespace("  ")],
+                                        GRAPHQL_NAME@309..310 "a" [] [],
+                                        COLON@310..313 ":" [] [Whitespace("  ")],
                                         GraphqlDirectiveList [],
                                     ],
                                 },
@@ -456,68 +442,68 @@ GraphqlRoot {
                 },
                 GraphqlDirectiveList [],
                 GraphqlSelectionSet {
-                    l_curly_token: L_CURLY@322..323 "{" [] [],
+                    l_curly_token: L_CURLY@313..314 "{" [] [],
                     selections: GraphqlSelectionList [
                         GraphqlField {
                             alias: missing (optional),
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@323..334 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                                value_token: GRAPHQL_NAME@314..325 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                             },
                             arguments: missing (optional),
                             directives: GraphqlDirectiveList [],
                             selection_set: missing (optional),
                         },
                     ],
-                    r_curly_token: R_CURLY@334..336 "}" [Newline("\n")] [],
+                    r_curly_token: R_CURLY@325..327 "}" [Newline("\n")] [],
                 },
             ],
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@336..344 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@327..335 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
-                l_paren_token: L_PAREN@344..345 "(" [] [],
+                l_paren_token: L_PAREN@335..336 "(" [] [],
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: missing (required),
-                        colon_token: COLON@345..347 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@336..338 ":" [] [Whitespace(" ")],
                         ty: missing (required),
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_paren_token: R_PAREN@347..349 ")" [] [Whitespace(" ")],
+                r_paren_token: R_PAREN@338..340 ")" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@349..350 "{" [] [],
+                l_curly_token: L_CURLY@340..341 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@350..361 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@341..352 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@361..363 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@352..354 "}" [Newline("\n")] [],
             },
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@363..371 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@354..362 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
-                l_paren_token: L_PAREN@371..372 "(" [] [],
+                l_paren_token: L_PAREN@362..363 "(" [] [],
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: missing (required),
-                        colon_token: COLON@372..375 ":" [] [Whitespace("  ")],
+                        colon_token: COLON@363..366 ":" [] [Whitespace("  ")],
                         ty: missing (required),
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
@@ -527,24 +513,24 @@ GraphqlRoot {
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@375..376 "{" [] [],
+                l_curly_token: L_CURLY@366..367 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@376..387 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@367..378 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@387..389 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@378..380 "}" [Newline("\n")] [],
             },
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@389..397 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@380..388 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
@@ -552,7 +538,7 @@ GraphqlRoot {
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: missing (required),
-                        colon_token: COLON@397..400 ":" [] [Whitespace("  ")],
+                        colon_token: COLON@388..391 ":" [] [Whitespace("  ")],
                         ty: missing (required),
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
@@ -562,72 +548,72 @@ GraphqlRoot {
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@400..401 "{" [] [],
+                l_curly_token: L_CURLY@391..392 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@401..412 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@392..403 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@412..414 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@403..405 "}" [Newline("\n")] [],
             },
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@414..422 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@405..413 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
-                l_paren_token: L_PAREN@422..425 "(" [] [Whitespace("  ")],
+                l_paren_token: L_PAREN@413..416 "(" [] [Whitespace("  ")],
                 elements: GraphqlVariableDefinitionList [],
                 r_paren_token: missing (required),
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@425..426 "{" [] [],
+                l_curly_token: L_CURLY@416..417 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@426..437 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@417..428 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@437..439 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@428..430 "}" [Newline("\n")] [],
             },
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@439..447 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@430..438 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
-                l_paren_token: L_PAREN@447..448 "(" [] [],
+                l_paren_token: L_PAREN@438..439 "(" [] [],
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: GraphqlVariable {
-                            dollar_token: DOLLAR@448..449 "$" [] [],
+                            dollar_token: DOLLAR@439..440 "$" [] [],
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@449..456 "storyId" [] [],
+                                value_token: GRAPHQL_NAME@440..447 "storyId" [] [],
                             },
                         },
-                        colon_token: COLON@456..458 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@447..449 ":" [] [Whitespace(" ")],
                         ty: missing (required),
                         default: GraphqlDefaultValue {
-                            eq_token: EQ@458..460 "=" [] [Whitespace(" ")],
+                            eq_token: EQ@449..451 "=" [] [Whitespace(" ")],
                             value: missing (required),
                         },
                         directives: GraphqlDirectiveList [
                             GraphqlDirective {
-                                at_token: AT@460..462 "@" [] [Whitespace(" ")],
+                                at_token: AT@451..453 "@" [] [Whitespace(" ")],
                                 name: missing (required),
                                 arguments: missing (optional),
                             },
@@ -638,61 +624,61 @@ GraphqlRoot {
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@462..463 "{" [] [],
+                l_curly_token: L_CURLY@453..454 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@463..474 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@454..465 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@474..476 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@465..467 "}" [Newline("\n")] [],
             },
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@476..503 "query" [Newline("\n"), Newline("\n"), Comments("# malformed alias"), Newline("\n")] [Whitespace("  ")],
+                value_token: QUERY_KW@467..494 "query" [Newline("\n"), Newline("\n"), Comments("# malformed alias"), Newline("\n")] [Whitespace("  ")],
             },
             name: missing (optional),
             variables: missing (optional),
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@503..504 "{" [] [],
+                l_curly_token: L_CURLY@494..495 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: GraphqlAlias {
                             value: missing (required),
-                            colon_token: COLON@504..508 ":" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                            colon_token: COLON@495..499 ":" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                         },
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@508..517 "likeStory" [] [],
+                            value_token: GRAPHQL_NAME@499..508 "likeStory" [] [],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@517..519 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@508..510 "}" [Newline("\n")] [],
             },
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@519..549 "query" [Newline("\n"), Newline("\n"), Comments("# malformed arguments"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@510..540 "query" [Newline("\n"), Newline("\n"), Comments("# malformed arguments"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: missing (optional),
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@549..550 "{" [] [],
+                l_curly_token: L_CURLY@540..541 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@550..562 "likeStory" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                            value_token: GRAPHQL_NAME@541..553 "likeStory" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
@@ -701,9 +687,9 @@ GraphqlRoot {
                     GraphqlField {
                         alias: GraphqlAlias {
                             value: GraphqlName {
-                                value_token: GRAPHQL_NAME@562..569 "storyId" [] [],
+                                value_token: GRAPHQL_NAME@553..560 "storyId" [] [],
                             },
-                            colon_token: COLON@569..571 ":" [] [Whitespace(" ")],
+                            colon_token: COLON@560..562 ":" [] [Whitespace(" ")],
                         },
                         name: missing (required),
                         arguments: missing (optional),
@@ -712,13 +698,13 @@ GraphqlRoot {
                     },
                     GraphqlBogusSelection {
                         items: [
-                            DOLLAR@571..572 "$" [] [],
+                            DOLLAR@562..563 "$" [] [],
                         ],
                     },
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@572..579 "storyId" [] [],
+                            value_token: GRAPHQL_NAME@563..570 "storyId" [] [],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
@@ -726,64 +712,64 @@ GraphqlRoot {
                     },
                     GraphqlBogusSelection {
                         items: [
-                            R_PAREN@579..580 ")" [] [],
+                            R_PAREN@570..571 ")" [] [],
                         ],
                     },
                 ],
-                r_curly_token: R_CURLY@580..582 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@571..573 "}" [Newline("\n")] [],
             },
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@582..590 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@573..581 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
-                l_paren_token: L_PAREN@590..591 "(" [] [],
+                l_paren_token: L_PAREN@581..582 "(" [] [],
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: GraphqlVariable {
-                            dollar_token: DOLLAR@591..592 "$" [] [],
+                            dollar_token: DOLLAR@582..583 "$" [] [],
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@592..599 "storyId" [] [],
+                                value_token: GRAPHQL_NAME@583..590 "storyId" [] [],
                             },
                         },
-                        colon_token: COLON@599..601 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@590..592 ":" [] [Whitespace(" ")],
                         ty: GraphqlNonNullType {
                             base: GraphqlNamedType {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@601..603 "ID" [] [],
+                                    value_token: GRAPHQL_NAME@592..594 "ID" [] [],
                                 },
                             },
-                            excl_token: BANG@603..604 "!" [] [],
+                            excl_token: BANG@594..595 "!" [] [],
                         },
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_paren_token: R_PAREN@604..606 ")" [] [Whitespace(" ")],
+                r_paren_token: R_PAREN@595..597 ")" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@606..607 "{" [] [],
+                l_curly_token: L_CURLY@597..598 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@607..618 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@598..609 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: GraphqlArguments {
-                            l_paren_token: L_PAREN@618..619 "(" [] [],
+                            l_paren_token: L_PAREN@609..610 "(" [] [],
                             arguments: GraphqlArgumentList [
                                 GraphqlArgument {
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@619..626 "storyId" [] [],
+                                        value_token: GRAPHQL_NAME@610..617 "storyId" [] [],
                                     },
-                                    colon_token: COLON@626..628 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@617..619 ":" [] [Whitespace(" ")],
                                     value: GraphqlVariable {
-                                        dollar_token: DOLLAR@628..629 "$" [] [],
+                                        dollar_token: DOLLAR@619..620 "$" [] [],
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@629..636 "storyId" [] [],
+                                            value_token: GRAPHQL_NAME@620..627 "storyId" [] [],
                                         },
                                     },
                                 },
@@ -794,47 +780,47 @@ GraphqlRoot {
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@636..638 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@627..629 "}" [Newline("\n")] [],
             },
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@638..646 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@629..637 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
-                l_paren_token: L_PAREN@646..647 "(" [] [],
+                l_paren_token: L_PAREN@637..638 "(" [] [],
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: GraphqlVariable {
-                            dollar_token: DOLLAR@647..648 "$" [] [],
+                            dollar_token: DOLLAR@638..639 "$" [] [],
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@648..655 "storyId" [] [],
+                                value_token: GRAPHQL_NAME@639..646 "storyId" [] [],
                             },
                         },
-                        colon_token: COLON@655..657 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@646..648 ":" [] [Whitespace(" ")],
                         ty: GraphqlNonNullType {
                             base: GraphqlNamedType {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@657..659 "ID" [] [],
+                                    value_token: GRAPHQL_NAME@648..650 "ID" [] [],
                                 },
                             },
-                            excl_token: BANG@659..660 "!" [] [],
+                            excl_token: BANG@650..651 "!" [] [],
                         },
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_paren_token: R_PAREN@660..663 ")" [] [Whitespace("  ")],
+                r_paren_token: R_PAREN@651..654 ")" [] [Whitespace("  ")],
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@663..664 "{" [] [],
+                l_curly_token: L_CURLY@654..655 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@664..676 "likeStory" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                            value_token: GRAPHQL_NAME@655..667 "likeStory" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
@@ -843,9 +829,9 @@ GraphqlRoot {
                     GraphqlField {
                         alias: GraphqlAlias {
                             value: GraphqlName {
-                                value_token: GRAPHQL_NAME@676..683 "storyId" [] [],
+                                value_token: GRAPHQL_NAME@667..674 "storyId" [] [],
                             },
-                            colon_token: COLON@683..685 ":" [] [Whitespace(" ")],
+                            colon_token: COLON@674..676 ":" [] [Whitespace(" ")],
                         },
                         name: missing (required),
                         arguments: missing (optional),
@@ -854,60 +840,60 @@ GraphqlRoot {
                     },
                     GraphqlBogusSelection {
                         items: [
-                            DOLLAR@685..686 "$" [] [],
+                            DOLLAR@676..677 "$" [] [],
                         ],
                     },
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@686..693 "storyId" [] [],
+                            value_token: GRAPHQL_NAME@677..684 "storyId" [] [],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@693..695 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@684..686 "}" [Newline("\n")] [],
             },
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@695..703 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@686..694 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
-                l_paren_token: L_PAREN@703..704 "(" [] [],
+                l_paren_token: L_PAREN@694..695 "(" [] [],
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: GraphqlVariable {
-                            dollar_token: DOLLAR@704..705 "$" [] [],
+                            dollar_token: DOLLAR@695..696 "$" [] [],
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@705..712 "storyId" [] [],
+                                value_token: GRAPHQL_NAME@696..703 "storyId" [] [],
                             },
                         },
-                        colon_token: COLON@712..714 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@703..705 ":" [] [Whitespace(" ")],
                         ty: GraphqlNonNullType {
                             base: GraphqlNamedType {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@714..716 "ID" [] [],
+                                    value_token: GRAPHQL_NAME@705..707 "ID" [] [],
                                 },
                             },
-                            excl_token: BANG@716..717 "!" [] [],
+                            excl_token: BANG@707..708 "!" [] [],
                         },
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_paren_token: R_PAREN@717..719 ")" [] [Whitespace(" ")],
+                r_paren_token: R_PAREN@708..710 ")" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@719..720 "{" [] [],
+                l_curly_token: L_CURLY@710..711 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@720..732 "likeStory" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                            value_token: GRAPHQL_NAME@711..723 "likeStory" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
@@ -916,9 +902,9 @@ GraphqlRoot {
                     GraphqlField {
                         alias: GraphqlAlias {
                             value: GraphqlName {
-                                value_token: GRAPHQL_NAME@732..739 "storyId" [] [],
+                                value_token: GRAPHQL_NAME@723..730 "storyId" [] [],
                             },
-                            colon_token: COLON@739..741 ":" [] [Whitespace(" ")],
+                            colon_token: COLON@730..732 ":" [] [Whitespace(" ")],
                         },
                         name: missing (required),
                         arguments: missing (optional),
@@ -927,26 +913,26 @@ GraphqlRoot {
                     },
                     GraphqlBogusSelection {
                         items: [
-                            DOLLAR@741..742 "$" [] [],
+                            DOLLAR@732..733 "$" [] [],
                         ],
                     },
                 ],
-                r_curly_token: R_CURLY@742..744 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@733..735 "}" [Newline("\n")] [],
             },
         },
         GraphqlBogusDefinition {
             items: [
                 GraphqlOperationType {
-                    value_token: QUERY_KW@744..752 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                    value_token: QUERY_KW@735..743 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
                 },
                 GraphqlBogus {
                     items: [
-                        L_PAREN@752..753 "(" [] [],
+                        L_PAREN@743..744 "(" [] [],
                         GraphqlBogus {
                             items: [
                                 GraphqlVariableDefinition {
                                     variable: GraphqlVariable {
-                                        dollar_token: DOLLAR@753..754 "$" [] [],
+                                        dollar_token: DOLLAR@744..745 "$" [] [],
                                         name: missing (required),
                                     },
                                     colon_token: missing (required),
@@ -956,15 +942,15 @@ GraphqlRoot {
                                 },
                                 GraphqlBogus {
                                     items: [
-                                        GRAPHQL_INT_LITERAL@754..757 "156" [] [],
-                                        COLON@757..759 ":" [] [Whitespace(" ")],
+                                        GRAPHQL_INT_LITERAL@745..748 "156" [] [],
+                                        COLON@748..750 ":" [] [Whitespace(" ")],
                                         GraphqlDefaultValue {
-                                            eq_token: EQ@759..761 "=" [] [Whitespace(" ")],
+                                            eq_token: EQ@750..752 "=" [] [Whitespace(" ")],
                                             value: missing (required),
                                         },
                                         GraphqlDirectiveList [
                                             GraphqlDirective {
-                                                at_token: AT@761..762 "@" [] [],
+                                                at_token: AT@752..753 "@" [] [],
                                                 name: missing (required),
                                                 arguments: missing (optional),
                                             },
@@ -973,91 +959,91 @@ GraphqlRoot {
                                 },
                             ],
                         },
-                        R_PAREN@762..764 ")" [] [Whitespace(" ")],
+                        R_PAREN@753..755 ")" [] [Whitespace(" ")],
                     ],
                 },
                 GraphqlDirectiveList [],
                 GraphqlSelectionSet {
-                    l_curly_token: L_CURLY@764..765 "{" [] [],
+                    l_curly_token: L_CURLY@755..756 "{" [] [],
                     selections: GraphqlSelectionList [
                         GraphqlField {
                             alias: missing (optional),
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@765..776 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                                value_token: GRAPHQL_NAME@756..767 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                             },
                             arguments: missing (optional),
                             directives: GraphqlDirectiveList [],
                             selection_set: missing (optional),
                         },
                     ],
-                    r_curly_token: R_CURLY@776..778 "}" [Newline("\n")] [],
+                    r_curly_token: R_CURLY@767..769 "}" [Newline("\n")] [],
                 },
             ],
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@778..809 "query" [Newline("\n"), Newline("\n"), Comments("# malformed directives"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@769..800 "query" [Newline("\n"), Newline("\n"), Comments("# malformed directives"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
-                l_paren_token: L_PAREN@809..810 "(" [] [],
+                l_paren_token: L_PAREN@800..801 "(" [] [],
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: GraphqlVariable {
-                            dollar_token: DOLLAR@810..811 "$" [] [],
+                            dollar_token: DOLLAR@801..802 "$" [] [],
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@811..818 "storyId" [] [],
+                                value_token: GRAPHQL_NAME@802..809 "storyId" [] [],
                             },
                         },
-                        colon_token: COLON@818..820 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@809..811 ":" [] [Whitespace(" ")],
                         ty: GraphqlNonNullType {
                             base: GraphqlNamedType {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@820..822 "ID" [] [],
+                                    value_token: GRAPHQL_NAME@811..813 "ID" [] [],
                                 },
                             },
-                            excl_token: BANG@822..823 "!" [] [],
+                            excl_token: BANG@813..814 "!" [] [],
                         },
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_paren_token: R_PAREN@823..825 ")" [] [Whitespace(" ")],
+                r_paren_token: R_PAREN@814..816 ")" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
-                    at_token: AT@825..827 "@" [] [Whitespace(" ")],
+                    at_token: AT@816..818 "@" [] [Whitespace(" ")],
                     name: missing (required),
                     arguments: missing (optional),
                 },
             ],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@827..828 "{" [] [],
+                l_curly_token: L_CURLY@818..819 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@828..839 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@819..830 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: missing (optional),
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@839..841 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@830..832 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@841..842 "" [Newline("\n")] [],
+    eof_token: EOF@832..833 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..842
+0: GRAPHQL_ROOT@0..833
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..841
+  1: GRAPHQL_DEFINITION_LIST@0..832
     0: GRAPHQL_OPERATION_DEFINITION@0..17
       0: GRAPHQL_OPERATION_TYPE@0..6
         0: QUERY_KW@0..6 "query" [] [Whitespace(" ")]
@@ -1069,647 +1055,643 @@ GraphqlRoot {
         0: (empty)
         1: GRAPHQL_SELECTION_LIST@16..16
         2: R_CURLY@16..17 "}" [] []
-    1: GRAPHQL_OPERATION_DEFINITION@17..34
+    1: GRAPHQL_OPERATION_DEFINITION@17..43
       0: GRAPHQL_OPERATION_TYPE@17..25
         0: QUERY_KW@17..25 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: GRAPHQL_NAME@25..34
         0: GRAPHQL_NAME@25..34 "likeStory" [] []
       2: (empty)
       3: GRAPHQL_DIRECTIVE_LIST@34..34
-      4: GRAPHQL_SELECTION_SET@34..34
+      4: GRAPHQL_SELECTION_SET@34..43
         0: (empty)
-        1: GRAPHQL_SELECTION_LIST@34..34
-        2: (empty)
-    2: GRAPHQL_BOGUS_DEFINITION@34..130
-      0: GRAPHQL_OPERATION_TYPE@34..42
-        0: QUERY_KW@34..42 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      1: GRAPHQL_NAME@42..46
-        0: GRAPHQL_NAME@42..46 "like" [] []
-      2: GRAPHQL_BOGUS@46..97
-        0: GRAPHQL_BOGUS@46..97
-          0: GRAPHQL_VARIABLE_DEFINITION@46..52
-            0: GRAPHQL_VARIABLE@46..52
-              0: DOLLAR@46..47 "$" [] []
-              1: GRAPHQL_NAME@47..52
-                0: GRAPHQL_NAME@47..52 "Story" [] []
-            1: (empty)
+        1: GRAPHQL_SELECTION_LIST@34..42
+          0: GRAPHQL_FIELD@34..42
+            0: (empty)
+            1: GRAPHQL_NAME@34..42
+              0: GRAPHQL_NAME@34..42 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
             2: (empty)
-            3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@52..52
-          1: GRAPHQL_BOGUS@52..83
-            0: QUERY_KW@52..82 "query" [Newline("\n"), Newline("\n"), Comments("# malformed variables"), Newline("\n")] [Whitespace(" ")]
-            1: L_PAREN@82..83 "(" [] []
-          2: GRAPHQL_VARIABLE_DEFINITION@83..97
-            0: GRAPHQL_VARIABLE@83..91
-              0: DOLLAR@83..84 "$" [] []
-              1: GRAPHQL_NAME@84..91
-                0: GRAPHQL_NAME@84..91 "storyId" [] []
-            1: COLON@91..93 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_NON_NULL_TYPE@93..97
-              0: GRAPHQL_NAMED_TYPE@93..95
-                0: GRAPHQL_NAME@93..95
-                  0: GRAPHQL_NAME@93..95 "ID" [] []
-              1: BANG@95..97 "!" [] [Whitespace(" ")]
-            3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@97..97
-      3: GRAPHQL_DIRECTIVE_LIST@97..97
-      4: GRAPHQL_SELECTION_SET@97..130
-        0: L_CURLY@97..98 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@98..128
-          0: GRAPHQL_FIELD@98..128
-            0: (empty)
-            1: GRAPHQL_NAME@98..109
-              0: GRAPHQL_NAME@98..109 "likeStory" [Newline("\n"), Whitespace("\t")] []
-            2: GRAPHQL_ARGUMENTS@109..128
-              0: L_PAREN@109..110 "(" [] []
-              1: GRAPHQL_ARGUMENT_LIST@110..127
-                0: GRAPHQL_ARGUMENT@110..127
-                  0: GRAPHQL_NAME@110..117
-                    0: GRAPHQL_NAME@110..117 "storyId" [] []
-                  1: COLON@117..119 ":" [] [Whitespace(" ")]
-                  2: GRAPHQL_VARIABLE@119..127
-                    0: DOLLAR@119..120 "$" [] []
-                    1: GRAPHQL_NAME@120..127
-                      0: GRAPHQL_NAME@120..127 "storyId" [] []
-              2: R_PAREN@127..128 ")" [] []
-            3: GRAPHQL_DIRECTIVE_LIST@128..128
+            3: GRAPHQL_DIRECTIVE_LIST@42..42
             4: (empty)
-        2: R_CURLY@128..130 "}" [Newline("\n")] []
-    3: GRAPHQL_OPERATION_DEFINITION@130..185
-      0: GRAPHQL_OPERATION_TYPE@130..138
-        0: QUERY_KW@130..138 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@42..43 "}" [] []
+    2: GRAPHQL_OPERATION_DEFINITION@43..121
+      0: GRAPHQL_OPERATION_TYPE@43..73
+        0: QUERY_KW@43..73 "query" [Newline("\n"), Newline("\n"), Comments("# malformed variables"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@138..152
-        0: (empty)
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@138..152
-          0: GRAPHQL_VARIABLE_DEFINITION@138..152
-            0: GRAPHQL_VARIABLE@138..146
-              0: DOLLAR@138..139 "$" [] []
-              1: GRAPHQL_NAME@139..146
-                0: GRAPHQL_NAME@139..146 "storyId" [] []
-            1: COLON@146..148 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_NON_NULL_TYPE@148..152
-              0: GRAPHQL_NAMED_TYPE@148..150
-                0: GRAPHQL_NAME@148..150
-                  0: GRAPHQL_NAME@148..150 "ID" [] []
-              1: BANG@150..152 "!" [] [Whitespace(" ")]
+      2: GRAPHQL_VARIABLE_DEFINITIONS@73..88
+        0: L_PAREN@73..74 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@74..88
+          0: GRAPHQL_VARIABLE_DEFINITION@74..88
+            0: GRAPHQL_VARIABLE@74..82
+              0: DOLLAR@74..75 "$" [] []
+              1: GRAPHQL_NAME@75..82
+                0: GRAPHQL_NAME@75..82 "storyId" [] []
+            1: COLON@82..84 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@84..88
+              0: GRAPHQL_NAMED_TYPE@84..86
+                0: GRAPHQL_NAME@84..86
+                  0: GRAPHQL_NAME@84..86 "ID" [] []
+              1: BANG@86..88 "!" [] [Whitespace(" ")]
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@152..152
+            4: GRAPHQL_DIRECTIVE_LIST@88..88
         2: (empty)
-      3: GRAPHQL_DIRECTIVE_LIST@152..152
-      4: GRAPHQL_SELECTION_SET@152..185
-        0: L_CURLY@152..153 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@153..183
-          0: GRAPHQL_FIELD@153..183
+      3: GRAPHQL_DIRECTIVE_LIST@88..88
+      4: GRAPHQL_SELECTION_SET@88..121
+        0: L_CURLY@88..89 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@89..119
+          0: GRAPHQL_FIELD@89..119
             0: (empty)
-            1: GRAPHQL_NAME@153..164
-              0: GRAPHQL_NAME@153..164 "likeStory" [Newline("\n"), Whitespace("\t")] []
-            2: GRAPHQL_ARGUMENTS@164..183
-              0: L_PAREN@164..165 "(" [] []
-              1: GRAPHQL_ARGUMENT_LIST@165..182
-                0: GRAPHQL_ARGUMENT@165..182
-                  0: GRAPHQL_NAME@165..172
-                    0: GRAPHQL_NAME@165..172 "storyId" [] []
-                  1: COLON@172..174 ":" [] [Whitespace(" ")]
-                  2: GRAPHQL_VARIABLE@174..182
-                    0: DOLLAR@174..175 "$" [] []
-                    1: GRAPHQL_NAME@175..182
-                      0: GRAPHQL_NAME@175..182 "storyId" [] []
-              2: R_PAREN@182..183 ")" [] []
-            3: GRAPHQL_DIRECTIVE_LIST@183..183
+            1: GRAPHQL_NAME@89..100
+              0: GRAPHQL_NAME@89..100 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: GRAPHQL_ARGUMENTS@100..119
+              0: L_PAREN@100..101 "(" [] []
+              1: GRAPHQL_ARGUMENT_LIST@101..118
+                0: GRAPHQL_ARGUMENT@101..118
+                  0: GRAPHQL_NAME@101..108
+                    0: GRAPHQL_NAME@101..108 "storyId" [] []
+                  1: COLON@108..110 ":" [] [Whitespace(" ")]
+                  2: GRAPHQL_VARIABLE@110..118
+                    0: DOLLAR@110..111 "$" [] []
+                    1: GRAPHQL_NAME@111..118
+                      0: GRAPHQL_NAME@111..118 "storyId" [] []
+              2: R_PAREN@118..119 ")" [] []
+            3: GRAPHQL_DIRECTIVE_LIST@119..119
             4: (empty)
-        2: R_CURLY@183..185 "}" [Newline("\n")] []
-    4: GRAPHQL_OPERATION_DEFINITION@185..241
-      0: GRAPHQL_OPERATION_TYPE@185..193
-        0: QUERY_KW@185..193 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@119..121 "}" [Newline("\n")] []
+    3: GRAPHQL_OPERATION_DEFINITION@121..176
+      0: GRAPHQL_OPERATION_TYPE@121..129
+        0: QUERY_KW@121..129 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@193..208
+      2: GRAPHQL_VARIABLE_DEFINITIONS@129..143
         0: (empty)
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@193..206
-          0: GRAPHQL_VARIABLE_DEFINITION@193..206
-            0: GRAPHQL_VARIABLE@193..201
-              0: DOLLAR@193..194 "$" [] []
-              1: GRAPHQL_NAME@194..201
-                0: GRAPHQL_NAME@194..201 "storyId" [] []
-            1: COLON@201..203 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_NON_NULL_TYPE@203..206
-              0: GRAPHQL_NAMED_TYPE@203..205
-                0: GRAPHQL_NAME@203..205
-                  0: GRAPHQL_NAME@203..205 "ID" [] []
-              1: BANG@205..206 "!" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@129..143
+          0: GRAPHQL_VARIABLE_DEFINITION@129..143
+            0: GRAPHQL_VARIABLE@129..137
+              0: DOLLAR@129..130 "$" [] []
+              1: GRAPHQL_NAME@130..137
+                0: GRAPHQL_NAME@130..137 "storyId" [] []
+            1: COLON@137..139 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@139..143
+              0: GRAPHQL_NAMED_TYPE@139..141
+                0: GRAPHQL_NAME@139..141
+                  0: GRAPHQL_NAME@139..141 "ID" [] []
+              1: BANG@141..143 "!" [] [Whitespace(" ")]
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@206..206
-        2: R_PAREN@206..208 ")" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@208..208
-      4: GRAPHQL_SELECTION_SET@208..241
-        0: L_CURLY@208..209 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@209..239
-          0: GRAPHQL_FIELD@209..239
+            4: GRAPHQL_DIRECTIVE_LIST@143..143
+        2: (empty)
+      3: GRAPHQL_DIRECTIVE_LIST@143..143
+      4: GRAPHQL_SELECTION_SET@143..176
+        0: L_CURLY@143..144 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@144..174
+          0: GRAPHQL_FIELD@144..174
             0: (empty)
-            1: GRAPHQL_NAME@209..220
-              0: GRAPHQL_NAME@209..220 "likeStory" [Newline("\n"), Whitespace("\t")] []
-            2: GRAPHQL_ARGUMENTS@220..239
-              0: L_PAREN@220..221 "(" [] []
-              1: GRAPHQL_ARGUMENT_LIST@221..238
-                0: GRAPHQL_ARGUMENT@221..238
-                  0: GRAPHQL_NAME@221..228
-                    0: GRAPHQL_NAME@221..228 "storyId" [] []
-                  1: COLON@228..230 ":" [] [Whitespace(" ")]
-                  2: GRAPHQL_VARIABLE@230..238
-                    0: DOLLAR@230..231 "$" [] []
-                    1: GRAPHQL_NAME@231..238
-                      0: GRAPHQL_NAME@231..238 "storyId" [] []
-              2: R_PAREN@238..239 ")" [] []
-            3: GRAPHQL_DIRECTIVE_LIST@239..239
+            1: GRAPHQL_NAME@144..155
+              0: GRAPHQL_NAME@144..155 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: GRAPHQL_ARGUMENTS@155..174
+              0: L_PAREN@155..156 "(" [] []
+              1: GRAPHQL_ARGUMENT_LIST@156..173
+                0: GRAPHQL_ARGUMENT@156..173
+                  0: GRAPHQL_NAME@156..163
+                    0: GRAPHQL_NAME@156..163 "storyId" [] []
+                  1: COLON@163..165 ":" [] [Whitespace(" ")]
+                  2: GRAPHQL_VARIABLE@165..173
+                    0: DOLLAR@165..166 "$" [] []
+                    1: GRAPHQL_NAME@166..173
+                      0: GRAPHQL_NAME@166..173 "storyId" [] []
+              2: R_PAREN@173..174 ")" [] []
+            3: GRAPHQL_DIRECTIVE_LIST@174..174
             4: (empty)
-        2: R_CURLY@239..241 "}" [Newline("\n")] []
-    5: GRAPHQL_OPERATION_DEFINITION@241..281
-      0: GRAPHQL_OPERATION_TYPE@241..249
-        0: QUERY_KW@241..249 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@174..176 "}" [Newline("\n")] []
+    4: GRAPHQL_OPERATION_DEFINITION@176..232
+      0: GRAPHQL_OPERATION_TYPE@176..184
+        0: QUERY_KW@176..184 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@249..255
-        0: L_PAREN@249..250 "(" [] []
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@250..253
-          0: GRAPHQL_VARIABLE_DEFINITION@250..253
-            0: GRAPHQL_VARIABLE@250..251
-              0: DOLLAR@250..251 "$" [] []
+      2: GRAPHQL_VARIABLE_DEFINITIONS@184..199
+        0: (empty)
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@184..197
+          0: GRAPHQL_VARIABLE_DEFINITION@184..197
+            0: GRAPHQL_VARIABLE@184..192
+              0: DOLLAR@184..185 "$" [] []
+              1: GRAPHQL_NAME@185..192
+                0: GRAPHQL_NAME@185..192 "storyId" [] []
+            1: COLON@192..194 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@194..197
+              0: GRAPHQL_NAMED_TYPE@194..196
+                0: GRAPHQL_NAME@194..196
+                  0: GRAPHQL_NAME@194..196 "ID" [] []
+              1: BANG@196..197 "!" [] []
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@197..197
+        2: R_PAREN@197..199 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@199..199
+      4: GRAPHQL_SELECTION_SET@199..232
+        0: L_CURLY@199..200 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@200..230
+          0: GRAPHQL_FIELD@200..230
+            0: (empty)
+            1: GRAPHQL_NAME@200..211
+              0: GRAPHQL_NAME@200..211 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: GRAPHQL_ARGUMENTS@211..230
+              0: L_PAREN@211..212 "(" [] []
+              1: GRAPHQL_ARGUMENT_LIST@212..229
+                0: GRAPHQL_ARGUMENT@212..229
+                  0: GRAPHQL_NAME@212..219
+                    0: GRAPHQL_NAME@212..219 "storyId" [] []
+                  1: COLON@219..221 ":" [] [Whitespace(" ")]
+                  2: GRAPHQL_VARIABLE@221..229
+                    0: DOLLAR@221..222 "$" [] []
+                    1: GRAPHQL_NAME@222..229
+                      0: GRAPHQL_NAME@222..229 "storyId" [] []
+              2: R_PAREN@229..230 ")" [] []
+            3: GRAPHQL_DIRECTIVE_LIST@230..230
+            4: (empty)
+        2: R_CURLY@230..232 "}" [Newline("\n")] []
+    5: GRAPHQL_OPERATION_DEFINITION@232..272
+      0: GRAPHQL_OPERATION_TYPE@232..240
+        0: QUERY_KW@232..240 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: (empty)
+      2: GRAPHQL_VARIABLE_DEFINITIONS@240..246
+        0: L_PAREN@240..241 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@241..244
+          0: GRAPHQL_VARIABLE_DEFINITION@241..244
+            0: GRAPHQL_VARIABLE@241..242
+              0: DOLLAR@241..242 "$" [] []
               1: (empty)
-            1: COLON@251..253 ":" [] [Whitespace(" ")]
+            1: COLON@242..244 ":" [] [Whitespace(" ")]
             2: (empty)
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@253..253
-        2: R_PAREN@253..255 ")" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@255..255
-      4: GRAPHQL_SELECTION_SET@255..281
-        0: L_CURLY@255..256 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@256..279
-          0: GRAPHQL_FIELD@256..279
+            4: GRAPHQL_DIRECTIVE_LIST@244..244
+        2: R_PAREN@244..246 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@246..246
+      4: GRAPHQL_SELECTION_SET@246..272
+        0: L_CURLY@246..247 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@247..270
+          0: GRAPHQL_FIELD@247..270
             0: (empty)
-            1: GRAPHQL_NAME@256..267
-              0: GRAPHQL_NAME@256..267 "likeStory" [Newline("\n"), Whitespace("\t")] []
-            2: GRAPHQL_ARGUMENTS@267..279
-              0: L_PAREN@267..268 "(" [] []
-              1: GRAPHQL_ARGUMENT_LIST@268..278
-                0: GRAPHQL_ARGUMENT@268..278
-                  0: GRAPHQL_NAME@268..275
-                    0: GRAPHQL_NAME@268..275 "storyId" [] []
-                  1: COLON@275..277 ":" [] [Whitespace(" ")]
-                  2: GRAPHQL_VARIABLE@277..278
-                    0: DOLLAR@277..278 "$" [] []
+            1: GRAPHQL_NAME@247..258
+              0: GRAPHQL_NAME@247..258 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: GRAPHQL_ARGUMENTS@258..270
+              0: L_PAREN@258..259 "(" [] []
+              1: GRAPHQL_ARGUMENT_LIST@259..269
+                0: GRAPHQL_ARGUMENT@259..269
+                  0: GRAPHQL_NAME@259..266
+                    0: GRAPHQL_NAME@259..266 "storyId" [] []
+                  1: COLON@266..268 ":" [] [Whitespace(" ")]
+                  2: GRAPHQL_VARIABLE@268..269
+                    0: DOLLAR@268..269 "$" [] []
                     1: (empty)
-              2: R_PAREN@278..279 ")" [] []
-            3: GRAPHQL_DIRECTIVE_LIST@279..279
+              2: R_PAREN@269..270 ")" [] []
+            3: GRAPHQL_DIRECTIVE_LIST@270..270
             4: (empty)
-        2: R_CURLY@279..281 "}" [Newline("\n")] []
-    6: GRAPHQL_BOGUS_DEFINITION@281..309
-      0: GRAPHQL_OPERATION_TYPE@281..289
-        0: QUERY_KW@281..289 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      1: GRAPHQL_BOGUS@289..295
-        0: L_PAREN@289..290 "(" [] []
-        1: GRAPHQL_BOGUS@290..293
-          0: GRAPHQL_BOGUS@290..293
-            0: GRAPHQL_NAME@290..291 "a" [] []
-            1: COLON@291..293 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_DIRECTIVE_LIST@293..293
-        2: R_PAREN@293..295 ")" [] [Whitespace(" ")]
-      2: GRAPHQL_DIRECTIVE_LIST@295..295
-      3: GRAPHQL_SELECTION_SET@295..309
-        0: L_CURLY@295..296 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@296..307
-          0: GRAPHQL_FIELD@296..307
+        2: R_CURLY@270..272 "}" [Newline("\n")] []
+    6: GRAPHQL_BOGUS_DEFINITION@272..300
+      0: GRAPHQL_OPERATION_TYPE@272..280
+        0: QUERY_KW@272..280 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_BOGUS@280..286
+        0: L_PAREN@280..281 "(" [] []
+        1: GRAPHQL_BOGUS@281..284
+          0: GRAPHQL_BOGUS@281..284
+            0: GRAPHQL_NAME@281..282 "a" [] []
+            1: COLON@282..284 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_DIRECTIVE_LIST@284..284
+        2: R_PAREN@284..286 ")" [] [Whitespace(" ")]
+      2: GRAPHQL_DIRECTIVE_LIST@286..286
+      3: GRAPHQL_SELECTION_SET@286..300
+        0: L_CURLY@286..287 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@287..298
+          0: GRAPHQL_FIELD@287..298
             0: (empty)
-            1: GRAPHQL_NAME@296..307
-              0: GRAPHQL_NAME@296..307 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            1: GRAPHQL_NAME@287..298
+              0: GRAPHQL_NAME@287..298 "likeStory" [Newline("\n"), Whitespace("\t")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@307..307
+            3: GRAPHQL_DIRECTIVE_LIST@298..298
             4: (empty)
-        2: R_CURLY@307..309 "}" [Newline("\n")] []
-    7: GRAPHQL_BOGUS_DEFINITION@309..336
-      0: GRAPHQL_OPERATION_TYPE@309..317
-        0: QUERY_KW@309..317 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      1: GRAPHQL_BOGUS@317..322
-        0: L_PAREN@317..318 "(" [] []
-        1: GRAPHQL_BOGUS@318..322
-          0: GRAPHQL_BOGUS@318..322
-            0: GRAPHQL_NAME@318..319 "a" [] []
-            1: COLON@319..322 ":" [] [Whitespace("  ")]
-            2: GRAPHQL_DIRECTIVE_LIST@322..322
-      2: GRAPHQL_DIRECTIVE_LIST@322..322
-      3: GRAPHQL_SELECTION_SET@322..336
-        0: L_CURLY@322..323 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@323..334
-          0: GRAPHQL_FIELD@323..334
+        2: R_CURLY@298..300 "}" [Newline("\n")] []
+    7: GRAPHQL_BOGUS_DEFINITION@300..327
+      0: GRAPHQL_OPERATION_TYPE@300..308
+        0: QUERY_KW@300..308 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_BOGUS@308..313
+        0: L_PAREN@308..309 "(" [] []
+        1: GRAPHQL_BOGUS@309..313
+          0: GRAPHQL_BOGUS@309..313
+            0: GRAPHQL_NAME@309..310 "a" [] []
+            1: COLON@310..313 ":" [] [Whitespace("  ")]
+            2: GRAPHQL_DIRECTIVE_LIST@313..313
+      2: GRAPHQL_DIRECTIVE_LIST@313..313
+      3: GRAPHQL_SELECTION_SET@313..327
+        0: L_CURLY@313..314 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@314..325
+          0: GRAPHQL_FIELD@314..325
             0: (empty)
-            1: GRAPHQL_NAME@323..334
-              0: GRAPHQL_NAME@323..334 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            1: GRAPHQL_NAME@314..325
+              0: GRAPHQL_NAME@314..325 "likeStory" [Newline("\n"), Whitespace("\t")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@334..334
+            3: GRAPHQL_DIRECTIVE_LIST@325..325
             4: (empty)
-        2: R_CURLY@334..336 "}" [Newline("\n")] []
-    8: GRAPHQL_OPERATION_DEFINITION@336..363
-      0: GRAPHQL_OPERATION_TYPE@336..344
-        0: QUERY_KW@336..344 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@325..327 "}" [Newline("\n")] []
+    8: GRAPHQL_OPERATION_DEFINITION@327..354
+      0: GRAPHQL_OPERATION_TYPE@327..335
+        0: QUERY_KW@327..335 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@344..349
-        0: L_PAREN@344..345 "(" [] []
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@345..347
-          0: GRAPHQL_VARIABLE_DEFINITION@345..347
+      2: GRAPHQL_VARIABLE_DEFINITIONS@335..340
+        0: L_PAREN@335..336 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@336..338
+          0: GRAPHQL_VARIABLE_DEFINITION@336..338
             0: (empty)
-            1: COLON@345..347 ":" [] [Whitespace(" ")]
+            1: COLON@336..338 ":" [] [Whitespace(" ")]
             2: (empty)
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@347..347
-        2: R_PAREN@347..349 ")" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@349..349
-      4: GRAPHQL_SELECTION_SET@349..363
-        0: L_CURLY@349..350 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@350..361
-          0: GRAPHQL_FIELD@350..361
+            4: GRAPHQL_DIRECTIVE_LIST@338..338
+        2: R_PAREN@338..340 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@340..340
+      4: GRAPHQL_SELECTION_SET@340..354
+        0: L_CURLY@340..341 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@341..352
+          0: GRAPHQL_FIELD@341..352
             0: (empty)
-            1: GRAPHQL_NAME@350..361
-              0: GRAPHQL_NAME@350..361 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            1: GRAPHQL_NAME@341..352
+              0: GRAPHQL_NAME@341..352 "likeStory" [Newline("\n"), Whitespace("\t")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@361..361
+            3: GRAPHQL_DIRECTIVE_LIST@352..352
             4: (empty)
-        2: R_CURLY@361..363 "}" [Newline("\n")] []
-    9: GRAPHQL_OPERATION_DEFINITION@363..389
-      0: GRAPHQL_OPERATION_TYPE@363..371
-        0: QUERY_KW@363..371 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@352..354 "}" [Newline("\n")] []
+    9: GRAPHQL_OPERATION_DEFINITION@354..380
+      0: GRAPHQL_OPERATION_TYPE@354..362
+        0: QUERY_KW@354..362 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@371..375
-        0: L_PAREN@371..372 "(" [] []
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@372..375
-          0: GRAPHQL_VARIABLE_DEFINITION@372..375
+      2: GRAPHQL_VARIABLE_DEFINITIONS@362..366
+        0: L_PAREN@362..363 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@363..366
+          0: GRAPHQL_VARIABLE_DEFINITION@363..366
             0: (empty)
-            1: COLON@372..375 ":" [] [Whitespace("  ")]
+            1: COLON@363..366 ":" [] [Whitespace("  ")]
             2: (empty)
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@375..375
+            4: GRAPHQL_DIRECTIVE_LIST@366..366
         2: (empty)
-      3: GRAPHQL_DIRECTIVE_LIST@375..375
-      4: GRAPHQL_SELECTION_SET@375..389
-        0: L_CURLY@375..376 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@376..387
-          0: GRAPHQL_FIELD@376..387
+      3: GRAPHQL_DIRECTIVE_LIST@366..366
+      4: GRAPHQL_SELECTION_SET@366..380
+        0: L_CURLY@366..367 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@367..378
+          0: GRAPHQL_FIELD@367..378
             0: (empty)
-            1: GRAPHQL_NAME@376..387
-              0: GRAPHQL_NAME@376..387 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            1: GRAPHQL_NAME@367..378
+              0: GRAPHQL_NAME@367..378 "likeStory" [Newline("\n"), Whitespace("\t")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@387..387
+            3: GRAPHQL_DIRECTIVE_LIST@378..378
             4: (empty)
-        2: R_CURLY@387..389 "}" [Newline("\n")] []
-    10: GRAPHQL_OPERATION_DEFINITION@389..414
-      0: GRAPHQL_OPERATION_TYPE@389..397
-        0: QUERY_KW@389..397 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@378..380 "}" [Newline("\n")] []
+    10: GRAPHQL_OPERATION_DEFINITION@380..405
+      0: GRAPHQL_OPERATION_TYPE@380..388
+        0: QUERY_KW@380..388 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@397..400
+      2: GRAPHQL_VARIABLE_DEFINITIONS@388..391
         0: (empty)
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@397..400
-          0: GRAPHQL_VARIABLE_DEFINITION@397..400
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@388..391
+          0: GRAPHQL_VARIABLE_DEFINITION@388..391
             0: (empty)
-            1: COLON@397..400 ":" [] [Whitespace("  ")]
+            1: COLON@388..391 ":" [] [Whitespace("  ")]
             2: (empty)
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@400..400
+            4: GRAPHQL_DIRECTIVE_LIST@391..391
         2: (empty)
-      3: GRAPHQL_DIRECTIVE_LIST@400..400
-      4: GRAPHQL_SELECTION_SET@400..414
-        0: L_CURLY@400..401 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@401..412
-          0: GRAPHQL_FIELD@401..412
+      3: GRAPHQL_DIRECTIVE_LIST@391..391
+      4: GRAPHQL_SELECTION_SET@391..405
+        0: L_CURLY@391..392 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@392..403
+          0: GRAPHQL_FIELD@392..403
             0: (empty)
-            1: GRAPHQL_NAME@401..412
-              0: GRAPHQL_NAME@401..412 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            1: GRAPHQL_NAME@392..403
+              0: GRAPHQL_NAME@392..403 "likeStory" [Newline("\n"), Whitespace("\t")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@412..412
+            3: GRAPHQL_DIRECTIVE_LIST@403..403
             4: (empty)
-        2: R_CURLY@412..414 "}" [Newline("\n")] []
-    11: GRAPHQL_OPERATION_DEFINITION@414..439
-      0: GRAPHQL_OPERATION_TYPE@414..422
-        0: QUERY_KW@414..422 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@403..405 "}" [Newline("\n")] []
+    11: GRAPHQL_OPERATION_DEFINITION@405..430
+      0: GRAPHQL_OPERATION_TYPE@405..413
+        0: QUERY_KW@405..413 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@422..425
-        0: L_PAREN@422..425 "(" [] [Whitespace("  ")]
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@425..425
+      2: GRAPHQL_VARIABLE_DEFINITIONS@413..416
+        0: L_PAREN@413..416 "(" [] [Whitespace("  ")]
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@416..416
         2: (empty)
-      3: GRAPHQL_DIRECTIVE_LIST@425..425
-      4: GRAPHQL_SELECTION_SET@425..439
-        0: L_CURLY@425..426 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@426..437
-          0: GRAPHQL_FIELD@426..437
+      3: GRAPHQL_DIRECTIVE_LIST@416..416
+      4: GRAPHQL_SELECTION_SET@416..430
+        0: L_CURLY@416..417 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@417..428
+          0: GRAPHQL_FIELD@417..428
             0: (empty)
-            1: GRAPHQL_NAME@426..437
-              0: GRAPHQL_NAME@426..437 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            1: GRAPHQL_NAME@417..428
+              0: GRAPHQL_NAME@417..428 "likeStory" [Newline("\n"), Whitespace("\t")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@437..437
+            3: GRAPHQL_DIRECTIVE_LIST@428..428
             4: (empty)
-        2: R_CURLY@437..439 "}" [Newline("\n")] []
-    12: GRAPHQL_OPERATION_DEFINITION@439..476
-      0: GRAPHQL_OPERATION_TYPE@439..447
-        0: QUERY_KW@439..447 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@428..430 "}" [Newline("\n")] []
+    12: GRAPHQL_OPERATION_DEFINITION@430..467
+      0: GRAPHQL_OPERATION_TYPE@430..438
+        0: QUERY_KW@430..438 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@447..462
-        0: L_PAREN@447..448 "(" [] []
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@448..462
-          0: GRAPHQL_VARIABLE_DEFINITION@448..462
-            0: GRAPHQL_VARIABLE@448..456
-              0: DOLLAR@448..449 "$" [] []
-              1: GRAPHQL_NAME@449..456
-                0: GRAPHQL_NAME@449..456 "storyId" [] []
-            1: COLON@456..458 ":" [] [Whitespace(" ")]
+      2: GRAPHQL_VARIABLE_DEFINITIONS@438..453
+        0: L_PAREN@438..439 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@439..453
+          0: GRAPHQL_VARIABLE_DEFINITION@439..453
+            0: GRAPHQL_VARIABLE@439..447
+              0: DOLLAR@439..440 "$" [] []
+              1: GRAPHQL_NAME@440..447
+                0: GRAPHQL_NAME@440..447 "storyId" [] []
+            1: COLON@447..449 ":" [] [Whitespace(" ")]
             2: (empty)
-            3: GRAPHQL_DEFAULT_VALUE@458..460
-              0: EQ@458..460 "=" [] [Whitespace(" ")]
+            3: GRAPHQL_DEFAULT_VALUE@449..451
+              0: EQ@449..451 "=" [] [Whitespace(" ")]
               1: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@460..462
-              0: GRAPHQL_DIRECTIVE@460..462
-                0: AT@460..462 "@" [] [Whitespace(" ")]
+            4: GRAPHQL_DIRECTIVE_LIST@451..453
+              0: GRAPHQL_DIRECTIVE@451..453
+                0: AT@451..453 "@" [] [Whitespace(" ")]
                 1: (empty)
                 2: (empty)
         2: (empty)
-      3: GRAPHQL_DIRECTIVE_LIST@462..462
-      4: GRAPHQL_SELECTION_SET@462..476
-        0: L_CURLY@462..463 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@463..474
-          0: GRAPHQL_FIELD@463..474
+      3: GRAPHQL_DIRECTIVE_LIST@453..453
+      4: GRAPHQL_SELECTION_SET@453..467
+        0: L_CURLY@453..454 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@454..465
+          0: GRAPHQL_FIELD@454..465
             0: (empty)
-            1: GRAPHQL_NAME@463..474
-              0: GRAPHQL_NAME@463..474 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            1: GRAPHQL_NAME@454..465
+              0: GRAPHQL_NAME@454..465 "likeStory" [Newline("\n"), Whitespace("\t")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@474..474
+            3: GRAPHQL_DIRECTIVE_LIST@465..465
             4: (empty)
-        2: R_CURLY@474..476 "}" [Newline("\n")] []
-    13: GRAPHQL_OPERATION_DEFINITION@476..519
-      0: GRAPHQL_OPERATION_TYPE@476..503
-        0: QUERY_KW@476..503 "query" [Newline("\n"), Newline("\n"), Comments("# malformed alias"), Newline("\n")] [Whitespace("  ")]
+        2: R_CURLY@465..467 "}" [Newline("\n")] []
+    13: GRAPHQL_OPERATION_DEFINITION@467..510
+      0: GRAPHQL_OPERATION_TYPE@467..494
+        0: QUERY_KW@467..494 "query" [Newline("\n"), Newline("\n"), Comments("# malformed alias"), Newline("\n")] [Whitespace("  ")]
       1: (empty)
       2: (empty)
-      3: GRAPHQL_DIRECTIVE_LIST@503..503
-      4: GRAPHQL_SELECTION_SET@503..519
-        0: L_CURLY@503..504 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@504..517
-          0: GRAPHQL_FIELD@504..517
-            0: GRAPHQL_ALIAS@504..508
+      3: GRAPHQL_DIRECTIVE_LIST@494..494
+      4: GRAPHQL_SELECTION_SET@494..510
+        0: L_CURLY@494..495 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@495..508
+          0: GRAPHQL_FIELD@495..508
+            0: GRAPHQL_ALIAS@495..499
               0: (empty)
-              1: COLON@504..508 ":" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
-            1: GRAPHQL_NAME@508..517
-              0: GRAPHQL_NAME@508..517 "likeStory" [] []
+              1: COLON@495..499 ":" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+            1: GRAPHQL_NAME@499..508
+              0: GRAPHQL_NAME@499..508 "likeStory" [] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@517..517
+            3: GRAPHQL_DIRECTIVE_LIST@508..508
             4: (empty)
-        2: R_CURLY@517..519 "}" [Newline("\n")] []
-    14: GRAPHQL_OPERATION_DEFINITION@519..582
-      0: GRAPHQL_OPERATION_TYPE@519..549
-        0: QUERY_KW@519..549 "query" [Newline("\n"), Newline("\n"), Comments("# malformed arguments"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@508..510 "}" [Newline("\n")] []
+    14: GRAPHQL_OPERATION_DEFINITION@510..573
+      0: GRAPHQL_OPERATION_TYPE@510..540
+        0: QUERY_KW@510..540 "query" [Newline("\n"), Newline("\n"), Comments("# malformed arguments"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: (empty)
-      3: GRAPHQL_DIRECTIVE_LIST@549..549
-      4: GRAPHQL_SELECTION_SET@549..582
-        0: L_CURLY@549..550 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@550..580
-          0: GRAPHQL_FIELD@550..562
+      3: GRAPHQL_DIRECTIVE_LIST@540..540
+      4: GRAPHQL_SELECTION_SET@540..573
+        0: L_CURLY@540..541 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@541..571
+          0: GRAPHQL_FIELD@541..553
             0: (empty)
-            1: GRAPHQL_NAME@550..562
-              0: GRAPHQL_NAME@550..562 "likeStory" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+            1: GRAPHQL_NAME@541..553
+              0: GRAPHQL_NAME@541..553 "likeStory" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@553..553
+            4: (empty)
+          1: GRAPHQL_FIELD@553..562
+            0: GRAPHQL_ALIAS@553..562
+              0: GRAPHQL_NAME@553..560
+                0: GRAPHQL_NAME@553..560 "storyId" [] []
+              1: COLON@560..562 ":" [] [Whitespace(" ")]
+            1: (empty)
             2: (empty)
             3: GRAPHQL_DIRECTIVE_LIST@562..562
             4: (empty)
-          1: GRAPHQL_FIELD@562..571
-            0: GRAPHQL_ALIAS@562..571
-              0: GRAPHQL_NAME@562..569
-                0: GRAPHQL_NAME@562..569 "storyId" [] []
-              1: COLON@569..571 ":" [] [Whitespace(" ")]
-            1: (empty)
-            2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@571..571
-            4: (empty)
-          2: GRAPHQL_BOGUS_SELECTION@571..572
-            0: DOLLAR@571..572 "$" [] []
-          3: GRAPHQL_FIELD@572..579
+          2: GRAPHQL_BOGUS_SELECTION@562..563
+            0: DOLLAR@562..563 "$" [] []
+          3: GRAPHQL_FIELD@563..570
             0: (empty)
-            1: GRAPHQL_NAME@572..579
-              0: GRAPHQL_NAME@572..579 "storyId" [] []
+            1: GRAPHQL_NAME@563..570
+              0: GRAPHQL_NAME@563..570 "storyId" [] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@579..579
+            3: GRAPHQL_DIRECTIVE_LIST@570..570
             4: (empty)
-          4: GRAPHQL_BOGUS_SELECTION@579..580
-            0: R_PAREN@579..580 ")" [] []
-        2: R_CURLY@580..582 "}" [Newline("\n")] []
-    15: GRAPHQL_OPERATION_DEFINITION@582..638
-      0: GRAPHQL_OPERATION_TYPE@582..590
-        0: QUERY_KW@582..590 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+          4: GRAPHQL_BOGUS_SELECTION@570..571
+            0: R_PAREN@570..571 ")" [] []
+        2: R_CURLY@571..573 "}" [Newline("\n")] []
+    15: GRAPHQL_OPERATION_DEFINITION@573..629
+      0: GRAPHQL_OPERATION_TYPE@573..581
+        0: QUERY_KW@573..581 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@590..606
-        0: L_PAREN@590..591 "(" [] []
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@591..604
-          0: GRAPHQL_VARIABLE_DEFINITION@591..604
-            0: GRAPHQL_VARIABLE@591..599
-              0: DOLLAR@591..592 "$" [] []
-              1: GRAPHQL_NAME@592..599
-                0: GRAPHQL_NAME@592..599 "storyId" [] []
-            1: COLON@599..601 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_NON_NULL_TYPE@601..604
-              0: GRAPHQL_NAMED_TYPE@601..603
-                0: GRAPHQL_NAME@601..603
-                  0: GRAPHQL_NAME@601..603 "ID" [] []
-              1: BANG@603..604 "!" [] []
+      2: GRAPHQL_VARIABLE_DEFINITIONS@581..597
+        0: L_PAREN@581..582 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@582..595
+          0: GRAPHQL_VARIABLE_DEFINITION@582..595
+            0: GRAPHQL_VARIABLE@582..590
+              0: DOLLAR@582..583 "$" [] []
+              1: GRAPHQL_NAME@583..590
+                0: GRAPHQL_NAME@583..590 "storyId" [] []
+            1: COLON@590..592 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@592..595
+              0: GRAPHQL_NAMED_TYPE@592..594
+                0: GRAPHQL_NAME@592..594
+                  0: GRAPHQL_NAME@592..594 "ID" [] []
+              1: BANG@594..595 "!" [] []
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@604..604
-        2: R_PAREN@604..606 ")" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@606..606
-      4: GRAPHQL_SELECTION_SET@606..638
-        0: L_CURLY@606..607 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@607..636
-          0: GRAPHQL_FIELD@607..636
+            4: GRAPHQL_DIRECTIVE_LIST@595..595
+        2: R_PAREN@595..597 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@597..597
+      4: GRAPHQL_SELECTION_SET@597..629
+        0: L_CURLY@597..598 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@598..627
+          0: GRAPHQL_FIELD@598..627
             0: (empty)
-            1: GRAPHQL_NAME@607..618
-              0: GRAPHQL_NAME@607..618 "likeStory" [Newline("\n"), Whitespace("\t")] []
-            2: GRAPHQL_ARGUMENTS@618..636
-              0: L_PAREN@618..619 "(" [] []
-              1: GRAPHQL_ARGUMENT_LIST@619..636
-                0: GRAPHQL_ARGUMENT@619..636
-                  0: GRAPHQL_NAME@619..626
-                    0: GRAPHQL_NAME@619..626 "storyId" [] []
-                  1: COLON@626..628 ":" [] [Whitespace(" ")]
-                  2: GRAPHQL_VARIABLE@628..636
-                    0: DOLLAR@628..629 "$" [] []
-                    1: GRAPHQL_NAME@629..636
-                      0: GRAPHQL_NAME@629..636 "storyId" [] []
+            1: GRAPHQL_NAME@598..609
+              0: GRAPHQL_NAME@598..609 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: GRAPHQL_ARGUMENTS@609..627
+              0: L_PAREN@609..610 "(" [] []
+              1: GRAPHQL_ARGUMENT_LIST@610..627
+                0: GRAPHQL_ARGUMENT@610..627
+                  0: GRAPHQL_NAME@610..617
+                    0: GRAPHQL_NAME@610..617 "storyId" [] []
+                  1: COLON@617..619 ":" [] [Whitespace(" ")]
+                  2: GRAPHQL_VARIABLE@619..627
+                    0: DOLLAR@619..620 "$" [] []
+                    1: GRAPHQL_NAME@620..627
+                      0: GRAPHQL_NAME@620..627 "storyId" [] []
               2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@636..636
+            3: GRAPHQL_DIRECTIVE_LIST@627..627
             4: (empty)
-        2: R_CURLY@636..638 "}" [Newline("\n")] []
-    16: GRAPHQL_OPERATION_DEFINITION@638..695
-      0: GRAPHQL_OPERATION_TYPE@638..646
-        0: QUERY_KW@638..646 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@627..629 "}" [Newline("\n")] []
+    16: GRAPHQL_OPERATION_DEFINITION@629..686
+      0: GRAPHQL_OPERATION_TYPE@629..637
+        0: QUERY_KW@629..637 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@646..663
-        0: L_PAREN@646..647 "(" [] []
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@647..660
-          0: GRAPHQL_VARIABLE_DEFINITION@647..660
-            0: GRAPHQL_VARIABLE@647..655
-              0: DOLLAR@647..648 "$" [] []
-              1: GRAPHQL_NAME@648..655
-                0: GRAPHQL_NAME@648..655 "storyId" [] []
-            1: COLON@655..657 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_NON_NULL_TYPE@657..660
-              0: GRAPHQL_NAMED_TYPE@657..659
-                0: GRAPHQL_NAME@657..659
-                  0: GRAPHQL_NAME@657..659 "ID" [] []
-              1: BANG@659..660 "!" [] []
+      2: GRAPHQL_VARIABLE_DEFINITIONS@637..654
+        0: L_PAREN@637..638 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@638..651
+          0: GRAPHQL_VARIABLE_DEFINITION@638..651
+            0: GRAPHQL_VARIABLE@638..646
+              0: DOLLAR@638..639 "$" [] []
+              1: GRAPHQL_NAME@639..646
+                0: GRAPHQL_NAME@639..646 "storyId" [] []
+            1: COLON@646..648 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@648..651
+              0: GRAPHQL_NAMED_TYPE@648..650
+                0: GRAPHQL_NAME@648..650
+                  0: GRAPHQL_NAME@648..650 "ID" [] []
+              1: BANG@650..651 "!" [] []
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@660..660
-        2: R_PAREN@660..663 ")" [] [Whitespace("  ")]
-      3: GRAPHQL_DIRECTIVE_LIST@663..663
-      4: GRAPHQL_SELECTION_SET@663..695
-        0: L_CURLY@663..664 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@664..693
-          0: GRAPHQL_FIELD@664..676
+            4: GRAPHQL_DIRECTIVE_LIST@651..651
+        2: R_PAREN@651..654 ")" [] [Whitespace("  ")]
+      3: GRAPHQL_DIRECTIVE_LIST@654..654
+      4: GRAPHQL_SELECTION_SET@654..686
+        0: L_CURLY@654..655 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@655..684
+          0: GRAPHQL_FIELD@655..667
             0: (empty)
-            1: GRAPHQL_NAME@664..676
-              0: GRAPHQL_NAME@664..676 "likeStory" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+            1: GRAPHQL_NAME@655..667
+              0: GRAPHQL_NAME@655..667 "likeStory" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@667..667
+            4: (empty)
+          1: GRAPHQL_FIELD@667..676
+            0: GRAPHQL_ALIAS@667..676
+              0: GRAPHQL_NAME@667..674
+                0: GRAPHQL_NAME@667..674 "storyId" [] []
+              1: COLON@674..676 ":" [] [Whitespace(" ")]
+            1: (empty)
             2: (empty)
             3: GRAPHQL_DIRECTIVE_LIST@676..676
             4: (empty)
-          1: GRAPHQL_FIELD@676..685
-            0: GRAPHQL_ALIAS@676..685
-              0: GRAPHQL_NAME@676..683
-                0: GRAPHQL_NAME@676..683 "storyId" [] []
-              1: COLON@683..685 ":" [] [Whitespace(" ")]
-            1: (empty)
-            2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@685..685
-            4: (empty)
-          2: GRAPHQL_BOGUS_SELECTION@685..686
-            0: DOLLAR@685..686 "$" [] []
-          3: GRAPHQL_FIELD@686..693
+          2: GRAPHQL_BOGUS_SELECTION@676..677
+            0: DOLLAR@676..677 "$" [] []
+          3: GRAPHQL_FIELD@677..684
             0: (empty)
-            1: GRAPHQL_NAME@686..693
-              0: GRAPHQL_NAME@686..693 "storyId" [] []
+            1: GRAPHQL_NAME@677..684
+              0: GRAPHQL_NAME@677..684 "storyId" [] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@693..693
+            3: GRAPHQL_DIRECTIVE_LIST@684..684
             4: (empty)
-        2: R_CURLY@693..695 "}" [Newline("\n")] []
-    17: GRAPHQL_OPERATION_DEFINITION@695..744
-      0: GRAPHQL_OPERATION_TYPE@695..703
-        0: QUERY_KW@695..703 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@684..686 "}" [Newline("\n")] []
+    17: GRAPHQL_OPERATION_DEFINITION@686..735
+      0: GRAPHQL_OPERATION_TYPE@686..694
+        0: QUERY_KW@686..694 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@703..719
-        0: L_PAREN@703..704 "(" [] []
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@704..717
-          0: GRAPHQL_VARIABLE_DEFINITION@704..717
-            0: GRAPHQL_VARIABLE@704..712
-              0: DOLLAR@704..705 "$" [] []
-              1: GRAPHQL_NAME@705..712
-                0: GRAPHQL_NAME@705..712 "storyId" [] []
-            1: COLON@712..714 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_NON_NULL_TYPE@714..717
-              0: GRAPHQL_NAMED_TYPE@714..716
-                0: GRAPHQL_NAME@714..716
-                  0: GRAPHQL_NAME@714..716 "ID" [] []
-              1: BANG@716..717 "!" [] []
+      2: GRAPHQL_VARIABLE_DEFINITIONS@694..710
+        0: L_PAREN@694..695 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@695..708
+          0: GRAPHQL_VARIABLE_DEFINITION@695..708
+            0: GRAPHQL_VARIABLE@695..703
+              0: DOLLAR@695..696 "$" [] []
+              1: GRAPHQL_NAME@696..703
+                0: GRAPHQL_NAME@696..703 "storyId" [] []
+            1: COLON@703..705 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@705..708
+              0: GRAPHQL_NAMED_TYPE@705..707
+                0: GRAPHQL_NAME@705..707
+                  0: GRAPHQL_NAME@705..707 "ID" [] []
+              1: BANG@707..708 "!" [] []
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@717..717
-        2: R_PAREN@717..719 ")" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@719..719
-      4: GRAPHQL_SELECTION_SET@719..744
-        0: L_CURLY@719..720 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@720..742
-          0: GRAPHQL_FIELD@720..732
+            4: GRAPHQL_DIRECTIVE_LIST@708..708
+        2: R_PAREN@708..710 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@710..710
+      4: GRAPHQL_SELECTION_SET@710..735
+        0: L_CURLY@710..711 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@711..733
+          0: GRAPHQL_FIELD@711..723
             0: (empty)
-            1: GRAPHQL_NAME@720..732
-              0: GRAPHQL_NAME@720..732 "likeStory" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+            1: GRAPHQL_NAME@711..723
+              0: GRAPHQL_NAME@711..723 "likeStory" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@723..723
+            4: (empty)
+          1: GRAPHQL_FIELD@723..732
+            0: GRAPHQL_ALIAS@723..732
+              0: GRAPHQL_NAME@723..730
+                0: GRAPHQL_NAME@723..730 "storyId" [] []
+              1: COLON@730..732 ":" [] [Whitespace(" ")]
+            1: (empty)
             2: (empty)
             3: GRAPHQL_DIRECTIVE_LIST@732..732
             4: (empty)
-          1: GRAPHQL_FIELD@732..741
-            0: GRAPHQL_ALIAS@732..741
-              0: GRAPHQL_NAME@732..739
-                0: GRAPHQL_NAME@732..739 "storyId" [] []
-              1: COLON@739..741 ":" [] [Whitespace(" ")]
-            1: (empty)
-            2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@741..741
-            4: (empty)
-          2: GRAPHQL_BOGUS_SELECTION@741..742
-            0: DOLLAR@741..742 "$" [] []
-        2: R_CURLY@742..744 "}" [Newline("\n")] []
-    18: GRAPHQL_BOGUS_DEFINITION@744..778
-      0: GRAPHQL_OPERATION_TYPE@744..752
-        0: QUERY_KW@744..752 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      1: GRAPHQL_BOGUS@752..764
-        0: L_PAREN@752..753 "(" [] []
-        1: GRAPHQL_BOGUS@753..762
-          0: GRAPHQL_VARIABLE_DEFINITION@753..754
-            0: GRAPHQL_VARIABLE@753..754
-              0: DOLLAR@753..754 "$" [] []
+          2: GRAPHQL_BOGUS_SELECTION@732..733
+            0: DOLLAR@732..733 "$" [] []
+        2: R_CURLY@733..735 "}" [Newline("\n")] []
+    18: GRAPHQL_BOGUS_DEFINITION@735..769
+      0: GRAPHQL_OPERATION_TYPE@735..743
+        0: QUERY_KW@735..743 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_BOGUS@743..755
+        0: L_PAREN@743..744 "(" [] []
+        1: GRAPHQL_BOGUS@744..753
+          0: GRAPHQL_VARIABLE_DEFINITION@744..745
+            0: GRAPHQL_VARIABLE@744..745
+              0: DOLLAR@744..745 "$" [] []
               1: (empty)
             1: (empty)
             2: (empty)
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@754..754
-          1: GRAPHQL_BOGUS@754..762
-            0: GRAPHQL_INT_LITERAL@754..757 "156" [] []
-            1: COLON@757..759 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_DEFAULT_VALUE@759..761
-              0: EQ@759..761 "=" [] [Whitespace(" ")]
+            4: GRAPHQL_DIRECTIVE_LIST@745..745
+          1: GRAPHQL_BOGUS@745..753
+            0: GRAPHQL_INT_LITERAL@745..748 "156" [] []
+            1: COLON@748..750 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_DEFAULT_VALUE@750..752
+              0: EQ@750..752 "=" [] [Whitespace(" ")]
               1: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@761..762
-              0: GRAPHQL_DIRECTIVE@761..762
-                0: AT@761..762 "@" [] []
+            3: GRAPHQL_DIRECTIVE_LIST@752..753
+              0: GRAPHQL_DIRECTIVE@752..753
+                0: AT@752..753 "@" [] []
                 1: (empty)
                 2: (empty)
-        2: R_PAREN@762..764 ")" [] [Whitespace(" ")]
-      2: GRAPHQL_DIRECTIVE_LIST@764..764
-      3: GRAPHQL_SELECTION_SET@764..778
-        0: L_CURLY@764..765 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@765..776
-          0: GRAPHQL_FIELD@765..776
+        2: R_PAREN@753..755 ")" [] [Whitespace(" ")]
+      2: GRAPHQL_DIRECTIVE_LIST@755..755
+      3: GRAPHQL_SELECTION_SET@755..769
+        0: L_CURLY@755..756 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@756..767
+          0: GRAPHQL_FIELD@756..767
             0: (empty)
-            1: GRAPHQL_NAME@765..776
-              0: GRAPHQL_NAME@765..776 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            1: GRAPHQL_NAME@756..767
+              0: GRAPHQL_NAME@756..767 "likeStory" [Newline("\n"), Whitespace("\t")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@776..776
+            3: GRAPHQL_DIRECTIVE_LIST@767..767
             4: (empty)
-        2: R_CURLY@776..778 "}" [Newline("\n")] []
-    19: GRAPHQL_OPERATION_DEFINITION@778..841
-      0: GRAPHQL_OPERATION_TYPE@778..809
-        0: QUERY_KW@778..809 "query" [Newline("\n"), Newline("\n"), Comments("# malformed directives"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@767..769 "}" [Newline("\n")] []
+    19: GRAPHQL_OPERATION_DEFINITION@769..832
+      0: GRAPHQL_OPERATION_TYPE@769..800
+        0: QUERY_KW@769..800 "query" [Newline("\n"), Newline("\n"), Comments("# malformed directives"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@809..825
-        0: L_PAREN@809..810 "(" [] []
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@810..823
-          0: GRAPHQL_VARIABLE_DEFINITION@810..823
-            0: GRAPHQL_VARIABLE@810..818
-              0: DOLLAR@810..811 "$" [] []
-              1: GRAPHQL_NAME@811..818
-                0: GRAPHQL_NAME@811..818 "storyId" [] []
-            1: COLON@818..820 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_NON_NULL_TYPE@820..823
-              0: GRAPHQL_NAMED_TYPE@820..822
-                0: GRAPHQL_NAME@820..822
-                  0: GRAPHQL_NAME@820..822 "ID" [] []
-              1: BANG@822..823 "!" [] []
+      2: GRAPHQL_VARIABLE_DEFINITIONS@800..816
+        0: L_PAREN@800..801 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@801..814
+          0: GRAPHQL_VARIABLE_DEFINITION@801..814
+            0: GRAPHQL_VARIABLE@801..809
+              0: DOLLAR@801..802 "$" [] []
+              1: GRAPHQL_NAME@802..809
+                0: GRAPHQL_NAME@802..809 "storyId" [] []
+            1: COLON@809..811 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@811..814
+              0: GRAPHQL_NAMED_TYPE@811..813
+                0: GRAPHQL_NAME@811..813
+                  0: GRAPHQL_NAME@811..813 "ID" [] []
+              1: BANG@813..814 "!" [] []
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@823..823
-        2: R_PAREN@823..825 ")" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@825..827
-        0: GRAPHQL_DIRECTIVE@825..827
-          0: AT@825..827 "@" [] [Whitespace(" ")]
+            4: GRAPHQL_DIRECTIVE_LIST@814..814
+        2: R_PAREN@814..816 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@816..818
+        0: GRAPHQL_DIRECTIVE@816..818
+          0: AT@816..818 "@" [] [Whitespace(" ")]
           1: (empty)
           2: (empty)
-      4: GRAPHQL_SELECTION_SET@827..841
-        0: L_CURLY@827..828 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@828..839
-          0: GRAPHQL_FIELD@828..839
+      4: GRAPHQL_SELECTION_SET@818..832
+        0: L_CURLY@818..819 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@819..830
+          0: GRAPHQL_FIELD@819..830
             0: (empty)
-            1: GRAPHQL_NAME@828..839
-              0: GRAPHQL_NAME@828..839 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            1: GRAPHQL_NAME@819..830
+              0: GRAPHQL_NAME@819..830 "likeStory" [Newline("\n"), Whitespace("\t")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@839..839
+            3: GRAPHQL_DIRECTIVE_LIST@830..830
             4: (empty)
-        2: R_CURLY@839..841 "}" [Newline("\n")] []
-  2: EOF@841..842 "" [Newline("\n")] []
+        2: R_CURLY@830..832 "}" [Newline("\n")] []
+  2: EOF@832..833 "" [Newline("\n")] []
 
 ```
 
@@ -1733,35 +1715,10 @@ operation.graphql:5:1 parse ━━━━━━━━━━━━━━━━━�
   
     3 │ query likeStory
     4 │ 
-  > 5 │ query like$Story
+  > 5 │ query }
       │ ^^^^^
     6 │ 
     7 │ # malformed variables
-  
-  i Remove query
-  
-operation.graphql:5:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `(` but instead found `$`
-  
-    3 │ query likeStory
-    4 │ 
-  > 5 │ query like$Story
-      │           ^
-    6 │ 
-    7 │ # malformed variables
-  
-  i Remove $
-  
-operation.graphql:8:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `:` but instead found `query`
-  
-     7 │ # malformed variables
-   > 8 │ query ($storyId: ID! {
-       │ ^^^^^
-     9 │ 	likeStory(storyId: $storyId)
-    10 │ }
   
   i Remove query
   

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/selection_set.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/selection_set.graphql
@@ -5,6 +5,8 @@
 
 }
 
+query }
+
 {
 	hero(name: "Tony Stark"
 }
@@ -31,10 +33,15 @@
 }
 
 {
+  0: (name: "Tony Stark")
+}
+
+{
   ironMan: hero(name: "Tony Stark" {
 		country,
 		firstWife: wife(name: "Pepper"){
 		}
+	}
 }
 
 {
@@ -47,22 +54,16 @@
 
 # Fragment spread
 {
-  ...
-}
-
-{
-  ... @deprecated
-}
-
-{
   ironMan: (: "Tony Stark") @ {
 		...
 	}
+}
 }
 
 {
   ... {
 		hero
+	}
 }
 
 {
@@ -77,3 +78,8 @@
 		age
 	}
 }
+
+{
+  ...
+}
+

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/selection_set.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/selection_set.graphql.snap
@@ -11,6 +11,8 @@ expression: snapshot
 
 }
 
+query }
+
 {
 	hero(name: "Tony Stark"
 }
@@ -37,10 +39,15 @@ expression: snapshot
 }
 
 {
+  0: (name: "Tony Stark")
+}
+
+{
   ironMan: hero(name: "Tony Stark" {
 		country,
 		firstWife: wife(name: "Pepper"){
 		}
+	}
 }
 
 {
@@ -53,22 +60,16 @@ expression: snapshot
 
 # Fragment spread
 {
-  ...
-}
-
-{
-  ... @deprecated
-}
-
-{
   ironMan: (: "Tony Stark") @ {
 		...
 	}
+}
 }
 
 {
   ... {
 		hero
+	}
 }
 
 {
@@ -83,6 +84,11 @@ expression: snapshot
 		age
 	}
 }
+
+{
+  ...
+}
+
 
 ```
 
@@ -127,27 +133,36 @@ GraphqlRoot {
                         r_curly_token: R_CURLY@23..26 "}" [Newline("\n"), Newline("\n")] [],
                     },
                 },
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@26..34 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                    },
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [],
+                    selection_set: missing (optional),
+                },
             ],
-            r_curly_token: missing (required),
+            r_curly_token: R_CURLY@34..35 "}" [] [],
         },
         GraphqlSelectionSet {
-            l_curly_token: L_CURLY@26..29 "{" [Newline("\n"), Newline("\n")] [],
+            l_curly_token: L_CURLY@35..38 "{" [Newline("\n"), Newline("\n")] [],
             selections: GraphqlSelectionList [
                 GraphqlField {
                     alias: missing (optional),
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@29..35 "hero" [Newline("\n"), Whitespace("\t")] [],
+                        value_token: GRAPHQL_NAME@38..44 "hero" [Newline("\n"), Whitespace("\t")] [],
                     },
                     arguments: GraphqlArguments {
-                        l_paren_token: L_PAREN@35..36 "(" [] [],
+                        l_paren_token: L_PAREN@44..45 "(" [] [],
                         arguments: GraphqlArgumentList [
                             GraphqlArgument {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@36..40 "name" [] [],
+                                    value_token: GRAPHQL_NAME@45..49 "name" [] [],
                                 },
-                                colon_token: COLON@40..42 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@49..51 ":" [] [Whitespace(" ")],
                                 value: GraphqlStringValue {
-                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@42..54 "\"Tony Stark\"" [] [],
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@51..63 "\"Tony Stark\"" [] [],
                                 },
                             },
                         ],
@@ -157,30 +172,30 @@ GraphqlRoot {
                     selection_set: missing (optional),
                 },
             ],
-            r_curly_token: R_CURLY@54..56 "}" [Newline("\n")] [],
+            r_curly_token: R_CURLY@63..65 "}" [Newline("\n")] [],
         },
         GraphqlSelectionSet {
-            l_curly_token: L_CURLY@56..59 "{" [Newline("\n"), Newline("\n")] [],
+            l_curly_token: L_CURLY@65..68 "{" [Newline("\n"), Newline("\n")] [],
             selections: GraphqlSelectionList [
                 GraphqlField {
                     alias: missing (optional),
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@59..65 "hero" [Newline("\n"), Whitespace("\t")] [],
+                        value_token: GRAPHQL_NAME@68..74 "hero" [Newline("\n"), Whitespace("\t")] [],
                     },
                     arguments: GraphqlArguments {
-                        l_paren_token: L_PAREN@65..66 "(" [] [],
+                        l_paren_token: L_PAREN@74..75 "(" [] [],
                         arguments: GraphqlArgumentList [
                             GraphqlArgument {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@66..71 "name" [] [Whitespace(" ")],
+                                    value_token: GRAPHQL_NAME@75..80 "name" [] [Whitespace(" ")],
                                 },
                                 colon_token: missing (required),
                                 value: GraphqlStringValue {
-                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@71..83 "\"Tony Stark\"" [] [],
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@80..92 "\"Tony Stark\"" [] [],
                                 },
                             },
                         ],
-                        r_paren_token: R_PAREN@83..84 ")" [] [],
+                        r_paren_token: R_PAREN@92..93 ")" [] [],
                     },
                     directives: GraphqlDirectiveList [],
                     selection_set: missing (optional),
@@ -188,16 +203,7 @@ GraphqlRoot {
                 GraphqlField {
                     alias: missing (optional),
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@84..95 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
-                    },
-                    arguments: missing (optional),
-                    directives: GraphqlDirectiveList [],
-                    selection_set: missing (optional),
-                },
-                GraphqlField {
-                    alias: missing (optional),
-                    name: GraphqlName {
-                        value_token: GRAPHQL_NAME@95..103 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                        value_token: GRAPHQL_NAME@93..104 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
                     },
                     arguments: missing (optional),
                     directives: GraphqlDirectiveList [],
@@ -206,51 +212,60 @@ GraphqlRoot {
                 GraphqlField {
                     alias: missing (optional),
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@103..109 "age" [Newline("\n"), Whitespace("\t\t")] [],
+                        value_token: GRAPHQL_NAME@104..112 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                    },
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [],
+                    selection_set: missing (optional),
+                },
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@112..118 "age" [Newline("\n"), Whitespace("\t\t")] [],
                     },
                     arguments: missing (optional),
                     directives: GraphqlDirectiveList [],
                     selection_set: missing (optional),
                 },
             ],
-            r_curly_token: R_CURLY@109..112 "}" [Newline("\n"), Whitespace("\t")] [],
+            r_curly_token: R_CURLY@118..121 "}" [Newline("\n"), Whitespace("\t")] [],
         },
         GraphqlBogusDefinition {
             items: [
-                R_CURLY@112..114 "}" [Newline("\n")] [],
+                R_CURLY@121..123 "}" [Newline("\n")] [],
             ],
         },
         GraphqlSelectionSet {
-            l_curly_token: L_CURLY@114..117 "{" [Newline("\n"), Newline("\n")] [],
+            l_curly_token: L_CURLY@123..126 "{" [Newline("\n"), Newline("\n")] [],
             selections: GraphqlSelectionList [
                 GraphqlField {
                     alias: missing (optional),
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@117..123 "hero" [Newline("\n"), Whitespace("\t")] [],
+                        value_token: GRAPHQL_NAME@126..132 "hero" [Newline("\n"), Whitespace("\t")] [],
                     },
                     arguments: GraphqlArguments {
-                        l_paren_token: L_PAREN@123..124 "(" [] [],
+                        l_paren_token: L_PAREN@132..133 "(" [] [],
                         arguments: GraphqlArgumentList [
                             GraphqlArgument {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@124..128 "name" [] [],
+                                    value_token: GRAPHQL_NAME@133..137 "name" [] [],
                                 },
-                                colon_token: COLON@128..130 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@137..139 ":" [] [Whitespace(" ")],
                                 value: GraphqlStringValue {
-                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@130..142 "\"Tony Stark\"" [] [],
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@139..151 "\"Tony Stark\"" [] [],
                                 },
                             },
                         ],
-                        r_paren_token: R_PAREN@142..144 ")" [] [Whitespace(" ")],
+                        r_paren_token: R_PAREN@151..153 ")" [] [Whitespace(" ")],
                     },
                     directives: GraphqlDirectiveList [],
                     selection_set: GraphqlSelectionSet {
-                        l_curly_token: L_CURLY@144..145 "{" [] [],
+                        l_curly_token: L_CURLY@153..154 "{" [] [],
                         selections: GraphqlSelectionList [
                             GraphqlField {
                                 alias: missing (optional),
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@145..156 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                    value_token: GRAPHQL_NAME@154..165 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
                                 },
                                 arguments: missing (optional),
                                 directives: GraphqlDirectiveList [],
@@ -259,7 +274,7 @@ GraphqlRoot {
                             GraphqlField {
                                 alias: missing (optional),
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@156..164 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                    value_token: GRAPHQL_NAME@165..173 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
                                 },
                                 arguments: missing (optional),
                                 directives: GraphqlDirectiveList [],
@@ -268,7 +283,7 @@ GraphqlRoot {
                             GraphqlField {
                                 alias: missing (optional),
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@164..171 "age" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                    value_token: GRAPHQL_NAME@173..180 "age" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
                                 },
                                 arguments: missing (optional),
                                 directives: GraphqlDirectiveList [],
@@ -277,19 +292,19 @@ GraphqlRoot {
                             GraphqlField {
                                 alias: missing (optional),
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@171..180 "height" [Newline("\n"), Whitespace("\t\t")] [],
+                                    value_token: GRAPHQL_NAME@180..189 "height" [Newline("\n"), Whitespace("\t\t")] [],
                                 },
                                 arguments: GraphqlArguments {
-                                    l_paren_token: L_PAREN@180..181 "(" [] [],
+                                    l_paren_token: L_PAREN@189..190 "(" [] [],
                                     arguments: GraphqlArgumentList [
                                         GraphqlArgument {
                                             name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@181..186 "unit" [] [Whitespace(" ")],
+                                                value_token: GRAPHQL_NAME@190..195 "unit" [] [Whitespace(" ")],
                                             },
                                             colon_token: missing (required),
                                             value: GraphqlEnumValue {
                                                 graphql_name: GraphqlName {
-                                                    value_token: GRAPHQL_NAME@186..191 "FOOT" [] [Skipped(",")],
+                                                    value_token: GRAPHQL_NAME@195..200 "FOOT" [] [Skipped(",")],
                                                 },
                                             },
                                         },
@@ -300,67 +315,99 @@ GraphqlRoot {
                                 selection_set: missing (optional),
                             },
                         ],
-                        r_curly_token: R_CURLY@191..194 "}" [Newline("\n"), Whitespace("\t")] [],
+                        r_curly_token: R_CURLY@200..203 "}" [Newline("\n"), Whitespace("\t")] [],
                     },
                 },
             ],
-            r_curly_token: R_CURLY@194..196 "}" [Newline("\n")] [],
+            r_curly_token: R_CURLY@203..205 "}" [Newline("\n")] [],
         },
         GraphqlSelectionSet {
-            l_curly_token: L_CURLY@196..199 "{" [Newline("\n"), Newline("\n")] [],
+            l_curly_token: L_CURLY@205..208 "{" [Newline("\n"), Newline("\n")] [],
             selections: GraphqlSelectionList [
                 GraphqlField {
                     alias: GraphqlAlias {
                         value: GraphqlName {
-                            value_token: GRAPHQL_NAME@199..209 "ironMan" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@208..218 "ironMan" [Newline("\n"), Whitespace("  ")] [],
                         },
-                        colon_token: COLON@209..211 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@218..220 ":" [] [Whitespace(" ")],
                     },
                     name: missing (required),
                     arguments: GraphqlArguments {
-                        l_paren_token: L_PAREN@211..212 "(" [] [],
+                        l_paren_token: L_PAREN@220..221 "(" [] [],
                         arguments: GraphqlArgumentList [
                             GraphqlArgument {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@212..216 "name" [] [],
+                                    value_token: GRAPHQL_NAME@221..225 "name" [] [],
                                 },
-                                colon_token: COLON@216..218 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@225..227 ":" [] [Whitespace(" ")],
                                 value: GraphqlStringValue {
-                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@218..230 "\"Tony Stark\"" [] [],
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@227..239 "\"Tony Stark\"" [] [],
                                 },
                             },
                         ],
-                        r_paren_token: R_PAREN@230..231 ")" [] [],
+                        r_paren_token: R_PAREN@239..240 ")" [] [],
                     },
                     directives: GraphqlDirectiveList [],
                     selection_set: missing (optional),
                 },
             ],
-            r_curly_token: R_CURLY@231..233 "}" [Newline("\n")] [],
+            r_curly_token: R_CURLY@240..242 "}" [Newline("\n")] [],
         },
         GraphqlSelectionSet {
-            l_curly_token: L_CURLY@233..236 "{" [Newline("\n"), Newline("\n")] [],
+            l_curly_token: L_CURLY@242..245 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlBogusSelection {
+                    items: [
+                        GraphqlBogus {
+                            items: [
+                                GRAPHQL_INT_LITERAL@245..249 "0" [Newline("\n"), Whitespace("  ")] [],
+                                COLON@249..251 ":" [] [Whitespace(" ")],
+                            ],
+                        },
+                        GraphqlArguments {
+                            l_paren_token: L_PAREN@251..252 "(" [] [],
+                            arguments: GraphqlArgumentList [
+                                GraphqlArgument {
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@252..256 "name" [] [],
+                                    },
+                                    colon_token: COLON@256..258 ":" [] [Whitespace(" ")],
+                                    value: GraphqlStringValue {
+                                        graphql_string_literal_token: GRAPHQL_STRING_LITERAL@258..270 "\"Tony Stark\"" [] [],
+                                    },
+                                },
+                            ],
+                            r_paren_token: R_PAREN@270..271 ")" [] [],
+                        },
+                        GraphqlDirectiveList [],
+                    ],
+                },
+            ],
+            r_curly_token: R_CURLY@271..273 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@273..276 "{" [Newline("\n"), Newline("\n")] [],
             selections: GraphqlSelectionList [
                 GraphqlField {
                     alias: GraphqlAlias {
                         value: GraphqlName {
-                            value_token: GRAPHQL_NAME@236..246 "ironMan" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@276..286 "ironMan" [Newline("\n"), Whitespace("  ")] [],
                         },
-                        colon_token: COLON@246..248 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@286..288 ":" [] [Whitespace(" ")],
                     },
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@248..252 "hero" [] [],
+                        value_token: GRAPHQL_NAME@288..292 "hero" [] [],
                     },
                     arguments: GraphqlArguments {
-                        l_paren_token: L_PAREN@252..253 "(" [] [],
+                        l_paren_token: L_PAREN@292..293 "(" [] [],
                         arguments: GraphqlArgumentList [
                             GraphqlArgument {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@253..257 "name" [] [],
+                                    value_token: GRAPHQL_NAME@293..297 "name" [] [],
                                 },
-                                colon_token: COLON@257..259 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@297..299 ":" [] [Whitespace(" ")],
                                 value: GraphqlStringValue {
-                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@259..272 "\"Tony Stark\"" [] [Whitespace(" ")],
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@299..312 "\"Tony Stark\"" [] [Whitespace(" ")],
                                 },
                             },
                         ],
@@ -368,12 +415,12 @@ GraphqlRoot {
                     },
                     directives: GraphqlDirectiveList [],
                     selection_set: GraphqlSelectionSet {
-                        l_curly_token: L_CURLY@272..273 "{" [] [],
+                        l_curly_token: L_CURLY@312..313 "{" [] [],
                         selections: GraphqlSelectionList [
                             GraphqlField {
                                 alias: missing (optional),
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@273..284 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                    value_token: GRAPHQL_NAME@313..324 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
                                 },
                                 arguments: missing (optional),
                                 directives: GraphqlDirectiveList [],
@@ -382,91 +429,91 @@ GraphqlRoot {
                             GraphqlField {
                                 alias: GraphqlAlias {
                                     value: GraphqlName {
-                                        value_token: GRAPHQL_NAME@284..296 "firstWife" [Newline("\n"), Whitespace("\t\t")] [],
+                                        value_token: GRAPHQL_NAME@324..336 "firstWife" [Newline("\n"), Whitespace("\t\t")] [],
                                     },
-                                    colon_token: COLON@296..298 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@336..338 ":" [] [Whitespace(" ")],
                                 },
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@298..302 "wife" [] [],
+                                    value_token: GRAPHQL_NAME@338..342 "wife" [] [],
                                 },
                                 arguments: GraphqlArguments {
-                                    l_paren_token: L_PAREN@302..303 "(" [] [],
+                                    l_paren_token: L_PAREN@342..343 "(" [] [],
                                     arguments: GraphqlArgumentList [
                                         GraphqlArgument {
                                             name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@303..307 "name" [] [],
+                                                value_token: GRAPHQL_NAME@343..347 "name" [] [],
                                             },
-                                            colon_token: COLON@307..309 ":" [] [Whitespace(" ")],
+                                            colon_token: COLON@347..349 ":" [] [Whitespace(" ")],
                                             value: GraphqlStringValue {
-                                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@309..317 "\"Pepper\"" [] [],
+                                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@349..357 "\"Pepper\"" [] [],
                                             },
                                         },
                                     ],
-                                    r_paren_token: R_PAREN@317..318 ")" [] [],
+                                    r_paren_token: R_PAREN@357..358 ")" [] [],
                                 },
                                 directives: GraphqlDirectiveList [],
                                 selection_set: GraphqlSelectionSet {
-                                    l_curly_token: L_CURLY@318..319 "{" [] [],
+                                    l_curly_token: L_CURLY@358..359 "{" [] [],
                                     selections: GraphqlSelectionList [],
-                                    r_curly_token: R_CURLY@319..323 "}" [Newline("\n"), Whitespace("\t\t")] [],
+                                    r_curly_token: R_CURLY@359..363 "}" [Newline("\n"), Whitespace("\t\t")] [],
                                 },
                             },
                         ],
-                        r_curly_token: R_CURLY@323..325 "}" [Newline("\n")] [],
+                        r_curly_token: R_CURLY@363..366 "}" [Newline("\n"), Whitespace("\t")] [],
                     },
                 },
             ],
-            r_curly_token: missing (required),
+            r_curly_token: R_CURLY@366..368 "}" [Newline("\n")] [],
         },
         GraphqlSelectionSet {
-            l_curly_token: L_CURLY@325..328 "{" [Newline("\n"), Newline("\n")] [],
+            l_curly_token: L_CURLY@368..371 "{" [Newline("\n"), Newline("\n")] [],
             selections: GraphqlSelectionList [
                 GraphqlField {
                     alias: GraphqlAlias {
                         value: GraphqlName {
-                            value_token: GRAPHQL_NAME@328..338 "ironMan" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@371..381 "ironMan" [Newline("\n"), Whitespace("  ")] [],
                         },
-                        colon_token: COLON@338..340 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@381..383 ":" [] [Whitespace(" ")],
                     },
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@340..344 "hero" [] [],
+                        value_token: GRAPHQL_NAME@383..387 "hero" [] [],
                     },
                     arguments: GraphqlArguments {
-                        l_paren_token: L_PAREN@344..345 "(" [] [],
+                        l_paren_token: L_PAREN@387..388 "(" [] [],
                         arguments: GraphqlArgumentList [
                             GraphqlArgument {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@345..349 "name" [] [],
+                                    value_token: GRAPHQL_NAME@388..392 "name" [] [],
                                 },
-                                colon_token: COLON@349..351 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@392..394 ":" [] [Whitespace(" ")],
                                 value: GraphqlStringValue {
-                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@351..363 "\"Tony Stark\"" [] [],
+                                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@394..406 "\"Tony Stark\"" [] [],
                                 },
                             },
                         ],
-                        r_paren_token: R_PAREN@363..365 ")" [] [Whitespace(" ")],
+                        r_paren_token: R_PAREN@406..408 ")" [] [Whitespace(" ")],
                     },
                     directives: GraphqlDirectiveList [
                         GraphqlDirective {
-                            at_token: AT@365..366 "@" [] [],
+                            at_token: AT@408..409 "@" [] [],
                             name: missing (required),
                             arguments: missing (optional),
                         },
                     ],
                     selection_set: GraphqlSelectionSet {
-                        l_curly_token: L_CURLY@366..367 "{" [] [],
+                        l_curly_token: L_CURLY@409..410 "{" [] [],
                         selections: GraphqlSelectionList [
                             GraphqlField {
                                 alias: missing (optional),
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@367..378 "country" [Newline("\n"), Whitespace("\t\t")] [Whitespace(" ")],
+                                    value_token: GRAPHQL_NAME@410..421 "country" [Newline("\n"), Whitespace("\t\t")] [Whitespace(" ")],
                                 },
                                 arguments: missing (optional),
                                 directives: GraphqlDirectiveList [
                                     GraphqlDirective {
-                                        at_token: AT@378..380 "@" [] [Skipped(",")],
+                                        at_token: AT@421..423 "@" [] [Skipped(",")],
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@380..388 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                                            value_token: GRAPHQL_NAME@423..431 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
                                         },
                                         arguments: missing (optional),
                                     },
@@ -476,151 +523,111 @@ GraphqlRoot {
                             GraphqlField {
                                 alias: missing (optional),
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@388..394 "age" [Newline("\n"), Whitespace("\t\t")] [],
+                                    value_token: GRAPHQL_NAME@431..437 "age" [Newline("\n"), Whitespace("\t\t")] [],
                                 },
                                 arguments: missing (optional),
                                 directives: GraphqlDirectiveList [],
                                 selection_set: missing (optional),
                             },
                         ],
-                        r_curly_token: R_CURLY@394..397 "}" [Newline("\n"), Whitespace("\t")] [],
+                        r_curly_token: R_CURLY@437..440 "}" [Newline("\n"), Whitespace("\t")] [],
                     },
                 },
             ],
-            r_curly_token: R_CURLY@397..399 "}" [Newline("\n")] [],
+            r_curly_token: R_CURLY@440..442 "}" [Newline("\n")] [],
         },
         GraphqlSelectionSet {
-            l_curly_token: L_CURLY@399..420 "{" [Newline("\n"), Newline("\n"), Comments("# Fragment spread"), Newline("\n")] [],
-            selections: GraphqlSelectionList [
-                GraphqlInlineFragment {
-                    dotdotdot_token: DOT3@420..426 "..." [Newline("\n"), Whitespace("  ")] [],
-                    type_condition: missing (optional),
-                    directives: GraphqlDirectiveList [],
-                    selection_set: GraphqlSelectionSet {
-                        l_curly_token: missing (required),
-                        selections: GraphqlSelectionList [],
-                        r_curly_token: R_CURLY@426..428 "}" [Newline("\n")] [],
-                    },
-                },
-            ],
-            r_curly_token: missing (required),
-        },
-        GraphqlSelectionSet {
-            l_curly_token: L_CURLY@428..431 "{" [Newline("\n"), Newline("\n")] [],
-            selections: GraphqlSelectionList [
-                GraphqlInlineFragment {
-                    dotdotdot_token: DOT3@431..438 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
-                    type_condition: missing (optional),
-                    directives: GraphqlDirectiveList [
-                        GraphqlDirective {
-                            at_token: AT@438..439 "@" [] [],
-                            name: GraphqlName {
-                                value_token: GRAPHQL_NAME@439..449 "deprecated" [] [],
-                            },
-                            arguments: missing (optional),
-                        },
-                    ],
-                    selection_set: GraphqlSelectionSet {
-                        l_curly_token: missing (required),
-                        selections: GraphqlSelectionList [],
-                        r_curly_token: R_CURLY@449..451 "}" [Newline("\n")] [],
-                    },
-                },
-            ],
-            r_curly_token: missing (required),
-        },
-        GraphqlSelectionSet {
-            l_curly_token: L_CURLY@451..454 "{" [Newline("\n"), Newline("\n")] [],
+            l_curly_token: L_CURLY@442..463 "{" [Newline("\n"), Newline("\n"), Comments("# Fragment spread"), Newline("\n")] [],
             selections: GraphqlSelectionList [
                 GraphqlBogusSelection {
                     items: [
                         GraphqlAlias {
                             value: GraphqlName {
-                                value_token: GRAPHQL_NAME@454..464 "ironMan" [Newline("\n"), Whitespace("  ")] [],
+                                value_token: GRAPHQL_NAME@463..473 "ironMan" [Newline("\n"), Whitespace("  ")] [],
                             },
-                            colon_token: COLON@464..466 ":" [] [Whitespace(" ")],
+                            colon_token: COLON@473..475 ":" [] [Whitespace(" ")],
                         },
                         GraphqlBogus {
                             items: [
-                                L_PAREN@466..467 "(" [] [],
+                                L_PAREN@475..476 "(" [] [],
                                 GraphqlBogus {
                                     items: [
                                         GraphqlBogus {
                                             items: [
-                                                COLON@467..469 ":" [] [Whitespace(" ")],
-                                                GRAPHQL_STRING_LITERAL@469..481 "\"Tony Stark\"" [] [],
+                                                COLON@476..478 ":" [] [Whitespace(" ")],
+                                                GRAPHQL_STRING_LITERAL@478..490 "\"Tony Stark\"" [] [],
                                             ],
                                         },
                                     ],
                                 },
-                                R_PAREN@481..483 ")" [] [Whitespace(" ")],
+                                R_PAREN@490..492 ")" [] [Whitespace(" ")],
                             ],
                         },
                         GraphqlDirectiveList [
                             GraphqlDirective {
-                                at_token: AT@483..485 "@" [] [Whitespace(" ")],
+                                at_token: AT@492..494 "@" [] [Whitespace(" ")],
                                 name: missing (required),
                                 arguments: missing (optional),
                             },
                         ],
                         GraphqlSelectionSet {
-                            l_curly_token: L_CURLY@485..486 "{" [] [],
+                            l_curly_token: L_CURLY@494..495 "{" [] [],
                             selections: GraphqlSelectionList [
                                 GraphqlInlineFragment {
-                                    dotdotdot_token: DOT3@486..492 "..." [Newline("\n"), Whitespace("\t\t")] [],
+                                    dotdotdot_token: DOT3@495..501 "..." [Newline("\n"), Whitespace("\t\t")] [],
                                     type_condition: missing (optional),
                                     directives: GraphqlDirectiveList [],
                                     selection_set: GraphqlSelectionSet {
                                         l_curly_token: missing (required),
                                         selections: GraphqlSelectionList [],
-                                        r_curly_token: R_CURLY@492..495 "}" [Newline("\n"), Whitespace("\t")] [],
+                                        r_curly_token: R_CURLY@501..504 "}" [Newline("\n"), Whitespace("\t")] [],
                                     },
                                 },
                             ],
-                            r_curly_token: R_CURLY@495..497 "}" [Newline("\n")] [],
+                            r_curly_token: R_CURLY@504..506 "}" [Newline("\n")] [],
                         },
                     ],
                 },
             ],
-            r_curly_token: missing (required),
+            r_curly_token: R_CURLY@506..508 "}" [Newline("\n")] [],
         },
         GraphqlSelectionSet {
-            l_curly_token: L_CURLY@497..500 "{" [Newline("\n"), Newline("\n")] [],
+            l_curly_token: L_CURLY@508..511 "{" [Newline("\n"), Newline("\n")] [],
             selections: GraphqlSelectionList [
                 GraphqlInlineFragment {
-                    dotdotdot_token: DOT3@500..507 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                    dotdotdot_token: DOT3@511..518 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                     type_condition: missing (optional),
                     directives: GraphqlDirectiveList [],
                     selection_set: GraphqlSelectionSet {
-                        l_curly_token: L_CURLY@507..508 "{" [] [],
+                        l_curly_token: L_CURLY@518..519 "{" [] [],
                         selections: GraphqlSelectionList [
                             GraphqlField {
                                 alias: missing (optional),
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@508..515 "hero" [Newline("\n"), Whitespace("\t\t")] [],
+                                    value_token: GRAPHQL_NAME@519..526 "hero" [Newline("\n"), Whitespace("\t\t")] [],
                                 },
                                 arguments: missing (optional),
                                 directives: GraphqlDirectiveList [],
                                 selection_set: missing (optional),
                             },
                         ],
-                        r_curly_token: R_CURLY@515..517 "}" [Newline("\n")] [],
+                        r_curly_token: R_CURLY@526..529 "}" [Newline("\n"), Whitespace("\t")] [],
                     },
                 },
             ],
-            r_curly_token: missing (required),
+            r_curly_token: R_CURLY@529..531 "}" [Newline("\n")] [],
         },
         GraphqlSelectionSet {
-            l_curly_token: L_CURLY@517..520 "{" [Newline("\n"), Newline("\n")] [],
+            l_curly_token: L_CURLY@531..534 "{" [Newline("\n"), Newline("\n")] [],
             selections: GraphqlSelectionList [
                 GraphqlInlineFragment {
-                    dotdotdot_token: DOT3@520..527 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                    dotdotdot_token: DOT3@534..541 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                     type_condition: missing (optional),
                     directives: GraphqlDirectiveList [
                         GraphqlDirective {
-                            at_token: AT@527..528 "@" [] [],
+                            at_token: AT@541..542 "@" [] [],
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@528..535 "hero" [Newline("\n"), Whitespace("\t\t")] [],
+                                value_token: GRAPHQL_NAME@542..549 "hero" [Newline("\n"), Whitespace("\t\t")] [],
                             },
                             arguments: missing (optional),
                         },
@@ -628,38 +635,37 @@ GraphqlRoot {
                     selection_set: GraphqlSelectionSet {
                         l_curly_token: missing (required),
                         selections: GraphqlSelectionList [],
-                        r_curly_token: R_CURLY@535..538 "}" [Newline("\n"), Whitespace("\t")] [],
+                        r_curly_token: R_CURLY@549..552 "}" [Newline("\n"), Whitespace("\t")] [],
                     },
                 },
             ],
-            r_curly_token: R_CURLY@538..540 "}" [Newline("\n")] [],
+            r_curly_token: R_CURLY@552..554 "}" [Newline("\n")] [],
         },
         GraphqlSelectionSet {
-            l_curly_token: L_CURLY@540..543 "{" [Newline("\n"), Newline("\n")] [],
+            l_curly_token: L_CURLY@554..557 "{" [Newline("\n"), Newline("\n")] [],
             selections: GraphqlSelectionList [
                 GraphqlFragmentSpread {
-                    dotdotdot_token: DOT3@543..550 "..." [Newline("\n"), Whitespace("\t")] [Whitespace("  ")],
+                    dotdotdot_token: DOT3@557..564 "..." [Newline("\n"), Whitespace("\t")] [Whitespace("  ")],
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@550..555 "Hero" [] [Whitespace(" ")],
+                        value_token: GRAPHQL_NAME@564..569 "Hero" [] [Whitespace(" ")],
                     },
                     directives: GraphqlDirectiveList [
                         GraphqlDirective {
-                            at_token: AT@555..557 "@" [] [Whitespace(" ")],
+                            at_token: AT@569..571 "@" [] [Whitespace(" ")],
                             name: missing (required),
                             arguments: missing (optional),
                         },
                     ],
                 },
-            ],
-            r_curly_token: missing (required),
-        },
-        GraphqlSelectionSet {
-            l_curly_token: L_CURLY@557..558 "{" [] [],
-            selections: GraphqlSelectionList [
+                GraphqlBogusSelection {
+                    items: [
+                        L_CURLY@571..572 "{" [] [],
+                    ],
+                },
                 GraphqlField {
                     alias: missing (optional),
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@558..566 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
+                        value_token: GRAPHQL_NAME@572..580 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")],
                     },
                     arguments: missing (optional),
                     directives: GraphqlDirectiveList [],
@@ -668,34 +674,50 @@ GraphqlRoot {
                 GraphqlField {
                     alias: missing (optional),
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@566..572 "age" [Newline("\n"), Whitespace("\t\t")] [],
+                        value_token: GRAPHQL_NAME@580..586 "age" [Newline("\n"), Whitespace("\t\t")] [],
                     },
                     arguments: missing (optional),
                     directives: GraphqlDirectiveList [],
                     selection_set: missing (optional),
                 },
             ],
-            r_curly_token: R_CURLY@572..575 "}" [Newline("\n"), Whitespace("\t")] [],
+            r_curly_token: R_CURLY@586..589 "}" [Newline("\n"), Whitespace("\t")] [],
         },
         GraphqlBogusDefinition {
             items: [
-                R_CURLY@575..577 "}" [Newline("\n")] [],
+                R_CURLY@589..591 "}" [Newline("\n")] [],
             ],
         },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@591..594 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlInlineFragment {
+                    dotdotdot_token: DOT3@594..600 "..." [Newline("\n"), Whitespace("  ")] [],
+                    type_condition: missing (optional),
+                    directives: GraphqlDirectiveList [],
+                    selection_set: GraphqlSelectionSet {
+                        l_curly_token: missing (required),
+                        selections: GraphqlSelectionList [],
+                        r_curly_token: R_CURLY@600..602 "}" [Newline("\n")] [],
+                    },
+                },
+            ],
+            r_curly_token: missing (required),
+        },
     ],
-    eof_token: EOF@577..578 "" [Newline("\n")] [],
+    eof_token: EOF@602..604 "" [Newline("\n"), Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..578
+0: GRAPHQL_ROOT@0..604
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..577
-    0: GRAPHQL_SELECTION_SET@0..26
+  1: GRAPHQL_DEFINITION_LIST@0..602
+    0: GRAPHQL_SELECTION_SET@0..35
       0: L_CURLY@0..1 "{" [] []
-      1: GRAPHQL_SELECTION_LIST@1..26
+      1: GRAPHQL_SELECTION_LIST@1..34
         0: GRAPHQL_FIELD@1..26
           0: (empty)
           1: GRAPHQL_NAME@1..8
@@ -720,732 +742,707 @@ GraphqlRoot {
                 3: GRAPHQL_DIRECTIVE_LIST@23..23
                 4: (empty)
             2: R_CURLY@23..26 "}" [Newline("\n"), Newline("\n")] []
-      2: (empty)
-    1: GRAPHQL_SELECTION_SET@26..56
-      0: L_CURLY@26..29 "{" [Newline("\n"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@29..54
-        0: GRAPHQL_FIELD@29..54
+        1: GRAPHQL_FIELD@26..34
           0: (empty)
-          1: GRAPHQL_NAME@29..35
-            0: GRAPHQL_NAME@29..35 "hero" [Newline("\n"), Whitespace("\t")] []
-          2: GRAPHQL_ARGUMENTS@35..54
-            0: L_PAREN@35..36 "(" [] []
-            1: GRAPHQL_ARGUMENT_LIST@36..54
-              0: GRAPHQL_ARGUMENT@36..54
-                0: GRAPHQL_NAME@36..40
-                  0: GRAPHQL_NAME@36..40 "name" [] []
-                1: COLON@40..42 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_STRING_VALUE@42..54
-                  0: GRAPHQL_STRING_LITERAL@42..54 "\"Tony Stark\"" [] []
-            2: (empty)
-          3: GRAPHQL_DIRECTIVE_LIST@54..54
+          1: GRAPHQL_NAME@26..34
+            0: GRAPHQL_NAME@26..34 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@34..34
           4: (empty)
-      2: R_CURLY@54..56 "}" [Newline("\n")] []
-    2: GRAPHQL_SELECTION_SET@56..112
-      0: L_CURLY@56..59 "{" [Newline("\n"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@59..109
-        0: GRAPHQL_FIELD@59..84
+      2: R_CURLY@34..35 "}" [] []
+    1: GRAPHQL_SELECTION_SET@35..65
+      0: L_CURLY@35..38 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@38..63
+        0: GRAPHQL_FIELD@38..63
           0: (empty)
-          1: GRAPHQL_NAME@59..65
-            0: GRAPHQL_NAME@59..65 "hero" [Newline("\n"), Whitespace("\t")] []
-          2: GRAPHQL_ARGUMENTS@65..84
-            0: L_PAREN@65..66 "(" [] []
-            1: GRAPHQL_ARGUMENT_LIST@66..83
-              0: GRAPHQL_ARGUMENT@66..83
-                0: GRAPHQL_NAME@66..71
-                  0: GRAPHQL_NAME@66..71 "name" [] [Whitespace(" ")]
+          1: GRAPHQL_NAME@38..44
+            0: GRAPHQL_NAME@38..44 "hero" [Newline("\n"), Whitespace("\t")] []
+          2: GRAPHQL_ARGUMENTS@44..63
+            0: L_PAREN@44..45 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@45..63
+              0: GRAPHQL_ARGUMENT@45..63
+                0: GRAPHQL_NAME@45..49
+                  0: GRAPHQL_NAME@45..49 "name" [] []
+                1: COLON@49..51 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@51..63
+                  0: GRAPHQL_STRING_LITERAL@51..63 "\"Tony Stark\"" [] []
+            2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@63..63
+          4: (empty)
+      2: R_CURLY@63..65 "}" [Newline("\n")] []
+    2: GRAPHQL_SELECTION_SET@65..121
+      0: L_CURLY@65..68 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@68..118
+        0: GRAPHQL_FIELD@68..93
+          0: (empty)
+          1: GRAPHQL_NAME@68..74
+            0: GRAPHQL_NAME@68..74 "hero" [Newline("\n"), Whitespace("\t")] []
+          2: GRAPHQL_ARGUMENTS@74..93
+            0: L_PAREN@74..75 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@75..92
+              0: GRAPHQL_ARGUMENT@75..92
+                0: GRAPHQL_NAME@75..80
+                  0: GRAPHQL_NAME@75..80 "name" [] [Whitespace(" ")]
                 1: (empty)
-                2: GRAPHQL_STRING_VALUE@71..83
-                  0: GRAPHQL_STRING_LITERAL@71..83 "\"Tony Stark\"" [] []
-            2: R_PAREN@83..84 ")" [] []
-          3: GRAPHQL_DIRECTIVE_LIST@84..84
+                2: GRAPHQL_STRING_VALUE@80..92
+                  0: GRAPHQL_STRING_LITERAL@80..92 "\"Tony Stark\"" [] []
+            2: R_PAREN@92..93 ")" [] []
+          3: GRAPHQL_DIRECTIVE_LIST@93..93
           4: (empty)
-        1: GRAPHQL_FIELD@84..95
+        1: GRAPHQL_FIELD@93..104
           0: (empty)
-          1: GRAPHQL_NAME@84..95
-            0: GRAPHQL_NAME@84..95 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+          1: GRAPHQL_NAME@93..104
+            0: GRAPHQL_NAME@93..104 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
           2: (empty)
-          3: GRAPHQL_DIRECTIVE_LIST@95..95
+          3: GRAPHQL_DIRECTIVE_LIST@104..104
           4: (empty)
-        2: GRAPHQL_FIELD@95..103
+        2: GRAPHQL_FIELD@104..112
           0: (empty)
-          1: GRAPHQL_NAME@95..103
-            0: GRAPHQL_NAME@95..103 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+          1: GRAPHQL_NAME@104..112
+            0: GRAPHQL_NAME@104..112 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
           2: (empty)
-          3: GRAPHQL_DIRECTIVE_LIST@103..103
+          3: GRAPHQL_DIRECTIVE_LIST@112..112
           4: (empty)
-        3: GRAPHQL_FIELD@103..109
+        3: GRAPHQL_FIELD@112..118
           0: (empty)
-          1: GRAPHQL_NAME@103..109
-            0: GRAPHQL_NAME@103..109 "age" [Newline("\n"), Whitespace("\t\t")] []
+          1: GRAPHQL_NAME@112..118
+            0: GRAPHQL_NAME@112..118 "age" [Newline("\n"), Whitespace("\t\t")] []
           2: (empty)
-          3: GRAPHQL_DIRECTIVE_LIST@109..109
+          3: GRAPHQL_DIRECTIVE_LIST@118..118
           4: (empty)
-      2: R_CURLY@109..112 "}" [Newline("\n"), Whitespace("\t")] []
-    3: GRAPHQL_BOGUS_DEFINITION@112..114
-      0: R_CURLY@112..114 "}" [Newline("\n")] []
-    4: GRAPHQL_SELECTION_SET@114..196
-      0: L_CURLY@114..117 "{" [Newline("\n"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@117..194
-        0: GRAPHQL_FIELD@117..194
+      2: R_CURLY@118..121 "}" [Newline("\n"), Whitespace("\t")] []
+    3: GRAPHQL_BOGUS_DEFINITION@121..123
+      0: R_CURLY@121..123 "}" [Newline("\n")] []
+    4: GRAPHQL_SELECTION_SET@123..205
+      0: L_CURLY@123..126 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@126..203
+        0: GRAPHQL_FIELD@126..203
           0: (empty)
-          1: GRAPHQL_NAME@117..123
-            0: GRAPHQL_NAME@117..123 "hero" [Newline("\n"), Whitespace("\t")] []
-          2: GRAPHQL_ARGUMENTS@123..144
-            0: L_PAREN@123..124 "(" [] []
-            1: GRAPHQL_ARGUMENT_LIST@124..142
-              0: GRAPHQL_ARGUMENT@124..142
-                0: GRAPHQL_NAME@124..128
-                  0: GRAPHQL_NAME@124..128 "name" [] []
-                1: COLON@128..130 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_STRING_VALUE@130..142
-                  0: GRAPHQL_STRING_LITERAL@130..142 "\"Tony Stark\"" [] []
-            2: R_PAREN@142..144 ")" [] [Whitespace(" ")]
-          3: GRAPHQL_DIRECTIVE_LIST@144..144
-          4: GRAPHQL_SELECTION_SET@144..194
-            0: L_CURLY@144..145 "{" [] []
-            1: GRAPHQL_SELECTION_LIST@145..191
-              0: GRAPHQL_FIELD@145..156
+          1: GRAPHQL_NAME@126..132
+            0: GRAPHQL_NAME@126..132 "hero" [Newline("\n"), Whitespace("\t")] []
+          2: GRAPHQL_ARGUMENTS@132..153
+            0: L_PAREN@132..133 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@133..151
+              0: GRAPHQL_ARGUMENT@133..151
+                0: GRAPHQL_NAME@133..137
+                  0: GRAPHQL_NAME@133..137 "name" [] []
+                1: COLON@137..139 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@139..151
+                  0: GRAPHQL_STRING_LITERAL@139..151 "\"Tony Stark\"" [] []
+            2: R_PAREN@151..153 ")" [] [Whitespace(" ")]
+          3: GRAPHQL_DIRECTIVE_LIST@153..153
+          4: GRAPHQL_SELECTION_SET@153..203
+            0: L_CURLY@153..154 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@154..200
+              0: GRAPHQL_FIELD@154..165
                 0: (empty)
-                1: GRAPHQL_NAME@145..156
-                  0: GRAPHQL_NAME@145..156 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                1: GRAPHQL_NAME@154..165
+                  0: GRAPHQL_NAME@154..165 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
                 2: (empty)
-                3: GRAPHQL_DIRECTIVE_LIST@156..156
+                3: GRAPHQL_DIRECTIVE_LIST@165..165
                 4: (empty)
-              1: GRAPHQL_FIELD@156..164
+              1: GRAPHQL_FIELD@165..173
                 0: (empty)
-                1: GRAPHQL_NAME@156..164
-                  0: GRAPHQL_NAME@156..164 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                1: GRAPHQL_NAME@165..173
+                  0: GRAPHQL_NAME@165..173 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
                 2: (empty)
-                3: GRAPHQL_DIRECTIVE_LIST@164..164
+                3: GRAPHQL_DIRECTIVE_LIST@173..173
                 4: (empty)
-              2: GRAPHQL_FIELD@164..171
+              2: GRAPHQL_FIELD@173..180
                 0: (empty)
-                1: GRAPHQL_NAME@164..171
-                  0: GRAPHQL_NAME@164..171 "age" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                1: GRAPHQL_NAME@173..180
+                  0: GRAPHQL_NAME@173..180 "age" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
                 2: (empty)
-                3: GRAPHQL_DIRECTIVE_LIST@171..171
+                3: GRAPHQL_DIRECTIVE_LIST@180..180
                 4: (empty)
-              3: GRAPHQL_FIELD@171..191
+              3: GRAPHQL_FIELD@180..200
                 0: (empty)
-                1: GRAPHQL_NAME@171..180
-                  0: GRAPHQL_NAME@171..180 "height" [Newline("\n"), Whitespace("\t\t")] []
-                2: GRAPHQL_ARGUMENTS@180..191
-                  0: L_PAREN@180..181 "(" [] []
-                  1: GRAPHQL_ARGUMENT_LIST@181..191
-                    0: GRAPHQL_ARGUMENT@181..191
-                      0: GRAPHQL_NAME@181..186
-                        0: GRAPHQL_NAME@181..186 "unit" [] [Whitespace(" ")]
+                1: GRAPHQL_NAME@180..189
+                  0: GRAPHQL_NAME@180..189 "height" [Newline("\n"), Whitespace("\t\t")] []
+                2: GRAPHQL_ARGUMENTS@189..200
+                  0: L_PAREN@189..190 "(" [] []
+                  1: GRAPHQL_ARGUMENT_LIST@190..200
+                    0: GRAPHQL_ARGUMENT@190..200
+                      0: GRAPHQL_NAME@190..195
+                        0: GRAPHQL_NAME@190..195 "unit" [] [Whitespace(" ")]
                       1: (empty)
-                      2: GRAPHQL_ENUM_VALUE@186..191
-                        0: GRAPHQL_NAME@186..191
-                          0: GRAPHQL_NAME@186..191 "FOOT" [] [Skipped(",")]
+                      2: GRAPHQL_ENUM_VALUE@195..200
+                        0: GRAPHQL_NAME@195..200
+                          0: GRAPHQL_NAME@195..200 "FOOT" [] [Skipped(",")]
                   2: (empty)
-                3: GRAPHQL_DIRECTIVE_LIST@191..191
+                3: GRAPHQL_DIRECTIVE_LIST@200..200
                 4: (empty)
-            2: R_CURLY@191..194 "}" [Newline("\n"), Whitespace("\t")] []
-      2: R_CURLY@194..196 "}" [Newline("\n")] []
-    5: GRAPHQL_SELECTION_SET@196..233
-      0: L_CURLY@196..199 "{" [Newline("\n"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@199..231
-        0: GRAPHQL_FIELD@199..231
-          0: GRAPHQL_ALIAS@199..211
-            0: GRAPHQL_NAME@199..209
-              0: GRAPHQL_NAME@199..209 "ironMan" [Newline("\n"), Whitespace("  ")] []
-            1: COLON@209..211 ":" [] [Whitespace(" ")]
+            2: R_CURLY@200..203 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@203..205 "}" [Newline("\n")] []
+    5: GRAPHQL_SELECTION_SET@205..242
+      0: L_CURLY@205..208 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@208..240
+        0: GRAPHQL_FIELD@208..240
+          0: GRAPHQL_ALIAS@208..220
+            0: GRAPHQL_NAME@208..218
+              0: GRAPHQL_NAME@208..218 "ironMan" [Newline("\n"), Whitespace("  ")] []
+            1: COLON@218..220 ":" [] [Whitespace(" ")]
           1: (empty)
-          2: GRAPHQL_ARGUMENTS@211..231
-            0: L_PAREN@211..212 "(" [] []
-            1: GRAPHQL_ARGUMENT_LIST@212..230
-              0: GRAPHQL_ARGUMENT@212..230
-                0: GRAPHQL_NAME@212..216
-                  0: GRAPHQL_NAME@212..216 "name" [] []
-                1: COLON@216..218 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_STRING_VALUE@218..230
-                  0: GRAPHQL_STRING_LITERAL@218..230 "\"Tony Stark\"" [] []
-            2: R_PAREN@230..231 ")" [] []
-          3: GRAPHQL_DIRECTIVE_LIST@231..231
+          2: GRAPHQL_ARGUMENTS@220..240
+            0: L_PAREN@220..221 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@221..239
+              0: GRAPHQL_ARGUMENT@221..239
+                0: GRAPHQL_NAME@221..225
+                  0: GRAPHQL_NAME@221..225 "name" [] []
+                1: COLON@225..227 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@227..239
+                  0: GRAPHQL_STRING_LITERAL@227..239 "\"Tony Stark\"" [] []
+            2: R_PAREN@239..240 ")" [] []
+          3: GRAPHQL_DIRECTIVE_LIST@240..240
           4: (empty)
-      2: R_CURLY@231..233 "}" [Newline("\n")] []
-    6: GRAPHQL_SELECTION_SET@233..325
-      0: L_CURLY@233..236 "{" [Newline("\n"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@236..325
-        0: GRAPHQL_FIELD@236..325
-          0: GRAPHQL_ALIAS@236..248
-            0: GRAPHQL_NAME@236..246
-              0: GRAPHQL_NAME@236..246 "ironMan" [Newline("\n"), Whitespace("  ")] []
-            1: COLON@246..248 ":" [] [Whitespace(" ")]
-          1: GRAPHQL_NAME@248..252
-            0: GRAPHQL_NAME@248..252 "hero" [] []
-          2: GRAPHQL_ARGUMENTS@252..272
-            0: L_PAREN@252..253 "(" [] []
-            1: GRAPHQL_ARGUMENT_LIST@253..272
-              0: GRAPHQL_ARGUMENT@253..272
-                0: GRAPHQL_NAME@253..257
-                  0: GRAPHQL_NAME@253..257 "name" [] []
-                1: COLON@257..259 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_STRING_VALUE@259..272
-                  0: GRAPHQL_STRING_LITERAL@259..272 "\"Tony Stark\"" [] [Whitespace(" ")]
+      2: R_CURLY@240..242 "}" [Newline("\n")] []
+    6: GRAPHQL_SELECTION_SET@242..273
+      0: L_CURLY@242..245 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@245..271
+        0: GRAPHQL_BOGUS_SELECTION@245..271
+          0: GRAPHQL_BOGUS@245..251
+            0: GRAPHQL_INT_LITERAL@245..249 "0" [Newline("\n"), Whitespace("  ")] []
+            1: COLON@249..251 ":" [] [Whitespace(" ")]
+          1: GRAPHQL_ARGUMENTS@251..271
+            0: L_PAREN@251..252 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@252..270
+              0: GRAPHQL_ARGUMENT@252..270
+                0: GRAPHQL_NAME@252..256
+                  0: GRAPHQL_NAME@252..256 "name" [] []
+                1: COLON@256..258 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@258..270
+                  0: GRAPHQL_STRING_LITERAL@258..270 "\"Tony Stark\"" [] []
+            2: R_PAREN@270..271 ")" [] []
+          2: GRAPHQL_DIRECTIVE_LIST@271..271
+      2: R_CURLY@271..273 "}" [Newline("\n")] []
+    7: GRAPHQL_SELECTION_SET@273..368
+      0: L_CURLY@273..276 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@276..366
+        0: GRAPHQL_FIELD@276..366
+          0: GRAPHQL_ALIAS@276..288
+            0: GRAPHQL_NAME@276..286
+              0: GRAPHQL_NAME@276..286 "ironMan" [Newline("\n"), Whitespace("  ")] []
+            1: COLON@286..288 ":" [] [Whitespace(" ")]
+          1: GRAPHQL_NAME@288..292
+            0: GRAPHQL_NAME@288..292 "hero" [] []
+          2: GRAPHQL_ARGUMENTS@292..312
+            0: L_PAREN@292..293 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@293..312
+              0: GRAPHQL_ARGUMENT@293..312
+                0: GRAPHQL_NAME@293..297
+                  0: GRAPHQL_NAME@293..297 "name" [] []
+                1: COLON@297..299 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@299..312
+                  0: GRAPHQL_STRING_LITERAL@299..312 "\"Tony Stark\"" [] [Whitespace(" ")]
             2: (empty)
-          3: GRAPHQL_DIRECTIVE_LIST@272..272
-          4: GRAPHQL_SELECTION_SET@272..325
-            0: L_CURLY@272..273 "{" [] []
-            1: GRAPHQL_SELECTION_LIST@273..323
-              0: GRAPHQL_FIELD@273..284
+          3: GRAPHQL_DIRECTIVE_LIST@312..312
+          4: GRAPHQL_SELECTION_SET@312..366
+            0: L_CURLY@312..313 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@313..363
+              0: GRAPHQL_FIELD@313..324
                 0: (empty)
-                1: GRAPHQL_NAME@273..284
-                  0: GRAPHQL_NAME@273..284 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                1: GRAPHQL_NAME@313..324
+                  0: GRAPHQL_NAME@313..324 "country" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
                 2: (empty)
-                3: GRAPHQL_DIRECTIVE_LIST@284..284
+                3: GRAPHQL_DIRECTIVE_LIST@324..324
                 4: (empty)
-              1: GRAPHQL_FIELD@284..323
-                0: GRAPHQL_ALIAS@284..298
-                  0: GRAPHQL_NAME@284..296
-                    0: GRAPHQL_NAME@284..296 "firstWife" [Newline("\n"), Whitespace("\t\t")] []
-                  1: COLON@296..298 ":" [] [Whitespace(" ")]
-                1: GRAPHQL_NAME@298..302
-                  0: GRAPHQL_NAME@298..302 "wife" [] []
-                2: GRAPHQL_ARGUMENTS@302..318
-                  0: L_PAREN@302..303 "(" [] []
-                  1: GRAPHQL_ARGUMENT_LIST@303..317
-                    0: GRAPHQL_ARGUMENT@303..317
-                      0: GRAPHQL_NAME@303..307
-                        0: GRAPHQL_NAME@303..307 "name" [] []
-                      1: COLON@307..309 ":" [] [Whitespace(" ")]
-                      2: GRAPHQL_STRING_VALUE@309..317
-                        0: GRAPHQL_STRING_LITERAL@309..317 "\"Pepper\"" [] []
-                  2: R_PAREN@317..318 ")" [] []
-                3: GRAPHQL_DIRECTIVE_LIST@318..318
-                4: GRAPHQL_SELECTION_SET@318..323
-                  0: L_CURLY@318..319 "{" [] []
-                  1: GRAPHQL_SELECTION_LIST@319..319
-                  2: R_CURLY@319..323 "}" [Newline("\n"), Whitespace("\t\t")] []
-            2: R_CURLY@323..325 "}" [Newline("\n")] []
-      2: (empty)
-    7: GRAPHQL_SELECTION_SET@325..399
-      0: L_CURLY@325..328 "{" [Newline("\n"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@328..397
-        0: GRAPHQL_FIELD@328..397
-          0: GRAPHQL_ALIAS@328..340
-            0: GRAPHQL_NAME@328..338
-              0: GRAPHQL_NAME@328..338 "ironMan" [Newline("\n"), Whitespace("  ")] []
-            1: COLON@338..340 ":" [] [Whitespace(" ")]
-          1: GRAPHQL_NAME@340..344
-            0: GRAPHQL_NAME@340..344 "hero" [] []
-          2: GRAPHQL_ARGUMENTS@344..365
-            0: L_PAREN@344..345 "(" [] []
-            1: GRAPHQL_ARGUMENT_LIST@345..363
-              0: GRAPHQL_ARGUMENT@345..363
-                0: GRAPHQL_NAME@345..349
-                  0: GRAPHQL_NAME@345..349 "name" [] []
-                1: COLON@349..351 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_STRING_VALUE@351..363
-                  0: GRAPHQL_STRING_LITERAL@351..363 "\"Tony Stark\"" [] []
-            2: R_PAREN@363..365 ")" [] [Whitespace(" ")]
-          3: GRAPHQL_DIRECTIVE_LIST@365..366
-            0: GRAPHQL_DIRECTIVE@365..366
-              0: AT@365..366 "@" [] []
+              1: GRAPHQL_FIELD@324..363
+                0: GRAPHQL_ALIAS@324..338
+                  0: GRAPHQL_NAME@324..336
+                    0: GRAPHQL_NAME@324..336 "firstWife" [Newline("\n"), Whitespace("\t\t")] []
+                  1: COLON@336..338 ":" [] [Whitespace(" ")]
+                1: GRAPHQL_NAME@338..342
+                  0: GRAPHQL_NAME@338..342 "wife" [] []
+                2: GRAPHQL_ARGUMENTS@342..358
+                  0: L_PAREN@342..343 "(" [] []
+                  1: GRAPHQL_ARGUMENT_LIST@343..357
+                    0: GRAPHQL_ARGUMENT@343..357
+                      0: GRAPHQL_NAME@343..347
+                        0: GRAPHQL_NAME@343..347 "name" [] []
+                      1: COLON@347..349 ":" [] [Whitespace(" ")]
+                      2: GRAPHQL_STRING_VALUE@349..357
+                        0: GRAPHQL_STRING_LITERAL@349..357 "\"Pepper\"" [] []
+                  2: R_PAREN@357..358 ")" [] []
+                3: GRAPHQL_DIRECTIVE_LIST@358..358
+                4: GRAPHQL_SELECTION_SET@358..363
+                  0: L_CURLY@358..359 "{" [] []
+                  1: GRAPHQL_SELECTION_LIST@359..359
+                  2: R_CURLY@359..363 "}" [Newline("\n"), Whitespace("\t\t")] []
+            2: R_CURLY@363..366 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@366..368 "}" [Newline("\n")] []
+    8: GRAPHQL_SELECTION_SET@368..442
+      0: L_CURLY@368..371 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@371..440
+        0: GRAPHQL_FIELD@371..440
+          0: GRAPHQL_ALIAS@371..383
+            0: GRAPHQL_NAME@371..381
+              0: GRAPHQL_NAME@371..381 "ironMan" [Newline("\n"), Whitespace("  ")] []
+            1: COLON@381..383 ":" [] [Whitespace(" ")]
+          1: GRAPHQL_NAME@383..387
+            0: GRAPHQL_NAME@383..387 "hero" [] []
+          2: GRAPHQL_ARGUMENTS@387..408
+            0: L_PAREN@387..388 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@388..406
+              0: GRAPHQL_ARGUMENT@388..406
+                0: GRAPHQL_NAME@388..392
+                  0: GRAPHQL_NAME@388..392 "name" [] []
+                1: COLON@392..394 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_STRING_VALUE@394..406
+                  0: GRAPHQL_STRING_LITERAL@394..406 "\"Tony Stark\"" [] []
+            2: R_PAREN@406..408 ")" [] [Whitespace(" ")]
+          3: GRAPHQL_DIRECTIVE_LIST@408..409
+            0: GRAPHQL_DIRECTIVE@408..409
+              0: AT@408..409 "@" [] []
               1: (empty)
               2: (empty)
-          4: GRAPHQL_SELECTION_SET@366..397
-            0: L_CURLY@366..367 "{" [] []
-            1: GRAPHQL_SELECTION_LIST@367..394
-              0: GRAPHQL_FIELD@367..388
+          4: GRAPHQL_SELECTION_SET@409..440
+            0: L_CURLY@409..410 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@410..437
+              0: GRAPHQL_FIELD@410..431
                 0: (empty)
-                1: GRAPHQL_NAME@367..378
-                  0: GRAPHQL_NAME@367..378 "country" [Newline("\n"), Whitespace("\t\t")] [Whitespace(" ")]
+                1: GRAPHQL_NAME@410..421
+                  0: GRAPHQL_NAME@410..421 "country" [Newline("\n"), Whitespace("\t\t")] [Whitespace(" ")]
                 2: (empty)
-                3: GRAPHQL_DIRECTIVE_LIST@378..388
-                  0: GRAPHQL_DIRECTIVE@378..388
-                    0: AT@378..380 "@" [] [Skipped(",")]
-                    1: GRAPHQL_NAME@380..388
-                      0: GRAPHQL_NAME@380..388 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+                3: GRAPHQL_DIRECTIVE_LIST@421..431
+                  0: GRAPHQL_DIRECTIVE@421..431
+                    0: AT@421..423 "@" [] [Skipped(",")]
+                    1: GRAPHQL_NAME@423..431
+                      0: GRAPHQL_NAME@423..431 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
                     2: (empty)
                 4: (empty)
-              1: GRAPHQL_FIELD@388..394
+              1: GRAPHQL_FIELD@431..437
                 0: (empty)
-                1: GRAPHQL_NAME@388..394
-                  0: GRAPHQL_NAME@388..394 "age" [Newline("\n"), Whitespace("\t\t")] []
+                1: GRAPHQL_NAME@431..437
+                  0: GRAPHQL_NAME@431..437 "age" [Newline("\n"), Whitespace("\t\t")] []
                 2: (empty)
-                3: GRAPHQL_DIRECTIVE_LIST@394..394
+                3: GRAPHQL_DIRECTIVE_LIST@437..437
                 4: (empty)
-            2: R_CURLY@394..397 "}" [Newline("\n"), Whitespace("\t")] []
-      2: R_CURLY@397..399 "}" [Newline("\n")] []
-    8: GRAPHQL_SELECTION_SET@399..428
-      0: L_CURLY@399..420 "{" [Newline("\n"), Newline("\n"), Comments("# Fragment spread"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@420..428
-        0: GRAPHQL_INLINE_FRAGMENT@420..428
-          0: DOT3@420..426 "..." [Newline("\n"), Whitespace("  ")] []
-          1: (empty)
-          2: GRAPHQL_DIRECTIVE_LIST@426..426
-          3: GRAPHQL_SELECTION_SET@426..428
-            0: (empty)
-            1: GRAPHQL_SELECTION_LIST@426..426
-            2: R_CURLY@426..428 "}" [Newline("\n")] []
-      2: (empty)
-    9: GRAPHQL_SELECTION_SET@428..451
-      0: L_CURLY@428..431 "{" [Newline("\n"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@431..451
-        0: GRAPHQL_INLINE_FRAGMENT@431..451
-          0: DOT3@431..438 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-          1: (empty)
-          2: GRAPHQL_DIRECTIVE_LIST@438..449
-            0: GRAPHQL_DIRECTIVE@438..449
-              0: AT@438..439 "@" [] []
-              1: GRAPHQL_NAME@439..449
-                0: GRAPHQL_NAME@439..449 "deprecated" [] []
-              2: (empty)
-          3: GRAPHQL_SELECTION_SET@449..451
-            0: (empty)
-            1: GRAPHQL_SELECTION_LIST@449..449
-            2: R_CURLY@449..451 "}" [Newline("\n")] []
-      2: (empty)
-    10: GRAPHQL_SELECTION_SET@451..497
-      0: L_CURLY@451..454 "{" [Newline("\n"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@454..497
-        0: GRAPHQL_BOGUS_SELECTION@454..497
-          0: GRAPHQL_ALIAS@454..466
-            0: GRAPHQL_NAME@454..464
-              0: GRAPHQL_NAME@454..464 "ironMan" [Newline("\n"), Whitespace("  ")] []
-            1: COLON@464..466 ":" [] [Whitespace(" ")]
-          1: GRAPHQL_BOGUS@466..483
-            0: L_PAREN@466..467 "(" [] []
-            1: GRAPHQL_BOGUS@467..481
-              0: GRAPHQL_BOGUS@467..481
-                0: COLON@467..469 ":" [] [Whitespace(" ")]
-                1: GRAPHQL_STRING_LITERAL@469..481 "\"Tony Stark\"" [] []
-            2: R_PAREN@481..483 ")" [] [Whitespace(" ")]
-          2: GRAPHQL_DIRECTIVE_LIST@483..485
-            0: GRAPHQL_DIRECTIVE@483..485
-              0: AT@483..485 "@" [] [Whitespace(" ")]
+            2: R_CURLY@437..440 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@440..442 "}" [Newline("\n")] []
+    9: GRAPHQL_SELECTION_SET@442..508
+      0: L_CURLY@442..463 "{" [Newline("\n"), Newline("\n"), Comments("# Fragment spread"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@463..506
+        0: GRAPHQL_BOGUS_SELECTION@463..506
+          0: GRAPHQL_ALIAS@463..475
+            0: GRAPHQL_NAME@463..473
+              0: GRAPHQL_NAME@463..473 "ironMan" [Newline("\n"), Whitespace("  ")] []
+            1: COLON@473..475 ":" [] [Whitespace(" ")]
+          1: GRAPHQL_BOGUS@475..492
+            0: L_PAREN@475..476 "(" [] []
+            1: GRAPHQL_BOGUS@476..490
+              0: GRAPHQL_BOGUS@476..490
+                0: COLON@476..478 ":" [] [Whitespace(" ")]
+                1: GRAPHQL_STRING_LITERAL@478..490 "\"Tony Stark\"" [] []
+            2: R_PAREN@490..492 ")" [] [Whitespace(" ")]
+          2: GRAPHQL_DIRECTIVE_LIST@492..494
+            0: GRAPHQL_DIRECTIVE@492..494
+              0: AT@492..494 "@" [] [Whitespace(" ")]
               1: (empty)
               2: (empty)
-          3: GRAPHQL_SELECTION_SET@485..497
-            0: L_CURLY@485..486 "{" [] []
-            1: GRAPHQL_SELECTION_LIST@486..495
-              0: GRAPHQL_INLINE_FRAGMENT@486..495
-                0: DOT3@486..492 "..." [Newline("\n"), Whitespace("\t\t")] []
+          3: GRAPHQL_SELECTION_SET@494..506
+            0: L_CURLY@494..495 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@495..504
+              0: GRAPHQL_INLINE_FRAGMENT@495..504
+                0: DOT3@495..501 "..." [Newline("\n"), Whitespace("\t\t")] []
                 1: (empty)
-                2: GRAPHQL_DIRECTIVE_LIST@492..492
-                3: GRAPHQL_SELECTION_SET@492..495
+                2: GRAPHQL_DIRECTIVE_LIST@501..501
+                3: GRAPHQL_SELECTION_SET@501..504
                   0: (empty)
-                  1: GRAPHQL_SELECTION_LIST@492..492
-                  2: R_CURLY@492..495 "}" [Newline("\n"), Whitespace("\t")] []
-            2: R_CURLY@495..497 "}" [Newline("\n")] []
-      2: (empty)
-    11: GRAPHQL_SELECTION_SET@497..517
-      0: L_CURLY@497..500 "{" [Newline("\n"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@500..517
-        0: GRAPHQL_INLINE_FRAGMENT@500..517
-          0: DOT3@500..507 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+                  1: GRAPHQL_SELECTION_LIST@501..501
+                  2: R_CURLY@501..504 "}" [Newline("\n"), Whitespace("\t")] []
+            2: R_CURLY@504..506 "}" [Newline("\n")] []
+      2: R_CURLY@506..508 "}" [Newline("\n")] []
+    10: GRAPHQL_SELECTION_SET@508..531
+      0: L_CURLY@508..511 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@511..529
+        0: GRAPHQL_INLINE_FRAGMENT@511..529
+          0: DOT3@511..518 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
           1: (empty)
-          2: GRAPHQL_DIRECTIVE_LIST@507..507
-          3: GRAPHQL_SELECTION_SET@507..517
-            0: L_CURLY@507..508 "{" [] []
-            1: GRAPHQL_SELECTION_LIST@508..515
-              0: GRAPHQL_FIELD@508..515
+          2: GRAPHQL_DIRECTIVE_LIST@518..518
+          3: GRAPHQL_SELECTION_SET@518..529
+            0: L_CURLY@518..519 "{" [] []
+            1: GRAPHQL_SELECTION_LIST@519..526
+              0: GRAPHQL_FIELD@519..526
                 0: (empty)
-                1: GRAPHQL_NAME@508..515
-                  0: GRAPHQL_NAME@508..515 "hero" [Newline("\n"), Whitespace("\t\t")] []
+                1: GRAPHQL_NAME@519..526
+                  0: GRAPHQL_NAME@519..526 "hero" [Newline("\n"), Whitespace("\t\t")] []
                 2: (empty)
-                3: GRAPHQL_DIRECTIVE_LIST@515..515
+                3: GRAPHQL_DIRECTIVE_LIST@526..526
                 4: (empty)
-            2: R_CURLY@515..517 "}" [Newline("\n")] []
-      2: (empty)
-    12: GRAPHQL_SELECTION_SET@517..540
-      0: L_CURLY@517..520 "{" [Newline("\n"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@520..538
-        0: GRAPHQL_INLINE_FRAGMENT@520..538
-          0: DOT3@520..527 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            2: R_CURLY@526..529 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@529..531 "}" [Newline("\n")] []
+    11: GRAPHQL_SELECTION_SET@531..554
+      0: L_CURLY@531..534 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@534..552
+        0: GRAPHQL_INLINE_FRAGMENT@534..552
+          0: DOT3@534..541 "..." [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
           1: (empty)
-          2: GRAPHQL_DIRECTIVE_LIST@527..535
-            0: GRAPHQL_DIRECTIVE@527..535
-              0: AT@527..528 "@" [] []
-              1: GRAPHQL_NAME@528..535
-                0: GRAPHQL_NAME@528..535 "hero" [Newline("\n"), Whitespace("\t\t")] []
+          2: GRAPHQL_DIRECTIVE_LIST@541..549
+            0: GRAPHQL_DIRECTIVE@541..549
+              0: AT@541..542 "@" [] []
+              1: GRAPHQL_NAME@542..549
+                0: GRAPHQL_NAME@542..549 "hero" [Newline("\n"), Whitespace("\t\t")] []
               2: (empty)
-          3: GRAPHQL_SELECTION_SET@535..538
+          3: GRAPHQL_SELECTION_SET@549..552
             0: (empty)
-            1: GRAPHQL_SELECTION_LIST@535..535
-            2: R_CURLY@535..538 "}" [Newline("\n"), Whitespace("\t")] []
-      2: R_CURLY@538..540 "}" [Newline("\n")] []
-    13: GRAPHQL_SELECTION_SET@540..557
-      0: L_CURLY@540..543 "{" [Newline("\n"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@543..557
-        0: GRAPHQL_FRAGMENT_SPREAD@543..557
-          0: DOT3@543..550 "..." [Newline("\n"), Whitespace("\t")] [Whitespace("  ")]
-          1: GRAPHQL_NAME@550..555
-            0: GRAPHQL_NAME@550..555 "Hero" [] [Whitespace(" ")]
-          2: GRAPHQL_DIRECTIVE_LIST@555..557
-            0: GRAPHQL_DIRECTIVE@555..557
-              0: AT@555..557 "@" [] [Whitespace(" ")]
+            1: GRAPHQL_SELECTION_LIST@549..549
+            2: R_CURLY@549..552 "}" [Newline("\n"), Whitespace("\t")] []
+      2: R_CURLY@552..554 "}" [Newline("\n")] []
+    12: GRAPHQL_SELECTION_SET@554..589
+      0: L_CURLY@554..557 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@557..586
+        0: GRAPHQL_FRAGMENT_SPREAD@557..571
+          0: DOT3@557..564 "..." [Newline("\n"), Whitespace("\t")] [Whitespace("  ")]
+          1: GRAPHQL_NAME@564..569
+            0: GRAPHQL_NAME@564..569 "Hero" [] [Whitespace(" ")]
+          2: GRAPHQL_DIRECTIVE_LIST@569..571
+            0: GRAPHQL_DIRECTIVE@569..571
+              0: AT@569..571 "@" [] [Whitespace(" ")]
               1: (empty)
               2: (empty)
+        1: GRAPHQL_BOGUS_SELECTION@571..572
+          0: L_CURLY@571..572 "{" [] []
+        2: GRAPHQL_FIELD@572..580
+          0: (empty)
+          1: GRAPHQL_NAME@572..580
+            0: GRAPHQL_NAME@572..580 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@580..580
+          4: (empty)
+        3: GRAPHQL_FIELD@580..586
+          0: (empty)
+          1: GRAPHQL_NAME@580..586
+            0: GRAPHQL_NAME@580..586 "age" [Newline("\n"), Whitespace("\t\t")] []
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@586..586
+          4: (empty)
+      2: R_CURLY@586..589 "}" [Newline("\n"), Whitespace("\t")] []
+    13: GRAPHQL_BOGUS_DEFINITION@589..591
+      0: R_CURLY@589..591 "}" [Newline("\n")] []
+    14: GRAPHQL_SELECTION_SET@591..602
+      0: L_CURLY@591..594 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@594..602
+        0: GRAPHQL_INLINE_FRAGMENT@594..602
+          0: DOT3@594..600 "..." [Newline("\n"), Whitespace("  ")] []
+          1: (empty)
+          2: GRAPHQL_DIRECTIVE_LIST@600..600
+          3: GRAPHQL_SELECTION_SET@600..602
+            0: (empty)
+            1: GRAPHQL_SELECTION_LIST@600..600
+            2: R_CURLY@600..602 "}" [Newline("\n")] []
       2: (empty)
-    14: GRAPHQL_SELECTION_SET@557..575
-      0: L_CURLY@557..558 "{" [] []
-      1: GRAPHQL_SELECTION_LIST@558..572
-        0: GRAPHQL_FIELD@558..566
-          0: (empty)
-          1: GRAPHQL_NAME@558..566
-            0: GRAPHQL_NAME@558..566 "name" [Newline("\n"), Whitespace("\t\t")] [Skipped(",")]
-          2: (empty)
-          3: GRAPHQL_DIRECTIVE_LIST@566..566
-          4: (empty)
-        1: GRAPHQL_FIELD@566..572
-          0: (empty)
-          1: GRAPHQL_NAME@566..572
-            0: GRAPHQL_NAME@566..572 "age" [Newline("\n"), Whitespace("\t\t")] []
-          2: (empty)
-          3: GRAPHQL_DIRECTIVE_LIST@572..572
-          4: (empty)
-      2: R_CURLY@572..575 "}" [Newline("\n"), Whitespace("\t")] []
-    15: GRAPHQL_BOGUS_DEFINITION@575..577
-      0: R_CURLY@575..577 "}" [Newline("\n")] []
-  2: EOF@577..578 "" [Newline("\n")] []
+  2: EOF@602..604 "" [Newline("\n"), Newline("\n")] []
 
 ```
 
 ## Diagnostics
 
 ```
-selection_set.graphql:8:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `}` but instead found `{`
-  
-     6 │ }
-     7 │ 
-   > 8 │ {
-       │ ^
-     9 │ 	hero(name: "Tony Stark"
-    10 │ }
-  
-  i Remove {
-  
-selection_set.graphql:10:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:12:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `}`
   
-     8 │ {
-     9 │ 	hero(name: "Tony Stark"
-  > 10 │ }
+    10 │ {
+    11 │ 	hero(name: "Tony Stark"
+  > 12 │ }
        │ ^
-    11 │ 
-    12 │ {
+    13 │ 
+    14 │ {
   
   i Remove }
   
-selection_set.graphql:13:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:15:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `:` but instead found `"Tony Stark"`
   
-    12 │ {
-  > 13 │ 	hero(name "Tony Stark")
+    14 │ {
+  > 15 │ 	hero(name "Tony Stark")
        │ 	          ^^^^^^^^^^^^
-    14 │ 		country,
-    15 │ 		name,
+    16 │ 		country,
+    17 │ 		name,
   
   i Remove "Tony Stark"
   
-selection_set.graphql:18:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:20:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a definition but instead found '}'.
   
-    16 │ 		age
-    17 │ 	}
-  > 18 │ }
+    18 │ 		age
+    19 │ 	}
+  > 20 │ }
        │ ^
-    19 │ 
-    20 │ {
+    21 │ 
+    22 │ {
   
   i Expected a definition here.
   
-    16 │ 		age
-    17 │ 	}
-  > 18 │ }
+    18 │ 		age
+    19 │ 	}
+  > 20 │ }
        │ ^
-    19 │ 
-    20 │ {
+    21 │ 
+    22 │ {
   
-selection_set.graphql:25:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:27:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `:` but instead found `FOOT`
   
-    23 │ 		name,
-    24 │ 		age,
-  > 25 │ 		height(unit FOOT,
+    25 │ 		name,
+    26 │ 		age,
+  > 27 │ 		height(unit FOOT,
        │ 		            ^^^^
-    26 │ 	}
-    27 │ }
+    28 │ 	}
+    29 │ }
   
   i Remove FOOT
   
-selection_set.graphql:26:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:28:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `}`
   
-    24 │ 		age,
-    25 │ 		height(unit FOOT,
-  > 26 │ 	}
+    26 │ 		age,
+    27 │ 		height(unit FOOT,
+  > 28 │ 	}
        │ 	^
-    27 │ }
-    28 │ 
+    29 │ }
+    30 │ 
   
   i Remove }
   
-selection_set.graphql:30:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:32:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a name but instead found '('.
   
-    29 │ {
-  > 30 │   ironMan: (name: "Tony Stark")
+    31 │ {
+  > 32 │   ironMan: (name: "Tony Stark")
        │            ^
-    31 │ }
-    32 │ 
+    33 │ }
+    34 │ 
   
   i Expected a name here.
   
-    29 │ {
-  > 30 │   ironMan: (name: "Tony Stark")
+    31 │ {
+  > 32 │   ironMan: (name: "Tony Stark")
        │            ^
-    31 │ }
-    32 │ 
+    33 │ }
+    34 │ 
   
-selection_set.graphql:34:36 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:36:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a name but instead found '0'.
+  
+    35 │ {
+  > 36 │   0: (name: "Tony Stark")
+       │   ^
+    37 │ }
+    38 │ 
+  
+  i Expected a name here.
+  
+    35 │ {
+  > 36 │   0: (name: "Tony Stark")
+       │   ^
+    37 │ }
+    38 │ 
+  
+selection_set.graphql:36:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a name but instead found '('.
+  
+    35 │ {
+  > 36 │   0: (name: "Tony Stark")
+       │      ^
+    37 │ }
+    38 │ 
+  
+  i Expected a name here.
+  
+    35 │ {
+  > 36 │   0: (name: "Tony Stark")
+       │      ^
+    37 │ }
+    38 │ 
+  
+selection_set.graphql:40:36 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead found `{`
   
-    33 │ {
-  > 34 │   ironMan: hero(name: "Tony Stark" {
+    39 │ {
+  > 40 │   ironMan: hero(name: "Tony Stark" {
        │                                    ^
-    35 │ 		country,
-    36 │ 		firstWife: wife(name: "Pepper"){
+    41 │ 		country,
+    42 │ 		firstWife: wife(name: "Pepper"){
   
   i Remove {
   
-selection_set.graphql:40:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `}` but instead found `{`
-  
-    38 │ }
-    39 │ 
-  > 40 │ {
-       │ ^
-    41 │   ironMan: hero(name: "Tony Stark") @{
-    42 │ 		country @,
-  
-  i Remove {
-  
-selection_set.graphql:41:38 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:48:38 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a name but instead found '{'.
   
-    40 │ {
-  > 41 │   ironMan: hero(name: "Tony Stark") @{
+    47 │ {
+  > 48 │   ironMan: hero(name: "Tony Stark") @{
        │                                      ^
-    42 │ 		country @,
-    43 │ 		name,
+    49 │ 		country @,
+    50 │ 		name,
   
   i Expected a name here.
   
-    40 │ {
-  > 41 │   ironMan: hero(name: "Tony Stark") @{
+    47 │ {
+  > 48 │   ironMan: hero(name: "Tony Stark") @{
        │                                      ^
-    42 │ 		country @,
-    43 │ 		name,
+    49 │ 		country @,
+    50 │ 		name,
   
-selection_set.graphql:51:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `{` but instead found `}`
-  
-    49 │ {
-    50 │   ...
-  > 51 │ }
-       │ ^
-    52 │ 
-    53 │ {
-  
-  i Remove }
-  
-selection_set.graphql:53:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `}` but instead found `{`
-  
-    51 │ }
-    52 │ 
-  > 53 │ {
-       │ ^
-    54 │   ... @deprecated
-    55 │ }
-  
-  i Remove {
-  
-selection_set.graphql:55:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `{` but instead found `}`
-  
-    53 │ {
-    54 │   ... @deprecated
-  > 55 │ }
-       │ ^
-    56 │ 
-    57 │ {
-  
-  i Remove }
-  
-selection_set.graphql:57:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `}` but instead found `{`
-  
-    55 │ }
-    56 │ 
-  > 57 │ {
-       │ ^
-    58 │   ironMan: (: "Tony Stark") @ {
-    59 │ 		...
-  
-  i Remove {
-  
-selection_set.graphql:58:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:57:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a name but instead found '('.
   
-    57 │ {
-  > 58 │   ironMan: (: "Tony Stark") @ {
+    55 │ # Fragment spread
+    56 │ {
+  > 57 │   ironMan: (: "Tony Stark") @ {
        │            ^
-    59 │ 		...
-    60 │ 	}
+    58 │ 		...
+    59 │ 	}
   
   i Expected a name here.
   
-    57 │ {
-  > 58 │   ironMan: (: "Tony Stark") @ {
+    55 │ # Fragment spread
+    56 │ {
+  > 57 │   ironMan: (: "Tony Stark") @ {
        │            ^
-    59 │ 		...
-    60 │ 	}
+    58 │ 		...
+    59 │ 	}
   
-selection_set.graphql:58:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:57:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an argument but instead found ': "Tony Stark"'.
   
-    57 │ {
-  > 58 │   ironMan: (: "Tony Stark") @ {
+    55 │ # Fragment spread
+    56 │ {
+  > 57 │   ironMan: (: "Tony Stark") @ {
        │             ^^^^^^^^^^^^^^
-    59 │ 		...
-    60 │ 	}
+    58 │ 		...
+    59 │ 	}
   
   i Expected an argument here.
   
-    57 │ {
-  > 58 │   ironMan: (: "Tony Stark") @ {
+    55 │ # Fragment spread
+    56 │ {
+  > 57 │   ironMan: (: "Tony Stark") @ {
        │             ^^^^^^^^^^^^^^
-    59 │ 		...
-    60 │ 	}
+    58 │ 		...
+    59 │ 	}
   
-selection_set.graphql:58:31 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:57:31 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a name but instead found '{'.
   
-    57 │ {
-  > 58 │   ironMan: (: "Tony Stark") @ {
+    55 │ # Fragment spread
+    56 │ {
+  > 57 │   ironMan: (: "Tony Stark") @ {
        │                               ^
-    59 │ 		...
-    60 │ 	}
+    58 │ 		...
+    59 │ 	}
   
   i Expected a name here.
   
-    57 │ {
-  > 58 │   ironMan: (: "Tony Stark") @ {
+    55 │ # Fragment spread
+    56 │ {
+  > 57 │   ironMan: (: "Tony Stark") @ {
        │                               ^
-    59 │ 		...
-    60 │ 	}
+    58 │ 		...
+    59 │ 	}
   
-selection_set.graphql:60:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:59:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `{` but instead found `}`
   
-    58 │   ironMan: (: "Tony Stark") @ {
-    59 │ 		...
-  > 60 │ 	}
+    57 │   ironMan: (: "Tony Stark") @ {
+    58 │ 		...
+  > 59 │ 	}
        │ 	^
+    60 │ }
     61 │ }
-    62 │ 
   
   i Remove }
   
-selection_set.graphql:63:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `}` but instead found `{`
-  
-    61 │ }
-    62 │ 
-  > 63 │ {
-       │ ^
-    64 │   ... {
-    65 │ 		hero
-  
-  i Remove {
-  
-selection_set.graphql:68:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `}` but instead found `{`
-  
-    66 │ }
-    67 │ 
-  > 68 │ {
-       │ ^
-    69 │   ... @
-    70 │ 		hero
-  
-  i Remove {
-  
-selection_set.graphql:71:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:72:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `{` but instead found `}`
   
-    69 │   ... @
-    70 │ 		hero
-  > 71 │ 	}
+    70 │   ... @
+    71 │ 		hero
+  > 72 │ 	}
        │ 	^
-    72 │ }
-    73 │ 
+    73 │ }
+    74 │ 
   
   i Remove }
   
-selection_set.graphql:75:14 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:76:14 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a name but instead found '{'.
   
-    74 │ {
-  > 75 │ 	...  Hero @ {
+    75 │ {
+  > 76 │ 	...  Hero @ {
        │ 	            ^
-    76 │ 		name,
-    77 │ 		age
+    77 │ 		name,
+    78 │ 		age
   
   i Expected a name here.
   
-    74 │ {
-  > 75 │ 	...  Hero @ {
+    75 │ {
+  > 76 │ 	...  Hero @ {
        │ 	            ^
-    76 │ 		name,
-    77 │ 		age
+    77 │ 		name,
+    78 │ 		age
   
-selection_set.graphql:79:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+selection_set.graphql:80:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a definition but instead found '}'.
   
-    77 │ 		age
-    78 │ 	}
-  > 79 │ }
+    78 │ 		age
+    79 │ 	}
+  > 80 │ }
        │ ^
-    80 │ 
+    81 │ 
+    82 │ {
   
   i Expected a definition here.
   
-    77 │ 		age
-    78 │ 	}
-  > 79 │ }
+    78 │ 		age
+    79 │ 	}
+  > 80 │ }
        │ ^
-    80 │ 
+    81 │ 
+    82 │ {
+  
+selection_set.graphql:84:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `{` but instead found `}`
+  
+    82 │ {
+    83 │   ...
+  > 84 │ }
+       │ ^
+    85 │ 
+  
+  i Remove }
+  
+selection_set.graphql:86:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `}` but instead the file ends
+  
+    84 │ }
+    85 │ 
+  > 86 │ 
+       │ 
+  
+  i the file ends here
+  
+    84 │ }
+    85 │ 
+  > 86 │ 
+       │ 
   
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/type.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/type.graphql
@@ -1,4 +1,4 @@
-query ($input: [InputType!) {
+query ($storyId: !, $comments: [!], $tags: [!]!, $posts: PostInput]!, $input: [InputType!) {
 	likeStory
 }
 

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/type.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/type.graphql.snap
@@ -4,7 +4,7 @@ expression: snapshot
 ---
 ## Input
 ```graphql
-query ($input: [InputType!) {
+query ($storyId: !, $comments: [!], $tags: [!]!, $posts: PostInput]!, $input: [InputType!) {
 	likeStory
 }
 
@@ -34,119 +34,191 @@ GraphqlRoot {
                                 GraphqlVariableDefinition {
                                     variable: GraphqlVariable {
                                         dollar_token: DOLLAR@7..8 "$" [] [],
-                                        name: missing (required),
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@8..15 "storyId" [] [],
+                                        },
                                     },
-                                    colon_token: missing (required),
-                                    ty: missing (required),
+                                    colon_token: COLON@15..17 ":" [] [Whitespace(" ")],
+                                    ty: GraphqlNonNullType {
+                                        base: missing (required),
+                                        excl_token: BANG@17..20 "!" [] [Skipped(","), Whitespace(" ")],
+                                    },
+                                    default: missing (optional),
+                                    directives: GraphqlDirectiveList [],
+                                },
+                                GraphqlVariableDefinition {
+                                    variable: GraphqlVariable {
+                                        dollar_token: DOLLAR@20..21 "$" [] [],
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@21..29 "comments" [] [],
+                                        },
+                                    },
+                                    colon_token: COLON@29..31 ":" [] [Whitespace(" ")],
+                                    ty: GraphqlListType {
+                                        l_brack_token: L_BRACK@31..32 "[" [] [],
+                                        element: GraphqlNonNullType {
+                                            base: missing (required),
+                                            excl_token: BANG@32..33 "!" [] [],
+                                        },
+                                        r_brack_token: R_BRACK@33..36 "]" [] [Skipped(","), Whitespace(" ")],
+                                    },
+                                    default: missing (optional),
+                                    directives: GraphqlDirectiveList [],
+                                },
+                                GraphqlVariableDefinition {
+                                    variable: GraphqlVariable {
+                                        dollar_token: DOLLAR@36..37 "$" [] [],
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@37..41 "tags" [] [],
+                                        },
+                                    },
+                                    colon_token: COLON@41..43 ":" [] [Whitespace(" ")],
+                                    ty: GraphqlNonNullType {
+                                        base: GraphqlListType {
+                                            l_brack_token: L_BRACK@43..44 "[" [] [],
+                                            element: GraphqlNonNullType {
+                                                base: missing (required),
+                                                excl_token: BANG@44..45 "!" [] [],
+                                            },
+                                            r_brack_token: R_BRACK@45..46 "]" [] [],
+                                        },
+                                        excl_token: BANG@46..49 "!" [] [Skipped(","), Whitespace(" ")],
+                                    },
+                                    default: missing (optional),
+                                    directives: GraphqlDirectiveList [],
+                                },
+                                GraphqlVariableDefinition {
+                                    variable: GraphqlVariable {
+                                        dollar_token: DOLLAR@49..50 "$" [] [],
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@50..55 "posts" [] [],
+                                        },
+                                    },
+                                    colon_token: COLON@55..57 ":" [] [Whitespace(" ")],
+                                    ty: GraphqlNamedType {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@57..66 "PostInput" [] [],
+                                        },
+                                    },
                                     default: missing (optional),
                                     directives: GraphqlDirectiveList [],
                                 },
                                 GraphqlBogus {
                                     items: [
-                                        INPUT_KW@8..13 "input" [] [],
-                                        COLON@13..15 ":" [] [Whitespace(" ")],
-                                        GraphqlListType {
-                                            l_brack_token: L_BRACK@15..16 "[" [] [],
-                                            element: GraphqlNonNullType {
-                                                base: GraphqlNamedType {
-                                                    name: GraphqlName {
-                                                        value_token: GRAPHQL_NAME@16..25 "InputType" [] [],
-                                                    },
-                                                },
-                                                excl_token: BANG@25..26 "!" [] [],
-                                            },
-                                            r_brack_token: missing (required),
-                                        },
-                                        GraphqlDirectiveList [],
+                                        R_BRACK@66..67 "]" [] [],
+                                        BANG@67..70 "!" [] [Skipped(","), Whitespace(" ")],
                                     ],
+                                },
+                                GraphqlVariableDefinition {
+                                    variable: GraphqlVariable {
+                                        dollar_token: DOLLAR@70..71 "$" [] [],
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@71..76 "input" [] [],
+                                        },
+                                    },
+                                    colon_token: COLON@76..78 ":" [] [Whitespace(" ")],
+                                    ty: GraphqlListType {
+                                        l_brack_token: L_BRACK@78..79 "[" [] [],
+                                        element: GraphqlNonNullType {
+                                            base: GraphqlNamedType {
+                                                name: GraphqlName {
+                                                    value_token: GRAPHQL_NAME@79..88 "InputType" [] [],
+                                                },
+                                            },
+                                            excl_token: BANG@88..89 "!" [] [],
+                                        },
+                                        r_brack_token: missing (required),
+                                    },
+                                    default: missing (optional),
+                                    directives: GraphqlDirectiveList [],
                                 },
                             ],
                         },
-                        R_PAREN@26..28 ")" [] [Whitespace(" ")],
+                        R_PAREN@89..91 ")" [] [Whitespace(" ")],
                     ],
                 },
                 GraphqlDirectiveList [],
                 GraphqlSelectionSet {
-                    l_curly_token: L_CURLY@28..29 "{" [] [],
+                    l_curly_token: L_CURLY@91..92 "{" [] [],
                     selections: GraphqlSelectionList [
                         GraphqlField {
                             alias: missing (optional),
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@29..40 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                                value_token: GRAPHQL_NAME@92..103 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                             },
                             arguments: missing (optional),
                             directives: GraphqlDirectiveList [],
                             selection_set: missing (optional),
                         },
                     ],
-                    r_curly_token: R_CURLY@40..42 "}" [Newline("\n")] [],
+                    r_curly_token: R_CURLY@103..105 "}" [Newline("\n")] [],
                 },
             ],
         },
         GraphqlBogusDefinition {
             items: [
                 GraphqlOperationType {
-                    value_token: QUERY_KW@42..50 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                    value_token: QUERY_KW@105..113 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
                 },
                 GraphqlBogus {
                     items: [
-                        L_PAREN@50..51 "(" [] [],
+                        L_PAREN@113..114 "(" [] [],
                         GraphqlBogus {
                             items: [
                                 GraphqlVariableDefinition {
                                     variable: GraphqlVariable {
-                                        dollar_token: DOLLAR@51..52 "$" [] [],
+                                        dollar_token: DOLLAR@114..115 "$" [] [],
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@52..59 "storyId" [] [],
+                                            value_token: GRAPHQL_NAME@115..122 "storyId" [] [],
                                         },
                                     },
-                                    colon_token: COLON@59..61 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@122..124 ":" [] [Whitespace(" ")],
                                     ty: GraphqlNonNullType {
                                         base: missing (required),
-                                        excl_token: BANG@61..62 "!" [] [],
+                                        excl_token: BANG@124..125 "!" [] [],
                                     },
                                     default: missing (optional),
                                     directives: GraphqlDirectiveList [],
                                 },
                                 GraphqlBogus {
                                     items: [
-                                        L_BRACK@62..65 "[" [] [Skipped(","), Whitespace(" ")],
+                                        L_BRACK@125..128 "[" [] [Skipped(","), Whitespace(" ")],
                                     ],
                                 },
                                 GraphqlVariableDefinition {
                                     variable: GraphqlVariable {
-                                        dollar_token: DOLLAR@65..66 "$" [] [],
+                                        dollar_token: DOLLAR@128..129 "$" [] [],
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@66..74 "comments" [] [],
+                                            value_token: GRAPHQL_NAME@129..137 "comments" [] [],
                                         },
                                     },
-                                    colon_token: COLON@74..76 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@137..139 ":" [] [Whitespace(" ")],
                                     ty: GraphqlNonNullType {
                                         base: missing (required),
-                                        excl_token: BANG@76..77 "!" [] [],
+                                        excl_token: BANG@139..140 "!" [] [],
                                     },
                                     default: missing (optional),
                                     directives: GraphqlDirectiveList [],
                                 },
                                 GraphqlBogus {
                                     items: [
-                                        R_BRACK@77..80 "]" [] [Skipped(","), Whitespace(" ")],
+                                        R_BRACK@140..143 "]" [] [Skipped(","), Whitespace(" ")],
                                     ],
                                 },
                                 GraphqlVariableDefinition {
                                     variable: GraphqlVariable {
-                                        dollar_token: DOLLAR@80..81 "$" [] [],
+                                        dollar_token: DOLLAR@143..144 "$" [] [],
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@81..85 "tags" [] [],
+                                            value_token: GRAPHQL_NAME@144..148 "tags" [] [],
                                         },
                                     },
-                                    colon_token: COLON@85..87 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@148..150 ":" [] [Whitespace(" ")],
                                     ty: GraphqlListType {
-                                        l_brack_token: L_BRACK@87..88 "[" [] [],
+                                        l_brack_token: L_BRACK@150..151 "[" [] [],
                                         element: GraphqlListType {
-                                            l_brack_token: L_BRACK@88..89 "[" [] [],
+                                            l_brack_token: L_BRACK@151..152 "[" [] [],
                                             element: GraphqlListType {
-                                                l_brack_token: L_BRACK@89..90 "[" [] [],
+                                                l_brack_token: L_BRACK@152..153 "[" [] [],
                                                 element: missing (required),
                                                 r_brack_token: missing (required),
                                             },
@@ -159,169 +231,268 @@ GraphqlRoot {
                                 },
                             ],
                         },
-                        R_PAREN@90..92 ")" [] [Whitespace(" ")],
+                        R_PAREN@153..155 ")" [] [Whitespace(" ")],
                     ],
                 },
                 GraphqlDirectiveList [],
                 GraphqlSelectionSet {
-                    l_curly_token: L_CURLY@92..93 "{" [] [],
+                    l_curly_token: L_CURLY@155..156 "{" [] [],
                     selections: GraphqlSelectionList [
                         GraphqlField {
                             alias: missing (optional),
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@93..104 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                                value_token: GRAPHQL_NAME@156..167 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                             },
                             arguments: missing (optional),
                             directives: GraphqlDirectiveList [],
                             selection_set: missing (optional),
                         },
                     ],
-                    r_curly_token: R_CURLY@104..106 "}" [Newline("\n")] [],
+                    r_curly_token: R_CURLY@167..169 "}" [Newline("\n")] [],
                 },
             ],
         },
     ],
-    eof_token: EOF@106..108 "" [Newline("\n"), Newline("\n")] [],
+    eof_token: EOF@169..171 "" [Newline("\n"), Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..108
+0: GRAPHQL_ROOT@0..171
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..106
-    0: GRAPHQL_BOGUS_DEFINITION@0..42
+  1: GRAPHQL_DEFINITION_LIST@0..169
+    0: GRAPHQL_BOGUS_DEFINITION@0..105
       0: GRAPHQL_OPERATION_TYPE@0..6
         0: QUERY_KW@0..6 "query" [] [Whitespace(" ")]
-      1: GRAPHQL_BOGUS@6..28
+      1: GRAPHQL_BOGUS@6..91
         0: L_PAREN@6..7 "(" [] []
-        1: GRAPHQL_BOGUS@7..26
-          0: GRAPHQL_VARIABLE_DEFINITION@7..8
-            0: GRAPHQL_VARIABLE@7..8
+        1: GRAPHQL_BOGUS@7..89
+          0: GRAPHQL_VARIABLE_DEFINITION@7..20
+            0: GRAPHQL_VARIABLE@7..15
               0: DOLLAR@7..8 "$" [] []
-              1: (empty)
-            1: (empty)
-            2: (empty)
+              1: GRAPHQL_NAME@8..15
+                0: GRAPHQL_NAME@8..15 "storyId" [] []
+            1: COLON@15..17 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@17..20
+              0: (empty)
+              1: BANG@17..20 "!" [] [Skipped(","), Whitespace(" ")]
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@8..8
-          1: GRAPHQL_BOGUS@8..26
-            0: INPUT_KW@8..13 "input" [] []
-            1: COLON@13..15 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_LIST_TYPE@15..26
-              0: L_BRACK@15..16 "[" [] []
-              1: GRAPHQL_NON_NULL_TYPE@16..26
-                0: GRAPHQL_NAMED_TYPE@16..25
-                  0: GRAPHQL_NAME@16..25
-                    0: GRAPHQL_NAME@16..25 "InputType" [] []
-                1: BANG@25..26 "!" [] []
+            4: GRAPHQL_DIRECTIVE_LIST@20..20
+          1: GRAPHQL_VARIABLE_DEFINITION@20..36
+            0: GRAPHQL_VARIABLE@20..29
+              0: DOLLAR@20..21 "$" [] []
+              1: GRAPHQL_NAME@21..29
+                0: GRAPHQL_NAME@21..29 "comments" [] []
+            1: COLON@29..31 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_LIST_TYPE@31..36
+              0: L_BRACK@31..32 "[" [] []
+              1: GRAPHQL_NON_NULL_TYPE@32..33
+                0: (empty)
+                1: BANG@32..33 "!" [] []
+              2: R_BRACK@33..36 "]" [] [Skipped(","), Whitespace(" ")]
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@36..36
+          2: GRAPHQL_VARIABLE_DEFINITION@36..49
+            0: GRAPHQL_VARIABLE@36..41
+              0: DOLLAR@36..37 "$" [] []
+              1: GRAPHQL_NAME@37..41
+                0: GRAPHQL_NAME@37..41 "tags" [] []
+            1: COLON@41..43 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@43..49
+              0: GRAPHQL_LIST_TYPE@43..46
+                0: L_BRACK@43..44 "[" [] []
+                1: GRAPHQL_NON_NULL_TYPE@44..45
+                  0: (empty)
+                  1: BANG@44..45 "!" [] []
+                2: R_BRACK@45..46 "]" [] []
+              1: BANG@46..49 "!" [] [Skipped(","), Whitespace(" ")]
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@49..49
+          3: GRAPHQL_VARIABLE_DEFINITION@49..66
+            0: GRAPHQL_VARIABLE@49..55
+              0: DOLLAR@49..50 "$" [] []
+              1: GRAPHQL_NAME@50..55
+                0: GRAPHQL_NAME@50..55 "posts" [] []
+            1: COLON@55..57 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NAMED_TYPE@57..66
+              0: GRAPHQL_NAME@57..66
+                0: GRAPHQL_NAME@57..66 "PostInput" [] []
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@66..66
+          4: GRAPHQL_BOGUS@66..70
+            0: R_BRACK@66..67 "]" [] []
+            1: BANG@67..70 "!" [] [Skipped(","), Whitespace(" ")]
+          5: GRAPHQL_VARIABLE_DEFINITION@70..89
+            0: GRAPHQL_VARIABLE@70..76
+              0: DOLLAR@70..71 "$" [] []
+              1: GRAPHQL_NAME@71..76
+                0: GRAPHQL_NAME@71..76 "input" [] []
+            1: COLON@76..78 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_LIST_TYPE@78..89
+              0: L_BRACK@78..79 "[" [] []
+              1: GRAPHQL_NON_NULL_TYPE@79..89
+                0: GRAPHQL_NAMED_TYPE@79..88
+                  0: GRAPHQL_NAME@79..88
+                    0: GRAPHQL_NAME@79..88 "InputType" [] []
+                1: BANG@88..89 "!" [] []
               2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@26..26
-        2: R_PAREN@26..28 ")" [] [Whitespace(" ")]
-      2: GRAPHQL_DIRECTIVE_LIST@28..28
-      3: GRAPHQL_SELECTION_SET@28..42
-        0: L_CURLY@28..29 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@29..40
-          0: GRAPHQL_FIELD@29..40
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@89..89
+        2: R_PAREN@89..91 ")" [] [Whitespace(" ")]
+      2: GRAPHQL_DIRECTIVE_LIST@91..91
+      3: GRAPHQL_SELECTION_SET@91..105
+        0: L_CURLY@91..92 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@92..103
+          0: GRAPHQL_FIELD@92..103
             0: (empty)
-            1: GRAPHQL_NAME@29..40
-              0: GRAPHQL_NAME@29..40 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            1: GRAPHQL_NAME@92..103
+              0: GRAPHQL_NAME@92..103 "likeStory" [Newline("\n"), Whitespace("\t")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@40..40
+            3: GRAPHQL_DIRECTIVE_LIST@103..103
             4: (empty)
-        2: R_CURLY@40..42 "}" [Newline("\n")] []
-    1: GRAPHQL_BOGUS_DEFINITION@42..106
-      0: GRAPHQL_OPERATION_TYPE@42..50
-        0: QUERY_KW@42..50 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      1: GRAPHQL_BOGUS@50..92
-        0: L_PAREN@50..51 "(" [] []
-        1: GRAPHQL_BOGUS@51..90
-          0: GRAPHQL_VARIABLE_DEFINITION@51..62
-            0: GRAPHQL_VARIABLE@51..59
-              0: DOLLAR@51..52 "$" [] []
-              1: GRAPHQL_NAME@52..59
-                0: GRAPHQL_NAME@52..59 "storyId" [] []
-            1: COLON@59..61 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_NON_NULL_TYPE@61..62
+        2: R_CURLY@103..105 "}" [Newline("\n")] []
+    1: GRAPHQL_BOGUS_DEFINITION@105..169
+      0: GRAPHQL_OPERATION_TYPE@105..113
+        0: QUERY_KW@105..113 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_BOGUS@113..155
+        0: L_PAREN@113..114 "(" [] []
+        1: GRAPHQL_BOGUS@114..153
+          0: GRAPHQL_VARIABLE_DEFINITION@114..125
+            0: GRAPHQL_VARIABLE@114..122
+              0: DOLLAR@114..115 "$" [] []
+              1: GRAPHQL_NAME@115..122
+                0: GRAPHQL_NAME@115..122 "storyId" [] []
+            1: COLON@122..124 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@124..125
               0: (empty)
-              1: BANG@61..62 "!" [] []
+              1: BANG@124..125 "!" [] []
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@62..62
-          1: GRAPHQL_BOGUS@62..65
-            0: L_BRACK@62..65 "[" [] [Skipped(","), Whitespace(" ")]
-          2: GRAPHQL_VARIABLE_DEFINITION@65..77
-            0: GRAPHQL_VARIABLE@65..74
-              0: DOLLAR@65..66 "$" [] []
-              1: GRAPHQL_NAME@66..74
-                0: GRAPHQL_NAME@66..74 "comments" [] []
-            1: COLON@74..76 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_NON_NULL_TYPE@76..77
+            4: GRAPHQL_DIRECTIVE_LIST@125..125
+          1: GRAPHQL_BOGUS@125..128
+            0: L_BRACK@125..128 "[" [] [Skipped(","), Whitespace(" ")]
+          2: GRAPHQL_VARIABLE_DEFINITION@128..140
+            0: GRAPHQL_VARIABLE@128..137
+              0: DOLLAR@128..129 "$" [] []
+              1: GRAPHQL_NAME@129..137
+                0: GRAPHQL_NAME@129..137 "comments" [] []
+            1: COLON@137..139 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@139..140
               0: (empty)
-              1: BANG@76..77 "!" [] []
+              1: BANG@139..140 "!" [] []
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@77..77
-          3: GRAPHQL_BOGUS@77..80
-            0: R_BRACK@77..80 "]" [] [Skipped(","), Whitespace(" ")]
-          4: GRAPHQL_VARIABLE_DEFINITION@80..90
-            0: GRAPHQL_VARIABLE@80..85
-              0: DOLLAR@80..81 "$" [] []
-              1: GRAPHQL_NAME@81..85
-                0: GRAPHQL_NAME@81..85 "tags" [] []
-            1: COLON@85..87 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_LIST_TYPE@87..90
-              0: L_BRACK@87..88 "[" [] []
-              1: GRAPHQL_LIST_TYPE@88..90
-                0: L_BRACK@88..89 "[" [] []
-                1: GRAPHQL_LIST_TYPE@89..90
-                  0: L_BRACK@89..90 "[" [] []
+            4: GRAPHQL_DIRECTIVE_LIST@140..140
+          3: GRAPHQL_BOGUS@140..143
+            0: R_BRACK@140..143 "]" [] [Skipped(","), Whitespace(" ")]
+          4: GRAPHQL_VARIABLE_DEFINITION@143..153
+            0: GRAPHQL_VARIABLE@143..148
+              0: DOLLAR@143..144 "$" [] []
+              1: GRAPHQL_NAME@144..148
+                0: GRAPHQL_NAME@144..148 "tags" [] []
+            1: COLON@148..150 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_LIST_TYPE@150..153
+              0: L_BRACK@150..151 "[" [] []
+              1: GRAPHQL_LIST_TYPE@151..153
+                0: L_BRACK@151..152 "[" [] []
+                1: GRAPHQL_LIST_TYPE@152..153
+                  0: L_BRACK@152..153 "[" [] []
                   1: (empty)
                   2: (empty)
                 2: (empty)
               2: (empty)
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@90..90
-        2: R_PAREN@90..92 ")" [] [Whitespace(" ")]
-      2: GRAPHQL_DIRECTIVE_LIST@92..92
-      3: GRAPHQL_SELECTION_SET@92..106
-        0: L_CURLY@92..93 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@93..104
-          0: GRAPHQL_FIELD@93..104
+            4: GRAPHQL_DIRECTIVE_LIST@153..153
+        2: R_PAREN@153..155 ")" [] [Whitespace(" ")]
+      2: GRAPHQL_DIRECTIVE_LIST@155..155
+      3: GRAPHQL_SELECTION_SET@155..169
+        0: L_CURLY@155..156 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@156..167
+          0: GRAPHQL_FIELD@156..167
             0: (empty)
-            1: GRAPHQL_NAME@93..104
-              0: GRAPHQL_NAME@93..104 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            1: GRAPHQL_NAME@156..167
+              0: GRAPHQL_NAME@156..167 "likeStory" [Newline("\n"), Whitespace("\t")] []
             2: (empty)
-            3: GRAPHQL_DIRECTIVE_LIST@104..104
+            3: GRAPHQL_DIRECTIVE_LIST@167..167
             4: (empty)
-        2: R_CURLY@104..106 "}" [Newline("\n")] []
-  2: EOF@106..108 "" [Newline("\n"), Newline("\n")] []
+        2: R_CURLY@167..169 "}" [Newline("\n")] []
+  2: EOF@169..171 "" [Newline("\n"), Newline("\n")] []
 
 ```
 
 ## Diagnostics
 
 ```
-type.graphql:1:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+type.graphql:1:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a name but instead found 'input'.
+  × Expected a named type, or a list type but instead found '$'.
   
-  > 1 │ query ($input: [InputType!) {
-      │         ^^^^^
+  > 1 │ query ($storyId: !, $comments: [!], $tags: [!]!, $posts: PostInput]!, $input: [InputType!) {
+      │                     ^
     2 │ 	likeStory
     3 │ }
   
-  i Expected a name here.
+  i Expected a named type, or a list type here.
   
-  > 1 │ query ($input: [InputType!) {
-      │         ^^^^^
+  > 1 │ query ($storyId: !, $comments: [!], $tags: [!]!, $posts: PostInput]!, $input: [InputType!) {
+      │                     ^
     2 │ 	likeStory
     3 │ }
   
-type.graphql:1:27 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+type.graphql:1:34 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a named type, or a list type but instead found ']'.
+  
+  > 1 │ query ($storyId: !, $comments: [!], $tags: [!]!, $posts: PostInput]!, $input: [InputType!) {
+      │                                  ^
+    2 │ 	likeStory
+    3 │ }
+  
+  i Expected a named type, or a list type here.
+  
+  > 1 │ query ($storyId: !, $comments: [!], $tags: [!]!, $posts: PostInput]!, $input: [InputType!) {
+      │                                  ^
+    2 │ 	likeStory
+    3 │ }
+  
+type.graphql:1:46 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a named type, or a list type but instead found ']'.
+  
+  > 1 │ query ($storyId: !, $comments: [!], $tags: [!]!, $posts: PostInput]!, $input: [InputType!) {
+      │                                              ^
+    2 │ 	likeStory
+    3 │ }
+  
+  i Expected a named type, or a list type here.
+  
+  > 1 │ query ($storyId: !, $comments: [!], $tags: [!]!, $posts: PostInput]!, $input: [InputType!) {
+      │                                              ^
+    2 │ 	likeStory
+    3 │ }
+  
+type.graphql:1:67 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a variable definition but instead found ']!'.
+  
+  > 1 │ query ($storyId: !, $comments: [!], $tags: [!]!, $posts: PostInput]!, $input: [InputType!) {
+      │                                                                   ^^
+    2 │ 	likeStory
+    3 │ }
+  
+  i Expected a variable definition here.
+  
+  > 1 │ query ($storyId: !, $comments: [!], $tags: [!]!, $posts: PostInput]!, $input: [InputType!) {
+      │                                                                   ^^
+    2 │ 	likeStory
+    3 │ }
+  
+type.graphql:1:90 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `]` but instead found `)`
   
-  > 1 │ query ($input: [InputType!) {
-      │                           ^
+  > 1 │ query ($storyId: !, $comments: [!], $tags: [!]!, $posts: PostInput]!, $input: [InputType!) {
+      │                                                                                          ^
     2 │ 	likeStory
     3 │ }
   

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/value.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/value.graphql
@@ -5,7 +5,6 @@
 		string_value: "string,
 		boolean_value: truee,
 		null_value: nulll,
-		enum_value: ENUM,
 		list_value: [1, 2, 3,
 		list_value: 1, 2, 3,
 		list_value: 1, 2, 3],

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/value.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/value.graphql.snap
@@ -11,7 +11,6 @@ expression: snapshot
 		string_value: "string,
 		boolean_value: truee,
 		null_value: nulll,
-		enum_value: ENUM,
 		list_value: [1, 2, 3,
 		list_value: 1, 2, 3,
 		list_value: 1, 2, 3],
@@ -106,32 +105,20 @@ GraphqlRoot {
                                         },
                                         GraphqlArgument {
                                             name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@135..148 "enum_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                                value_token: GRAPHQL_NAME@135..148 "list_value" [Newline("\n"), Whitespace("\t\t")] [],
                                             },
                                             colon_token: COLON@148..150 ":" [] [Whitespace(" ")],
-                                            value: missing (required),
-                                        },
-                                        GraphqlBogus {
-                                            items: [
-                                                UPPER_ENUM_KW@150..155 "ENUM" [] [Skipped(",")],
-                                            ],
-                                        },
-                                        GraphqlArgument {
-                                            name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@155..168 "list_value" [Newline("\n"), Whitespace("\t\t")] [],
-                                            },
-                                            colon_token: COLON@168..170 ":" [] [Whitespace(" ")],
                                             value: GraphqlListValue {
-                                                l_brack_token: L_BRACK@170..171 "[" [] [],
+                                                l_brack_token: L_BRACK@150..151 "[" [] [],
                                                 elements: GraphqlListValueElementList [
                                                     GraphqlIntValue {
-                                                        graphql_int_literal_token: GRAPHQL_INT_LITERAL@171..174 "1" [] [Skipped(","), Whitespace(" ")],
+                                                        graphql_int_literal_token: GRAPHQL_INT_LITERAL@151..154 "1" [] [Skipped(","), Whitespace(" ")],
                                                     },
                                                     GraphqlIntValue {
-                                                        graphql_int_literal_token: GRAPHQL_INT_LITERAL@174..177 "2" [] [Skipped(","), Whitespace(" ")],
+                                                        graphql_int_literal_token: GRAPHQL_INT_LITERAL@154..157 "2" [] [Skipped(","), Whitespace(" ")],
                                                     },
                                                     GraphqlIntValue {
-                                                        graphql_int_literal_token: GRAPHQL_INT_LITERAL@177..179 "3" [] [Skipped(",")],
+                                                        graphql_int_literal_token: GRAPHQL_INT_LITERAL@157..159 "3" [] [Skipped(",")],
                                                     },
                                                 ],
                                                 r_brack_token: missing (required),
@@ -139,147 +126,147 @@ GraphqlRoot {
                                         },
                                         GraphqlArgument {
                                             name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@179..192 "list_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                                value_token: GRAPHQL_NAME@159..172 "list_value" [Newline("\n"), Whitespace("\t\t")] [],
                                             },
-                                            colon_token: COLON@192..194 ":" [] [Whitespace(" ")],
+                                            colon_token: COLON@172..174 ":" [] [Whitespace(" ")],
                                             value: GraphqlIntValue {
-                                                graphql_int_literal_token: GRAPHQL_INT_LITERAL@194..197 "1" [] [Skipped(","), Whitespace(" ")],
+                                                graphql_int_literal_token: GRAPHQL_INT_LITERAL@174..177 "1" [] [Skipped(","), Whitespace(" ")],
                                             },
                                         },
                                         GraphqlBogus {
                                             items: [
-                                                GRAPHQL_INT_LITERAL@197..200 "2" [] [Skipped(","), Whitespace(" ")],
-                                                GRAPHQL_INT_LITERAL@200..202 "3" [] [Skipped(",")],
+                                                GRAPHQL_INT_LITERAL@177..180 "2" [] [Skipped(","), Whitespace(" ")],
+                                                GRAPHQL_INT_LITERAL@180..182 "3" [] [Skipped(",")],
                                             ],
                                         },
                                         GraphqlArgument {
                                             name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@202..215 "list_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                                value_token: GRAPHQL_NAME@182..195 "list_value" [Newline("\n"), Whitespace("\t\t")] [],
                                             },
-                                            colon_token: COLON@215..217 ":" [] [Whitespace(" ")],
+                                            colon_token: COLON@195..197 ":" [] [Whitespace(" ")],
                                             value: GraphqlIntValue {
-                                                graphql_int_literal_token: GRAPHQL_INT_LITERAL@217..220 "1" [] [Skipped(","), Whitespace(" ")],
+                                                graphql_int_literal_token: GRAPHQL_INT_LITERAL@197..200 "1" [] [Skipped(","), Whitespace(" ")],
                                             },
                                         },
                                         GraphqlBogus {
                                             items: [
-                                                GRAPHQL_INT_LITERAL@220..223 "2" [] [Skipped(","), Whitespace(" ")],
-                                                GRAPHQL_INT_LITERAL@223..224 "3" [] [],
-                                                R_BRACK@224..226 "]" [] [Skipped(",")],
+                                                GRAPHQL_INT_LITERAL@200..203 "2" [] [Skipped(","), Whitespace(" ")],
+                                                GRAPHQL_INT_LITERAL@203..204 "3" [] [],
+                                                R_BRACK@204..206 "]" [] [Skipped(",")],
                                             ],
                                         },
                                         GraphqlArgument {
                                             name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@226..241 "object_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                                value_token: GRAPHQL_NAME@206..221 "object_value" [Newline("\n"), Whitespace("\t\t")] [],
                                             },
-                                            colon_token: COLON@241..243 ":" [] [Whitespace(" ")],
+                                            colon_token: COLON@221..223 ":" [] [Whitespace(" ")],
                                             value: GraphqlObjectValue {
-                                                l_curly_token: L_CURLY@243..244 "{" [] [],
+                                                l_curly_token: L_CURLY@223..224 "{" [] [],
                                                 members: GraphqlObjectValueMemberList [
                                                     GraphqlObjectField {
                                                         name: GraphqlName {
-                                                            value_token: GRAPHQL_NAME@244..247 "key" [] [],
+                                                            value_token: GRAPHQL_NAME@224..227 "key" [] [],
                                                         },
-                                                        colon_token: COLON@247..249 ":" [] [Whitespace(" ")],
+                                                        colon_token: COLON@227..229 ":" [] [Whitespace(" ")],
                                                         value: GraphqlStringValue {
-                                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@249..256 "\"value\"" [] [],
+                                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@229..236 "\"value\"" [] [],
                                                         },
                                                     },
                                                     GraphqlObjectField {
                                                         name: GraphqlName {
-                                                            value_token: GRAPHQL_NAME@256..271 "object_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                                            value_token: GRAPHQL_NAME@236..251 "object_value" [Newline("\n"), Whitespace("\t\t")] [],
                                                         },
-                                                        colon_token: COLON@271..273 ":" [] [Whitespace(" ")],
+                                                        colon_token: COLON@251..253 ":" [] [Whitespace(" ")],
                                                         value: GraphqlObjectValue {
-                                                            l_curly_token: L_CURLY@273..274 "{" [] [],
+                                                            l_curly_token: L_CURLY@253..254 "{" [] [],
                                                             members: GraphqlObjectValueMemberList [
                                                                 GraphqlObjectField {
                                                                     name: GraphqlName {
-                                                                        value_token: GRAPHQL_NAME@274..277 "key" [] [],
+                                                                        value_token: GRAPHQL_NAME@254..257 "key" [] [],
                                                                     },
-                                                                    colon_token: COLON@277..278 ":" [] [],
+                                                                    colon_token: COLON@257..258 ":" [] [],
                                                                     value: missing (required),
                                                                 },
                                                             ],
-                                                            r_curly_token: R_CURLY@278..279 "}" [] [],
+                                                            r_curly_token: R_CURLY@258..259 "}" [] [],
                                                         },
                                                     },
                                                     GraphqlObjectField {
                                                         name: GraphqlName {
-                                                            value_token: GRAPHQL_NAME@279..294 "object_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                                            value_token: GRAPHQL_NAME@259..274 "object_value" [Newline("\n"), Whitespace("\t\t")] [],
                                                         },
-                                                        colon_token: COLON@294..296 ":" [] [Whitespace(" ")],
+                                                        colon_token: COLON@274..276 ":" [] [Whitespace(" ")],
                                                         value: GraphqlObjectValue {
-                                                            l_curly_token: L_CURLY@296..297 "{" [] [],
+                                                            l_curly_token: L_CURLY@276..277 "{" [] [],
                                                             members: GraphqlObjectValueMemberList [
                                                                 GraphqlObjectField {
                                                                     name: GraphqlName {
-                                                                        value_token: GRAPHQL_NAME@297..300 "key" [] [],
+                                                                        value_token: GRAPHQL_NAME@277..280 "key" [] [],
                                                                     },
                                                                     colon_token: missing (required),
                                                                     value: missing (required),
                                                                 },
                                                             ],
-                                                            r_curly_token: R_CURLY@300..301 "}" [] [],
+                                                            r_curly_token: R_CURLY@280..281 "}" [] [],
                                                         },
                                                     },
                                                     GraphqlObjectField {
                                                         name: GraphqlName {
-                                                            value_token: GRAPHQL_NAME@301..316 "object_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                                            value_token: GRAPHQL_NAME@281..296 "object_value" [Newline("\n"), Whitespace("\t\t")] [],
                                                         },
-                                                        colon_token: COLON@316..318 ":" [] [Whitespace(" ")],
+                                                        colon_token: COLON@296..298 ":" [] [Whitespace(" ")],
                                                         value: GraphqlEnumValue {
                                                             graphql_name: GraphqlName {
-                                                                value_token: GRAPHQL_NAME@318..321 "key" [] [],
+                                                                value_token: GRAPHQL_NAME@298..301 "key" [] [],
                                                             },
                                                         },
                                                     },
                                                 ],
-                                                r_curly_token: R_CURLY@321..322 "}" [] [],
+                                                r_curly_token: R_CURLY@301..302 "}" [] [],
                                             },
                                         },
                                         GraphqlArgument {
                                             name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@322..337 "object_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                                value_token: GRAPHQL_NAME@302..317 "object_value" [Newline("\n"), Whitespace("\t\t")] [],
                                             },
-                                            colon_token: COLON@337..339 ":" [] [Whitespace(" ")],
+                                            colon_token: COLON@317..319 ":" [] [Whitespace(" ")],
                                             value: GraphqlObjectValue {
-                                                l_curly_token: L_CURLY@339..340 "{" [] [],
+                                                l_curly_token: L_CURLY@319..320 "{" [] [],
                                                 members: GraphqlObjectValueMemberList [],
                                                 r_curly_token: missing (required),
                                             },
                                         },
                                     ],
                                 },
-                                R_PAREN@340..343 ")" [Newline("\n"), Whitespace("\t")] [],
+                                R_PAREN@320..323 ")" [Newline("\n"), Whitespace("\t")] [],
                             ],
                         },
                         GraphqlDirectiveList [],
                     ],
                 },
             ],
-            r_curly_token: R_CURLY@343..345 "}" [Newline("\n")] [],
+            r_curly_token: R_CURLY@323..325 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@345..346 "" [Newline("\n")] [],
+    eof_token: EOF@325..326 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..346
+0: GRAPHQL_ROOT@0..326
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..345
-    0: GRAPHQL_SELECTION_SET@0..345
+  1: GRAPHQL_DEFINITION_LIST@0..325
+    0: GRAPHQL_SELECTION_SET@0..325
       0: L_CURLY@0..1 "{" [] []
-      1: GRAPHQL_SELECTION_LIST@1..343
-        0: GRAPHQL_BOGUS_SELECTION@1..343
+      1: GRAPHQL_SELECTION_LIST@1..323
+        0: GRAPHQL_BOGUS_SELECTION@1..323
           0: GRAPHQL_NAME@1..14
             0: GRAPHQL_NAME@1..14 "field_value" [Newline("\n"), Whitespace("\t")] []
-          1: GRAPHQL_BOGUS@14..343
+          1: GRAPHQL_BOGUS@14..323
             0: L_PAREN@14..15 "(" [] []
-            1: GRAPHQL_BOGUS@15..340
+            1: GRAPHQL_BOGUS@15..320
               0: GRAPHQL_ARGUMENT@15..31
                 0: GRAPHQL_NAME@15..29
                   0: GRAPHQL_NAME@15..29 "float_value" [Newline("\n"), Whitespace("\t\t")] []
@@ -316,105 +303,98 @@ GraphqlRoot {
                 2: GRAPHQL_ENUM_VALUE@129..135
                   0: GRAPHQL_NAME@129..135
                     0: GRAPHQL_NAME@129..135 "nulll" [] [Skipped(",")]
-              8: GRAPHQL_ARGUMENT@135..150
+              8: GRAPHQL_ARGUMENT@135..159
                 0: GRAPHQL_NAME@135..148
-                  0: GRAPHQL_NAME@135..148 "enum_value" [Newline("\n"), Whitespace("\t\t")] []
+                  0: GRAPHQL_NAME@135..148 "list_value" [Newline("\n"), Whitespace("\t\t")] []
                 1: COLON@148..150 ":" [] [Whitespace(" ")]
-                2: (empty)
-              9: GRAPHQL_BOGUS@150..155
-                0: UPPER_ENUM_KW@150..155 "ENUM" [] [Skipped(",")]
-              10: GRAPHQL_ARGUMENT@155..179
-                0: GRAPHQL_NAME@155..168
-                  0: GRAPHQL_NAME@155..168 "list_value" [Newline("\n"), Whitespace("\t\t")] []
-                1: COLON@168..170 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_LIST_VALUE@170..179
-                  0: L_BRACK@170..171 "[" [] []
-                  1: GRAPHQL_LIST_VALUE_ELEMENT_LIST@171..179
-                    0: GRAPHQL_INT_VALUE@171..174
-                      0: GRAPHQL_INT_LITERAL@171..174 "1" [] [Skipped(","), Whitespace(" ")]
-                    1: GRAPHQL_INT_VALUE@174..177
-                      0: GRAPHQL_INT_LITERAL@174..177 "2" [] [Skipped(","), Whitespace(" ")]
-                    2: GRAPHQL_INT_VALUE@177..179
-                      0: GRAPHQL_INT_LITERAL@177..179 "3" [] [Skipped(",")]
+                2: GRAPHQL_LIST_VALUE@150..159
+                  0: L_BRACK@150..151 "[" [] []
+                  1: GRAPHQL_LIST_VALUE_ELEMENT_LIST@151..159
+                    0: GRAPHQL_INT_VALUE@151..154
+                      0: GRAPHQL_INT_LITERAL@151..154 "1" [] [Skipped(","), Whitespace(" ")]
+                    1: GRAPHQL_INT_VALUE@154..157
+                      0: GRAPHQL_INT_LITERAL@154..157 "2" [] [Skipped(","), Whitespace(" ")]
+                    2: GRAPHQL_INT_VALUE@157..159
+                      0: GRAPHQL_INT_LITERAL@157..159 "3" [] [Skipped(",")]
                   2: (empty)
-              11: GRAPHQL_ARGUMENT@179..197
-                0: GRAPHQL_NAME@179..192
-                  0: GRAPHQL_NAME@179..192 "list_value" [Newline("\n"), Whitespace("\t\t")] []
-                1: COLON@192..194 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_INT_VALUE@194..197
-                  0: GRAPHQL_INT_LITERAL@194..197 "1" [] [Skipped(","), Whitespace(" ")]
-              12: GRAPHQL_BOGUS@197..202
-                0: GRAPHQL_INT_LITERAL@197..200 "2" [] [Skipped(","), Whitespace(" ")]
-                1: GRAPHQL_INT_LITERAL@200..202 "3" [] [Skipped(",")]
-              13: GRAPHQL_ARGUMENT@202..220
-                0: GRAPHQL_NAME@202..215
-                  0: GRAPHQL_NAME@202..215 "list_value" [Newline("\n"), Whitespace("\t\t")] []
-                1: COLON@215..217 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_INT_VALUE@217..220
-                  0: GRAPHQL_INT_LITERAL@217..220 "1" [] [Skipped(","), Whitespace(" ")]
-              14: GRAPHQL_BOGUS@220..226
-                0: GRAPHQL_INT_LITERAL@220..223 "2" [] [Skipped(","), Whitespace(" ")]
-                1: GRAPHQL_INT_LITERAL@223..224 "3" [] []
-                2: R_BRACK@224..226 "]" [] [Skipped(",")]
-              15: GRAPHQL_ARGUMENT@226..322
-                0: GRAPHQL_NAME@226..241
-                  0: GRAPHQL_NAME@226..241 "object_value" [Newline("\n"), Whitespace("\t\t")] []
-                1: COLON@241..243 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_OBJECT_VALUE@243..322
-                  0: L_CURLY@243..244 "{" [] []
-                  1: GRAPHQL_OBJECT_VALUE_MEMBER_LIST@244..321
-                    0: GRAPHQL_OBJECT_FIELD@244..256
-                      0: GRAPHQL_NAME@244..247
-                        0: GRAPHQL_NAME@244..247 "key" [] []
-                      1: COLON@247..249 ":" [] [Whitespace(" ")]
-                      2: GRAPHQL_STRING_VALUE@249..256
-                        0: GRAPHQL_STRING_LITERAL@249..256 "\"value\"" [] []
-                    1: GRAPHQL_OBJECT_FIELD@256..279
-                      0: GRAPHQL_NAME@256..271
-                        0: GRAPHQL_NAME@256..271 "object_value" [Newline("\n"), Whitespace("\t\t")] []
-                      1: COLON@271..273 ":" [] [Whitespace(" ")]
-                      2: GRAPHQL_OBJECT_VALUE@273..279
-                        0: L_CURLY@273..274 "{" [] []
-                        1: GRAPHQL_OBJECT_VALUE_MEMBER_LIST@274..278
-                          0: GRAPHQL_OBJECT_FIELD@274..278
-                            0: GRAPHQL_NAME@274..277
-                              0: GRAPHQL_NAME@274..277 "key" [] []
-                            1: COLON@277..278 ":" [] []
+              9: GRAPHQL_ARGUMENT@159..177
+                0: GRAPHQL_NAME@159..172
+                  0: GRAPHQL_NAME@159..172 "list_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@172..174 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_INT_VALUE@174..177
+                  0: GRAPHQL_INT_LITERAL@174..177 "1" [] [Skipped(","), Whitespace(" ")]
+              10: GRAPHQL_BOGUS@177..182
+                0: GRAPHQL_INT_LITERAL@177..180 "2" [] [Skipped(","), Whitespace(" ")]
+                1: GRAPHQL_INT_LITERAL@180..182 "3" [] [Skipped(",")]
+              11: GRAPHQL_ARGUMENT@182..200
+                0: GRAPHQL_NAME@182..195
+                  0: GRAPHQL_NAME@182..195 "list_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@195..197 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_INT_VALUE@197..200
+                  0: GRAPHQL_INT_LITERAL@197..200 "1" [] [Skipped(","), Whitespace(" ")]
+              12: GRAPHQL_BOGUS@200..206
+                0: GRAPHQL_INT_LITERAL@200..203 "2" [] [Skipped(","), Whitespace(" ")]
+                1: GRAPHQL_INT_LITERAL@203..204 "3" [] []
+                2: R_BRACK@204..206 "]" [] [Skipped(",")]
+              13: GRAPHQL_ARGUMENT@206..302
+                0: GRAPHQL_NAME@206..221
+                  0: GRAPHQL_NAME@206..221 "object_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@221..223 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_OBJECT_VALUE@223..302
+                  0: L_CURLY@223..224 "{" [] []
+                  1: GRAPHQL_OBJECT_VALUE_MEMBER_LIST@224..301
+                    0: GRAPHQL_OBJECT_FIELD@224..236
+                      0: GRAPHQL_NAME@224..227
+                        0: GRAPHQL_NAME@224..227 "key" [] []
+                      1: COLON@227..229 ":" [] [Whitespace(" ")]
+                      2: GRAPHQL_STRING_VALUE@229..236
+                        0: GRAPHQL_STRING_LITERAL@229..236 "\"value\"" [] []
+                    1: GRAPHQL_OBJECT_FIELD@236..259
+                      0: GRAPHQL_NAME@236..251
+                        0: GRAPHQL_NAME@236..251 "object_value" [Newline("\n"), Whitespace("\t\t")] []
+                      1: COLON@251..253 ":" [] [Whitespace(" ")]
+                      2: GRAPHQL_OBJECT_VALUE@253..259
+                        0: L_CURLY@253..254 "{" [] []
+                        1: GRAPHQL_OBJECT_VALUE_MEMBER_LIST@254..258
+                          0: GRAPHQL_OBJECT_FIELD@254..258
+                            0: GRAPHQL_NAME@254..257
+                              0: GRAPHQL_NAME@254..257 "key" [] []
+                            1: COLON@257..258 ":" [] []
                             2: (empty)
-                        2: R_CURLY@278..279 "}" [] []
-                    2: GRAPHQL_OBJECT_FIELD@279..301
-                      0: GRAPHQL_NAME@279..294
-                        0: GRAPHQL_NAME@279..294 "object_value" [Newline("\n"), Whitespace("\t\t")] []
-                      1: COLON@294..296 ":" [] [Whitespace(" ")]
-                      2: GRAPHQL_OBJECT_VALUE@296..301
-                        0: L_CURLY@296..297 "{" [] []
-                        1: GRAPHQL_OBJECT_VALUE_MEMBER_LIST@297..300
-                          0: GRAPHQL_OBJECT_FIELD@297..300
-                            0: GRAPHQL_NAME@297..300
-                              0: GRAPHQL_NAME@297..300 "key" [] []
+                        2: R_CURLY@258..259 "}" [] []
+                    2: GRAPHQL_OBJECT_FIELD@259..281
+                      0: GRAPHQL_NAME@259..274
+                        0: GRAPHQL_NAME@259..274 "object_value" [Newline("\n"), Whitespace("\t\t")] []
+                      1: COLON@274..276 ":" [] [Whitespace(" ")]
+                      2: GRAPHQL_OBJECT_VALUE@276..281
+                        0: L_CURLY@276..277 "{" [] []
+                        1: GRAPHQL_OBJECT_VALUE_MEMBER_LIST@277..280
+                          0: GRAPHQL_OBJECT_FIELD@277..280
+                            0: GRAPHQL_NAME@277..280
+                              0: GRAPHQL_NAME@277..280 "key" [] []
                             1: (empty)
                             2: (empty)
-                        2: R_CURLY@300..301 "}" [] []
-                    3: GRAPHQL_OBJECT_FIELD@301..321
-                      0: GRAPHQL_NAME@301..316
-                        0: GRAPHQL_NAME@301..316 "object_value" [Newline("\n"), Whitespace("\t\t")] []
-                      1: COLON@316..318 ":" [] [Whitespace(" ")]
-                      2: GRAPHQL_ENUM_VALUE@318..321
-                        0: GRAPHQL_NAME@318..321
-                          0: GRAPHQL_NAME@318..321 "key" [] []
-                  2: R_CURLY@321..322 "}" [] []
-              16: GRAPHQL_ARGUMENT@322..340
-                0: GRAPHQL_NAME@322..337
-                  0: GRAPHQL_NAME@322..337 "object_value" [Newline("\n"), Whitespace("\t\t")] []
-                1: COLON@337..339 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_OBJECT_VALUE@339..340
-                  0: L_CURLY@339..340 "{" [] []
-                  1: GRAPHQL_OBJECT_VALUE_MEMBER_LIST@340..340
+                        2: R_CURLY@280..281 "}" [] []
+                    3: GRAPHQL_OBJECT_FIELD@281..301
+                      0: GRAPHQL_NAME@281..296
+                        0: GRAPHQL_NAME@281..296 "object_value" [Newline("\n"), Whitespace("\t\t")] []
+                      1: COLON@296..298 ":" [] [Whitespace(" ")]
+                      2: GRAPHQL_ENUM_VALUE@298..301
+                        0: GRAPHQL_NAME@298..301
+                          0: GRAPHQL_NAME@298..301 "key" [] []
+                  2: R_CURLY@301..302 "}" [] []
+              14: GRAPHQL_ARGUMENT@302..320
+                0: GRAPHQL_NAME@302..317
+                  0: GRAPHQL_NAME@302..317 "object_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@317..319 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_OBJECT_VALUE@319..320
+                  0: L_CURLY@319..320 "{" [] []
+                  1: GRAPHQL_OBJECT_VALUE_MEMBER_LIST@320..320
                   2: (empty)
-            2: R_PAREN@340..343 ")" [Newline("\n"), Whitespace("\t")] []
-          2: GRAPHQL_DIRECTIVE_LIST@343..343
-      2: R_CURLY@343..345 "}" [Newline("\n")] []
-  2: EOF@345..346 "" [Newline("\n")] []
+            2: R_PAREN@320..323 ")" [Newline("\n"), Whitespace("\t")] []
+          2: GRAPHQL_DIRECTIVE_LIST@323..323
+      2: R_CURLY@323..325 "}" [Newline("\n")] []
+  2: EOF@325..326 "" [Newline("\n")] []
 
 ```
 
@@ -483,122 +463,102 @@ value.graphql:5:17 parse ━━━━━━━━━━━━━━━━━━�
     6 │ 		boolean_value: truee,
     7 │ 		null_value: nulll,
   
-value.graphql:8:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected a value but instead found 'ENUM'.
-  
-     6 │ 		boolean_value: truee,
-     7 │ 		null_value: nulll,
-   > 8 │ 		enum_value: ENUM,
-       │ 		            ^^^^
-     9 │ 		list_value: [1, 2, 3,
-    10 │ 		list_value: 1, 2, 3,
-  
-  i Expected a value here.
-  
-     6 │ 		boolean_value: truee,
-     7 │ 		null_value: nulll,
-   > 8 │ 		enum_value: ENUM,
-       │ 		            ^^^^
-     9 │ 		list_value: [1, 2, 3,
-    10 │ 		list_value: 1, 2, 3,
-  
-value.graphql:10:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+value.graphql:9:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `]` but instead found `list_value`
   
-     8 │ 		enum_value: ENUM,
-     9 │ 		list_value: [1, 2, 3,
-  > 10 │ 		list_value: 1, 2, 3,
+     7 │ 		null_value: nulll,
+     8 │ 		list_value: [1, 2, 3,
+   > 9 │ 		list_value: 1, 2, 3,
        │ 		^^^^^^^^^^
-    11 │ 		list_value: 1, 2, 3],
-    12 │ 		object_value: {key: "value"
+    10 │ 		list_value: 1, 2, 3],
+    11 │ 		object_value: {key: "value"
   
   i Remove list_value
   
-value.graphql:10:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+value.graphql:9:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an argument but instead found '2, 3'.
   
-     8 │ 		enum_value: ENUM,
-     9 │ 		list_value: [1, 2, 3,
-  > 10 │ 		list_value: 1, 2, 3,
+     7 │ 		null_value: nulll,
+     8 │ 		list_value: [1, 2, 3,
+   > 9 │ 		list_value: 1, 2, 3,
        │ 		               ^^^^
-    11 │ 		list_value: 1, 2, 3],
-    12 │ 		object_value: {key: "value"
+    10 │ 		list_value: 1, 2, 3],
+    11 │ 		object_value: {key: "value"
   
   i Expected an argument here.
   
-     8 │ 		enum_value: ENUM,
-     9 │ 		list_value: [1, 2, 3,
-  > 10 │ 		list_value: 1, 2, 3,
+     7 │ 		null_value: nulll,
+     8 │ 		list_value: [1, 2, 3,
+   > 9 │ 		list_value: 1, 2, 3,
        │ 		               ^^^^
-    11 │ 		list_value: 1, 2, 3],
-    12 │ 		object_value: {key: "value"
+    10 │ 		list_value: 1, 2, 3],
+    11 │ 		object_value: {key: "value"
   
-value.graphql:11:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+value.graphql:10:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected an argument but instead found '2, 3]'.
   
-     9 │ 		list_value: [1, 2, 3,
-    10 │ 		list_value: 1, 2, 3,
-  > 11 │ 		list_value: 1, 2, 3],
+     8 │ 		list_value: [1, 2, 3,
+     9 │ 		list_value: 1, 2, 3,
+  > 10 │ 		list_value: 1, 2, 3],
        │ 		               ^^^^^
-    12 │ 		object_value: {key: "value"
-    13 │ 		object_value: {key:}
+    11 │ 		object_value: {key: "value"
+    12 │ 		object_value: {key:}
   
   i Expected an argument here.
   
-     9 │ 		list_value: [1, 2, 3,
-    10 │ 		list_value: 1, 2, 3,
-  > 11 │ 		list_value: 1, 2, 3],
+     8 │ 		list_value: [1, 2, 3,
+     9 │ 		list_value: 1, 2, 3,
+  > 10 │ 		list_value: 1, 2, 3],
        │ 		               ^^^^^
-    12 │ 		object_value: {key: "value"
-    13 │ 		object_value: {key:}
+    11 │ 		object_value: {key: "value"
+    12 │ 		object_value: {key:}
   
-value.graphql:13:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+value.graphql:12:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a value but instead found '}'.
   
-    11 │ 		list_value: 1, 2, 3],
-    12 │ 		object_value: {key: "value"
-  > 13 │ 		object_value: {key:}
+    10 │ 		list_value: 1, 2, 3],
+    11 │ 		object_value: {key: "value"
+  > 12 │ 		object_value: {key:}
        │ 		                   ^
-    14 │ 		object_value: {key}
-    15 │ 		object_value: key}
+    13 │ 		object_value: {key}
+    14 │ 		object_value: key}
   
   i Expected a value here.
   
-    11 │ 		list_value: 1, 2, 3],
-    12 │ 		object_value: {key: "value"
-  > 13 │ 		object_value: {key:}
+    10 │ 		list_value: 1, 2, 3],
+    11 │ 		object_value: {key: "value"
+  > 12 │ 		object_value: {key:}
        │ 		                   ^
-    14 │ 		object_value: {key}
-    15 │ 		object_value: key}
+    13 │ 		object_value: {key}
+    14 │ 		object_value: key}
   
-value.graphql:14:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+value.graphql:13:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `:` but instead found `}`
   
-    12 │ 		object_value: {key: "value"
-    13 │ 		object_value: {key:}
-  > 14 │ 		object_value: {key}
+    11 │ 		object_value: {key: "value"
+    12 │ 		object_value: {key:}
+  > 13 │ 		object_value: {key}
        │ 		                  ^
-    15 │ 		object_value: key}
-    16 │ 		object_value: {
+    14 │ 		object_value: key}
+    15 │ 		object_value: {
   
   i Remove }
   
-value.graphql:17:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+value.graphql:16:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `}` but instead found `)`
   
-    15 │ 		object_value: key}
-    16 │ 		object_value: {
-  > 17 │ 	)
+    14 │ 		object_value: key}
+    15 │ 		object_value: {
+  > 16 │ 	)
        │ 	^
-    18 │ }
-    19 │ 
+    17 │ }
+    18 │ 
   
   i Remove )
   

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/directive_definition.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/directive_definition.graphql
@@ -8,3 +8,5 @@ directive @example on
   | INLINE_FRAGMENT
 
 "deprecated" directive @delegateField(name: String!) repeatable on OBJECT | INTERFACE
+
+directive @directive(directive: directive) on FIELD

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/directive_definition.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/directive_definition.graphql.snap
@@ -15,6 +15,8 @@ directive @example on
 
 "deprecated" directive @delegateField(name: String!) repeatable on OBJECT | INTERFACE
 
+directive @directive(directive: directive) on FIELD
+
 ```
 
 ## AST
@@ -133,17 +135,53 @@ GraphqlRoot {
                 },
             ],
         },
+        GraphqlDirectiveDefinition {
+            description: missing (optional),
+            directive_token: DIRECTIVE_KW@249..261 "directive" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            at_token: AT@261..262 "@" [] [],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@262..271 "directive" [] [],
+            },
+            arguments: GraphqlArgumentsDefinition {
+                l_paren_token: L_PAREN@271..272 "(" [] [],
+                arguments: GraphqlArgumentDefinitionList [
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@272..281 "directive" [] [],
+                        },
+                        colon_token: COLON@281..283 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@283..292 "directive" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_paren_token: R_PAREN@292..294 ")" [] [Whitespace(" ")],
+            },
+            repeatable_token: missing (optional),
+            on_token: ON_KW@294..297 "on" [] [Whitespace(" ")],
+            bitwise_or_token: missing (optional),
+            locations: GraphqlDirectiveLocationList [
+                GraphqlDirectiveLocation {
+                    value_token: UPPER_FIELD_KW@297..302 "FIELD" [] [],
+                },
+            ],
+        },
     ],
-    eof_token: EOF@249..250 "" [Newline("\n")] [],
+    eof_token: EOF@302..303 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..250
+0: GRAPHQL_ROOT@0..303
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..249
+  1: GRAPHQL_DEFINITION_LIST@0..302
     0: GRAPHQL_DIRECTIVE_DEFINITION@0..27
       0: (empty)
       1: DIRECTIVE_KW@0..10 "directive" [] [Whitespace(" ")]
@@ -225,6 +263,32 @@ GraphqlRoot {
         1: PIPE@238..240 "|" [] [Whitespace(" ")]
         2: GRAPHQL_DIRECTIVE_LOCATION@240..249
           0: UPPER_INTERFACE_KW@240..249 "INTERFACE" [] []
-  2: EOF@249..250 "" [Newline("\n")] []
+    4: GRAPHQL_DIRECTIVE_DEFINITION@249..302
+      0: (empty)
+      1: DIRECTIVE_KW@249..261 "directive" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: AT@261..262 "@" [] []
+      3: GRAPHQL_NAME@262..271
+        0: GRAPHQL_NAME@262..271 "directive" [] []
+      4: GRAPHQL_ARGUMENTS_DEFINITION@271..294
+        0: L_PAREN@271..272 "(" [] []
+        1: GRAPHQL_ARGUMENT_DEFINITION_LIST@272..292
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@272..292
+            0: (empty)
+            1: GRAPHQL_NAME@272..281
+              0: GRAPHQL_NAME@272..281 "directive" [] []
+            2: COLON@281..283 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@283..292
+              0: GRAPHQL_NAME@283..292
+                0: GRAPHQL_NAME@283..292 "directive" [] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@292..292
+        2: R_PAREN@292..294 ")" [] [Whitespace(" ")]
+      5: (empty)
+      6: ON_KW@294..297 "on" [] [Whitespace(" ")]
+      7: (empty)
+      8: GRAPHQL_DIRECTIVE_LOCATION_LIST@297..302
+        0: GRAPHQL_DIRECTIVE_LOCATION@297..302
+          0: UPPER_FIELD_KW@297..302 "FIELD" [] []
+  2: EOF@302..303 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/enum.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/enum.graphql
@@ -1,8 +1,12 @@
-enum Direction {
+enum name {
   NORTH
   EAST
   SOUTH
   WEST
+  union
+  type
+  interface
+  enum
 }
 
 enum Direction {}
@@ -10,7 +14,7 @@ enum Direction {}
 enum Direction
 
 enum Direction @deprecated {
-  NORTH
+  "north" NORTH @deprecated
 }
 
 "This is an enum" enum Direction @deprecated

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/enum.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/enum.graphql.snap
@@ -4,11 +4,15 @@ expression: snapshot
 ---
 ## Input
 ```graphql
-enum Direction {
+enum name {
   NORTH
   EAST
   SOUTH
   WEST
+  union
+  type
+  interface
+  enum
 }
 
 enum Direction {}
@@ -16,7 +20,7 @@ enum Direction {}
 enum Direction
 
 enum Direction @deprecated {
-  NORTH
+  "north" NORTH @deprecated
 }
 
 "This is an enum" enum Direction @deprecated
@@ -33,17 +37,17 @@ GraphqlRoot {
             description: missing (optional),
             enum_token: ENUM_KW@0..5 "enum" [] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@5..15 "Direction" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@5..10 "name" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
             enum_values: GraphqlEnumValuesDefinition {
-                l_curly_token: L_CURLY@15..16 "{" [] [],
+                l_curly_token: L_CURLY@10..11 "{" [] [],
                 values: GraphqlEnumValueList [
                     GraphqlEnumValueDefinition {
                         description: missing (optional),
                         value: GraphqlEnumValue {
                             graphql_name: GraphqlName {
-                                value_token: GRAPHQL_NAME@16..24 "NORTH" [Newline("\n"), Whitespace("  ")] [],
+                                value_token: GRAPHQL_NAME@11..19 "NORTH" [Newline("\n"), Whitespace("  ")] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
@@ -52,7 +56,7 @@ GraphqlRoot {
                         description: missing (optional),
                         value: GraphqlEnumValue {
                             graphql_name: GraphqlName {
-                                value_token: GRAPHQL_NAME@24..31 "EAST" [Newline("\n"), Whitespace("  ")] [],
+                                value_token: GRAPHQL_NAME@19..26 "EAST" [Newline("\n"), Whitespace("  ")] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
@@ -61,7 +65,7 @@ GraphqlRoot {
                         description: missing (optional),
                         value: GraphqlEnumValue {
                             graphql_name: GraphqlName {
-                                value_token: GRAPHQL_NAME@31..39 "SOUTH" [Newline("\n"), Whitespace("  ")] [],
+                                value_token: GRAPHQL_NAME@26..34 "SOUTH" [Newline("\n"), Whitespace("  ")] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
@@ -70,83 +74,131 @@ GraphqlRoot {
                         description: missing (optional),
                         value: GraphqlEnumValue {
                             graphql_name: GraphqlName {
-                                value_token: GRAPHQL_NAME@39..46 "WEST" [Newline("\n"), Whitespace("  ")] [],
+                                value_token: GRAPHQL_NAME@34..41 "WEST" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlEnumValueDefinition {
+                        description: missing (optional),
+                        value: GraphqlEnumValue {
+                            graphql_name: GraphqlName {
+                                value_token: GRAPHQL_NAME@41..49 "union" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlEnumValueDefinition {
+                        description: missing (optional),
+                        value: GraphqlEnumValue {
+                            graphql_name: GraphqlName {
+                                value_token: GRAPHQL_NAME@49..56 "type" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlEnumValueDefinition {
+                        description: missing (optional),
+                        value: GraphqlEnumValue {
+                            graphql_name: GraphqlName {
+                                value_token: GRAPHQL_NAME@56..68 "interface" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlEnumValueDefinition {
+                        description: missing (optional),
+                        value: GraphqlEnumValue {
+                            graphql_name: GraphqlName {
+                                value_token: GRAPHQL_NAME@68..75 "enum" [Newline("\n"), Whitespace("  ")] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_curly_token: R_CURLY@46..48 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@75..77 "}" [Newline("\n")] [],
             },
         },
         GraphqlEnumTypeDefinition {
             description: missing (optional),
-            enum_token: ENUM_KW@48..55 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            enum_token: ENUM_KW@77..84 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@55..65 "Direction" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@84..94 "Direction" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
             enum_values: GraphqlEnumValuesDefinition {
-                l_curly_token: L_CURLY@65..66 "{" [] [],
+                l_curly_token: L_CURLY@94..95 "{" [] [],
                 values: GraphqlEnumValueList [],
-                r_curly_token: R_CURLY@66..67 "}" [] [],
+                r_curly_token: R_CURLY@95..96 "}" [] [],
             },
         },
         GraphqlEnumTypeDefinition {
             description: missing (optional),
-            enum_token: ENUM_KW@67..74 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            enum_token: ENUM_KW@96..103 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@74..83 "Direction" [] [],
+                value_token: GRAPHQL_NAME@103..112 "Direction" [] [],
             },
             directives: GraphqlDirectiveList [],
             enum_values: missing (optional),
         },
         GraphqlEnumTypeDefinition {
             description: missing (optional),
-            enum_token: ENUM_KW@83..90 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            enum_token: ENUM_KW@112..119 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@90..100 "Direction" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@119..129 "Direction" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
-                    at_token: AT@100..101 "@" [] [],
+                    at_token: AT@129..130 "@" [] [],
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@101..112 "deprecated" [] [Whitespace(" ")],
+                        value_token: GRAPHQL_NAME@130..141 "deprecated" [] [Whitespace(" ")],
                     },
                     arguments: missing (optional),
                 },
             ],
             enum_values: GraphqlEnumValuesDefinition {
-                l_curly_token: L_CURLY@112..113 "{" [] [],
+                l_curly_token: L_CURLY@141..142 "{" [] [],
                 values: GraphqlEnumValueList [
                     GraphqlEnumValueDefinition {
-                        description: missing (optional),
-                        value: GraphqlEnumValue {
-                            graphql_name: GraphqlName {
-                                value_token: GRAPHQL_NAME@113..121 "NORTH" [Newline("\n"), Whitespace("  ")] [],
+                        description: GraphqlDescription {
+                            graphql_string_value: GraphqlStringValue {
+                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@142..153 "\"north\"" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                             },
                         },
-                        directives: GraphqlDirectiveList [],
+                        value: GraphqlEnumValue {
+                            graphql_name: GraphqlName {
+                                value_token: GRAPHQL_NAME@153..159 "NORTH" [] [Whitespace(" ")],
+                            },
+                        },
+                        directives: GraphqlDirectiveList [
+                            GraphqlDirective {
+                                at_token: AT@159..160 "@" [] [],
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@160..170 "deprecated" [] [],
+                                },
+                                arguments: missing (optional),
+                            },
+                        ],
                     },
                 ],
-                r_curly_token: R_CURLY@121..123 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@170..172 "}" [Newline("\n")] [],
             },
         },
         GraphqlEnumTypeDefinition {
             description: GraphqlDescription {
                 graphql_string_value: GraphqlStringValue {
-                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@123..143 "\"This is an enum\"" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@172..192 "\"This is an enum\"" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
                 },
             },
-            enum_token: ENUM_KW@143..148 "enum" [] [Whitespace(" ")],
+            enum_token: ENUM_KW@192..197 "enum" [] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@148..158 "Direction" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@197..207 "Direction" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
-                    at_token: AT@158..159 "@" [] [],
+                    at_token: AT@207..208 "@" [] [],
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@159..169 "deprecated" [] [],
+                        value_token: GRAPHQL_NAME@208..218 "deprecated" [] [],
                     },
                     arguments: missing (optional),
                 },
@@ -154,102 +206,133 @@ GraphqlRoot {
             enum_values: missing (optional),
         },
     ],
-    eof_token: EOF@169..170 "" [Newline("\n")] [],
+    eof_token: EOF@218..219 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..170
+0: GRAPHQL_ROOT@0..219
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..169
-    0: GRAPHQL_ENUM_TYPE_DEFINITION@0..48
+  1: GRAPHQL_DEFINITION_LIST@0..218
+    0: GRAPHQL_ENUM_TYPE_DEFINITION@0..77
       0: (empty)
       1: ENUM_KW@0..5 "enum" [] [Whitespace(" ")]
-      2: GRAPHQL_NAME@5..15
-        0: GRAPHQL_NAME@5..15 "Direction" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@15..15
-      4: GRAPHQL_ENUM_VALUES_DEFINITION@15..48
-        0: L_CURLY@15..16 "{" [] []
-        1: GRAPHQL_ENUM_VALUE_LIST@16..46
-          0: GRAPHQL_ENUM_VALUE_DEFINITION@16..24
+      2: GRAPHQL_NAME@5..10
+        0: GRAPHQL_NAME@5..10 "name" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@10..10
+      4: GRAPHQL_ENUM_VALUES_DEFINITION@10..77
+        0: L_CURLY@10..11 "{" [] []
+        1: GRAPHQL_ENUM_VALUE_LIST@11..75
+          0: GRAPHQL_ENUM_VALUE_DEFINITION@11..19
             0: (empty)
-            1: GRAPHQL_ENUM_VALUE@16..24
-              0: GRAPHQL_NAME@16..24
-                0: GRAPHQL_NAME@16..24 "NORTH" [Newline("\n"), Whitespace("  ")] []
-            2: GRAPHQL_DIRECTIVE_LIST@24..24
-          1: GRAPHQL_ENUM_VALUE_DEFINITION@24..31
+            1: GRAPHQL_ENUM_VALUE@11..19
+              0: GRAPHQL_NAME@11..19
+                0: GRAPHQL_NAME@11..19 "NORTH" [Newline("\n"), Whitespace("  ")] []
+            2: GRAPHQL_DIRECTIVE_LIST@19..19
+          1: GRAPHQL_ENUM_VALUE_DEFINITION@19..26
             0: (empty)
-            1: GRAPHQL_ENUM_VALUE@24..31
-              0: GRAPHQL_NAME@24..31
-                0: GRAPHQL_NAME@24..31 "EAST" [Newline("\n"), Whitespace("  ")] []
-            2: GRAPHQL_DIRECTIVE_LIST@31..31
-          2: GRAPHQL_ENUM_VALUE_DEFINITION@31..39
+            1: GRAPHQL_ENUM_VALUE@19..26
+              0: GRAPHQL_NAME@19..26
+                0: GRAPHQL_NAME@19..26 "EAST" [Newline("\n"), Whitespace("  ")] []
+            2: GRAPHQL_DIRECTIVE_LIST@26..26
+          2: GRAPHQL_ENUM_VALUE_DEFINITION@26..34
             0: (empty)
-            1: GRAPHQL_ENUM_VALUE@31..39
-              0: GRAPHQL_NAME@31..39
-                0: GRAPHQL_NAME@31..39 "SOUTH" [Newline("\n"), Whitespace("  ")] []
-            2: GRAPHQL_DIRECTIVE_LIST@39..39
-          3: GRAPHQL_ENUM_VALUE_DEFINITION@39..46
+            1: GRAPHQL_ENUM_VALUE@26..34
+              0: GRAPHQL_NAME@26..34
+                0: GRAPHQL_NAME@26..34 "SOUTH" [Newline("\n"), Whitespace("  ")] []
+            2: GRAPHQL_DIRECTIVE_LIST@34..34
+          3: GRAPHQL_ENUM_VALUE_DEFINITION@34..41
             0: (empty)
-            1: GRAPHQL_ENUM_VALUE@39..46
-              0: GRAPHQL_NAME@39..46
-                0: GRAPHQL_NAME@39..46 "WEST" [Newline("\n"), Whitespace("  ")] []
-            2: GRAPHQL_DIRECTIVE_LIST@46..46
-        2: R_CURLY@46..48 "}" [Newline("\n")] []
-    1: GRAPHQL_ENUM_TYPE_DEFINITION@48..67
+            1: GRAPHQL_ENUM_VALUE@34..41
+              0: GRAPHQL_NAME@34..41
+                0: GRAPHQL_NAME@34..41 "WEST" [Newline("\n"), Whitespace("  ")] []
+            2: GRAPHQL_DIRECTIVE_LIST@41..41
+          4: GRAPHQL_ENUM_VALUE_DEFINITION@41..49
+            0: (empty)
+            1: GRAPHQL_ENUM_VALUE@41..49
+              0: GRAPHQL_NAME@41..49
+                0: GRAPHQL_NAME@41..49 "union" [Newline("\n"), Whitespace("  ")] []
+            2: GRAPHQL_DIRECTIVE_LIST@49..49
+          5: GRAPHQL_ENUM_VALUE_DEFINITION@49..56
+            0: (empty)
+            1: GRAPHQL_ENUM_VALUE@49..56
+              0: GRAPHQL_NAME@49..56
+                0: GRAPHQL_NAME@49..56 "type" [Newline("\n"), Whitespace("  ")] []
+            2: GRAPHQL_DIRECTIVE_LIST@56..56
+          6: GRAPHQL_ENUM_VALUE_DEFINITION@56..68
+            0: (empty)
+            1: GRAPHQL_ENUM_VALUE@56..68
+              0: GRAPHQL_NAME@56..68
+                0: GRAPHQL_NAME@56..68 "interface" [Newline("\n"), Whitespace("  ")] []
+            2: GRAPHQL_DIRECTIVE_LIST@68..68
+          7: GRAPHQL_ENUM_VALUE_DEFINITION@68..75
+            0: (empty)
+            1: GRAPHQL_ENUM_VALUE@68..75
+              0: GRAPHQL_NAME@68..75
+                0: GRAPHQL_NAME@68..75 "enum" [Newline("\n"), Whitespace("  ")] []
+            2: GRAPHQL_DIRECTIVE_LIST@75..75
+        2: R_CURLY@75..77 "}" [Newline("\n")] []
+    1: GRAPHQL_ENUM_TYPE_DEFINITION@77..96
       0: (empty)
-      1: ENUM_KW@48..55 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@55..65
-        0: GRAPHQL_NAME@55..65 "Direction" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@65..65
-      4: GRAPHQL_ENUM_VALUES_DEFINITION@65..67
-        0: L_CURLY@65..66 "{" [] []
-        1: GRAPHQL_ENUM_VALUE_LIST@66..66
-        2: R_CURLY@66..67 "}" [] []
-    2: GRAPHQL_ENUM_TYPE_DEFINITION@67..83
+      1: ENUM_KW@77..84 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@84..94
+        0: GRAPHQL_NAME@84..94 "Direction" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@94..94
+      4: GRAPHQL_ENUM_VALUES_DEFINITION@94..96
+        0: L_CURLY@94..95 "{" [] []
+        1: GRAPHQL_ENUM_VALUE_LIST@95..95
+        2: R_CURLY@95..96 "}" [] []
+    2: GRAPHQL_ENUM_TYPE_DEFINITION@96..112
       0: (empty)
-      1: ENUM_KW@67..74 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@74..83
-        0: GRAPHQL_NAME@74..83 "Direction" [] []
-      3: GRAPHQL_DIRECTIVE_LIST@83..83
+      1: ENUM_KW@96..103 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@103..112
+        0: GRAPHQL_NAME@103..112 "Direction" [] []
+      3: GRAPHQL_DIRECTIVE_LIST@112..112
       4: (empty)
-    3: GRAPHQL_ENUM_TYPE_DEFINITION@83..123
+    3: GRAPHQL_ENUM_TYPE_DEFINITION@112..172
       0: (empty)
-      1: ENUM_KW@83..90 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@90..100
-        0: GRAPHQL_NAME@90..100 "Direction" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@100..112
-        0: GRAPHQL_DIRECTIVE@100..112
-          0: AT@100..101 "@" [] []
-          1: GRAPHQL_NAME@101..112
-            0: GRAPHQL_NAME@101..112 "deprecated" [] [Whitespace(" ")]
+      1: ENUM_KW@112..119 "enum" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@119..129
+        0: GRAPHQL_NAME@119..129 "Direction" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@129..141
+        0: GRAPHQL_DIRECTIVE@129..141
+          0: AT@129..130 "@" [] []
+          1: GRAPHQL_NAME@130..141
+            0: GRAPHQL_NAME@130..141 "deprecated" [] [Whitespace(" ")]
           2: (empty)
-      4: GRAPHQL_ENUM_VALUES_DEFINITION@112..123
-        0: L_CURLY@112..113 "{" [] []
-        1: GRAPHQL_ENUM_VALUE_LIST@113..121
-          0: GRAPHQL_ENUM_VALUE_DEFINITION@113..121
-            0: (empty)
-            1: GRAPHQL_ENUM_VALUE@113..121
-              0: GRAPHQL_NAME@113..121
-                0: GRAPHQL_NAME@113..121 "NORTH" [Newline("\n"), Whitespace("  ")] []
-            2: GRAPHQL_DIRECTIVE_LIST@121..121
-        2: R_CURLY@121..123 "}" [Newline("\n")] []
-    4: GRAPHQL_ENUM_TYPE_DEFINITION@123..169
-      0: GRAPHQL_DESCRIPTION@123..143
-        0: GRAPHQL_STRING_VALUE@123..143
-          0: GRAPHQL_STRING_LITERAL@123..143 "\"This is an enum\"" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      1: ENUM_KW@143..148 "enum" [] [Whitespace(" ")]
-      2: GRAPHQL_NAME@148..158
-        0: GRAPHQL_NAME@148..158 "Direction" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@158..169
-        0: GRAPHQL_DIRECTIVE@158..169
-          0: AT@158..159 "@" [] []
-          1: GRAPHQL_NAME@159..169
-            0: GRAPHQL_NAME@159..169 "deprecated" [] []
+      4: GRAPHQL_ENUM_VALUES_DEFINITION@141..172
+        0: L_CURLY@141..142 "{" [] []
+        1: GRAPHQL_ENUM_VALUE_LIST@142..170
+          0: GRAPHQL_ENUM_VALUE_DEFINITION@142..170
+            0: GRAPHQL_DESCRIPTION@142..153
+              0: GRAPHQL_STRING_VALUE@142..153
+                0: GRAPHQL_STRING_LITERAL@142..153 "\"north\"" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            1: GRAPHQL_ENUM_VALUE@153..159
+              0: GRAPHQL_NAME@153..159
+                0: GRAPHQL_NAME@153..159 "NORTH" [] [Whitespace(" ")]
+            2: GRAPHQL_DIRECTIVE_LIST@159..170
+              0: GRAPHQL_DIRECTIVE@159..170
+                0: AT@159..160 "@" [] []
+                1: GRAPHQL_NAME@160..170
+                  0: GRAPHQL_NAME@160..170 "deprecated" [] []
+                2: (empty)
+        2: R_CURLY@170..172 "}" [Newline("\n")] []
+    4: GRAPHQL_ENUM_TYPE_DEFINITION@172..218
+      0: GRAPHQL_DESCRIPTION@172..192
+        0: GRAPHQL_STRING_VALUE@172..192
+          0: GRAPHQL_STRING_LITERAL@172..192 "\"This is an enum\"" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: ENUM_KW@192..197 "enum" [] [Whitespace(" ")]
+      2: GRAPHQL_NAME@197..207
+        0: GRAPHQL_NAME@197..207 "Direction" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@207..218
+        0: GRAPHQL_DIRECTIVE@207..218
+          0: AT@207..208 "@" [] []
+          1: GRAPHQL_NAME@208..218
+            0: GRAPHQL_NAME@208..218 "deprecated" [] []
           2: (empty)
       4: (empty)
-  2: EOF@169..170 "" [Newline("\n")] []
+  2: EOF@218..219 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/fragment.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/fragment.graphql
@@ -8,4 +8,7 @@ fragment friendFields on User @deprecated {
   id
   name
   profilePic(size: 50)
+	query {
+    fragment
+	}
 }

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/fragment.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/fragment.graphql.snap
@@ -14,6 +14,9 @@ fragment friendFields on User @deprecated {
   id
   name
   profilePic(size: 50)
+	query {
+    fragment
+	}
 }
 
 ```
@@ -152,21 +155,44 @@ GraphqlRoot {
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@148..156 "query" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                        },
+                        arguments: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                        selection_set: GraphqlSelectionSet {
+                            l_curly_token: L_CURLY@156..157 "{" [] [],
+                            selections: GraphqlSelectionList [
+                                GraphqlField {
+                                    alias: missing (optional),
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@157..170 "fragment" [Newline("\n"), Whitespace("    ")] [],
+                                    },
+                                    arguments: missing (optional),
+                                    directives: GraphqlDirectiveList [],
+                                    selection_set: missing (optional),
+                                },
+                            ],
+                            r_curly_token: R_CURLY@170..173 "}" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                    },
                 ],
-                r_curly_token: R_CURLY@148..150 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@173..175 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@150..151 "" [Newline("\n")] [],
+    eof_token: EOF@175..176 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..151
+0: GRAPHQL_ROOT@0..176
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..150
+  1: GRAPHQL_DEFINITION_LIST@0..175
     0: GRAPHQL_FRAGMENT_DEFINITION@0..68
       0: FRAGMENT_KW@0..9 "fragment" [] [Whitespace(" ")]
       1: GRAPHQL_NAME@9..22
@@ -211,7 +237,7 @@ GraphqlRoot {
             3: GRAPHQL_DIRECTIVE_LIST@66..66
             4: (empty)
         2: R_CURLY@66..68 "}" [Newline("\n")] []
-    1: GRAPHQL_FRAGMENT_DEFINITION@68..150
+    1: GRAPHQL_FRAGMENT_DEFINITION@68..175
       0: FRAGMENT_KW@68..79 "fragment" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: GRAPHQL_NAME@79..92
         0: GRAPHQL_NAME@79..92 "friendFields" [] [Whitespace(" ")]
@@ -226,9 +252,9 @@ GraphqlRoot {
           1: GRAPHQL_NAME@101..112
             0: GRAPHQL_NAME@101..112 "deprecated" [] [Whitespace(" ")]
           2: (empty)
-      4: GRAPHQL_SELECTION_SET@112..150
+      4: GRAPHQL_SELECTION_SET@112..175
         0: L_CURLY@112..113 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@113..148
+        1: GRAPHQL_SELECTION_LIST@113..173
           0: GRAPHQL_FIELD@113..118
             0: (empty)
             1: GRAPHQL_NAME@113..118
@@ -259,7 +285,24 @@ GraphqlRoot {
               2: R_PAREN@147..148 ")" [] []
             3: GRAPHQL_DIRECTIVE_LIST@148..148
             4: (empty)
-        2: R_CURLY@148..150 "}" [Newline("\n")] []
-  2: EOF@150..151 "" [Newline("\n")] []
+          3: GRAPHQL_FIELD@148..173
+            0: (empty)
+            1: GRAPHQL_NAME@148..156
+              0: GRAPHQL_NAME@148..156 "query" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@156..156
+            4: GRAPHQL_SELECTION_SET@156..173
+              0: L_CURLY@156..157 "{" [] []
+              1: GRAPHQL_SELECTION_LIST@157..170
+                0: GRAPHQL_FIELD@157..170
+                  0: (empty)
+                  1: GRAPHQL_NAME@157..170
+                    0: GRAPHQL_NAME@157..170 "fragment" [Newline("\n"), Whitespace("    ")] []
+                  2: (empty)
+                  3: GRAPHQL_DIRECTIVE_LIST@170..170
+                  4: (empty)
+              2: R_CURLY@170..173 "}" [Newline("\n"), Whitespace("\t")] []
+        2: R_CURLY@173..175 "}" [Newline("\n")] []
+  2: EOF@175..176 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/input_object.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/input_object.graphql
@@ -17,3 +17,8 @@ input Point2D {
   x: Float = 0
   "this is y" y: Float @deprecated
 }
+
+input input @input {
+	input: input
+}
+

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/input_object.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/input_object.graphql.snap
@@ -24,6 +24,11 @@ input Point2D {
   "this is y" y: Float @deprecated
 }
 
+input input @input {
+	input: input
+}
+
+
 ```
 
 ## AST
@@ -212,17 +217,53 @@ GraphqlRoot {
                 r_curly_token: R_CURLY@233..235 "}" [Newline("\n")] [],
             },
         },
+        GraphqlInputObjectTypeDefinition {
+            description: missing (optional),
+            input_token: INPUT_KW@235..243 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@243..249 "input" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [
+                GraphqlDirective {
+                    at_token: AT@249..250 "@" [] [],
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@250..256 "input" [] [Whitespace(" ")],
+                    },
+                    arguments: missing (optional),
+                },
+            ],
+            input_fields: GraphqlInputFieldsDefinition {
+                l_curly_token: L_CURLY@256..257 "{" [] [],
+                fields: GraphqlInputFieldList [
+                    GraphqlInputValueDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@257..264 "input" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        colon_token: COLON@264..266 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@266..271 "input" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_curly_token: R_CURLY@271..273 "}" [Newline("\n")] [],
+            },
+        },
     ],
-    eof_token: EOF@235..236 "" [Newline("\n")] [],
+    eof_token: EOF@273..275 "" [Newline("\n"), Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..236
+0: GRAPHQL_ROOT@0..275
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..235
+  1: GRAPHQL_DEFINITION_LIST@0..273
     0: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@0..39
       0: (empty)
       1: INPUT_KW@0..6 "input" [] [Whitespace(" ")]
@@ -349,6 +390,31 @@ GraphqlRoot {
                   0: GRAPHQL_NAME@223..233 "deprecated" [] []
                 2: (empty)
         2: R_CURLY@233..235 "}" [Newline("\n")] []
-  2: EOF@235..236 "" [Newline("\n")] []
+    6: GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION@235..273
+      0: (empty)
+      1: INPUT_KW@235..243 "input" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@243..249
+        0: GRAPHQL_NAME@243..249 "input" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@249..256
+        0: GRAPHQL_DIRECTIVE@249..256
+          0: AT@249..250 "@" [] []
+          1: GRAPHQL_NAME@250..256
+            0: GRAPHQL_NAME@250..256 "input" [] [Whitespace(" ")]
+          2: (empty)
+      4: GRAPHQL_INPUT_FIELDS_DEFINITION@256..273
+        0: L_CURLY@256..257 "{" [] []
+        1: GRAPHQL_INPUT_FIELD_LIST@257..271
+          0: GRAPHQL_INPUT_VALUE_DEFINITION@257..271
+            0: (empty)
+            1: GRAPHQL_NAME@257..264
+              0: GRAPHQL_NAME@257..264 "input" [Newline("\n"), Whitespace("\t")] []
+            2: COLON@264..266 ":" [] [Whitespace(" ")]
+            3: GRAPHQL_NAMED_TYPE@266..271
+              0: GRAPHQL_NAME@266..271
+                0: GRAPHQL_NAME@266..271 "input" [] []
+            4: (empty)
+            5: GRAPHQL_DIRECTIVE_LIST@271..271
+        2: R_CURLY@271..273 "}" [Newline("\n")] []
+  2: EOF@273..275 "" [Newline("\n"), Newline("\n")] []
 
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/interface.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/interface.graphql
@@ -34,3 +34,6 @@ interface Person {
   weight("filter by weight" greater_than: Int = 0 @deprecated): Int
 }
 
+interface interface implements interface {
+  interface: interface
+}

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/interface.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/interface.graphql.snap
@@ -40,6 +40,9 @@ interface Person {
   weight("filter by weight" greater_than: Int = 0 @deprecated): Int
 }
 
+interface interface implements interface {
+  interface: interface
+}
 
 ```
 
@@ -546,17 +549,56 @@ GraphqlRoot {
                 r_curly_token: R_CURLY@696..698 "}" [Newline("\n")] [],
             },
         },
+        GraphqlInterfaceTypeDefinition {
+            description: missing (optional),
+            interface_token: INTERFACE_KW@698..710 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@710..720 "interface" [] [Whitespace(" ")],
+            },
+            implements: GraphqlImplementsInterfaces {
+                implements_token: IMPLEMENTS_KW@720..731 "implements" [] [Whitespace(" ")],
+                amp_token: missing (optional),
+                interfaces: GraphqlImplementsInterfaceList [
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@731..741 "interface" [] [Whitespace(" ")],
+                        },
+                    },
+                ],
+            },
+            directives: GraphqlDirectiveList [],
+            fields: GraphqlFieldsDefinition {
+                l_curly_token: L_CURLY@741..742 "{" [] [],
+                fields: GraphqlFieldDefinitionList [
+                    GraphqlFieldDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@742..754 "interface" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        arguments: missing (optional),
+                        colon_token: COLON@754..756 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@756..765 "interface" [] [],
+                            },
+                        },
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_curly_token: R_CURLY@765..767 "}" [Newline("\n")] [],
+            },
+        },
     ],
-    eof_token: EOF@698..700 "" [Newline("\n"), Newline("\n")] [],
+    eof_token: EOF@767..768 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..700
+0: GRAPHQL_ROOT@0..768
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..698
+  1: GRAPHQL_DEFINITION_LIST@0..767
     0: GRAPHQL_INTERFACE_TYPE_DEFINITION@0..61
       0: (empty)
       1: INTERFACE_KW@0..10 "interface" [] [Whitespace(" ")]
@@ -900,6 +942,33 @@ GraphqlRoot {
                 0: GRAPHQL_NAME@693..696 "Int" [] []
             5: GRAPHQL_DIRECTIVE_LIST@696..696
         2: R_CURLY@696..698 "}" [Newline("\n")] []
-  2: EOF@698..700 "" [Newline("\n"), Newline("\n")] []
+    10: GRAPHQL_INTERFACE_TYPE_DEFINITION@698..767
+      0: (empty)
+      1: INTERFACE_KW@698..710 "interface" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@710..720
+        0: GRAPHQL_NAME@710..720 "interface" [] [Whitespace(" ")]
+      3: GRAPHQL_IMPLEMENTS_INTERFACES@720..741
+        0: IMPLEMENTS_KW@720..731 "implements" [] [Whitespace(" ")]
+        1: (empty)
+        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@731..741
+          0: GRAPHQL_NAMED_TYPE@731..741
+            0: GRAPHQL_NAME@731..741
+              0: GRAPHQL_NAME@731..741 "interface" [] [Whitespace(" ")]
+      4: GRAPHQL_DIRECTIVE_LIST@741..741
+      5: GRAPHQL_FIELDS_DEFINITION@741..767
+        0: L_CURLY@741..742 "{" [] []
+        1: GRAPHQL_FIELD_DEFINITION_LIST@742..765
+          0: GRAPHQL_FIELD_DEFINITION@742..765
+            0: (empty)
+            1: GRAPHQL_NAME@742..754
+              0: GRAPHQL_NAME@742..754 "interface" [Newline("\n"), Whitespace("  ")] []
+            2: (empty)
+            3: COLON@754..756 ":" [] [Whitespace(" ")]
+            4: GRAPHQL_NAMED_TYPE@756..765
+              0: GRAPHQL_NAME@756..765
+                0: GRAPHQL_NAME@756..765 "interface" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@765..765
+        2: R_CURLY@765..767 "}" [Newline("\n")] []
+  2: EOF@767..768 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/object.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/object.graphql
@@ -8,6 +8,11 @@ type Person @deprecated {
   name: String
 }
 
+type Animal {
+  "type of the animal"
+  type: String
+}
+
 type Person implements Character @deprecated {
   name: String
 }
@@ -19,6 +24,8 @@ type Person implements Character {
 type Person
 
 type Person implements Character
+
+type Person implements Character & type
 
 type Person @deprecated
 
@@ -34,5 +41,9 @@ type Person {
   height("filter by height" greater_than: Int @deprecated): Int
   weight("filter by weight" greater_than: Int = 0 @deprecated): Int
   "filter by weight" weight("filter by weight" greater_than: Int = 0 @deprecated): Int
+}
+
+type type implements type {
+  type: type
 }
 

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/object.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/object.graphql.snap
@@ -14,6 +14,11 @@ type Person @deprecated {
   name: String
 }
 
+type Animal {
+  "type of the animal"
+  type: String
+}
+
 type Person implements Character @deprecated {
   name: String
 }
@@ -25,6 +30,8 @@ type Person implements Character {
 type Person
 
 type Person implements Character
+
+type Person implements Character & type
 
 type Person @deprecated
 
@@ -40,6 +47,10 @@ type Person {
   height("filter by height" greater_than: Int @deprecated): Int
   weight("filter by weight" greater_than: Int = 0 @deprecated): Int
   "filter by weight" weight("filter by weight" greater_than: Int = 0 @deprecated): Int
+}
+
+type type implements type {
+  type: type
 }
 
 
@@ -149,93 +160,126 @@ GraphqlRoot {
             description: missing (optional),
             type_token: TYPE_KW@100..107 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@107..114 "Person" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@107..114 "Animal" [] [Whitespace(" ")],
+            },
+            implements: missing (optional),
+            directives: GraphqlDirectiveList [],
+            fields: GraphqlFieldsDefinition {
+                l_curly_token: L_CURLY@114..115 "{" [] [],
+                fields: GraphqlFieldDefinitionList [
+                    GraphqlFieldDefinition {
+                        description: GraphqlDescription {
+                            graphql_string_value: GraphqlStringValue {
+                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@115..138 "\"type of the animal\"" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@138..145 "type" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        arguments: missing (optional),
+                        colon_token: COLON@145..147 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@147..153 "String" [] [],
+                            },
+                        },
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_curly_token: R_CURLY@153..155 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlObjectTypeDefinition {
+            description: missing (optional),
+            type_token: TYPE_KW@155..162 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@162..169 "Person" [] [Whitespace(" ")],
             },
             implements: GraphqlImplementsInterfaces {
-                implements_token: IMPLEMENTS_KW@114..125 "implements" [] [Whitespace(" ")],
+                implements_token: IMPLEMENTS_KW@169..180 "implements" [] [Whitespace(" ")],
                 amp_token: missing (optional),
                 interfaces: GraphqlImplementsInterfaceList [
                     GraphqlNamedType {
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@125..135 "Character" [] [Whitespace(" ")],
+                            value_token: GRAPHQL_NAME@180..190 "Character" [] [Whitespace(" ")],
                         },
                     },
                 ],
             },
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
-                    at_token: AT@135..136 "@" [] [],
+                    at_token: AT@190..191 "@" [] [],
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@136..147 "deprecated" [] [Whitespace(" ")],
+                        value_token: GRAPHQL_NAME@191..202 "deprecated" [] [Whitespace(" ")],
                     },
                     arguments: missing (optional),
                 },
             ],
             fields: GraphqlFieldsDefinition {
-                l_curly_token: L_CURLY@147..148 "{" [] [],
+                l_curly_token: L_CURLY@202..203 "{" [] [],
                 fields: GraphqlFieldDefinitionList [
                     GraphqlFieldDefinition {
                         description: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@148..155 "name" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@203..210 "name" [Newline("\n"), Whitespace("  ")] [],
                         },
                         arguments: missing (optional),
-                        colon_token: COLON@155..157 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@210..212 ":" [] [Whitespace(" ")],
                         ty: GraphqlNamedType {
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@157..163 "String" [] [],
+                                value_token: GRAPHQL_NAME@212..218 "String" [] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_curly_token: R_CURLY@163..165 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@218..220 "}" [Newline("\n")] [],
             },
         },
         GraphqlObjectTypeDefinition {
             description: missing (optional),
-            type_token: TYPE_KW@165..172 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            type_token: TYPE_KW@220..227 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@172..179 "Person" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@227..234 "Person" [] [Whitespace(" ")],
             },
             implements: GraphqlImplementsInterfaces {
-                implements_token: IMPLEMENTS_KW@179..190 "implements" [] [Whitespace(" ")],
+                implements_token: IMPLEMENTS_KW@234..245 "implements" [] [Whitespace(" ")],
                 amp_token: missing (optional),
                 interfaces: GraphqlImplementsInterfaceList [
                     GraphqlNamedType {
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@190..200 "Character" [] [Whitespace(" ")],
+                            value_token: GRAPHQL_NAME@245..255 "Character" [] [Whitespace(" ")],
                         },
                     },
                 ],
             },
             directives: GraphqlDirectiveList [],
             fields: GraphqlFieldsDefinition {
-                l_curly_token: L_CURLY@200..201 "{" [] [],
+                l_curly_token: L_CURLY@255..256 "{" [] [],
                 fields: GraphqlFieldDefinitionList [
                     GraphqlFieldDefinition {
                         description: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@201..208 "name" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@256..263 "name" [Newline("\n"), Whitespace("  ")] [],
                         },
                         arguments: missing (optional),
-                        colon_token: COLON@208..210 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@263..265 ":" [] [Whitespace(" ")],
                         ty: GraphqlNamedType {
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@210..216 "String" [] [],
+                                value_token: GRAPHQL_NAME@265..271 "String" [] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_curly_token: R_CURLY@216..218 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@271..273 "}" [Newline("\n")] [],
             },
         },
         GraphqlObjectTypeDefinition {
             description: missing (optional),
-            type_token: TYPE_KW@218..225 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            type_token: TYPE_KW@273..280 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@225..231 "Person" [] [],
+                value_token: GRAPHQL_NAME@280..286 "Person" [] [],
             },
             implements: missing (optional),
             directives: GraphqlDirectiveList [],
@@ -243,17 +287,17 @@ GraphqlRoot {
         },
         GraphqlObjectTypeDefinition {
             description: missing (optional),
-            type_token: TYPE_KW@231..238 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            type_token: TYPE_KW@286..293 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@238..245 "Person" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@293..300 "Person" [] [Whitespace(" ")],
             },
             implements: GraphqlImplementsInterfaces {
-                implements_token: IMPLEMENTS_KW@245..256 "implements" [] [Whitespace(" ")],
+                implements_token: IMPLEMENTS_KW@300..311 "implements" [] [Whitespace(" ")],
                 amp_token: missing (optional),
                 interfaces: GraphqlImplementsInterfaceList [
                     GraphqlNamedType {
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@256..265 "Character" [] [],
+                            value_token: GRAPHQL_NAME@311..320 "Character" [] [],
                         },
                     },
                 ],
@@ -263,16 +307,42 @@ GraphqlRoot {
         },
         GraphqlObjectTypeDefinition {
             description: missing (optional),
-            type_token: TYPE_KW@265..272 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            type_token: TYPE_KW@320..327 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@272..279 "Person" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@327..334 "Person" [] [Whitespace(" ")],
+            },
+            implements: GraphqlImplementsInterfaces {
+                implements_token: IMPLEMENTS_KW@334..345 "implements" [] [Whitespace(" ")],
+                amp_token: missing (optional),
+                interfaces: GraphqlImplementsInterfaceList [
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@345..355 "Character" [] [Whitespace(" ")],
+                        },
+                    },
+                    AMP@355..357 "&" [] [Whitespace(" ")],
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@357..361 "type" [] [],
+                        },
+                    },
+                ],
+            },
+            directives: GraphqlDirectiveList [],
+            fields: missing (optional),
+        },
+        GraphqlObjectTypeDefinition {
+            description: missing (optional),
+            type_token: TYPE_KW@361..368 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@368..375 "Person" [] [Whitespace(" ")],
             },
             implements: missing (optional),
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
-                    at_token: AT@279..280 "@" [] [],
+                    at_token: AT@375..376 "@" [] [],
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@280..290 "deprecated" [] [],
+                        value_token: GRAPHQL_NAME@376..386 "deprecated" [] [],
                     },
                     arguments: missing (optional),
                 },
@@ -281,26 +351,26 @@ GraphqlRoot {
         },
         GraphqlObjectTypeDefinition {
             description: missing (optional),
-            type_token: TYPE_KW@290..297 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            type_token: TYPE_KW@386..393 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@297..304 "Person" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@393..400 "Person" [] [Whitespace(" ")],
             },
             implements: GraphqlImplementsInterfaces {
-                implements_token: IMPLEMENTS_KW@304..315 "implements" [] [Whitespace(" ")],
+                implements_token: IMPLEMENTS_KW@400..411 "implements" [] [Whitespace(" ")],
                 amp_token: missing (optional),
                 interfaces: GraphqlImplementsInterfaceList [
                     GraphqlNamedType {
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@315..325 "Character" [] [Whitespace(" ")],
+                            value_token: GRAPHQL_NAME@411..421 "Character" [] [Whitespace(" ")],
                         },
                     },
                 ],
             },
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
-                    at_token: AT@325..326 "@" [] [],
+                    at_token: AT@421..422 "@" [] [],
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@326..336 "deprecated" [] [],
+                        value_token: GRAPHQL_NAME@422..432 "deprecated" [] [],
                     },
                     arguments: missing (optional),
                 },
@@ -309,32 +379,32 @@ GraphqlRoot {
         },
         GraphqlObjectTypeDefinition {
             description: missing (optional),
-            type_token: TYPE_KW@336..343 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            type_token: TYPE_KW@432..439 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@343..350 "Person" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@439..446 "Person" [] [Whitespace(" ")],
             },
             implements: GraphqlImplementsInterfaces {
-                implements_token: IMPLEMENTS_KW@350..361 "implements" [] [Whitespace(" ")],
+                implements_token: IMPLEMENTS_KW@446..457 "implements" [] [Whitespace(" ")],
                 amp_token: missing (optional),
                 interfaces: GraphqlImplementsInterfaceList [
                     GraphqlNamedType {
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@361..371 "Character" [] [Whitespace(" ")],
+                            value_token: GRAPHQL_NAME@457..467 "Character" [] [Whitespace(" ")],
                         },
                     },
-                    AMP@371..373 "&" [] [Whitespace(" ")],
+                    AMP@467..469 "&" [] [Whitespace(" ")],
                     GraphqlNamedType {
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@373..384 "Character1" [] [Whitespace(" ")],
+                            value_token: GRAPHQL_NAME@469..480 "Character1" [] [Whitespace(" ")],
                         },
                     },
                 ],
             },
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
-                    at_token: AT@384..385 "@" [] [],
+                    at_token: AT@480..481 "@" [] [],
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@385..395 "deprecated" [] [],
+                        value_token: GRAPHQL_NAME@481..491 "deprecated" [] [],
                     },
                     arguments: missing (optional),
                 },
@@ -344,47 +414,47 @@ GraphqlRoot {
         GraphqlObjectTypeDefinition {
             description: GraphqlDescription {
                 graphql_string_value: GraphqlStringValue {
-                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@395..415 "\"This is a person\"" [Newline("\n"), Newline("\n")] [],
+                    graphql_string_literal_token: GRAPHQL_STRING_LITERAL@491..511 "\"This is a person\"" [Newline("\n"), Newline("\n")] [],
                 },
             },
-            type_token: TYPE_KW@415..421 "type" [Newline("\n")] [Whitespace(" ")],
+            type_token: TYPE_KW@511..517 "type" [Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@421..428 "Person" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@517..524 "Person" [] [Whitespace(" ")],
             },
             implements: missing (optional),
             directives: GraphqlDirectiveList [],
             fields: GraphqlFieldsDefinition {
-                l_curly_token: L_CURLY@428..429 "{" [] [],
+                l_curly_token: L_CURLY@524..525 "{" [] [],
                 fields: GraphqlFieldDefinitionList [
                     GraphqlFieldDefinition {
                         description: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@429..436 "name" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@525..532 "name" [Newline("\n"), Whitespace("  ")] [],
                         },
                         arguments: GraphqlArgumentsDefinition {
-                            l_paren_token: L_PAREN@436..437 "(" [] [],
+                            l_paren_token: L_PAREN@532..533 "(" [] [],
                             arguments: GraphqlArgumentDefinitionList [
                                 GraphqlInputValueDefinition {
                                     description: missing (optional),
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@437..447 "start_with" [] [],
+                                        value_token: GRAPHQL_NAME@533..543 "start_with" [] [],
                                     },
-                                    colon_token: COLON@447..449 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@543..545 ":" [] [Whitespace(" ")],
                                     ty: GraphqlNamedType {
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@449..455 "String" [] [],
+                                            value_token: GRAPHQL_NAME@545..551 "String" [] [],
                                         },
                                     },
                                     default: missing (optional),
                                     directives: GraphqlDirectiveList [],
                                 },
                             ],
-                            r_paren_token: R_PAREN@455..456 ")" [] [],
+                            r_paren_token: R_PAREN@551..552 ")" [] [],
                         },
-                        colon_token: COLON@456..458 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@552..554 ":" [] [Whitespace(" ")],
                         ty: GraphqlNamedType {
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@458..464 "String" [] [],
+                                value_token: GRAPHQL_NAME@554..560 "String" [] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
@@ -392,24 +462,24 @@ GraphqlRoot {
                     GraphqlFieldDefinition {
                         description: GraphqlDescription {
                             graphql_string_value: GraphqlStringValue {
-                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@464..483 "\"filder by age\"" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@560..579 "\"filder by age\"" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                             },
                         },
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@483..486 "age" [] [],
+                            value_token: GRAPHQL_NAME@579..582 "age" [] [],
                         },
                         arguments: missing (optional),
-                        colon_token: COLON@486..488 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@582..584 ":" [] [Whitespace(" ")],
                         ty: GraphqlNamedType {
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@488..492 "Int" [] [Whitespace(" ")],
+                                value_token: GRAPHQL_NAME@584..588 "Int" [] [Whitespace(" ")],
                             },
                         },
                         directives: GraphqlDirectiveList [
                             GraphqlDirective {
-                                at_token: AT@492..493 "@" [] [],
+                                at_token: AT@588..589 "@" [] [],
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@493..503 "deprecated" [] [],
+                                    value_token: GRAPHQL_NAME@589..599 "deprecated" [] [],
                                 },
                                 arguments: missing (optional),
                             },
@@ -418,37 +488,37 @@ GraphqlRoot {
                     GraphqlFieldDefinition {
                         description: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@503..513 "picture" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@599..609 "picture" [Newline("\n"), Whitespace("  ")] [],
                         },
                         arguments: GraphqlArgumentsDefinition {
-                            l_paren_token: L_PAREN@513..514 "(" [] [],
+                            l_paren_token: L_PAREN@609..610 "(" [] [],
                             arguments: GraphqlArgumentDefinitionList [
                                 GraphqlInputValueDefinition {
                                     description: missing (optional),
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@514..518 "size" [] [],
+                                        value_token: GRAPHQL_NAME@610..614 "size" [] [],
                                     },
-                                    colon_token: COLON@518..520 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@614..616 ":" [] [Whitespace(" ")],
                                     ty: GraphqlNamedType {
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@520..524 "Int" [] [Whitespace(" ")],
+                                            value_token: GRAPHQL_NAME@616..620 "Int" [] [Whitespace(" ")],
                                         },
                                     },
                                     default: GraphqlDefaultValue {
-                                        eq_token: EQ@524..526 "=" [] [Whitespace(" ")],
+                                        eq_token: EQ@620..622 "=" [] [Whitespace(" ")],
                                         value: GraphqlIntValue {
-                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@526..527 "0" [] [],
+                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@622..623 "0" [] [],
                                         },
                                     },
                                     directives: GraphqlDirectiveList [],
                                 },
                             ],
-                            r_paren_token: R_PAREN@527..528 ")" [] [],
+                            r_paren_token: R_PAREN@623..624 ")" [] [],
                         },
-                        colon_token: COLON@528..530 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@624..626 ":" [] [Whitespace(" ")],
                         ty: GraphqlNamedType {
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@530..533 "Url" [] [],
+                                value_token: GRAPHQL_NAME@626..629 "Url" [] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
@@ -456,44 +526,44 @@ GraphqlRoot {
                     GraphqlFieldDefinition {
                         description: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@533..542 "height" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@629..638 "height" [Newline("\n"), Whitespace("  ")] [],
                         },
                         arguments: GraphqlArgumentsDefinition {
-                            l_paren_token: L_PAREN@542..543 "(" [] [],
+                            l_paren_token: L_PAREN@638..639 "(" [] [],
                             arguments: GraphqlArgumentDefinitionList [
                                 GraphqlInputValueDefinition {
                                     description: GraphqlDescription {
                                         graphql_string_value: GraphqlStringValue {
-                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@543..562 "\"filter by height\"" [] [Whitespace(" ")],
+                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@639..658 "\"filter by height\"" [] [Whitespace(" ")],
                                         },
                                     },
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@562..574 "greater_than" [] [],
+                                        value_token: GRAPHQL_NAME@658..670 "greater_than" [] [],
                                     },
-                                    colon_token: COLON@574..576 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@670..672 ":" [] [Whitespace(" ")],
                                     ty: GraphqlNamedType {
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@576..580 "Int" [] [Whitespace(" ")],
+                                            value_token: GRAPHQL_NAME@672..676 "Int" [] [Whitespace(" ")],
                                         },
                                     },
                                     default: missing (optional),
                                     directives: GraphqlDirectiveList [
                                         GraphqlDirective {
-                                            at_token: AT@580..581 "@" [] [],
+                                            at_token: AT@676..677 "@" [] [],
                                             name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@581..591 "deprecated" [] [],
+                                                value_token: GRAPHQL_NAME@677..687 "deprecated" [] [],
                                             },
                                             arguments: missing (optional),
                                         },
                                     ],
                                 },
                             ],
-                            r_paren_token: R_PAREN@591..592 ")" [] [],
+                            r_paren_token: R_PAREN@687..688 ")" [] [],
                         },
-                        colon_token: COLON@592..594 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@688..690 ":" [] [Whitespace(" ")],
                         ty: GraphqlNamedType {
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@594..597 "Int" [] [],
+                                value_token: GRAPHQL_NAME@690..693 "Int" [] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
@@ -501,49 +571,49 @@ GraphqlRoot {
                     GraphqlFieldDefinition {
                         description: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@597..606 "weight" [Newline("\n"), Whitespace("  ")] [],
+                            value_token: GRAPHQL_NAME@693..702 "weight" [Newline("\n"), Whitespace("  ")] [],
                         },
                         arguments: GraphqlArgumentsDefinition {
-                            l_paren_token: L_PAREN@606..607 "(" [] [],
+                            l_paren_token: L_PAREN@702..703 "(" [] [],
                             arguments: GraphqlArgumentDefinitionList [
                                 GraphqlInputValueDefinition {
                                     description: GraphqlDescription {
                                         graphql_string_value: GraphqlStringValue {
-                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@607..626 "\"filter by weight\"" [] [Whitespace(" ")],
+                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@703..722 "\"filter by weight\"" [] [Whitespace(" ")],
                                         },
                                     },
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@626..638 "greater_than" [] [],
+                                        value_token: GRAPHQL_NAME@722..734 "greater_than" [] [],
                                     },
-                                    colon_token: COLON@638..640 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@734..736 ":" [] [Whitespace(" ")],
                                     ty: GraphqlNamedType {
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@640..644 "Int" [] [Whitespace(" ")],
+                                            value_token: GRAPHQL_NAME@736..740 "Int" [] [Whitespace(" ")],
                                         },
                                     },
                                     default: GraphqlDefaultValue {
-                                        eq_token: EQ@644..646 "=" [] [Whitespace(" ")],
+                                        eq_token: EQ@740..742 "=" [] [Whitespace(" ")],
                                         value: GraphqlIntValue {
-                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@646..648 "0" [] [Whitespace(" ")],
+                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@742..744 "0" [] [Whitespace(" ")],
                                         },
                                     },
                                     directives: GraphqlDirectiveList [
                                         GraphqlDirective {
-                                            at_token: AT@648..649 "@" [] [],
+                                            at_token: AT@744..745 "@" [] [],
                                             name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@649..659 "deprecated" [] [],
+                                                value_token: GRAPHQL_NAME@745..755 "deprecated" [] [],
                                             },
                                             arguments: missing (optional),
                                         },
                                     ],
                                 },
                             ],
-                            r_paren_token: R_PAREN@659..660 ")" [] [],
+                            r_paren_token: R_PAREN@755..756 ")" [] [],
                         },
-                        colon_token: COLON@660..662 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@756..758 ":" [] [Whitespace(" ")],
                         ty: GraphqlNamedType {
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@662..665 "Int" [] [],
+                                value_token: GRAPHQL_NAME@758..761 "Int" [] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
@@ -551,72 +621,111 @@ GraphqlRoot {
                     GraphqlFieldDefinition {
                         description: GraphqlDescription {
                             graphql_string_value: GraphqlStringValue {
-                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@665..687 "\"filter by weight\"" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@761..783 "\"filter by weight\"" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                             },
                         },
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@687..693 "weight" [] [],
+                            value_token: GRAPHQL_NAME@783..789 "weight" [] [],
                         },
                         arguments: GraphqlArgumentsDefinition {
-                            l_paren_token: L_PAREN@693..694 "(" [] [],
+                            l_paren_token: L_PAREN@789..790 "(" [] [],
                             arguments: GraphqlArgumentDefinitionList [
                                 GraphqlInputValueDefinition {
                                     description: GraphqlDescription {
                                         graphql_string_value: GraphqlStringValue {
-                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@694..713 "\"filter by weight\"" [] [Whitespace(" ")],
+                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@790..809 "\"filter by weight\"" [] [Whitespace(" ")],
                                         },
                                     },
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@713..725 "greater_than" [] [],
+                                        value_token: GRAPHQL_NAME@809..821 "greater_than" [] [],
                                     },
-                                    colon_token: COLON@725..727 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@821..823 ":" [] [Whitespace(" ")],
                                     ty: GraphqlNamedType {
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@727..731 "Int" [] [Whitespace(" ")],
+                                            value_token: GRAPHQL_NAME@823..827 "Int" [] [Whitespace(" ")],
                                         },
                                     },
                                     default: GraphqlDefaultValue {
-                                        eq_token: EQ@731..733 "=" [] [Whitespace(" ")],
+                                        eq_token: EQ@827..829 "=" [] [Whitespace(" ")],
                                         value: GraphqlIntValue {
-                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@733..735 "0" [] [Whitespace(" ")],
+                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@829..831 "0" [] [Whitespace(" ")],
                                         },
                                     },
                                     directives: GraphqlDirectiveList [
                                         GraphqlDirective {
-                                            at_token: AT@735..736 "@" [] [],
+                                            at_token: AT@831..832 "@" [] [],
                                             name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@736..746 "deprecated" [] [],
+                                                value_token: GRAPHQL_NAME@832..842 "deprecated" [] [],
                                             },
                                             arguments: missing (optional),
                                         },
                                     ],
                                 },
                             ],
-                            r_paren_token: R_PAREN@746..747 ")" [] [],
+                            r_paren_token: R_PAREN@842..843 ")" [] [],
                         },
-                        colon_token: COLON@747..749 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@843..845 ":" [] [Whitespace(" ")],
                         ty: GraphqlNamedType {
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@749..752 "Int" [] [],
+                                value_token: GRAPHQL_NAME@845..848 "Int" [] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_curly_token: R_CURLY@752..754 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@848..850 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlObjectTypeDefinition {
+            description: missing (optional),
+            type_token: TYPE_KW@850..857 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@857..862 "type" [] [Whitespace(" ")],
+            },
+            implements: GraphqlImplementsInterfaces {
+                implements_token: IMPLEMENTS_KW@862..873 "implements" [] [Whitespace(" ")],
+                amp_token: missing (optional),
+                interfaces: GraphqlImplementsInterfaceList [
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@873..878 "type" [] [Whitespace(" ")],
+                        },
+                    },
+                ],
+            },
+            directives: GraphqlDirectiveList [],
+            fields: GraphqlFieldsDefinition {
+                l_curly_token: L_CURLY@878..879 "{" [] [],
+                fields: GraphqlFieldDefinitionList [
+                    GraphqlFieldDefinition {
+                        description: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@879..886 "type" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        arguments: missing (optional),
+                        colon_token: COLON@886..888 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@888..892 "type" [] [],
+                            },
+                        },
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_curly_token: R_CURLY@892..894 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@754..756 "" [Newline("\n"), Newline("\n")] [],
+    eof_token: EOF@894..896 "" [Newline("\n"), Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..756
+0: GRAPHQL_ROOT@0..896
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..754
+  1: GRAPHQL_DEFINITION_LIST@0..894
     0: GRAPHQL_OBJECT_TYPE_DEFINITION@0..56
       0: (empty)
       1: TYPE_KW@0..5 "type" [] [Whitespace(" ")]
@@ -684,319 +793,387 @@ GraphqlRoot {
                 0: GRAPHQL_NAME@92..98 "String" [] []
             5: GRAPHQL_DIRECTIVE_LIST@98..98
         2: R_CURLY@98..100 "}" [Newline("\n")] []
-    2: GRAPHQL_OBJECT_TYPE_DEFINITION@100..165
+    2: GRAPHQL_OBJECT_TYPE_DEFINITION@100..155
       0: (empty)
       1: TYPE_KW@100..107 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@107..114
-        0: GRAPHQL_NAME@107..114 "Person" [] [Whitespace(" ")]
-      3: GRAPHQL_IMPLEMENTS_INTERFACES@114..135
-        0: IMPLEMENTS_KW@114..125 "implements" [] [Whitespace(" ")]
-        1: (empty)
-        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@125..135
-          0: GRAPHQL_NAMED_TYPE@125..135
-            0: GRAPHQL_NAME@125..135
-              0: GRAPHQL_NAME@125..135 "Character" [] [Whitespace(" ")]
-      4: GRAPHQL_DIRECTIVE_LIST@135..147
-        0: GRAPHQL_DIRECTIVE@135..147
-          0: AT@135..136 "@" [] []
-          1: GRAPHQL_NAME@136..147
-            0: GRAPHQL_NAME@136..147 "deprecated" [] [Whitespace(" ")]
-          2: (empty)
-      5: GRAPHQL_FIELDS_DEFINITION@147..165
-        0: L_CURLY@147..148 "{" [] []
-        1: GRAPHQL_FIELD_DEFINITION_LIST@148..163
-          0: GRAPHQL_FIELD_DEFINITION@148..163
-            0: (empty)
-            1: GRAPHQL_NAME@148..155
-              0: GRAPHQL_NAME@148..155 "name" [Newline("\n"), Whitespace("  ")] []
+        0: GRAPHQL_NAME@107..114 "Animal" [] [Whitespace(" ")]
+      3: (empty)
+      4: GRAPHQL_DIRECTIVE_LIST@114..114
+      5: GRAPHQL_FIELDS_DEFINITION@114..155
+        0: L_CURLY@114..115 "{" [] []
+        1: GRAPHQL_FIELD_DEFINITION_LIST@115..153
+          0: GRAPHQL_FIELD_DEFINITION@115..153
+            0: GRAPHQL_DESCRIPTION@115..138
+              0: GRAPHQL_STRING_VALUE@115..138
+                0: GRAPHQL_STRING_LITERAL@115..138 "\"type of the animal\"" [Newline("\n"), Whitespace("  ")] []
+            1: GRAPHQL_NAME@138..145
+              0: GRAPHQL_NAME@138..145 "type" [Newline("\n"), Whitespace("  ")] []
             2: (empty)
-            3: COLON@155..157 ":" [] [Whitespace(" ")]
-            4: GRAPHQL_NAMED_TYPE@157..163
-              0: GRAPHQL_NAME@157..163
-                0: GRAPHQL_NAME@157..163 "String" [] []
-            5: GRAPHQL_DIRECTIVE_LIST@163..163
-        2: R_CURLY@163..165 "}" [Newline("\n")] []
-    3: GRAPHQL_OBJECT_TYPE_DEFINITION@165..218
+            3: COLON@145..147 ":" [] [Whitespace(" ")]
+            4: GRAPHQL_NAMED_TYPE@147..153
+              0: GRAPHQL_NAME@147..153
+                0: GRAPHQL_NAME@147..153 "String" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@153..153
+        2: R_CURLY@153..155 "}" [Newline("\n")] []
+    3: GRAPHQL_OBJECT_TYPE_DEFINITION@155..220
       0: (empty)
-      1: TYPE_KW@165..172 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@172..179
-        0: GRAPHQL_NAME@172..179 "Person" [] [Whitespace(" ")]
-      3: GRAPHQL_IMPLEMENTS_INTERFACES@179..200
-        0: IMPLEMENTS_KW@179..190 "implements" [] [Whitespace(" ")]
+      1: TYPE_KW@155..162 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@162..169
+        0: GRAPHQL_NAME@162..169 "Person" [] [Whitespace(" ")]
+      3: GRAPHQL_IMPLEMENTS_INTERFACES@169..190
+        0: IMPLEMENTS_KW@169..180 "implements" [] [Whitespace(" ")]
         1: (empty)
-        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@190..200
-          0: GRAPHQL_NAMED_TYPE@190..200
-            0: GRAPHQL_NAME@190..200
-              0: GRAPHQL_NAME@190..200 "Character" [] [Whitespace(" ")]
-      4: GRAPHQL_DIRECTIVE_LIST@200..200
-      5: GRAPHQL_FIELDS_DEFINITION@200..218
-        0: L_CURLY@200..201 "{" [] []
-        1: GRAPHQL_FIELD_DEFINITION_LIST@201..216
-          0: GRAPHQL_FIELD_DEFINITION@201..216
+        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@180..190
+          0: GRAPHQL_NAMED_TYPE@180..190
+            0: GRAPHQL_NAME@180..190
+              0: GRAPHQL_NAME@180..190 "Character" [] [Whitespace(" ")]
+      4: GRAPHQL_DIRECTIVE_LIST@190..202
+        0: GRAPHQL_DIRECTIVE@190..202
+          0: AT@190..191 "@" [] []
+          1: GRAPHQL_NAME@191..202
+            0: GRAPHQL_NAME@191..202 "deprecated" [] [Whitespace(" ")]
+          2: (empty)
+      5: GRAPHQL_FIELDS_DEFINITION@202..220
+        0: L_CURLY@202..203 "{" [] []
+        1: GRAPHQL_FIELD_DEFINITION_LIST@203..218
+          0: GRAPHQL_FIELD_DEFINITION@203..218
             0: (empty)
-            1: GRAPHQL_NAME@201..208
-              0: GRAPHQL_NAME@201..208 "name" [Newline("\n"), Whitespace("  ")] []
+            1: GRAPHQL_NAME@203..210
+              0: GRAPHQL_NAME@203..210 "name" [Newline("\n"), Whitespace("  ")] []
             2: (empty)
-            3: COLON@208..210 ":" [] [Whitespace(" ")]
-            4: GRAPHQL_NAMED_TYPE@210..216
-              0: GRAPHQL_NAME@210..216
-                0: GRAPHQL_NAME@210..216 "String" [] []
-            5: GRAPHQL_DIRECTIVE_LIST@216..216
-        2: R_CURLY@216..218 "}" [Newline("\n")] []
-    4: GRAPHQL_OBJECT_TYPE_DEFINITION@218..231
+            3: COLON@210..212 ":" [] [Whitespace(" ")]
+            4: GRAPHQL_NAMED_TYPE@212..218
+              0: GRAPHQL_NAME@212..218
+                0: GRAPHQL_NAME@212..218 "String" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@218..218
+        2: R_CURLY@218..220 "}" [Newline("\n")] []
+    4: GRAPHQL_OBJECT_TYPE_DEFINITION@220..273
       0: (empty)
-      1: TYPE_KW@218..225 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@225..231
-        0: GRAPHQL_NAME@225..231 "Person" [] []
-      3: (empty)
-      4: GRAPHQL_DIRECTIVE_LIST@231..231
-      5: (empty)
-    5: GRAPHQL_OBJECT_TYPE_DEFINITION@231..265
-      0: (empty)
-      1: TYPE_KW@231..238 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@238..245
-        0: GRAPHQL_NAME@238..245 "Person" [] [Whitespace(" ")]
-      3: GRAPHQL_IMPLEMENTS_INTERFACES@245..265
-        0: IMPLEMENTS_KW@245..256 "implements" [] [Whitespace(" ")]
+      1: TYPE_KW@220..227 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@227..234
+        0: GRAPHQL_NAME@227..234 "Person" [] [Whitespace(" ")]
+      3: GRAPHQL_IMPLEMENTS_INTERFACES@234..255
+        0: IMPLEMENTS_KW@234..245 "implements" [] [Whitespace(" ")]
         1: (empty)
-        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@256..265
-          0: GRAPHQL_NAMED_TYPE@256..265
-            0: GRAPHQL_NAME@256..265
-              0: GRAPHQL_NAME@256..265 "Character" [] []
-      4: GRAPHQL_DIRECTIVE_LIST@265..265
-      5: (empty)
-    6: GRAPHQL_OBJECT_TYPE_DEFINITION@265..290
-      0: (empty)
-      1: TYPE_KW@265..272 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@272..279
-        0: GRAPHQL_NAME@272..279 "Person" [] [Whitespace(" ")]
-      3: (empty)
-      4: GRAPHQL_DIRECTIVE_LIST@279..290
-        0: GRAPHQL_DIRECTIVE@279..290
-          0: AT@279..280 "@" [] []
-          1: GRAPHQL_NAME@280..290
-            0: GRAPHQL_NAME@280..290 "deprecated" [] []
-          2: (empty)
-      5: (empty)
-    7: GRAPHQL_OBJECT_TYPE_DEFINITION@290..336
-      0: (empty)
-      1: TYPE_KW@290..297 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@297..304
-        0: GRAPHQL_NAME@297..304 "Person" [] [Whitespace(" ")]
-      3: GRAPHQL_IMPLEMENTS_INTERFACES@304..325
-        0: IMPLEMENTS_KW@304..315 "implements" [] [Whitespace(" ")]
-        1: (empty)
-        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@315..325
-          0: GRAPHQL_NAMED_TYPE@315..325
-            0: GRAPHQL_NAME@315..325
-              0: GRAPHQL_NAME@315..325 "Character" [] [Whitespace(" ")]
-      4: GRAPHQL_DIRECTIVE_LIST@325..336
-        0: GRAPHQL_DIRECTIVE@325..336
-          0: AT@325..326 "@" [] []
-          1: GRAPHQL_NAME@326..336
-            0: GRAPHQL_NAME@326..336 "deprecated" [] []
-          2: (empty)
-      5: (empty)
-    8: GRAPHQL_OBJECT_TYPE_DEFINITION@336..395
-      0: (empty)
-      1: TYPE_KW@336..343 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@343..350
-        0: GRAPHQL_NAME@343..350 "Person" [] [Whitespace(" ")]
-      3: GRAPHQL_IMPLEMENTS_INTERFACES@350..384
-        0: IMPLEMENTS_KW@350..361 "implements" [] [Whitespace(" ")]
-        1: (empty)
-        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@361..384
-          0: GRAPHQL_NAMED_TYPE@361..371
-            0: GRAPHQL_NAME@361..371
-              0: GRAPHQL_NAME@361..371 "Character" [] [Whitespace(" ")]
-          1: AMP@371..373 "&" [] [Whitespace(" ")]
-          2: GRAPHQL_NAMED_TYPE@373..384
-            0: GRAPHQL_NAME@373..384
-              0: GRAPHQL_NAME@373..384 "Character1" [] [Whitespace(" ")]
-      4: GRAPHQL_DIRECTIVE_LIST@384..395
-        0: GRAPHQL_DIRECTIVE@384..395
-          0: AT@384..385 "@" [] []
-          1: GRAPHQL_NAME@385..395
-            0: GRAPHQL_NAME@385..395 "deprecated" [] []
-          2: (empty)
-      5: (empty)
-    9: GRAPHQL_OBJECT_TYPE_DEFINITION@395..754
-      0: GRAPHQL_DESCRIPTION@395..415
-        0: GRAPHQL_STRING_VALUE@395..415
-          0: GRAPHQL_STRING_LITERAL@395..415 "\"This is a person\"" [Newline("\n"), Newline("\n")] []
-      1: TYPE_KW@415..421 "type" [Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@421..428
-        0: GRAPHQL_NAME@421..428 "Person" [] [Whitespace(" ")]
-      3: (empty)
-      4: GRAPHQL_DIRECTIVE_LIST@428..428
-      5: GRAPHQL_FIELDS_DEFINITION@428..754
-        0: L_CURLY@428..429 "{" [] []
-        1: GRAPHQL_FIELD_DEFINITION_LIST@429..752
-          0: GRAPHQL_FIELD_DEFINITION@429..464
+        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@245..255
+          0: GRAPHQL_NAMED_TYPE@245..255
+            0: GRAPHQL_NAME@245..255
+              0: GRAPHQL_NAME@245..255 "Character" [] [Whitespace(" ")]
+      4: GRAPHQL_DIRECTIVE_LIST@255..255
+      5: GRAPHQL_FIELDS_DEFINITION@255..273
+        0: L_CURLY@255..256 "{" [] []
+        1: GRAPHQL_FIELD_DEFINITION_LIST@256..271
+          0: GRAPHQL_FIELD_DEFINITION@256..271
             0: (empty)
-            1: GRAPHQL_NAME@429..436
-              0: GRAPHQL_NAME@429..436 "name" [Newline("\n"), Whitespace("  ")] []
-            2: GRAPHQL_ARGUMENTS_DEFINITION@436..456
-              0: L_PAREN@436..437 "(" [] []
-              1: GRAPHQL_ARGUMENT_DEFINITION_LIST@437..455
-                0: GRAPHQL_INPUT_VALUE_DEFINITION@437..455
+            1: GRAPHQL_NAME@256..263
+              0: GRAPHQL_NAME@256..263 "name" [Newline("\n"), Whitespace("  ")] []
+            2: (empty)
+            3: COLON@263..265 ":" [] [Whitespace(" ")]
+            4: GRAPHQL_NAMED_TYPE@265..271
+              0: GRAPHQL_NAME@265..271
+                0: GRAPHQL_NAME@265..271 "String" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@271..271
+        2: R_CURLY@271..273 "}" [Newline("\n")] []
+    5: GRAPHQL_OBJECT_TYPE_DEFINITION@273..286
+      0: (empty)
+      1: TYPE_KW@273..280 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@280..286
+        0: GRAPHQL_NAME@280..286 "Person" [] []
+      3: (empty)
+      4: GRAPHQL_DIRECTIVE_LIST@286..286
+      5: (empty)
+    6: GRAPHQL_OBJECT_TYPE_DEFINITION@286..320
+      0: (empty)
+      1: TYPE_KW@286..293 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@293..300
+        0: GRAPHQL_NAME@293..300 "Person" [] [Whitespace(" ")]
+      3: GRAPHQL_IMPLEMENTS_INTERFACES@300..320
+        0: IMPLEMENTS_KW@300..311 "implements" [] [Whitespace(" ")]
+        1: (empty)
+        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@311..320
+          0: GRAPHQL_NAMED_TYPE@311..320
+            0: GRAPHQL_NAME@311..320
+              0: GRAPHQL_NAME@311..320 "Character" [] []
+      4: GRAPHQL_DIRECTIVE_LIST@320..320
+      5: (empty)
+    7: GRAPHQL_OBJECT_TYPE_DEFINITION@320..361
+      0: (empty)
+      1: TYPE_KW@320..327 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@327..334
+        0: GRAPHQL_NAME@327..334 "Person" [] [Whitespace(" ")]
+      3: GRAPHQL_IMPLEMENTS_INTERFACES@334..361
+        0: IMPLEMENTS_KW@334..345 "implements" [] [Whitespace(" ")]
+        1: (empty)
+        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@345..361
+          0: GRAPHQL_NAMED_TYPE@345..355
+            0: GRAPHQL_NAME@345..355
+              0: GRAPHQL_NAME@345..355 "Character" [] [Whitespace(" ")]
+          1: AMP@355..357 "&" [] [Whitespace(" ")]
+          2: GRAPHQL_NAMED_TYPE@357..361
+            0: GRAPHQL_NAME@357..361
+              0: GRAPHQL_NAME@357..361 "type" [] []
+      4: GRAPHQL_DIRECTIVE_LIST@361..361
+      5: (empty)
+    8: GRAPHQL_OBJECT_TYPE_DEFINITION@361..386
+      0: (empty)
+      1: TYPE_KW@361..368 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@368..375
+        0: GRAPHQL_NAME@368..375 "Person" [] [Whitespace(" ")]
+      3: (empty)
+      4: GRAPHQL_DIRECTIVE_LIST@375..386
+        0: GRAPHQL_DIRECTIVE@375..386
+          0: AT@375..376 "@" [] []
+          1: GRAPHQL_NAME@376..386
+            0: GRAPHQL_NAME@376..386 "deprecated" [] []
+          2: (empty)
+      5: (empty)
+    9: GRAPHQL_OBJECT_TYPE_DEFINITION@386..432
+      0: (empty)
+      1: TYPE_KW@386..393 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@393..400
+        0: GRAPHQL_NAME@393..400 "Person" [] [Whitespace(" ")]
+      3: GRAPHQL_IMPLEMENTS_INTERFACES@400..421
+        0: IMPLEMENTS_KW@400..411 "implements" [] [Whitespace(" ")]
+        1: (empty)
+        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@411..421
+          0: GRAPHQL_NAMED_TYPE@411..421
+            0: GRAPHQL_NAME@411..421
+              0: GRAPHQL_NAME@411..421 "Character" [] [Whitespace(" ")]
+      4: GRAPHQL_DIRECTIVE_LIST@421..432
+        0: GRAPHQL_DIRECTIVE@421..432
+          0: AT@421..422 "@" [] []
+          1: GRAPHQL_NAME@422..432
+            0: GRAPHQL_NAME@422..432 "deprecated" [] []
+          2: (empty)
+      5: (empty)
+    10: GRAPHQL_OBJECT_TYPE_DEFINITION@432..491
+      0: (empty)
+      1: TYPE_KW@432..439 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@439..446
+        0: GRAPHQL_NAME@439..446 "Person" [] [Whitespace(" ")]
+      3: GRAPHQL_IMPLEMENTS_INTERFACES@446..480
+        0: IMPLEMENTS_KW@446..457 "implements" [] [Whitespace(" ")]
+        1: (empty)
+        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@457..480
+          0: GRAPHQL_NAMED_TYPE@457..467
+            0: GRAPHQL_NAME@457..467
+              0: GRAPHQL_NAME@457..467 "Character" [] [Whitespace(" ")]
+          1: AMP@467..469 "&" [] [Whitespace(" ")]
+          2: GRAPHQL_NAMED_TYPE@469..480
+            0: GRAPHQL_NAME@469..480
+              0: GRAPHQL_NAME@469..480 "Character1" [] [Whitespace(" ")]
+      4: GRAPHQL_DIRECTIVE_LIST@480..491
+        0: GRAPHQL_DIRECTIVE@480..491
+          0: AT@480..481 "@" [] []
+          1: GRAPHQL_NAME@481..491
+            0: GRAPHQL_NAME@481..491 "deprecated" [] []
+          2: (empty)
+      5: (empty)
+    11: GRAPHQL_OBJECT_TYPE_DEFINITION@491..850
+      0: GRAPHQL_DESCRIPTION@491..511
+        0: GRAPHQL_STRING_VALUE@491..511
+          0: GRAPHQL_STRING_LITERAL@491..511 "\"This is a person\"" [Newline("\n"), Newline("\n")] []
+      1: TYPE_KW@511..517 "type" [Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@517..524
+        0: GRAPHQL_NAME@517..524 "Person" [] [Whitespace(" ")]
+      3: (empty)
+      4: GRAPHQL_DIRECTIVE_LIST@524..524
+      5: GRAPHQL_FIELDS_DEFINITION@524..850
+        0: L_CURLY@524..525 "{" [] []
+        1: GRAPHQL_FIELD_DEFINITION_LIST@525..848
+          0: GRAPHQL_FIELD_DEFINITION@525..560
+            0: (empty)
+            1: GRAPHQL_NAME@525..532
+              0: GRAPHQL_NAME@525..532 "name" [Newline("\n"), Whitespace("  ")] []
+            2: GRAPHQL_ARGUMENTS_DEFINITION@532..552
+              0: L_PAREN@532..533 "(" [] []
+              1: GRAPHQL_ARGUMENT_DEFINITION_LIST@533..551
+                0: GRAPHQL_INPUT_VALUE_DEFINITION@533..551
                   0: (empty)
-                  1: GRAPHQL_NAME@437..447
-                    0: GRAPHQL_NAME@437..447 "start_with" [] []
-                  2: COLON@447..449 ":" [] [Whitespace(" ")]
-                  3: GRAPHQL_NAMED_TYPE@449..455
-                    0: GRAPHQL_NAME@449..455
-                      0: GRAPHQL_NAME@449..455 "String" [] []
+                  1: GRAPHQL_NAME@533..543
+                    0: GRAPHQL_NAME@533..543 "start_with" [] []
+                  2: COLON@543..545 ":" [] [Whitespace(" ")]
+                  3: GRAPHQL_NAMED_TYPE@545..551
+                    0: GRAPHQL_NAME@545..551
+                      0: GRAPHQL_NAME@545..551 "String" [] []
                   4: (empty)
-                  5: GRAPHQL_DIRECTIVE_LIST@455..455
-              2: R_PAREN@455..456 ")" [] []
-            3: COLON@456..458 ":" [] [Whitespace(" ")]
-            4: GRAPHQL_NAMED_TYPE@458..464
-              0: GRAPHQL_NAME@458..464
-                0: GRAPHQL_NAME@458..464 "String" [] []
-            5: GRAPHQL_DIRECTIVE_LIST@464..464
-          1: GRAPHQL_FIELD_DEFINITION@464..503
-            0: GRAPHQL_DESCRIPTION@464..483
-              0: GRAPHQL_STRING_VALUE@464..483
-                0: GRAPHQL_STRING_LITERAL@464..483 "\"filder by age\"" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-            1: GRAPHQL_NAME@483..486
-              0: GRAPHQL_NAME@483..486 "age" [] []
+                  5: GRAPHQL_DIRECTIVE_LIST@551..551
+              2: R_PAREN@551..552 ")" [] []
+            3: COLON@552..554 ":" [] [Whitespace(" ")]
+            4: GRAPHQL_NAMED_TYPE@554..560
+              0: GRAPHQL_NAME@554..560
+                0: GRAPHQL_NAME@554..560 "String" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@560..560
+          1: GRAPHQL_FIELD_DEFINITION@560..599
+            0: GRAPHQL_DESCRIPTION@560..579
+              0: GRAPHQL_STRING_VALUE@560..579
+                0: GRAPHQL_STRING_LITERAL@560..579 "\"filder by age\"" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            1: GRAPHQL_NAME@579..582
+              0: GRAPHQL_NAME@579..582 "age" [] []
             2: (empty)
-            3: COLON@486..488 ":" [] [Whitespace(" ")]
-            4: GRAPHQL_NAMED_TYPE@488..492
-              0: GRAPHQL_NAME@488..492
-                0: GRAPHQL_NAME@488..492 "Int" [] [Whitespace(" ")]
-            5: GRAPHQL_DIRECTIVE_LIST@492..503
-              0: GRAPHQL_DIRECTIVE@492..503
-                0: AT@492..493 "@" [] []
-                1: GRAPHQL_NAME@493..503
-                  0: GRAPHQL_NAME@493..503 "deprecated" [] []
+            3: COLON@582..584 ":" [] [Whitespace(" ")]
+            4: GRAPHQL_NAMED_TYPE@584..588
+              0: GRAPHQL_NAME@584..588
+                0: GRAPHQL_NAME@584..588 "Int" [] [Whitespace(" ")]
+            5: GRAPHQL_DIRECTIVE_LIST@588..599
+              0: GRAPHQL_DIRECTIVE@588..599
+                0: AT@588..589 "@" [] []
+                1: GRAPHQL_NAME@589..599
+                  0: GRAPHQL_NAME@589..599 "deprecated" [] []
                 2: (empty)
-          2: GRAPHQL_FIELD_DEFINITION@503..533
+          2: GRAPHQL_FIELD_DEFINITION@599..629
             0: (empty)
-            1: GRAPHQL_NAME@503..513
-              0: GRAPHQL_NAME@503..513 "picture" [Newline("\n"), Whitespace("  ")] []
-            2: GRAPHQL_ARGUMENTS_DEFINITION@513..528
-              0: L_PAREN@513..514 "(" [] []
-              1: GRAPHQL_ARGUMENT_DEFINITION_LIST@514..527
-                0: GRAPHQL_INPUT_VALUE_DEFINITION@514..527
+            1: GRAPHQL_NAME@599..609
+              0: GRAPHQL_NAME@599..609 "picture" [Newline("\n"), Whitespace("  ")] []
+            2: GRAPHQL_ARGUMENTS_DEFINITION@609..624
+              0: L_PAREN@609..610 "(" [] []
+              1: GRAPHQL_ARGUMENT_DEFINITION_LIST@610..623
+                0: GRAPHQL_INPUT_VALUE_DEFINITION@610..623
                   0: (empty)
-                  1: GRAPHQL_NAME@514..518
-                    0: GRAPHQL_NAME@514..518 "size" [] []
-                  2: COLON@518..520 ":" [] [Whitespace(" ")]
-                  3: GRAPHQL_NAMED_TYPE@520..524
-                    0: GRAPHQL_NAME@520..524
-                      0: GRAPHQL_NAME@520..524 "Int" [] [Whitespace(" ")]
-                  4: GRAPHQL_DEFAULT_VALUE@524..527
-                    0: EQ@524..526 "=" [] [Whitespace(" ")]
-                    1: GRAPHQL_INT_VALUE@526..527
-                      0: GRAPHQL_INT_LITERAL@526..527 "0" [] []
-                  5: GRAPHQL_DIRECTIVE_LIST@527..527
-              2: R_PAREN@527..528 ")" [] []
-            3: COLON@528..530 ":" [] [Whitespace(" ")]
-            4: GRAPHQL_NAMED_TYPE@530..533
-              0: GRAPHQL_NAME@530..533
-                0: GRAPHQL_NAME@530..533 "Url" [] []
-            5: GRAPHQL_DIRECTIVE_LIST@533..533
-          3: GRAPHQL_FIELD_DEFINITION@533..597
+                  1: GRAPHQL_NAME@610..614
+                    0: GRAPHQL_NAME@610..614 "size" [] []
+                  2: COLON@614..616 ":" [] [Whitespace(" ")]
+                  3: GRAPHQL_NAMED_TYPE@616..620
+                    0: GRAPHQL_NAME@616..620
+                      0: GRAPHQL_NAME@616..620 "Int" [] [Whitespace(" ")]
+                  4: GRAPHQL_DEFAULT_VALUE@620..623
+                    0: EQ@620..622 "=" [] [Whitespace(" ")]
+                    1: GRAPHQL_INT_VALUE@622..623
+                      0: GRAPHQL_INT_LITERAL@622..623 "0" [] []
+                  5: GRAPHQL_DIRECTIVE_LIST@623..623
+              2: R_PAREN@623..624 ")" [] []
+            3: COLON@624..626 ":" [] [Whitespace(" ")]
+            4: GRAPHQL_NAMED_TYPE@626..629
+              0: GRAPHQL_NAME@626..629
+                0: GRAPHQL_NAME@626..629 "Url" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@629..629
+          3: GRAPHQL_FIELD_DEFINITION@629..693
             0: (empty)
-            1: GRAPHQL_NAME@533..542
-              0: GRAPHQL_NAME@533..542 "height" [Newline("\n"), Whitespace("  ")] []
-            2: GRAPHQL_ARGUMENTS_DEFINITION@542..592
-              0: L_PAREN@542..543 "(" [] []
-              1: GRAPHQL_ARGUMENT_DEFINITION_LIST@543..591
-                0: GRAPHQL_INPUT_VALUE_DEFINITION@543..591
-                  0: GRAPHQL_DESCRIPTION@543..562
-                    0: GRAPHQL_STRING_VALUE@543..562
-                      0: GRAPHQL_STRING_LITERAL@543..562 "\"filter by height\"" [] [Whitespace(" ")]
-                  1: GRAPHQL_NAME@562..574
-                    0: GRAPHQL_NAME@562..574 "greater_than" [] []
-                  2: COLON@574..576 ":" [] [Whitespace(" ")]
-                  3: GRAPHQL_NAMED_TYPE@576..580
-                    0: GRAPHQL_NAME@576..580
-                      0: GRAPHQL_NAME@576..580 "Int" [] [Whitespace(" ")]
+            1: GRAPHQL_NAME@629..638
+              0: GRAPHQL_NAME@629..638 "height" [Newline("\n"), Whitespace("  ")] []
+            2: GRAPHQL_ARGUMENTS_DEFINITION@638..688
+              0: L_PAREN@638..639 "(" [] []
+              1: GRAPHQL_ARGUMENT_DEFINITION_LIST@639..687
+                0: GRAPHQL_INPUT_VALUE_DEFINITION@639..687
+                  0: GRAPHQL_DESCRIPTION@639..658
+                    0: GRAPHQL_STRING_VALUE@639..658
+                      0: GRAPHQL_STRING_LITERAL@639..658 "\"filter by height\"" [] [Whitespace(" ")]
+                  1: GRAPHQL_NAME@658..670
+                    0: GRAPHQL_NAME@658..670 "greater_than" [] []
+                  2: COLON@670..672 ":" [] [Whitespace(" ")]
+                  3: GRAPHQL_NAMED_TYPE@672..676
+                    0: GRAPHQL_NAME@672..676
+                      0: GRAPHQL_NAME@672..676 "Int" [] [Whitespace(" ")]
                   4: (empty)
-                  5: GRAPHQL_DIRECTIVE_LIST@580..591
-                    0: GRAPHQL_DIRECTIVE@580..591
-                      0: AT@580..581 "@" [] []
-                      1: GRAPHQL_NAME@581..591
-                        0: GRAPHQL_NAME@581..591 "deprecated" [] []
+                  5: GRAPHQL_DIRECTIVE_LIST@676..687
+                    0: GRAPHQL_DIRECTIVE@676..687
+                      0: AT@676..677 "@" [] []
+                      1: GRAPHQL_NAME@677..687
+                        0: GRAPHQL_NAME@677..687 "deprecated" [] []
                       2: (empty)
-              2: R_PAREN@591..592 ")" [] []
-            3: COLON@592..594 ":" [] [Whitespace(" ")]
-            4: GRAPHQL_NAMED_TYPE@594..597
-              0: GRAPHQL_NAME@594..597
-                0: GRAPHQL_NAME@594..597 "Int" [] []
-            5: GRAPHQL_DIRECTIVE_LIST@597..597
-          4: GRAPHQL_FIELD_DEFINITION@597..665
+              2: R_PAREN@687..688 ")" [] []
+            3: COLON@688..690 ":" [] [Whitespace(" ")]
+            4: GRAPHQL_NAMED_TYPE@690..693
+              0: GRAPHQL_NAME@690..693
+                0: GRAPHQL_NAME@690..693 "Int" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@693..693
+          4: GRAPHQL_FIELD_DEFINITION@693..761
             0: (empty)
-            1: GRAPHQL_NAME@597..606
-              0: GRAPHQL_NAME@597..606 "weight" [Newline("\n"), Whitespace("  ")] []
-            2: GRAPHQL_ARGUMENTS_DEFINITION@606..660
-              0: L_PAREN@606..607 "(" [] []
-              1: GRAPHQL_ARGUMENT_DEFINITION_LIST@607..659
-                0: GRAPHQL_INPUT_VALUE_DEFINITION@607..659
-                  0: GRAPHQL_DESCRIPTION@607..626
-                    0: GRAPHQL_STRING_VALUE@607..626
-                      0: GRAPHQL_STRING_LITERAL@607..626 "\"filter by weight\"" [] [Whitespace(" ")]
-                  1: GRAPHQL_NAME@626..638
-                    0: GRAPHQL_NAME@626..638 "greater_than" [] []
-                  2: COLON@638..640 ":" [] [Whitespace(" ")]
-                  3: GRAPHQL_NAMED_TYPE@640..644
-                    0: GRAPHQL_NAME@640..644
-                      0: GRAPHQL_NAME@640..644 "Int" [] [Whitespace(" ")]
-                  4: GRAPHQL_DEFAULT_VALUE@644..648
-                    0: EQ@644..646 "=" [] [Whitespace(" ")]
-                    1: GRAPHQL_INT_VALUE@646..648
-                      0: GRAPHQL_INT_LITERAL@646..648 "0" [] [Whitespace(" ")]
-                  5: GRAPHQL_DIRECTIVE_LIST@648..659
-                    0: GRAPHQL_DIRECTIVE@648..659
-                      0: AT@648..649 "@" [] []
-                      1: GRAPHQL_NAME@649..659
-                        0: GRAPHQL_NAME@649..659 "deprecated" [] []
+            1: GRAPHQL_NAME@693..702
+              0: GRAPHQL_NAME@693..702 "weight" [Newline("\n"), Whitespace("  ")] []
+            2: GRAPHQL_ARGUMENTS_DEFINITION@702..756
+              0: L_PAREN@702..703 "(" [] []
+              1: GRAPHQL_ARGUMENT_DEFINITION_LIST@703..755
+                0: GRAPHQL_INPUT_VALUE_DEFINITION@703..755
+                  0: GRAPHQL_DESCRIPTION@703..722
+                    0: GRAPHQL_STRING_VALUE@703..722
+                      0: GRAPHQL_STRING_LITERAL@703..722 "\"filter by weight\"" [] [Whitespace(" ")]
+                  1: GRAPHQL_NAME@722..734
+                    0: GRAPHQL_NAME@722..734 "greater_than" [] []
+                  2: COLON@734..736 ":" [] [Whitespace(" ")]
+                  3: GRAPHQL_NAMED_TYPE@736..740
+                    0: GRAPHQL_NAME@736..740
+                      0: GRAPHQL_NAME@736..740 "Int" [] [Whitespace(" ")]
+                  4: GRAPHQL_DEFAULT_VALUE@740..744
+                    0: EQ@740..742 "=" [] [Whitespace(" ")]
+                    1: GRAPHQL_INT_VALUE@742..744
+                      0: GRAPHQL_INT_LITERAL@742..744 "0" [] [Whitespace(" ")]
+                  5: GRAPHQL_DIRECTIVE_LIST@744..755
+                    0: GRAPHQL_DIRECTIVE@744..755
+                      0: AT@744..745 "@" [] []
+                      1: GRAPHQL_NAME@745..755
+                        0: GRAPHQL_NAME@745..755 "deprecated" [] []
                       2: (empty)
-              2: R_PAREN@659..660 ")" [] []
-            3: COLON@660..662 ":" [] [Whitespace(" ")]
-            4: GRAPHQL_NAMED_TYPE@662..665
-              0: GRAPHQL_NAME@662..665
-                0: GRAPHQL_NAME@662..665 "Int" [] []
-            5: GRAPHQL_DIRECTIVE_LIST@665..665
-          5: GRAPHQL_FIELD_DEFINITION@665..752
-            0: GRAPHQL_DESCRIPTION@665..687
-              0: GRAPHQL_STRING_VALUE@665..687
-                0: GRAPHQL_STRING_LITERAL@665..687 "\"filter by weight\"" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-            1: GRAPHQL_NAME@687..693
-              0: GRAPHQL_NAME@687..693 "weight" [] []
-            2: GRAPHQL_ARGUMENTS_DEFINITION@693..747
-              0: L_PAREN@693..694 "(" [] []
-              1: GRAPHQL_ARGUMENT_DEFINITION_LIST@694..746
-                0: GRAPHQL_INPUT_VALUE_DEFINITION@694..746
-                  0: GRAPHQL_DESCRIPTION@694..713
-                    0: GRAPHQL_STRING_VALUE@694..713
-                      0: GRAPHQL_STRING_LITERAL@694..713 "\"filter by weight\"" [] [Whitespace(" ")]
-                  1: GRAPHQL_NAME@713..725
-                    0: GRAPHQL_NAME@713..725 "greater_than" [] []
-                  2: COLON@725..727 ":" [] [Whitespace(" ")]
-                  3: GRAPHQL_NAMED_TYPE@727..731
-                    0: GRAPHQL_NAME@727..731
-                      0: GRAPHQL_NAME@727..731 "Int" [] [Whitespace(" ")]
-                  4: GRAPHQL_DEFAULT_VALUE@731..735
-                    0: EQ@731..733 "=" [] [Whitespace(" ")]
-                    1: GRAPHQL_INT_VALUE@733..735
-                      0: GRAPHQL_INT_LITERAL@733..735 "0" [] [Whitespace(" ")]
-                  5: GRAPHQL_DIRECTIVE_LIST@735..746
-                    0: GRAPHQL_DIRECTIVE@735..746
-                      0: AT@735..736 "@" [] []
-                      1: GRAPHQL_NAME@736..746
-                        0: GRAPHQL_NAME@736..746 "deprecated" [] []
+              2: R_PAREN@755..756 ")" [] []
+            3: COLON@756..758 ":" [] [Whitespace(" ")]
+            4: GRAPHQL_NAMED_TYPE@758..761
+              0: GRAPHQL_NAME@758..761
+                0: GRAPHQL_NAME@758..761 "Int" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@761..761
+          5: GRAPHQL_FIELD_DEFINITION@761..848
+            0: GRAPHQL_DESCRIPTION@761..783
+              0: GRAPHQL_STRING_VALUE@761..783
+                0: GRAPHQL_STRING_LITERAL@761..783 "\"filter by weight\"" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            1: GRAPHQL_NAME@783..789
+              0: GRAPHQL_NAME@783..789 "weight" [] []
+            2: GRAPHQL_ARGUMENTS_DEFINITION@789..843
+              0: L_PAREN@789..790 "(" [] []
+              1: GRAPHQL_ARGUMENT_DEFINITION_LIST@790..842
+                0: GRAPHQL_INPUT_VALUE_DEFINITION@790..842
+                  0: GRAPHQL_DESCRIPTION@790..809
+                    0: GRAPHQL_STRING_VALUE@790..809
+                      0: GRAPHQL_STRING_LITERAL@790..809 "\"filter by weight\"" [] [Whitespace(" ")]
+                  1: GRAPHQL_NAME@809..821
+                    0: GRAPHQL_NAME@809..821 "greater_than" [] []
+                  2: COLON@821..823 ":" [] [Whitespace(" ")]
+                  3: GRAPHQL_NAMED_TYPE@823..827
+                    0: GRAPHQL_NAME@823..827
+                      0: GRAPHQL_NAME@823..827 "Int" [] [Whitespace(" ")]
+                  4: GRAPHQL_DEFAULT_VALUE@827..831
+                    0: EQ@827..829 "=" [] [Whitespace(" ")]
+                    1: GRAPHQL_INT_VALUE@829..831
+                      0: GRAPHQL_INT_LITERAL@829..831 "0" [] [Whitespace(" ")]
+                  5: GRAPHQL_DIRECTIVE_LIST@831..842
+                    0: GRAPHQL_DIRECTIVE@831..842
+                      0: AT@831..832 "@" [] []
+                      1: GRAPHQL_NAME@832..842
+                        0: GRAPHQL_NAME@832..842 "deprecated" [] []
                       2: (empty)
-              2: R_PAREN@746..747 ")" [] []
-            3: COLON@747..749 ":" [] [Whitespace(" ")]
-            4: GRAPHQL_NAMED_TYPE@749..752
-              0: GRAPHQL_NAME@749..752
-                0: GRAPHQL_NAME@749..752 "Int" [] []
-            5: GRAPHQL_DIRECTIVE_LIST@752..752
-        2: R_CURLY@752..754 "}" [Newline("\n")] []
-  2: EOF@754..756 "" [Newline("\n"), Newline("\n")] []
+              2: R_PAREN@842..843 ")" [] []
+            3: COLON@843..845 ":" [] [Whitespace(" ")]
+            4: GRAPHQL_NAMED_TYPE@845..848
+              0: GRAPHQL_NAME@845..848
+                0: GRAPHQL_NAME@845..848 "Int" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@848..848
+        2: R_CURLY@848..850 "}" [Newline("\n")] []
+    12: GRAPHQL_OBJECT_TYPE_DEFINITION@850..894
+      0: (empty)
+      1: TYPE_KW@850..857 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@857..862
+        0: GRAPHQL_NAME@857..862 "type" [] [Whitespace(" ")]
+      3: GRAPHQL_IMPLEMENTS_INTERFACES@862..878
+        0: IMPLEMENTS_KW@862..873 "implements" [] [Whitespace(" ")]
+        1: (empty)
+        2: GRAPHQL_IMPLEMENTS_INTERFACE_LIST@873..878
+          0: GRAPHQL_NAMED_TYPE@873..878
+            0: GRAPHQL_NAME@873..878
+              0: GRAPHQL_NAME@873..878 "type" [] [Whitespace(" ")]
+      4: GRAPHQL_DIRECTIVE_LIST@878..878
+      5: GRAPHQL_FIELDS_DEFINITION@878..894
+        0: L_CURLY@878..879 "{" [] []
+        1: GRAPHQL_FIELD_DEFINITION_LIST@879..892
+          0: GRAPHQL_FIELD_DEFINITION@879..892
+            0: (empty)
+            1: GRAPHQL_NAME@879..886
+              0: GRAPHQL_NAME@879..886 "type" [Newline("\n"), Whitespace("  ")] []
+            2: (empty)
+            3: COLON@886..888 ":" [] [Whitespace(" ")]
+            4: GRAPHQL_NAMED_TYPE@888..892
+              0: GRAPHQL_NAME@888..892
+                0: GRAPHQL_NAME@888..892 "type" [] []
+            5: GRAPHQL_DIRECTIVE_LIST@892..892
+        2: R_CURLY@892..894 "}" [Newline("\n")] []
+  2: EOF@894..896 "" [Newline("\n"), Newline("\n")] []
 
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/scalar.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/scalar.graphql
@@ -1,2 +1,4 @@
 scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
 "abc" scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
+
+scalar scalar @scalar(scalar: scalar)

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/scalar.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/scalar.graphql.snap
@@ -7,6 +7,8 @@ expression: snapshot
 scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
 "abc" scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 
+scalar scalar @scalar(scalar: scalar)
+
 ```
 
 ## AST
@@ -79,17 +81,49 @@ GraphqlRoot {
                 },
             ],
         },
+        GraphqlScalarTypeDefinition {
+            description: missing (optional),
+            scalar_token: SCALAR_KW@142..151 "scalar" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@151..158 "scalar" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [
+                GraphqlDirective {
+                    at_token: AT@158..159 "@" [] [],
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@159..165 "scalar" [] [],
+                    },
+                    arguments: GraphqlArguments {
+                        l_paren_token: L_PAREN@165..166 "(" [] [],
+                        arguments: GraphqlArgumentList [
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@166..172 "scalar" [] [],
+                                },
+                                colon_token: COLON@172..174 ":" [] [Whitespace(" ")],
+                                value: GraphqlEnumValue {
+                                    graphql_name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@174..180 "scalar" [] [],
+                                    },
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@180..181 ")" [] [],
+                    },
+                },
+            ],
+        },
     ],
-    eof_token: EOF@142..143 "" [Newline("\n")] [],
+    eof_token: EOF@181..182 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..143
+0: GRAPHQL_ROOT@0..182
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..142
+  1: GRAPHQL_DEFINITION_LIST@0..181
     0: GRAPHQL_SCALAR_TYPE_DEFINITION@0..68
       0: (empty)
       1: SCALAR_KW@0..7 "scalar" [] [Whitespace(" ")]
@@ -132,6 +166,27 @@ GraphqlRoot {
                 2: GRAPHQL_STRING_VALUE@104..141
                   0: GRAPHQL_STRING_LITERAL@104..141 "\"https://tools.ietf.org/html/rfc3986\"" [] []
             2: R_PAREN@141..142 ")" [] []
-  2: EOF@142..143 "" [Newline("\n")] []
+    2: GRAPHQL_SCALAR_TYPE_DEFINITION@142..181
+      0: (empty)
+      1: SCALAR_KW@142..151 "scalar" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@151..158
+        0: GRAPHQL_NAME@151..158 "scalar" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@158..181
+        0: GRAPHQL_DIRECTIVE@158..181
+          0: AT@158..159 "@" [] []
+          1: GRAPHQL_NAME@159..165
+            0: GRAPHQL_NAME@159..165 "scalar" [] []
+          2: GRAPHQL_ARGUMENTS@165..181
+            0: L_PAREN@165..166 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@166..180
+              0: GRAPHQL_ARGUMENT@166..180
+                0: GRAPHQL_NAME@166..172
+                  0: GRAPHQL_NAME@166..172 "scalar" [] []
+                1: COLON@172..174 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_ENUM_VALUE@174..180
+                  0: GRAPHQL_NAME@174..180
+                    0: GRAPHQL_NAME@174..180 "scalar" [] []
+            2: R_PAREN@180..181 ")" [] []
+  2: EOF@181..182 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/schema.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/schema.graphql
@@ -14,3 +14,8 @@ schema {
   query: MyQueryRootType
 }
 
+schema {
+  query: query
+  mutation: mutation
+	subscription: subscription
+}

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/schema.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/schema.graphql.snap
@@ -20,6 +20,11 @@ schema {
   query: MyQueryRootType
 }
 
+schema {
+  query: query
+  mutation: mutation
+	subscription: subscription
+}
 
 ```
 
@@ -130,17 +135,59 @@ GraphqlRoot {
             ],
             r_curly_token: R_CURLY@224..226 "}" [Newline("\n")] [],
         },
+        GraphqlSchemaDefinition {
+            description: missing (optional),
+            schema_token: SCHEMA_KW@226..235 "schema" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            directives: GraphqlDirectiveList [],
+            l_curly_token: L_CURLY@235..236 "{" [] [],
+            root_operation_type: GraphqlRootOperationTypeDefinitionList [
+                GraphqlRootOperationTypeDefinition {
+                    operation_type: GraphqlOperationType {
+                        value_token: QUERY_KW@236..244 "query" [Newline("\n"), Whitespace("  ")] [],
+                    },
+                    colon_token: COLON@244..246 ":" [] [Whitespace(" ")],
+                    named_type: GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@246..251 "query" [] [],
+                        },
+                    },
+                },
+                GraphqlRootOperationTypeDefinition {
+                    operation_type: GraphqlOperationType {
+                        value_token: MUTATION_KW@251..262 "mutation" [Newline("\n"), Whitespace("  ")] [],
+                    },
+                    colon_token: COLON@262..264 ":" [] [Whitespace(" ")],
+                    named_type: GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@264..272 "mutation" [] [],
+                        },
+                    },
+                },
+                GraphqlRootOperationTypeDefinition {
+                    operation_type: GraphqlOperationType {
+                        value_token: SUBSCRIPTION_KW@272..286 "subscription" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                    colon_token: COLON@286..288 ":" [] [Whitespace(" ")],
+                    named_type: GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@288..300 "subscription" [] [],
+                        },
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@300..302 "}" [Newline("\n")] [],
+        },
     ],
-    eof_token: EOF@226..228 "" [Newline("\n"), Newline("\n")] [],
+    eof_token: EOF@302..303 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..228
+0: GRAPHQL_ROOT@0..303
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..226
+  1: GRAPHQL_DEFINITION_LIST@0..302
     0: GRAPHQL_SCHEMA_DEFINITION@0..104
       0: (empty)
       1: SCHEMA_KW@0..7 "schema" [] [Whitespace(" ")]
@@ -208,6 +255,34 @@ GraphqlRoot {
             0: GRAPHQL_NAME@209..224
               0: GRAPHQL_NAME@209..224 "MyQueryRootType" [] []
       5: R_CURLY@224..226 "}" [Newline("\n")] []
-  2: EOF@226..228 "" [Newline("\n"), Newline("\n")] []
+    3: GRAPHQL_SCHEMA_DEFINITION@226..302
+      0: (empty)
+      1: SCHEMA_KW@226..235 "schema" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_DIRECTIVE_LIST@235..235
+      3: L_CURLY@235..236 "{" [] []
+      4: GRAPHQL_ROOT_OPERATION_TYPE_DEFINITION_LIST@236..300
+        0: GRAPHQL_ROOT_OPERATION_TYPE_DEFINITION@236..251
+          0: GRAPHQL_OPERATION_TYPE@236..244
+            0: QUERY_KW@236..244 "query" [Newline("\n"), Whitespace("  ")] []
+          1: COLON@244..246 ":" [] [Whitespace(" ")]
+          2: GRAPHQL_NAMED_TYPE@246..251
+            0: GRAPHQL_NAME@246..251
+              0: GRAPHQL_NAME@246..251 "query" [] []
+        1: GRAPHQL_ROOT_OPERATION_TYPE_DEFINITION@251..272
+          0: GRAPHQL_OPERATION_TYPE@251..262
+            0: MUTATION_KW@251..262 "mutation" [Newline("\n"), Whitespace("  ")] []
+          1: COLON@262..264 ":" [] [Whitespace(" ")]
+          2: GRAPHQL_NAMED_TYPE@264..272
+            0: GRAPHQL_NAME@264..272
+              0: GRAPHQL_NAME@264..272 "mutation" [] []
+        2: GRAPHQL_ROOT_OPERATION_TYPE_DEFINITION@272..300
+          0: GRAPHQL_OPERATION_TYPE@272..286
+            0: SUBSCRIPTION_KW@272..286 "subscription" [Newline("\n"), Whitespace("\t")] []
+          1: COLON@286..288 ":" [] [Whitespace(" ")]
+          2: GRAPHQL_NAMED_TYPE@288..300
+            0: GRAPHQL_NAME@288..300
+              0: GRAPHQL_NAME@288..300 "subscription" [] []
+      5: R_CURLY@300..302 "}" [Newline("\n")] []
+  2: EOF@302..303 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/union.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/union.graphql
@@ -3,8 +3,9 @@ union SearchResult = Photo | Person
 union SearchResult =
 	| Photo
 	| Person
+	| union
 
-union SearchResult
+union union = union | union
 
 union SearchResult @deprecated
 

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/union.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/union.graphql.snap
@@ -9,8 +9,9 @@ union SearchResult = Photo | Person
 union SearchResult =
 	| Photo
 	| Person
+	| union
 
-union SearchResult
+union union = union | union
 
 union SearchResult @deprecated
 
@@ -58,8 +59,10 @@ GraphqlRoot {
             directives: GraphqlDirectiveList [],
             union_members: GraphqlUnionMemberTypes {
                 eq_token: EQ@56..57 "=" [] [],
-                bitwise_or_token: PIPE@57..61 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                bitwise_or_token: missing (optional),
                 members: GraphqlUnionMemberTypeList [
+                    missing element,
+                    PIPE@57..61 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     GraphqlNamedType {
                         name: GraphqlName {
                             value_token: GRAPHQL_NAME@61..66 "Photo" [] [],
@@ -71,29 +74,51 @@ GraphqlRoot {
                             value_token: GRAPHQL_NAME@70..76 "Person" [] [],
                         },
                     },
+                    PIPE@76..80 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@80..85 "union" [] [],
+                        },
+                    },
                 ],
             },
         },
         GraphqlUnionTypeDefinition {
             description: missing (optional),
-            union_token: UNION_KW@76..84 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            union_token: UNION_KW@85..93 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@84..96 "SearchResult" [] [],
+                value_token: GRAPHQL_NAME@93..99 "union" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
-            union_members: missing (optional),
+            union_members: GraphqlUnionMemberTypes {
+                eq_token: EQ@99..101 "=" [] [Whitespace(" ")],
+                bitwise_or_token: missing (optional),
+                members: GraphqlUnionMemberTypeList [
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@101..107 "union" [] [Whitespace(" ")],
+                        },
+                    },
+                    PIPE@107..109 "|" [] [Whitespace(" ")],
+                    GraphqlNamedType {
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@109..114 "union" [] [],
+                        },
+                    },
+                ],
+            },
         },
         GraphqlUnionTypeDefinition {
             description: missing (optional),
-            union_token: UNION_KW@96..104 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            union_token: UNION_KW@114..122 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@104..117 "SearchResult" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@122..135 "SearchResult" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
-                    at_token: AT@117..118 "@" [] [],
+                    at_token: AT@135..136 "@" [] [],
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@118..128 "deprecated" [] [],
+                        value_token: GRAPHQL_NAME@136..146 "deprecated" [] [],
                     },
                     arguments: missing (optional),
                 },
@@ -102,48 +127,48 @@ GraphqlRoot {
         },
         GraphqlUnionTypeDefinition {
             description: missing (optional),
-            union_token: UNION_KW@128..136 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            union_token: UNION_KW@146..154 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             name: GraphqlName {
-                value_token: GRAPHQL_NAME@136..149 "SearchResult" [] [Whitespace(" ")],
+                value_token: GRAPHQL_NAME@154..167 "SearchResult" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
-                    at_token: AT@149..150 "@" [] [],
+                    at_token: AT@167..168 "@" [] [],
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@150..161 "deprecated" [] [Whitespace(" ")],
+                        value_token: GRAPHQL_NAME@168..179 "deprecated" [] [Whitespace(" ")],
                     },
                     arguments: missing (optional),
                 },
             ],
             union_members: GraphqlUnionMemberTypes {
-                eq_token: EQ@161..163 "=" [] [Whitespace(" ")],
+                eq_token: EQ@179..181 "=" [] [Whitespace(" ")],
                 bitwise_or_token: missing (optional),
                 members: GraphqlUnionMemberTypeList [
                     GraphqlNamedType {
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@163..169 "Photo" [] [Whitespace(" ")],
+                            value_token: GRAPHQL_NAME@181..187 "Photo" [] [Whitespace(" ")],
                         },
                     },
-                    PIPE@169..171 "|" [] [Whitespace(" ")],
+                    PIPE@187..189 "|" [] [Whitespace(" ")],
                     GraphqlNamedType {
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@171..177 "Person" [] [],
+                            value_token: GRAPHQL_NAME@189..195 "Person" [] [],
                         },
                     },
                 ],
             },
         },
     ],
-    eof_token: EOF@177..178 "" [Newline("\n")] [],
+    eof_token: EOF@195..196 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..178
+0: GRAPHQL_ROOT@0..196
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..177
+  1: GRAPHQL_DEFINITION_LIST@0..195
     0: GRAPHQL_UNION_TYPE_DEFINITION@0..35
       0: (empty)
       1: UNION_KW@0..6 "union" [] [Whitespace(" ")]
@@ -161,64 +186,80 @@ GraphqlRoot {
           2: GRAPHQL_NAMED_TYPE@29..35
             0: GRAPHQL_NAME@29..35
               0: GRAPHQL_NAME@29..35 "Person" [] []
-    1: GRAPHQL_UNION_TYPE_DEFINITION@35..76
+    1: GRAPHQL_UNION_TYPE_DEFINITION@35..85
       0: (empty)
       1: UNION_KW@35..43 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       2: GRAPHQL_NAME@43..56
         0: GRAPHQL_NAME@43..56 "SearchResult" [] [Whitespace(" ")]
       3: GRAPHQL_DIRECTIVE_LIST@56..56
-      4: GRAPHQL_UNION_MEMBER_TYPES@56..76
+      4: GRAPHQL_UNION_MEMBER_TYPES@56..85
         0: EQ@56..57 "=" [] []
-        1: PIPE@57..61 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
-        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@61..76
-          0: GRAPHQL_NAMED_TYPE@61..66
+        1: (empty)
+        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@57..85
+          0: (empty)
+          1: PIPE@57..61 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+          2: GRAPHQL_NAMED_TYPE@61..66
             0: GRAPHQL_NAME@61..66
               0: GRAPHQL_NAME@61..66 "Photo" [] []
-          1: PIPE@66..70 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
-          2: GRAPHQL_NAMED_TYPE@70..76
+          3: PIPE@66..70 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+          4: GRAPHQL_NAMED_TYPE@70..76
             0: GRAPHQL_NAME@70..76
               0: GRAPHQL_NAME@70..76 "Person" [] []
-    2: GRAPHQL_UNION_TYPE_DEFINITION@76..96
+          5: PIPE@76..80 "|" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+          6: GRAPHQL_NAMED_TYPE@80..85
+            0: GRAPHQL_NAME@80..85
+              0: GRAPHQL_NAME@80..85 "union" [] []
+    2: GRAPHQL_UNION_TYPE_DEFINITION@85..114
       0: (empty)
-      1: UNION_KW@76..84 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@84..96
-        0: GRAPHQL_NAME@84..96 "SearchResult" [] []
-      3: GRAPHQL_DIRECTIVE_LIST@96..96
-      4: (empty)
-    3: GRAPHQL_UNION_TYPE_DEFINITION@96..128
-      0: (empty)
-      1: UNION_KW@96..104 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@104..117
-        0: GRAPHQL_NAME@104..117 "SearchResult" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@117..128
-        0: GRAPHQL_DIRECTIVE@117..128
-          0: AT@117..118 "@" [] []
-          1: GRAPHQL_NAME@118..128
-            0: GRAPHQL_NAME@118..128 "deprecated" [] []
-          2: (empty)
-      4: (empty)
-    4: GRAPHQL_UNION_TYPE_DEFINITION@128..177
-      0: (empty)
-      1: UNION_KW@128..136 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
-      2: GRAPHQL_NAME@136..149
-        0: GRAPHQL_NAME@136..149 "SearchResult" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@149..161
-        0: GRAPHQL_DIRECTIVE@149..161
-          0: AT@149..150 "@" [] []
-          1: GRAPHQL_NAME@150..161
-            0: GRAPHQL_NAME@150..161 "deprecated" [] [Whitespace(" ")]
-          2: (empty)
-      4: GRAPHQL_UNION_MEMBER_TYPES@161..177
-        0: EQ@161..163 "=" [] [Whitespace(" ")]
+      1: UNION_KW@85..93 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@93..99
+        0: GRAPHQL_NAME@93..99 "union" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@99..99
+      4: GRAPHQL_UNION_MEMBER_TYPES@99..114
+        0: EQ@99..101 "=" [] [Whitespace(" ")]
         1: (empty)
-        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@163..177
-          0: GRAPHQL_NAMED_TYPE@163..169
-            0: GRAPHQL_NAME@163..169
-              0: GRAPHQL_NAME@163..169 "Photo" [] [Whitespace(" ")]
-          1: PIPE@169..171 "|" [] [Whitespace(" ")]
-          2: GRAPHQL_NAMED_TYPE@171..177
-            0: GRAPHQL_NAME@171..177
-              0: GRAPHQL_NAME@171..177 "Person" [] []
-  2: EOF@177..178 "" [Newline("\n")] []
+        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@101..114
+          0: GRAPHQL_NAMED_TYPE@101..107
+            0: GRAPHQL_NAME@101..107
+              0: GRAPHQL_NAME@101..107 "union" [] [Whitespace(" ")]
+          1: PIPE@107..109 "|" [] [Whitespace(" ")]
+          2: GRAPHQL_NAMED_TYPE@109..114
+            0: GRAPHQL_NAME@109..114
+              0: GRAPHQL_NAME@109..114 "union" [] []
+    3: GRAPHQL_UNION_TYPE_DEFINITION@114..146
+      0: (empty)
+      1: UNION_KW@114..122 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@122..135
+        0: GRAPHQL_NAME@122..135 "SearchResult" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@135..146
+        0: GRAPHQL_DIRECTIVE@135..146
+          0: AT@135..136 "@" [] []
+          1: GRAPHQL_NAME@136..146
+            0: GRAPHQL_NAME@136..146 "deprecated" [] []
+          2: (empty)
+      4: (empty)
+    4: GRAPHQL_UNION_TYPE_DEFINITION@146..195
+      0: (empty)
+      1: UNION_KW@146..154 "union" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRAPHQL_NAME@154..167
+        0: GRAPHQL_NAME@154..167 "SearchResult" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@167..179
+        0: GRAPHQL_DIRECTIVE@167..179
+          0: AT@167..168 "@" [] []
+          1: GRAPHQL_NAME@168..179
+            0: GRAPHQL_NAME@168..179 "deprecated" [] [Whitespace(" ")]
+          2: (empty)
+      4: GRAPHQL_UNION_MEMBER_TYPES@179..195
+        0: EQ@179..181 "=" [] [Whitespace(" ")]
+        1: (empty)
+        2: GRAPHQL_UNION_MEMBER_TYPE_LIST@181..195
+          0: GRAPHQL_NAMED_TYPE@181..187
+            0: GRAPHQL_NAME@181..187
+              0: GRAPHQL_NAME@181..187 "Photo" [] [Whitespace(" ")]
+          1: PIPE@187..189 "|" [] [Whitespace(" ")]
+          2: GRAPHQL_NAMED_TYPE@189..195
+            0: GRAPHQL_NAME@189..195
+              0: GRAPHQL_NAME@189..195 "Person" [] []
+  2: EOF@195..196 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/directive.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/directive.graphql
@@ -7,6 +7,10 @@
 }
 
 {
+  hero @input(type: String)
+}
+
+{
   hero
 		@deprecated(reason: "Deprecated")
 		@addExternalFields(source: "profiles")

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/directive.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/directive.graphql.snap
@@ -13,6 +13,10 @@ expression: snapshot
 }
 
 {
+  hero @input(type: String)
+}
+
+{
   hero
 		@deprecated(reason: "Deprecated")
 		@addExternalFields(source: "profiles")
@@ -92,69 +96,108 @@ GraphqlRoot {
                 GraphqlField {
                     alias: missing (optional),
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@71..78 "hero" [Newline("\n"), Whitespace("  ")] [],
+                        value_token: GRAPHQL_NAME@71..79 "hero" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                     },
                     arguments: missing (optional),
                     directives: GraphqlDirectiveList [
                         GraphqlDirective {
-                            at_token: AT@78..82 "@" [Newline("\n"), Whitespace("\t\t")] [],
+                            at_token: AT@79..80 "@" [] [],
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@82..92 "deprecated" [] [],
+                                value_token: GRAPHQL_NAME@80..85 "input" [] [],
                             },
                             arguments: GraphqlArguments {
-                                l_paren_token: L_PAREN@92..93 "(" [] [],
+                                l_paren_token: L_PAREN@85..86 "(" [] [],
                                 arguments: GraphqlArgumentList [
                                     GraphqlArgument {
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@93..99 "reason" [] [],
+                                            value_token: GRAPHQL_NAME@86..90 "type" [] [],
                                         },
-                                        colon_token: COLON@99..101 ":" [] [Whitespace(" ")],
-                                        value: GraphqlStringValue {
-                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@101..113 "\"Deprecated\"" [] [],
-                                        },
-                                    },
-                                ],
-                                r_paren_token: R_PAREN@113..114 ")" [] [],
-                            },
-                        },
-                        GraphqlDirective {
-                            at_token: AT@114..118 "@" [Newline("\n"), Whitespace("\t\t")] [],
-                            name: GraphqlName {
-                                value_token: GRAPHQL_NAME@118..135 "addExternalFields" [] [],
-                            },
-                            arguments: GraphqlArguments {
-                                l_paren_token: L_PAREN@135..136 "(" [] [],
-                                arguments: GraphqlArgumentList [
-                                    GraphqlArgument {
-                                        name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@136..142 "source" [] [],
-                                        },
-                                        colon_token: COLON@142..144 ":" [] [Whitespace(" ")],
-                                        value: GraphqlStringValue {
-                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@144..154 "\"profiles\"" [] [],
+                                        colon_token: COLON@90..92 ":" [] [Whitespace(" ")],
+                                        value: GraphqlEnumValue {
+                                            graphql_name: GraphqlName {
+                                                value_token: GRAPHQL_NAME@92..98 "String" [] [],
+                                            },
                                         },
                                     },
                                 ],
-                                r_paren_token: R_PAREN@154..155 ")" [] [],
+                                r_paren_token: R_PAREN@98..99 ")" [] [],
                             },
                         },
                     ],
                     selection_set: missing (optional),
                 },
             ],
-            r_curly_token: R_CURLY@155..157 "}" [Newline("\n")] [],
+            r_curly_token: R_CURLY@99..101 "}" [Newline("\n")] [],
+        },
+        GraphqlSelectionSet {
+            l_curly_token: L_CURLY@101..104 "{" [Newline("\n"), Newline("\n")] [],
+            selections: GraphqlSelectionList [
+                GraphqlField {
+                    alias: missing (optional),
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@104..111 "hero" [Newline("\n"), Whitespace("  ")] [],
+                    },
+                    arguments: missing (optional),
+                    directives: GraphqlDirectiveList [
+                        GraphqlDirective {
+                            at_token: AT@111..115 "@" [Newline("\n"), Whitespace("\t\t")] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@115..125 "deprecated" [] [],
+                            },
+                            arguments: GraphqlArguments {
+                                l_paren_token: L_PAREN@125..126 "(" [] [],
+                                arguments: GraphqlArgumentList [
+                                    GraphqlArgument {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@126..132 "reason" [] [],
+                                        },
+                                        colon_token: COLON@132..134 ":" [] [Whitespace(" ")],
+                                        value: GraphqlStringValue {
+                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@134..146 "\"Deprecated\"" [] [],
+                                        },
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@146..147 ")" [] [],
+                            },
+                        },
+                        GraphqlDirective {
+                            at_token: AT@147..151 "@" [Newline("\n"), Whitespace("\t\t")] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@151..168 "addExternalFields" [] [],
+                            },
+                            arguments: GraphqlArguments {
+                                l_paren_token: L_PAREN@168..169 "(" [] [],
+                                arguments: GraphqlArgumentList [
+                                    GraphqlArgument {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@169..175 "source" [] [],
+                                        },
+                                        colon_token: COLON@175..177 ":" [] [Whitespace(" ")],
+                                        value: GraphqlStringValue {
+                                            graphql_string_literal_token: GRAPHQL_STRING_LITERAL@177..187 "\"profiles\"" [] [],
+                                        },
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@187..188 ")" [] [],
+                            },
+                        },
+                    ],
+                    selection_set: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@188..190 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@157..158 "" [Newline("\n")] [],
+    eof_token: EOF@190..191 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..158
+0: GRAPHQL_ROOT@0..191
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..157
+  1: GRAPHQL_DEFINITION_LIST@0..190
     0: GRAPHQL_SELECTION_SET@0..22
       0: L_CURLY@0..1 "{" [] []
       1: GRAPHQL_SELECTION_LIST@1..20
@@ -196,45 +239,71 @@ GraphqlRoot {
                 2: R_PAREN@65..66 ")" [] []
           4: (empty)
       2: R_CURLY@66..68 "}" [Newline("\n")] []
-    2: GRAPHQL_SELECTION_SET@68..157
+    2: GRAPHQL_SELECTION_SET@68..101
       0: L_CURLY@68..71 "{" [Newline("\n"), Newline("\n")] []
-      1: GRAPHQL_SELECTION_LIST@71..155
-        0: GRAPHQL_FIELD@71..155
+      1: GRAPHQL_SELECTION_LIST@71..99
+        0: GRAPHQL_FIELD@71..99
           0: (empty)
-          1: GRAPHQL_NAME@71..78
-            0: GRAPHQL_NAME@71..78 "hero" [Newline("\n"), Whitespace("  ")] []
+          1: GRAPHQL_NAME@71..79
+            0: GRAPHQL_NAME@71..79 "hero" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
           2: (empty)
-          3: GRAPHQL_DIRECTIVE_LIST@78..155
-            0: GRAPHQL_DIRECTIVE@78..114
-              0: AT@78..82 "@" [Newline("\n"), Whitespace("\t\t")] []
-              1: GRAPHQL_NAME@82..92
-                0: GRAPHQL_NAME@82..92 "deprecated" [] []
-              2: GRAPHQL_ARGUMENTS@92..114
-                0: L_PAREN@92..93 "(" [] []
-                1: GRAPHQL_ARGUMENT_LIST@93..113
-                  0: GRAPHQL_ARGUMENT@93..113
-                    0: GRAPHQL_NAME@93..99
-                      0: GRAPHQL_NAME@93..99 "reason" [] []
-                    1: COLON@99..101 ":" [] [Whitespace(" ")]
-                    2: GRAPHQL_STRING_VALUE@101..113
-                      0: GRAPHQL_STRING_LITERAL@101..113 "\"Deprecated\"" [] []
-                2: R_PAREN@113..114 ")" [] []
-            1: GRAPHQL_DIRECTIVE@114..155
-              0: AT@114..118 "@" [Newline("\n"), Whitespace("\t\t")] []
-              1: GRAPHQL_NAME@118..135
-                0: GRAPHQL_NAME@118..135 "addExternalFields" [] []
-              2: GRAPHQL_ARGUMENTS@135..155
-                0: L_PAREN@135..136 "(" [] []
-                1: GRAPHQL_ARGUMENT_LIST@136..154
-                  0: GRAPHQL_ARGUMENT@136..154
-                    0: GRAPHQL_NAME@136..142
-                      0: GRAPHQL_NAME@136..142 "source" [] []
-                    1: COLON@142..144 ":" [] [Whitespace(" ")]
-                    2: GRAPHQL_STRING_VALUE@144..154
-                      0: GRAPHQL_STRING_LITERAL@144..154 "\"profiles\"" [] []
-                2: R_PAREN@154..155 ")" [] []
+          3: GRAPHQL_DIRECTIVE_LIST@79..99
+            0: GRAPHQL_DIRECTIVE@79..99
+              0: AT@79..80 "@" [] []
+              1: GRAPHQL_NAME@80..85
+                0: GRAPHQL_NAME@80..85 "input" [] []
+              2: GRAPHQL_ARGUMENTS@85..99
+                0: L_PAREN@85..86 "(" [] []
+                1: GRAPHQL_ARGUMENT_LIST@86..98
+                  0: GRAPHQL_ARGUMENT@86..98
+                    0: GRAPHQL_NAME@86..90
+                      0: GRAPHQL_NAME@86..90 "type" [] []
+                    1: COLON@90..92 ":" [] [Whitespace(" ")]
+                    2: GRAPHQL_ENUM_VALUE@92..98
+                      0: GRAPHQL_NAME@92..98
+                        0: GRAPHQL_NAME@92..98 "String" [] []
+                2: R_PAREN@98..99 ")" [] []
           4: (empty)
-      2: R_CURLY@155..157 "}" [Newline("\n")] []
-  2: EOF@157..158 "" [Newline("\n")] []
+      2: R_CURLY@99..101 "}" [Newline("\n")] []
+    3: GRAPHQL_SELECTION_SET@101..190
+      0: L_CURLY@101..104 "{" [Newline("\n"), Newline("\n")] []
+      1: GRAPHQL_SELECTION_LIST@104..188
+        0: GRAPHQL_FIELD@104..188
+          0: (empty)
+          1: GRAPHQL_NAME@104..111
+            0: GRAPHQL_NAME@104..111 "hero" [Newline("\n"), Whitespace("  ")] []
+          2: (empty)
+          3: GRAPHQL_DIRECTIVE_LIST@111..188
+            0: GRAPHQL_DIRECTIVE@111..147
+              0: AT@111..115 "@" [Newline("\n"), Whitespace("\t\t")] []
+              1: GRAPHQL_NAME@115..125
+                0: GRAPHQL_NAME@115..125 "deprecated" [] []
+              2: GRAPHQL_ARGUMENTS@125..147
+                0: L_PAREN@125..126 "(" [] []
+                1: GRAPHQL_ARGUMENT_LIST@126..146
+                  0: GRAPHQL_ARGUMENT@126..146
+                    0: GRAPHQL_NAME@126..132
+                      0: GRAPHQL_NAME@126..132 "reason" [] []
+                    1: COLON@132..134 ":" [] [Whitespace(" ")]
+                    2: GRAPHQL_STRING_VALUE@134..146
+                      0: GRAPHQL_STRING_LITERAL@134..146 "\"Deprecated\"" [] []
+                2: R_PAREN@146..147 ")" [] []
+            1: GRAPHQL_DIRECTIVE@147..188
+              0: AT@147..151 "@" [Newline("\n"), Whitespace("\t\t")] []
+              1: GRAPHQL_NAME@151..168
+                0: GRAPHQL_NAME@151..168 "addExternalFields" [] []
+              2: GRAPHQL_ARGUMENTS@168..188
+                0: L_PAREN@168..169 "(" [] []
+                1: GRAPHQL_ARGUMENT_LIST@169..187
+                  0: GRAPHQL_ARGUMENT@169..187
+                    0: GRAPHQL_NAME@169..175
+                      0: GRAPHQL_NAME@169..175 "source" [] []
+                    1: COLON@175..177 ":" [] [Whitespace(" ")]
+                    2: GRAPHQL_STRING_VALUE@177..187
+                      0: GRAPHQL_STRING_LITERAL@177..187 "\"profiles\"" [] []
+                2: R_PAREN@187..188 ")" [] []
+          4: (empty)
+      2: R_CURLY@188..190 "}" [Newline("\n")] []
+  2: EOF@190..191 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/operation.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/operation.graphql
@@ -15,6 +15,15 @@ subscription {
 	storyLiked
 }
 
+# with name
+query likeStory {
+	likeStory
+}
+
+query query {
+	likeStory
+}
+
 # with variables
 query ($storyId: ID!) {
 	likeStory(storyId: $storyId)
@@ -27,4 +36,13 @@ query ($storyId: ID = "1") {
 # with directives
 query ($storyId: ID!) @skip(if: true){
 	likeStory(storyId: $storyId)
+}
+
+query enum($true: false) {
+  null
+  mutation
+  enum Direction @deprecated {
+    NORTH
+    WEST
+  }
 }

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/operation.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/operation.graphql.snap
@@ -21,6 +21,15 @@ subscription {
 	storyLiked
 }
 
+# with name
+query likeStory {
+	likeStory
+}
+
+query query {
+	likeStory
+}
+
 # with variables
 query ($storyId: ID!) {
 	likeStory(storyId: $storyId)
@@ -33,6 +42,15 @@ query ($storyId: ID = "1") {
 # with directives
 query ($storyId: ID!) @skip(if: true){
 	likeStory(storyId: $storyId)
+}
+
+query enum($true: false) {
+  null
+  mutation
+  enum Direction @deprecated {
+    NORTH
+    WEST
+  }
 }
 
 ```
@@ -129,231 +147,385 @@ GraphqlRoot {
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@105..130 "query" [Newline("\n"), Newline("\n"), Comments("# with variables"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@105..125 "query" [Newline("\n"), Newline("\n"), Comments("# with name"), Newline("\n")] [Whitespace(" ")],
+            },
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@125..135 "likeStory" [] [Whitespace(" ")],
+            },
+            variables: missing (optional),
+            directives: GraphqlDirectiveList [],
+            selection_set: GraphqlSelectionSet {
+                l_curly_token: L_CURLY@135..136 "{" [] [],
+                selections: GraphqlSelectionList [
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@136..147 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        arguments: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@147..149 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlOperationDefinition {
+            ty: GraphqlOperationType {
+                value_token: QUERY_KW@149..157 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            },
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@157..163 "query" [] [Whitespace(" ")],
+            },
+            variables: missing (optional),
+            directives: GraphqlDirectiveList [],
+            selection_set: GraphqlSelectionSet {
+                l_curly_token: L_CURLY@163..164 "{" [] [],
+                selections: GraphqlSelectionList [
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@164..175 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                        arguments: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@175..177 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlOperationDefinition {
+            ty: GraphqlOperationType {
+                value_token: QUERY_KW@177..202 "query" [Newline("\n"), Newline("\n"), Comments("# with variables"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
-                l_paren_token: L_PAREN@130..131 "(" [] [],
+                l_paren_token: L_PAREN@202..203 "(" [] [],
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: GraphqlVariable {
-                            dollar_token: DOLLAR@131..132 "$" [] [],
+                            dollar_token: DOLLAR@203..204 "$" [] [],
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@132..139 "storyId" [] [],
+                                value_token: GRAPHQL_NAME@204..211 "storyId" [] [],
                             },
                         },
-                        colon_token: COLON@139..141 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@211..213 ":" [] [Whitespace(" ")],
                         ty: GraphqlNonNullType {
                             base: GraphqlNamedType {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@141..143 "ID" [] [],
+                                    value_token: GRAPHQL_NAME@213..215 "ID" [] [],
                                 },
                             },
-                            excl_token: BANG@143..144 "!" [] [],
+                            excl_token: BANG@215..216 "!" [] [],
                         },
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_paren_token: R_PAREN@144..146 ")" [] [Whitespace(" ")],
+                r_paren_token: R_PAREN@216..218 ")" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@146..147 "{" [] [],
+                l_curly_token: L_CURLY@218..219 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@147..158 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@219..230 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: GraphqlArguments {
-                            l_paren_token: L_PAREN@158..159 "(" [] [],
+                            l_paren_token: L_PAREN@230..231 "(" [] [],
                             arguments: GraphqlArgumentList [
                                 GraphqlArgument {
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@159..166 "storyId" [] [],
+                                        value_token: GRAPHQL_NAME@231..238 "storyId" [] [],
                                     },
-                                    colon_token: COLON@166..168 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@238..240 ":" [] [Whitespace(" ")],
                                     value: GraphqlVariable {
-                                        dollar_token: DOLLAR@168..169 "$" [] [],
+                                        dollar_token: DOLLAR@240..241 "$" [] [],
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@169..176 "storyId" [] [],
+                                            value_token: GRAPHQL_NAME@241..248 "storyId" [] [],
                                         },
                                     },
                                 },
                             ],
-                            r_paren_token: R_PAREN@176..177 ")" [] [],
+                            r_paren_token: R_PAREN@248..249 ")" [] [],
                         },
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@177..179 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@249..251 "}" [Newline("\n")] [],
             },
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@179..187 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@251..259 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
-                l_paren_token: L_PAREN@187..188 "(" [] [],
+                l_paren_token: L_PAREN@259..260 "(" [] [],
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: GraphqlVariable {
-                            dollar_token: DOLLAR@188..189 "$" [] [],
+                            dollar_token: DOLLAR@260..261 "$" [] [],
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@189..196 "storyId" [] [],
+                                value_token: GRAPHQL_NAME@261..268 "storyId" [] [],
                             },
                         },
-                        colon_token: COLON@196..198 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@268..270 ":" [] [Whitespace(" ")],
                         ty: GraphqlNamedType {
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@198..201 "ID" [] [Whitespace(" ")],
+                                value_token: GRAPHQL_NAME@270..273 "ID" [] [Whitespace(" ")],
                             },
                         },
                         default: GraphqlDefaultValue {
-                            eq_token: EQ@201..203 "=" [] [Whitespace(" ")],
+                            eq_token: EQ@273..275 "=" [] [Whitespace(" ")],
                             value: GraphqlStringValue {
-                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@203..206 "\"1\"" [] [],
+                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@275..278 "\"1\"" [] [],
                             },
                         },
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_paren_token: R_PAREN@206..208 ")" [] [Whitespace(" ")],
+                r_paren_token: R_PAREN@278..280 ")" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@208..209 "{" [] [],
+                l_curly_token: L_CURLY@280..281 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@209..220 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@281..292 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: GraphqlArguments {
-                            l_paren_token: L_PAREN@220..221 "(" [] [],
+                            l_paren_token: L_PAREN@292..293 "(" [] [],
                             arguments: GraphqlArgumentList [
                                 GraphqlArgument {
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@221..228 "storyId" [] [],
+                                        value_token: GRAPHQL_NAME@293..300 "storyId" [] [],
                                     },
-                                    colon_token: COLON@228..230 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@300..302 ":" [] [Whitespace(" ")],
                                     value: GraphqlVariable {
-                                        dollar_token: DOLLAR@230..231 "$" [] [],
+                                        dollar_token: DOLLAR@302..303 "$" [] [],
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@231..238 "storyId" [] [],
+                                            value_token: GRAPHQL_NAME@303..310 "storyId" [] [],
                                         },
                                     },
                                 },
                             ],
-                            r_paren_token: R_PAREN@238..239 ")" [] [],
+                            r_paren_token: R_PAREN@310..311 ")" [] [],
                         },
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@239..241 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@311..313 "}" [Newline("\n")] [],
             },
         },
         GraphqlOperationDefinition {
             ty: GraphqlOperationType {
-                value_token: QUERY_KW@241..267 "query" [Newline("\n"), Newline("\n"), Comments("# with directives"), Newline("\n")] [Whitespace(" ")],
+                value_token: QUERY_KW@313..339 "query" [Newline("\n"), Newline("\n"), Comments("# with directives"), Newline("\n")] [Whitespace(" ")],
             },
             name: missing (optional),
             variables: GraphqlVariableDefinitions {
-                l_paren_token: L_PAREN@267..268 "(" [] [],
+                l_paren_token: L_PAREN@339..340 "(" [] [],
                 elements: GraphqlVariableDefinitionList [
                     GraphqlVariableDefinition {
                         variable: GraphqlVariable {
-                            dollar_token: DOLLAR@268..269 "$" [] [],
+                            dollar_token: DOLLAR@340..341 "$" [] [],
                             name: GraphqlName {
-                                value_token: GRAPHQL_NAME@269..276 "storyId" [] [],
+                                value_token: GRAPHQL_NAME@341..348 "storyId" [] [],
                             },
                         },
-                        colon_token: COLON@276..278 ":" [] [Whitespace(" ")],
+                        colon_token: COLON@348..350 ":" [] [Whitespace(" ")],
                         ty: GraphqlNonNullType {
                             base: GraphqlNamedType {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@278..280 "ID" [] [],
+                                    value_token: GRAPHQL_NAME@350..352 "ID" [] [],
                                 },
                             },
-                            excl_token: BANG@280..281 "!" [] [],
+                            excl_token: BANG@352..353 "!" [] [],
                         },
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_paren_token: R_PAREN@281..283 ")" [] [Whitespace(" ")],
+                r_paren_token: R_PAREN@353..355 ")" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [
                 GraphqlDirective {
-                    at_token: AT@283..284 "@" [] [],
+                    at_token: AT@355..356 "@" [] [],
                     name: GraphqlName {
-                        value_token: GRAPHQL_NAME@284..288 "skip" [] [],
+                        value_token: GRAPHQL_NAME@356..360 "skip" [] [],
                     },
                     arguments: GraphqlArguments {
-                        l_paren_token: L_PAREN@288..289 "(" [] [],
+                        l_paren_token: L_PAREN@360..361 "(" [] [],
                         arguments: GraphqlArgumentList [
                             GraphqlArgument {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@289..291 "if" [] [],
+                                    value_token: GRAPHQL_NAME@361..363 "if" [] [],
                                 },
-                                colon_token: COLON@291..293 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@363..365 ":" [] [Whitespace(" ")],
                                 value: GraphqlBooleanValue {
-                                    value_token: TRUE_KW@293..297 "true" [] [],
+                                    value_token: TRUE_KW@365..369 "true" [] [],
                                 },
                             },
                         ],
-                        r_paren_token: R_PAREN@297..298 ")" [] [],
+                        r_paren_token: R_PAREN@369..370 ")" [] [],
                     },
                 },
             ],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@298..299 "{" [] [],
+                l_curly_token: L_CURLY@370..371 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@299..310 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@371..382 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: GraphqlArguments {
-                            l_paren_token: L_PAREN@310..311 "(" [] [],
+                            l_paren_token: L_PAREN@382..383 "(" [] [],
                             arguments: GraphqlArgumentList [
                                 GraphqlArgument {
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@311..318 "storyId" [] [],
+                                        value_token: GRAPHQL_NAME@383..390 "storyId" [] [],
                                     },
-                                    colon_token: COLON@318..320 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@390..392 ":" [] [Whitespace(" ")],
                                     value: GraphqlVariable {
-                                        dollar_token: DOLLAR@320..321 "$" [] [],
+                                        dollar_token: DOLLAR@392..393 "$" [] [],
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@321..328 "storyId" [] [],
+                                            value_token: GRAPHQL_NAME@393..400 "storyId" [] [],
                                         },
                                     },
                                 },
                             ],
-                            r_paren_token: R_PAREN@328..329 ")" [] [],
+                            r_paren_token: R_PAREN@400..401 ")" [] [],
                         },
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@329..331 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@401..403 "}" [Newline("\n")] [],
+            },
+        },
+        GraphqlOperationDefinition {
+            ty: GraphqlOperationType {
+                value_token: QUERY_KW@403..411 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            },
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@411..415 "enum" [] [],
+            },
+            variables: GraphqlVariableDefinitions {
+                l_paren_token: L_PAREN@415..416 "(" [] [],
+                elements: GraphqlVariableDefinitionList [
+                    GraphqlVariableDefinition {
+                        variable: GraphqlVariable {
+                            dollar_token: DOLLAR@416..417 "$" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@417..421 "true" [] [],
+                            },
+                        },
+                        colon_token: COLON@421..423 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNamedType {
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@423..428 "false" [] [],
+                            },
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                ],
+                r_paren_token: R_PAREN@428..430 ")" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [],
+            selection_set: GraphqlSelectionSet {
+                l_curly_token: L_CURLY@430..431 "{" [] [],
+                selections: GraphqlSelectionList [
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@431..438 "null" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        arguments: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@438..449 "mutation" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                        arguments: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@449..457 "enum" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                        },
+                        arguments: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                        selection_set: missing (optional),
+                    },
+                    GraphqlField {
+                        alias: missing (optional),
+                        name: GraphqlName {
+                            value_token: GRAPHQL_NAME@457..467 "Direction" [] [Whitespace(" ")],
+                        },
+                        arguments: missing (optional),
+                        directives: GraphqlDirectiveList [
+                            GraphqlDirective {
+                                at_token: AT@467..468 "@" [] [],
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@468..479 "deprecated" [] [Whitespace(" ")],
+                                },
+                                arguments: missing (optional),
+                            },
+                        ],
+                        selection_set: GraphqlSelectionSet {
+                            l_curly_token: L_CURLY@479..480 "{" [] [],
+                            selections: GraphqlSelectionList [
+                                GraphqlField {
+                                    alias: missing (optional),
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@480..490 "NORTH" [Newline("\n"), Whitespace("    ")] [],
+                                    },
+                                    arguments: missing (optional),
+                                    directives: GraphqlDirectiveList [],
+                                    selection_set: missing (optional),
+                                },
+                                GraphqlField {
+                                    alias: missing (optional),
+                                    name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@490..499 "WEST" [Newline("\n"), Whitespace("    ")] [],
+                                    },
+                                    arguments: missing (optional),
+                                    directives: GraphqlDirectiveList [],
+                                    selection_set: missing (optional),
+                                },
+                            ],
+                            r_curly_token: R_CURLY@499..503 "}" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                    },
+                ],
+                r_curly_token: R_CURLY@503..505 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@331..332 "" [Newline("\n")] [],
+    eof_token: EOF@505..506 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..332
+0: GRAPHQL_ROOT@0..506
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..331
+  1: GRAPHQL_DEFINITION_LIST@0..505
     0: GRAPHQL_OPERATION_DEFINITION@0..21
       0: GRAPHQL_OPERATION_TYPE@0..6
         0: QUERY_KW@0..6 "query" [] [Whitespace(" ")]
@@ -416,153 +588,264 @@ GraphqlRoot {
             3: GRAPHQL_DIRECTIVE_LIST@103..103
             4: (empty)
         2: R_CURLY@103..105 "}" [Newline("\n")] []
-    4: GRAPHQL_OPERATION_DEFINITION@105..179
-      0: GRAPHQL_OPERATION_TYPE@105..130
-        0: QUERY_KW@105..130 "query" [Newline("\n"), Newline("\n"), Comments("# with variables"), Newline("\n")] [Whitespace(" ")]
+    4: GRAPHQL_OPERATION_DEFINITION@105..149
+      0: GRAPHQL_OPERATION_TYPE@105..125
+        0: QUERY_KW@105..125 "query" [Newline("\n"), Newline("\n"), Comments("# with name"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@125..135
+        0: GRAPHQL_NAME@125..135 "likeStory" [] [Whitespace(" ")]
+      2: (empty)
+      3: GRAPHQL_DIRECTIVE_LIST@135..135
+      4: GRAPHQL_SELECTION_SET@135..149
+        0: L_CURLY@135..136 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@136..147
+          0: GRAPHQL_FIELD@136..147
+            0: (empty)
+            1: GRAPHQL_NAME@136..147
+              0: GRAPHQL_NAME@136..147 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@147..147
+            4: (empty)
+        2: R_CURLY@147..149 "}" [Newline("\n")] []
+    5: GRAPHQL_OPERATION_DEFINITION@149..177
+      0: GRAPHQL_OPERATION_TYPE@149..157
+        0: QUERY_KW@149..157 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@157..163
+        0: GRAPHQL_NAME@157..163 "query" [] [Whitespace(" ")]
+      2: (empty)
+      3: GRAPHQL_DIRECTIVE_LIST@163..163
+      4: GRAPHQL_SELECTION_SET@163..177
+        0: L_CURLY@163..164 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@164..175
+          0: GRAPHQL_FIELD@164..175
+            0: (empty)
+            1: GRAPHQL_NAME@164..175
+              0: GRAPHQL_NAME@164..175 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@175..175
+            4: (empty)
+        2: R_CURLY@175..177 "}" [Newline("\n")] []
+    6: GRAPHQL_OPERATION_DEFINITION@177..251
+      0: GRAPHQL_OPERATION_TYPE@177..202
+        0: QUERY_KW@177..202 "query" [Newline("\n"), Newline("\n"), Comments("# with variables"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@130..146
-        0: L_PAREN@130..131 "(" [] []
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@131..144
-          0: GRAPHQL_VARIABLE_DEFINITION@131..144
-            0: GRAPHQL_VARIABLE@131..139
-              0: DOLLAR@131..132 "$" [] []
-              1: GRAPHQL_NAME@132..139
-                0: GRAPHQL_NAME@132..139 "storyId" [] []
-            1: COLON@139..141 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_NON_NULL_TYPE@141..144
-              0: GRAPHQL_NAMED_TYPE@141..143
-                0: GRAPHQL_NAME@141..143
-                  0: GRAPHQL_NAME@141..143 "ID" [] []
-              1: BANG@143..144 "!" [] []
+      2: GRAPHQL_VARIABLE_DEFINITIONS@202..218
+        0: L_PAREN@202..203 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@203..216
+          0: GRAPHQL_VARIABLE_DEFINITION@203..216
+            0: GRAPHQL_VARIABLE@203..211
+              0: DOLLAR@203..204 "$" [] []
+              1: GRAPHQL_NAME@204..211
+                0: GRAPHQL_NAME@204..211 "storyId" [] []
+            1: COLON@211..213 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@213..216
+              0: GRAPHQL_NAMED_TYPE@213..215
+                0: GRAPHQL_NAME@213..215
+                  0: GRAPHQL_NAME@213..215 "ID" [] []
+              1: BANG@215..216 "!" [] []
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@144..144
-        2: R_PAREN@144..146 ")" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@146..146
-      4: GRAPHQL_SELECTION_SET@146..179
-        0: L_CURLY@146..147 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@147..177
-          0: GRAPHQL_FIELD@147..177
+            4: GRAPHQL_DIRECTIVE_LIST@216..216
+        2: R_PAREN@216..218 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@218..218
+      4: GRAPHQL_SELECTION_SET@218..251
+        0: L_CURLY@218..219 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@219..249
+          0: GRAPHQL_FIELD@219..249
             0: (empty)
-            1: GRAPHQL_NAME@147..158
-              0: GRAPHQL_NAME@147..158 "likeStory" [Newline("\n"), Whitespace("\t")] []
-            2: GRAPHQL_ARGUMENTS@158..177
-              0: L_PAREN@158..159 "(" [] []
-              1: GRAPHQL_ARGUMENT_LIST@159..176
-                0: GRAPHQL_ARGUMENT@159..176
-                  0: GRAPHQL_NAME@159..166
-                    0: GRAPHQL_NAME@159..166 "storyId" [] []
-                  1: COLON@166..168 ":" [] [Whitespace(" ")]
-                  2: GRAPHQL_VARIABLE@168..176
-                    0: DOLLAR@168..169 "$" [] []
-                    1: GRAPHQL_NAME@169..176
-                      0: GRAPHQL_NAME@169..176 "storyId" [] []
-              2: R_PAREN@176..177 ")" [] []
-            3: GRAPHQL_DIRECTIVE_LIST@177..177
+            1: GRAPHQL_NAME@219..230
+              0: GRAPHQL_NAME@219..230 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: GRAPHQL_ARGUMENTS@230..249
+              0: L_PAREN@230..231 "(" [] []
+              1: GRAPHQL_ARGUMENT_LIST@231..248
+                0: GRAPHQL_ARGUMENT@231..248
+                  0: GRAPHQL_NAME@231..238
+                    0: GRAPHQL_NAME@231..238 "storyId" [] []
+                  1: COLON@238..240 ":" [] [Whitespace(" ")]
+                  2: GRAPHQL_VARIABLE@240..248
+                    0: DOLLAR@240..241 "$" [] []
+                    1: GRAPHQL_NAME@241..248
+                      0: GRAPHQL_NAME@241..248 "storyId" [] []
+              2: R_PAREN@248..249 ")" [] []
+            3: GRAPHQL_DIRECTIVE_LIST@249..249
             4: (empty)
-        2: R_CURLY@177..179 "}" [Newline("\n")] []
-    5: GRAPHQL_OPERATION_DEFINITION@179..241
-      0: GRAPHQL_OPERATION_TYPE@179..187
-        0: QUERY_KW@179..187 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@249..251 "}" [Newline("\n")] []
+    7: GRAPHQL_OPERATION_DEFINITION@251..313
+      0: GRAPHQL_OPERATION_TYPE@251..259
+        0: QUERY_KW@251..259 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@187..208
-        0: L_PAREN@187..188 "(" [] []
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@188..206
-          0: GRAPHQL_VARIABLE_DEFINITION@188..206
-            0: GRAPHQL_VARIABLE@188..196
-              0: DOLLAR@188..189 "$" [] []
-              1: GRAPHQL_NAME@189..196
-                0: GRAPHQL_NAME@189..196 "storyId" [] []
-            1: COLON@196..198 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_NAMED_TYPE@198..201
-              0: GRAPHQL_NAME@198..201
-                0: GRAPHQL_NAME@198..201 "ID" [] [Whitespace(" ")]
-            3: GRAPHQL_DEFAULT_VALUE@201..206
-              0: EQ@201..203 "=" [] [Whitespace(" ")]
-              1: GRAPHQL_STRING_VALUE@203..206
-                0: GRAPHQL_STRING_LITERAL@203..206 "\"1\"" [] []
-            4: GRAPHQL_DIRECTIVE_LIST@206..206
-        2: R_PAREN@206..208 ")" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@208..208
-      4: GRAPHQL_SELECTION_SET@208..241
-        0: L_CURLY@208..209 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@209..239
-          0: GRAPHQL_FIELD@209..239
+      2: GRAPHQL_VARIABLE_DEFINITIONS@259..280
+        0: L_PAREN@259..260 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@260..278
+          0: GRAPHQL_VARIABLE_DEFINITION@260..278
+            0: GRAPHQL_VARIABLE@260..268
+              0: DOLLAR@260..261 "$" [] []
+              1: GRAPHQL_NAME@261..268
+                0: GRAPHQL_NAME@261..268 "storyId" [] []
+            1: COLON@268..270 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NAMED_TYPE@270..273
+              0: GRAPHQL_NAME@270..273
+                0: GRAPHQL_NAME@270..273 "ID" [] [Whitespace(" ")]
+            3: GRAPHQL_DEFAULT_VALUE@273..278
+              0: EQ@273..275 "=" [] [Whitespace(" ")]
+              1: GRAPHQL_STRING_VALUE@275..278
+                0: GRAPHQL_STRING_LITERAL@275..278 "\"1\"" [] []
+            4: GRAPHQL_DIRECTIVE_LIST@278..278
+        2: R_PAREN@278..280 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@280..280
+      4: GRAPHQL_SELECTION_SET@280..313
+        0: L_CURLY@280..281 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@281..311
+          0: GRAPHQL_FIELD@281..311
             0: (empty)
-            1: GRAPHQL_NAME@209..220
-              0: GRAPHQL_NAME@209..220 "likeStory" [Newline("\n"), Whitespace("\t")] []
-            2: GRAPHQL_ARGUMENTS@220..239
-              0: L_PAREN@220..221 "(" [] []
-              1: GRAPHQL_ARGUMENT_LIST@221..238
-                0: GRAPHQL_ARGUMENT@221..238
-                  0: GRAPHQL_NAME@221..228
-                    0: GRAPHQL_NAME@221..228 "storyId" [] []
-                  1: COLON@228..230 ":" [] [Whitespace(" ")]
-                  2: GRAPHQL_VARIABLE@230..238
-                    0: DOLLAR@230..231 "$" [] []
-                    1: GRAPHQL_NAME@231..238
-                      0: GRAPHQL_NAME@231..238 "storyId" [] []
-              2: R_PAREN@238..239 ")" [] []
-            3: GRAPHQL_DIRECTIVE_LIST@239..239
+            1: GRAPHQL_NAME@281..292
+              0: GRAPHQL_NAME@281..292 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: GRAPHQL_ARGUMENTS@292..311
+              0: L_PAREN@292..293 "(" [] []
+              1: GRAPHQL_ARGUMENT_LIST@293..310
+                0: GRAPHQL_ARGUMENT@293..310
+                  0: GRAPHQL_NAME@293..300
+                    0: GRAPHQL_NAME@293..300 "storyId" [] []
+                  1: COLON@300..302 ":" [] [Whitespace(" ")]
+                  2: GRAPHQL_VARIABLE@302..310
+                    0: DOLLAR@302..303 "$" [] []
+                    1: GRAPHQL_NAME@303..310
+                      0: GRAPHQL_NAME@303..310 "storyId" [] []
+              2: R_PAREN@310..311 ")" [] []
+            3: GRAPHQL_DIRECTIVE_LIST@311..311
             4: (empty)
-        2: R_CURLY@239..241 "}" [Newline("\n")] []
-    6: GRAPHQL_OPERATION_DEFINITION@241..331
-      0: GRAPHQL_OPERATION_TYPE@241..267
-        0: QUERY_KW@241..267 "query" [Newline("\n"), Newline("\n"), Comments("# with directives"), Newline("\n")] [Whitespace(" ")]
+        2: R_CURLY@311..313 "}" [Newline("\n")] []
+    8: GRAPHQL_OPERATION_DEFINITION@313..403
+      0: GRAPHQL_OPERATION_TYPE@313..339
+        0: QUERY_KW@313..339 "query" [Newline("\n"), Newline("\n"), Comments("# with directives"), Newline("\n")] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@267..283
-        0: L_PAREN@267..268 "(" [] []
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@268..281
-          0: GRAPHQL_VARIABLE_DEFINITION@268..281
-            0: GRAPHQL_VARIABLE@268..276
-              0: DOLLAR@268..269 "$" [] []
-              1: GRAPHQL_NAME@269..276
-                0: GRAPHQL_NAME@269..276 "storyId" [] []
-            1: COLON@276..278 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_NON_NULL_TYPE@278..281
-              0: GRAPHQL_NAMED_TYPE@278..280
-                0: GRAPHQL_NAME@278..280
-                  0: GRAPHQL_NAME@278..280 "ID" [] []
-              1: BANG@280..281 "!" [] []
+      2: GRAPHQL_VARIABLE_DEFINITIONS@339..355
+        0: L_PAREN@339..340 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@340..353
+          0: GRAPHQL_VARIABLE_DEFINITION@340..353
+            0: GRAPHQL_VARIABLE@340..348
+              0: DOLLAR@340..341 "$" [] []
+              1: GRAPHQL_NAME@341..348
+                0: GRAPHQL_NAME@341..348 "storyId" [] []
+            1: COLON@348..350 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@350..353
+              0: GRAPHQL_NAMED_TYPE@350..352
+                0: GRAPHQL_NAME@350..352
+                  0: GRAPHQL_NAME@350..352 "ID" [] []
+              1: BANG@352..353 "!" [] []
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@281..281
-        2: R_PAREN@281..283 ")" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@283..298
-        0: GRAPHQL_DIRECTIVE@283..298
-          0: AT@283..284 "@" [] []
-          1: GRAPHQL_NAME@284..288
-            0: GRAPHQL_NAME@284..288 "skip" [] []
-          2: GRAPHQL_ARGUMENTS@288..298
-            0: L_PAREN@288..289 "(" [] []
-            1: GRAPHQL_ARGUMENT_LIST@289..297
-              0: GRAPHQL_ARGUMENT@289..297
-                0: GRAPHQL_NAME@289..291
-                  0: GRAPHQL_NAME@289..291 "if" [] []
-                1: COLON@291..293 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_BOOLEAN_VALUE@293..297
-                  0: TRUE_KW@293..297 "true" [] []
-            2: R_PAREN@297..298 ")" [] []
-      4: GRAPHQL_SELECTION_SET@298..331
-        0: L_CURLY@298..299 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@299..329
-          0: GRAPHQL_FIELD@299..329
+            4: GRAPHQL_DIRECTIVE_LIST@353..353
+        2: R_PAREN@353..355 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@355..370
+        0: GRAPHQL_DIRECTIVE@355..370
+          0: AT@355..356 "@" [] []
+          1: GRAPHQL_NAME@356..360
+            0: GRAPHQL_NAME@356..360 "skip" [] []
+          2: GRAPHQL_ARGUMENTS@360..370
+            0: L_PAREN@360..361 "(" [] []
+            1: GRAPHQL_ARGUMENT_LIST@361..369
+              0: GRAPHQL_ARGUMENT@361..369
+                0: GRAPHQL_NAME@361..363
+                  0: GRAPHQL_NAME@361..363 "if" [] []
+                1: COLON@363..365 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_BOOLEAN_VALUE@365..369
+                  0: TRUE_KW@365..369 "true" [] []
+            2: R_PAREN@369..370 ")" [] []
+      4: GRAPHQL_SELECTION_SET@370..403
+        0: L_CURLY@370..371 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@371..401
+          0: GRAPHQL_FIELD@371..401
             0: (empty)
-            1: GRAPHQL_NAME@299..310
-              0: GRAPHQL_NAME@299..310 "likeStory" [Newline("\n"), Whitespace("\t")] []
-            2: GRAPHQL_ARGUMENTS@310..329
-              0: L_PAREN@310..311 "(" [] []
-              1: GRAPHQL_ARGUMENT_LIST@311..328
-                0: GRAPHQL_ARGUMENT@311..328
-                  0: GRAPHQL_NAME@311..318
-                    0: GRAPHQL_NAME@311..318 "storyId" [] []
-                  1: COLON@318..320 ":" [] [Whitespace(" ")]
-                  2: GRAPHQL_VARIABLE@320..328
-                    0: DOLLAR@320..321 "$" [] []
-                    1: GRAPHQL_NAME@321..328
-                      0: GRAPHQL_NAME@321..328 "storyId" [] []
-              2: R_PAREN@328..329 ")" [] []
-            3: GRAPHQL_DIRECTIVE_LIST@329..329
+            1: GRAPHQL_NAME@371..382
+              0: GRAPHQL_NAME@371..382 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: GRAPHQL_ARGUMENTS@382..401
+              0: L_PAREN@382..383 "(" [] []
+              1: GRAPHQL_ARGUMENT_LIST@383..400
+                0: GRAPHQL_ARGUMENT@383..400
+                  0: GRAPHQL_NAME@383..390
+                    0: GRAPHQL_NAME@383..390 "storyId" [] []
+                  1: COLON@390..392 ":" [] [Whitespace(" ")]
+                  2: GRAPHQL_VARIABLE@392..400
+                    0: DOLLAR@392..393 "$" [] []
+                    1: GRAPHQL_NAME@393..400
+                      0: GRAPHQL_NAME@393..400 "storyId" [] []
+              2: R_PAREN@400..401 ")" [] []
+            3: GRAPHQL_DIRECTIVE_LIST@401..401
             4: (empty)
-        2: R_CURLY@329..331 "}" [Newline("\n")] []
-  2: EOF@331..332 "" [Newline("\n")] []
+        2: R_CURLY@401..403 "}" [Newline("\n")] []
+    9: GRAPHQL_OPERATION_DEFINITION@403..505
+      0: GRAPHQL_OPERATION_TYPE@403..411
+        0: QUERY_KW@403..411 "query" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: GRAPHQL_NAME@411..415
+        0: GRAPHQL_NAME@411..415 "enum" [] []
+      2: GRAPHQL_VARIABLE_DEFINITIONS@415..430
+        0: L_PAREN@415..416 "(" [] []
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@416..428
+          0: GRAPHQL_VARIABLE_DEFINITION@416..428
+            0: GRAPHQL_VARIABLE@416..421
+              0: DOLLAR@416..417 "$" [] []
+              1: GRAPHQL_NAME@417..421
+                0: GRAPHQL_NAME@417..421 "true" [] []
+            1: COLON@421..423 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NAMED_TYPE@423..428
+              0: GRAPHQL_NAME@423..428
+                0: GRAPHQL_NAME@423..428 "false" [] []
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@428..428
+        2: R_PAREN@428..430 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@430..430
+      4: GRAPHQL_SELECTION_SET@430..505
+        0: L_CURLY@430..431 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@431..503
+          0: GRAPHQL_FIELD@431..438
+            0: (empty)
+            1: GRAPHQL_NAME@431..438
+              0: GRAPHQL_NAME@431..438 "null" [Newline("\n"), Whitespace("  ")] []
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@438..438
+            4: (empty)
+          1: GRAPHQL_FIELD@438..449
+            0: (empty)
+            1: GRAPHQL_NAME@438..449
+              0: GRAPHQL_NAME@438..449 "mutation" [Newline("\n"), Whitespace("  ")] []
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@449..449
+            4: (empty)
+          2: GRAPHQL_FIELD@449..457
+            0: (empty)
+            1: GRAPHQL_NAME@449..457
+              0: GRAPHQL_NAME@449..457 "enum" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@457..457
+            4: (empty)
+          3: GRAPHQL_FIELD@457..503
+            0: (empty)
+            1: GRAPHQL_NAME@457..467
+              0: GRAPHQL_NAME@457..467 "Direction" [] [Whitespace(" ")]
+            2: (empty)
+            3: GRAPHQL_DIRECTIVE_LIST@467..479
+              0: GRAPHQL_DIRECTIVE@467..479
+                0: AT@467..468 "@" [] []
+                1: GRAPHQL_NAME@468..479
+                  0: GRAPHQL_NAME@468..479 "deprecated" [] [Whitespace(" ")]
+                2: (empty)
+            4: GRAPHQL_SELECTION_SET@479..503
+              0: L_CURLY@479..480 "{" [] []
+              1: GRAPHQL_SELECTION_LIST@480..499
+                0: GRAPHQL_FIELD@480..490
+                  0: (empty)
+                  1: GRAPHQL_NAME@480..490
+                    0: GRAPHQL_NAME@480..490 "NORTH" [Newline("\n"), Whitespace("    ")] []
+                  2: (empty)
+                  3: GRAPHQL_DIRECTIVE_LIST@490..490
+                  4: (empty)
+                1: GRAPHQL_FIELD@490..499
+                  0: (empty)
+                  1: GRAPHQL_NAME@490..499
+                    0: GRAPHQL_NAME@490..499 "WEST" [Newline("\n"), Whitespace("    ")] []
+                  2: (empty)
+                  3: GRAPHQL_DIRECTIVE_LIST@499..499
+                  4: (empty)
+              2: R_CURLY@499..503 "}" [Newline("\n"), Whitespace("  ")] []
+        2: R_CURLY@503..505 "}" [Newline("\n")] []
+  2: EOF@505..506 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/type.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/type.graphql
@@ -1,4 +1,4 @@
-query ($storyId: ID!, $like: Boolean, $comments: [String!], $tags: [String!]!, $posts: [PostInput]!) {
+query ($storyId: ID!, $like: Boolean, $comments: [String!], $tags: [String!]!, $posts: [PostInput]!, $input: [input!]!) {
 	likeStory(storyId: $storyId)
 }
 

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/type.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/type.graphql.snap
@@ -4,7 +4,7 @@ expression: snapshot
 ---
 ## Input
 ```graphql
-query ($storyId: ID!, $like: Boolean, $comments: [String!], $tags: [String!]!, $posts: [PostInput]!) {
+query ($storyId: ID!, $like: Boolean, $comments: [String!], $tags: [String!]!, $posts: [PostInput]!, $input: [input!]!) {
 	likeStory(storyId: $storyId)
 }
 
@@ -127,66 +127,92 @@ GraphqlRoot {
                                 },
                                 r_brack_token: R_BRACK@97..98 "]" [] [],
                             },
-                            excl_token: BANG@98..99 "!" [] [],
+                            excl_token: BANG@98..101 "!" [] [Skipped(","), Whitespace(" ")],
+                        },
+                        default: missing (optional),
+                        directives: GraphqlDirectiveList [],
+                    },
+                    GraphqlVariableDefinition {
+                        variable: GraphqlVariable {
+                            dollar_token: DOLLAR@101..102 "$" [] [],
+                            name: GraphqlName {
+                                value_token: GRAPHQL_NAME@102..107 "input" [] [],
+                            },
+                        },
+                        colon_token: COLON@107..109 ":" [] [Whitespace(" ")],
+                        ty: GraphqlNonNullType {
+                            base: GraphqlListType {
+                                l_brack_token: L_BRACK@109..110 "[" [] [],
+                                element: GraphqlNonNullType {
+                                    base: GraphqlNamedType {
+                                        name: GraphqlName {
+                                            value_token: GRAPHQL_NAME@110..115 "input" [] [],
+                                        },
+                                    },
+                                    excl_token: BANG@115..116 "!" [] [],
+                                },
+                                r_brack_token: R_BRACK@116..117 "]" [] [],
+                            },
+                            excl_token: BANG@117..118 "!" [] [],
                         },
                         default: missing (optional),
                         directives: GraphqlDirectiveList [],
                     },
                 ],
-                r_paren_token: R_PAREN@99..101 ")" [] [Whitespace(" ")],
+                r_paren_token: R_PAREN@118..120 ")" [] [Whitespace(" ")],
             },
             directives: GraphqlDirectiveList [],
             selection_set: GraphqlSelectionSet {
-                l_curly_token: L_CURLY@101..102 "{" [] [],
+                l_curly_token: L_CURLY@120..121 "{" [] [],
                 selections: GraphqlSelectionList [
                     GraphqlField {
                         alias: missing (optional),
                         name: GraphqlName {
-                            value_token: GRAPHQL_NAME@102..113 "likeStory" [Newline("\n"), Whitespace("\t")] [],
+                            value_token: GRAPHQL_NAME@121..132 "likeStory" [Newline("\n"), Whitespace("\t")] [],
                         },
                         arguments: GraphqlArguments {
-                            l_paren_token: L_PAREN@113..114 "(" [] [],
+                            l_paren_token: L_PAREN@132..133 "(" [] [],
                             arguments: GraphqlArgumentList [
                                 GraphqlArgument {
                                     name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@114..121 "storyId" [] [],
+                                        value_token: GRAPHQL_NAME@133..140 "storyId" [] [],
                                     },
-                                    colon_token: COLON@121..123 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@140..142 ":" [] [Whitespace(" ")],
                                     value: GraphqlVariable {
-                                        dollar_token: DOLLAR@123..124 "$" [] [],
+                                        dollar_token: DOLLAR@142..143 "$" [] [],
                                         name: GraphqlName {
-                                            value_token: GRAPHQL_NAME@124..131 "storyId" [] [],
+                                            value_token: GRAPHQL_NAME@143..150 "storyId" [] [],
                                         },
                                     },
                                 },
                             ],
-                            r_paren_token: R_PAREN@131..132 ")" [] [],
+                            r_paren_token: R_PAREN@150..151 ")" [] [],
                         },
                         directives: GraphqlDirectiveList [],
                         selection_set: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@132..134 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@151..153 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@134..136 "" [Newline("\n"), Newline("\n")] [],
+    eof_token: EOF@153..155 "" [Newline("\n"), Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..136
+0: GRAPHQL_ROOT@0..155
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..134
-    0: GRAPHQL_OPERATION_DEFINITION@0..134
+  1: GRAPHQL_DEFINITION_LIST@0..153
+    0: GRAPHQL_OPERATION_DEFINITION@0..153
       0: GRAPHQL_OPERATION_TYPE@0..6
         0: QUERY_KW@0..6 "query" [] [Whitespace(" ")]
       1: (empty)
-      2: GRAPHQL_VARIABLE_DEFINITIONS@6..101
+      2: GRAPHQL_VARIABLE_DEFINITIONS@6..120
         0: L_PAREN@6..7 "(" [] []
-        1: GRAPHQL_VARIABLE_DEFINITION_LIST@7..99
+        1: GRAPHQL_VARIABLE_DEFINITION_LIST@7..118
           0: GRAPHQL_VARIABLE_DEFINITION@7..22
             0: GRAPHQL_VARIABLE@7..15
               0: DOLLAR@7..8 "$" [] []
@@ -245,46 +271,64 @@ GraphqlRoot {
               1: BANG@76..79 "!" [] [Skipped(","), Whitespace(" ")]
             3: (empty)
             4: GRAPHQL_DIRECTIVE_LIST@79..79
-          4: GRAPHQL_VARIABLE_DEFINITION@79..99
+          4: GRAPHQL_VARIABLE_DEFINITION@79..101
             0: GRAPHQL_VARIABLE@79..85
               0: DOLLAR@79..80 "$" [] []
               1: GRAPHQL_NAME@80..85
                 0: GRAPHQL_NAME@80..85 "posts" [] []
             1: COLON@85..87 ":" [] [Whitespace(" ")]
-            2: GRAPHQL_NON_NULL_TYPE@87..99
+            2: GRAPHQL_NON_NULL_TYPE@87..101
               0: GRAPHQL_LIST_TYPE@87..98
                 0: L_BRACK@87..88 "[" [] []
                 1: GRAPHQL_NAMED_TYPE@88..97
                   0: GRAPHQL_NAME@88..97
                     0: GRAPHQL_NAME@88..97 "PostInput" [] []
                 2: R_BRACK@97..98 "]" [] []
-              1: BANG@98..99 "!" [] []
+              1: BANG@98..101 "!" [] [Skipped(","), Whitespace(" ")]
             3: (empty)
-            4: GRAPHQL_DIRECTIVE_LIST@99..99
-        2: R_PAREN@99..101 ")" [] [Whitespace(" ")]
-      3: GRAPHQL_DIRECTIVE_LIST@101..101
-      4: GRAPHQL_SELECTION_SET@101..134
-        0: L_CURLY@101..102 "{" [] []
-        1: GRAPHQL_SELECTION_LIST@102..132
-          0: GRAPHQL_FIELD@102..132
+            4: GRAPHQL_DIRECTIVE_LIST@101..101
+          5: GRAPHQL_VARIABLE_DEFINITION@101..118
+            0: GRAPHQL_VARIABLE@101..107
+              0: DOLLAR@101..102 "$" [] []
+              1: GRAPHQL_NAME@102..107
+                0: GRAPHQL_NAME@102..107 "input" [] []
+            1: COLON@107..109 ":" [] [Whitespace(" ")]
+            2: GRAPHQL_NON_NULL_TYPE@109..118
+              0: GRAPHQL_LIST_TYPE@109..117
+                0: L_BRACK@109..110 "[" [] []
+                1: GRAPHQL_NON_NULL_TYPE@110..116
+                  0: GRAPHQL_NAMED_TYPE@110..115
+                    0: GRAPHQL_NAME@110..115
+                      0: GRAPHQL_NAME@110..115 "input" [] []
+                  1: BANG@115..116 "!" [] []
+                2: R_BRACK@116..117 "]" [] []
+              1: BANG@117..118 "!" [] []
+            3: (empty)
+            4: GRAPHQL_DIRECTIVE_LIST@118..118
+        2: R_PAREN@118..120 ")" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@120..120
+      4: GRAPHQL_SELECTION_SET@120..153
+        0: L_CURLY@120..121 "{" [] []
+        1: GRAPHQL_SELECTION_LIST@121..151
+          0: GRAPHQL_FIELD@121..151
             0: (empty)
-            1: GRAPHQL_NAME@102..113
-              0: GRAPHQL_NAME@102..113 "likeStory" [Newline("\n"), Whitespace("\t")] []
-            2: GRAPHQL_ARGUMENTS@113..132
-              0: L_PAREN@113..114 "(" [] []
-              1: GRAPHQL_ARGUMENT_LIST@114..131
-                0: GRAPHQL_ARGUMENT@114..131
-                  0: GRAPHQL_NAME@114..121
-                    0: GRAPHQL_NAME@114..121 "storyId" [] []
-                  1: COLON@121..123 ":" [] [Whitespace(" ")]
-                  2: GRAPHQL_VARIABLE@123..131
-                    0: DOLLAR@123..124 "$" [] []
-                    1: GRAPHQL_NAME@124..131
-                      0: GRAPHQL_NAME@124..131 "storyId" [] []
-              2: R_PAREN@131..132 ")" [] []
-            3: GRAPHQL_DIRECTIVE_LIST@132..132
+            1: GRAPHQL_NAME@121..132
+              0: GRAPHQL_NAME@121..132 "likeStory" [Newline("\n"), Whitespace("\t")] []
+            2: GRAPHQL_ARGUMENTS@132..151
+              0: L_PAREN@132..133 "(" [] []
+              1: GRAPHQL_ARGUMENT_LIST@133..150
+                0: GRAPHQL_ARGUMENT@133..150
+                  0: GRAPHQL_NAME@133..140
+                    0: GRAPHQL_NAME@133..140 "storyId" [] []
+                  1: COLON@140..142 ":" [] [Whitespace(" ")]
+                  2: GRAPHQL_VARIABLE@142..150
+                    0: DOLLAR@142..143 "$" [] []
+                    1: GRAPHQL_NAME@143..150
+                      0: GRAPHQL_NAME@143..150 "storyId" [] []
+              2: R_PAREN@150..151 ")" [] []
+            3: GRAPHQL_DIRECTIVE_LIST@151..151
             4: (empty)
-        2: R_CURLY@132..134 "}" [Newline("\n")] []
-  2: EOF@134..136 "" [Newline("\n"), Newline("\n")] []
+        2: R_CURLY@151..153 "}" [Newline("\n")] []
+  2: EOF@153..155 "" [Newline("\n"), Newline("\n")] []
 
 ```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/value.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/value.graphql
@@ -5,7 +5,9 @@
 		string_value: "string",
 		boolean_value: true,
 		null_value: null,
-		enum_value: AN_ENUM_VALUE,
+		enum_value: ENUM_VALUE,
+		enum_value: enum,
+		enum_value: on,
 		list_value: [1, 2, 3],
 		object_value: {key: "value"}
 	)

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/value.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/value.graphql.snap
@@ -11,7 +11,9 @@ expression: snapshot
 		string_value: "string",
 		boolean_value: true,
 		null_value: null,
-		enum_value: AN_ENUM_VALUE,
+		enum_value: ENUM_VALUE,
+		enum_value: enum,
+		enum_value: on,
 		list_value: [1, 2, 3],
 		object_value: {key: "value"}
 	)
@@ -88,82 +90,104 @@ GraphqlRoot {
                                 colon_token: COLON@133..135 ":" [] [Whitespace(" ")],
                                 value: GraphqlEnumValue {
                                     graphql_name: GraphqlName {
-                                        value_token: GRAPHQL_NAME@135..149 "AN_ENUM_VALUE" [] [Skipped(",")],
+                                        value_token: GRAPHQL_NAME@135..146 "ENUM_VALUE" [] [Skipped(",")],
                                     },
                                 },
                             },
                             GraphqlArgument {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@149..162 "list_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                    value_token: GRAPHQL_NAME@146..159 "enum_value" [Newline("\n"), Whitespace("\t\t")] [],
                                 },
-                                colon_token: COLON@162..164 ":" [] [Whitespace(" ")],
-                                value: GraphqlListValue {
-                                    l_brack_token: L_BRACK@164..165 "[" [] [],
-                                    elements: GraphqlListValueElementList [
-                                        GraphqlIntValue {
-                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@165..168 "1" [] [Skipped(","), Whitespace(" ")],
-                                        },
-                                        GraphqlIntValue {
-                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@168..171 "2" [] [Skipped(","), Whitespace(" ")],
-                                        },
-                                        GraphqlIntValue {
-                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@171..172 "3" [] [],
-                                        },
-                                    ],
-                                    r_brack_token: R_BRACK@172..174 "]" [] [Skipped(",")],
+                                colon_token: COLON@159..161 ":" [] [Whitespace(" ")],
+                                value: GraphqlEnumValue {
+                                    graphql_name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@161..166 "enum" [] [Skipped(",")],
+                                    },
                                 },
                             },
                             GraphqlArgument {
                                 name: GraphqlName {
-                                    value_token: GRAPHQL_NAME@174..189 "object_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                    value_token: GRAPHQL_NAME@166..179 "enum_value" [Newline("\n"), Whitespace("\t\t")] [],
                                 },
-                                colon_token: COLON@189..191 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@179..181 ":" [] [Whitespace(" ")],
+                                value: GraphqlEnumValue {
+                                    graphql_name: GraphqlName {
+                                        value_token: GRAPHQL_NAME@181..184 "on" [] [Skipped(",")],
+                                    },
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@184..197 "list_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@197..199 ":" [] [Whitespace(" ")],
+                                value: GraphqlListValue {
+                                    l_brack_token: L_BRACK@199..200 "[" [] [],
+                                    elements: GraphqlListValueElementList [
+                                        GraphqlIntValue {
+                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@200..203 "1" [] [Skipped(","), Whitespace(" ")],
+                                        },
+                                        GraphqlIntValue {
+                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@203..206 "2" [] [Skipped(","), Whitespace(" ")],
+                                        },
+                                        GraphqlIntValue {
+                                            graphql_int_literal_token: GRAPHQL_INT_LITERAL@206..207 "3" [] [],
+                                        },
+                                    ],
+                                    r_brack_token: R_BRACK@207..209 "]" [] [Skipped(",")],
+                                },
+                            },
+                            GraphqlArgument {
+                                name: GraphqlName {
+                                    value_token: GRAPHQL_NAME@209..224 "object_value" [Newline("\n"), Whitespace("\t\t")] [],
+                                },
+                                colon_token: COLON@224..226 ":" [] [Whitespace(" ")],
                                 value: GraphqlObjectValue {
-                                    l_curly_token: L_CURLY@191..192 "{" [] [],
+                                    l_curly_token: L_CURLY@226..227 "{" [] [],
                                     members: GraphqlObjectValueMemberList [
                                         GraphqlObjectField {
                                             name: GraphqlName {
-                                                value_token: GRAPHQL_NAME@192..195 "key" [] [],
+                                                value_token: GRAPHQL_NAME@227..230 "key" [] [],
                                             },
-                                            colon_token: COLON@195..197 ":" [] [Whitespace(" ")],
+                                            colon_token: COLON@230..232 ":" [] [Whitespace(" ")],
                                             value: GraphqlStringValue {
-                                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@197..204 "\"value\"" [] [],
+                                                graphql_string_literal_token: GRAPHQL_STRING_LITERAL@232..239 "\"value\"" [] [],
                                             },
                                         },
                                     ],
-                                    r_curly_token: R_CURLY@204..205 "}" [] [],
+                                    r_curly_token: R_CURLY@239..240 "}" [] [],
                                 },
                             },
                         ],
-                        r_paren_token: R_PAREN@205..208 ")" [Newline("\n"), Whitespace("\t")] [],
+                        r_paren_token: R_PAREN@240..243 ")" [Newline("\n"), Whitespace("\t")] [],
                     },
                     directives: GraphqlDirectiveList [],
                     selection_set: missing (optional),
                 },
             ],
-            r_curly_token: R_CURLY@208..210 "}" [Newline("\n")] [],
+            r_curly_token: R_CURLY@243..245 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@210..211 "" [Newline("\n")] [],
+    eof_token: EOF@245..246 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: GRAPHQL_ROOT@0..211
+0: GRAPHQL_ROOT@0..246
   0: (empty)
-  1: GRAPHQL_DEFINITION_LIST@0..210
-    0: GRAPHQL_SELECTION_SET@0..210
+  1: GRAPHQL_DEFINITION_LIST@0..245
+    0: GRAPHQL_SELECTION_SET@0..245
       0: L_CURLY@0..1 "{" [] []
-      1: GRAPHQL_SELECTION_LIST@1..208
-        0: GRAPHQL_FIELD@1..208
+      1: GRAPHQL_SELECTION_LIST@1..243
+        0: GRAPHQL_FIELD@1..243
           0: (empty)
           1: GRAPHQL_NAME@1..14
             0: GRAPHQL_NAME@1..14 "field_value" [Newline("\n"), Whitespace("\t")] []
-          2: GRAPHQL_ARGUMENTS@14..208
+          2: GRAPHQL_ARGUMENTS@14..243
             0: L_PAREN@14..15 "(" [] []
-            1: GRAPHQL_ARGUMENT_LIST@15..205
+            1: GRAPHQL_ARGUMENT_LIST@15..240
               0: GRAPHQL_ARGUMENT@15..31
                 0: GRAPHQL_NAME@15..27
                   0: GRAPHQL_NAME@15..27 "int_value" [Newline("\n"), Whitespace("\t\t")] []
@@ -194,45 +218,59 @@ GraphqlRoot {
                 1: COLON@113..115 ":" [] [Whitespace(" ")]
                 2: GRAPHQL_NULL_VALUE@115..120
                   0: NULL_KW@115..120 "null" [] [Skipped(",")]
-              5: GRAPHQL_ARGUMENT@120..149
+              5: GRAPHQL_ARGUMENT@120..146
                 0: GRAPHQL_NAME@120..133
                   0: GRAPHQL_NAME@120..133 "enum_value" [Newline("\n"), Whitespace("\t\t")] []
                 1: COLON@133..135 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_ENUM_VALUE@135..149
-                  0: GRAPHQL_NAME@135..149
-                    0: GRAPHQL_NAME@135..149 "AN_ENUM_VALUE" [] [Skipped(",")]
-              6: GRAPHQL_ARGUMENT@149..174
-                0: GRAPHQL_NAME@149..162
-                  0: GRAPHQL_NAME@149..162 "list_value" [Newline("\n"), Whitespace("\t\t")] []
-                1: COLON@162..164 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_LIST_VALUE@164..174
-                  0: L_BRACK@164..165 "[" [] []
-                  1: GRAPHQL_LIST_VALUE_ELEMENT_LIST@165..172
-                    0: GRAPHQL_INT_VALUE@165..168
-                      0: GRAPHQL_INT_LITERAL@165..168 "1" [] [Skipped(","), Whitespace(" ")]
-                    1: GRAPHQL_INT_VALUE@168..171
-                      0: GRAPHQL_INT_LITERAL@168..171 "2" [] [Skipped(","), Whitespace(" ")]
-                    2: GRAPHQL_INT_VALUE@171..172
-                      0: GRAPHQL_INT_LITERAL@171..172 "3" [] []
-                  2: R_BRACK@172..174 "]" [] [Skipped(",")]
-              7: GRAPHQL_ARGUMENT@174..205
-                0: GRAPHQL_NAME@174..189
-                  0: GRAPHQL_NAME@174..189 "object_value" [Newline("\n"), Whitespace("\t\t")] []
-                1: COLON@189..191 ":" [] [Whitespace(" ")]
-                2: GRAPHQL_OBJECT_VALUE@191..205
-                  0: L_CURLY@191..192 "{" [] []
-                  1: GRAPHQL_OBJECT_VALUE_MEMBER_LIST@192..204
-                    0: GRAPHQL_OBJECT_FIELD@192..204
-                      0: GRAPHQL_NAME@192..195
-                        0: GRAPHQL_NAME@192..195 "key" [] []
-                      1: COLON@195..197 ":" [] [Whitespace(" ")]
-                      2: GRAPHQL_STRING_VALUE@197..204
-                        0: GRAPHQL_STRING_LITERAL@197..204 "\"value\"" [] []
-                  2: R_CURLY@204..205 "}" [] []
-            2: R_PAREN@205..208 ")" [Newline("\n"), Whitespace("\t")] []
-          3: GRAPHQL_DIRECTIVE_LIST@208..208
+                2: GRAPHQL_ENUM_VALUE@135..146
+                  0: GRAPHQL_NAME@135..146
+                    0: GRAPHQL_NAME@135..146 "ENUM_VALUE" [] [Skipped(",")]
+              6: GRAPHQL_ARGUMENT@146..166
+                0: GRAPHQL_NAME@146..159
+                  0: GRAPHQL_NAME@146..159 "enum_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@159..161 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_ENUM_VALUE@161..166
+                  0: GRAPHQL_NAME@161..166
+                    0: GRAPHQL_NAME@161..166 "enum" [] [Skipped(",")]
+              7: GRAPHQL_ARGUMENT@166..184
+                0: GRAPHQL_NAME@166..179
+                  0: GRAPHQL_NAME@166..179 "enum_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@179..181 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_ENUM_VALUE@181..184
+                  0: GRAPHQL_NAME@181..184
+                    0: GRAPHQL_NAME@181..184 "on" [] [Skipped(",")]
+              8: GRAPHQL_ARGUMENT@184..209
+                0: GRAPHQL_NAME@184..197
+                  0: GRAPHQL_NAME@184..197 "list_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@197..199 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_LIST_VALUE@199..209
+                  0: L_BRACK@199..200 "[" [] []
+                  1: GRAPHQL_LIST_VALUE_ELEMENT_LIST@200..207
+                    0: GRAPHQL_INT_VALUE@200..203
+                      0: GRAPHQL_INT_LITERAL@200..203 "1" [] [Skipped(","), Whitespace(" ")]
+                    1: GRAPHQL_INT_VALUE@203..206
+                      0: GRAPHQL_INT_LITERAL@203..206 "2" [] [Skipped(","), Whitespace(" ")]
+                    2: GRAPHQL_INT_VALUE@206..207
+                      0: GRAPHQL_INT_LITERAL@206..207 "3" [] []
+                  2: R_BRACK@207..209 "]" [] [Skipped(",")]
+              9: GRAPHQL_ARGUMENT@209..240
+                0: GRAPHQL_NAME@209..224
+                  0: GRAPHQL_NAME@209..224 "object_value" [Newline("\n"), Whitespace("\t\t")] []
+                1: COLON@224..226 ":" [] [Whitespace(" ")]
+                2: GRAPHQL_OBJECT_VALUE@226..240
+                  0: L_CURLY@226..227 "{" [] []
+                  1: GRAPHQL_OBJECT_VALUE_MEMBER_LIST@227..239
+                    0: GRAPHQL_OBJECT_FIELD@227..239
+                      0: GRAPHQL_NAME@227..230
+                        0: GRAPHQL_NAME@227..230 "key" [] []
+                      1: COLON@230..232 ":" [] [Whitespace(" ")]
+                      2: GRAPHQL_STRING_VALUE@232..239
+                        0: GRAPHQL_STRING_LITERAL@232..239 "\"value\"" [] []
+                  2: R_CURLY@239..240 "}" [] []
+            2: R_PAREN@240..243 ")" [Newline("\n"), Whitespace("\t")] []
+          3: GRAPHQL_DIRECTIVE_LIST@243..243
           4: (empty)
-      2: R_CURLY@208..210 "}" [Newline("\n")] []
-  2: EOF@210..211 "" [Newline("\n")] []
+      2: R_CURLY@243..245 "}" [Newline("\n")] []
+  2: EOF@245..246 "" [Newline("\n")] []
 
 ```


### PR DESCRIPTION
## Summary

It's hard to believe, but GraphQL allows using keyword as identifier. This means that the parser must be able to handle a GraphQL query like this:

```graphql
query enum($true: false) {
  null
  mutation
  enum Direction @deprecated {
    NORTH
    WEST
  }
}
```

This means many assumptions made when handling parsing errors are no longer applicable. In the above example, suppose the query misses the closing brace:

```graphql
query enum($true: false) {
  null
  mutation
  enum Direction @deprecated {
    NORTH
    WEST
  }
```

This could either mean the entire expression is a giant query, or there is a query and an enum definition, depending on where the users want to put the closing braces.

This PR adds support for using keywords as identifier, and removes several assumptions made when handling errors.

## Test Plan

All tests should pass.
