### PR TITLE
refactor: improve diagnostic for too large files

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large.snap
@@ -18,7 +18,9 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```
@@ -26,7 +28,9 @@ check.js lint ━━━━━━━━━━━━━━━━━━━━━━
 ```block
 check.js organizeImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```
@@ -34,7 +38,9 @@ check.js organizeImports ━━━━━━━━━━━━━━━━━━�
 ```block
 check.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large_cli_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large_cli_limit.snap
@@ -25,7 +25,9 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```
@@ -33,7 +35,9 @@ check.js lint ━━━━━━━━━━━━━━━━━━━━━━
 ```block
 check.js organizeImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```
@@ -41,7 +45,9 @@ check.js organizeImports ━━━━━━━━━━━━━━━━━━�
 ```block
 check.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large_config_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large_config_limit.snap
@@ -35,7 +35,9 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```
@@ -43,7 +45,9 @@ check.js lint ━━━━━━━━━━━━━━━━━━━━━━
 ```block
 check.js organizeImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```
@@ -51,7 +55,9 @@ check.js organizeImports ━━━━━━━━━━━━━━━━━━�
 ```block
 check.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large.snap
@@ -18,7 +18,9 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 ci.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of ci.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of ci.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```
@@ -26,7 +28,9 @@ ci.js lint ━━━━━━━━━━━━━━━━━━━━━━━
 ```block
 ci.js organizeImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of ci.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of ci.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```
@@ -34,7 +38,9 @@ ci.js organizeImports ━━━━━━━━━━━━━━━━━━━�
 ```block
 ci.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of ci.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of ci.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large_cli_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large_cli_limit.snap
@@ -25,7 +25,9 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 ci.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```
@@ -33,7 +35,9 @@ ci.js lint ━━━━━━━━━━━━━━━━━━━━━━━
 ```block
 ci.js organizeImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```
@@ -41,7 +45,9 @@ ci.js organizeImports ━━━━━━━━━━━━━━━━━━━�
 ```block
 ci.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large_config_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large_config_limit.snap
@@ -35,7 +35,9 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 ci.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```
@@ -43,7 +45,9 @@ ci.js lint ━━━━━━━━━━━━━━━━━━━━━━━
 ```block
 ci.js organizeImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```
@@ -51,7 +55,9 @@ ci.js organizeImports ━━━━━━━━━━━━━━━━━━━�
 ```block
 ci.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large.snap
@@ -18,7 +18,9 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 ```block
 format.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of format.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of format.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large_cli_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large_cli_limit.snap
@@ -25,7 +25,9 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 ```block
 format.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of format.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of format.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large_config_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large_config_limit.snap
@@ -35,7 +35,9 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 ```block
 format.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of format.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of format.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large.snap
@@ -18,7 +18,9 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 ```block
 check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large_cli_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large_cli_limit.snap
@@ -25,7 +25,9 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 ```block
 check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large_config_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large_config_limit.snap
@@ -35,7 +35,9 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 ```block
 check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project.
+    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+    Use the `files.maxSize` configuration to change the maximum size of files processed.
   
 
 ```

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -251,15 +251,18 @@ impl Diagnostic for FileTooLarge {
     fn message(&self, fmt: &mut biome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
         fmt.write_markup(
             markup!{
-                "Size of "{self.path}" is "{Bytes(self.size)}" which exceeds configured maximum of "{Bytes(self.limit)}" for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't."
+                "Size of "{self.path}" is "{Bytes(self.size)}" which exceeds configured maximum of "{Bytes(self.limit)}" for this project.
+                The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+                Use the `files.maxSize` configuration to change the maximum size of files processed."
             }
         )
     }
 
     fn description(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         write!(fmt,
-               "Size of {} is {} which exceeds configured maximum of {} for this project. \
-               The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.",
+               "Size of {} is {} which exceeds configured maximum of {} for this project.\n\
+               The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.\n\
+               Use the `files.maxSize` configuration to change the maximum size of files processed.",
                self.path, Bytes(self.size), Bytes(self.limit)
         )
     }

--- a/crates/biome_service/src/snapshots/file_too_large.snap
+++ b/crates/biome_service/src/snapshots/file_too_large.snap
@@ -4,4 +4,6 @@ expression: content
 ---
 example.js internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of example.js is 500 B which exceeds configured maximum of 100 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of example.js is 500 B which exceeds configured maximum of 100 B for this project.
+                    The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+                    Use the `files.maxSize` configuration to change the maximum size of files processed.


### PR DESCRIPTION
## Summary

We now suggest using `files.maxSize` when we hit a file that exceeds this limit.

## Test Plan

I updated the existing snapshots.
