### PR TITLE
fix(lint/noExportsInTest): avoid mistakenly identifying files with in-source testing as test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,8 @@ z.object({})
   .describe('');
 ```
 
+- [noExportsInTest](https://biomejs.dev/linter/rules/no-exports-in-test/) rule no longer treats files with in-source testing as test files https://github.com/biomejs/biome/issues/2859. Contributed by @ah-yu
+
 ### Parser
 
 #### Enhancements

--- a/crates/biome_js_analyze/src/lint/suspicious/no_exports_in_test.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_exports_in_test.rs
@@ -111,7 +111,32 @@ impl Visitor for AnyExportInTestVisitor {
 
                 if !self.has_test {
                     if let Some(call_expr) = JsCallExpression::cast_ref(node) {
-                        self.has_test = call_expr.is_test_call_expression().unwrap_or(false);
+                        self.has_test = call_expr
+                            .is_test_call_expression()
+                            .ok()
+                            .and_then(|is_test_call_expr| {
+                                if is_test_call_expr {
+                                    // Ensure the test call is at the top level to avoid mistakenly identifying files with in-source testing as test files.
+                                    // Example:
+                                    // ```js
+                                    // if (import.meta.vitest) {
+                                    //   const { describe, expect } = import.meta.vitest;
+                                    //   describe("a test", () => {
+                                    //     expect(test).toEqual("");
+                                    //   });
+                                    // }
+                                    // ```
+                                    // The ancestors of the top-level call expression are:
+                                    // [JsScript, JsStatementList, JsExpressionStatement, JsCallExpression]
+                                    // [JsModule, JsModuleItemList, JsExpressionStatement, JsCallExpression]
+                                    //
+                                    // **Note**: The ancestors start with the current node.
+                                    Some(call_expr.syntax().ancestors().count() == 4)
+                                } else {
+                                    None
+                                }
+                            })
+                            .unwrap_or(false);
                     }
                 }
             }

--- a/crates/biome_js_analyze/tests/specs/suspicious/noExportsInTest/in-source-testing.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noExportsInTest/in-source-testing.js
@@ -1,0 +1,8 @@
+export const test = "abcdef"
+
+if (import.meta.vitest) {
+    const { describe, expect } = import.meta.vitest
+    describe("a test", () => {
+        expect(test).toEqual("abcdef")
+    })
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noExportsInTest/in-source-testing.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noExportsInTest/in-source-testing.js.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: in-source-testing.js
+---
+# Input
+```jsx
+export const test = "abcdef"
+
+if (import.meta.vitest) {
+    const { describe, expect } = import.meta.vitest
+    describe("a test", () => {
+        expect(test).toEqual("abcdef")
+    })
+}
+
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

- Closes https://github.com/biomejs/biome/issues/2859

Now we treat files containing a top-level test call as test files.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

Added a new test
