### PR TITLE
docs(noEvolvingAny): improve docs

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_evolving_any.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_evolving_any.rs
@@ -6,9 +6,14 @@ declare_rule! {
     /// Disallow variables from evolving into `any` type through reassignments.
     ///
     /// In TypeScript, variables without explicit type annotations can evolve their types based on subsequent assignments.
-    /// This behaviour can accidentally lead to variables with an `any` type, weakening type safety.
+    ///
+    /// When  TypeScript's [noImplicitAny](https://www.typescriptlang.org/tsconfig/#noImplicitAny) is disabled,
+    /// variables without explicit type annotations have implicitly the type `any`.
     /// Just like the `any` type, evolved `any` types disable many type-checking rules and should be avoided to maintain strong type safety.
     /// This rule prevents such cases by ensuring variables do not evolve into `any` type, encouraging explicit type annotations and controlled type evolutions.
+    ///
+    /// If you enabled TypeScript's [noImplicitAny](https://www.typescriptlang.org/tsconfig/#noImplicitAny) and want to benefit of evolving types,
+    /// then we recommend to disable this rule.
     ///
     /// ## Examples
     ///
@@ -113,11 +118,11 @@ impl Rule for NoEvolvingAny {
                 rule_category!(),
                 variable.text_trimmed_range(),
                 markup! {
-                    "This variable's type is not allowed to evolve implicitly, leading to potential "<Emphasis>"any"</Emphasis>" types."
+                    "The type of this variable may evolve implicitly to any type, including the "<Emphasis>"any"</Emphasis>" type."
                 },
             )
             .note(markup! {
-                "The variable's type may evolve, leading to "<Emphasis>"any"</Emphasis>". Use explicit type or initialization. Specifying an explicit type or initial value to avoid implicit type evolution."
+                "Add an explicit type or initialization to avoid implicit type evolution."
             }),
         )
     }

