### PR TITLE
refactor(diagnostics): change enum hierarchy for configuration diagnostics

### DIFF
--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -16,7 +16,7 @@ use biome_configuration::{
     PartialCssFormatter, PartialFilesConfiguration, PartialFormatterConfiguration,
     PartialJavascriptFormatter, PartialJsonFormatter, PartialLinterConfiguration,
 };
-use biome_configuration::{ConfigurationDiagnostic, PartialConfiguration};
+use biome_configuration::{BiomeDiagnostic, PartialConfiguration};
 use biome_console::{markup, Console, ConsoleExt};
 use biome_diagnostics::{Diagnostic, PrintDiagnostic};
 use biome_fs::{BiomePath, FileSystem};
@@ -541,9 +541,10 @@ pub(crate) fn validate_configuration_diagnostics(
 
     if loaded_configuration.has_errors() {
         return Err(CliDiagnostic::workspace_error(
-            WorkspaceError::Configuration(ConfigurationDiagnostic::invalid_configuration(
+            BiomeDiagnostic::invalid_configuration(
                 "Biome exited because the configuration resulted in errors. Please fix them.",
-            )),
+            )
+            .into(),
         ));
     }
 

--- a/crates/biome_configuration/src/diagnostics.rs
+++ b/crates/biome_configuration/src/diagnostics.rs
@@ -7,9 +7,30 @@ use biome_rowan::SyntaxError;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 
-/// Series of errors that can be thrown while computing the configuration
-#[derive(Deserialize, Diagnostic, Serialize)]
+/// Series of errors that can be thrown while computing the configuration.
+#[derive(Debug, Deserialize, Diagnostic, Serialize)]
 pub enum ConfigurationDiagnostic {
+    /// Diagnostics related to `biome.json` files
+    Biome(BiomeDiagnostic),
+    /// Diagnostics related to `.editorconfig` files
+    EditorConfig(EditorConfigDiagnostic),
+}
+
+impl From<BiomeDiagnostic> for ConfigurationDiagnostic {
+    fn from(value: BiomeDiagnostic) -> Self {
+        Self::Biome(value)
+    }
+}
+
+impl From<EditorConfigDiagnostic> for ConfigurationDiagnostic {
+    fn from(value: EditorConfigDiagnostic) -> Self {
+        Self::EditorConfig(value)
+    }
+}
+
+/// Series of errors that can be thrown while computing the configuration, specifically for `biome.json`.
+#[derive(Deserialize, Diagnostic, Serialize)]
+pub enum BiomeDiagnostic {
     /// Thrown when the program can't serialize the configuration, while saving it
     SerializationError(SerializationError),
 
@@ -35,21 +56,19 @@ pub enum ConfigurationDiagnostic {
     CantResolve(CantResolve),
 }
 
-impl From<SyntaxError> for ConfigurationDiagnostic {
+impl From<SyntaxError> for BiomeDiagnostic {
     fn from(_: SyntaxError) -> Self {
-        ConfigurationDiagnostic::Deserialization(DeserializationDiagnostic::new(
-            markup! {"Syntax Error"},
-        ))
+        BiomeDiagnostic::Deserialization(DeserializationDiagnostic::new(markup! {"Syntax Error"}))
     }
 }
 
-impl From<DeserializationDiagnostic> for ConfigurationDiagnostic {
+impl From<DeserializationDiagnostic> for BiomeDiagnostic {
     fn from(value: DeserializationDiagnostic) -> Self {
-        ConfigurationDiagnostic::Deserialization(value)
+        BiomeDiagnostic::Deserialization(value)
     }
 }
 
-impl ConfigurationDiagnostic {
+impl BiomeDiagnostic {
     pub fn new_serialization_error() -> Self {
         Self::SerializationError(SerializationError)
     }
@@ -90,13 +109,13 @@ impl ConfigurationDiagnostic {
     }
 }
 
-impl Debug for ConfigurationDiagnostic {
+impl Debug for BiomeDiagnostic {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self, f)
     }
 }
 
-impl std::fmt::Display for ConfigurationDiagnostic {
+impl std::fmt::Display for BiomeDiagnostic {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.description(f)
     }
@@ -237,7 +256,7 @@ impl EditorConfigDiagnostic {
 #[diagnostic(
     category = "configuration",
     severity = Error,
-    message = "Failed the parse the .editorconfig file.",
+    message = "Failed to parse the .editorconfig file.",
 )]
 pub struct ParseFailedDiagnostic {
     #[serde(skip)]
@@ -269,7 +288,7 @@ pub struct UnknownGlobPatternDiagnostic {
 
 #[cfg(test)]
 mod test {
-    use crate::{ConfigurationDiagnostic, PartialConfiguration};
+    use crate::{BiomeDiagnostic, PartialConfiguration};
     use biome_deserialize::json::deserialize_from_json_str;
     use biome_diagnostics::{print_diagnostic_to_string, DiagnosticExt, Error};
     use biome_json_parser::JsonParserOptions;
@@ -286,14 +305,14 @@ mod test {
 
     #[test]
     fn diagnostic_size() {
-        assert_eq!(std::mem::size_of::<ConfigurationDiagnostic>(), 96);
+        assert_eq!(std::mem::size_of::<BiomeDiagnostic>(), 96);
     }
 
     #[test]
     fn config_already_exists() {
         snap_diagnostic(
             "config_already_exists",
-            ConfigurationDiagnostic::new_already_exists().with_file_path("biome.json"),
+            BiomeDiagnostic::new_already_exists().with_file_path("biome.json"),
         )
     }
 

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -14,8 +14,8 @@ pub mod organize_imports;
 mod overrides;
 pub mod vcs;
 
+pub use crate::diagnostics::BiomeDiagnostic;
 pub use crate::diagnostics::CantLoadExtendFile;
-pub use crate::diagnostics::ConfigurationDiagnostic;
 pub use crate::generated::push_to_analyzer_rules;
 use crate::organize_imports::{partial_organize_imports, OrganizeImports, PartialOrganizeImports};
 use crate::vcs::{partial_vcs_configuration, PartialVcsConfiguration, VcsConfiguration};

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -1,6 +1,6 @@
 use crate::workspace::DocumentFileSource;
-use biome_configuration::diagnostics::EditorConfigDiagnostic;
-use biome_configuration::{CantLoadExtendFile, ConfigurationDiagnostic};
+use biome_configuration::diagnostics::{ConfigurationDiagnostic, EditorConfigDiagnostic};
+use biome_configuration::{BiomeDiagnostic, CantLoadExtendFile};
 use biome_console::fmt::Bytes;
 use biome_console::markup;
 use biome_diagnostics::{
@@ -60,8 +60,6 @@ pub enum WorkspaceError {
     ProtectedFile(ProtectedFile),
     /// Error when searching for a pattern
     SearchError(SearchError),
-    /// Thrown when a `.editorconfig` file is found, but it can't be parsed.
-    EditorConfigDiagnostic(EditorConfigDiagnostic),
 }
 
 impl WorkspaceError {
@@ -153,15 +151,21 @@ impl From<FileSystemDiagnostic> for WorkspaceError {
     }
 }
 
-impl From<ConfigurationDiagnostic> for WorkspaceError {
-    fn from(value: ConfigurationDiagnostic) -> Self {
-        Self::Configuration(value)
+impl From<BiomeDiagnostic> for WorkspaceError {
+    fn from(value: BiomeDiagnostic) -> Self {
+        Self::Configuration(value.into())
+    }
+}
+
+impl From<EditorConfigDiagnostic> for WorkspaceError {
+    fn from(value: EditorConfigDiagnostic) -> Self {
+        Self::Configuration(value.into())
     }
 }
 
 impl From<CantLoadExtendFile> for WorkspaceError {
     fn from(value: CantLoadExtendFile) -> Self {
-        WorkspaceError::Configuration(ConfigurationDiagnostic::CantLoadExtendFile(value))
+        WorkspaceError::Configuration(BiomeDiagnostic::CantLoadExtendFile(value).into())
     }
 }
 

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -5,7 +5,7 @@ use biome_configuration::diagnostics::InvalidIgnorePattern;
 use biome_configuration::javascript::JsxRuntime;
 use biome_configuration::organize_imports::OrganizeImports;
 use biome_configuration::{
-    push_to_analyzer_rules, ConfigurationDiagnostic, CssConfiguration, FilesConfiguration,
+    push_to_analyzer_rules, BiomeDiagnostic, CssConfiguration, FilesConfiguration,
     FormatterConfiguration, JavascriptConfiguration, JsonConfiguration, LinterConfiguration,
     OverrideFormatterConfiguration, OverrideLinterConfiguration,
     OverrideOrganizeImportsConfiguration, Overrides, PartialConfiguration, PartialCssConfiguration,
@@ -1186,10 +1186,10 @@ pub fn to_matcher(
     if let Some(string_set) = string_set {
         for pattern in string_set.iter() {
             matcher.add_pattern(pattern).map_err(|err| {
-                WorkspaceError::Configuration(ConfigurationDiagnostic::new_invalid_ignore_pattern(
+                BiomeDiagnostic::new_invalid_ignore_pattern(
                     pattern.to_string(),
                     err.msg.to_string(),
-                ))
+                )
             })?;
         }
     }
@@ -1203,19 +1203,15 @@ fn to_git_ignore(path: PathBuf, matches: &[String]) -> Result<Gitignore, Workspa
         gitignore_builder
             .add_line(Some(path.clone()), the_match)
             .map_err(|err| {
-                WorkspaceError::Configuration(ConfigurationDiagnostic::InvalidIgnorePattern(
-                    InvalidIgnorePattern {
-                        message: err.to_string(),
-                    },
-                ))
+                BiomeDiagnostic::InvalidIgnorePattern(InvalidIgnorePattern {
+                    message: err.to_string(),
+                })
             })?;
     }
     let gitignore = gitignore_builder.build().map_err(|err| {
-        WorkspaceError::Configuration(ConfigurationDiagnostic::InvalidIgnorePattern(
-            InvalidIgnorePattern {
-                message: err.to_string(),
-            },
-        ))
+        BiomeDiagnostic::InvalidIgnorePattern(InvalidIgnorePattern {
+            message: err.to_string(),
+        })
     })?;
     Ok(gitignore)
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This is part of a series of PRs for adding `.editorconfig` support to biome. Specifically, this PR follows up on this comment thread: https://github.com/biomejs/biome/pull/2884#discussion_r1605721658

Part of this refactor is also to prefer using `into()`, or the `?` operator's implicit call to `into()` on error types because it's a little bit easier to read, and can make it a little less tedious to do future refactors.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
Related to: #1724

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
It compiles and tests pass.
