### PR TITLE
chore: fix typos in the `useNamingConvention` documentation

### DIFF
--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -256,7 +256,7 @@ declare_rule! {
     ///         "strictCase": false,
     ///         "requireAscii": true,
     ///         "enumMemberCase": "CONSTANT_CASE",
-    ///         "custon": [
+    ///         "conventions": [
     ///             {
     ///                 "selector": {
     ///                     "kind": "memberLike",
@@ -286,7 +286,7 @@ declare_rule! {
     /// When this option is set to `true`, it forbids names that include non-ASCII characters.
     /// For instance,  when the option is set to `true`, `café` or `안녕하세요` will throw an error.
     ///
-    /// When the option is set to `false`, anames may include non-ASCII characters.
+    /// When the option is set to `false`, names may include non-ASCII characters.
     /// `café` and `안녕하세요` are so valid.
     ///
     /// Default: `false`
@@ -329,8 +329,8 @@ declare_rule! {
     /// }
     /// ```
     ///
-    /// A selector descibes which decalrations the convention applies to.
-    /// You can select a decalration based on several criteria:
+    /// A selector describes which declarations the convention applies to.
+    /// You can select a declaration based on several criteria:
     ///
     /// - `kind`: the kind of the declaration among:
     ///   - `any` (default kind if the kind is unset)
@@ -340,7 +340,7 @@ declare_rule! {
     ///   - `interface`
     ///   - `typeAlias`
     ///   - `function`: named function declarations and expressions
-    ///   - `namespaceLike`: TypeScript namespaces, import and export namespaces (`import * as namspace from`)
+    ///   - `namespaceLike`: TypeScript namespaces, import and export namespaces (`import * as namespace from`)
     ///   - `namespace`: TypeScript namespaces
     ///   - `importNamespace`
     ///   - `exportNamespace`
@@ -365,7 +365,7 @@ declare_rule! {
     ///   - `objectLiteralMethod`
     ///   - `objectLiteralGetter`
     ///   - `objectLiteralSetter`
-    ///   - `typeMember`: properties, methods, getters, and setters declared in type alaises and interfaces
+    ///   - `typeMember`: properties, methods, getters, and setters declared in type aliases and interfaces
     ///   - `typeProperty`
     ///   - `typeMethod`
     ///   - `typeGetter`
@@ -413,7 +413,7 @@ declare_rule! {
     /// {
     ///     "//": "...",
     ///     "options": {
-    ///         "custon": [
+    ///         "conventions": [
     ///             {
     ///                 "selector": {
     ///                     "kind": "classMember",


### PR DESCRIPTION
## Summary

I have noticed some typos in the `useNamingConvention` documentation. Naming of the `custon` option looked very puzzling [on website](https://biomejs.dev/linter/rules/use-naming-convention/#options). I guess it is picked up from here, or?

## Test Plan

Not applicable, because there are no code changes.