### PR TITLE
feat(cli): rage now prints all enabled rules 

### DIFF
--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -815,6 +815,19 @@ impl<'a> Display for RuleFilter<'a> {
     }
 }
 
+impl<'a> biome_console::fmt::Display for RuleFilter<'a> {
+    fn fmt(&self, fmt: &mut biome_console::fmt::Formatter) -> std::io::Result<()> {
+        match self {
+            RuleFilter::Group(group) => {
+                write!(fmt, "{group}")
+            }
+            RuleFilter::Rule(group, rule) => {
+                write!(fmt, "{group}/{rule}")
+            }
+        }
+    }
+}
+
 /// Allows filtering the list of rules that will be executed in a run of the analyzer,
 /// and at what source code range signals (diagnostics or actions) may be raised
 #[derive(Debug, Default, Clone, Copy)]

--- a/crates/biome_cli/tests/commands/rage.rs
+++ b/crates/biome_cli/tests/commands/rage.rs
@@ -300,14 +300,6 @@ fn with_linter_configuration() {
       "correctness": {
         "all": true
       },
-      "nursery": {
-        "useConsistentArrayType": {
-          "level": "warn",
-          "options": {
-            "syntax": "shorthand"
-          }
-        }
-      },
       "suspicious": {
         "noCommentText": {
           "level": "warn"

--- a/crates/biome_cli/tests/commands/rage.rs
+++ b/crates/biome_cli/tests/commands/rage.rs
@@ -289,16 +289,13 @@ fn with_linter_configuration() {
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "recommended": false,
       "a11y": {
         "noAccessKey": "off",
         "noAutofocus": "off"
       },
       "complexity": {
         "recommended": true
-      },
-      "correctness": {
-        "all": true
       },
       "suspicious": {
         "noCommentText": {

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_configuration.snap
@@ -20,14 +20,6 @@ expression: content
       "correctness": {
         "all": true
       },
-      "nursery": {
-        "useConsistentArrayType": {
-          "level": "warn",
-          "options": {
-            "syntax": "shorthand"
-          }
-        }
-      },
       "suspicious": {
         "noCommentText": {
           "level": "warn"
@@ -61,22 +53,207 @@ Environment:
   NODE_PACKAGE_MANAGER:         unset
 
 Biome Configuration:
-  Error:                        Found an unknown key `useConsistentArrayType`.
-  Status:                       Loaded with errors
+  Status:                       Loaded successfully
   Formatter disabled:           false
   Linter disabled:              false
   Organize imports disabled:    false
   VCS disabled:                 true
 
 Linter:
+  JavaScript enabled:           true
+  JSON enabled:                 true
+  CSS enabled:                  false
   Recommended:                  true
   All:                          false
-  Rules:                        a11y/noAccessKey = "off"
-                                a11y/noAutofocus = "off"
-                                complexity/recommended = true
-                                correctness/all = true
-                                style/noNonNullAssertion = "off"
-                                suspicious/noCommentText = {"level":"warn","options":null}
+  Enabled rules:
+  a11y/noAriaHiddenOnFocusable
+  a11y/noAriaUnsupportedElements
+  a11y/noBlankTarget
+  a11y/noDistractingElements
+  a11y/noHeaderScope
+  a11y/noInteractiveElementToNoninteractiveRole
+  a11y/noNoninteractiveElementToInteractiveRole
+  a11y/noNoninteractiveTabindex
+  a11y/noPositiveTabindex
+  a11y/noRedundantAlt
+  a11y/noRedundantRoles
+  a11y/noSvgWithoutTitle
+  a11y/useAltText
+  a11y/useAnchorContent
+  a11y/useAriaActivedescendantWithTabindex
+  a11y/useAriaPropsForRole
+  a11y/useButtonType
+  a11y/useHeadingContent
+  a11y/useHtmlLang
+  a11y/useIframeTitle
+  a11y/useKeyWithClickEvents
+  a11y/useKeyWithMouseEvents
+  a11y/useMediaCaption
+  a11y/useValidAnchor
+  a11y/useValidAriaProps
+  a11y/useValidAriaRole
+  a11y/useValidAriaValues
+  a11y/useValidLang
+  complexity/noBannedTypes
+  complexity/noEmptyTypeParameters
+  complexity/noExcessiveNestedTestSuites
+  complexity/noExtraBooleanCast
+  complexity/noForEach
+  complexity/noMultipleSpacesInRegularExpressionLiterals
+  complexity/noStaticOnlyClass
+  complexity/noThisInStatic
+  complexity/noUselessCatch
+  complexity/noUselessConstructor
+  complexity/noUselessEmptyExport
+  complexity/noUselessFragments
+  complexity/noUselessLabel
+  complexity/noUselessLoneBlockStatements
+  complexity/noUselessRename
+  complexity/noUselessSwitchCase
+  complexity/noUselessTernary
+  complexity/noUselessThisAlias
+  complexity/noUselessTypeConstraint
+  complexity/noWith
+  complexity/useArrowFunction
+  complexity/useFlatMap
+  complexity/useLiteralKeys
+  complexity/useOptionalChain
+  complexity/useRegexLiterals
+  complexity/useSimpleNumberKeys
+  correctness/noChildrenProp
+  correctness/noConstAssign
+  correctness/noConstantCondition
+  correctness/noConstructorReturn
+  correctness/noEmptyCharacterClassInRegex
+  correctness/noEmptyPattern
+  correctness/noGlobalObjectCalls
+  correctness/noInnerDeclarations
+  correctness/noInvalidConstructorSuper
+  correctness/noInvalidNewBuiltin
+  correctness/noInvalidUseBeforeDeclaration
+  correctness/noNewSymbol
+  correctness/noNonoctalDecimalEscape
+  correctness/noPrecisionLoss
+  correctness/noRenderReturnValue
+  correctness/noSelfAssign
+  correctness/noSetterReturn
+  correctness/noStringCaseMismatch
+  correctness/noSwitchDeclarations
+  correctness/noUndeclaredVariables
+  correctness/noUnnecessaryContinue
+  correctness/noUnreachable
+  correctness/noUnreachableSuper
+  correctness/noUnsafeFinally
+  correctness/noUnsafeOptionalChaining
+  correctness/noUnusedImports
+  correctness/noUnusedLabels
+  correctness/noUnusedPrivateClassMembers
+  correctness/noUnusedVariables
+  correctness/noVoidElementsWithChildren
+  correctness/noVoidTypeReturn
+  correctness/useExhaustiveDependencies
+  correctness/useHookAtTopLevel
+  correctness/useIsNan
+  correctness/useJsxKeyInIterable
+  correctness/useValidForDirection
+  correctness/useYield
+  nursery/noCssEmptyBlock
+  nursery/noDoneCallback
+  nursery/noDuplicateAtImportRules
+  nursery/noDuplicateElseIf
+  nursery/noDuplicateFontNames
+  nursery/noDuplicateJsonKeys
+  nursery/noDuplicateSelectorsKeyframeBlock
+  nursery/noEvolvingAny
+  nursery/noFlatMapIdentity
+  nursery/noImportantInKeyframe
+  nursery/noInvalidPositionAtImportRule
+  nursery/noUnknownFunction
+  nursery/noUnknownSelectorPseudoElement
+  nursery/noUnknownUnit
+  nursery/noUnmatchableAnbSelector
+  nursery/useFocusableInteractive
+  nursery/useGenericFontNames
+  nursery/useSemanticElements
+  performance/noAccumulatingSpread
+  performance/noDelete
+  security/noDangerouslySetInnerHtml
+  security/noDangerouslySetInnerHtmlWithChildren
+  security/noGlobalEval
+  style/noArguments
+  style/noCommaOperator
+  style/noInferrableTypes
+  style/noParameterAssign
+  style/noUnusedTemplateLiteral
+  style/noUselessElse
+  style/noVar
+  style/useAsConstAssertion
+  style/useConst
+  style/useDefaultParameterLast
+  style/useEnumInitializers
+  style/useExponentiationOperator
+  style/useExportType
+  style/useImportType
+  style/useLiteralEnumMembers
+  style/useNodejsImportProtocol
+  style/useNumberNamespace
+  style/useNumericLiterals
+  style/useSelfClosingElements
+  style/useShorthandFunctionType
+  style/useSingleVarDeclarator
+  style/useTemplate
+  style/useWhile
+  suspicious/noApproximativeNumericConstant
+  suspicious/noArrayIndexKey
+  suspicious/noAssignInExpressions
+  suspicious/noAsyncPromiseExecutor
+  suspicious/noCatchAssign
+  suspicious/noClassAssign
+  suspicious/noCommentText
+  suspicious/noCompareNegZero
+  suspicious/noConfusingLabels
+  suspicious/noConfusingVoidType
+  suspicious/noConstEnum
+  suspicious/noControlCharactersInRegex
+  suspicious/noDebugger
+  suspicious/noDoubleEquals
+  suspicious/noDuplicateCase
+  suspicious/noDuplicateClassMembers
+  suspicious/noDuplicateJsxProps
+  suspicious/noDuplicateObjectKeys
+  suspicious/noDuplicateParameters
+  suspicious/noDuplicateTestHooks
+  suspicious/noEmptyInterface
+  suspicious/noExplicitAny
+  suspicious/noExportsInTest
+  suspicious/noExtraNonNullAssertion
+  suspicious/noFallthroughSwitchClause
+  suspicious/noFocusedTests
+  suspicious/noFunctionAssign
+  suspicious/noGlobalAssign
+  suspicious/noGlobalIsFinite
+  suspicious/noGlobalIsNan
+  suspicious/noImplicitAnyLet
+  suspicious/noImportAssign
+  suspicious/noLabelVar
+  suspicious/noMisleadingCharacterClass
+  suspicious/noMisleadingInstantiator
+  suspicious/noMisrefactoredShorthandAssign
+  suspicious/noPrototypeBuiltins
+  suspicious/noRedeclare
+  suspicious/noRedundantUseStrict
+  suspicious/noSelfCompare
+  suspicious/noShadowRestrictedNames
+  suspicious/noSparseArray
+  suspicious/noSuspiciousSemicolonInJsx
+  suspicious/noThenProperty
+  suspicious/noUnsafeDeclarationMerging
+  suspicious/noUnsafeNegation
+  suspicious/useDefaultSwitchClauseLast
+  suspicious/useGetterReturn
+  suspicious/useIsArray
+  suspicious/useNamespaceKeyword
+  suspicious/useValidTypeof
 
 Server:
   Version:                      0.0.0
@@ -87,5 +264,3 @@ Server:
 Workspace:
   Open Documents:               0
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_configuration.snap
@@ -9,16 +9,13 @@ expression: content
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "recommended": false,
       "a11y": {
         "noAccessKey": "off",
         "noAutofocus": "off"
       },
       "complexity": {
         "recommended": true
-      },
-      "correctness": {
-        "all": true
       },
       "suspicious": {
         "noCommentText": {
@@ -63,197 +60,36 @@ Linter:
   JavaScript enabled:           true
   JSON enabled:                 true
   CSS enabled:                  false
-  Recommended:                  true
+  Recommended:                  false
   All:                          false
   Enabled rules:
-  a11y/noAriaHiddenOnFocusable
-  a11y/noAriaUnsupportedElements
-  a11y/noBlankTarget
-  a11y/noDistractingElements
-  a11y/noHeaderScope
-  a11y/noInteractiveElementToNoninteractiveRole
-  a11y/noNoninteractiveElementToInteractiveRole
-  a11y/noNoninteractiveTabindex
-  a11y/noPositiveTabindex
-  a11y/noRedundantAlt
-  a11y/noRedundantRoles
-  a11y/noSvgWithoutTitle
-  a11y/useAltText
-  a11y/useAnchorContent
-  a11y/useAriaActivedescendantWithTabindex
-  a11y/useAriaPropsForRole
-  a11y/useButtonType
-  a11y/useHeadingContent
-  a11y/useHtmlLang
-  a11y/useIframeTitle
-  a11y/useKeyWithClickEvents
-  a11y/useKeyWithMouseEvents
-  a11y/useMediaCaption
-  a11y/useValidAnchor
-  a11y/useValidAriaProps
-  a11y/useValidAriaRole
-  a11y/useValidAriaValues
-  a11y/useValidLang
   complexity/noBannedTypes
-  complexity/noEmptyTypeParameters
-  complexity/noExcessiveNestedTestSuites
-  complexity/noExtraBooleanCast
-  complexity/noForEach
-  complexity/noMultipleSpacesInRegularExpressionLiterals
-  complexity/noStaticOnlyClass
   complexity/noThisInStatic
-  complexity/noUselessCatch
   complexity/noUselessConstructor
-  complexity/noUselessEmptyExport
-  complexity/noUselessFragments
-  complexity/noUselessLabel
-  complexity/noUselessLoneBlockStatements
-  complexity/noUselessRename
-  complexity/noUselessSwitchCase
-  complexity/noUselessTernary
-  complexity/noUselessThisAlias
-  complexity/noUselessTypeConstraint
-  complexity/noWith
-  complexity/useArrowFunction
-  complexity/useFlatMap
   complexity/useLiteralKeys
   complexity/useOptionalChain
+  complexity/noMultipleSpacesInRegularExpressionLiterals
+  complexity/noUselessLoneBlockStatements
+  complexity/noUselessEmptyExport
+  complexity/noUselessSwitchCase
+  complexity/noStaticOnlyClass
+  complexity/noUselessTypeConstraint
+  complexity/noWith
   complexity/useRegexLiterals
+  complexity/useArrowFunction
+  complexity/noExtraBooleanCast
+  complexity/noEmptyTypeParameters
   complexity/useSimpleNumberKeys
-  correctness/noChildrenProp
-  correctness/noConstAssign
-  correctness/noConstantCondition
-  correctness/noConstructorReturn
-  correctness/noEmptyCharacterClassInRegex
-  correctness/noEmptyPattern
-  correctness/noGlobalObjectCalls
-  correctness/noInnerDeclarations
-  correctness/noInvalidConstructorSuper
-  correctness/noInvalidNewBuiltin
-  correctness/noInvalidUseBeforeDeclaration
-  correctness/noNewSymbol
-  correctness/noNonoctalDecimalEscape
-  correctness/noPrecisionLoss
-  correctness/noRenderReturnValue
-  correctness/noSelfAssign
-  correctness/noSetterReturn
-  correctness/noStringCaseMismatch
-  correctness/noSwitchDeclarations
-  correctness/noUndeclaredVariables
-  correctness/noUnnecessaryContinue
-  correctness/noUnreachable
-  correctness/noUnreachableSuper
-  correctness/noUnsafeFinally
-  correctness/noUnsafeOptionalChaining
-  correctness/noUnusedImports
-  correctness/noUnusedLabels
-  correctness/noUnusedPrivateClassMembers
-  correctness/noUnusedVariables
-  correctness/noVoidElementsWithChildren
-  correctness/noVoidTypeReturn
-  correctness/useExhaustiveDependencies
-  correctness/useHookAtTopLevel
-  correctness/useIsNan
-  correctness/useJsxKeyInIterable
-  correctness/useValidForDirection
-  correctness/useYield
-  nursery/noCssEmptyBlock
-  nursery/noDoneCallback
-  nursery/noDuplicateAtImportRules
-  nursery/noDuplicateElseIf
-  nursery/noDuplicateFontNames
-  nursery/noDuplicateJsonKeys
-  nursery/noDuplicateSelectorsKeyframeBlock
-  nursery/noEvolvingAny
-  nursery/noFlatMapIdentity
-  nursery/noImportantInKeyframe
-  nursery/noInvalidPositionAtImportRule
-  nursery/noUnknownFunction
-  nursery/noUnknownSelectorPseudoElement
-  nursery/noUnknownUnit
-  nursery/noUnmatchableAnbSelector
-  nursery/useFocusableInteractive
-  nursery/useGenericFontNames
-  nursery/useSemanticElements
-  performance/noAccumulatingSpread
-  performance/noDelete
-  security/noDangerouslySetInnerHtml
-  security/noDangerouslySetInnerHtmlWithChildren
-  security/noGlobalEval
-  style/noArguments
-  style/noCommaOperator
-  style/noInferrableTypes
-  style/noParameterAssign
-  style/noUnusedTemplateLiteral
-  style/noUselessElse
-  style/noVar
-  style/useAsConstAssertion
-  style/useConst
-  style/useDefaultParameterLast
-  style/useEnumInitializers
-  style/useExponentiationOperator
-  style/useExportType
-  style/useImportType
-  style/useLiteralEnumMembers
-  style/useNodejsImportProtocol
-  style/useNumberNamespace
-  style/useNumericLiterals
-  style/useSelfClosingElements
-  style/useShorthandFunctionType
-  style/useSingleVarDeclarator
-  style/useTemplate
-  style/useWhile
-  suspicious/noApproximativeNumericConstant
-  suspicious/noArrayIndexKey
-  suspicious/noAssignInExpressions
-  suspicious/noAsyncPromiseExecutor
-  suspicious/noCatchAssign
-  suspicious/noClassAssign
   suspicious/noCommentText
-  suspicious/noCompareNegZero
-  suspicious/noConfusingLabels
-  suspicious/noConfusingVoidType
-  suspicious/noConstEnum
-  suspicious/noControlCharactersInRegex
-  suspicious/noDebugger
-  suspicious/noDoubleEquals
-  suspicious/noDuplicateCase
-  suspicious/noDuplicateClassMembers
-  suspicious/noDuplicateJsxProps
-  suspicious/noDuplicateObjectKeys
-  suspicious/noDuplicateParameters
-  suspicious/noDuplicateTestHooks
-  suspicious/noEmptyInterface
-  suspicious/noExplicitAny
-  suspicious/noExportsInTest
-  suspicious/noExtraNonNullAssertion
-  suspicious/noFallthroughSwitchClause
-  suspicious/noFocusedTests
-  suspicious/noFunctionAssign
-  suspicious/noGlobalAssign
-  suspicious/noGlobalIsFinite
-  suspicious/noGlobalIsNan
-  suspicious/noImplicitAnyLet
-  suspicious/noImportAssign
-  suspicious/noLabelVar
-  suspicious/noMisleadingCharacterClass
-  suspicious/noMisleadingInstantiator
-  suspicious/noMisrefactoredShorthandAssign
-  suspicious/noPrototypeBuiltins
-  suspicious/noRedeclare
-  suspicious/noRedundantUseStrict
-  suspicious/noSelfCompare
-  suspicious/noShadowRestrictedNames
-  suspicious/noSparseArray
-  suspicious/noSuspiciousSemicolonInJsx
-  suspicious/noThenProperty
-  suspicious/noUnsafeDeclarationMerging
-  suspicious/noUnsafeNegation
-  suspicious/useDefaultSwitchClauseLast
-  suspicious/useGetterReturn
-  suspicious/useIsArray
-  suspicious/useNamespaceKeyword
-  suspicious/useValidTypeof
+  complexity/noExcessiveNestedTestSuites
+  complexity/noUselessLabel
+  complexity/noUselessCatch
+  complexity/noUselessFragments
+  complexity/noUselessTernary
+  complexity/noForEach
+  complexity/useFlatMap
+  complexity/noUselessRename
+  complexity/noUselessThisAlias
 
 Server:
   Version:                      0.0.0

--- a/crates/biome_configuration/src/css.rs
+++ b/crates/biome_configuration/src/css.rs
@@ -92,3 +92,11 @@ pub struct CssLinter {
     #[partial(bpaf(long("css-linter-enabled"), argument("true|false"), optional))]
     pub enabled: bool,
 }
+
+impl PartialCssLinter {
+    pub fn get_linter_configuration(&self) -> CssLinter {
+        CssLinter {
+            enabled: self.enabled.unwrap_or_default(),
+        }
+    }
+}

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -146,28 +146,3 @@ impl Default for JavascriptFormatter {
         }
     }
 }
-
-/// Linter options specific to the JavaScript linter
-#[derive(Clone, Debug, Deserialize, Eq, Partial, PartialEq, Serialize)]
-#[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
-#[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
-#[partial(serde(rename_all = "camelCase", default, deny_unknown_fields))]
-pub struct JavascriptLinter {
-    /// Control the linter for JavaScript (and its super languages) files.
-    #[partial(bpaf(long("javascript-linter-enabled"), argument("true|false"), optional))]
-    pub enabled: bool,
-}
-
-impl Default for JavascriptLinter {
-    fn default() -> Self {
-        Self { enabled: true }
-    }
-}
-
-impl PartialJavascriptLinter {
-    pub fn get_formatter_configuration(&self) -> JavascriptLinter {
-        JavascriptLinter {
-            enabled: self.enabled.unwrap_or_default(),
-        }
-    }
-}

--- a/crates/biome_configuration/src/javascript/mod.rs
+++ b/crates/biome_configuration/src/javascript/mod.rs
@@ -2,13 +2,11 @@ mod formatter;
 
 use std::str::FromStr;
 
-use crate::javascript::formatter::JavascriptLinter;
 use biome_deserialize::StringSet;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use bpaf::Bpaf;
 pub use formatter::{
-    partial_javascript_formatter, partial_javascript_linter, JavascriptFormatter,
-    PartialJavascriptFormatter, PartialJavascriptLinter,
+    partial_javascript_formatter, JavascriptFormatter, PartialJavascriptFormatter,
 };
 use serde::{Deserialize, Serialize};
 
@@ -94,6 +92,31 @@ impl FromStr for JsxRuntime {
             "transparent" => Ok(Self::Transparent),
             "react-classic" | "reactClassic" => Ok(Self::ReactClassic),
             _ => Err("Unexpected value".to_string()),
+        }
+    }
+}
+
+/// Linter options specific to the JavaScript linter
+#[derive(Clone, Debug, Deserialize, Eq, Partial, PartialEq, Serialize)]
+#[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
+#[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
+#[partial(serde(rename_all = "camelCase", default, deny_unknown_fields))]
+pub struct JavascriptLinter {
+    /// Control the linter for JavaScript (and its super languages) files.
+    #[partial(bpaf(long("javascript-linter-enabled"), argument("true|false"), optional))]
+    pub enabled: bool,
+}
+
+impl Default for JavascriptLinter {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+impl PartialJavascriptLinter {
+    pub fn get_linter_configuration(&self) -> JavascriptLinter {
+        JavascriptLinter {
+            enabled: self.enabled.unwrap_or_default(),
         }
     }
 }

--- a/crates/biome_configuration/src/json.rs
+++ b/crates/biome_configuration/src/json.rs
@@ -126,3 +126,11 @@ impl Default for JsonLinter {
         Self { enabled: true }
     }
 }
+
+impl PartialJsonLinter {
+    pub fn get_linter_configuration(&self) -> JsonLinter {
+        JsonLinter {
+            enabled: self.enabled.unwrap_or_default(),
+        }
+    }
+}

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -14,9 +14,12 @@ pub mod organize_imports;
 mod overrides;
 pub mod vcs;
 
+use crate::css::CssLinter;
 pub use crate::diagnostics::BiomeDiagnostic;
 pub use crate::diagnostics::CantLoadExtendFile;
 pub use crate::generated::push_to_analyzer_rules;
+use crate::javascript::{JavascriptLinter, PartialJavascriptLinter};
+use crate::json::JsonLinter;
 use crate::organize_imports::{partial_organize_imports, OrganizeImports, PartialOrganizeImports};
 use crate::vcs::{partial_vcs_configuration, PartialVcsConfiguration, VcsConfiguration};
 use biome_deserialize::{Deserialized, StringSet};
@@ -155,6 +158,18 @@ impl PartialConfiguration {
             .unwrap_or_default()
     }
 
+    pub fn get_javascript_linter_configuration(&self) -> JavascriptLinter {
+        self.javascript
+            .as_ref()
+            .map(|f| {
+                f.linter
+                    .as_ref()
+                    .map(|f| f.get_linter_configuration())
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default()
+    }
+
     pub fn get_json_formatter_configuration(&self) -> JsonFormatter {
         self.json
             .as_ref()
@@ -167,6 +182,18 @@ impl PartialConfiguration {
             .unwrap_or_default()
     }
 
+    pub fn get_json_linter_configuration(&self) -> JsonLinter {
+        self.json
+            .as_ref()
+            .map(|f| {
+                f.linter
+                    .as_ref()
+                    .map(|f| f.get_linter_configuration())
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default()
+    }
+
     pub fn get_css_formatter_configuration(&self) -> CssFormatter {
         self.css
             .as_ref()
@@ -174,6 +201,18 @@ impl PartialConfiguration {
                 f.formatter
                     .as_ref()
                     .map(|f| f.get_formatter_configuration())
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn get_css_linter_configuration(&self) -> CssLinter {
+        self.css
+            .as_ref()
+            .map(|f| {
+                f.linter
+                    .as_ref()
+                    .map(|f| f.get_linter_configuration())
                     .unwrap_or_default()
             })
             .unwrap_or_default()

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -18,7 +18,7 @@ use crate::css::CssLinter;
 pub use crate::diagnostics::BiomeDiagnostic;
 pub use crate::diagnostics::CantLoadExtendFile;
 pub use crate::generated::push_to_analyzer_rules;
-use crate::javascript::{JavascriptLinter, PartialJavascriptLinter};
+use crate::javascript::JavascriptLinter;
 use crate::json::JsonLinter;
 use crate::organize_imports::{partial_organize_imports, OrganizeImports, PartialOrganizeImports};
 use crate::vcs::{partial_vcs_configuration, PartialVcsConfiguration, VcsConfiguration};


### PR DESCRIPTION

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR changes the `biome rage` output for the rules:
- it prints if the linter is enabled for the various languages
- it prints the enabled rules. It's a bit long, but at least we don't need to check which rules are recommended on the website.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Updated the snapshot

<!-- What demonstrates that your implementation is correct? -->
