### PR TITLE
fix: stale `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,13 +495,6 @@ dependencies = [
 [[package]]
 name = "biome_grit_formatter"
 version = "0.0.0"
-dependencies = [
- "biome_formatter",
- "biome_grit_syntax",
- "biome_rowan",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "biome_grit_parser"


### PR DESCRIPTION
## Summary

It seems we have a stale `Cargo.lock` file, and `rust-analyzer` wants to update it.

## Test Plan

N/A