### PR TITLE
feat(biome_deserialize): implement necessary traits for `#[deserializable(rest)]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "indexmap 2.2.6",
  "schemars",
  "serde",
+ "serde_json",
  "smallvec",
 ]
 

--- a/crates/biome_deserialize/Cargo.toml
+++ b/crates/biome_deserialize/Cargo.toml
@@ -21,10 +21,12 @@ bitflags                 = { workspace = true }
 indexmap                 = { workspace = true, features = ["serde"] }
 schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true }
+serde_json               = { workspace = true, optional = true }
 smallvec                 = { workspace = true, optional = true }
 
 [features]
 schema   = ["schemars", "schemars/indexmap"]
+serde    = ["serde_json"]
 smallvec = ["dep:smallvec"]
 
 [lints]

--- a/crates/biome_deserialize/src/impls.rs
+++ b/crates/biome_deserialize/src/impls.rs
@@ -25,6 +25,26 @@ impl Text {
         self.0.text()
     }
 }
+
+impl PartialOrd for Text {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Text {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.text().cmp(other.text())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Text {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.text().serialize(serializer)
+    }
+}
+
 impl Deref for Text {
     type Target = str;
     fn deref(&self) -> &Self::Target {

--- a/crates/biome_deserialize/src/impls.rs
+++ b/crates/biome_deserialize/src/impls.rs
@@ -38,13 +38,6 @@ impl Ord for Text {
     }
 }
 
-#[cfg(feature = "serde")]
-impl serde::Serialize for Text {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.0.text().serialize(serializer)
-    }
-}
-
 impl Deref for Text {
     type Target = str;
     fn deref(&self) -> &Self::Target {

--- a/crates/biome_deserialize/src/json.rs
+++ b/crates/biome_deserialize/src/json.rs
@@ -138,6 +138,92 @@ impl DeserializableValue for AnyJsonValue {
     }
 }
 
+#[cfg(feature = "serde")]
+impl Deserializable for serde_json::Value {
+    fn deserialize(
+        value: &impl DeserializableValue,
+        name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self> {
+        struct Visitor;
+        impl DeserializationVisitor for Visitor {
+            type Output = serde_json::Value;
+            const EXPECTED_TYPE: VisitableType = VisitableType::ARRAY;
+            fn visit_null(
+                self,
+                _range: biome_rowan::TextRange,
+                _name: &str,
+                _diagnostics: &mut Vec<DeserializationDiagnostic>,
+            ) -> Option<Self::Output> {
+                Some(serde_json::Value::Null)
+            }
+
+            fn visit_bool(
+                self,
+                value: bool,
+                _range: biome_rowan::TextRange,
+                _name: &str,
+                _diagnostics: &mut Vec<DeserializationDiagnostic>,
+            ) -> Option<Self::Output> {
+                Some(serde_json::Value::Bool(value))
+            }
+
+            fn visit_number(
+                self,
+                value: TextNumber,
+                _range: biome_rowan::TextRange,
+                _name: &str,
+                diagnostics: &mut Vec<DeserializationDiagnostic>,
+            ) -> Option<Self::Output> {
+                match serde_json::from_str(value.text()) {
+                    Ok(num) => Some(serde_json::Value::Number(num)),
+                    Err(err) => {
+                        diagnostics.push(DeserializationDiagnostic::new(err.to_string()));
+                        None
+                    }
+                }
+            }
+
+            fn visit_array(
+                self,
+                values: impl Iterator<Item = Option<impl DeserializableValue>>,
+                _range: biome_rowan::TextRange,
+                _name: &str,
+                diagnostics: &mut Vec<DeserializationDiagnostic>,
+            ) -> Option<Self::Output> {
+                Some(serde_json::Value::Array(
+                    values
+                        .filter_map(|value| Deserializable::deserialize(&value?, "", diagnostics))
+                        .collect(),
+                ))
+            }
+
+            fn visit_map(
+                self,
+                members: impl Iterator<
+                    Item = Option<(impl DeserializableValue, impl DeserializableValue)>,
+                >,
+                _range: biome_rowan::TextRange,
+                _name: &str,
+                diagnostics: &mut Vec<DeserializationDiagnostic>,
+            ) -> Option<Self::Output> {
+                Some(serde_json::Value::Object(
+                    members
+                        .filter_map(|entry| {
+                            let (key, value) = entry?;
+                            let key = Deserializable::deserialize(&key, "", diagnostics)?;
+                            let value = value.deserialize(Visitor, "", diagnostics)?;
+                            Some((key, value))
+                        })
+                        .collect(),
+                ))
+            }
+        }
+
+        value.deserialize(Visitor, name, diagnostics)
+    }
+}
+
 impl DeserializableValue for JsonMemberName {
     fn range(&self) -> biome_rowan::TextRange {
         AstNode::range(self)

--- a/crates/biome_deserialize/src/json.rs
+++ b/crates/biome_deserialize/src/json.rs
@@ -148,7 +148,7 @@ impl Deserializable for serde_json::Value {
         struct Visitor;
         impl DeserializationVisitor for Visitor {
             type Output = serde_json::Value;
-            const EXPECTED_TYPE: VisitableType = VisitableType::ARRAY;
+            const EXPECTED_TYPE: VisitableType = VisitableType::all();
             fn visit_null(
                 self,
                 _range: biome_rowan::TextRange,
@@ -182,6 +182,16 @@ impl Deserializable for serde_json::Value {
                         None
                     }
                 }
+            }
+
+            fn visit_str(
+                self,
+                value: Text,
+                _range: biome_rowan::TextRange,
+                _name: &str,
+                _diagnostics: &mut Vec<DeserializationDiagnostic>,
+            ) -> Option<Self::Output> {
+                Some(serde_json::Value::String(value.text().to_string()))
             }
 
             fn visit_array(


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

To facilitate #2757, we need a generic `Value`. We decided on implementing `Deserializable` on `serde_json::Value`. This also implements `PartialOrd` and `Order` on `Text`, so we can collect fields into a `BTreeMap`

## Test Plan


