### PR TITLE
feat(noUselessUndefinedInitialization): move comments after the statement on code action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,13 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   The diagnosis is also clearer.
 
   Contributed by @Conaclos
+- Improve code action for [nursery/noUselessUndefinedInitialization](https://biomejs.dev/linter/rules/no-useless-undefined-initialization/) to handle comments.
+
+  The rule now places inline comments after the declaration statement, instead of removing them.
+  The code action is now safe to apply.
+  
+  Contributed by @lutaok
+
 
 #### Bug fixes
 

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -1243,14 +1243,14 @@ pub(crate) fn migrate_eslint_any_rule(
         "react/no-danger" => {
             let group = rules.security.get_or_insert_with(Default::default);
             let rule = group
-                .no_dangerously_set_inner_html_with_children
+                .no_dangerously_set_inner_html
                 .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
         "react/no-danger-with-children" => {
             let group = rules.security.get_or_insert_with(Default::default);
             let rule = group
-                .no_dangerously_set_inner_html
+                .no_dangerously_set_inner_html_with_children
                 .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_undefined_initialization.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_undefined_initialization.rs
@@ -3,7 +3,9 @@ use biome_analyze::{
     RuleSource, RuleSourceKind,
 };
 use biome_console::markup;
-use biome_js_syntax::JsVariableDeclaration;
+use biome_js_factory::make::js_variable_declarator_list;
+use biome_js_syntax::{JsLanguage, JsVariableDeclarator, JsVariableStatement};
+use biome_rowan::{chain_trivia_pieces, SyntaxToken, SyntaxTriviaPiece};
 use biome_rowan::{AstNode, BatchMutationExt, TextRange};
 
 use crate::JsRuleAction;
@@ -13,8 +15,8 @@ declare_rule! {
     ///
     /// A variable that is declared and not initialized to any value automatically gets the value of `undefined`.
     /// It’s considered a best practice to avoid initializing variables to `undefined`.
-    /// Please note that any inline comments attached to the initialization value or variable will be removed on auto-fix.
-    /// Please be also aware that this differs from Eslint's behaviour and we are still discussing on how to properly handle this case.
+    /// Please note that any inline comments attached to the initialization value or variable will be moved at the end of the variable declaration on auto-fix.
+    /// Please be also aware that this differs from Eslint's behaviour.
     ///
     /// ## Examples
     ///
@@ -51,22 +53,26 @@ declare_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-undef-init")],
         source_kind: RuleSourceKind::Inspired,
-        fix_kind: FixKind::Unsafe,
+        fix_kind: FixKind::Safe,
         recommended: false,
     }
 }
 
 impl Rule for NoUselessUndefinedInitialization {
-    type Query = Ast<JsVariableDeclaration>;
+    type Query = Ast<JsVariableStatement>;
     type State = (String, TextRange);
     type Signals = Vec<Self::State>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let node = ctx.query();
-        let let_or_var_kind = node.is_let() || node.is_var();
+        let statement = ctx.query();
 
         let mut signals = vec![];
+        let Ok(node) = statement.declaration() else {
+            return signals;
+        };
+
+        let let_or_var_kind = node.is_let() || node.is_var();
 
         if !let_or_var_kind {
             return signals;
@@ -110,23 +116,70 @@ impl Rule for NoUselessUndefinedInitialization {
     }
 
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
-        let declarators = ctx.query().declarators();
+        let node = ctx.query();
+        let assignment_statement = node.clone();
 
-        let initializer = declarators
+        let current_declaration_statement = node.clone().declaration().ok()?;
+        let declarators = current_declaration_statement.declarators();
+
+        let current_declaration = declarators
             .clone()
             .into_iter()
-            .find(|el| {
-                el.as_ref()
-                    .ok()
-                    .and_then(|element| element.id().ok())
-                    .is_some_and(|id| id.text() == state.0)
+            .flat_map(|declarator| declarator.ok())
+            .find(|decl| decl.id().is_ok_and(|id| id.text() == state.0))?;
+
+        let current_initializer = current_declaration.initializer()?;
+
+        let eq_token_trivia = current_initializer
+            .eq_token()
+            .map(|token| token.trailing_trivia())
+            .ok()?
+            .pieces();
+
+        let expression_trivia = current_initializer
+            .expression()
+            .ok()?
+            .as_js_reference_identifier()
+            .map(|reference| reference.value_token())?
+            .ok()?
+            .trailing_trivia()
+            .pieces();
+
+        // Save the separators too
+        let separators_syntax = declarators.clone().into_syntax();
+        let separators: Vec<SyntaxToken<JsLanguage>> = separators_syntax.tokens().collect();
+
+        let new_declaration = current_declaration.clone().with_initializer(None);
+        let new_declarators: Vec<JsVariableDeclarator> = declarators
+            .clone()
+            .into_iter()
+            .flat_map(|decl| decl.ok())
+            .map(|decl| {
+                if decl == current_declaration {
+                    new_declaration.clone()
+                } else {
+                    decl
+                }
             })
-            .map(|decl| decl.ok())?
-            .and_then(|declarator| declarator.initializer())?;
+            .collect();
+
+        // Recreate the declaration statement with updated declarators
+        let new_declaration_statement = current_declaration_statement
+            .with_declarators(js_variable_declarator_list(new_declarators, separators));
+
+        let chained_comments: Vec<SyntaxTriviaPiece<JsLanguage>> =
+            chain_trivia_pieces(eq_token_trivia, expression_trivia)
+                .filter(|trivia| trivia.is_comments())
+                .collect();
+
+        // Create the whole statement using updated subtree and append comments to the statement
+        let new_node = assignment_statement
+            .clone()
+            .with_declaration(new_declaration_statement)
+            .append_trivia_pieces(chained_comments)?;
 
         let mut mutation = ctx.root().begin();
-        // This will remove any comments attached to the initialization clause
-        mutation.remove_node(initializer);
+        mutation.replace_node_discard_trivia(assignment_statement, new_node);
 
         Some(JsRuleAction::new(
             ActionCategory::QuickFix,

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_undefined_initialization.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_undefined_initialization.rs
@@ -125,7 +125,7 @@ impl Rule for NoUselessUndefinedInitialization {
         let current_declaration = declarators
             .clone()
             .into_iter()
-            .flat_map(|declarator| declarator.ok())
+            .filter_map(|declarator| declarator.ok())
             .find(|decl| decl.id().is_ok_and(|id| id.text() == state.0))?;
 
         let current_initializer = current_declaration.initializer()?;
@@ -153,7 +153,7 @@ impl Rule for NoUselessUndefinedInitialization {
         let new_declarators: Vec<JsVariableDeclarator> = declarators
             .clone()
             .into_iter()
-            .flat_map(|decl| decl.ok())
+            .filter_map(|decl| decl.ok())
             .map(|decl| {
                 if decl == current_declaration {
                     new_declaration.clone()

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessUndefinedInitialization/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessUndefinedInitialization/invalid.js
@@ -7,7 +7,7 @@ for (let i = 0; i < 100; i++) {
 	let i = undefined;
 }
 
-let x = 1, y = undefined, z = 40
+let x = 1, y = undefined /* comment here */, z = 40
 
 let /* comment */d = undefined;
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessUndefinedInitialization/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessUndefinedInitialization/invalid.js.snap
@@ -13,7 +13,7 @@ for (let i = 0; i < 100; i++) {
 	let i = undefined;
 }
 
-let x = 1, y = undefined, z = 40
+let x = 1, y = undefined /* comment here */, z = 40
 
 let /* comment */d = undefined;
 
@@ -37,7 +37,7 @@ invalid.js:2:8 lint/nursery/noUselessUndefinedInitialization  FIXABLE  ━━━
   
   i A variable that is declared and not initialized to any value automatically gets the value of undefined.
   
-  i Unsafe fix: Remove undefined initialization.
+  i Safe fix: Remove undefined initialization.
   
     2 │ → test2·=·undefined;
       │         ----------- 
@@ -58,7 +58,7 @@ invalid.js:3:7 lint/nursery/noUselessUndefinedInitialization  FIXABLE  ━━━
   
   i A variable that is declared and not initialized to any value automatically gets the value of undefined.
   
-  i Unsafe fix: Remove undefined initialization.
+  i Safe fix: Remove undefined initialization.
   
     3 │ var·c·=·undefined,
       │       ----------- 
@@ -79,7 +79,7 @@ invalid.js:4:4 lint/nursery/noUselessUndefinedInitialization  FIXABLE  ━━━
   
   i A variable that is declared and not initialized to any value automatically gets the value of undefined.
   
-  i Unsafe fix: Remove undefined initialization.
+  i Safe fix: Remove undefined initialization.
   
     4 │ → o·=·undefined;
       │     ----------- 
@@ -99,7 +99,7 @@ invalid.js:7:8 lint/nursery/noUselessUndefinedInitialization  FIXABLE  ━━━
   
   i A variable that is declared and not initialized to any value automatically gets the value of undefined.
   
-  i Unsafe fix: Remove undefined initialization.
+  i Safe fix: Remove undefined initialization.
   
     7 │ → let·i·=·undefined;
       │         ----------- 
@@ -113,17 +113,22 @@ invalid.js:10:14 lint/nursery/noUselessUndefinedInitialization  FIXABLE  ━━�
   
      8 │ }
      9 │ 
-  > 10 │ let x = 1, y = undefined, z = 40
+  > 10 │ let x = 1, y = undefined /* comment here */, z = 40
        │              ^^^^^^^^^^^
     11 │ 
     12 │ let /* comment */d = undefined;
   
   i A variable that is declared and not initialized to any value automatically gets the value of undefined.
   
-  i Unsafe fix: Remove undefined initialization.
+  i Safe fix: Remove undefined initialization.
   
-    10 │ let·x·=·1,·y·=·undefined,·z·=·40
-       │              -----------        
+     8  8 │   }
+     9  9 │   
+    10    │ - let·x·=·1,·y·=·undefined·/*·comment·here·*/,·z·=·40
+       10 │ + let·x·=·1,·y·,·z·=·40/*·comment·here·*/
+    11 11 │   
+    12 12 │   let /* comment */d = undefined;
+  
 
 ```
 
@@ -132,7 +137,7 @@ invalid.js:12:20 lint/nursery/noUselessUndefinedInitialization  FIXABLE  ━━�
 
   ! It's not necessary to initialize d to undefined.
   
-    10 │ let x = 1, y = undefined, z = 40
+    10 │ let x = 1, y = undefined /* comment here */, z = 40
     11 │ 
   > 12 │ let /* comment */d = undefined;
        │                    ^^^^^^^^^^^
@@ -141,7 +146,7 @@ invalid.js:12:20 lint/nursery/noUselessUndefinedInitialization  FIXABLE  ━━�
   
   i A variable that is declared and not initialized to any value automatically gets the value of undefined.
   
-  i Unsafe fix: Remove undefined initialization.
+  i Safe fix: Remove undefined initialization.
   
     12 │ let·/*·comment·*/d·=·undefined;
        │                    ----------- 
@@ -162,10 +167,15 @@ invalid.js:14:7 lint/nursery/noUselessUndefinedInitialization  FIXABLE  ━━�
   
   i A variable that is declared and not initialized to any value automatically gets the value of undefined.
   
-  i Unsafe fix: Remove undefined initialization.
+  i Safe fix: Remove undefined initialization.
   
-    14 │ let·e·=·undefined/**/·;
-       │       ---------------- 
+    12 12 │   let /* comment */d = undefined;
+    13 13 │   
+    14    │ - let·e·=·undefined/**/·;
+       14 │ + let·e·;/**/
+    15 15 │   let f = /**/undefined/**/ ;
+    16 16 │   let g·
+  
 
 ```
 
@@ -182,10 +192,15 @@ invalid.js:15:7 lint/nursery/noUselessUndefinedInitialization  FIXABLE  ━━�
   
   i A variable that is declared and not initialized to any value automatically gets the value of undefined.
   
-  i Unsafe fix: Remove undefined initialization.
+  i Safe fix: Remove undefined initialization.
   
-    15 │ let·f·=·/**/undefined/**/·;
-       │       -------------------- 
+    13 13 │   
+    14 14 │   let e = undefined/**/ ;
+    15    │ - let·f·=·/**/undefined/**/·;
+       15 │ + let·f·;/**//**/
+    16 16 │   let g·
+    17 17 │     /**/= /**/undefined/**/ ;
+  
 
 ```
 
@@ -201,13 +216,13 @@ invalid.js:17:7 lint/nursery/noUselessUndefinedInitialization  FIXABLE  ━━�
   
   i A variable that is declared and not initialized to any value automatically gets the value of undefined.
   
-  i Unsafe fix: Remove undefined initialization.
+  i Safe fix: Remove undefined initialization.
   
     14 14 │   let e = undefined/**/ ;
     15 15 │   let f = /**/undefined/**/ ;
     16    │ - let·g·
     17    │ - ··/**/=·/**/undefined/**/·;
-       16 │ + let·g·;
+       16 │ + let·g·;/**//**/
   
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #2879 

The changes are relevant to the code action, but I also had to change the query type in order to place comments after declaration statement.

I changed the `Fix_Kind` of the action to `Safe` since it doesn't remove any user relevant information anymore.

## Test Plan

Added comments on test cases to demonstrate the autofix correctness.
I hope I tackled any test case relevant to this action, let me know if you know of any edge case I might have not considered.