### PR TITLE
feat(biome_service,biome_cli): resolve `.editorconfig` files and merge configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "oxc_resolver",
  "schemars",
  "serde",
+ "serde_ini",
  "serde_json",
  "termcolor",
  "trybuild",

--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -9,8 +9,10 @@ use biome_configuration::{
     organize_imports::PartialOrganizeImports, PartialConfiguration, PartialFormatterConfiguration,
     PartialLinterConfiguration,
 };
+use biome_console::{markup, ConsoleExt};
 use biome_deserialize::Merge;
-use biome_service::configuration::PartialConfigurationExt;
+use biome_diagnostics::PrintDiagnostic;
+use biome_service::configuration::{load_editorconfig, PartialConfigurationExt};
 use biome_service::workspace::RegisterProjectFolderParams;
 use biome_service::{
     configuration::{load_configuration, LoadedConfiguration},
@@ -74,13 +76,34 @@ pub(crate) fn check(
         session.app.console,
         cli_options.verbose,
     )?;
+    let fs = &session.app.fs;
+    let (editorconfig, editorconfig_diagnostics) = {
+        let search_path = loaded_configuration
+            .directory_path
+            .clone()
+            .unwrap_or_else(|| fs.working_directory().unwrap_or_default());
+        load_editorconfig(fs, search_path)?
+    };
+    for diagnostic in editorconfig_diagnostics {
+        session.app.console.error(markup! {
+            {PrintDiagnostic::simple(&diagnostic)}
+        })
+    }
+
     resolve_manifest(&session)?;
 
     let LoadedConfiguration {
-        configuration: mut fs_configuration,
+        configuration: biome_configuration,
         directory_path: configuration_path,
         ..
     } = loaded_configuration;
+    let mut fs_configuration = if let Some(mut fs_configuration) = editorconfig {
+        // this makes biome configuration take precedence over editorconfig configuration
+        fs_configuration.merge_with(biome_configuration);
+        fs_configuration
+    } else {
+        biome_configuration
+    };
 
     let formatter = fs_configuration
         .formatter

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -15,7 +15,7 @@ use biome_console::{markup, ConsoleExt};
 use biome_deserialize::Merge;
 use biome_diagnostics::PrintDiagnostic;
 use biome_service::configuration::{
-    load_configuration, LoadedConfiguration, PartialConfigurationExt,
+    load_configuration, load_editorconfig, LoadedConfiguration, PartialConfigurationExt,
 };
 use biome_service::workspace::{RegisterProjectFolderParams, UpdateSettingsParams};
 use std::ffi::OsString;
@@ -65,12 +65,34 @@ pub(crate) fn format(
         session.app.console,
         cli_options.verbose,
     )?;
+    let fs = &session.app.fs;
+    let (editorconfig, editorconfig_diagnostics) = {
+        let search_path = loaded_configuration
+            .directory_path
+            .clone()
+            .unwrap_or_else(|| fs.working_directory().unwrap_or_default());
+        load_editorconfig(fs, search_path)?
+    };
+    for diagnostic in editorconfig_diagnostics {
+        session.app.console.error(markup! {
+            {PrintDiagnostic::simple(&diagnostic)}
+        })
+    }
+
     resolve_manifest(&session)?;
     let LoadedConfiguration {
-        mut configuration,
+        configuration: biome_configuration,
         directory_path: configuration_path,
         ..
     } = loaded_configuration;
+    let mut configuration = if let Some(mut configuration) = editorconfig {
+        // this makes biome configuration take precedence over editorconfig configuration
+        configuration.merge_with(biome_configuration);
+        configuration
+    } else {
+        biome_configuration
+    };
+
     // TODO: remove in biome 2.0
     let console = &mut *session.app.console;
     if let Some(config) = formatter_configuration.as_mut() {

--- a/crates/biome_cli/tests/cases/editorconfig.rs
+++ b/crates/biome_cli/tests/cases/editorconfig.rs
@@ -1,0 +1,109 @@
+use crate::run_cli;
+use crate::snap_test::{assert_cli_snapshot, assert_file_contents, SnapshotPayload};
+use biome_console::BufferConsole;
+use biome_fs::MemoryFileSystem;
+use biome_service::DynRef;
+use bpaf::Args;
+use std::path::Path;
+
+#[test]
+fn should_use_editorconfig() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let editorconfig = Path::new(".editorconfig");
+    fs.insert(
+        editorconfig.into(),
+        r#"
+[*]
+max_line_length = 300
+"#,
+    );
+
+    let test_file = Path::new("test.js");
+    let contents = r#"console.log("really long string that should cause a break if the line width remains at the default 80 characters");
+"#;
+    fs.insert(test_file.into(), contents);
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                ("--write"),
+                test_file.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, test_file, contents);
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_use_editorconfig",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_have_biome_override_editorconfig() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let editorconfig = Path::new(".editorconfig");
+    fs.insert(
+        editorconfig.into(),
+        r#"
+[*]
+max_line_length = 100
+indent_style = tab
+"#,
+    );
+    let biomeconfig = Path::new("biome.json");
+    fs.insert(
+        biomeconfig.into(),
+        r#"
+{
+    "formatter": {
+        "lineWidth": 90
+    }
+}
+"#,
+    );
+
+    let test_file = Path::new("test.js");
+    let contents = r#"console.log(
+	"really long string that should break if the line width is <=90, but not at 100",
+);
+"#;
+    fs.insert(test_file.into(), contents);
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                ("--write"),
+                test_file.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, test_file, contents);
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_have_biome_override_editorconfig",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/cases/mod.rs
+++ b/crates/biome_cli/tests/cases/mod.rs
@@ -6,6 +6,7 @@ mod config_extends;
 mod config_path;
 mod cts_files;
 mod diagnostics;
