### PR TITLE
fix(noUnusedVariables): no longer panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,6 +358,7 @@ z.object({})
     4 4 │   </>
   ```
 - [noUndeclaredDependencies](https://biomejs.dev/linter/rules/no-undeclared-dependencies/) is correctly triggered when running `biome ci`. Contributed by @ematipico
+- [noUnusedVariables](https://biomejs.dev/linter/rules/no-unused-variables/) no longer panics when a certain combination of characters is typed. Contributed by @ematipico
 ### Parser
 
 #### Enhancements

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -194,7 +194,7 @@ fn suggested_fix_if_unused(binding: &AnyJsIdentifierBinding) -> Option<Suggested
         | AnyJsBindingDeclaration::JsObjectBindingPatternProperty(_)
         | AnyJsBindingDeclaration::JsObjectBindingPatternRest(_)
         | AnyJsBindingDeclaration::JsObjectBindingPatternShorthandProperty(_) => {
-            unreachable!("The declaration should be resolved to its parent declaration");
+            None
         }
         node @ AnyJsBindingDeclaration::JsVariableDeclarator(_) => {
             if is_in_ambient_context(node.syntax()) {

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/issue_2886.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/issue_2886.ts
@@ -1,0 +1,2 @@
+// should not panic
+const [a(

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/issue_2886.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/issue_2886.ts.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue_2886.ts
+---
+# Input
+```ts
+// should not panic
+const [a(
+
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

The rule `noUnusedVariables` no longer panics.

Closes https://github.com/biomejs/biome/issues/2886

@biomejs/maintainers @biomejs/core-contributors This is a reminder that we should never use code that panics, e.g. `unwrap`, `unreachable!`, etc. We should never forget that Biome's parser is recoverable, so we can always receive broken that could be weird and mapped to unexpected nodes

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a regression

<!-- What demonstrates that your implementation is correct? -->
