### PR TITLE
chore(ci): fix nextest on windows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,6 +21,7 @@ concurrency:
 env:
   RUST_LOG: info
   RUST_BACKTRACE: 1
+  RUSTUP_WINDOWS_PATH_ADD_BIN: 1
 
 jobs:
   format:


### PR DESCRIPTION
## Summary

Follow up of #2887 to fix CI tests on Windows in the `pull_request.yml` workflow.

## Test Plan

Merge to main and check rebased or following PRs.