### PR TITLE
refactor(biome_analyze): derive `Applicability` from `FixKind`

### DIFF
--- a/crates/biome_analyze/src/signals.rs
+++ b/crates/biome_analyze/src/signals.rs
@@ -384,8 +384,8 @@ where
             if let Some(action) = R::action(&ctx, &self.state) {
                 actions.push(AnalyzerAction {
                     rule_name: Some((<R::Group as RuleGroup>::NAME, R::METADATA.name)),
+                    applicability: action.applicability(),
                     category: action.category,
-                    applicability: action.applicability,
                     mutation: action.mutation,
                     message: action.message,
                 });

--- a/crates/biome_js_analyze/src/assists/correctness/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assists/correctness/organize_imports.rs
@@ -4,7 +4,6 @@ use biome_analyze::{
     context::RuleContext, declare_rule, ActionCategory, Ast, FixKind, Rule, SourceActionKind,
 };
 use biome_console::markup;
-use biome_diagnostics::Applicability;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsImportClause, AnyJsModuleItem, AnyJsNamedImportSpecifier, JsImport, JsLanguage, JsModule,
@@ -262,7 +261,7 @@ impl Rule for OrganizeImports {
 
         Some(JsRuleAction::new(
             ActionCategory::Source(SourceActionKind::OrganizeImports),
-            Applicability::MaybeIncorrect,
+            ctx.metadata().to_applicability(),
             markup! { "Organize Imports (Biome)" },
             mutation,
         ))

--- a/crates/biome_migrate/src/analyzers/nursery_rules.rs
+++ b/crates/biome_migrate/src/analyzers/nursery_rules.rs
@@ -2,7 +2,7 @@ use crate::{declare_migration, MigrationAction};
 use biome_analyze::context::RuleContext;
 use biome_analyze::{ActionCategory, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
-use biome_diagnostics::{category, Applicability};
+use biome_diagnostics::category;
 use biome_json_factory::make::{
     json_member, json_member_list, json_member_name, json_object_value, json_string_literal, token,
 };
@@ -299,15 +299,15 @@ impl Rule for NurseryRules {
             mutation.replace_node(rules, json_member_list(new_members, separators));
         };
 
-        Some(MigrationAction {
-            mutation,
-            message: markup! {
+        Some(MigrationAction::new(
+            ActionCategory::QuickFix,
+            ctx.metadata().to_applicability(),
+            markup! {
                 "Move the rule to the new stable group."
             }
             .to_owned(),
-            category: ActionCategory::QuickFix,
-            applicability: Applicability::MaybeIncorrect,
-        })
+            mutation,
+        ))
     }
 }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
`FixKind` and `Applicability` line up one to one, and need to remain in sync. This adds `RuleMetadata::to_applicability()` and a `impl From<FixKind> for Applicability`.

I'll follow up this PR with another codemod to change all the rules to call this function instead.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
Related to: #2799

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
It compiles.
