### PR TITLE
refactor: make suppression action generic via trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,7 @@ dependencies = [
  "biome_deserialize_macros",
  "biome_diagnostics",
  "biome_rowan",
+ "biome_suppression",
  "biome_test_utils",
  "insta",
  "lazy_static",

--- a/crates/biome_analyze/src/registry.rs
+++ b/crates/biome_analyze/src/registry.rs
@@ -439,7 +439,7 @@ impl<L: Language + Default> RegistryRule<L> {
                     query_result.clone(),
                     result,
                     params.services,
-                    params.apply_suppression_comment,
+                    params.suppression_action,
                     params.options,
                 ));
 

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -1,9 +1,7 @@
 use crate::categories::{ActionCategory, RuleCategory};
 use crate::context::RuleContext;
 use crate::registry::{RegistryVisitor, RuleLanguage, RuleSuppressions};
-use crate::{
-    Phase, Phases, Queryable, SuppressionCommentEmitter, SuppressionCommentEmitterPayload,
-};
+use crate::{Phase, Phases, Queryable, SuppressionAction, SuppressionCommentEmitterPayload};
 use biome_console::fmt::Display;
 use biome_console::{markup, MarkupBuf};
 use biome_diagnostics::advice::CodeSuggestionAdvice;
@@ -621,7 +619,7 @@ pub trait Rule: RuleMeta + Sized {
     fn suppress(
         ctx: &RuleContext<Self>,
         text_range: &TextRange,
-        apply_suppression_comment: SuppressionCommentEmitter<RuleLanguage<Self>>,
+        suppression_action: &dyn SuppressionAction<Language = RuleLanguage<Self>>,
     ) -> Option<SuppressAction<RuleLanguage<Self>>>
     where
         Self: 'static,
@@ -637,7 +635,7 @@ pub trait Rule: RuleMeta + Sized {
             let root = ctx.root();
             let token = root.syntax().token_at_offset(text_range.start());
             let mut mutation = root.begin();
-            apply_suppression_comment(SuppressionCommentEmitterPayload {
+            suppression_action.apply_suppression_comment(SuppressionCommentEmitterPayload {
                 suppression_text: suppression_text.as_str(),
                 mutation: &mut mutation,
                 token_offset: token,

--- a/crates/biome_analyze/src/signals.rs
+++ b/crates/biome_analyze/src/signals.rs
@@ -4,8 +4,7 @@ use crate::{
     context::RuleContext,
     registry::{RuleLanguage, RuleRoot},
     rule::Rule,
-    AnalyzerDiagnostic, AnalyzerOptions, Queryable, RuleGroup, ServiceBag,
-    SuppressionCommentEmitter,
+    AnalyzerDiagnostic, AnalyzerOptions, Queryable, RuleGroup, ServiceBag, SuppressionAction,
 };
 use biome_console::MarkupBuf;
 use biome_diagnostics::{advice::CodeSuggestionAdvice, Applicability, CodeSuggestion, Error};
@@ -310,7 +309,7 @@ pub(crate) struct RuleSignal<'phase, R: Rule> {
     state: R::State,
     services: &'phase ServiceBag,
     /// An optional action to suppress the rule.
-    apply_suppression_comment: SuppressionCommentEmitter<RuleLanguage<R>>,
+    suppression_action: &'phase dyn SuppressionAction<Language = RuleLanguage<R>>,
     /// A list of strings that are considered "globals" inside the analyzer
     options: &'phase AnalyzerOptions,
 }
@@ -324,9 +323,10 @@ where
         query_result: <<R as Rule>::Query as Queryable>::Output,
         state: R::State,
         services: &'phase ServiceBag,
-        apply_suppression_comment: SuppressionCommentEmitter<
-            <<R as Rule>::Query as Queryable>::Language,
+        suppression_action: &'phase dyn SuppressionAction<
+            Language = <<R as Rule>::Query as Queryable>::Language,
         >,
+
         options: &'phase AnalyzerOptions,
     ) -> Self {
         Self {
@@ -334,7 +334,7 @@ where
             query_result,
             state,
             services,
-            apply_suppression_comment,
+            suppression_action,
             options,
         }
     }
@@ -404,7 +404,7 @@ where
             };
             if let Some(text_range) = R::text_range(&ctx, &self.state) {
                 if let Some(suppression_action) =
-                    R::suppress(&ctx, &text_range, self.apply_suppression_comment)
+                    R::suppress(&ctx, &text_range, self.suppression_action)
                 {
                     let action = AnalyzerAction {
                         rule_name: Some((<R::Group as RuleGroup>::NAME, R::METADATA.name)),

--- a/crates/biome_analyze/src/suppression_action.rs
+++ b/crates/biome_analyze/src/suppression_action.rs
@@ -1,0 +1,86 @@
+use crate::SuppressionCommentEmitterPayload;
+use biome_rowan::{BatchMutation, Language, SyntaxToken, TextRange, TokenAtOffset};
+
+pub trait SuppressionAction {
+    type Language: Language;
+
+    fn apply_suppression_comment(&self, payload: SuppressionCommentEmitterPayload<Self::Language>) {
+        let SuppressionCommentEmitterPayload {
+            token_offset,
+            mutation,
+            suppression_text,
+            diagnostic_text_range,
+        } = payload;
+
+        // retrieve the most suited, most left token where the diagnostics was emitted
+        let original_token = self.get_token_from_offset(token_offset, diagnostic_text_range);
+
+        // considering that our suppression system works via lines, we need to look for the first newline,
+        // so we can place the comment there
+        let apply_suppression = original_token.as_ref().and_then(|original_token| {
+            self.find_token_to_apply_suppression(original_token.clone())
+        });
+
+        if let Some(apply_suppression) = apply_suppression {
+            self.apply_suppression(mutation, apply_suppression, suppression_text);
+        }
+    }
+
+    /// Finds the first token, starting with the current token and traversing backwards,
+    /// until it find one that has a leading newline trivia.
+    ///
+    /// Sometimes, the offset is between tokens, we need to decide which one to take.
+    ///
+    /// For example:
+    /// ```jsx
+    /// function f() {
+    ///     return <div
+    ///     ><img /> {/* <--- diagnostic emitted in this line */}
+    ///     </div>
+    /// }
+    /// ```
+    ///
+    /// In these case it's best to peek the right token, because it belongs to the node where error actually occurred,
+    /// and becomes easier to add the suppression comment.
+    fn get_token_from_offset(
+        &self,
+        token_at_offset: TokenAtOffset<SyntaxToken<Self::Language>>,
+        diagnostic_text_range: &TextRange,
+    ) -> Option<SyntaxToken<Self::Language>> {
+        match token_at_offset {
+            TokenAtOffset::None => None,
+            TokenAtOffset::Single(token) => Some(token),
+            TokenAtOffset::Between(left_token, right_token) => {
+                let chosen_token =
+                    if right_token.text_range().start() == diagnostic_text_range.start() {
+                        right_token
+                    } else {
+                        left_token
+                    };
+                Some(chosen_token)
+            }
+        }
+    }
+
+    fn find_token_to_apply_suppression(
+        &self,
+        original_token: SyntaxToken<Self::Language>,
+    ) -> Option<ApplySuppression<Self::Language>>;
+
+    fn apply_suppression(
+        &self,
+        mutation: &mut BatchMutation<Self::Language>,
+        apply_suppression: ApplySuppression<Self::Language>,
+        suppression_text: &str,
+    );
+}
+
+/// Convenient type to store useful information
+pub struct ApplySuppression<L: Language> {
+    /// If the token is following by trailing comments
+    pub token_has_trailing_comments: bool,
+    /// The token to attach the suppression
+    pub token_to_apply_suppression: SyntaxToken<L>,
+    /// If the suppression should have a leading newline
+    pub should_insert_leading_newline: bool,
+}

--- a/crates/biome_analyze/src/visitor.rs
+++ b/crates/biome_analyze/src/visitor.rs
@@ -2,7 +2,7 @@ use crate::{
     matcher::{MatchQueryParams, Query},
     registry::{NodeLanguage, Phases},
     AnalyzerOptions, LanguageRoot, QueryMatch, QueryMatcher, ServiceBag, SignalEntry,
-    SuppressionCommentEmitter,
+    SuppressionAction,
 };
 use biome_rowan::{AstNode, Language, SyntaxNode, TextRange, WalkEvent};
 use std::collections::BinaryHeap;
@@ -12,10 +12,10 @@ pub struct VisitorContext<'phase, 'query, L: Language> {
     pub phase: Phases,
     pub root: &'phase LanguageRoot<L>,
     pub services: &'phase ServiceBag,
+    pub suppression_action: &'phase dyn SuppressionAction<Language = L>,
     pub range: Option<TextRange>,
     pub(crate) query_matcher: &'query mut dyn QueryMatcher<L>,
     pub(crate) signal_queue: &'query mut BinaryHeap<SignalEntry<'phase, L>>,
-    pub apply_suppression_comment: SuppressionCommentEmitter<L>,
     pub options: &'phase AnalyzerOptions,
 }
 
@@ -27,7 +27,7 @@ impl<'phase, 'query, L: Language> VisitorContext<'phase, 'query, L> {
             query: Query::new(query),
             services: self.services,
             signal_queue: self.signal_queue,
-            apply_suppression_comment: self.apply_suppression_comment,
+            suppression_action: self.suppression_action,
             options: self.options,
         })
     }

--- a/crates/biome_css_analyze/Cargo.toml
+++ b/crates/biome_css_analyze/Cargo.toml
@@ -20,6 +20,7 @@ biome_deserialize        = { workspace = true }
 biome_deserialize_macros = { workspace = true }
 biome_diagnostics        = { workspace = true }
 biome_rowan              = { workspace = true }
+biome_suppression        = { workspace = true }
 lazy_static              = { workspace = true }
 schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true, features = ["derive"] }

--- a/crates/biome_css_analyze/src/suppression_action.rs
+++ b/crates/biome_css_analyze/src/suppression_action.rs
@@ -1,0 +1,26 @@
+use biome_analyze::{ApplySuppression, SuppressionAction};
+use biome_css_syntax::CssLanguage;
+use biome_rowan::{BatchMutation, SyntaxToken};
+
+pub(crate) struct CssSuppressionAction;
+
+impl SuppressionAction for CssSuppressionAction {
+    type Language = CssLanguage;
+
+    fn find_token_to_apply_suppression(
+        &self,
+        _original_token: SyntaxToken<Self::Language>,
+    ) -> Option<ApplySuppression<Self::Language>> {
+        // TODO: property implement. Look for the JsSuppressionAction for an example
+        None
+    }
+
+    fn apply_suppression(
+        &self,
+        _mutation: &mut BatchMutation<Self::Language>,
+        _apply_suppression: ApplySuppression<Self::Language>,
+        _suppression_text: &str,
+    ) {
+        unreachable!("find_token_to_apply_suppression return None")
+    }
+}

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::needless_pass_by_value)]
 
-use crate::suppression_action::apply_suppression_comment;
+use crate::suppression_action::JsSuppressionAction;
 use biome_analyze::{
     AnalysisFilter, Analyzer, AnalyzerContext, AnalyzerOptions, AnalyzerSignal, ControlFlow,
     InspectMatcher, LanguageRoot, MatchQueryParams, MetadataRegistry, RuleAction, RuleRegistry,
@@ -117,7 +117,7 @@ where
         metadata(),
         InspectMatcher::new(registry, inspect_matcher),
         parse_linter_suppression_comment,
-        apply_suppression_comment,
+        Box::new(JsSuppressionAction),
         &mut emit_signal,
     );
 

--- a/crates/biome_js_analyze/src/suppression_action.rs
+++ b/crates/biome_js_analyze/src/suppression_action.rs
@@ -1,39 +1,138 @@
 use crate::utils::batch::JsBatchMutation;
-use biome_analyze::SuppressionCommentEmitterPayload;
+use biome_analyze::{ApplySuppression, SuppressionAction};
 use biome_js_factory::make::{jsx_expression_child, jsx_ident, jsx_text, token};
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::{
     AnyJsxChild, JsLanguage, JsSyntaxKind, JsSyntaxToken, JsxChildList, JsxElement,
-    JsxOpeningElement, JsxSelfClosingElement, JsxText, TextRange, T,
+    JsxOpeningElement, JsxSelfClosingElement, JsxText, T,
 };
-use biome_rowan::{AstNode, TokenAtOffset, TriviaPieceKind};
+use biome_rowan::{AstNode, BatchMutation, TriviaPieceKind};
 
-/// Considering that the detection of suppression comments in the linter is "line based", the function starts
-/// querying the node covered by the text range of the diagnostic, until it finds the first token that has a newline
-/// among its leading trivia.
+/// Creates a new [JsxText], where its content are the computed spaces from `current_element`.
 ///
-/// There are some edge cases:
-/// - JSX elements might have newlines in their content;
-/// - JS templates are an exception to the rule. JS templates might contain expressions inside their
-/// content, and those expressions can contain diagnostics. The function uses the token `${` as boundary
-/// and tries to place the suppression comment after it;
-pub(crate) fn apply_suppression_comment(payload: SuppressionCommentEmitterPayload<JsLanguage>) {
-    let SuppressionCommentEmitterPayload {
-        token_offset,
-        mutation,
-        suppression_text,
-        diagnostic_text_range,
-    } = payload;
-    // retrieve the most suited, most left token where the diagnostics was emitted
-    let original_token = get_token_from_offset(token_offset, diagnostic_text_range);
+/// This new element will serve as trailing "newline" for the suppression comment.
+fn make_indentation_from_jsx_element(current_element: &JsxText) -> JsxText {
+    if let Ok(text) = current_element.value_token() {
+        let chars = text.text().chars();
+        let mut newlines = 0;
+        let mut spaces = 0;
+        let mut string_found = false;
+        for char in chars {
+            if char == '\"' {
+                if string_found {
+                    string_found = false;
+                } else {
+                    string_found = true;
+                    continue;
+                }
+            }
+            if string_found {
+                continue;
+            }
 
-    // considering that our suppression system works via lines, we need to look for the first newline,
-    // so we can place the comment there
-    let apply_suppression = original_token
-        .as_ref()
-        .map(|original_token| find_token_to_apply_suppression(original_token.clone()));
+            if matches!(char, '\r' | '\n') {
+                newlines += 1;
+            }
+            if matches!(char, ' ') && newlines == 1 && !string_found {
+                spaces += 1;
+            }
+        }
 
-    if let Some(apply_suppression) = apply_suppression {
+        let content = format!("\n{}", " ".repeat(spaces));
+        jsx_text(jsx_ident(content.as_str()))
+    } else {
+        jsx_text(jsx_ident("\n"))
+    }
+}
+
+pub struct JsSuppressionAction;
+
+impl SuppressionAction for JsSuppressionAction {
+    type Language = JsLanguage;
+
+    fn find_token_to_apply_suppression(
+        &self,
+        token: JsSyntaxToken,
+    ) -> Option<ApplySuppression<Self::Language>> {
+        let mut apply_suppression = ApplySuppression {
+            token_has_trailing_comments: false,
+            token_to_apply_suppression: token.clone(),
+            should_insert_leading_newline: false,
+        };
+        let mut current_token = token;
+        let mut should_insert_leading_newline = loop {
+            let trivia = current_token.leading_trivia();
+            // There are some tokens that might contains newlines in their tokens, only
+            // few nodes matches this criteria. If the token is inside one of those nodes,
+            // then we check its content.
+            let nodes_that_might_contain_newlines = current_token
+                .parent()
+                .map(|node| {
+                    matches!(
+                        node.kind(),
+                        JsSyntaxKind::JSX_TEXT
+                            | JsSyntaxKind::JS_STRING_LITERAL
+                            | JsSyntaxKind::TEMPLATE_CHUNK
+                    )
+                })
+                .unwrap_or_default();
+            if current_token
+                .trailing_trivia()
+                .pieces()
+                .any(|trivia| trivia.kind().is_multiline_comment())
+            {
+                break true;
+            } else if trivia.pieces().any(|trivia| trivia.is_newline())
+                || (nodes_that_might_contain_newlines
+                    && current_token.text_trimmed().contains(['\n', '\r']))
+            {
+                break false;
+            } else if matches!(current_token.kind(), JsSyntaxKind::DOLLAR_CURLY) {
+                if let Some(next_token) = current_token.next_token() {
+                    current_token = next_token;
+                    break false;
+                }
+            } else if let Some(token) = current_token.prev_token() {
+                current_token = token;
+            } else {
+                break true;
+            }
+        };
+        // If the flag has been set to `true`, it means we are at the beginning of the file.
+        if !should_insert_leading_newline {
+            // Still, if there's a a multiline comment, we want to try to attach the suppression comment
+            // to the existing multiline comment without newlines.
+            should_insert_leading_newline = current_token
+                .leading_trivia()
+                .pieces()
+                .all(|piece| !piece.kind().is_multiline_comment());
+        }
+
+        apply_suppression.should_insert_leading_newline = should_insert_leading_newline;
+        apply_suppression.token_has_trailing_comments = current_token
+            .trailing_trivia()
+            .pieces()
+            .any(|trivia| trivia.kind().is_multiline_comment());
+        apply_suppression.token_to_apply_suppression = current_token;
+
+        Some(apply_suppression)
+    }
+
+    /// Considering that the detection of suppression comments in the linter is "line based", the function starts
+    /// querying the node covered by the text range of the diagnostic, until it finds the first token that has a newline
+    /// among its leading trivia.
+    ///
+    /// There are some edge cases:
+    /// - JSX elements might have newlines in their content;
+    /// - JS templates are an exception to the rule. JS templates might contain expressions inside their
+    /// content, and those expressions can contain diagnostics. The function uses the token `${` as boundary
+    /// and tries to place the suppression comment after it;
+    fn apply_suppression(
+        &self,
+        mutation: &mut BatchMutation<Self::Language>,
+        apply_suppression: ApplySuppression<Self::Language>,
+        suppression_text: &str,
+    ) {
         let ApplySuppression {
             token_to_apply_suppression,
             token_has_trailing_comments,
@@ -163,160 +262,5 @@ pub(crate) fn apply_suppression_comment(payload: SuppressionCommentEmitterPayloa
             };
             mutation.replace_token_transfer_trivia(token_to_apply_suppression, new_token);
         }
-    }
-}
-
-/// Convenient type to store useful information
-struct ApplySuppression {
-    /// If the token is following by trailing comments
-    token_has_trailing_comments: bool,
-    /// The token to apply attach the suppression
-    token_to_apply_suppression: JsSyntaxToken,
-    /// If the suppression should have a leading newline
-    should_insert_leading_newline: bool,
-}
-
-/// It checks if the current token has leading trivia newline. If not, it
-/// it peeks the previous token and recursively call itself.
-///
-/// Due to the nature of JSX, sometimes the current token might contain text that contains
-/// some newline. In case that happens, we choose that token.
-///
-/// Due to the nature of JavaScript templates, we also check if the tokens we browse are
-/// `${` and if so, we stop there.
-fn find_token_to_apply_suppression(token: JsSyntaxToken) -> ApplySuppression {
-    let mut apply_suppression = ApplySuppression {
-        token_has_trailing_comments: false,
-        token_to_apply_suppression: token.clone(),
-        should_insert_leading_newline: false,
-    };
-    let mut current_token = token;
-    let mut should_insert_leading_newline = loop {
-        let trivia = current_token.leading_trivia();
-        // There are some tokens that might contains newlines in their tokens, only
-        // few nodes matches this criteria. If the token is inside one of those nodes,
-        // then we check its content.
-        let nodes_that_might_contain_newlines = current_token
-            .parent()
-            .map(|node| {
-                matches!(
-                    node.kind(),
-                    JsSyntaxKind::JSX_TEXT
-                        | JsSyntaxKind::JS_STRING_LITERAL
-                        | JsSyntaxKind::TEMPLATE_CHUNK
-                )
-            })
-            .unwrap_or_default();
-        if current_token
-            .trailing_trivia()
-            .pieces()
-            .any(|trivia| trivia.kind().is_multiline_comment())
-        {
-            break true;
-        } else if trivia.pieces().any(|trivia| trivia.is_newline())
-            || (nodes_that_might_contain_newlines
-                && current_token.text_trimmed().contains(['\n', '\r']))
-        {
-            break false;
-        } else if matches!(current_token.kind(), JsSyntaxKind::DOLLAR_CURLY) {
-            if let Some(next_token) = current_token.next_token() {
-                current_token = next_token;
-                break false;
-            }
-        } else if let Some(token) = current_token.prev_token() {
-            current_token = token;
-        } else {
-            break true;
-        }
-    };
-    // If the flag has been set to `true`, it means we are at the beginning of the file.
-    if !should_insert_leading_newline {
-        // Still, if there's a a multiline comment, we want to try to attach the suppression comment
-        // to the existing multiline comment without newlines.
-        should_insert_leading_newline = current_token
-            .leading_trivia()
-            .pieces()
-            .all(|piece| !piece.kind().is_multiline_comment());
-    }
-
-    apply_suppression.should_insert_leading_newline = should_insert_leading_newline;
-    apply_suppression.token_has_trailing_comments = current_token
-        .trailing_trivia()
-        .pieces()
-        .any(|trivia| trivia.kind().is_multiline_comment());
-    apply_suppression.token_to_apply_suppression = current_token;
-
-    apply_suppression
-}
-
-/// Finds the first token, starting with the current token and traversing backwards,
-/// until if find one that has has a leading newline trivia.
-///
-/// Sometimes, the offset is between tokens, we need to decide which one to take.
-///
-/// For example:
-/// ```jsx
-/// function f() {
-///     return <div
-///     ><img /> {/* <--- diagnostic emitted in this line */}
-///     </div>
-/// }
-/// ```
-///
-/// In these case it's best to peek the right token, because it belongs to the node where error actually occurred,
-/// and becomes easier to add the suppression comment.
-fn get_token_from_offset(
-    token_offset: TokenAtOffset<JsSyntaxToken>,
-    diagnostic_text_range: &TextRange,
-) -> Option<JsSyntaxToken> {
-    match token_offset {
-        TokenAtOffset::None => None,
-        TokenAtOffset::Single(token) => Some(token),
-        TokenAtOffset::Between(left_token, right_token) => {
-            let chosen_token = if right_token.text_range().start() == diagnostic_text_range.start()
-            {
-                right_token
-            } else {
-                left_token
-            };
-            Some(chosen_token)
-        }
-    }
-}
-
-/// Creates a new [JsxText], where its content are the computed spaces from `current_element`.
-///
-/// This new element will serve as trailing "newline" for the suppression comment.
-fn make_indentation_from_jsx_element(current_element: &JsxText) -> JsxText {
-    if let Ok(text) = current_element.value_token() {
-        let chars = text.text().chars();
-        let mut newlines = 0;
-        let mut spaces = 0;
-        let mut string_found = false;
-        for char in chars {
-            if char == '\"' {
-                if string_found {
-                    string_found = false;
-                } else {
-                    string_found = true;
-                    continue;
-                }
-            }
-            if string_found {
-                continue;
-            }
-
-            if matches!(char, '\r' | '\n') {
-                newlines += 1;
-            }
-            if matches!(char, ' ') && newlines == 1 && !string_found {
-                spaces += 1;
-            }
-        }
-
-        let content = format!("\n{}", " ".repeat(spaces));
-        jsx_text(jsx_ident(content.as_str()))
-    } else {
-        jsx_text(jsx_ident("\n"))
     }
 }

--- a/crates/biome_json_analyze/src/lib.rs
+++ b/crates/biome_json_analyze/src/lib.rs
@@ -1,9 +1,11 @@
 mod lint;
 pub mod options;
 mod registry;
+mod suppression_action;
 pub mod utils;
 
 pub use crate::registry::visit_registry;
+use crate::suppression_action::JsonSuppressionAction;
 use biome_analyze::{
     AnalysisFilter, AnalyzerOptions, AnalyzerSignal, ControlFlow, LanguageRoot, MatchQueryParams,
     MetadataRegistry, RuleRegistry, SuppressionDiagnostic, SuppressionKind,
@@ -77,7 +79,7 @@ where
         metadata(),
         biome_analyze::InspectMatcher::new(registry, inspect_matcher),
         parse_linter_suppression_comment,
-        |_| {},
+        Box::new(JsonSuppressionAction),
         &mut emit_signal,
     );
 

--- a/crates/biome_json_analyze/src/suppression_action.rs
+++ b/crates/biome_json_analyze/src/suppression_action.rs
@@ -1,0 +1,26 @@
+use biome_analyze::{ApplySuppression, SuppressionAction};
+use biome_json_syntax::JsonLanguage;
+use biome_rowan::{BatchMutation, SyntaxToken};
+
+pub(crate) struct JsonSuppressionAction;
+
+impl SuppressionAction for JsonSuppressionAction {
+    type Language = JsonLanguage;
+
+    fn find_token_to_apply_suppression(
+        &self,
+        _original_token: SyntaxToken<Self::Language>,
+    ) -> Option<ApplySuppression<Self::Language>> {
+        // TODO: property implement. Look for the JsSuppressionAction for an example
+        None
+    }
+
+    fn apply_suppression(
+        &self,
+        _mutation: &mut BatchMutation<Self::Language>,
+        _apply_suppression: ApplySuppression<Self::Language>,
+        _suppression_text: &str,
+    ) {
+        unreachable!("find_token_to_apply_suppression return None")
+    }
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

The suppression action system was tied to the JS language.

This refactors the system by making it generic using a trait called `SuppressionAction` inside `biome_analyze`.

Users will need to implement two functions:
- the function that returns `ApplySuppression`, which contains info on where and how to apply the mutation
- the function that actually adds the suppression comment in the right place


The CSS and JSON languages don't have suppression actions at this time.

The idea is to land a PR that applies suppression to CSS lint rules. @togami2864 I think we need to land at least a basic heuristic to apply suppression comments; otherwise, people won't see the "Quick fix" tooltip in the IDEs/editors.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

The current CI should work.

<!-- What demonstrates that your implementation is correct? -->
