### PR TITLE
ci: fix nightly version and restore update of manifest

### DIFF
--- a/packages/@biomejs/biome/scripts/generate-packages.mjs
+++ b/packages/@biomejs/biome/scripts/generate-packages.mjs
@@ -20,6 +20,35 @@ function copyBinaryToNativePackage(platform, arch) {
 	const os = platform.split("-")[0];
 	const buildName = getName(platform, arch);
 	const packageRoot = resolve(PACKAGES_ROOT, buildName);
+	const packageName = `@biomejs/${buildName}`;
+
+	// Update the package.json manifest
+	const { version, license, repository, engines, homepage } = rootManifest;
+
+	const manifest = JSON.stringify(
+		{
+			name: packageName,
+			version,
+			license,
+			repository,
+			engines,
+			homepage,
+			os: [os],
+			cpu: [arch],
+			libc:
+				os === "linux"
+					? packageName.endsWith("musl")
+						? ["musl"]
+						: ["glibc"]
+					: undefined,
+		},
+		null,
+		2,
+	);
+
+	const manifestPath = resolve(packageRoot, "package.json");
+	console.log(`Update manifest ${manifestPath}`);
+	fs.writeFileSync(manifestPath, manifest);
 
 	// Copy the CLI binary
 	const ext = os === "win32" ? ".exe" : "";

--- a/packages/@biomejs/biome/scripts/update-nightly-version.mjs
+++ b/packages/@biomejs/biome/scripts/update-nightly-version.mjs
@@ -2,8 +2,8 @@ import * as fs from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const ROMECLI_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
-const MANIFEST_PATH = resolve(ROMECLI_ROOT, "package.json");
+const BIOME_CLI_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
+const MANIFEST_PATH = resolve(BIOME_CLI_ROOT, "package.json");
 
 const rootManifest = JSON.parse(
 	fs.readFileSync(MANIFEST_PATH).toString("utf-8"),
@@ -14,7 +14,7 @@ let [major, minor, patch] = rootManifest.version
 	.map((num) => Number.parseInt(num));
 // increment patch version
 patch += 1;
-let version = rootManifest.version;
+let version = `${major}.${minor}.${patch}`;
 
 if (
 	typeof process.env.GITHUB_SHA !== "string" ||


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

I accidentally broke the script that was used to update the `@biomejs/cli-*` manifests. In fact, the latest nightly didn't work.

Also, I fixed a bug where the nightly script didn't correctly bump the patch.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Merge it and trigger another nightly release

<!-- What demonstrates that your implementation is correct? -->
