### PR TITLE
fix(biome_service): add magic vue compiler macros to globals for vue single file components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Analyzer
 
+#### Enhancements
+
+- Assume Vue compiler macros are globals when processing `.vue` files. ([#2771](https://github.com/biomejs/biome/pull/2771)) Contributed by @dyc3
+
 ### CLI
 
 #### New features

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/vue_compiler_macros_as_globals.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/vue_compiler_macros_as_globals.snap
@@ -1,0 +1,63 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.vue`
+
+```vue
+<script setup lang="ts">
+// These are magic vue macros, and should be treated as globals.
+defineProps(['foo'])
+defineEmits(['change', 'delete'])
+defineModel()
+
+const a = 1
+defineExpose({
+		a,
+})
+
+defineOptions({
+		inheritAttrs: false,
+})
+
+const slots = defineSlots<{
+		default(props: { msg: string }): any
+}>()
+
+</script>
+<template></template>
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.vue:16:36 lint/suspicious/noExplicitAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unexpected any. Specify a different type.
+  
+    15 │ const slots = defineSlots<{
+  > 16 │ 		default(props: { msg: string }): any
+       │ 		                                 ^^^
+    17 │ }>()
+    18 │ 
+  
+  i any disables many type checking rules. Its use should be avoided.
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 1 error.
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Vue has some magic compiler macros that are treated like globals when writing single file components. This makes it unnecessary for users to manually configure biome to treat them as globals.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

closes #2771

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added a test.
