### PR TITLE
fix(ci): nextest on windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ on:
 env:
   RUST_LOG: info
   RUST_BACKTRACE: 1
+  RUSTUP_WINDOWS_PATH_ADD_BIN: 1
 
 jobs:
   format:


### PR DESCRIPTION
## Summary

After searching I believe the current failing CI jobs on Windows is caused by a recent rustup change that breaks nextests. So this PR uses the workaround mentioned by those smart minds that are also affected by and fixed this problem.

Refs:
- https://github.com/rust-lang/rustup/pull/3703
- https://github.com/nextest-rs/nextest/issues/267

## Test Plan

Merge to main and check whether the CI on Windows will succeed.
