### PR TITLE
fix(workspace): remove caching of file features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Add support for LSP Workspaces
 
+#### Bug fixes
+
+- Fixes [#2781](https://github.com/biomejs/biome/issues/2781), by correctly computing the configuration to apply to a specific file. Contributed by @ematipico
+
 ### Formatter
 
 #### Bug fixes

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -48,8 +48,6 @@ pub(super) struct WorkspaceServer {
     documents: DashMap<BiomePath, Document>,
     /// Stores the result of the parser (syntax tree + diagnostics) for a given URL
     syntax: DashMap<BiomePath, AnyParse>,
-    /// Stores the features supported for each file
-    file_features: DashMap<BiomePath, FileFeaturesResult>,
     /// Stores the parsed manifests
     manifests: DashMap<BiomePath, NodeJsProject>,
     /// The current focused project
@@ -90,7 +88,6 @@ impl WorkspaceServer {
             settings: RwLock::default(),
             documents: DashMap::default(),
             syntax: DashMap::default(),
-            file_features: DashMap::default(),
             manifests: DashMap::default(),
             current_project_path: RwLock::default(),
             file_sources: RwLock::default(),
@@ -347,53 +344,43 @@ impl Workspace for WorkspaceServer {
         &self,
         params: SupportsFeatureParams,
     ) -> Result<FileFeaturesResult, WorkspaceError> {
-        let file_features_result = self.file_features.entry(params.path.clone());
-        match file_features_result {
-            Entry::Occupied(entry) => {
-                let result = entry.get();
-                Ok(result.clone())
-            }
-            Entry::Vacant(entry) => {
-                let capabilities = self.get_file_capabilities(&params.path);
-                let language = DocumentFileSource::from_path(&params.path);
-                let path = params.path.as_path();
-                let settings = self.workspace();
-                let settings = settings.settings();
-                let mut file_features = FileFeaturesResult::new();
-                let file_name = path.file_name().and_then(|s| s.to_str());
-                file_features = file_features
-                    .with_capabilities(&capabilities)
-                    .with_settings_and_language(settings, &language, path);
+        let capabilities = self.get_file_capabilities(&params.path);
+        let language = DocumentFileSource::from_path(&params.path);
+        let path = params.path.as_path();
+        let settings = self.workspace();
+        let settings = settings.settings();
+        let mut file_features = FileFeaturesResult::new();
+        let file_name = path.file_name().and_then(|s| s.to_str());
+        file_features = file_features
+            .with_capabilities(&capabilities)
+            .with_settings_and_language(settings, &language, path);
 
-                if settings.files.ignore_unknown
-                    && language == DocumentFileSource::Unknown
-                    && self.get_file_source(&params.path) == DocumentFileSource::Unknown
-                {
-                    file_features.ignore_not_supported();
-                } else if file_name == Some(ConfigName::biome_json())
-                    || file_name == Some(ConfigName::biome_jsonc())
-                {
-                    // Never ignore Biome's config file
-                } else if self.is_ignored_by_top_level_config(path) {
-                    file_features.set_ignored_for_all_features();
-                } else {
-                    for feature in params.features {
-                        if self.is_ignored_by_feature_config(path, feature) {
-                            file_features.ignored(feature);
-                        }
-                    }
+        if settings.files.ignore_unknown
+            && language == DocumentFileSource::Unknown
+            && self.get_file_source(&params.path) == DocumentFileSource::Unknown
+        {
+            file_features.ignore_not_supported();
+        } else if file_name == Some(ConfigName::biome_json())
+            || file_name == Some(ConfigName::biome_jsonc())
+        {
+            // Never ignore Biome's config file
+        } else if self.is_ignored_by_top_level_config(path) {
+            file_features.set_ignored_for_all_features();
+        } else {
+            for feature in params.features {
+                if self.is_ignored_by_feature_config(path, feature) {
+                    file_features.ignored(feature);
                 }
-
-                // If the file is not ignored by at least one feature,
-                // then check that the file is not protected.
-                // Protected files must be ignored.
-                if !file_features.is_not_processed() && FileFeaturesResult::is_protected_file(path)
-                {
-                    file_features.set_protected_for_all_features();
-                }
-                Ok(entry.insert(file_features).clone())
             }
         }
+
+        // If the file is not ignored by at least one feature,
+        // then check that the file is not protected.
+        // Protected files must be ignored.
+        if !file_features.is_not_processed() && FileFeaturesResult::is_protected_file(path) {
+            file_features.set_protected_for_all_features();
+        }
+        Ok(file_features)
     }
     fn is_path_ignored(&self, params: IsPathIgnoredParams) -> Result<bool, WorkspaceError> {
         Ok(self.is_ignored(params.biome_path.as_path(), params.features))
@@ -416,8 +403,6 @@ impl Workspace for WorkspaceServer {
                 params.gitignore_matches.as_slice(),
             )?;
 
-        // settings changed, hence everything that is computed from the settings needs to be purged
-        self.file_features.clear();
         Ok(())
     }
     /// Add a new file to the workspace


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary


Closes https://github.com/biomejs/biome/issues/2781

The issue was the aggressive caching of `FileFeatureResult`, maybe designed with poor judgement from my side.

Here's the issue explained: when a file is opened, the LSP request diagnostics from a certain file. We pull diagnostics using these feature set:

```rust
        let file_features = self.workspace.file_features(SupportsFeatureParams {
            features: FeaturesBuilder::new()
                .with_linter()
                .with_organize_imports()
                .build(),
            path: biome_path.clone(),
        })?;
```

A formatter doesn't have proper diagnostics, so we exclude it from the features. Since the formatter feature isn't requested, the default value is used, which is `Supported` because `ignore` part is checked only on a parameter basis. 

However, this was then cached inside our workspace. 

When calling the formatting, we pull the formatter feature:

```rust
    let file_features = session.workspace.file_features(SupportsFeatureParams {
        path: biome_path.clone(),
        features: FeaturesBuilder::new().with_formatter().build(),
    })?;
```

Which is flagged as `Supported` because we retrieve the cached value.


As for a solution, for now, I removed the cache. 

I plan to re-introduce the caching again, but I plan to rewrite the logic is a more pure way.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I manually tested it.

<!-- What demonstrates that your implementation is correct? -->
