### PR TITLE
feat(biome_graphql_parser): parse scalar extension

### DIFF
--- a/crates/biome_graphql_parser/src/parser/definitions/mod.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/mod.rs
@@ -28,7 +28,7 @@ use self::{
     object::parse_object_type_definition,
     operation::{parse_operation_definition, parse_selection_set},
     r#enum::parse_enum_type_definition,
-    scalar::parse_scalar_type_definition,
+    scalar::{parse_scalar_type_definition, parse_scalar_type_extension},
     schema::{parse_schema_definition, parse_schema_extension},
     union::parse_union_type_definition,
 };
@@ -97,6 +97,7 @@ fn parse_definition(p: &mut GraphqlParser) -> ParsedSyntax {
 fn parse_extension(p: &mut GraphqlParser) -> ParsedSyntax {
     match p.nth(1) {
         T![schema] => parse_schema_extension(p),
+        T![scalar] => parse_scalar_type_extension(p),
         _ => Absent,
     }
 }
@@ -119,5 +120,6 @@ fn is_at_definition(p: &mut GraphqlParser<'_>) -> bool {
             | T![enum]
             | T![input]
             | T![directive]
+            | T![extend]
     )
 }

--- a/crates/biome_graphql_parser/src/parser/definitions/scalar.rs
+++ b/crates/biome_graphql_parser/src/parser/definitions/scalar.rs
@@ -1,10 +1,13 @@
 use crate::parser::{
-    directive::DirectiveList, parse_description, parse_error::expected_name, parse_name,
-    GraphqlParser,
+    directive::DirectiveList,
+    parse_description,
+    parse_error::{expected_directive, expected_name},
+    parse_name, GraphqlParser,
 };
 use biome_graphql_syntax::{GraphqlSyntaxKind::*, T};
 use biome_parser::{
-    parse_lists::ParseNodeList, parsed_syntax::ParsedSyntax, prelude::ParsedSyntax::*, Parser,
+    parse_lists::ParseNodeList, parsed_syntax::ParsedSyntax, prelude::ParsedSyntax::*,
+    token_source::TokenSource, Parser,
 };
 
 #[inline]
@@ -19,4 +22,22 @@ pub(crate) fn parse_scalar_type_definition(p: &mut GraphqlParser) -> ParsedSynta
     DirectiveList.parse_list(p);
 
     Present(m.complete(p, GRAPHQL_SCALAR_TYPE_DEFINITION))
+}
+
+#[inline]
+pub(crate) fn parse_scalar_type_extension(p: &mut GraphqlParser) -> ParsedSyntax {
+    let m = p.start();
+
+    p.bump(T![extend]);
+    p.bump(T![scalar]);
+
+    parse_name(p).or_add_diagnostic(p, expected_name);
+    let pos = p.source().position();
+    DirectiveList.parse_list(p);
+    let directive_empty = p.source().position() == pos;
+    if directive_empty {
+        p.error(expected_directive(p, p.cur_range()));
+    }
+
+    Present(m.complete(p, GRAPHQL_SCALAR_TYPE_EXTENSION))
 }

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/scalar_extension.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/scalar_extension.graphql
@@ -1,0 +1,1 @@
+extend scalar Date

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/scalar_extension.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/err/definitions/scalar_extension.graphql.snap
@@ -1,0 +1,63 @@
+---
+source: crates/biome_graphql_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```graphql
+extend scalar Date
+
+```
+
+## AST
+
+```
+GraphqlRoot {
+    bom_token: missing (optional),
+    definitions: GraphqlDefinitionList [
+        GraphqlScalarTypeExtension {
+            extend_token: EXTEND_KW@0..7 "extend" [] [Whitespace(" ")],
+            scalar_token: SCALAR_KW@7..14 "scalar" [] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@14..18 "Date" [] [],
+            },
+            directives: GraphqlDirectiveList [],
+        },
+    ],
+    eof_token: EOF@18..19 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: GRAPHQL_ROOT@0..19
+  0: (empty)
+  1: GRAPHQL_DEFINITION_LIST@0..18
+    0: GRAPHQL_SCALAR_TYPE_EXTENSION@0..18
+      0: EXTEND_KW@0..7 "extend" [] [Whitespace(" ")]
+      1: SCALAR_KW@7..14 "scalar" [] [Whitespace(" ")]
+      2: GRAPHQL_NAME@14..18
+        0: GRAPHQL_NAME@14..18 "Date" [] []
+      3: GRAPHQL_DIRECTIVE_LIST@18..18
+  2: EOF@18..19 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+scalar_extension.graphql:2:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a directive but instead found the end of the file.
+  
+    1 │ extend scalar Date
+  > 2 │ 
+      │ 
+  
+  i Expected a directive here.
+  
+    1 │ extend scalar Date
+  > 2 │ 
+      │ 
+  
+```

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/scalar_extension.graphql
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/scalar_extension.graphql
@@ -1,0 +1,1 @@
+extend scalar Date @scalar_extension

