### PR TITLE
refactor(noUndeclaredVariables): suggest using javascript.globals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,13 +495,6 @@ dependencies = [
 [[package]]
 name = "biome_grit_formatter"
 version = "0.0.0"
-dependencies = [
- "biome_formatter",
- "biome_grit_syntax",
- "biome_rowan",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "biome_grit_parser"

--- a/crates/biome_cli/tests/snapshots/main_commands_check/top_level_all_down_level_not_all.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/top_level_all_down_level_not_all.snap
@@ -43,12 +43,15 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 fix.js:2:19 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The arguments variable is undeclared
+  ! The arguments variable is undeclared.
   
   > 2 │     function f() {arguments;}
       │                   ^^^^^^^^^
     3 │     const FOO = "FOO";
     4 │     var x, y;
+  
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_true_group_level_all_false.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_true_group_level_all_false.snap
@@ -32,12 +32,15 @@ expression: content
 ```block
 fix.js:2:19 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The arguments variable is undeclared
+  ! The arguments variable is undeclared.
   
   > 2 │     function f() {arguments;}
       │                   ^^^^^^^^^
     3 │     const FOO = "FOO";
     4 │     var x, y;
+  
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_configuration/override_globals.snap
+++ b/crates/biome_cli/tests/snapshots/main_configuration/override_globals.snap
@@ -54,7 +54,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 ```block
 tests/test.js:3:9 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The React variable is undeclared
+  × The React variable is undeclared.
   
     1 │ test("globals", () => {
     2 │     it("uses React", () => {
@@ -62,6 +62,9 @@ tests/test.js:3:9 lint/correctness/noUndeclaredVariables ━━━━━━━�
       │         ^^^^^
     4 │     });
     5 │ });
+  
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
   
 
 ```

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
@@ -83,9 +83,11 @@ impl Rule for NoUndeclaredVariables {
             rule_category!(),
             *span,
             markup! {
-                "The "<Emphasis>{name}</Emphasis>" variable is undeclared"
+                "The "<Emphasis>{name}</Emphasis>" variable is undeclared."
             },
-        ))
+        ).note(markup! {
+            "By default, Biome recognizes browser and Mode.js globals.\nYou can ignore more globals using the "<Hyperlink href="https://biomejs.dev/reference/configuration/#javascriptglobals">"javascript.globals"</Hyperlink>" configuration."
+        }))
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/infer_incorrect.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/infer_incorrect.ts.snap
@@ -12,13 +12,14 @@ type A = number extends infer T ? never : T;
 ```
 infer_incorrect.ts:1:43 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The T variable is undeclared
+  ! The T variable is undeclared.
   
   > 1 │ type A = number extends infer T ? never : T;
       │                                           ^
     2 │ 
   
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalidNamesapceReference.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalidNamesapceReference.ts.snap
@@ -15,7 +15,7 @@ export type T2 = Ns2;  // This doesn't reference the import namespace `Ns1`
 ```
 invalidNamesapceReference.ts:2:18 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The Ns1 variable is undeclared
+  ! The Ns1 variable is undeclared.
   
     1 │ import * as Ns1 from "";
   > 2 │ export type T1 = Ns1; // This doesn't reference the import namespace `Ns1`
@@ -23,17 +23,23 @@ invalidNamesapceReference.ts:2:18 lint/correctness/noUndeclaredVariables ━━�
     3 │ 
     4 │ import type * as Ns2 from "";
   
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
 
 ```
 
 ```
 invalidNamesapceReference.ts:5:18 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The Ns2 variable is undeclared
+  ! The Ns2 variable is undeclared.
   
     4 │ import type * as Ns2 from "";
   > 5 │ export type T2 = Ns2;  // This doesn't reference the import namespace `Ns1`
       │                  ^^^
+  
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalidTsInJs.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalidTsInJs.js.snap
@@ -13,12 +13,15 @@ PromiseLike;
 ```
 invalidTsInJs.js:1:1 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The ArrayLike variable is undeclared
+  ! The ArrayLike variable is undeclared.
   
   > 1 │ ArrayLike;
       │ ^^^^^^^^^
     2 │ PromiseLike;
     3 │ 
+  
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
   
 
 ```
@@ -26,14 +29,15 @@ invalidTsInJs.js:1:1 lint/correctness/noUndeclaredVariables ━━━━━━�
 ```
 invalidTsInJs.js:2:1 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The PromiseLike variable is undeclared
+  ! The PromiseLike variable is undeclared.
   
     1 │ ArrayLike;
   > 2 │ PromiseLike;
       │ ^^^^^^^^^^^
     3 │ 
   
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalidTypeValueWithSameName.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalidTypeValueWithSameName.ts.snap
@@ -12,13 +12,14 @@ export type { a }
 ```
 invalidTypeValueWithSameName.ts:2:15 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The a variable is undeclared
+  ! The a variable is undeclared.
   
     1 │ const a = 0;
   > 2 │ export type { a }
       │               ^
   
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/noUndeclaredVariables.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/noUndeclaredVariables.js.snap
@@ -24,7 +24,7 @@ new AggregateError();
 ```
 noUndeclaredVariables.js:2:1 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The foobar variable is undeclared
+  ! The foobar variable is undeclared.
   
     1 │ // invalid
   > 2 │ foobar;
@@ -32,13 +32,16 @@ noUndeclaredVariables.js:2:1 lint/correctness/noUndeclaredVariables ━━━━
     3 │ function f() {
     4 │     lorem;
   
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
 
 ```
 
 ```
 noUndeclaredVariables.js:4:5 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The lorem variable is undeclared
+  ! The lorem variable is undeclared.
   
     2 │ foobar;
     3 │ function f() {
@@ -47,13 +50,16 @@ noUndeclaredVariables.js:4:5 lint/correctness/noUndeclaredVariables ━━━━
     5 │ }
     6 │ assignment = "value";
   
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
 
 ```
 
 ```
 noUndeclaredVariables.js:6:1 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The assignment variable is undeclared
+  ! The assignment variable is undeclared.
   
     4 │     lorem;
     5 │ }
@@ -62,13 +68,16 @@ noUndeclaredVariables.js:6:1 lint/correctness/noUndeclaredVariables ━━━━
     7 │ <Missing />;
     8 │ 
   
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
 
 ```
 
 ```
 noUndeclaredVariables.js:7:2 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The Missing variable is undeclared
+  ! The Missing variable is undeclared.
   
     5 │ }
     6 │ assignment = "value";
@@ -77,7 +86,8 @@ noUndeclaredVariables.js:7:2 lint/correctness/noUndeclaredVariables ━━━━
     8 │ 
     9 │ // valid
   
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/noUndeclaredVariables.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/noUndeclaredVariables.ts.snap
@@ -37,14 +37,15 @@ export type Invalid<S extends number> = `Hello ${T}`
 ```
 noUndeclaredVariables.ts:26:50 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The T variable is undeclared
+  ! The T variable is undeclared.
   
     25 │ // Invalid
   > 26 │ export type Invalid<S extends number> = `Hello ${T}`
        │                                                  ^
     27 │ 
   
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/suppression/correctness/noUndeclaredVariables/noUndeclaredVariables.ts.snap
+++ b/crates/biome_js_analyze/tests/suppression/correctness/noUndeclaredVariables/noUndeclaredVariables.ts.snap
@@ -16,12 +16,15 @@ export type Invalid<S extends number> = `
 ```
 noUndeclaredVariables.ts:1:50 lint/correctness/noUndeclaredVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
 
-  ! The T variable is undeclared
+  ! The T variable is undeclared.
   
   > 1 │ export type Invalid<S extends number> = `Hello ${T}`
       │                                                  ^
     2 │ 
     3 │ export type Invalid<S extends number> = `
+  
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
   
   i Safe fix: Suppress rule lint/correctness/noUndeclaredVariables
   
@@ -37,13 +40,16 @@ noUndeclaredVariables.ts:1:50 lint/correctness/noUndeclaredVariables  FIXABLE  �
 ```
 noUndeclaredVariables.ts:5:7 lint/correctness/noUndeclaredVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The T variable is undeclared
+  ! The T variable is undeclared.
   
     3 │ export type Invalid<S extends number> = `
     4 │     Hello
   > 5 │     ${T}
       │       ^
     6 │ `
+  
+  i By default, Biome recognizes browser and Mode.js globals.
+    You can ignore more globals using the javascript.globals configuration.
   
   i Safe fix: Suppress rule lint/correctness/noUndeclaredVariables
   
@@ -56,5 +62,3 @@ noUndeclaredVariables.ts:5:7 lint/correctness/noUndeclaredVariables  FIXABLE  �
   
 
 ```
-
-


### PR DESCRIPTION
## Summary

This PR improves the diagnostic of `noUndeclaredVariables`.
We now suggest using the `javascript.globals` option when we found an undeclared variable.

## Test Plan

CI must pass.
