### PR TITLE
fix(useSortedClasses): keep trailing and leading spaces in code action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,7 +321,17 @@ z.object({})
 ```
 
 - [noExportsInTest](https://biomejs.dev/linter/rules/no-exports-in-test/) rule no longer treats files with in-source testing as test files https://github.com/biomejs/biome/issues/2859. Contributed by @ah-yu
+- [useSortedClasses](https://biomejs.dev/linter/rules/use-sorted-classes/) now keeps leading and trailing spaces when applying the code action inside template literals:
 
+  ```
+  i Unsafe fix: Sort the classes.
+
+    1 1 │   <>
+    2   │ - → <div·class={`${variable}·px-2·foo·p-4·bar`}/>
+      2 │ + → <div·class={`${variable}·foo·bar·p-4·px-2`}/>
+    3 3 │   	<div class={`px-2 foo p-4 bar ${variable}`}/>
+    4 4 │   </>
+  ```
 ### Parser
 
 #### Enhancements

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -240,7 +240,7 @@ mod tests {
     use crate::react::hooks::StableHookResult;
     use crate::{analyze, AnalysisFilter, ControlFlow};
 
-    #[ignore]
+    // #[ignore]
     #[test]
     fn quick_test() {
         fn markup_to_string(markup: Markup) -> String {
@@ -252,7 +252,7 @@ mod tests {
             String::from_utf8(buffer).unwrap()
         }
 
-        const SOURCE: &str = r#"foo(<>{bar}</>);"#;
+        const SOURCE: &str = r#"<div class={`px-2 foo p-4 bar ${variable}`}/>"#;
 
         let parsed = parse(SOURCE, JsFileSource::tsx(), JsParserOptions::default());
 
@@ -264,7 +264,7 @@ mod tests {
             dependencies_index: Some(1),
             stable_result: StableHookResult::None,
         };
-        let rule_filter = RuleFilter::Rule("complexity", "noUselessFragments");
+        let rule_filter = RuleFilter::Rule("nursery", "useSortedClasses");
 
         options.configuration.rules.push_rule(
             RuleKey::new("nursery", "useHookAtTopLevel"),

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -240,7 +240,7 @@ mod tests {
     use crate::react::hooks::StableHookResult;
     use crate::{analyze, AnalysisFilter, ControlFlow};
 
-    // #[ignore]
+       #[ignore]
     #[test]
     fn quick_test() {
         fn markup_to_string(markup: Markup) -> String {

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
@@ -140,7 +140,7 @@ declare_rule! {
     pub UseSortedClasses {
         version: "1.6.0",
         name: "useSortedClasses",
-        language: "jsx",
+        language: "js",
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort.rs
@@ -85,11 +85,12 @@ fn compare_classes(a: &ClassInfo, b: &ClassInfo) -> Ordering {
 pub fn sort_class_name(class_name: &TokenText, sort_config: &SortConfig) -> String {
     // Obtain classes by splitting the class string by whitespace.
     let classes = class_name.split_whitespace().collect::<Vec<&str>>();
+    let classes_len = classes.len();
 
     // Separate custom classes from recognized classes, and compute the recognized classes' info.
     // Custom classes always go first, in the order that they appear in.
-    let mut sorted_classes: Vec<&str> = Vec::new();
-    let mut classes_info: Vec<ClassInfo> = Vec::new();
+    let mut sorted_classes = Vec::new();
+    let mut classes_info = Vec::new();
     for class in classes {
         match get_class_info(class, sort_config) {
             Some(class_info) => {
@@ -117,6 +118,18 @@ pub fn sort_class_name(class_name: &TokenText, sort_config: &SortConfig) -> Stri
             .map(|class_info| class_info.text.as_str()),
     );
 
-    // Join the classes back into a string.
-    sorted_classes.join(" ")
+    let mut result = sorted_classes.join(" ");
+    if classes_len > 0 {
+        // restore front space
+        if class_name.starts_with(' ') {
+            result.insert(0, ' ');
+        }
+
+        // restore final space
+        if class_name.ends_with(' ') {
+            result.push(' ');
+        }
+    }
+
+    result
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/templateLiteralSpace.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/templateLiteralSpace.jsx
@@ -1,0 +1,4 @@
+<>
+	<div class={`${variable} px-2 foo p-4 bar`}/>
+	<div class={`px-2 foo p-4 bar ${variable}`}/>
+</>

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/templateLiteralSpace.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/templateLiteralSpace.jsx.snap
@@ -1,0 +1,59 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: templateLiteralSpace.jsx
+---
+# Input
+```jsx
+<>
+	<div class={`${variable} px-2 foo p-4 bar`}/>
+	<div class={`px-2 foo p-4 bar ${variable}`}/>
+</>
+
+```
+
+# Diagnostics
+```
+templateLiteralSpace.jsx:2:26 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! These CSS classes should be sorted.
+  
+    1 │ <>
+  > 2 │ 	<div class={`${variable} px-2 foo p-4 bar`}/>
+      │ 	                        ^^^^^^^^^^^^^^^^^
+    3 │ 	<div class={`px-2 foo p-4 bar ${variable}`}/>
+    4 │ </>
+  
+  i Unsafe fix: Sort the classes.
+  
+    1 1 │   <>
+    2   │ - → <div·class={`${variable}·px-2·foo·p-4·bar`}/>
+      2 │ + → <div·class={`${variable}·foo·bar·p-4·px-2`}/>
+    3 3 │   	<div class={`px-2 foo p-4 bar ${variable}`}/>
+    4 4 │   </>
+  
+
+```
+
+```
+templateLiteralSpace.jsx:3:15 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! These CSS classes should be sorted.
+  
+    1 │ <>
+    2 │ 	<div class={`${variable} px-2 foo p-4 bar`}/>
+  > 3 │ 	<div class={`px-2 foo p-4 bar ${variable}`}/>
+      │ 	             ^^^^^^^^^^^^^^^^^
+    4 │ </>
+    5 │ 
+  
+  i Unsafe fix: Sort the classes.
+  
+    1 1 │   <>
+    2 2 │   	<div class={`${variable} px-2 foo p-4 bar`}/>
+    3   │ - → <div·class={`px-2·foo·p-4·bar·${variable}`}/>
+      3 │ + → <div·class={`foo·bar·p-4·px-2·${variable}`}/>
+    4 4 │   </>
+    5 5 │   
+  
+
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Now leading and trailing spaces are kept when applying the code action of `useSortedClasses`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added two new test cases 

<!-- What demonstrates that your implementation is correct? -->
