### PR TITLE
refactor(biome_fs): make `BiomePath::extension_as_str` not panic

### DIFF
--- a/crates/biome_cli/src/execute/std_in.rs
+++ b/crates/biome_cli/src/execute/std_in.rs
@@ -58,9 +58,9 @@ pub(crate) fn run<'a>(
 
             let code = printed.into_code();
             let output = match biome_path.extension_as_str() {
-                "astro" => AstroFileHandler::output(content, code.as_str()),
-                "vue" => VueFileHandler::output(content, code.as_str()),
-                "svelte" => SvelteFileHandler::output(content, code.as_str()),
+                Some("astro") => AstroFileHandler::output(content, code.as_str()),
+                Some("vue") => VueFileHandler::output(content, code.as_str()),
+                Some("svelte") => SvelteFileHandler::output(content, code.as_str()),
                 _ => code,
             };
             console.append(markup! {
@@ -117,9 +117,9 @@ pub(crate) fn run<'a>(
                 })?;
                 let code = fix_file_result.code;
                 let output = match biome_path.extension_as_str() {
-                    "astro" => AstroFileHandler::output(&new_content, code.as_str()),
-                    "vue" => VueFileHandler::output(&new_content, code.as_str()),
-                    "svelte" => SvelteFileHandler::output(&new_content, code.as_str()),
+                    Some("astro") => AstroFileHandler::output(&new_content, code.as_str()),
+                    Some("vue") => VueFileHandler::output(&new_content, code.as_str()),
+                    Some("svelte") => SvelteFileHandler::output(&new_content, code.as_str()),
                     _ => code,
                 };
                 if output != new_content {
@@ -139,9 +139,9 @@ pub(crate) fn run<'a>(
                 })?;
                 let code = result.code;
                 let output = match biome_path.extension_as_str() {
-                    "astro" => AstroFileHandler::output(&new_content, code.as_str()),
-                    "vue" => VueFileHandler::output(&new_content, code.as_str()),
-                    "svelte" => SvelteFileHandler::output(&new_content, code.as_str()),
+                    Some("astro") => AstroFileHandler::output(&new_content, code.as_str()),
+                    Some("vue") => VueFileHandler::output(&new_content, code.as_str()),
+                    Some("svelte") => SvelteFileHandler::output(&new_content, code.as_str()),
                     _ => code,
                 };
                 if output != new_content {
@@ -171,9 +171,9 @@ pub(crate) fn run<'a>(
             })?;
             let code = printed.into_code();
             let output = match biome_path.extension_as_str() {
-                "astro" => AstroFileHandler::output(&new_content, code.as_str()),
-                "vue" => VueFileHandler::output(&new_content, code.as_str()),
-                "svelte" => SvelteFileHandler::output(&new_content, code.as_str()),
+                Some("astro") => AstroFileHandler::output(&new_content, code.as_str()),
+                Some("vue") => VueFileHandler::output(&new_content, code.as_str()),
+                Some("svelte") => SvelteFileHandler::output(&new_content, code.as_str()),
                 _ => code,
             };
             if mode.is_check_apply() || mode.is_check_apply_unsafe() {

--- a/crates/biome_fs/src/path.rs
+++ b/crates/biome_fs/src/path.rs
@@ -3,6 +3,7 @@
 //! give additional information around the file that holds:
 //! - the [FileHandlers] for the specific file
 //! - shortcuts to open/write to the file
+use std::ffi::OsStr;
 use std::fs::{self, read_to_string};
 use std::{fs::File, io, io::Write, ops::Deref, path::PathBuf};
 
@@ -49,10 +50,7 @@ impl BiomePath {
         read_to_string(path)
     }
 
-    pub fn extension_as_str(&self) -> &str {
-        self.extension()
-            .expect("Can't read the file")
-            .to_str()
-            .expect("Can't read the file")
+    pub fn extension_as_str(&self) -> Option<&str> {
+        self.extension().and_then(OsStr::to_str)
     }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
There's no reason to let this particular function panic. I encountered this behavior when working on #2823.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
It compiles, and tests pass.