--- a/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/scalar_extension.graphql.snap
+++ b/crates/biome_graphql_parser/tests/graphql_test_suite/ok/definitions/scalar_extension.graphql.snap
@@ -1,0 +1,57 @@
+---
+source: crates/biome_graphql_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```graphql
+extend scalar Date @scalar_extension
+
+```
+
+## AST
+
+```
+GraphqlRoot {
+    bom_token: missing (optional),
+    definitions: GraphqlDefinitionList [
+        GraphqlScalarTypeExtension {
+            extend_token: EXTEND_KW@0..7 "extend" [] [Whitespace(" ")],
+            scalar_token: SCALAR_KW@7..14 "scalar" [] [Whitespace(" ")],
+            name: GraphqlName {
+                value_token: GRAPHQL_NAME@14..19 "Date" [] [Whitespace(" ")],
+            },
+            directives: GraphqlDirectiveList [
+                GraphqlDirective {
+                    at_token: AT@19..20 "@" [] [],
+                    name: GraphqlName {
+                        value_token: GRAPHQL_NAME@20..36 "scalar_extension" [] [],
+                    },
+                    arguments: missing (optional),
+                },
+            ],
+        },
+    ],
+    eof_token: EOF@36..37 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: GRAPHQL_ROOT@0..37
+  0: (empty)
+  1: GRAPHQL_DEFINITION_LIST@0..36
+    0: GRAPHQL_SCALAR_TYPE_EXTENSION@0..36
+      0: EXTEND_KW@0..7 "extend" [] [Whitespace(" ")]
+      1: SCALAR_KW@7..14 "scalar" [] [Whitespace(" ")]
+      2: GRAPHQL_NAME@14..19
+        0: GRAPHQL_NAME@14..19 "Date" [] [Whitespace(" ")]
+      3: GRAPHQL_DIRECTIVE_LIST@19..36
+        0: GRAPHQL_DIRECTIVE@19..36
+          0: AT@19..20 "@" [] []
+          1: GRAPHQL_NAME@20..36
+            0: GRAPHQL_NAME@20..36 "scalar_extension" [] []
+          2: (empty)
+  2: EOF@36..37 "" [Newline("\n")] []
+
+```

--- a/xtask/codegen/graphql.ungram
+++ b/xtask/codegen/graphql.ungram
@@ -69,7 +69,6 @@ AnyGraphqlDefinition =
 	| GraphqlBogusDefinition
 	// Type System Extensions: we may possible want to group those in an enum outside of 'Definition'
 	| GraphqlSchemaExtension
-	// Type Extensions
 	| GraphqlScalarTypeExtension
 	| AnyGraphqlObjectTypeExtension
 	| AnyGraphqlInterfaceTypeExtension


### PR DESCRIPTION
## Summary

Parse GraphQL scalar extensions. This is a small case, as almost all parsing logic was handled by a previous PR focusing on parsing scalar definition.

## Test Plan

All tests should pass.
