### PR TITLE
refactor(biome_analyze): add `RuleAction::new`

### DIFF
--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -810,6 +810,22 @@ pub struct RuleAction<L: Language> {
     pub mutation: BatchMutation<L>,
 }
 
+impl<L: Language> RuleAction<L> {
+    pub fn new(
+        category: ActionCategory,
+        applicability: impl Into<Applicability>,
+        message: impl biome_console::fmt::Display,
+        mutation: BatchMutation<L>,
+    ) -> Self {
+        Self {
+            category,
+            applicability: applicability.into(),
+            message: markup! {{message}}.to_owned(),
+            mutation,
+        }
+    }
+}
+
 /// An action meant to suppress a lint rule
 #[derive(Clone)]
 pub struct SuppressAction<L: Language> {

--- a/crates/biome_js_analyze/src/assists/correctness/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assists/correctness/organize_imports.rs
@@ -260,12 +260,12 @@ impl Rule for OrganizeImports {
         let mut mutation = ctx.root().begin();
         mutation.replace_node_discard_trivia(old_list, new_list);
 
-        Some(JsRuleAction {
-            category: ActionCategory::Source(SourceActionKind::OrganizeImports),
-            applicability: Applicability::MaybeIncorrect,
-            message: markup! { "Organize Imports (Biome)" }.to_owned(),
+        Some(JsRuleAction::new(
+            ActionCategory::Source(SourceActionKind::OrganizeImports),
+            Applicability::MaybeIncorrect,
+            markup! { "Organize Imports (Biome)" },
             mutation,
-        })
+        ))
     }
 }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

For #2799, we want to phase out the manual construction of the `RuleAction` struct to make the `applicability` field private.

This is intensionally small to make it easy to review before I do a huge codemod to actually phase out the manual construction.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
related to: #2799

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
It compiles.
