### PR TITLE
refactor(migrate/eslint): propagate NodeJS error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- `biome migrate eslint` now propagates NodeJS errors to the user.
+
+  This will help users to identify why Biome is unable to load some ESLint configurations.
+
+  Contributed by @Conaclos
+
 - Add a new `--reporter` called `summary`. This reporter will print diagnostics in a different way, based on the tools (formatter, linter, etc.) that are executed.
   Import sorting and formatter shows the name of the files that require formatting. Instead, the linter will group the number of rules triggered and the number of errors/warnings:
 

--- a/crates/biome_cli/src/execute/migrate/eslint.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint.rs
@@ -263,17 +263,10 @@ fn load_eslint_extends_config(
             }
         };
         // load ESLint preset
-        let Ok(node::Resolution {
+        let node::Resolution {
             content,
             resolved_path,
-        }) = node::load_config(&module_name)
-        else {
-            return Err(CliDiagnostic::MigrateError(MigrationDiagnostic {
-                reason: format!(
-                    "The module '{rest}' cannot be loaded. Make sure that the module exists."
-                ),
-            }));
-        };
+        } = node::load_config(&module_name)?;
         let deserialized = deserialize_from_json_str::<eslint_eslint::PluginExport>(
             &content,
             JsonParserOptions::default(),
@@ -299,17 +292,10 @@ fn load_eslint_extends_config(
         } else {
             EslintPackage::Config.resolve_name(name)
         };
-        let Ok(node::Resolution {
+        let node::Resolution {
             content,
             resolved_path,
-        }) = node::load_config(&module_name)
-        else {
-            return Err(CliDiagnostic::MigrateError(MigrationDiagnostic {
-                reason: format!(
-                    "The module '{module_name}' cannot be loaded. Make sure that the module exists."
-                ),
-            }));
-        };
+        } = node::load_config(&module_name)?;
         let deserialized = deserialize_from_json_str::<eslint_eslint::LegacyConfigData>(
             &content,
             JsonParserOptions::default(),


### PR DESCRIPTION
## Summary

Propagate errors reported by NodeJS when loading ESLint presets.
This helps to identify what is going on.
See #2935

## Test Plan

We are not currently able to test this.
I tested the fix locally,
