### PR TITLE
refactor(biome_graphql_parser): remove is_at_*_definition

### DIFF
--- a/crates/biome_graphql_parser/src/parser/definitions/directive.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/directive.rs
@@ -1,9 +1,7 @@
 use crate::parser::{
     parse_description,
     parse_error::{expected_directive_location, expected_name},
-    parse_name,
-    value::is_at_string,
-    GraphqlParser,
+    parse_name, GraphqlParser,
 };
 use biome_graphql_syntax::{
     GraphqlSyntaxKind::{self, *},
@@ -41,9 +39,6 @@ const DIRECTIVE_LOCATION_SET: TokenSet<GraphqlSyntaxKind> = token_set!(
 
 #[inline]
 pub(crate) fn parse_directive_definition(p: &mut GraphqlParser) -> ParsedSyntax {
-    if !is_at_directive_definition(p) {
-        return Absent;
-    }
     let m = p.start();
 
     // description is optional
@@ -132,9 +127,4 @@ fn parse_directive_location(p: &mut GraphqlParser) -> ParsedSyntax {
     let m = p.start();
     p.bump_ts(DIRECTIVE_LOCATION_SET);
     Present(m.complete(p, GRAPHQL_DIRECTIVE_LOCATION))
-}
-
-#[inline]
-pub(crate) fn is_at_directive_definition(p: &mut GraphqlParser) -> bool {
-    p.at(T![directive]) || (is_at_string(p) && p.nth_at(1, T![directive]))
 }

--- a/crates/biome_graphql_parser/src/parser/definitions/enum.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/enum.rs
@@ -17,9 +17,6 @@ use biome_parser::{
 
 #[inline]
 pub(crate) fn parse_enum_type_definition(p: &mut GraphqlParser) -> ParsedSyntax {
-    if !is_at_enum_type_definition(p) {
-        return Absent;
-    }
     let m = p.start();
 
     // description is optional
@@ -104,11 +101,6 @@ pub(crate) fn parse_enum_value_definition(p: &mut GraphqlParser) -> ParsedSyntax
     DirectiveList.parse_list(p);
 
     Present(m.complete(p, GRAPHQL_ENUM_VALUE_DEFINITION))
-}
-
-#[inline]
-pub(crate) fn is_at_enum_type_definition(p: &mut GraphqlParser) -> bool {
-    p.at(T![enum]) || (is_at_string(p) && p.nth_at(1, T![enum]))
 }
 
 /// Either a `{`, `|`, or a non kw name token must be present, else this is

--- a/crates/biome_graphql_parser/src/parser/definitions/fragment.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/fragment.rs
@@ -15,10 +15,6 @@ use super::operation::parse_selection_set;
 
 #[inline]
 pub(crate) fn parse_fragment_definition(p: &mut GraphqlParser) -> ParsedSyntax {
-    if !is_at_fragment_definition(p) {
-        return Absent;
-    }
-
     let m = p.start();
     p.bump(T![fragment]);
 
@@ -40,11 +36,6 @@ pub(crate) fn parse_type_condition(p: &mut GraphqlParser) -> CompletedMarker {
     p.expect(T![on]);
     parse_named_type(p).or_add_diagnostic(p, expected_named_type);
     m.complete(p, GRAPHQL_TYPE_CONDITION)
-}
-
-#[inline]
-pub(crate) fn is_at_fragment_definition(p: &GraphqlParser<'_>) -> bool {
-    p.at(T![fragment])
 }
 
 #[inline]

--- a/crates/biome_graphql_parser/src/parser/definitions/input_object.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/input_object.rs
@@ -1,6 +1,6 @@
 use crate::parser::{
     directive::DirectiveList, parse_description, parse_error::expected_name, parse_name,
-    value::is_at_string, GraphqlParser,
+    GraphqlParser,
 };
 use biome_graphql_syntax::{
     GraphqlSyntaxKind::{self, *},
@@ -15,9 +15,6 @@ use super::field::{is_at_input_value_definition, parse_input_value_definition};
 
 #[inline]
 pub(crate) fn parse_input_object_type_definition(p: &mut GraphqlParser) -> ParsedSyntax {
-    if !is_at_input_object_type_definition(p) {
-        return Absent;
-    }
     let m = p.start();
 
     // description is optional
@@ -85,11 +82,6 @@ impl ParseRecovery for InputFieldListParseRecovery {
     fn is_at_recovered(&self, p: &mut Self::Parser<'_>) -> bool {
         is_at_input_value_definition(p) || is_input_fields_end(p)
     }
-}
-
-#[inline]
-pub(crate) fn is_at_input_object_type_definition(p: &mut GraphqlParser) -> bool {
-    p.at(T![input]) || (is_at_string(p) && p.nth_at(1, T![input]))
 }
 
 #[inline]

--- a/crates/biome_graphql_parser/src/parser/definitions/interface.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/interface.rs
@@ -4,7 +4,6 @@ use crate::parser::{
     parse_error::{expected_name, expected_named_type},
     parse_name,
     r#type::parse_named_type,
-    value::is_at_string,
     GraphqlParser,
 };
 use biome_graphql_syntax::{
@@ -23,9 +22,6 @@ use super::{
 
 #[inline]
 pub(super) fn parse_interface_type_definition(p: &mut GraphqlParser) -> ParsedSyntax {
-    if !is_at_interface_type_definition(p) {
-        return Absent;
-    }
     let m = p.start();
 
     // description is optional
@@ -116,11 +112,6 @@ impl ParseRecovery for ImplementsInterfaceListParseRecovery {
     fn is_at_recovered(&self, p: &mut Self::Parser<'_>) -> bool {
         is_nth_at_name(p, 0) || p.at(T![&]) || is_at_implements_interface_end(p)
     }
-}
-
-#[inline]
-pub(super) fn is_at_interface_type_definition(p: &mut GraphqlParser<'_>) -> bool {
-    p.at(T![interface]) || (is_at_string(p) && p.nth_at(1, T![interface]))
 }
 
 #[inline]

--- a/crates/biome_graphql_parser/src/parser/definitions/object.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/object.rs
@@ -1,6 +1,6 @@
 use crate::parser::{
     directive::DirectiveList, parse_description, parse_error::expected_name, parse_name,
-    value::is_at_string, GraphqlParser,
+    GraphqlParser,
 };
 use biome_graphql_syntax::{GraphqlSyntaxKind::*, T};
 use biome_parser::{
@@ -11,9 +11,6 @@ use super::{field::parse_fields_definition, interface::parse_implements_interfac
 
 #[inline]
 pub(crate) fn parse_object_type_definition(p: &mut GraphqlParser) -> ParsedSyntax {
-    if !is_at_object_type_definition(p) {
-        return Absent;
-    }
     let m = p.start();
 
     // description is optional
@@ -31,9 +28,4 @@ pub(crate) fn parse_object_type_definition(p: &mut GraphqlParser) -> ParsedSynta
     parse_fields_definition(p).ok();
 
     Present(m.complete(p, GRAPHQL_OBJECT_TYPE_DEFINITION))
-}
-
-#[inline]
-pub(crate) fn is_at_object_type_definition(p: &mut GraphqlParser<'_>) -> bool {
-    p.at(T![type]) || (is_at_string(p) && p.nth_at(1, T![type]))
 }

--- a/crates/biome_graphql_parser/src/parser/definitions/scalar.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/scalar.rs
@@ -1,6 +1,6 @@
 use crate::parser::{
     directive::DirectiveList, parse_description, parse_error::expected_name, parse_name,
-    value::is_at_string, GraphqlParser,
+    GraphqlParser,
 };
 use biome_graphql_syntax::{GraphqlSyntaxKind::*, T};
 use biome_parser::{
@@ -9,9 +9,6 @@ use biome_parser::{
 
 #[inline]
 pub(crate) fn parse_scalar_type_definition(p: &mut GraphqlParser) -> ParsedSyntax {
-    if !is_at_scalar_type_definition(p) {
-        return Absent;
-    }
     let m = p.start();
     // description is optional
     parse_description(p).ok();
@@ -22,9 +19,4 @@ pub(crate) fn parse_scalar_type_definition(p: &mut GraphqlParser) -> ParsedSynta
     DirectiveList.parse_list(p);
 
     Present(m.complete(p, GRAPHQL_SCALAR_TYPE_DEFINITION))
-}
-
-#[inline]
-pub(crate) fn is_at_scalar_type_definition(p: &mut GraphqlParser<'_>) -> bool {
-    p.at(T![scalar]) || (is_at_string(p) && p.nth_at(1, T![scalar]))
 }

--- a/crates/biome_graphql_parser/src/parser/definitions/schema.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/schema.rs
@@ -5,7 +5,6 @@ use crate::parser::{
         expected_named_type, expected_operation_type, expected_root_operation_type_definition,
     },
     r#type::parse_named_type,
-    value::is_at_string,
     GraphqlParser,
 };
 use biome_graphql_syntax::{
@@ -21,9 +20,6 @@ use super::{is_at_definition, operation::OPERATION_TYPE};
 
 #[inline]
 pub(crate) fn parse_schema_definition(p: &mut GraphqlParser) -> ParsedSyntax {
-    if !is_at_schema_definition(p) {
-        return Absent;
-    }
     let m = p.start();
     // description is optional
     parse_description(p).ok();
@@ -104,11 +100,6 @@ fn parse_root_operation_type_definition(p: &mut GraphqlParser) -> ParsedSyntax {
     parse_named_type(p).or_add_diagnostic(p, expected_named_type);
 
     Present(m.complete(p, GRAPHQL_ROOT_OPERATION_TYPE_DEFINITION))
-}
-
-#[inline]
-pub(crate) fn is_at_schema_definition(p: &mut GraphqlParser<'_>) -> bool {
-    p.at(T![schema]) || (is_at_string(p) && p.nth_at(1, T![schema]))
 }
 
 #[inline]

--- a/crates/biome_graphql_parser/src/parser/definitions/union.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/union.rs
@@ -4,7 +4,6 @@ use crate::parser::{
     parse_error::{expected_name, expected_named_type},
     parse_name,
     r#type::parse_named_type,
-    value::is_at_string,
     GraphqlParser,
 };
 use biome_graphql_syntax::{
@@ -23,9 +22,6 @@ use super::is_at_definition;
 
 #[inline]
 pub(crate) fn parse_union_type_definition(p: &mut GraphqlParser) -> ParsedSyntax {
-    if !is_at_union_type_definition(p) {
-        return Absent;
-    }
     let m = p.start();
 
     // description is optional
@@ -121,11 +117,6 @@ fn parse_union_member(p: &mut GraphqlParser) -> ParsedSyntax {
     }
 
     parse_named_type(p)
-}
-
-#[inline]
-pub(crate) fn is_at_union_type_definition(p: &mut GraphqlParser<'_>) -> bool {
-    p.at(T![union]) || (is_at_string(p) && p.nth_at(1, T![union]))
 }
 
 /// We must enforce either a `=`, `|`, or a non kw name token to be present, as


### PR DESCRIPTION
## Summary

Following the fix that add support for using keywords as identifiers in GraphQL, the conditions used to verify the absence of definitions have become simpler. This PR simplifies those checks in to a simple match clause, making it clearer under which condition a definition is parsed.
Additionally, this PR servers as a stepping stone toward parsing extensions in GraphQL.

## Test Plan

This PR solely refactors the checks for GraphQL definitions, no tests was modified. All tests should still pass.