+mod editorconfig;
 mod handle_astro_files;
 mod handle_css_files;
 mod handle_svelte_files;

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_have_biome_override_editorconfig.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_have_biome_override_editorconfig.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "lineWidth": 90
+  }
+}
+```
+
+## `.editorconfig`
+
+```editorconfig
+
+[*]
+max_line_length = 100
+indent_style = tab
+
+```
+
+## `test.js`
+
+```js
+console.log(
+	"really long string that should break if the line width is <=90, but not at 100",
+);
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. No fixes needed.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_use_editorconfig.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_use_editorconfig.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `.editorconfig`
+
+```editorconfig
+
+[*]
+max_line_length = 300
+
+```
+
+## `test.js`
+
+```js
+console.log("really long string that should cause a break if the line width remains at the default 80 characters");
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. No fixes needed.
+```

--- a/crates/biome_configuration/src/diagnostics.rs
+++ b/crates/biome_configuration/src/diagnostics.rs
@@ -203,6 +203,70 @@ pub struct CantResolve {
     source: Option<Error>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Diagnostic)]
+pub enum EditorConfigDiagnostic {
+    /// Failed to parse the .editorconfig file.
+    ParseFailed(ParseFailedDiagnostic),
+    /// An option is completely incompatible with biome.
+    Incompatible(InconpatibleDiagnostic),
+    /// A glob pattern that biome doesn't support.
+    UnknownGlobPattern(UnknownGlobPatternDiagnostic),
+}
+
+impl EditorConfigDiagnostic {
+    pub fn incompatible(key: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Incompatible(InconpatibleDiagnostic {
+            message: MessageAndDescription::from(
+                markup! { "Key '"{key.into()}"' is incompatible with biome: "{message.into()}}
+                    .to_owned(),
+            ),
+        })
+    }
+
+    pub fn unknown_glob_pattern(pattern: impl Into<String>) -> Self {
+        Self::UnknownGlobPattern(UnknownGlobPatternDiagnostic {
+            message: MessageAndDescription::from(
+                markup! { "This glob pattern is incompatible with biome: "{pattern.into()}}
+                    .to_owned(),
+            ),
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Diagnostic)]
+#[diagnostic(
+    category = "configuration",
+    severity = Error,
+    message = "Failed the parse the .editorconfig file.",
+)]
+pub struct ParseFailedDiagnostic {
+    #[serde(skip)]
+    #[source]
+    pub source: Option<Error>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Diagnostic)]
+#[diagnostic(
+    category = "configuration",
+    severity = Error,
+)]
+pub struct InconpatibleDiagnostic {
+    #[message]
+    #[description]
+    pub message: MessageAndDescription,
+}
+
+#[derive(Debug, Serialize, Deserialize, Diagnostic)]
+#[diagnostic(
+    category = "configuration",
+    severity = Warning,
+)]
+pub struct UnknownGlobPatternDiagnostic {
+    #[message]
+    #[description]
+    pub message: MessageAndDescription,
+}
+
 #[cfg(test)]
 mod test {
     use crate::{ConfigurationDiagnostic, PartialConfiguration};

--- a/crates/biome_diagnostics/Cargo.toml
+++ b/crates/biome_diagnostics/Cargo.toml
@@ -39,6 +39,7 @@ bpaf                         = { workspace = true }
 oxc_resolver                 = { workspace = true }
 schemars                     = { workspace = true, optional = true }
 serde                        = { workspace = true, features = ["derive"] }
+serde_ini                    = { workspace = true }
 serde_json                   = { workspace = true }
 termcolor                    = { workspace = true }
 unicode-width                = { workspace = true }

--- a/crates/biome_diagnostics/src/adapters.rs
+++ b/crates/biome_diagnostics/src/adapters.rs
@@ -4,7 +4,10 @@
 
 use std::io;
 
-use biome_console::{fmt, markup};
+use biome_console::{
+    fmt::{self, Display},
+    markup,
+};
 
 use crate::{category, Category, Diagnostic, DiagnosticTags};
 
@@ -154,5 +157,40 @@ impl Diagnostic for SerdeJsonError {
 
     fn message(&self, fmt: &mut fmt::Formatter<'_>) -> io::Result<()> {
         fmt.write_markup(markup!({ AsConsoleDisplay(&self.error) }))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IniError {
+    error: serde_ini::de::Error,
+}
+
+impl Diagnostic for IniError {
+    fn category(&self) -> Option<&'static Category> {
+        Some(category!("configuration"))
+    }
+
+    fn severity(&self) -> crate::Severity {
+        crate::Severity::Error
+    }
+
+    fn description(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(fmt, "{}", self.error)
+    }
+
+    fn message(&self, fmt: &mut fmt::Formatter<'_>) -> std::io::Result<()> {
+        fmt.write_markup(markup!({ AsConsoleDisplay(&self.error) }))
+    }
+}
+
+impl Display for IniError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> std::io::Result<()> {
+        write!(fmt, "{:?}", self.error)
+    }
+}
+
+impl From<serde_ini::de::Error> for IniError {
+    fn from(error: serde_ini::de::Error) -> Self {
+        Self { error }
     }
 }

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -1,4 +1,5 @@
 use crate::workspace::DocumentFileSource;
+use biome_configuration::diagnostics::EditorConfigDiagnostic;
 use biome_configuration::{CantLoadExtendFile, ConfigurationDiagnostic};
 use biome_console::fmt::Bytes;
 use biome_console::markup;
@@ -59,6 +60,8 @@ pub enum WorkspaceError {
     ProtectedFile(ProtectedFile),
     /// Error when searching for a pattern
     SearchError(SearchError),
+    /// Thrown when a `.editorconfig` file is found, but it can't be parsed.
+    EditorConfigDiagnostic(EditorConfigDiagnostic),
 }
 
 impl WorkspaceError {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This is part of a series of PRs to add `.editorconfig` support to biome. As with the previous PR, this is intentionally small to help make code reviews easier. The goal is to add functions that look for and load the .editorconfig files, and merge the loaded configurations.

Here's how the configurations are prioritized:
- cli args overrides `biome.json`
- `biome.json` overrides `.editorconfig`
- `.editorconfig` overrides biome defaults

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
Related to: #1724

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
I've added one test just to show that it works in this PR, but I have more tests in another branch that I could bring into this PR instead of making another one.
```bash
cargo test -p biome_service
cargo test -p biome_cli
```

