### PR TITLE
fix(bench): json formatter benchmark suites

### DIFF
--- a/xtask/bench/benches/json_formatter.rs
+++ b/xtask/bench/benches/json_formatter.rs
@@ -18,7 +18,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 static GLOBAL: std::alloc::System = std::alloc::System;
 fn bench_json_formatter(criterion: &mut Criterion) {
     let mut all_suites = HashMap::new();
-    all_suites.insert("json", include_str!("libs-js.txt"));
+    all_suites.insert("json", include_str!("libs-json.txt"));
     let mut libs = vec![];
     libs.extend(all_suites.values().flat_map(|suite| suite.lines()));
 


### PR DESCRIPTION
## Summary

We were using the wrong suites to benchmark the json formatter. 🤣

## Test Plan

Codspeed will use the correct one to benchmark the json formatter.
