### PR TITLE
chore(git): ignore more generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,27 +1,33 @@
 # Generated files, sorted alphabetically.
 * text=auto eol=lf
 **/generated/* linguist-generated=true text=auto eol=lf
-crates/biome_js_analyze/src/syntax.rs linguist-generated=true text=auto eol=lf
-crates/biome_js_analyze/src/syntax/*.rs linguist-generated=true text=auto eol=lf
-crates/biome_js_analyze/src/assists.rs linguist-generated=true text=auto eol=lf
-crates/biome_js_analyze/src/assists/*.rs linguist-generated=true text=auto eol=lf
-crates/biome_js_analyze/src/lint.rs linguist-generated=true text=auto eol=lf
-crates/biome_js_analyze/src/lint/*.rs linguist-generated=true text=auto eol=lf
-crates/biome_js_analyze/src/registry.rs linguist-generated=true text=auto eol=lf
-crates/biome_configuration/src/linter/rules.rs linguist-generated=true text=auto eol=lf
-crates/biome_configuration/src/parse/json/rules.rs linguist-generated=true text=auto eol=lf
-crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs linguist-generated=true text=auto eol=lf
-crates/biome_unicode_table/src/tables.rs linguist-generated=true text=auto eol=lf
-packages/@biomejs/backend-jsonrpc/src/workspace.ts linguist-generated=true text=auto eol=lf
-packages/@biomejs/biome/configuration_schema.json linguist-generated=true text=auto eol=lf
+/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs linguist-generated=true text=auto eol=lf
+/crates/biome_configuration/src/generated.rs linguist-generated=true text=auto eol=lf
+/crates/biome_configuration/src/linter/rules.rs linguist-generated=true text=auto eol=lf
+/crates/biome_configuration/src/parse/json/rules.rs linguist-generated=true text=auto eol=lf
+/crates/biome_css_analyze/src/lint.rs linguist-generated=true text=auto eol=lf
+/crates/biome_css_analyze/src/lint/*.rs linguist-generated=true text=auto eol=lf
+/crates/biome_css_analyze/src/options.rs linguist-generated=true text=auto eol=lf
+/crates/biome_css_analyze/src/registry.rs linguist-generated=true text=auto eol=lf
+/crates/biome_js_analyze/src/assists.rs linguist-generated=true text=auto eol=lf
+/crates/biome_js_analyze/src/assists/*.rs linguist-generated=true text=auto eol=lf
+/crates/biome_js_analyze/src/lint.rs linguist-generated=true text=auto eol=lf
+/crates/biome_js_analyze/src/lint/*.rs linguist-generated=true text=auto eol=lf
+/crates/biome_js_analyze/src/options.rs linguist-generated=true text=auto eol=lf
+/crates/biome_js_analyze/src/registry.rs linguist-generated=true text=auto eol=lf
+/crates/biome_js_analyze/src/syntax.rs linguist-generated=true text=auto eol=lf
+/crates/biome_js_analyze/src/syntax/*.rs linguist-generated=true text=auto eol=lf
+/crates/biome_unicode_table/src/tables.rs linguist-generated=true text=auto eol=lf
+/packages/@biomejs/backend-jsonrpc/src/workspace.ts linguist-generated=true text=auto eol=lf
+/packages/@biomejs/biome/configuration_schema.json linguist-generated=true text=auto eol=lf
 pnpm-lock.yaml linguist-generated=true text=auto eol=lf
 
 # Files with the language manually specified, sorted alphabetically.
-crates/biome_cli/tests/**/*.snap linguist-language=Markdown
-crates/biome_js_analyze/tests/specs/**/*.snap linguist-language=Markdown
-crates/biome_css_formatter/tests/**/*.css.prettier-snap linguist-language=CSS
-crates/biome_css_formatter/tests/**/*.css.snap linguist-language=Markdown
-crates/biome_js_formatter/tests/**/*.ts.prettier-snap linguist-language=TypeScript
-crates/biome_js_formatter/tests/**/*.js.prettier-snap linguist-language=JavaScript
-crates/biome_js_formatter/tests/**/*.ts.snap linguist-language=Markdown
-crates/biome_js_formatter/tests/**/*.js.snap linguist-language=Markdown
+/crates/biome_cli/tests/**/*.snap linguist-language=Markdown
+/crates/biome_js_analyze/tests/specs/**/*.snap linguist-language=Markdown
+/crates/biome_css_formatter/tests/**/*.css.prettier-snap linguist-language=CSS
+/crates/biome_css_formatter/tests/**/*.css.snap linguist-language=Markdown
+/crates/biome_js_formatter/tests/**/*.ts.prettier-snap linguist-language=TypeScript
+/crates/biome_js_formatter/tests/**/*.js.prettier-snap linguist-language=JavaScript
+/crates/biome_js_formatter/tests/**/*.ts.snap linguist-language=Markdown
+/crates/biome_js_formatter/tests/**/*.js.snap linguist-language=Markdown

--- a/.gitignore
+++ b/.gitignore
@@ -13,17 +13,17 @@ Profile-*.json
 **/dist
 **/build
 .pnpm-debug.log
+.vercel
 
 # https://github.com/nnethercote/dhat-rs output file
 dhat-heap.json
 
-crates/biome_css_formatter/report.*
-crates/biome_js_formatter/report.*
-crates/biome_json_formatter/report.*
-crates/biome_json_formatter/report_incompatible.*
-.vercel
+/crates/biome_css_formatter/report.*
+/crates/biome_js_formatter/report.*
+/crates/biome_json_formatter/report.*
+/crates/biome_json_formatter/report_incompatible.*
 
 # don't ignore any files inside prettier test specs
-!crates/biome_js_formatter/tests/specs/prettier/**/*
-!crates/biome_json_formatter/tests/specs/prettier/**/*
-!crates/biome_css_formatter/tests/specs/prettier/**/*
+!/crates/biome_js_formatter/tests/specs/prettier/**/*
+!/crates/biome_json_formatter/tests/specs/prettier/**/*
+!/crates/biome_css_formatter/tests/specs/prettier/**/*


### PR DESCRIPTION
## Summary

Add more generated files to `.gitattributes` and use `gitignore`/`gitattribute` relative path marker `/` for the `crates` folder.

## Test Plan

CI must pass