### PR TITLE
refactor(configuration): disallow `fix` field for unfixable rules

### DIFF
--- a/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
@@ -215,7 +215,6 @@ fn migrate_eslint_rule(
                 group.no_restricted_globals = Some(biome_config::RuleConfiguration::WithOptions(
                     biome_config::RuleWithOptions {
                         level: severity.into(),
-                        fix: None,
                         options: Box::new(no_restricted_globals::RestrictedGlobalsOptions {
                             denied_globals: globals.collect(),
                         }),
@@ -227,13 +226,14 @@ fn migrate_eslint_rule(
             if migrate_eslint_any_rule(rules, &name, conf.severity(), opts, results) {
                 if let eslint_eslint::RuleConf::Option(severity, rule_options) = conf {
                     let group = rules.a11y.get_or_insert_with(Default::default);
-                    group.use_valid_aria_role = Some(biome_config::RuleConfiguration::WithOptions(
-                        biome_config::RuleWithOptions {
-                            level: severity.into(),
-                            fix: None,
-                            options: Box::new((*rule_options).into()),
-                        },
-                    ));
+                    group.use_valid_aria_role =
+                        Some(biome_config::RuleFixConfiguration::WithOptions(
+                            biome_config::RuleWithFixOptions {
+                                level: severity.into(),
+                                fix: None,
+                                options: Box::new((*rule_options).into()),
+                            },
+                        ));
                 }
             }
         }
@@ -242,8 +242,8 @@ fn migrate_eslint_rule(
                 if let eslint_eslint::RuleConf::Option(severity, rule_options) = conf {
                     let group = rules.style.get_or_insert_with(Default::default);
                     group.use_consistent_array_type =
-                        Some(biome_config::RuleConfiguration::WithOptions(
-                            biome_config::RuleWithOptions {
+                        Some(biome_config::RuleFixConfiguration::WithOptions(
+                            biome_config::RuleWithFixOptions {
                                 level: severity.into(),
                                 fix: None,
                                 options: rule_options.into(),
@@ -259,13 +259,14 @@ fn migrate_eslint_rule(
                     conf.into_vec().into_iter().map(|v| *v),
                 );
                 let group = rules.style.get_or_insert_with(Default::default);
-                group.use_naming_convention = Some(biome_config::RuleConfiguration::WithOptions(
-                    biome_config::RuleWithOptions {
-                        level: severity.into(),
-                        fix: None,
-                        options: options.into(),
-                    },
-                ));
+                group.use_naming_convention =
+                    Some(biome_config::RuleFixConfiguration::WithOptions(
+                        biome_config::RuleWithFixOptions {
+                            level: severity.into(),
+                            fix: None,
+                            options: options.into(),
+                        },
+                    ));
             }
         }
         eslint_eslint::Rule::UnicornFilenameCase(conf) => {
@@ -274,7 +275,6 @@ fn migrate_eslint_rule(
                 group.use_filenaming_convention = Some(
                     biome_config::RuleConfiguration::WithOptions(biome_config::RuleWithOptions {
                         level: conf.severity().into(),
-                        fix: None,
                         options: Box::new(conf.option_or_default().into()),
                     }),
                 );
@@ -372,7 +372,7 @@ mod tests {
         );
         assert_eq!(
             linter.rules.unwrap().suspicious.unwrap().no_double_equals,
-            Some(biome_config::RuleConfiguration::Plain(
+            Some(biome_config::RuleFixConfiguration::Plain(
                 biome_config::RulePlainConfiguration::Error
             ))
         );
@@ -393,7 +393,7 @@ mod tests {
                 .suspicious
                 .unwrap()
                 .no_double_equals,
-            Some(biome_config::RuleConfiguration::Plain(
+            Some(biome_config::RuleFixConfiguration::Plain(
                 biome_config::RulePlainConfiguration::Off
             ))
         );

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -40,7 +40,8 @@ pub use json::{
 };
 pub use linter::{
     partial_linter_configuration, LinterConfiguration, PartialLinterConfiguration,
-    RuleConfiguration, RulePlainConfiguration, RuleWithOptions, Rules,
+    RuleConfiguration, RuleFixConfiguration, RulePlainConfiguration, RuleWithFixOptions,
+    RuleWithOptions, Rules,
 };
 pub use overrides::{
     OverrideFormatterConfiguration, OverrideLinterConfiguration,

--- a/crates/biome_configuration/src/linter/rules.rs
+++ b/crates/biome_configuration/src/linter/rules.rs
@@ -1,7 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 use super::RulePlainConfiguration;
-use crate::RuleConfiguration;
+use crate::{RuleConfiguration, RuleFixConfiguration};
 use biome_analyze::{options::RuleOptions, RuleFilter};
 use biome_console::markup;
 use biome_css_analyze::options::*;
@@ -511,45 +511,45 @@ pub struct A11y {
     pub all: Option<bool>,
     #[doc = "Enforce that the accessKey attribute is not used on any HTML element."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_access_key: Option<RuleConfiguration<NoAccessKey>>,
+    pub no_access_key: Option<RuleFixConfiguration<NoAccessKey>>,
     #[doc = "Enforce that aria-hidden=\"true\" is not set on focusable elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_aria_hidden_on_focusable: Option<RuleConfiguration<NoAriaHiddenOnFocusable>>,
+    pub no_aria_hidden_on_focusable: Option<RuleFixConfiguration<NoAriaHiddenOnFocusable>>,
     #[doc = "Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_aria_unsupported_elements: Option<RuleConfiguration<NoAriaUnsupportedElements>>,
+    pub no_aria_unsupported_elements: Option<RuleFixConfiguration<NoAriaUnsupportedElements>>,
     #[doc = "Enforce that autoFocus prop is not used on elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_autofocus: Option<RuleConfiguration<NoAutofocus>>,
+    pub no_autofocus: Option<RuleFixConfiguration<NoAutofocus>>,
     #[doc = "Disallow target=\"_blank\" attribute without rel=\"noreferrer\""]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_blank_target: Option<RuleConfiguration<NoBlankTarget>>,
+    pub no_blank_target: Option<RuleFixConfiguration<NoBlankTarget>>,
     #[doc = "Enforces that no distracting elements are used."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_distracting_elements: Option<RuleConfiguration<NoDistractingElements>>,
+    pub no_distracting_elements: Option<RuleFixConfiguration<NoDistractingElements>>,
     #[doc = "The scope prop should be used only on \\<th> elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_header_scope: Option<RuleConfiguration<NoHeaderScope>>,
+    pub no_header_scope: Option<RuleFixConfiguration<NoHeaderScope>>,
     #[doc = "Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_interactive_element_to_noninteractive_role:
-        Option<RuleConfiguration<NoInteractiveElementToNoninteractiveRole>>,
+        Option<RuleFixConfiguration<NoInteractiveElementToNoninteractiveRole>>,
     #[doc = "Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_noninteractive_element_to_interactive_role:
-        Option<RuleConfiguration<NoNoninteractiveElementToInteractiveRole>>,
+        Option<RuleFixConfiguration<NoNoninteractiveElementToInteractiveRole>>,
     #[doc = "Enforce that tabIndex is not assigned to non-interactive HTML elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_noninteractive_tabindex: Option<RuleConfiguration<NoNoninteractiveTabindex>>,
+    pub no_noninteractive_tabindex: Option<RuleFixConfiguration<NoNoninteractiveTabindex>>,
     #[doc = "Prevent the usage of positive integers on tabIndex property"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_positive_tabindex: Option<RuleConfiguration<NoPositiveTabindex>>,
+    pub no_positive_tabindex: Option<RuleFixConfiguration<NoPositiveTabindex>>,
     #[doc = "Enforce img alt prop does not contain the word \"image\", \"picture\", or \"photo\"."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_redundant_alt: Option<RuleConfiguration<NoRedundantAlt>>,
     #[doc = "Enforce explicit role property is not the same as implicit/default role property on an element."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_redundant_roles: Option<RuleConfiguration<NoRedundantRoles>>,
+    pub no_redundant_roles: Option<RuleFixConfiguration<NoRedundantRoles>>,
     #[doc = "Enforces the usage of the title element for the svg element."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_svg_without_title: Option<RuleConfiguration<NoSvgWithoutTitle>>,
@@ -558,11 +558,11 @@ pub struct A11y {
     pub use_alt_text: Option<RuleConfiguration<UseAltText>>,
     #[doc = "Enforce that anchors have content and that the content is accessible to screen readers."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_anchor_content: Option<RuleConfiguration<UseAnchorContent>>,
+    pub use_anchor_content: Option<RuleFixConfiguration<UseAnchorContent>>,
     #[doc = "Enforce that tabIndex is assigned to non-interactive HTML elements with aria-activedescendant."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_aria_activedescendant_with_tabindex:
-        Option<RuleConfiguration<UseAriaActivedescendantWithTabindex>>,
+        Option<RuleFixConfiguration<UseAriaActivedescendantWithTabindex>>,
     #[doc = "Enforce that elements with ARIA roles must have all required ARIA attributes for that role."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_aria_props_for_role: Option<RuleConfiguration<UseAriaPropsForRole>>,
@@ -592,10 +592,10 @@ pub struct A11y {
     pub use_valid_anchor: Option<RuleConfiguration<UseValidAnchor>>,
     #[doc = "Ensures that ARIA properties aria-* are all valid."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_valid_aria_props: Option<RuleConfiguration<UseValidAriaProps>>,
+    pub use_valid_aria_props: Option<RuleFixConfiguration<UseValidAriaProps>>,
     #[doc = "Elements with ARIA roles must use a valid, non-abstract ARIA role."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_valid_aria_role: Option<RuleConfiguration<UseValidAriaRole>>,
+    pub use_valid_aria_role: Option<RuleFixConfiguration<UseValidAriaRole>>,
     #[doc = "Enforce that ARIA state and property values are valid."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_valid_aria_values: Option<RuleConfiguration<UseValidAriaValues>>,
@@ -1395,7 +1395,7 @@ pub struct Complexity {
     pub all: Option<bool>,
     #[doc = "Disallow primitive type aliases and misleading types."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_banned_types: Option<RuleConfiguration<NoBannedTypes>>,
+    pub no_banned_types: Option<RuleFixConfiguration<NoBannedTypes>>,
     #[doc = "Disallow empty type parameters in type aliases and interfaces."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_empty_type_parameters: Option<RuleConfiguration<NoEmptyTypeParameters>>,
@@ -1408,53 +1408,54 @@ pub struct Complexity {
     pub no_excessive_nested_test_suites: Option<RuleConfiguration<NoExcessiveNestedTestSuites>>,
     #[doc = "Disallow unnecessary boolean casts"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_extra_boolean_cast: Option<RuleConfiguration<NoExtraBooleanCast>>,
+    pub no_extra_boolean_cast: Option<RuleFixConfiguration<NoExtraBooleanCast>>,
     #[doc = "Prefer for...of statement instead of Array.forEach."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_for_each: Option<RuleConfiguration<NoForEach>>,
     #[doc = "Disallow unclear usage of consecutive space characters in regular expression literals"]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_multiple_spaces_in_regular_expression_literals:
-        Option<RuleConfiguration<NoMultipleSpacesInRegularExpressionLiterals>>,
+        Option<RuleFixConfiguration<NoMultipleSpacesInRegularExpressionLiterals>>,
     #[doc = "This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_static_only_class: Option<RuleConfiguration<NoStaticOnlyClass>>,
     #[doc = "Disallow this and super in static contexts."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_this_in_static: Option<RuleConfiguration<NoThisInStatic>>,
+    pub no_this_in_static: Option<RuleFixConfiguration<NoThisInStatic>>,
     #[doc = "Disallow unnecessary catch clauses."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_catch: Option<RuleConfiguration<NoUselessCatch>>,
     #[doc = "Disallow unnecessary constructors."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_constructor: Option<RuleConfiguration<NoUselessConstructor>>,
+    pub no_useless_constructor: Option<RuleFixConfiguration<NoUselessConstructor>>,
     #[doc = "Disallow empty exports that don't change anything in a module file."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_empty_export: Option<RuleConfiguration<NoUselessEmptyExport>>,
+    pub no_useless_empty_export: Option<RuleFixConfiguration<NoUselessEmptyExport>>,
     #[doc = "Disallow unnecessary fragments"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_fragments: Option<RuleConfiguration<NoUselessFragments>>,
+    pub no_useless_fragments: Option<RuleFixConfiguration<NoUselessFragments>>,
     #[doc = "Disallow unnecessary labels."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_label: Option<RuleConfiguration<NoUselessLabel>>,
+    pub no_useless_label: Option<RuleFixConfiguration<NoUselessLabel>>,
     #[doc = "Disallow unnecessary nested block statements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_lone_block_statements: Option<RuleConfiguration<NoUselessLoneBlockStatements>>,
+    pub no_useless_lone_block_statements:
+        Option<RuleFixConfiguration<NoUselessLoneBlockStatements>>,
     #[doc = "Disallow renaming import, export, and destructured assignments to the same name."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_rename: Option<RuleConfiguration<NoUselessRename>>,
+    pub no_useless_rename: Option<RuleFixConfiguration<NoUselessRename>>,
     #[doc = "Disallow useless case in switch statements."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_switch_case: Option<RuleConfiguration<NoUselessSwitchCase>>,
+    pub no_useless_switch_case: Option<RuleFixConfiguration<NoUselessSwitchCase>>,
     #[doc = "Disallow ternary operators when simpler alternatives exist."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_ternary: Option<RuleConfiguration<NoUselessTernary>>,
+    pub no_useless_ternary: Option<RuleFixConfiguration<NoUselessTernary>>,
     #[doc = "Disallow useless this aliasing."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_this_alias: Option<RuleConfiguration<NoUselessThisAlias>>,
+    pub no_useless_this_alias: Option<RuleFixConfiguration<NoUselessThisAlias>>,
     #[doc = "Disallow using any or unknown as type constraint."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_type_constraint: Option<RuleConfiguration<NoUselessTypeConstraint>>,
+    pub no_useless_type_constraint: Option<RuleFixConfiguration<NoUselessTypeConstraint>>,
     #[doc = "Disallow the use of void operators, which is not a familiar operator."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_void: Option<RuleConfiguration<NoVoid>>,
@@ -1463,25 +1464,25 @@ pub struct Complexity {
     pub no_with: Option<RuleConfiguration<NoWith>>,
     #[doc = "Use arrow functions over function expressions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_arrow_function: Option<RuleConfiguration<UseArrowFunction>>,
+    pub use_arrow_function: Option<RuleFixConfiguration<UseArrowFunction>>,
     #[doc = "Promotes the use of .flatMap() when map().flat() are used together."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_flat_map: Option<RuleConfiguration<UseFlatMap>>,
+    pub use_flat_map: Option<RuleFixConfiguration<UseFlatMap>>,
     #[doc = "Enforce the usage of a literal access to properties over computed property access."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_literal_keys: Option<RuleConfiguration<UseLiteralKeys>>,
+    pub use_literal_keys: Option<RuleFixConfiguration<UseLiteralKeys>>,
     #[doc = "Enforce using concise optional chain instead of chained logical expressions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_optional_chain: Option<RuleConfiguration<UseOptionalChain>>,
+    pub use_optional_chain: Option<RuleFixConfiguration<UseOptionalChain>>,
     #[doc = "Enforce the use of the regular expression literals instead of the RegExp constructor if possible."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_regex_literals: Option<RuleConfiguration<UseRegexLiterals>>,
+    pub use_regex_literals: Option<RuleFixConfiguration<UseRegexLiterals>>,
     #[doc = "Disallow number literal object member names which are not base10 or uses underscore as separator"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_simple_number_keys: Option<RuleConfiguration<UseSimpleNumberKeys>>,
+    pub use_simple_number_keys: Option<RuleFixConfiguration<UseSimpleNumberKeys>>,
     #[doc = "Discard redundant terms from logical expressions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_simplified_logic_expression: Option<RuleConfiguration<UseSimplifiedLogicExpression>>,
+    pub use_simplified_logic_expression: Option<RuleFixConfiguration<UseSimplifiedLogicExpression>>,
 }
 impl DeserializableValidator for Complexity {
     fn validate(
@@ -2256,7 +2257,7 @@ pub struct Correctness {
     pub no_children_prop: Option<RuleConfiguration<NoChildrenProp>>,
     #[doc = "Prevents from having const variables being re-assigned."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_const_assign: Option<RuleConfiguration<NoConstAssign>>,
+    pub no_const_assign: Option<RuleFixConfiguration<NoConstAssign>>,
     #[doc = "Disallow constant expressions in conditions"]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_constant_condition: Option<RuleConfiguration<NoConstantCondition>>,
@@ -2280,16 +2281,16 @@ pub struct Correctness {
     pub no_invalid_constructor_super: Option<RuleConfiguration<NoInvalidConstructorSuper>>,
     #[doc = "Disallow new operators with global non-constructor functions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_invalid_new_builtin: Option<RuleConfiguration<NoInvalidNewBuiltin>>,
+    pub no_invalid_new_builtin: Option<RuleFixConfiguration<NoInvalidNewBuiltin>>,
     #[doc = "Disallow the use of variables and function parameters before their declaration"]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_invalid_use_before_declaration: Option<RuleConfiguration<NoInvalidUseBeforeDeclaration>>,
     #[doc = "Disallow new operators with the Symbol object."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_new_symbol: Option<RuleConfiguration<NoNewSymbol>>,
+    pub no_new_symbol: Option<RuleFixConfiguration<NoNewSymbol>>,
     #[doc = "Disallow \\8 and \\9 escape sequences in string literals."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_nonoctal_decimal_escape: Option<RuleConfiguration<NoNonoctalDecimalEscape>>,
+    pub no_nonoctal_decimal_escape: Option<RuleFixConfiguration<NoNonoctalDecimalEscape>>,
     #[doc = "Disallow literal numbers that lose precision"]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_precision_loss: Option<RuleConfiguration<NoPrecisionLoss>>,
@@ -2304,16 +2305,16 @@ pub struct Correctness {
     pub no_setter_return: Option<RuleConfiguration<NoSetterReturn>>,
     #[doc = "Disallow comparison of expressions modifying the string case with non-compliant value."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_string_case_mismatch: Option<RuleConfiguration<NoStringCaseMismatch>>,
+    pub no_string_case_mismatch: Option<RuleFixConfiguration<NoStringCaseMismatch>>,
     #[doc = "Disallow lexical declarations in switch clauses."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_switch_declarations: Option<RuleConfiguration<NoSwitchDeclarations>>,
+    pub no_switch_declarations: Option<RuleFixConfiguration<NoSwitchDeclarations>>,
     #[doc = "Prevents the usage of variables that haven't been declared inside the document."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_undeclared_variables: Option<RuleConfiguration<NoUndeclaredVariables>>,
     #[doc = "Avoid using unnecessary continue."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unnecessary_continue: Option<RuleConfiguration<NoUnnecessaryContinue>>,
+    pub no_unnecessary_continue: Option<RuleFixConfiguration<NoUnnecessaryContinue>>,
     #[doc = "Disallow unreachable code"]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_unreachable: Option<RuleConfiguration<NoUnreachable>>,
@@ -2328,19 +2329,19 @@ pub struct Correctness {
     pub no_unsafe_optional_chaining: Option<RuleConfiguration<NoUnsafeOptionalChaining>>,
     #[doc = "Disallow unused imports."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unused_imports: Option<RuleConfiguration<NoUnusedImports>>,
+    pub no_unused_imports: Option<RuleFixConfiguration<NoUnusedImports>>,
     #[doc = "Disallow unused labels."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unused_labels: Option<RuleConfiguration<NoUnusedLabels>>,
+    pub no_unused_labels: Option<RuleFixConfiguration<NoUnusedLabels>>,
     #[doc = "Disallow unused private class members"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unused_private_class_members: Option<RuleConfiguration<NoUnusedPrivateClassMembers>>,
+    pub no_unused_private_class_members: Option<RuleFixConfiguration<NoUnusedPrivateClassMembers>>,
     #[doc = "Disallow unused variables."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unused_variables: Option<RuleConfiguration<NoUnusedVariables>>,
+    pub no_unused_variables: Option<RuleFixConfiguration<NoUnusedVariables>>,
     #[doc = "This rules prevents void elements (AKA self-closing elements) from having children."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_void_elements_with_children: Option<RuleConfiguration<NoVoidElementsWithChildren>>,
+    pub no_void_elements_with_children: Option<RuleFixConfiguration<NoVoidElementsWithChildren>>,
     #[doc = "Disallow returning a value from a function with the return type 'void'"]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_void_type_return: Option<RuleConfiguration<NoVoidTypeReturn>>,
@@ -2352,7 +2353,7 @@ pub struct Correctness {
     pub use_hook_at_top_level: Option<RuleConfiguration<UseHookAtTopLevel>>,
     #[doc = "Require calls to isNaN() when checking for NaN."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_is_nan: Option<RuleConfiguration<UseIsNan>>,
+    pub use_is_nan: Option<RuleFixConfiguration<UseIsNan>>,
     #[doc = "Disallow missing key props in iterators/collection literals."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_jsx_key_in_iterable: Option<RuleConfiguration<UseJsxKeyInIterable>>,
@@ -3307,10 +3308,10 @@ pub struct Nursery {
     pub no_color_invalid_hex: Option<RuleConfiguration<NoColorInvalidHex>>,
     #[doc = "Disallow the use of console."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_console: Option<RuleConfiguration<NoConsole>>,
+    pub no_console: Option<RuleFixConfiguration<NoConsole>>,
     #[doc = "Disallow the use of Math.min and Math.max to clamp a value where the result itself is constant."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_constant_math_min_max_clamp: Option<RuleConfiguration<NoConstantMathMinMaxClamp>>,
+    pub no_constant_math_min_max_clamp: Option<RuleFixConfiguration<NoConstantMathMinMaxClamp>>,
     #[doc = "Disallow CSS empty blocks."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_css_empty_block: Option<RuleConfiguration<NoCssEmptyBlock>>,
@@ -3338,7 +3339,7 @@ pub struct Nursery {
     pub no_evolving_any: Option<RuleConfiguration<NoEvolvingAny>>,
     #[doc = "Disallow to use unnecessary callback on flatMap."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_flat_map_identity: Option<RuleConfiguration<NoFlatMapIdentity>>,
+    pub no_flat_map_identity: Option<RuleFixConfiguration<NoFlatMapIdentity>>,
     #[doc = "Disallow invalid !important within keyframe declarations"]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_important_in_keyframe: Option<RuleConfiguration<NoImportantInKeyframe>>,
@@ -3354,7 +3355,7 @@ pub struct Nursery {
     pub no_nodejs_modules: Option<RuleConfiguration<NoNodejsModules>>,
     #[doc = "Prevents React-specific JSX properties from being used."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_react_specific_props: Option<RuleConfiguration<NoReactSpecificProps>>,
+    pub no_react_specific_props: Option<RuleFixConfiguration<NoReactSpecificProps>>,
     #[doc = "Disallow specified modules when loaded by import or require."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_restricted_imports: Option<RuleConfiguration<NoRestrictedImports>>,
@@ -3382,24 +3383,24 @@ pub struct Nursery {
     pub no_unmatchable_anb_selector: Option<RuleConfiguration<NoUnmatchableAnbSelector>>,
     #[doc = "Disallow unnecessary concatenation of string or template literals."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_string_concat: Option<RuleConfiguration<NoUselessStringConcat>>,
+    pub no_useless_string_concat: Option<RuleFixConfiguration<NoUselessStringConcat>>,
     #[doc = "Disallow initializing variables to undefined."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_undefined_initialization:
-        Option<RuleConfiguration<NoUselessUndefinedInitialization>>,
+        Option<RuleFixConfiguration<NoUselessUndefinedInitialization>>,
     #[doc = "Disallow Array constructors."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_array_literals: Option<RuleConfiguration<UseArrayLiterals>>,
+    pub use_array_literals: Option<RuleFixConfiguration<UseArrayLiterals>>,
     #[doc = "Enforce the use of new for all builtins, except String, Number, Boolean, Symbol and BigInt."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_consistent_builtin_instantiation:
-        Option<RuleConfiguration<UseConsistentBuiltinInstantiation>>,
+        Option<RuleFixConfiguration<UseConsistentBuiltinInstantiation>>,
     #[doc = "Require the default clause in switch statements."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_default_switch_clause: Option<RuleConfiguration<UseDefaultSwitchClause>>,
     #[doc = "Enforce explicitly comparing the length, size, byteLength or byteOffset property of a value."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_explicit_length_check: Option<RuleConfiguration<UseExplicitLengthCheck>>,
+    pub use_explicit_length_check: Option<RuleFixConfiguration<UseExplicitLengthCheck>>,
     #[doc = "Elements with an interactive role and interaction handlers must be focusable."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_focusable_interactive: Option<RuleConfiguration<UseFocusableInteractive>>,
@@ -3411,10 +3412,10 @@ pub struct Nursery {
     pub use_import_restrictions: Option<RuleConfiguration<UseImportRestrictions>>,
     #[doc = "Enforce the sorting of CSS utility classes."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_sorted_classes: Option<RuleConfiguration<UseSortedClasses>>,
+    pub use_sorted_classes: Option<RuleFixConfiguration<UseSortedClasses>>,
     #[doc = "Require new when throwing an error."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_throw_new_error: Option<RuleConfiguration<UseThrowNewError>>,
+    pub use_throw_new_error: Option<RuleFixConfiguration<UseThrowNewError>>,
     #[doc = "Require all regex literals to be declared at the top level."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_top_level_regex: Option<RuleConfiguration<UseTopLevelRegex>>,
@@ -4338,7 +4339,7 @@ pub struct Performance {
     pub no_barrel_file: Option<RuleConfiguration<NoBarrelFile>>,
     #[doc = "Disallow the use of the delete operator."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_delete: Option<RuleConfiguration<NoDelete>>,
+    pub no_delete: Option<RuleFixConfiguration<NoDelete>>,
     #[doc = "Avoid re-export all."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_re_export_all: Option<RuleConfiguration<NoReExportAll>>,
@@ -4719,10 +4720,10 @@ pub struct Style {
     pub no_default_export: Option<RuleConfiguration<NoDefaultExport>>,
     #[doc = "Disallow implicit true values on JSX boolean attributes"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_implicit_boolean: Option<RuleConfiguration<NoImplicitBoolean>>,
+    pub no_implicit_boolean: Option<RuleFixConfiguration<NoImplicitBoolean>>,
     #[doc = "Disallow type annotations for variables, parameters, and class properties initialized with a literal expression."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_inferrable_types: Option<RuleConfiguration<NoInferrableTypes>>,
+    pub no_inferrable_types: Option<RuleFixConfiguration<NoInferrableTypes>>,
     #[doc = "Disallow the use of TypeScript's namespaces."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_namespace: Option<RuleConfiguration<NoNamespace>>,
@@ -4731,10 +4732,10 @@ pub struct Style {
     pub no_namespace_import: Option<RuleConfiguration<NoNamespaceImport>>,
     #[doc = "Disallow negation in the condition of an if statement if it has an else clause."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_negation_else: Option<RuleConfiguration<NoNegationElse>>,
+    pub no_negation_else: Option<RuleFixConfiguration<NoNegationElse>>,
     #[doc = "Disallow non-null assertions using the ! postfix operator."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_non_null_assertion: Option<RuleConfiguration<NoNonNullAssertion>>,
+    pub no_non_null_assertion: Option<RuleFixConfiguration<NoNonNullAssertion>>,
     #[doc = "Disallow reassigning function parameters."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_parameter_assign: Option<RuleConfiguration<NoParameterAssign>>,
@@ -4746,43 +4747,43 @@ pub struct Style {
     pub no_restricted_globals: Option<RuleConfiguration<NoRestrictedGlobals>>,
     #[doc = "Disallow the use of constants which its value is the upper-case version of its name."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_shouty_constants: Option<RuleConfiguration<NoShoutyConstants>>,
+    pub no_shouty_constants: Option<RuleFixConfiguration<NoShoutyConstants>>,
     #[doc = "Disallow template literals if interpolation and special-character handling are not needed"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unused_template_literal: Option<RuleConfiguration<NoUnusedTemplateLiteral>>,
+    pub no_unused_template_literal: Option<RuleFixConfiguration<NoUnusedTemplateLiteral>>,
     #[doc = "Disallow else block when the if block breaks early."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_useless_else: Option<RuleConfiguration<NoUselessElse>>,
+    pub no_useless_else: Option<RuleFixConfiguration<NoUselessElse>>,
     #[doc = "Disallow the use of var"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_var: Option<RuleConfiguration<NoVar>>,
+    pub no_var: Option<RuleFixConfiguration<NoVar>>,
     #[doc = "Enforce the use of as const over literal type and type annotation."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_as_const_assertion: Option<RuleConfiguration<UseAsConstAssertion>>,
+    pub use_as_const_assertion: Option<RuleFixConfiguration<UseAsConstAssertion>>,
     #[doc = "Requires following curly brace conventions."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_block_statements: Option<RuleConfiguration<UseBlockStatements>>,
+    pub use_block_statements: Option<RuleFixConfiguration<UseBlockStatements>>,
     #[doc = "Enforce using else if instead of nested if in else clauses."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_collapsed_else_if: Option<RuleConfiguration<UseCollapsedElseIf>>,
+    pub use_collapsed_else_if: Option<RuleFixConfiguration<UseCollapsedElseIf>>,
     #[doc = "Require consistently using either T\\[] or Array\\<T>"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_consistent_array_type: Option<RuleConfiguration<UseConsistentArrayType>>,
+    pub use_consistent_array_type: Option<RuleFixConfiguration<UseConsistentArrayType>>,
     #[doc = "Require const declarations for variables that are only assigned once."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_const: Option<RuleConfiguration<UseConst>>,
+    pub use_const: Option<RuleFixConfiguration<UseConst>>,
     #[doc = "Enforce default function parameters and optional function parameters to be last."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_default_parameter_last: Option<RuleConfiguration<UseDefaultParameterLast>>,
+    pub use_default_parameter_last: Option<RuleFixConfiguration<UseDefaultParameterLast>>,
     #[doc = "Require that each enum member value be explicitly initialized."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_enum_initializers: Option<RuleConfiguration<UseEnumInitializers>>,
+    pub use_enum_initializers: Option<RuleFixConfiguration<UseEnumInitializers>>,
     #[doc = "Disallow the use of Math.pow in favor of the ** operator."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_exponentiation_operator: Option<RuleConfiguration<UseExponentiationOperator>>,
+    pub use_exponentiation_operator: Option<RuleFixConfiguration<UseExponentiationOperator>>,
     #[doc = "Promotes the use of export type for types."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_export_type: Option<RuleConfiguration<UseExportType>>,
+    pub use_export_type: Option<RuleFixConfiguration<UseExportType>>,
     #[doc = "Enforce naming conventions for JavaScript and TypeScript filenames."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_filenaming_convention: Option<RuleConfiguration<UseFilenamingConvention>>,
@@ -4791,52 +4792,52 @@ pub struct Style {
     pub use_for_of: Option<RuleConfiguration<UseForOf>>,
     #[doc = "This rule enforces the use of \\<>...\\</> over \\<Fragment>...\\</Fragment>."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_fragment_syntax: Option<RuleConfiguration<UseFragmentSyntax>>,
+    pub use_fragment_syntax: Option<RuleFixConfiguration<UseFragmentSyntax>>,
     #[doc = "Promotes the use of import type for types."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_import_type: Option<RuleConfiguration<UseImportType>>,
+    pub use_import_type: Option<RuleFixConfiguration<UseImportType>>,
     #[doc = "Require all enum members to be literal values."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_literal_enum_members: Option<RuleConfiguration<UseLiteralEnumMembers>>,
     #[doc = "Enforce naming conventions for everything across a codebase."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_naming_convention: Option<RuleConfiguration<UseNamingConvention>>,
+    pub use_naming_convention: Option<RuleFixConfiguration<UseNamingConvention>>,
     #[doc = "Promotes the usage of node:assert/strict over node:assert."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_node_assert_strict: Option<RuleConfiguration<UseNodeAssertStrict>>,
+    pub use_node_assert_strict: Option<RuleFixConfiguration<UseNodeAssertStrict>>,
     #[doc = "Enforces using the node: protocol for Node.js builtin modules."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_nodejs_import_protocol: Option<RuleConfiguration<UseNodejsImportProtocol>>,
+    pub use_nodejs_import_protocol: Option<RuleFixConfiguration<UseNodejsImportProtocol>>,
     #[doc = "Use the Number properties instead of global ones."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_number_namespace: Option<RuleConfiguration<UseNumberNamespace>>,
+    pub use_number_namespace: Option<RuleFixConfiguration<UseNumberNamespace>>,
     #[doc = "Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_numeric_literals: Option<RuleConfiguration<UseNumericLiterals>>,
+    pub use_numeric_literals: Option<RuleFixConfiguration<UseNumericLiterals>>,
     #[doc = "Prevent extra closing tags for components without children"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_self_closing_elements: Option<RuleConfiguration<UseSelfClosingElements>>,
+    pub use_self_closing_elements: Option<RuleFixConfiguration<UseSelfClosingElements>>,
     #[doc = "When expressing array types, this rule promotes the usage of T\\[] shorthand instead of Array\\<T>."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_shorthand_array_type: Option<RuleConfiguration<UseShorthandArrayType>>,
+    pub use_shorthand_array_type: Option<RuleFixConfiguration<UseShorthandArrayType>>,
     #[doc = "Require assignment operator shorthand where possible."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_shorthand_assign: Option<RuleConfiguration<UseShorthandAssign>>,
+    pub use_shorthand_assign: Option<RuleFixConfiguration<UseShorthandAssign>>,
     #[doc = "Enforce using function types instead of object type with call signatures."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_shorthand_function_type: Option<RuleConfiguration<UseShorthandFunctionType>>,
+    pub use_shorthand_function_type: Option<RuleFixConfiguration<UseShorthandFunctionType>>,
     #[doc = "Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_single_case_statement: Option<RuleConfiguration<UseSingleCaseStatement>>,
+    pub use_single_case_statement: Option<RuleFixConfiguration<UseSingleCaseStatement>>,
     #[doc = "Disallow multiple variable declarations in the same variable statement"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_single_var_declarator: Option<RuleConfiguration<UseSingleVarDeclarator>>,
+    pub use_single_var_declarator: Option<RuleFixConfiguration<UseSingleVarDeclarator>>,
     #[doc = "Prefer template literals over string concatenation."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_template: Option<RuleConfiguration<UseTemplate>>,
+    pub use_template: Option<RuleFixConfiguration<UseTemplate>>,
     #[doc = "Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_while: Option<RuleConfiguration<UseWhile>>,
+    pub use_while: Option<RuleFixConfiguration<UseWhile>>,
 }
 impl DeserializableValidator for Style {
     fn validate(
@@ -5892,7 +5893,7 @@ pub struct Suspicious {
     #[doc = "Use standard constants instead of approximated literals."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_approximative_numeric_constant:
-        Option<RuleConfiguration<NoApproximativeNumericConstant>>,
+        Option<RuleFixConfiguration<NoApproximativeNumericConstant>>,
     #[doc = "Discourage the usage of Array index in keys."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_array_index_key: Option<RuleConfiguration<NoArrayIndexKey>>,
@@ -5910,31 +5911,31 @@ pub struct Suspicious {
     pub no_class_assign: Option<RuleConfiguration<NoClassAssign>>,
     #[doc = "Prevent comments from being inserted as text nodes"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_comment_text: Option<RuleConfiguration<NoCommentText>>,
+    pub no_comment_text: Option<RuleFixConfiguration<NoCommentText>>,
     #[doc = "Disallow comparing against -0"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_compare_neg_zero: Option<RuleConfiguration<NoCompareNegZero>>,
+    pub no_compare_neg_zero: Option<RuleFixConfiguration<NoCompareNegZero>>,
     #[doc = "Disallow labeled statements that are not loops."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_confusing_labels: Option<RuleConfiguration<NoConfusingLabels>>,
     #[doc = "Disallow void type outside of generic or return types."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_confusing_void_type: Option<RuleConfiguration<NoConfusingVoidType>>,
+    pub no_confusing_void_type: Option<RuleFixConfiguration<NoConfusingVoidType>>,
     #[doc = "Disallow the use of console.log"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_console_log: Option<RuleConfiguration<NoConsoleLog>>,
+    pub no_console_log: Option<RuleFixConfiguration<NoConsoleLog>>,
     #[doc = "Disallow TypeScript const enum"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_const_enum: Option<RuleConfiguration<NoConstEnum>>,
+    pub no_const_enum: Option<RuleFixConfiguration<NoConstEnum>>,
     #[doc = "Prevents from having control characters and some escape sequences that match control characters in regular expressions."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_control_characters_in_regex: Option<RuleConfiguration<NoControlCharactersInRegex>>,
     #[doc = "Disallow the use of debugger"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_debugger: Option<RuleConfiguration<NoDebugger>>,
+    pub no_debugger: Option<RuleFixConfiguration<NoDebugger>>,
     #[doc = "Require the use of === and !=="]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_double_equals: Option<RuleConfiguration<NoDoubleEquals>>,
+    pub no_double_equals: Option<RuleFixConfiguration<NoDoubleEquals>>,
     #[doc = "Disallow duplicate case labels."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_duplicate_case: Option<RuleConfiguration<NoDuplicateCase>>,
@@ -5946,7 +5947,7 @@ pub struct Suspicious {
     pub no_duplicate_jsx_props: Option<RuleConfiguration<NoDuplicateJsxProps>>,
     #[doc = "Prevents object literals having more than one property declaration for the same name."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_duplicate_object_keys: Option<RuleConfiguration<NoDuplicateObjectKeys>>,
+    pub no_duplicate_object_keys: Option<RuleFixConfiguration<NoDuplicateObjectKeys>>,
     #[doc = "Disallow duplicate function parameter name."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_duplicate_parameters: Option<RuleConfiguration<NoDuplicateParameters>>,
@@ -5958,7 +5959,7 @@ pub struct Suspicious {
     pub no_empty_block_statements: Option<RuleConfiguration<NoEmptyBlockStatements>>,
     #[doc = "Disallow the declaration of empty interfaces."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_empty_interface: Option<RuleConfiguration<NoEmptyInterface>>,
+    pub no_empty_interface: Option<RuleFixConfiguration<NoEmptyInterface>>,
     #[doc = "Disallow the any type usage."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_explicit_any: Option<RuleConfiguration<NoExplicitAny>>,
@@ -5967,13 +5968,13 @@ pub struct Suspicious {
     pub no_exports_in_test: Option<RuleConfiguration<NoExportsInTest>>,
     #[doc = "Prevents the wrong usage of the non-null assertion operator (!) in TypeScript files."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_extra_non_null_assertion: Option<RuleConfiguration<NoExtraNonNullAssertion>>,
+    pub no_extra_non_null_assertion: Option<RuleFixConfiguration<NoExtraNonNullAssertion>>,
     #[doc = "Disallow fallthrough of switch clauses."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_fallthrough_switch_clause: Option<RuleConfiguration<NoFallthroughSwitchClause>>,
     #[doc = "Disallow focused tests."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_focused_tests: Option<RuleConfiguration<NoFocusedTests>>,
+    pub no_focused_tests: Option<RuleFixConfiguration<NoFocusedTests>>,
     #[doc = "Disallow reassigning function declarations."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_function_assign: Option<RuleConfiguration<NoFunctionAssign>>,
@@ -5982,10 +5983,10 @@ pub struct Suspicious {
     pub no_global_assign: Option<RuleConfiguration<NoGlobalAssign>>,
     #[doc = "Use Number.isFinite instead of global isFinite."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_global_is_finite: Option<RuleConfiguration<NoGlobalIsFinite>>,
+    pub no_global_is_finite: Option<RuleFixConfiguration<NoGlobalIsFinite>>,
     #[doc = "Use Number.isNaN instead of global isNaN."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_global_is_nan: Option<RuleConfiguration<NoGlobalIsNan>>,
+    pub no_global_is_nan: Option<RuleFixConfiguration<NoGlobalIsNan>>,
     #[doc = "Disallow use of implicit any type on variable declarations."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_implicit_any_let: Option<RuleConfiguration<NoImplicitAnyLet>>,
@@ -5997,14 +5998,14 @@ pub struct Suspicious {
     pub no_label_var: Option<RuleConfiguration<NoLabelVar>>,
     #[doc = "Disallow characters made with multiple code points in character class syntax."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_misleading_character_class: Option<RuleConfiguration<NoMisleadingCharacterClass>>,
+    pub no_misleading_character_class: Option<RuleFixConfiguration<NoMisleadingCharacterClass>>,
     #[doc = "Enforce proper usage of new and constructor."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_misleading_instantiator: Option<RuleConfiguration<NoMisleadingInstantiator>>,
     #[doc = "Disallow shorthand assign when variable appears on both sides."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_misrefactored_shorthand_assign:
-        Option<RuleConfiguration<NoMisrefactoredShorthandAssign>>,
+        Option<RuleFixConfiguration<NoMisrefactoredShorthandAssign>>,
     #[doc = "Disallow direct use of Object.prototype builtins."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_prototype_builtins: Option<RuleConfiguration<NoPrototypeBuiltins>>,
@@ -6013,7 +6014,7 @@ pub struct Suspicious {
     pub no_redeclare: Option<RuleConfiguration<NoRedeclare>>,
     #[doc = "Prevents from having redundant \"use strict\"."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_redundant_use_strict: Option<RuleConfiguration<NoRedundantUseStrict>>,
+    pub no_redundant_use_strict: Option<RuleFixConfiguration<NoRedundantUseStrict>>,
     #[doc = "Disallow comparisons where both sides are exactly the same."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_self_compare: Option<RuleConfiguration<NoSelfCompare>>,
@@ -6022,10 +6023,10 @@ pub struct Suspicious {
     pub no_shadow_restricted_names: Option<RuleConfiguration<NoShadowRestrictedNames>>,
     #[doc = "Disallow disabled tests."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_skipped_tests: Option<RuleConfiguration<NoSkippedTests>>,
+    pub no_skipped_tests: Option<RuleFixConfiguration<NoSkippedTests>>,
     #[doc = "Disallow sparse arrays"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_sparse_array: Option<RuleConfiguration<NoSparseArray>>,
+    pub no_sparse_array: Option<RuleFixConfiguration<NoSparseArray>>,
     #[doc = "It detects possible \"wrong\" semicolons inside JSX elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_suspicious_semicolon_in_jsx: Option<RuleConfiguration<NoSuspiciousSemicolonInJsx>>,
@@ -6037,7 +6038,7 @@ pub struct Suspicious {
     pub no_unsafe_declaration_merging: Option<RuleConfiguration<NoUnsafeDeclarationMerging>>,
     #[doc = "Disallow using unsafe negation."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_unsafe_negation: Option<RuleConfiguration<NoUnsafeNegation>>,
+    pub no_unsafe_negation: Option<RuleFixConfiguration<NoUnsafeNegation>>,
     #[doc = "Ensure async functions utilize await."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_await: Option<RuleConfiguration<UseAwait>>,
@@ -6049,13 +6050,13 @@ pub struct Suspicious {
     pub use_getter_return: Option<RuleConfiguration<UseGetterReturn>>,
     #[doc = "Use Array.isArray() instead of instanceof Array."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_is_array: Option<RuleConfiguration<UseIsArray>>,
+    pub use_is_array: Option<RuleFixConfiguration<UseIsArray>>,
     #[doc = "Require using the namespace keyword over the module keyword to declare TypeScript namespaces."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_namespace_keyword: Option<RuleConfiguration<UseNamespaceKeyword>>,
+    pub use_namespace_keyword: Option<RuleFixConfiguration<UseNamespaceKeyword>>,
     #[doc = "This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions"]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_valid_typeof: Option<RuleConfiguration<UseValidTypeof>>,
+    pub use_valid_typeof: Option<RuleFixConfiguration<UseValidTypeof>>,
 }
 impl DeserializableValidator for Suspicious {
     fn validate(

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -492,47 +492,47 @@ export interface A11y {
 	/**
 	 * Enforce that the accessKey attribute is not used on any HTML element.
 	 */
-	noAccessKey?: RuleConfiguration_for_Null;
+	noAccessKey?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce that aria-hidden="true" is not set on focusable elements.
 	 */
-	noAriaHiddenOnFocusable?: RuleConfiguration_for_Null;
+	noAriaHiddenOnFocusable?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.
 	 */
-	noAriaUnsupportedElements?: RuleConfiguration_for_Null;
+	noAriaUnsupportedElements?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce that autoFocus prop is not used on elements.
 	 */
-	noAutofocus?: RuleConfiguration_for_Null;
+	noAutofocus?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow target="_blank" attribute without rel="noreferrer"
 	 */
-	noBlankTarget?: RuleConfiguration_for_Null;
+	noBlankTarget?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforces that no distracting elements are used.
 	 */
-	noDistractingElements?: RuleConfiguration_for_Null;
+	noDistractingElements?: RuleFixConfiguration_for_Null;
 	/**
 	 * The scope prop should be used only on \<th> elements.
 	 */
-	noHeaderScope?: RuleConfiguration_for_Null;
+	noHeaderScope?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements.
 	 */
-	noInteractiveElementToNoninteractiveRole?: RuleConfiguration_for_Null;
+	noInteractiveElementToNoninteractiveRole?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.
 	 */
-	noNoninteractiveElementToInteractiveRole?: RuleConfiguration_for_Null;
+	noNoninteractiveElementToInteractiveRole?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce that tabIndex is not assigned to non-interactive HTML elements.
 	 */
-	noNoninteractiveTabindex?: RuleConfiguration_for_Null;
+	noNoninteractiveTabindex?: RuleFixConfiguration_for_Null;
 	/**
 	 * Prevent the usage of positive integers on tabIndex property
 	 */
-	noPositiveTabindex?: RuleConfiguration_for_Null;
+	noPositiveTabindex?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce img alt prop does not contain the word "image", "picture", or "photo".
 	 */
@@ -540,7 +540,7 @@ export interface A11y {
 	/**
 	 * Enforce explicit role property is not the same as implicit/default role property on an element.
 	 */
-	noRedundantRoles?: RuleConfiguration_for_Null;
+	noRedundantRoles?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforces the usage of the title element for the svg element.
 	 */
@@ -556,11 +556,11 @@ export interface A11y {
 	/**
 	 * Enforce that anchors have content and that the content is accessible to screen readers.
 	 */
-	useAnchorContent?: RuleConfiguration_for_Null;
+	useAnchorContent?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce that tabIndex is assigned to non-interactive HTML elements with aria-activedescendant.
 	 */
-	useAriaActivedescendantWithTabindex?: RuleConfiguration_for_Null;
+	useAriaActivedescendantWithTabindex?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce that elements with ARIA roles must have all required ARIA attributes for that role.
 	 */
@@ -600,11 +600,11 @@ export interface A11y {
 	/**
 	 * Ensures that ARIA properties aria-* are all valid.
 	 */
-	useValidAriaProps?: RuleConfiguration_for_Null;
+	useValidAriaProps?: RuleFixConfiguration_for_Null;
 	/**
 	 * Elements with ARIA roles must use a valid, non-abstract ARIA role.
 	 */
-	useValidAriaRole?: RuleConfiguration_for_ValidAriaRoleOptions;
+	useValidAriaRole?: RuleFixConfiguration_for_ValidAriaRoleOptions;
 	/**
 	 * Enforce that ARIA state and property values are valid.
 	 */
@@ -625,7 +625,7 @@ export interface Complexity {
 	/**
 	 * Disallow primitive type aliases and misleading types.
 	 */
-	noBannedTypes?: RuleConfiguration_for_Null;
+	noBannedTypes?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow empty type parameters in type aliases and interfaces.
 	 */
@@ -641,7 +641,7 @@ export interface Complexity {
 	/**
 	 * Disallow unnecessary boolean casts
 	 */
-	noExtraBooleanCast?: RuleConfiguration_for_Null;
+	noExtraBooleanCast?: RuleFixConfiguration_for_Null;
 	/**
 	 * Prefer for...of statement instead of Array.forEach.
 	 */
@@ -649,7 +649,7 @@ export interface Complexity {
 	/**
 	 * Disallow unclear usage of consecutive space characters in regular expression literals
 	 */
-	noMultipleSpacesInRegularExpressionLiterals?: RuleConfiguration_for_Null;
+	noMultipleSpacesInRegularExpressionLiterals?: RuleFixConfiguration_for_Null;
 	/**
 	 * This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace.
 	 */
@@ -657,7 +657,7 @@ export interface Complexity {
 	/**
 	 * Disallow this and super in static contexts.
 	 */
-	noThisInStatic?: RuleConfiguration_for_Null;
+	noThisInStatic?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow unnecessary catch clauses.
 	 */
@@ -665,43 +665,43 @@ export interface Complexity {
 	/**
 	 * Disallow unnecessary constructors.
 	 */
-	noUselessConstructor?: RuleConfiguration_for_Null;
+	noUselessConstructor?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow empty exports that don't change anything in a module file.
 	 */
-	noUselessEmptyExport?: RuleConfiguration_for_Null;
+	noUselessEmptyExport?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow unnecessary fragments
 	 */
-	noUselessFragments?: RuleConfiguration_for_Null;
+	noUselessFragments?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow unnecessary labels.
 	 */
-	noUselessLabel?: RuleConfiguration_for_Null;
+	noUselessLabel?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow unnecessary nested block statements.
 	 */
-	noUselessLoneBlockStatements?: RuleConfiguration_for_Null;
+	noUselessLoneBlockStatements?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow renaming import, export, and destructured assignments to the same name.
 	 */
-	noUselessRename?: RuleConfiguration_for_Null;
+	noUselessRename?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow useless case in switch statements.
 	 */
-	noUselessSwitchCase?: RuleConfiguration_for_Null;
+	noUselessSwitchCase?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow ternary operators when simpler alternatives exist.
 	 */
-	noUselessTernary?: RuleConfiguration_for_Null;
+	noUselessTernary?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow useless this aliasing.
 	 */
-	noUselessThisAlias?: RuleConfiguration_for_Null;
+	noUselessThisAlias?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow using any or unknown as type constraint.
 	 */
-	noUselessTypeConstraint?: RuleConfiguration_for_Null;
+	noUselessTypeConstraint?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow the use of void operators, which is not a familiar operator.
 	 */
@@ -717,31 +717,31 @@ export interface Complexity {
 	/**
 	 * Use arrow functions over function expressions.
 	 */
-	useArrowFunction?: RuleConfiguration_for_Null;
+	useArrowFunction?: RuleFixConfiguration_for_Null;
 	/**
 	 * Promotes the use of .flatMap() when map().flat() are used together.
 	 */
-	useFlatMap?: RuleConfiguration_for_Null;
+	useFlatMap?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce the usage of a literal access to properties over computed property access.
 	 */
-	useLiteralKeys?: RuleConfiguration_for_Null;
+	useLiteralKeys?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce using concise optional chain instead of chained logical expressions.
 	 */
-	useOptionalChain?: RuleConfiguration_for_Null;
+	useOptionalChain?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce the use of the regular expression literals instead of the RegExp constructor if possible.
 	 */
-	useRegexLiterals?: RuleConfiguration_for_Null;
+	useRegexLiterals?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow number literal object member names which are not base10 or uses underscore as separator
 	 */
-	useSimpleNumberKeys?: RuleConfiguration_for_Null;
+	useSimpleNumberKeys?: RuleFixConfiguration_for_Null;
 	/**
 	 * Discard redundant terms from logical expressions.
 	 */
-	useSimplifiedLogicExpression?: RuleConfiguration_for_Null;
+	useSimplifiedLogicExpression?: RuleFixConfiguration_for_Null;
 }
 /**
  * A list of rules that belong to this group
@@ -758,7 +758,7 @@ export interface Correctness {
 	/**
 	 * Prevents from having const variables being re-assigned.
 	 */
-	noConstAssign?: RuleConfiguration_for_Null;
+	noConstAssign?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow constant expressions in conditions
 	 */
@@ -790,7 +790,7 @@ export interface Correctness {
 	/**
 	 * Disallow new operators with global non-constructor functions.
 	 */
-	noInvalidNewBuiltin?: RuleConfiguration_for_Null;
+	noInvalidNewBuiltin?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow the use of variables and function parameters before their declaration
 	 */
@@ -798,11 +798,11 @@ export interface Correctness {
 	/**
 	 * Disallow new operators with the Symbol object.
 	 */
-	noNewSymbol?: RuleConfiguration_for_Null;
+	noNewSymbol?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow \8 and \9 escape sequences in string literals.
 	 */
-	noNonoctalDecimalEscape?: RuleConfiguration_for_Null;
+	noNonoctalDecimalEscape?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow literal numbers that lose precision
 	 */
@@ -822,11 +822,11 @@ export interface Correctness {
 	/**
 	 * Disallow comparison of expressions modifying the string case with non-compliant value.
 	 */
-	noStringCaseMismatch?: RuleConfiguration_for_Null;
+	noStringCaseMismatch?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow lexical declarations in switch clauses.
 	 */
-	noSwitchDeclarations?: RuleConfiguration_for_Null;
+	noSwitchDeclarations?: RuleFixConfiguration_for_Null;
 	/**
 	 * Prevents the usage of variables that haven't been declared inside the document.
 	 */
@@ -834,7 +834,7 @@ export interface Correctness {
 	/**
 	 * Avoid using unnecessary continue.
 	 */
-	noUnnecessaryContinue?: RuleConfiguration_for_Null;
+	noUnnecessaryContinue?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow unreachable code
 	 */
@@ -854,23 +854,23 @@ export interface Correctness {
 	/**
 	 * Disallow unused imports.
 	 */
-	noUnusedImports?: RuleConfiguration_for_Null;
+	noUnusedImports?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow unused labels.
 	 */
-	noUnusedLabels?: RuleConfiguration_for_Null;
+	noUnusedLabels?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow unused private class members
 	 */
-	noUnusedPrivateClassMembers?: RuleConfiguration_for_Null;
+	noUnusedPrivateClassMembers?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow unused variables.
 	 */
-	noUnusedVariables?: RuleConfiguration_for_Null;
+	noUnusedVariables?: RuleFixConfiguration_for_Null;
 	/**
 	 * This rules prevents void elements (AKA self-closing elements) from having children.
 	 */
-	noVoidElementsWithChildren?: RuleConfiguration_for_Null;
+	noVoidElementsWithChildren?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow returning a value from a function with the return type 'void'
 	 */
@@ -890,7 +890,7 @@ export interface Correctness {
 	/**
 	 * Require calls to isNaN() when checking for NaN.
 	 */
-	useIsNan?: RuleConfiguration_for_Null;
+	useIsNan?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow missing key props in iterators/collection literals.
 	 */
@@ -919,11 +919,11 @@ export interface Nursery {
 	/**
 	 * Disallow the use of console.
 	 */
-	noConsole?: RuleConfiguration_for_Null;
+	noConsole?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow the use of Math.min and Math.max to clamp a value where the result itself is constant.
 	 */
-	noConstantMathMinMaxClamp?: RuleConfiguration_for_Null;
+	noConstantMathMinMaxClamp?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow CSS empty blocks.
 	 */
@@ -959,7 +959,7 @@ export interface Nursery {
 	/**
 	 * Disallow to use unnecessary callback on flatMap.
 	 */
-	noFlatMapIdentity?: RuleConfiguration_for_Null;
+	noFlatMapIdentity?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow invalid !important within keyframe declarations
 	 */
@@ -979,7 +979,7 @@ export interface Nursery {
 	/**
 	 * Prevents React-specific JSX properties from being used.
 	 */
-	noReactSpecificProps?: RuleConfiguration_for_Null;
+	noReactSpecificProps?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow specified modules when loaded by import or require.
 	 */
@@ -1015,11 +1015,11 @@ export interface Nursery {
 	/**
 	 * Disallow unnecessary concatenation of string or template literals.
 	 */
-	noUselessStringConcat?: RuleConfiguration_for_Null;
+	noUselessStringConcat?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow initializing variables to undefined.
 	 */
-	noUselessUndefinedInitialization?: RuleConfiguration_for_Null;
+	noUselessUndefinedInitialization?: RuleFixConfiguration_for_Null;
 	/**
 	 * It enables the recommended rules for this group
 	 */
@@ -1027,11 +1027,11 @@ export interface Nursery {
 	/**
 	 * Disallow Array constructors.
 	 */
-	useArrayLiterals?: RuleConfiguration_for_Null;
+	useArrayLiterals?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce the use of new for all builtins, except String, Number, Boolean, Symbol and BigInt.
 	 */
-	useConsistentBuiltinInstantiation?: RuleConfiguration_for_Null;
+	useConsistentBuiltinInstantiation?: RuleFixConfiguration_for_Null;
 	/**
 	 * Require the default clause in switch statements.
 	 */
@@ -1039,7 +1039,7 @@ export interface Nursery {
 	/**
 	 * Enforce explicitly comparing the length, size, byteLength or byteOffset property of a value.
 	 */
-	useExplicitLengthCheck?: RuleConfiguration_for_Null;
+	useExplicitLengthCheck?: RuleFixConfiguration_for_Null;
 	/**
 	 * Elements with an interactive role and interaction handlers must be focusable.
 	 */
@@ -1055,11 +1055,11 @@ export interface Nursery {
 	/**
 	 * Enforce the sorting of CSS utility classes.
 	 */
-	useSortedClasses?: RuleConfiguration_for_UtilityClassSortingOptions;
+	useSortedClasses?: RuleFixConfiguration_for_UtilityClassSortingOptions;
 	/**
 	 * Require new when throwing an error.
 	 */
-	useThrowNewError?: RuleConfiguration_for_Null;
+	useThrowNewError?: RuleFixConfiguration_for_Null;
 	/**
 	 * Require all regex literals to be declared at the top level.
 	 */
@@ -1084,7 +1084,7 @@ export interface Performance {
 	/**
 	 * Disallow the use of the delete operator.
 	 */
-	noDelete?: RuleConfiguration_for_Null;
+	noDelete?: RuleFixConfiguration_for_Null;
 	/**
 	 * Avoid re-export all.
 	 */
@@ -1142,11 +1142,11 @@ export interface Style {
 	/**
 	 * Disallow implicit true values on JSX boolean attributes
 	 */
-	noImplicitBoolean?: RuleConfiguration_for_Null;
+	noImplicitBoolean?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow type annotations for variables, parameters, and class properties initialized with a literal expression.
 	 */
-	noInferrableTypes?: RuleConfiguration_for_Null;
+	noInferrableTypes?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow the use of TypeScript's namespaces.
 	 */
@@ -1158,11 +1158,11 @@ export interface Style {
 	/**
 	 * Disallow negation in the condition of an if statement if it has an else clause.
 	 */
-	noNegationElse?: RuleConfiguration_for_Null;
+	noNegationElse?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow non-null assertions using the ! postfix operator.
 	 */
-	noNonNullAssertion?: RuleConfiguration_for_Null;
+	noNonNullAssertion?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow reassigning function parameters.
 	 */
@@ -1178,19 +1178,19 @@ export interface Style {
 	/**
 	 * Disallow the use of constants which its value is the upper-case version of its name.
 	 */
-	noShoutyConstants?: RuleConfiguration_for_Null;
+	noShoutyConstants?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow template literals if interpolation and special-character handling are not needed
 	 */
-	noUnusedTemplateLiteral?: RuleConfiguration_for_Null;
+	noUnusedTemplateLiteral?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow else block when the if block breaks early.
 	 */
-	noUselessElse?: RuleConfiguration_for_Null;
+	noUselessElse?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow the use of var
 	 */
-	noVar?: RuleConfiguration_for_Null;
+	noVar?: RuleFixConfiguration_for_Null;
 	/**
 	 * It enables the recommended rules for this group
 	 */
@@ -1198,39 +1198,39 @@ export interface Style {
 	/**
 	 * Enforce the use of as const over literal type and type annotation.
 	 */
-	useAsConstAssertion?: RuleConfiguration_for_Null;
+	useAsConstAssertion?: RuleFixConfiguration_for_Null;
 	/**
 	 * Requires following curly brace conventions.
 	 */
-	useBlockStatements?: RuleConfiguration_for_Null;
+	useBlockStatements?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce using else if instead of nested if in else clauses.
 	 */
-	useCollapsedElseIf?: RuleConfiguration_for_Null;
+	useCollapsedElseIf?: RuleFixConfiguration_for_Null;
 	/**
 	 * Require consistently using either T\[] or Array\<T>
 	 */
-	useConsistentArrayType?: RuleConfiguration_for_ConsistentArrayTypeOptions;
+	useConsistentArrayType?: RuleFixConfiguration_for_ConsistentArrayTypeOptions;
 	/**
 	 * Require const declarations for variables that are only assigned once.
 	 */
-	useConst?: RuleConfiguration_for_Null;
+	useConst?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce default function parameters and optional function parameters to be last.
 	 */
-	useDefaultParameterLast?: RuleConfiguration_for_Null;
+	useDefaultParameterLast?: RuleFixConfiguration_for_Null;
 	/**
 	 * Require that each enum member value be explicitly initialized.
 	 */
-	useEnumInitializers?: RuleConfiguration_for_Null;
+	useEnumInitializers?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow the use of Math.pow in favor of the ** operator.
 	 */
-	useExponentiationOperator?: RuleConfiguration_for_Null;
+	useExponentiationOperator?: RuleFixConfiguration_for_Null;
 	/**
 	 * Promotes the use of export type for types.
 	 */
-	useExportType?: RuleConfiguration_for_Null;
+	useExportType?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce naming conventions for JavaScript and TypeScript filenames.
 	 */
@@ -1242,11 +1242,11 @@ export interface Style {
 	/**
 	 * This rule enforces the use of \<>...\</> over \<Fragment>...\</Fragment>.
 	 */
-	useFragmentSyntax?: RuleConfiguration_for_Null;
+	useFragmentSyntax?: RuleFixConfiguration_for_Null;
 	/**
 	 * Promotes the use of import type for types.
 	 */
-	useImportType?: RuleConfiguration_for_Null;
+	useImportType?: RuleFixConfiguration_for_Null;
 	/**
 	 * Require all enum members to be literal values.
 	 */
@@ -1254,55 +1254,55 @@ export interface Style {
 	/**
 	 * Enforce naming conventions for everything across a codebase.
 	 */
-	useNamingConvention?: RuleConfiguration_for_NamingConventionOptions;
+	useNamingConvention?: RuleFixConfiguration_for_NamingConventionOptions;
 	/**
 	 * Promotes the usage of node:assert/strict over node:assert.
 	 */
-	useNodeAssertStrict?: RuleConfiguration_for_Null;
+	useNodeAssertStrict?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforces using the node: protocol for Node.js builtin modules.
 	 */
-	useNodejsImportProtocol?: RuleConfiguration_for_Null;
+	useNodejsImportProtocol?: RuleFixConfiguration_for_Null;
 	/**
 	 * Use the Number properties instead of global ones.
 	 */
-	useNumberNamespace?: RuleConfiguration_for_Null;
+	useNumberNamespace?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals
 	 */
-	useNumericLiterals?: RuleConfiguration_for_Null;
+	useNumericLiterals?: RuleFixConfiguration_for_Null;
 	/**
 	 * Prevent extra closing tags for components without children
 	 */
-	useSelfClosingElements?: RuleConfiguration_for_Null;
+	useSelfClosingElements?: RuleFixConfiguration_for_Null;
 	/**
 	 * When expressing array types, this rule promotes the usage of T\[] shorthand instead of Array\<T>.
 	 */
-	useShorthandArrayType?: RuleConfiguration_for_Null;
+	useShorthandArrayType?: RuleFixConfiguration_for_Null;
 	/**
 	 * Require assignment operator shorthand where possible.
 	 */
-	useShorthandAssign?: RuleConfiguration_for_Null;
+	useShorthandAssign?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce using function types instead of object type with call signatures.
 	 */
-	useShorthandFunctionType?: RuleConfiguration_for_Null;
+	useShorthandFunctionType?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block.
 	 */
-	useSingleCaseStatement?: RuleConfiguration_for_Null;
+	useSingleCaseStatement?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow multiple variable declarations in the same variable statement
 	 */
-	useSingleVarDeclarator?: RuleConfiguration_for_Null;
+	useSingleVarDeclarator?: RuleFixConfiguration_for_Null;
 	/**
 	 * Prefer template literals over string concatenation.
 	 */
-	useTemplate?: RuleConfiguration_for_Null;
+	useTemplate?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed.
 	 */
-	useWhile?: RuleConfiguration_for_Null;
+	useWhile?: RuleFixConfiguration_for_Null;
 }
 /**
  * A list of rules that belong to this group
@@ -1315,7 +1315,7 @@ export interface Suspicious {
 	/**
 	 * Use standard constants instead of approximated literals.
 	 */
-	noApproximativeNumericConstant?: RuleConfiguration_for_Null;
+	noApproximativeNumericConstant?: RuleFixConfiguration_for_Null;
 	/**
 	 * Discourage the usage of Array index in keys.
 	 */
@@ -1339,11 +1339,11 @@ export interface Suspicious {
 	/**
 	 * Prevent comments from being inserted as text nodes
 	 */
-	noCommentText?: RuleConfiguration_for_Null;
+	noCommentText?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow comparing against -0
 	 */
-	noCompareNegZero?: RuleConfiguration_for_Null;
+	noCompareNegZero?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow labeled statements that are not loops.
 	 */
@@ -1351,15 +1351,15 @@ export interface Suspicious {
 	/**
 	 * Disallow void type outside of generic or return types.
 	 */
-	noConfusingVoidType?: RuleConfiguration_for_Null;
+	noConfusingVoidType?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow the use of console.log
 	 */
-	noConsoleLog?: RuleConfiguration_for_Null;
+	noConsoleLog?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow TypeScript const enum
 	 */
-	noConstEnum?: RuleConfiguration_for_Null;
+	noConstEnum?: RuleFixConfiguration_for_Null;
 	/**
 	 * Prevents from having control characters and some escape sequences that match control characters in regular expressions.
 	 */
@@ -1367,11 +1367,11 @@ export interface Suspicious {
 	/**
 	 * Disallow the use of debugger
 	 */
-	noDebugger?: RuleConfiguration_for_Null;
+	noDebugger?: RuleFixConfiguration_for_Null;
 	/**
 	 * Require the use of === and !==
 	 */
-	noDoubleEquals?: RuleConfiguration_for_Null;
+	noDoubleEquals?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow duplicate case labels.
 	 */
@@ -1387,7 +1387,7 @@ export interface Suspicious {
 	/**
 	 * Prevents object literals having more than one property declaration for the same name.
 	 */
-	noDuplicateObjectKeys?: RuleConfiguration_for_Null;
+	noDuplicateObjectKeys?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow duplicate function parameter name.
 	 */
@@ -1403,7 +1403,7 @@ export interface Suspicious {
 	/**
 	 * Disallow the declaration of empty interfaces.
 	 */
-	noEmptyInterface?: RuleConfiguration_for_Null;
+	noEmptyInterface?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow the any type usage.
 	 */
@@ -1415,7 +1415,7 @@ export interface Suspicious {
 	/**
 	 * Prevents the wrong usage of the non-null assertion operator (!) in TypeScript files.
 	 */
-	noExtraNonNullAssertion?: RuleConfiguration_for_Null;
+	noExtraNonNullAssertion?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow fallthrough of switch clauses.
 	 */
@@ -1423,7 +1423,7 @@ export interface Suspicious {
 	/**
 	 * Disallow focused tests.
 	 */
-	noFocusedTests?: RuleConfiguration_for_Null;
+	noFocusedTests?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow reassigning function declarations.
 	 */
@@ -1435,11 +1435,11 @@ export interface Suspicious {
 	/**
 	 * Use Number.isFinite instead of global isFinite.
 	 */
-	noGlobalIsFinite?: RuleConfiguration_for_Null;
+	noGlobalIsFinite?: RuleFixConfiguration_for_Null;
 	/**
 	 * Use Number.isNaN instead of global isNaN.
 	 */
-	noGlobalIsNan?: RuleConfiguration_for_Null;
+	noGlobalIsNan?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow use of implicit any type on variable declarations.
 	 */
@@ -1455,7 +1455,7 @@ export interface Suspicious {
 	/**
 	 * Disallow characters made with multiple code points in character class syntax.
 	 */
-	noMisleadingCharacterClass?: RuleConfiguration_for_Null;
+	noMisleadingCharacterClass?: RuleFixConfiguration_for_Null;
 	/**
 	 * Enforce proper usage of new and constructor.
 	 */
@@ -1463,7 +1463,7 @@ export interface Suspicious {
 	/**
 	 * Disallow shorthand assign when variable appears on both sides.
 	 */
-	noMisrefactoredShorthandAssign?: RuleConfiguration_for_Null;
+	noMisrefactoredShorthandAssign?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow direct use of Object.prototype builtins.
 	 */
@@ -1475,7 +1475,7 @@ export interface Suspicious {
 	/**
 	 * Prevents from having redundant "use strict".
 	 */
-	noRedundantUseStrict?: RuleConfiguration_for_Null;
+	noRedundantUseStrict?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow comparisons where both sides are exactly the same.
 	 */
@@ -1487,11 +1487,11 @@ export interface Suspicious {
 	/**
 	 * Disallow disabled tests.
 	 */
-	noSkippedTests?: RuleConfiguration_for_Null;
+	noSkippedTests?: RuleFixConfiguration_for_Null;
 	/**
 	 * Disallow sparse arrays
 	 */
-	noSparseArray?: RuleConfiguration_for_Null;
+	noSparseArray?: RuleFixConfiguration_for_Null;
 	/**
 	 * It detects possible "wrong" semicolons inside JSX elements.
 	 */
@@ -1507,7 +1507,7 @@ export interface Suspicious {
 	/**
 	 * Disallow using unsafe negation.
 	 */
-	noUnsafeNegation?: RuleConfiguration_for_Null;
+	noUnsafeNegation?: RuleFixConfiguration_for_Null;
 	/**
 	 * It enables the recommended rules for this group
 	 */
@@ -1527,15 +1527,15 @@ export interface Suspicious {
 	/**
 	 * Use Array.isArray() instead of instanceof Array.
 	 */
-	useIsArray?: RuleConfiguration_for_Null;
+	useIsArray?: RuleFixConfiguration_for_Null;
 	/**
 	 * Require using the namespace keyword over the module keyword to declare TypeScript namespaces.
 	 */
-	useNamespaceKeyword?: RuleConfiguration_for_Null;
+	useNamespaceKeyword?: RuleFixConfiguration_for_Null;
 	/**
 	 * This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions
 	 */
-	useValidTypeof?: RuleConfiguration_for_Null;
+	useValidTypeof?: RuleFixConfiguration_for_Null;
 }
 export interface OverrideFormatterConfiguration {
 	/**
@@ -1584,12 +1584,15 @@ export interface OverrideOrganizeImportsConfiguration {
 	 */
 	enabled?: boolean;
 }
+export type RuleFixConfiguration_for_Null =
+	| RulePlainConfiguration
+	| RuleWithFixOptions_for_Null;
 export type RuleConfiguration_for_Null =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_Null;
-export type RuleConfiguration_for_ValidAriaRoleOptions =
+export type RuleFixConfiguration_for_ValidAriaRoleOptions =
 	| RulePlainConfiguration
-	| RuleWithOptions_for_ValidAriaRoleOptions;
+	| RuleWithFixOptions_for_ValidAriaRoleOptions;
 export type RuleConfiguration_for_ComplexityOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_ComplexityOptions;
@@ -1605,23 +1608,23 @@ export type RuleConfiguration_for_NoCssEmptyBlockOptions =
 export type RuleConfiguration_for_RestrictedImportsOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_RestrictedImportsOptions;
-export type RuleConfiguration_for_UtilityClassSortingOptions =
+export type RuleFixConfiguration_for_UtilityClassSortingOptions =
 	| RulePlainConfiguration
-	| RuleWithOptions_for_UtilityClassSortingOptions;
+	| RuleWithFixOptions_for_UtilityClassSortingOptions;
 export type RuleConfiguration_for_RestrictedGlobalsOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_RestrictedGlobalsOptions;
-export type RuleConfiguration_for_ConsistentArrayTypeOptions =
+export type RuleFixConfiguration_for_ConsistentArrayTypeOptions =
 	| RulePlainConfiguration
-	| RuleWithOptions_for_ConsistentArrayTypeOptions;
+	| RuleWithFixOptions_for_ConsistentArrayTypeOptions;
 export type RuleConfiguration_for_FilenamingConventionOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_FilenamingConventionOptions;
-export type RuleConfiguration_for_NamingConventionOptions =
+export type RuleFixConfiguration_for_NamingConventionOptions =
 	| RulePlainConfiguration
-	| RuleWithOptions_for_NamingConventionOptions;
+	| RuleWithFixOptions_for_NamingConventionOptions;
 export type RulePlainConfiguration = "warn" | "error" | "off";
-export interface RuleWithOptions_for_Null {
+export interface RuleWithFixOptions_for_Null {
 	/**
 	 * The kind of the code actions emitted by the rule
 	 */
@@ -1635,7 +1638,17 @@ export interface RuleWithOptions_for_Null {
 	 */
 	options: null;
 }
-export interface RuleWithOptions_for_ValidAriaRoleOptions {
+export interface RuleWithOptions_for_Null {
+	/**
+	 * The severity of the emitted diagnostics by the rule
+	 */
+	level: RulePlainConfiguration;
+	/**
+	 * Rule's options
+	 */
+	options: null;
+}
+export interface RuleWithFixOptions_for_ValidAriaRoleOptions {
 	/**
 	 * The kind of the code actions emitted by the rule
 	 */
@@ -1651,10 +1664,6 @@ export interface RuleWithOptions_for_ValidAriaRoleOptions {
 }
 export interface RuleWithOptions_for_ComplexityOptions {
 	/**
-	 * The kind of the code actions emitted by the rule
-	 */
-	fix?: FixKind;
-	/**
 	 * The severity of the emitted diagnostics by the rule
 	 */
 	level: RulePlainConfiguration;
@@ -1664,10 +1673,6 @@ export interface RuleWithOptions_for_ComplexityOptions {
 	options: ComplexityOptions;
 }
 export interface RuleWithOptions_for_HooksOptions {
-	/**
-	 * The kind of the code actions emitted by the rule
-	 */
-	fix?: FixKind;
 	/**
 	 * The severity of the emitted diagnostics by the rule
 	 */
@@ -1679,10 +1684,6 @@ export interface RuleWithOptions_for_HooksOptions {
 }
 export interface RuleWithOptions_for_DeprecatedHooksOptions {
 	/**
-	 * The kind of the code actions emitted by the rule
-	 */
-	fix?: FixKind;
-	/**
 	 * The severity of the emitted diagnostics by the rule
 	 */
 	level: RulePlainConfiguration;
@@ -1692,10 +1693,6 @@ export interface RuleWithOptions_for_DeprecatedHooksOptions {
 	options: DeprecatedHooksOptions;
 }
 export interface RuleWithOptions_for_NoCssEmptyBlockOptions {
-	/**
-	 * The kind of the code actions emitted by the rule
-	 */
-	fix?: FixKind;
 	/**
 	 * The severity of the emitted diagnostics by the rule
 	 */
@@ -1707,10 +1704,6 @@ export interface RuleWithOptions_for_NoCssEmptyBlockOptions {
 }
 export interface RuleWithOptions_for_RestrictedImportsOptions {
 	/**
-	 * The kind of the code actions emitted by the rule
-	 */
-	fix?: FixKind;
-	/**
 	 * The severity of the emitted diagnostics by the rule
 	 */
 	level: RulePlainConfiguration;
@@ -1719,7 +1712,7 @@ export interface RuleWithOptions_for_RestrictedImportsOptions {
 	 */
 	options: RestrictedImportsOptions;
 }
-export interface RuleWithOptions_for_UtilityClassSortingOptions {
+export interface RuleWithFixOptions_for_UtilityClassSortingOptions {
 	/**
 	 * The kind of the code actions emitted by the rule
 	 */
@@ -1735,10 +1728,6 @@ export interface RuleWithOptions_for_UtilityClassSortingOptions {
 }
 export interface RuleWithOptions_for_RestrictedGlobalsOptions {
 	/**
-	 * The kind of the code actions emitted by the rule
-	 */
-	fix?: FixKind;
-	/**
 	 * The severity of the emitted diagnostics by the rule
 	 */
 	level: RulePlainConfiguration;
@@ -1747,7 +1736,7 @@ export interface RuleWithOptions_for_RestrictedGlobalsOptions {
 	 */
 	options: RestrictedGlobalsOptions;
 }
-export interface RuleWithOptions_for_ConsistentArrayTypeOptions {
+export interface RuleWithFixOptions_for_ConsistentArrayTypeOptions {
 	/**
 	 * The kind of the code actions emitted by the rule
 	 */
@@ -1763,10 +1752,6 @@ export interface RuleWithOptions_for_ConsistentArrayTypeOptions {
 }
 export interface RuleWithOptions_for_FilenamingConventionOptions {
 	/**
-	 * The kind of the code actions emitted by the rule
-	 */
-	fix?: FixKind;
-	/**
 	 * The severity of the emitted diagnostics by the rule
 	 */
 	level: RulePlainConfiguration;
@@ -1775,7 +1760,7 @@ export interface RuleWithOptions_for_FilenamingConventionOptions {
 	 */
 	options: FilenamingConventionOptions;
 }
-export interface RuleWithOptions_for_NamingConventionOptions {
+export interface RuleWithFixOptions_for_NamingConventionOptions {
 	/**
 	 * The kind of the code actions emitted by the rule
 	 */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -83,77 +83,77 @@
 				"noAccessKey": {
 					"description": "Enforce that the accessKey attribute is not used on any HTML element.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noAriaHiddenOnFocusable": {
 					"description": "Enforce that aria-hidden=\"true\" is not set on focusable elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noAriaUnsupportedElements": {
 					"description": "Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noAutofocus": {
 					"description": "Enforce that autoFocus prop is not used on elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noBlankTarget": {
 					"description": "Disallow target=\"_blank\" attribute without rel=\"noreferrer\"",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDistractingElements": {
 					"description": "Enforces that no distracting elements are used.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noHeaderScope": {
 					"description": "The scope prop should be used only on \\<th> elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noInteractiveElementToNoninteractiveRole": {
 					"description": "Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noNoninteractiveElementToInteractiveRole": {
 					"description": "Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noNoninteractiveTabindex": {
 					"description": "Enforce that tabIndex is not assigned to non-interactive HTML elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noPositiveTabindex": {
 					"description": "Prevent the usage of positive integers on tabIndex property",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -167,7 +167,7 @@
 				"noRedundantRoles": {
 					"description": "Enforce explicit role property is not the same as implicit/default role property on an element.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -192,14 +192,14 @@
 				"useAnchorContent": {
 					"description": "Enforce that anchors have content and that the content is accessible to screen readers.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useAriaActivedescendantWithTabindex": {
 					"description": "Enforce that tabIndex is assigned to non-interactive HTML elements with aria-activedescendant.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -269,14 +269,16 @@
 				"useValidAriaProps": {
 					"description": "Ensures that ARIA properties aria-* are all valid.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useValidAriaRole": {
 					"description": "Elements with ARIA roles must use a valid, non-abstract ARIA role.",
 					"anyOf": [
-						{ "$ref": "#/definitions/ValidAriaRoleConfiguration" },
+						{
+							"$ref": "#/definitions/RuleFixConfiguration_for_ValidAriaRoleOptions"
+						},
 						{ "type": "null" }
 					]
 				},
@@ -310,7 +312,7 @@
 				"noBannedTypes": {
 					"description": "Disallow primitive type aliases and misleading types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -338,7 +340,7 @@
 				"noExtraBooleanCast": {
 					"description": "Disallow unnecessary boolean casts",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -352,7 +354,7 @@
 				"noMultipleSpacesInRegularExpressionLiterals": {
 					"description": "Disallow unclear usage of consecutive space characters in regular expression literals",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -366,7 +368,7 @@
 				"noThisInStatic": {
 					"description": "Disallow this and super in static contexts.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -380,70 +382,70 @@
 				"noUselessConstructor": {
 					"description": "Disallow unnecessary constructors.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessEmptyExport": {
 					"description": "Disallow empty exports that don't change anything in a module file.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessFragments": {
 					"description": "Disallow unnecessary fragments",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessLabel": {
 					"description": "Disallow unnecessary labels.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessLoneBlockStatements": {
 					"description": "Disallow unnecessary nested block statements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessRename": {
 					"description": "Disallow renaming import, export, and destructured assignments to the same name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessSwitchCase": {
 					"description": "Disallow useless case in switch statements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessTernary": {
 					"description": "Disallow ternary operators when simpler alternatives exist.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessThisAlias": {
 					"description": "Disallow useless this aliasing.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessTypeConstraint": {
 					"description": "Disallow using any or unknown as type constraint.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -468,49 +470,49 @@
 				"useArrowFunction": {
 					"description": "Use arrow functions over function expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useFlatMap": {
 					"description": "Promotes the use of .flatMap() when map().flat() are used together.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useLiteralKeys": {
 					"description": "Enforce the usage of a literal access to properties over computed property access.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useOptionalChain": {
 					"description": "Enforce using concise optional chain instead of chained logical expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useRegexLiterals": {
 					"description": "Enforce the use of the regular expression literals instead of the RegExp constructor if possible.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useSimpleNumberKeys": {
 					"description": "Disallow number literal object member names which are not base10 or uses underscore as separator",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useSimplifiedLogicExpression": {
 					"description": "Discard redundant terms from logical expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				}
@@ -549,12 +551,6 @@
 					"type": "string",
 					"enum": ["generic"]
 				}
-			]
-		},
-		"ConsistentArrayTypeConfiguration": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithConsistentArrayTypeOptions" }
 			]
 		},
 		"ConsistentArrayTypeOptions": {
@@ -601,7 +597,7 @@
 				"noConstAssign": {
 					"description": "Prevents from having const variables being re-assigned.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -657,7 +653,7 @@
 				"noInvalidNewBuiltin": {
 					"description": "Disallow new operators with global non-constructor functions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -671,14 +667,14 @@
 				"noNewSymbol": {
 					"description": "Disallow new operators with the Symbol object.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noNonoctalDecimalEscape": {
 					"description": "Disallow \\8 and \\9 escape sequences in string literals.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -713,14 +709,14 @@
 				"noStringCaseMismatch": {
 					"description": "Disallow comparison of expressions modifying the string case with non-compliant value.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noSwitchDeclarations": {
 					"description": "Disallow lexical declarations in switch clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -734,7 +730,7 @@
 				"noUnnecessaryContinue": {
 					"description": "Avoid using unnecessary continue.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -769,35 +765,35 @@
 				"noUnusedImports": {
 					"description": "Disallow unused imports.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedLabels": {
 					"description": "Disallow unused labels.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedPrivateClassMembers": {
 					"description": "Disallow unused private class members",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedVariables": {
 					"description": "Disallow unused variables.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noVoidElementsWithChildren": {
 					"description": "This rules prevents void elements (AKA self-closing elements) from having children.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -829,7 +825,7 @@
 				"useIsNan": {
 					"description": "Require calls to isNaN() when checking for NaN.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -1535,12 +1531,6 @@
 			"items": { "$ref": "#/definitions/RestrictedModifier" },
 			"uniqueItems": true
 		},
-		"NamingConventionConfiguration": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithNamingConventionOptions" }
-			]
-		},
 		"NamingConventionOptions": {
 			"description": "Rule's options.",
 			"type": "object",
@@ -1595,14 +1585,14 @@
 				"noConsole": {
 					"description": "Disallow the use of console.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noConstantMathMinMaxClamp": {
 					"description": "Disallow the use of Math.min and Math.max to clamp a value where the result itself is constant.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -1665,7 +1655,7 @@
 				"noFlatMapIdentity": {
 					"description": "Disallow to use unnecessary callback on flatMap.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -1700,7 +1690,7 @@
 				"noReactSpecificProps": {
 					"description": "Prevents React-specific JSX properties from being used.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -1763,14 +1753,14 @@
 				"noUselessStringConcat": {
 					"description": "Disallow unnecessary concatenation of string or template literals.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessUndefinedInitialization": {
 					"description": "Disallow initializing variables to undefined.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -1781,14 +1771,14 @@
 				"useArrayLiterals": {
 					"description": "Disallow Array constructors.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useConsistentBuiltinInstantiation": {
 					"description": "Enforce the use of new for all builtins, except String, Number, Boolean, Symbol and BigInt.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -1802,7 +1792,7 @@
 				"useExplicitLengthCheck": {
 					"description": "Enforce explicitly comparing the length, size, byteLength or byteOffset property of a value.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -1830,14 +1820,16 @@
 				"useSortedClasses": {
 					"description": "Enforce the sorting of CSS utility classes.",
 					"anyOf": [
-						{ "$ref": "#/definitions/UtilityClassSortingConfiguration" },
+						{
+							"$ref": "#/definitions/RuleFixConfiguration_for_UtilityClassSortingOptions"
+						},
 						{ "type": "null" }
 					]
 				},
 				"useThrowNewError": {
 					"description": "Require new when throwing an error.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2023,7 +2015,7 @@
 				"noDelete": {
 					"description": "Disallow the use of the delete operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2098,6 +2090,42 @@
 				{ "$ref": "#/definitions/RuleWithNoOptions" }
 			]
 		},
+		"RuleFixConfiguration_for_ConsistentArrayTypeOptions": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{
+					"$ref": "#/definitions/RuleWithFixOptions_for_ConsistentArrayTypeOptions"
+				}
+			]
+		},
+		"RuleFixConfiguration_for_NamingConventionOptions": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{
+					"$ref": "#/definitions/RuleWithFixOptions_for_NamingConventionOptions"
+				}
+			]
+		},
+		"RuleFixConfiguration_for_Null": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithFixOptions_for_Null" }
+			]
+		},
+		"RuleFixConfiguration_for_UtilityClassSortingOptions": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{
+					"$ref": "#/definitions/RuleWithFixOptions_for_UtilityClassSortingOptions"
+				}
+			]
+		},
+		"RuleFixConfiguration_for_ValidAriaRoleOptions": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithFixOptions_for_ValidAriaRoleOptions" }
+			]
+		},
 		"RulePlainConfiguration": {
 			"type": "string",
 			"enum": ["warn", "error", "off"]
@@ -2106,10 +2134,6 @@
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
-				"fix": {
-					"description": "The kind of the code actions emitted by the rule",
-					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
-				},
 				"level": {
 					"description": "The severity of the emitted diagnostics by the rule",
 					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
@@ -2121,7 +2145,37 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithConsistentArrayTypeOptions": {
+		"RuleWithDeprecatedHooksOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/DeprecatedHooksOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithFilenamingConventionOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/FilenamingConventionOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithFixOptions_for_ConsistentArrayTypeOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -2140,64 +2194,7 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithDeprecatedHooksOptions": {
-			"type": "object",
-			"required": ["level", "options"],
-			"properties": {
-				"fix": {
-					"description": "The kind of the code actions emitted by the rule",
-					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
-				},
-				"level": {
-					"description": "The severity of the emitted diagnostics by the rule",
-					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
-				},
-				"options": {
-					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/DeprecatedHooksOptions" }]
-				}
-			},
-			"additionalProperties": false
-		},
-		"RuleWithFilenamingConventionOptions": {
-			"type": "object",
-			"required": ["level", "options"],
-			"properties": {
-				"fix": {
-					"description": "The kind of the code actions emitted by the rule",
-					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
-				},
-				"level": {
-					"description": "The severity of the emitted diagnostics by the rule",
-					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
-				},
-				"options": {
-					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/FilenamingConventionOptions" }]
-				}
-			},
-			"additionalProperties": false
-		},
-		"RuleWithHooksOptions": {
-			"type": "object",
-			"required": ["level", "options"],
-			"properties": {
-				"fix": {
-					"description": "The kind of the code actions emitted by the rule",
-					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
-				},
-				"level": {
-					"description": "The severity of the emitted diagnostics by the rule",
-					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
-				},
-				"options": {
-					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/HooksOptions" }]
-				}
-			},
-			"additionalProperties": false
-		},
-		"RuleWithNamingConventionOptions": {
+		"RuleWithFixOptions_for_NamingConventionOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -2216,7 +2213,7 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithNoCssEmptyBlockOptions": {
+		"RuleWithFixOptions_for_Null": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -2228,67 +2225,11 @@
 					"description": "The severity of the emitted diagnostics by the rule",
 					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
 				},
-				"options": {
-					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoCssEmptyBlockOptions" }]
-				}
+				"options": { "description": "Rule's options", "type": "null" }
 			},
 			"additionalProperties": false
 		},
-		"RuleWithNoOptions": {
-			"type": "object",
-			"required": ["level"],
-			"properties": {
-				"fix": {
-					"description": "The kind of the code actions emitted by the rule",
-					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
-				},
-				"level": {
-					"description": "The severity of the emitted diagnostics by the rule",
-					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
-				}
-			},
-			"additionalProperties": false
-		},
-		"RuleWithRestrictedGlobalsOptions": {
-			"type": "object",
-			"required": ["level", "options"],
-			"properties": {
-				"fix": {
-					"description": "The kind of the code actions emitted by the rule",
-					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
-				},
-				"level": {
-					"description": "The severity of the emitted diagnostics by the rule",
-					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
-				},
-				"options": {
-					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/RestrictedGlobalsOptions" }]
-				}
-			},
-			"additionalProperties": false
-		},
-		"RuleWithRestrictedImportsOptions": {
-			"type": "object",
-			"required": ["level", "options"],
-			"properties": {
-				"fix": {
-					"description": "The kind of the code actions emitted by the rule",
-					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
-				},
-				"level": {
-					"description": "The severity of the emitted diagnostics by the rule",
-					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
-				},
-				"options": {
-					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/RestrictedImportsOptions" }]
-				}
-			},
-			"additionalProperties": false
-		},
-		"RuleWithUtilityClassSortingOptions": {
+		"RuleWithFixOptions_for_UtilityClassSortingOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -2307,7 +2248,7 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithValidAriaRoleOptions": {
+		"RuleWithFixOptions_for_ValidAriaRoleOptions": {
 			"type": "object",
 			"required": ["level", "options"],
 			"properties": {
@@ -2322,6 +2263,77 @@
 				"options": {
 					"description": "Rule's options",
 					"allOf": [{ "$ref": "#/definitions/ValidAriaRoleOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithHooksOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/HooksOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNoCssEmptyBlockOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/NoCssEmptyBlockOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNoOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithRestrictedGlobalsOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/RestrictedGlobalsOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithRestrictedImportsOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/RestrictedImportsOptions" }]
 				}
 			},
 			"additionalProperties": false
@@ -2476,14 +2488,14 @@
 				"noImplicitBoolean": {
 					"description": "Disallow implicit true values on JSX boolean attributes",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noInferrableTypes": {
 					"description": "Disallow type annotations for variables, parameters, and class properties initialized with a literal expression.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2504,14 +2516,14 @@
 				"noNegationElse": {
 					"description": "Disallow negation in the condition of an if statement if it has an else clause.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noNonNullAssertion": {
 					"description": "Disallow non-null assertions using the ! postfix operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2539,28 +2551,28 @@
 				"noShoutyConstants": {
 					"description": "Disallow the use of constants which its value is the upper-case version of its name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedTemplateLiteral": {
 					"description": "Disallow template literals if interpolation and special-character handling are not needed",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessElse": {
 					"description": "Disallow else block when the if block breaks early.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noVar": {
 					"description": "Disallow the use of var",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2571,63 +2583,65 @@
 				"useAsConstAssertion": {
 					"description": "Enforce the use of as const over literal type and type annotation.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useBlockStatements": {
 					"description": "Requires following curly brace conventions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useCollapsedElseIf": {
 					"description": "Enforce using else if instead of nested if in else clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useConsistentArrayType": {
 					"description": "Require consistently using either T\\[] or Array\\<T>",
 					"anyOf": [
-						{ "$ref": "#/definitions/ConsistentArrayTypeConfiguration" },
+						{
+							"$ref": "#/definitions/RuleFixConfiguration_for_ConsistentArrayTypeOptions"
+						},
 						{ "type": "null" }
 					]
 				},
 				"useConst": {
 					"description": "Require const declarations for variables that are only assigned once.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useDefaultParameterLast": {
 					"description": "Enforce default function parameters and optional function parameters to be last.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useEnumInitializers": {
 					"description": "Require that each enum member value be explicitly initialized.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useExponentiationOperator": {
 					"description": "Disallow the use of Math.pow in favor of the ** operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useExportType": {
 					"description": "Promotes the use of export type for types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2648,14 +2662,14 @@
 				"useFragmentSyntax": {
 					"description": "This rule enforces the use of \\<>...\\</> over \\<Fragment>...\\</Fragment>.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useImportType": {
 					"description": "Promotes the use of import type for types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2669,91 +2683,93 @@
 				"useNamingConvention": {
 					"description": "Enforce naming conventions for everything across a codebase.",
 					"anyOf": [
-						{ "$ref": "#/definitions/NamingConventionConfiguration" },
+						{
+							"$ref": "#/definitions/RuleFixConfiguration_for_NamingConventionOptions"
+						},
 						{ "type": "null" }
 					]
 				},
 				"useNodeAssertStrict": {
 					"description": "Promotes the usage of node:assert/strict over node:assert.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useNodejsImportProtocol": {
 					"description": "Enforces using the node: protocol for Node.js builtin modules.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useNumberNamespace": {
 					"description": "Use the Number properties instead of global ones.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useNumericLiterals": {
 					"description": "Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useSelfClosingElements": {
 					"description": "Prevent extra closing tags for components without children",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useShorthandArrayType": {
 					"description": "When expressing array types, this rule promotes the usage of T\\[] shorthand instead of Array\\<T>.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useShorthandAssign": {
 					"description": "Require assignment operator shorthand where possible.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useShorthandFunctionType": {
 					"description": "Enforce using function types instead of object type with call signatures.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useSingleCaseStatement": {
 					"description": "Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useSingleVarDeclarator": {
 					"description": "Disallow multiple variable declarations in the same variable statement",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useTemplate": {
 					"description": "Prefer template literals over string concatenation.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useWhile": {
 					"description": "Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				}
@@ -2771,7 +2787,7 @@
 				"noApproximativeNumericConstant": {
 					"description": "Use standard constants instead of approximated literals.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2813,14 +2829,14 @@
 				"noCommentText": {
 					"description": "Prevent comments from being inserted as text nodes",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noCompareNegZero": {
 					"description": "Disallow comparing against -0",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2834,21 +2850,21 @@
 				"noConfusingVoidType": {
 					"description": "Disallow void type outside of generic or return types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noConsoleLog": {
 					"description": "Disallow the use of console.log",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noConstEnum": {
 					"description": "Disallow TypeScript const enum",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2862,14 +2878,14 @@
 				"noDebugger": {
 					"description": "Disallow the use of debugger",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noDoubleEquals": {
 					"description": "Require the use of === and !==",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2897,7 +2913,7 @@
 				"noDuplicateObjectKeys": {
 					"description": "Prevents object literals having more than one property declaration for the same name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2925,7 +2941,7 @@
 				"noEmptyInterface": {
 					"description": "Disallow the declaration of empty interfaces.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2946,7 +2962,7 @@
 				"noExtraNonNullAssertion": {
 					"description": "Prevents the wrong usage of the non-null assertion operator (!) in TypeScript files.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2960,7 +2976,7 @@
 				"noFocusedTests": {
 					"description": "Disallow focused tests.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -2981,14 +2997,14 @@
 				"noGlobalIsFinite": {
 					"description": "Use Number.isFinite instead of global isFinite.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noGlobalIsNan": {
 					"description": "Use Number.isNaN instead of global isNaN.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -3016,7 +3032,7 @@
 				"noMisleadingCharacterClass": {
 					"description": "Disallow characters made with multiple code points in character class syntax.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -3030,7 +3046,7 @@
 				"noMisrefactoredShorthandAssign": {
 					"description": "Disallow shorthand assign when variable appears on both sides.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -3051,7 +3067,7 @@
 				"noRedundantUseStrict": {
 					"description": "Prevents from having redundant \"use strict\".",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -3072,14 +3088,14 @@
 				"noSkippedTests": {
 					"description": "Disallow disabled tests.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"noSparseArray": {
 					"description": "Disallow sparse arrays",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -3107,7 +3123,7 @@
 				"noUnsafeNegation": {
 					"description": "Disallow using unsafe negation.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
@@ -3139,21 +3155,21 @@
 				"useIsArray": {
 					"description": "Use Array.isArray() instead of instanceof Array.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useNamespaceKeyword": {
 					"description": "Require using the namespace keyword over the module keyword to declare TypeScript namespaces.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				},
 				"useValidTypeof": {
 					"description": "This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
 						{ "type": "null" }
 					]
 				}
@@ -3194,12 +3210,6 @@
 				}
 			]
 		},
-		"UtilityClassSortingConfiguration": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithUtilityClassSortingOptions" }
-			]
-		},
 		"UtilityClassSortingOptions": {
 			"type": "object",
 			"properties": {
@@ -3215,12 +3225,6 @@
 				}
 			},
 			"additionalProperties": false
-		},
-		"ValidAriaRoleConfiguration": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithValidAriaRoleOptions" }
-			]
 		},
 		"ValidAriaRoleOptions": {
 			"type": "object",


### PR DESCRIPTION
## Summary

This PR addresses a concern of @ematipico.
Previously `fix` field was available for any rules, even the ones without code actions. 

To address the issue, I added two new types: `RuleFixConfiguration` and `RuleWithFixOptions` and changed the script that generates `Rules`. Fixable rules use `RuleFixConfiguration`, and unfixable rules use `RuleConfiguration`.

Doing that has also some benefits:

- We reduce the size of the configuration because some rules don't have the `fix` field
- We don't introduce any dynamic check because it is statically generated.
- We get a perfect JSON schema

I am not fond of having dual types `RuleConfiguration`/`RuleFixConfiguration` and `RuleWithOptions`/`RuleWithFixOptions`. However, for this looks like a good tradeoff for now.

## Test Plan

CI must pass.
