### PR TITLE
fix(js_semantic): ignore `this` in JSX components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,22 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [noUndeclaredVariables](https://biomejs.dev/linter/rules/no-undeclared-variables/) now ignores `this` in JSX components ([#2636](https://github.com/biomejs/biome/issues/2636)).
+
+  The ruel no longer reports `this` as undeclared in following code.
+
+  ```jsx
+  import { Component } from 'react';
+
+  export class MyComponent extends Component {
+    render() {
+      return <this.foo />
+    }
+  }
+  ```
+
+  Contributed by @printfn and @Conaclos
+
 - `useJsxKeyInIterable` now handles more cases involving fragments. See the snippets below. Contributed by @dyc3
 ```jsx
 // valid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - [noUndeclaredVariables](https://biomejs.dev/linter/rules/no-undeclared-variables/) now ignores `this` in JSX components ([#2636](https://github.com/biomejs/biome/issues/2636)).
 
-  The ruel no longer reports `this` as undeclared in following code.
+  The rule no longer reports `this` as undeclared in following code.
 
   ```jsx
   import { Component } from 'react';

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validThis.tsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validThis.tsx
@@ -1,0 +1,6 @@
+export class MyComponent {
+  render() {
+    type T = typeof this.foo;
+    return <this.foo />
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validThis.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validThis.tsx.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validThis.tsx
+---
+# Input
+```tsx
+export class MyComponent {
+  render() {
+    type T = typeof this.foo;
+    return <this.foo />
+  }
+}
+
+```

--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -628,6 +628,10 @@ impl SemanticEventExtractor {
                 }
             }
             AnyJsIdentifierUsage::JsxReferenceIdentifier(_) => {
+                if name.text() == "this" {
+                    // Ignore `this` in JSX. e.g. `<this.foo />`.
+                    return;
+                }
                 self.push_reference(BindingName::Value(name), Reference::Read(range));
             }
             AnyJsIdentifierUsage::JsIdentifierAssignment(_) => {


### PR DESCRIPTION
## Summary

Fix #2636

@printfn submitted #2656 that fixed the issue by modifying the grammar and the parser.

This PR supersedes #2656. Instead of modifying the grammar and the parser, it adds an exception in the semantic model.
We already used this strategy to ignore `typeof this.foo`.

I credited @printfn in the CHANGELOG for its investigations and the submitted PR :)

## Test Plan

I added a non regression test.