--- a/crates/biome_js_analyze/tests/specs/nursery/noEvolvingAny/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noEvolvingAny/invalid.ts.snap
@@ -30,14 +30,14 @@ function ex() {
 ```
 invalid.ts:1:5 lint/nursery/noEvolvingAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This variable's type is not allowed to evolve implicitly, leading to potential any types.
+  ! The type of this variable may evolve implicitly to any type, including the any type.
   
   > 1 │ let a;
       │     ^
     2 │ const b = [];
     3 │ let c = null;
   
-  i The variable's type may evolve, leading to any. Use explicit type or initialization. Specifying an explicit type or initial value to avoid implicit type evolution.
+  i Add an explicit type or initialization to avoid implicit type evolution.
   
 
 ```
@@ -45,7 +45,7 @@ invalid.ts:1:5 lint/nursery/noEvolvingAny ━━━━━━━━━━━━�
 ```
 invalid.ts:2:7 lint/nursery/noEvolvingAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This variable's type is not allowed to evolve implicitly, leading to potential any types.
+  ! The type of this variable may evolve implicitly to any type, including the any type.
   
     1 │ let a;
   > 2 │ const b = [];
@@ -53,7 +53,7 @@ invalid.ts:2:7 lint/nursery/noEvolvingAny ━━━━━━━━━━━━�
     3 │ let c = null;
     4 │ 
   
-  i The variable's type may evolve, leading to any. Use explicit type or initialization. Specifying an explicit type or initial value to avoid implicit type evolution.
+  i Add an explicit type or initialization to avoid implicit type evolution.
   
 
 ```
@@ -61,7 +61,7 @@ invalid.ts:2:7 lint/nursery/noEvolvingAny ━━━━━━━━━━━━�
 ```
 invalid.ts:3:5 lint/nursery/noEvolvingAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This variable's type is not allowed to evolve implicitly, leading to potential any types.
+  ! The type of this variable may evolve implicitly to any type, including the any type.
   
     1 │ let a;
     2 │ const b = [];
@@ -70,7 +70,7 @@ invalid.ts:3:5 lint/nursery/noEvolvingAny ━━━━━━━━━━━━�
     4 │ 
     5 │ let someVar1;
   
-  i The variable's type may evolve, leading to any. Use explicit type or initialization. Specifying an explicit type or initial value to avoid implicit type evolution.
+  i Add an explicit type or initialization to avoid implicit type evolution.
   
 
 ```
@@ -78,7 +78,7 @@ invalid.ts:3:5 lint/nursery/noEvolvingAny ━━━━━━━━━━━━�
 ```
 invalid.ts:5:5 lint/nursery/noEvolvingAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This variable's type is not allowed to evolve implicitly, leading to potential any types.
+  ! The type of this variable may evolve implicitly to any type, including the any type.
   
     3 │ let c = null;
     4 │ 
@@ -87,7 +87,7 @@ invalid.ts:5:5 lint/nursery/noEvolvingAny ━━━━━━━━━━━━�
     6 │ someVar1 = '123';
     7 │ someVar1 = 123;
   
-  i The variable's type may evolve, leading to any. Use explicit type or initialization. Specifying an explicit type or initial value to avoid implicit type evolution.
+  i Add an explicit type or initialization to avoid implicit type evolution.
   
 
 ```
@@ -95,7 +95,7 @@ invalid.ts:5:5 lint/nursery/noEvolvingAny ━━━━━━━━━━━━�
 ```
 invalid.ts:9:5 lint/nursery/noEvolvingAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This variable's type is not allowed to evolve implicitly, leading to potential any types.
+  ! The type of this variable may evolve implicitly to any type, including the any type.
   
      7 │ someVar1 = 123;
      8 │ 
@@ -104,7 +104,7 @@ invalid.ts:9:5 lint/nursery/noEvolvingAny ━━━━━━━━━━━━�
     10 │ someVar1 = '123';
     11 │ someVar1 = 123;
   
-  i The variable's type may evolve, leading to any. Use explicit type or initialization. Specifying an explicit type or initial value to avoid implicit type evolution.
+  i Add an explicit type or initialization to avoid implicit type evolution.
   
 
 ```
@@ -112,7 +112,7 @@ invalid.ts:9:5 lint/nursery/noEvolvingAny ━━━━━━━━━━━━�
 ```
 invalid.ts:13:12 lint/nursery/noEvolvingAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This variable's type is not allowed to evolve implicitly, leading to potential any types.
+  ! The type of this variable may evolve implicitly to any type, including the any type.
   
     11 │ someVar1 = 123;
     12 │ 
@@ -121,7 +121,7 @@ invalid.ts:13:12 lint/nursery/noEvolvingAny ━━━━━━━━━━━━
     14 │ var x = 0, y, z = 0;
     15 │ for(let a = 0, b; a < 5; a++) {}
   
-  i The variable's type may evolve, leading to any. Use explicit type or initialization. Specifying an explicit type or initial value to avoid implicit type evolution.
+  i Add an explicit type or initialization to avoid implicit type evolution.
   
 
 ```
@@ -129,7 +129,7 @@ invalid.ts:13:12 lint/nursery/noEvolvingAny ━━━━━━━━━━━━
 ```
 invalid.ts:14:12 lint/nursery/noEvolvingAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This variable's type is not allowed to evolve implicitly, leading to potential any types.
+  ! The type of this variable may evolve implicitly to any type, including the any type.
   
     13 │ let x = 0, y, z = 0;
   > 14 │ var x = 0, y, z = 0;
@@ -137,7 +137,7 @@ invalid.ts:14:12 lint/nursery/noEvolvingAny ━━━━━━━━━━━━
     15 │ for(let a = 0, b; a < 5; a++) {}
     16 │ 
   
-  i The variable's type may evolve, leading to any. Use explicit type or initialization. Specifying an explicit type or initial value to avoid implicit type evolution.
+  i Add an explicit type or initialization to avoid implicit type evolution.
   
 
 ```
@@ -145,7 +145,7 @@ invalid.ts:14:12 lint/nursery/noEvolvingAny ━━━━━━━━━━━━
 ```
 invalid.ts:15:16 lint/nursery/noEvolvingAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This variable's type is not allowed to evolve implicitly, leading to potential any types.
+  ! The type of this variable may evolve implicitly to any type, including the any type.
   
     13 │ let x = 0, y, z = 0;
     14 │ var x = 0, y, z = 0;
@@ -154,7 +154,7 @@ invalid.ts:15:16 lint/nursery/noEvolvingAny ━━━━━━━━━━━━
     16 │ 
     17 │ function ex() {
   
-  i The variable's type may evolve, leading to any. Use explicit type or initialization. Specifying an explicit type or initial value to avoid implicit type evolution.
+  i Add an explicit type or initialization to avoid implicit type evolution.
   
 
 ```
@@ -162,7 +162,7 @@ invalid.ts:15:16 lint/nursery/noEvolvingAny ━━━━━━━━━━━━
 ```
 invalid.ts:18:9 lint/nursery/noEvolvingAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This variable's type is not allowed to evolve implicitly, leading to potential any types.
+  ! The type of this variable may evolve implicitly to any type, including the any type.
   
     17 │ function ex() {
   > 18 │     let b;
@@ -170,7 +170,7 @@ invalid.ts:18:9 lint/nursery/noEvolvingAny ━━━━━━━━━━━━�
     19 │ }
     20 │ 
   
-  i The variable's type may evolve, leading to any. Use explicit type or initialization. Specifying an explicit type or initial value to avoid implicit type evolution.
+  i Add an explicit type or initialization to avoid implicit type evolution.
   
 
 ```


### PR DESCRIPTION
## Summary

This PR applies only the change to the docs and diagnostics of #2959
I think the undesired side effect of #2959 is caused by the renaming of the rule. 

## Test Plan

Tests updated.