### PR TITLE
fix(formatter): don't let overrides erroneously enable formatter if unspecified

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/complex_enable_disable_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/complex_enable_disable_overrides.snap
@@ -1,0 +1,53 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "lineWidth": 20
+  },
+  "javascript": {
+    "formatter": {
+      "enabled": false
+    }
+  },
+  "overrides": [
+    { "include": ["formatted.js"], "formatter": { "enabled": true } },
+    {
+      "include": ["dirty.js"],
+      "linter": {
+        "rules": {
+          "performance": {
+            "noBarrelFile": "off"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+## `dirty.js`
+
+```js
+const a = ["loreum", "ipsum"]
+```
+
+## `formatted.js`
+
+```js
+const a = [
+	"loreum",
+	"ipsum",
+];
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1307,7 +1307,13 @@ pub(crate) fn to_override_format_settings(
         .unwrap_or(format_settings.format_with_errors);
 
     OverrideFormatSettings {
-        enabled: conf.enabled.or(Some(format_settings.enabled)),
+        enabled: conf.enabled.or(
+            if format_settings.enabled != FormatSettings::default().enabled {
+                Some(format_settings.enabled)
+            } else {
+                None
+            },
+        ),
         indent_style,
         indent_width,
         line_ending,


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Previously, overrides could erroneously enable the formatter if it was supposed to be disabled, specifically in configurations like this:

```jsonc
{
  "formatter": {
    "enabled": true,
    "lineWidth": 20
  },
  "javascript": {
    "formatter": {
      "enabled": false
    }
  },
  "overrides": [
    { "include": ["formatted.js"], "formatter": { "enabled": true } },
    {
      // this override doesn't have a formatter section, so it would assume the global value, ignoring the language config
      "include": ["dirty.js"],
      "linter": {
        "rules": {
          "performance": {
            "noBarrelFile": "off"
          }
        }
      }
    }
  ]
}
```

This PR fixes that behavior by not forcing the override settings to have a `Some` value no matter what. I briefly looked into whether or not this affects the linter too, and I _think_ it does, but I think that fix is outside the scope of this PR. This area of the code is likely going to be significantly changed by work on #2228. It's somewhat unclear what the semantics of overrides should be (if 2 overrides match the same file, do they get merged? do we take the first matching override and ignore the rest? the last one? etc etc)

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
Fixes #2924

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added a test with snapshots
