### PR TITLE
feat(lint/noStaticElementInteractions): add rule

### DIFF
--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -605,6 +605,16 @@ pub(crate) fn migrate_eslint_any_rule(
             let rule = group.no_redundant_roles.get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
+        "jsx-a11y/no-static-element-interactions" => {
+            if !options.include_nursery {
+                return false;
+            }
+            let group = rules.nursery.get_or_insert_with(Default::default);
+            let rule = group
+                .no_static_element_interactions
+                .get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
         "jsx-a11y/role-has-required-aria-props" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group

--- a/crates/biome_configuration/src/linter/rules.rs
+++ b/crates/biome_configuration/src/linter/rules.rs
@@ -3358,6 +3358,9 @@ pub struct Nursery {
     #[doc = "Disallow specified modules when loaded by import or require."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_restricted_imports: Option<RuleConfiguration<NoRestrictedImports>>,
+    #[doc = "Enforce that non-interactive, visible elements (such as \\<div>) that have click handlers use the role attribute."]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_static_element_interactions: Option<RuleConfiguration<NoStaticElementInteractions>>,
     #[doc = "Disallow the use of dependencies that aren't specified in the package.json."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_undeclared_dependencies: Option<RuleConfiguration<NoUndeclaredDependencies>>,
@@ -3454,6 +3457,7 @@ impl Nursery {
         "noNodejsModules",
         "noReactSpecificProps",
         "noRestrictedImports",
+        "noStaticElementInteractions",
         "noUndeclaredDependencies",
         "noUnknownFunction",
         "noUnknownMediaFeatureName",
@@ -3505,12 +3509,12 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
     ];
     const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
@@ -3550,6 +3554,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended_true(&self) -> bool {
@@ -3656,99 +3661,104 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_undeclared_dependencies.as_ref() {
+        if let Some(rule) = self.no_static_element_interactions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.no_unknown_function.as_ref() {
+        if let Some(rule) = self.no_undeclared_dependencies.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.no_unknown_media_feature_name.as_ref() {
+        if let Some(rule) = self.no_unknown_function.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.no_unknown_property.as_ref() {
+        if let Some(rule) = self.no_unknown_media_feature_name.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.no_unknown_selector_pseudo_element.as_ref() {
+        if let Some(rule) = self.no_unknown_property.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.no_unknown_unit.as_ref() {
+        if let Some(rule) = self.no_unknown_selector_pseudo_element.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.no_unmatchable_anb_selector.as_ref() {
+        if let Some(rule) = self.no_unknown_unit.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-        if let Some(rule) = self.no_useless_string_concat.as_ref() {
+        if let Some(rule) = self.no_unmatchable_anb_selector.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.no_useless_undefined_initialization.as_ref() {
+        if let Some(rule) = self.no_useless_string_concat.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.use_array_literals.as_ref() {
+        if let Some(rule) = self.no_useless_undefined_initialization.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.use_consistent_builtin_instantiation.as_ref() {
+        if let Some(rule) = self.use_array_literals.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.use_default_switch_clause.as_ref() {
+        if let Some(rule) = self.use_consistent_builtin_instantiation.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.use_explicit_length_check.as_ref() {
+        if let Some(rule) = self.use_default_switch_clause.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-        if let Some(rule) = self.use_focusable_interactive.as_ref() {
+        if let Some(rule) = self.use_explicit_length_check.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-        if let Some(rule) = self.use_generic_font_names.as_ref() {
+        if let Some(rule) = self.use_focusable_interactive.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_generic_font_names.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-        if let Some(rule) = self.use_throw_new_error.as_ref() {
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
-        if let Some(rule) = self.use_top_level_regex.as_ref() {
+        if let Some(rule) = self.use_throw_new_error.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
+            }
+        }
+        if let Some(rule) = self.use_top_level_regex.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
         index_set
@@ -3845,99 +3855,104 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_undeclared_dependencies.as_ref() {
+        if let Some(rule) = self.no_static_element_interactions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.no_unknown_function.as_ref() {
+        if let Some(rule) = self.no_undeclared_dependencies.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.no_unknown_media_feature_name.as_ref() {
+        if let Some(rule) = self.no_unknown_function.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.no_unknown_property.as_ref() {
+        if let Some(rule) = self.no_unknown_media_feature_name.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.no_unknown_selector_pseudo_element.as_ref() {
+        if let Some(rule) = self.no_unknown_property.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.no_unknown_unit.as_ref() {
+        if let Some(rule) = self.no_unknown_selector_pseudo_element.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.no_unmatchable_anb_selector.as_ref() {
+        if let Some(rule) = self.no_unknown_unit.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-        if let Some(rule) = self.no_useless_string_concat.as_ref() {
+        if let Some(rule) = self.no_unmatchable_anb_selector.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.no_useless_undefined_initialization.as_ref() {
+        if let Some(rule) = self.no_useless_string_concat.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.use_array_literals.as_ref() {
+        if let Some(rule) = self.no_useless_undefined_initialization.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.use_consistent_builtin_instantiation.as_ref() {
+        if let Some(rule) = self.use_array_literals.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.use_default_switch_clause.as_ref() {
+        if let Some(rule) = self.use_consistent_builtin_instantiation.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.use_explicit_length_check.as_ref() {
+        if let Some(rule) = self.use_default_switch_clause.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-        if let Some(rule) = self.use_focusable_interactive.as_ref() {
+        if let Some(rule) = self.use_explicit_length_check.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-        if let Some(rule) = self.use_generic_font_names.as_ref() {
+        if let Some(rule) = self.use_focusable_interactive.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_generic_font_names.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-        if let Some(rule) = self.use_throw_new_error.as_ref() {
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
-        if let Some(rule) = self.use_top_level_regex.as_ref() {
+        if let Some(rule) = self.use_throw_new_error.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
+            }
+        }
+        if let Some(rule) = self.use_top_level_regex.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
         index_set
@@ -4046,6 +4061,10 @@ impl Nursery {
                 .map(|conf| (conf.level(), conf.get_options())),
             "noRestrictedImports" => self
                 .no_restricted_imports
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noStaticElementInteractions" => self
+                .no_static_element_interactions
                 .as_ref()
                 .map(|conf| (conf.level(), conf.get_options())),
             "noUndeclaredDependencies" => self
@@ -4216,6 +4235,11 @@ impl Nursery {
             }
             "noRestrictedImports" => {
                 if let Some(rule_conf) = &mut self.no_restricted_imports {
+                    rule_conf.set_level(severity);
+                }
+            }
+            "noStaticElementInteractions" => {
+                if let Some(rule_conf) = &mut self.no_static_element_interactions {
                     rule_conf.set_level(severity);
                 }
             }

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -129,6 +129,7 @@ define_categories! {
     "lint/nursery/noNodejsModules": "https://biomejs.dev/linter/rules/no-nodejs-modules",
     "lint/nursery/noReactSpecificProps": "https://biomejs.dev/linter/rules/no-react-specific-props",
     "lint/nursery/noRestrictedImports": "https://biomejs.dev/linter/rules/no-restricted-imports",
+    "lint/nursery/noStaticElementInteractions": "https://biomejs.dev/linter/rules/no-static-element-interactions",
     "lint/nursery/noTypeOnlyImportAttributes": "https://biomejs.dev/linter/rules/no-type-only-import-attributes",
     "lint/nursery/noUndeclaredDependencies": "https://biomejs.dev/linter/rules/no-undeclared-dependencies",
     "lint/nursery/noUnknownFunction": "https://biomejs.dev/linter/rules/no-unknown-function",

--- a/crates/biome_js_analyze/src/lint/nursery.rs
+++ b/crates/biome_js_analyze/src/lint/nursery.rs
@@ -12,6 +12,7 @@ pub mod no_misplaced_assertion;
 pub mod no_nodejs_modules;
 pub mod no_react_specific_props;
 pub mod no_restricted_imports;
+pub mod no_static_element_interactions;
 pub mod no_undeclared_dependencies;
 pub mod no_useless_string_concat;
 pub mod no_useless_undefined_initialization;
@@ -39,6 +40,7 @@ declare_group! {
             self :: no_nodejs_modules :: NoNodejsModules ,
             self :: no_react_specific_props :: NoReactSpecificProps ,
             self :: no_restricted_imports :: NoRestrictedImports ,
+            self :: no_static_element_interactions :: NoStaticElementInteractions ,
             self :: no_undeclared_dependencies :: NoUndeclaredDependencies ,
             self :: no_useless_string_concat :: NoUselessStringConcat ,
             self :: no_useless_undefined_initialization :: NoUselessUndefinedInitialization ,

--- a/crates/biome_js_analyze/src/lint/nursery/no_static_element_interactions.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_static_element_interactions.rs
@@ -1,0 +1,311 @@
+use crate::services::aria::Aria;
+use biome_analyze::context::RuleContext;
+use biome_analyze::{declare_rule, Rule, RuleDiagnostic, RuleSource};
+use biome_console::markup;
+use biome_js_syntax::jsx_ext::AnyJsxElement;
+use biome_js_syntax::{AnyJsxAttribute, JsxAttributeList};
+use biome_rowan::AstNode;
+use rustc_hash::FxHashMap;
+use std::collections::HashMap;
+
+declare_rule! {
+    /// Enforce that non-interactive, visible elements (such as `<div>`) that have click handlers use the role attribute.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <div onClick={()=>{})}></div>;
+    /// ```
+    /// ```jsx,expect_diagnostic
+    /// <span onClick={()=>{})}></span>;
+    /// ```
+    ///
+    /// When `<a>` does not have "href" attribute, that is non-interactive.
+    /// ```jsx,expect_diagnostic
+    /// <a onClick={()=>{})}></a>
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```jsx
+    /// <div role="button" onClick={()=>{})}></div>
+    /// <span role="link" onClick={()=>{})}></span>
+    /// <a href="http://example.com" onClick={()=>{})}></a>
+    /// ```
+    ///
+    pub NoStaticElementInteractions {
+        version: "next",
+        name: "noStaticElementInteractions",
+        language: "js",
+        sources: &[RuleSource::EslintJsxA11y("no-static-element-interactions")],
+        recommended: false,
+    }
+}
+
+lazy_static::lazy_static! {
+    static ref INTERACTIVE_HANDLER_LIST: HashMap<&'static str, Vec<&'static str>> = {
+        let mut m = HashMap::new();
+        m.insert("clipboard", vec!["onCopy", "onCut", "onPaste"]);
+        m.insert("composition", vec!["onCompositionEnd", "onCompositionStart", "onCompositionUpdate"]);
+        m.insert("keyboard", vec!["onKeyDown", "onKeyPress", "onKeyUp"]);
+        m.insert("focus", vec!["onFocus", "onBlur"]);
+        m.insert("form", vec!["onChange", "onInput", "onSubmit"]);
+        m.insert("mouse", vec![
+            "onClick", "onContextMenu", "onDblClick", "onDoubleClick", "onDrag", "onDragEnd",
+            "onDragEnter", "onDragExit", "onDragLeave", "onDragOver", "onDragStart", "onDrop",
+            "onMouseDown", "onMouseEnter", "onMouseLeave", "onMouseMove", "onMouseOut",
+            "onMouseOver", "onMouseUp"
+        ]);
+        m.insert("selection", vec!["onSelect"]);
+        m.insert("touch", vec!["onTouchCancel", "onTouchEnd", "onTouchMove", "onTouchStart"]);
+        m.insert("ui", vec!["onScroll"]);
+        m.insert("wheel", vec!["onWheel"]);
+        m.insert("media", vec![
+            "onAbort", "onCanPlay", "onCanPlayThrough", "onDurationChange", "onEmptied",
+            "onEncrypted", "onEnded", "onError", "onLoadedData", "onLoadedMetadata", "onLoadStart",
+            "onPause", "onPlay", "onPlaying", "onProgress", "onRateChange", "onSeeked", "onSeeking",
+            "onStalled", "onSuspend", "onTimeUpdate", "onVolumeChange", "onWaiting"
+        ]);
+        m.insert("image", vec!["onLoad", "onError"]);
+        m.insert("animation", vec!["onAnimationStart", "onAnimationEnd", "onAnimationIteration"]);
+        m.insert("transition", vec!["onTransitionEnd"]);
+        m
+    };
+}
+
+impl Rule for NoStaticElementInteractions {
+    type Query = Aria<AnyJsxElement>;
+    type State = ();
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+        let aria_roles = ctx.aria_roles();
+        let element_name = node.name().ok()?.as_jsx_name()?.value_token().ok()?;
+        let attributes = extract_attrs(&node.attributes());
+        let elm = element_name.text_trimmed();
+
+        if let Some(attributes_ref) = attributes.as_ref() {
+            if !is_interactive_handler_present(attributes_ref) {
+                return None;
+            }
+        } else {
+            return None;
+        }
+
+        let default_attributes = FxHashMap::default();
+        let attributes_ref = attributes.as_ref().unwrap_or(&default_attributes);
+
+        let attributes_option = if !attributes_ref.is_empty() {
+            Some(attributes_ref.clone())
+        } else {
+            None
+        };
+
+        if has_truthy_ariahidden_attr(node) {
+            return None;
+        }
+
+        let is_valid_element = match elm {
+            "section" => ["aria-label", "aria-labelledby"].iter().any(|&attr_name| {
+                node.find_attribute_by_name(attr_name)
+                    .map_or(false, |attr| {
+                        attr.as_static_value()
+                            .map_or(false, |val| !val.text().is_empty())
+                    })
+            }),
+            "a" => node.find_attribute_by_name("href").map_or(false, |attr| {
+                attr.as_static_value()
+                    .map_or(false, |val| !val.text().is_empty())
+            }),
+            _ => {
+                (!aria_roles.is_not_interactive_element(
+                    element_name.text_trimmed(),
+                    attributes_option.clone(),
+                ) && !is_invalid_element(elm))
+                    || is_valid_element(elm)
+            }
+        };
+
+        if is_valid_element {
+            return None;
+        }
+
+        if attributes_option.is_some() {
+            match node.find_attribute_by_name("role") {
+                Some(attr) => {
+                    let role_value = attr.as_static_value()?;
+                    let role_text = role_value.text();
+
+                    if has_valid_role(role_text) || aria_roles.is_role_interactive(role_text) {
+                        return None;
+                    }
+                }
+                None => {
+                    return Some(());
+                }
+            };
+        }
+
+        Some(())
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {
+        let node = ctx.query();
+        Some(RuleDiagnostic::new(
+            rule_category!(),
+            node.range(),
+            markup! {{"Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element"}},
+        ))
+    }
+}
+
+/// Check if any interactive handler is present in the attributes.
+fn is_interactive_handler_present(attributes: &FxHashMap<String, Vec<String>>) -> bool {
+    let categories_to_check = vec!["focus", "keyboard", "mouse"];
+    for category in categories_to_check {
+        if let Some(handlers) = INTERACTIVE_HANDLER_LIST.get(category) {
+            for handler in handlers {
+                if let Some(values) = attributes.get(*handler) {
+                    if values.iter().any(|value| value != "null") {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// This method is an override of AriaService::extract_attributes.
+///
+/// This modified version can extract attributes with dynamic values as well.
+/// The original extract_attributes in AriaService skips extracting other static attributes if a dynamic value is encountered.
+pub fn extract_attrs(attribute_list: &JsxAttributeList) -> Option<FxHashMap<String, Vec<String>>> {
+    let mut defined_attributes: FxHashMap<String, Vec<String>> = FxHashMap::default();
+    for attribute in attribute_list {
+        if let AnyJsxAttribute::JsxAttribute(attr) = attribute {
+            let name = attr.name().ok()?.syntax().text_trimmed().to_string();
+            let values = if let Some(initializer) = attr.initializer() {
+                let initializer = initializer.value().ok()?;
+                if let Some(static_value) = initializer.as_static_value() {
+                    static_value
+                        .text()
+                        .split(' ')
+                        .map(|s| s.to_string())
+                        .collect::<Vec<String>>()
+                } else {
+                    vec![initializer.syntax().text().to_string()]
+                }
+            } else {
+                vec!["true".to_string()]
+            };
+
+            defined_attributes.entry(name).or_insert(values);
+        }
+    }
+    Some(defined_attributes)
+}
+
+fn has_truthy_ariahidden_attr(node: &AnyJsxElement) -> bool {
+    return node
+        .find_attribute_by_name("aria-hidden")
+        .map_or(false, |attr| {
+            attr.as_static_value()
+                .map_or(true, |val| val.text() == "true")
+        });
+}
+
+/// This function allows non-interactive Roles.
+/// That is because these are Roles enabled in eslint-plugin-jsx-a11y.
+fn has_valid_role(role: &str) -> bool {
+    matches!(
+        role,
+        "columnheader"
+            | "form"
+            | "rowheader"
+            | "treeitem"
+            | "alert"
+            | "alertdialog"
+            | "application"
+            | "article"
+            | "banner"
+            | "cell"
+            | "complementary"
+            | "contentinfo"
+            | "definition"
+            | "dialog"
+            | "directory"
+            | "document"
+            | "feed"
+            | "figure"
+            | "grid"
+            | "group"
+            | "heading"
+            | "img"
+            | "list"
+            | "listitem"
+            | "log"
+            | "main"
+            | "marquee"
+            | "math"
+            | "menu"
+            | "menubar"
+            | "navigation"
+            | "note"
+            | "radiogroup"
+            | "region"
+            | "rowgroup"
+            | "section"
+            | "search"
+            | "status"
+            | "table"
+            | "tablist"
+            | "tabpanel"
+            | "term"
+            | "timer"
+            | "toolbar"
+            | "tooltip"
+            | "tree"
+            | "treegrid"
+    )
+}
+
+/// This function disables interactive elements.
+/// This is because this is an element that is disabled by eslint-plugin-jsx-a11y.
+fn is_invalid_element(element_name: &str) -> bool {
+    match element_name {
+        // This case is interactive with the is_not_interactive_element method,
+        // but is an invalid test case element for eslint-plugin-jsx-a11y.
+        "link" | "header" => true,
+        // This case is not handled by the is_not_interactive_element method
+        // and is an element from the eslint-plugin-jsx-a11y invalid test case.
+        "area" | "b" | "bdi" | "bdo" | "hgroup" | "i" | "u" | "q" | "small" | "data" | "samp"
+        | "acronym" | "applet" | "base" | "big" | "blink" | "center" | "cite" | "col"
+        | "colgroup" | "content" | "font" | "frameset" | "head" | "kbd" | "keygen" | "map"
+        | "meta" | "noembed" | "noscript" | "object" | "param" | "picture" | "rp" | "rt"
+        | "rtc" | "s" | "script" | "source" | "spacer" | "strike" | "style" | "summary"
+        | "title" | "track" | "tt" | "var" | "wbr" | "xmp" => true,
+        _ => false,
+    }
+}
+
+/// This function ables non-interactive elements.
+/// This is because this is an element that is abled by eslint-plugin-jsx-a11y.
+fn is_valid_element(element_name: &str) -> bool {
+    match element_name {
+        // This case is interactive with the is_not_interactive_element method,
+        // but is an invalid test case element for eslint-plugin-jsx-a11y.
+        "input" | "form" | "iframe" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "ruby" | "pre"
+        | "mark" | "aside" | "blockquote" => true,
+        "address" | "article" | "caption" | "output" | "p" | "li" | "ol" | "ul" | "nav"
+        | "table" | "thead" | "tbody" | "tfoot" | "time" | "dfn" | "main" | "br" | "details"
+        | "dd" | "dir" | "dl" | "dt" | "fieldset" | "figcaption" | "figure" | "footer" | "img"
+        | "label" | "legend" | "marquee" | "menu" | "meter" | "optgroup" | "progress" | "th"
+        | "td" => true,
+        _ => false,
+    }
+}

--- a/crates/biome_js_analyze/src/options.rs
+++ b/crates/biome_js_analyze/src/options.rs
@@ -181,6 +181,7 @@ pub type NoSkippedTests =
     <lint::suspicious::no_skipped_tests::NoSkippedTests as biome_analyze::Rule>::Options;
 pub type NoSparseArray =
     <lint::suspicious::no_sparse_array::NoSparseArray as biome_analyze::Rule>::Options;
+pub type NoStaticElementInteractions = < lint :: nursery :: no_static_element_interactions :: NoStaticElementInteractions as biome_analyze :: Rule > :: Options ;
 pub type NoStaticOnlyClass =
     <lint::complexity::no_static_only_class::NoStaticOnlyClass as biome_analyze::Rule>::Options;
 pub type NoStringCaseMismatch = < lint :: correctness :: no_string_case_mismatch :: NoStringCaseMismatch as biome_analyze :: Rule > :: Options ;

--- a/crates/biome_js_analyze/tests/specs/nursery/noStaticElementInteractions/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noStaticElementInteractions/invalid.jsx
@@ -1,0 +1,89 @@
+<>
+	<div onClick={() => void 0} />
+	<div onClick={() => void 0} role={undefined} />
+	<div onClick={() => void 0} {...props} />
+	<div onKeyUp={() => void 0} aria-hidden={false} />
+	{/*Static elements; no inherent role */}
+	<a onClick={() => void 0} />
+	<a onClick={() => {}} />
+	<a tabIndex="0" onClick={() => void 0} />
+	<area onClick={() => {}} />
+	<acronym onClick={() => {}} />
+	<applet onClick={() => {}} />
+	<b onClick={() => {}} />
+	<base onClick={() => {}} />
+	<bdi onClick={() => {}} />
+	<bdo onClick={() => {}} />
+	<big onClick={() => {}} />
+	<blink onClick={() => {}} />
+	<body onClick={() => {}} />
+	<center onClick={() => {}} />
+	<cite onClick={() => {}} />
+	<col onClick={() => {}} />
+	<colgroup onClick={() => {}} />
+	<content onClick={() => {}} />
+	<data onClick={() => {}} />
+	<div onClick={() => {}} />
+	<font onClick={() => {}} />
+	<frame onClick={() => {}} />
+	<frameset onClick={() => {}} />
+	<head onClick={() => {}} />
+	<header onClick={() => {}} />
+	<hgroup onClick={() => {}} />
+	<i onClick={() => {}} />
+	<kbd onClick={() => {}} />
+	<keygen onClick={() => {}} />
+	<link onClick={() => {}} href="#" />
+	<map onClick={() => {}} />
+	<meta onClick={() => {}} />
+	<noembed onClick={() => {}} />
+	<noscript onClick={() => {}} />
+	<object onClick={() => {}} />
+	<param onClick={() => {}} />
+	<picture onClick={() => {}} />
+	<q onClick={() => {}} />
+	<rp onClick={() => {}} />
+	<rt onClick={() => {}} />
+	<rtc onClick={() => {}} />
+	<s onClick={() => {}} />
+	<samp onClick={() => {}} />
+	<script onClick={() => {}} />
+	<section onClick={() => {}} />
+	<small onClick={() => {}} />
+	<source onClick={() => {}} />
+	<spacer onClick={() => {}} />
+	<span onClick={() => {}} />
+	<strike onClick={() => {}} />
+	<style onClick={() => {}} />
+	<summary onClick={() => {}} />
+	<title onClick={() => {}} />
+	<track onClick={() => {}} />
+	<tt onClick={() => {}} />
+	<u onClick={() => {}} />
+	<var onClick={() => {}} />
+	<wbr onClick={() => {}} />
+	<xmp onClick={() => {}} />
+	{/* // Handlers */}
+	<div onKeyDown={() => {}} />
+	<div onKeyPress={() => {}} />
+	<div onKeyUp={() => {}} />
+	<div onClick={() => {}} />
+	<div onMouseDown={() => {}} />
+	<div onMouseUp={() => {}} />
+
+	{/* Presentation is a special case role that indicates intentional static semantics */}
+	<div role="presentation" onClick={() => {}} />
+	<div role="presentation" onKeyDown={() => {}} />
+	{/* HTML elements attributed with an abstract role */}
+	<div role="command" onClick={() => {}} />
+	<div role="composite" onClick={() => {}} />
+	<div role="input" onClick={() => {}} />
+	<div role="landmark" onClick={() => {}} />
+	<div role="range" onClick={() => {}} />
+	<div role="roletype" onClick={() => {}} />
+	<div role="sectionhead" onClick={() => {}} />
+	<div role="select" onClick={() => {}} />
+	<div role="structure" onClick={() => {}} />
+	<div role="widget" onClick={() => {}} />
+	<div role="window" onClick={() => {}} />
+</>;

--- a/crates/biome_js_analyze/tests/specs/nursery/noStaticElementInteractions/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noStaticElementInteractions/invalid.jsx.snap
@@ -1,0 +1,1326 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.jsx
+---
+# Input
+```jsx
+<>
+	<div onClick={() => void 0} />
+	<div onClick={() => void 0} role={undefined} />
+	<div onClick={() => void 0} {...props} />
+	<div onKeyUp={() => void 0} aria-hidden={false} />
+	{/*Static elements; no inherent role */}
+	<a onClick={() => void 0} />
+	<a onClick={() => {}} />
+	<a tabIndex="0" onClick={() => void 0} />
+	<area onClick={() => {}} />
+	<acronym onClick={() => {}} />
+	<applet onClick={() => {}} />
+	<b onClick={() => {}} />
+	<base onClick={() => {}} />
+	<bdi onClick={() => {}} />
+	<bdo onClick={() => {}} />
+	<big onClick={() => {}} />
+	<blink onClick={() => {}} />
+	<body onClick={() => {}} />
+	<center onClick={() => {}} />
+	<cite onClick={() => {}} />
+	<col onClick={() => {}} />
+	<colgroup onClick={() => {}} />
+	<content onClick={() => {}} />
+	<data onClick={() => {}} />
+	<div onClick={() => {}} />
+	<font onClick={() => {}} />
+	<frame onClick={() => {}} />
+	<frameset onClick={() => {}} />
+	<head onClick={() => {}} />
+	<header onClick={() => {}} />
+	<hgroup onClick={() => {}} />
+	<i onClick={() => {}} />
+	<kbd onClick={() => {}} />
+	<keygen onClick={() => {}} />
+	<link onClick={() => {}} href="#" />
+	<map onClick={() => {}} />
+	<meta onClick={() => {}} />
+	<noembed onClick={() => {}} />
+	<noscript onClick={() => {}} />
+	<object onClick={() => {}} />
+	<param onClick={() => {}} />
+	<picture onClick={() => {}} />
+	<q onClick={() => {}} />
+	<rp onClick={() => {}} />
+	<rt onClick={() => {}} />
+	<rtc onClick={() => {}} />
+	<s onClick={() => {}} />
+	<samp onClick={() => {}} />
+	<script onClick={() => {}} />
+	<section onClick={() => {}} />
+	<small onClick={() => {}} />
+	<source onClick={() => {}} />
+	<spacer onClick={() => {}} />
+	<span onClick={() => {}} />
+	<strike onClick={() => {}} />
+	<style onClick={() => {}} />
+	<summary onClick={() => {}} />
+	<title onClick={() => {}} />
+	<track onClick={() => {}} />
+	<tt onClick={() => {}} />
+	<u onClick={() => {}} />
+	<var onClick={() => {}} />
+	<wbr onClick={() => {}} />
+	<xmp onClick={() => {}} />
+	{/* // Handlers */}
+	<div onKeyDown={() => {}} />
+	<div onKeyPress={() => {}} />
+	<div onKeyUp={() => {}} />
+	<div onClick={() => {}} />
+	<div onMouseDown={() => {}} />
+	<div onMouseUp={() => {}} />
+
+	{/* Presentation is a special case role that indicates intentional static semantics */}
+	<div role="presentation" onClick={() => {}} />
+	<div role="presentation" onKeyDown={() => {}} />
+	{/* HTML elements attributed with an abstract role */}
+	<div role="command" onClick={() => {}} />
+	<div role="composite" onClick={() => {}} />
+	<div role="input" onClick={() => {}} />
+	<div role="landmark" onClick={() => {}} />
+	<div role="range" onClick={() => {}} />
+	<div role="roletype" onClick={() => {}} />
+	<div role="sectionhead" onClick={() => {}} />
+	<div role="select" onClick={() => {}} />
+	<div role="structure" onClick={() => {}} />
+	<div role="widget" onClick={() => {}} />
+	<div role="window" onClick={() => {}} />
+</>;
+
+```
+
+# Diagnostics
+```
+invalid.jsx:2:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    1 │ <>
+  > 2 │ 	<div onClick={() => void 0} />
+      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 	<div onClick={() => void 0} role={undefined} />
+    4 │ 	<div onClick={() => void 0} {...props} />
+  
+
+```
+
+```
+invalid.jsx:3:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    1 │ <>
+    2 │ 	<div onClick={() => void 0} />
+  > 3 │ 	<div onClick={() => void 0} role={undefined} />
+      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 	<div onClick={() => void 0} {...props} />
+    5 │ 	<div onKeyUp={() => void 0} aria-hidden={false} />
+  
+
+```
+
+```
+invalid.jsx:4:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    2 │ 	<div onClick={() => void 0} />
+    3 │ 	<div onClick={() => void 0} role={undefined} />
+  > 4 │ 	<div onClick={() => void 0} {...props} />
+      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ 	<div onKeyUp={() => void 0} aria-hidden={false} />
+    6 │ 	{/*Static elements; no inherent role */}
+  
+
+```
+
+```
+invalid.jsx:5:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    3 │ 	<div onClick={() => void 0} role={undefined} />
+    4 │ 	<div onClick={() => void 0} {...props} />
+  > 5 │ 	<div onKeyUp={() => void 0} aria-hidden={false} />
+      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 	{/*Static elements; no inherent role */}
+    7 │ 	<a onClick={() => void 0} />
+  
+
+```
+
+```
+invalid.jsx:7:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    5 │ 	<div onKeyUp={() => void 0} aria-hidden={false} />
+    6 │ 	{/*Static elements; no inherent role */}
+  > 7 │ 	<a onClick={() => void 0} />
+      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 	<a onClick={() => {}} />
+    9 │ 	<a tabIndex="0" onClick={() => void 0} />
+  
+
+```
+
+```
+invalid.jsx:8:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+     6 │ 	{/*Static elements; no inherent role */}
+     7 │ 	<a onClick={() => void 0} />
+   > 8 │ 	<a onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 	<a tabIndex="0" onClick={() => void 0} />
+    10 │ 	<area onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:9:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+     7 │ 	<a onClick={() => void 0} />
+     8 │ 	<a onClick={() => {}} />
+   > 9 │ 	<a tabIndex="0" onClick={() => void 0} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 	<area onClick={() => {}} />
+    11 │ 	<acronym onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:10:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+     8 │ 	<a onClick={() => {}} />
+     9 │ 	<a tabIndex="0" onClick={() => void 0} />
+  > 10 │ 	<area onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    11 │ 	<acronym onClick={() => {}} />
+    12 │ 	<applet onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:11:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+     9 │ 	<a tabIndex="0" onClick={() => void 0} />
+    10 │ 	<area onClick={() => {}} />
+  > 11 │ 	<acronym onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 	<applet onClick={() => {}} />
+    13 │ 	<b onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:12:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    10 │ 	<area onClick={() => {}} />
+    11 │ 	<acronym onClick={() => {}} />
+  > 12 │ 	<applet onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    13 │ 	<b onClick={() => {}} />
+    14 │ 	<base onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:13:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    11 │ 	<acronym onClick={() => {}} />
+    12 │ 	<applet onClick={() => {}} />
+  > 13 │ 	<b onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ 	<base onClick={() => {}} />
+    15 │ 	<bdi onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:14:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    12 │ 	<applet onClick={() => {}} />
+    13 │ 	<b onClick={() => {}} />
+  > 14 │ 	<base onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    15 │ 	<bdi onClick={() => {}} />
+    16 │ 	<bdo onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:15:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    13 │ 	<b onClick={() => {}} />
+    14 │ 	<base onClick={() => {}} />
+  > 15 │ 	<bdi onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^
+    16 │ 	<bdo onClick={() => {}} />
+    17 │ 	<big onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:16:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    14 │ 	<base onClick={() => {}} />
+    15 │ 	<bdi onClick={() => {}} />
+  > 16 │ 	<bdo onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^
+    17 │ 	<big onClick={() => {}} />
+    18 │ 	<blink onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:17:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    15 │ 	<bdi onClick={() => {}} />
+    16 │ 	<bdo onClick={() => {}} />
+  > 17 │ 	<big onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^
+    18 │ 	<blink onClick={() => {}} />
+    19 │ 	<body onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:18:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    16 │ 	<bdo onClick={() => {}} />
+    17 │ 	<big onClick={() => {}} />
+  > 18 │ 	<blink onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    19 │ 	<body onClick={() => {}} />
+    20 │ 	<center onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:19:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    17 │ 	<big onClick={() => {}} />
+    18 │ 	<blink onClick={() => {}} />
+  > 19 │ 	<body onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    20 │ 	<center onClick={() => {}} />
+    21 │ 	<cite onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:20:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    18 │ 	<blink onClick={() => {}} />
+    19 │ 	<body onClick={() => {}} />
+  > 20 │ 	<center onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ 	<cite onClick={() => {}} />
+    22 │ 	<col onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:21:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    19 │ 	<body onClick={() => {}} />
+    20 │ 	<center onClick={() => {}} />
+  > 21 │ 	<cite onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    22 │ 	<col onClick={() => {}} />
+    23 │ 	<colgroup onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:22:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    20 │ 	<center onClick={() => {}} />
+    21 │ 	<cite onClick={() => {}} />
+  > 22 │ 	<col onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^
+    23 │ 	<colgroup onClick={() => {}} />
+    24 │ 	<content onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:23:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    21 │ 	<cite onClick={() => {}} />
+    22 │ 	<col onClick={() => {}} />
+  > 23 │ 	<colgroup onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    24 │ 	<content onClick={() => {}} />
+    25 │ 	<data onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:24:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    22 │ 	<col onClick={() => {}} />
+    23 │ 	<colgroup onClick={() => {}} />
+  > 24 │ 	<content onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    25 │ 	<data onClick={() => {}} />
+    26 │ 	<div onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:25:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    23 │ 	<colgroup onClick={() => {}} />
+    24 │ 	<content onClick={() => {}} />
+  > 25 │ 	<data onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    26 │ 	<div onClick={() => {}} />
+    27 │ 	<font onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:26:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    24 │ 	<content onClick={() => {}} />
+    25 │ 	<data onClick={() => {}} />
+  > 26 │ 	<div onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^
+    27 │ 	<font onClick={() => {}} />
+    28 │ 	<frame onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:27:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    25 │ 	<data onClick={() => {}} />
+    26 │ 	<div onClick={() => {}} />
+  > 27 │ 	<font onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    28 │ 	<frame onClick={() => {}} />
+    29 │ 	<frameset onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:28:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    26 │ 	<div onClick={() => {}} />
+    27 │ 	<font onClick={() => {}} />
+  > 28 │ 	<frame onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    29 │ 	<frameset onClick={() => {}} />
+    30 │ 	<head onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:29:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    27 │ 	<font onClick={() => {}} />
+    28 │ 	<frame onClick={() => {}} />
+  > 29 │ 	<frameset onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    30 │ 	<head onClick={() => {}} />
+    31 │ 	<header onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:30:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    28 │ 	<frame onClick={() => {}} />
+    29 │ 	<frameset onClick={() => {}} />
+  > 30 │ 	<head onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    31 │ 	<header onClick={() => {}} />
+    32 │ 	<hgroup onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:31:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    29 │ 	<frameset onClick={() => {}} />
+    30 │ 	<head onClick={() => {}} />
+  > 31 │ 	<header onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    32 │ 	<hgroup onClick={() => {}} />
+    33 │ 	<i onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:32:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    30 │ 	<head onClick={() => {}} />
+    31 │ 	<header onClick={() => {}} />
+  > 32 │ 	<hgroup onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    33 │ 	<i onClick={() => {}} />
+    34 │ 	<kbd onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:33:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    31 │ 	<header onClick={() => {}} />
+    32 │ 	<hgroup onClick={() => {}} />
+  > 33 │ 	<i onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^
+    34 │ 	<kbd onClick={() => {}} />
+    35 │ 	<keygen onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:34:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    32 │ 	<hgroup onClick={() => {}} />
+    33 │ 	<i onClick={() => {}} />
+  > 34 │ 	<kbd onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^
+    35 │ 	<keygen onClick={() => {}} />
+    36 │ 	<link onClick={() => {}} href="#" />
+  
+
+```
+
+```
+invalid.jsx:35:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    33 │ 	<i onClick={() => {}} />
+    34 │ 	<kbd onClick={() => {}} />
+  > 35 │ 	<keygen onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    36 │ 	<link onClick={() => {}} href="#" />
+    37 │ 	<map onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:36:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    34 │ 	<kbd onClick={() => {}} />
+    35 │ 	<keygen onClick={() => {}} />
+  > 36 │ 	<link onClick={() => {}} href="#" />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    37 │ 	<map onClick={() => {}} />
+    38 │ 	<meta onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:37:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    35 │ 	<keygen onClick={() => {}} />
+    36 │ 	<link onClick={() => {}} href="#" />
+  > 37 │ 	<map onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^
+    38 │ 	<meta onClick={() => {}} />
+    39 │ 	<noembed onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:38:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    36 │ 	<link onClick={() => {}} href="#" />
+    37 │ 	<map onClick={() => {}} />
+  > 38 │ 	<meta onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    39 │ 	<noembed onClick={() => {}} />
+    40 │ 	<noscript onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:39:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    37 │ 	<map onClick={() => {}} />
+    38 │ 	<meta onClick={() => {}} />
+  > 39 │ 	<noembed onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    40 │ 	<noscript onClick={() => {}} />
+    41 │ 	<object onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:40:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    38 │ 	<meta onClick={() => {}} />
+    39 │ 	<noembed onClick={() => {}} />
+  > 40 │ 	<noscript onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    41 │ 	<object onClick={() => {}} />
+    42 │ 	<param onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:41:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    39 │ 	<noembed onClick={() => {}} />
+    40 │ 	<noscript onClick={() => {}} />
+  > 41 │ 	<object onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    42 │ 	<param onClick={() => {}} />
+    43 │ 	<picture onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:42:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    40 │ 	<noscript onClick={() => {}} />
+    41 │ 	<object onClick={() => {}} />
+  > 42 │ 	<param onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    43 │ 	<picture onClick={() => {}} />
+    44 │ 	<q onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:43:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    41 │ 	<object onClick={() => {}} />
+    42 │ 	<param onClick={() => {}} />
+  > 43 │ 	<picture onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    44 │ 	<q onClick={() => {}} />
+    45 │ 	<rp onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:44:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    42 │ 	<param onClick={() => {}} />
+    43 │ 	<picture onClick={() => {}} />
+  > 44 │ 	<q onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^
+    45 │ 	<rp onClick={() => {}} />
+    46 │ 	<rt onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:45:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    43 │ 	<picture onClick={() => {}} />
+    44 │ 	<q onClick={() => {}} />
+  > 45 │ 	<rp onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^
+    46 │ 	<rt onClick={() => {}} />
+    47 │ 	<rtc onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:46:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    44 │ 	<q onClick={() => {}} />
+    45 │ 	<rp onClick={() => {}} />
+  > 46 │ 	<rt onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^
+    47 │ 	<rtc onClick={() => {}} />
+    48 │ 	<s onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:47:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    45 │ 	<rp onClick={() => {}} />
+    46 │ 	<rt onClick={() => {}} />
+  > 47 │ 	<rtc onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^
+    48 │ 	<s onClick={() => {}} />
+    49 │ 	<samp onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:48:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    46 │ 	<rt onClick={() => {}} />
+    47 │ 	<rtc onClick={() => {}} />
+  > 48 │ 	<s onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^
+    49 │ 	<samp onClick={() => {}} />
+    50 │ 	<script onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:49:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    47 │ 	<rtc onClick={() => {}} />
+    48 │ 	<s onClick={() => {}} />
+  > 49 │ 	<samp onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    50 │ 	<script onClick={() => {}} />
+    51 │ 	<section onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:50:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    48 │ 	<s onClick={() => {}} />
+    49 │ 	<samp onClick={() => {}} />
+  > 50 │ 	<script onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    51 │ 	<section onClick={() => {}} />
+    52 │ 	<small onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:51:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    49 │ 	<samp onClick={() => {}} />
+    50 │ 	<script onClick={() => {}} />
+  > 51 │ 	<section onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    52 │ 	<small onClick={() => {}} />
+    53 │ 	<source onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:52:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    50 │ 	<script onClick={() => {}} />
+    51 │ 	<section onClick={() => {}} />
+  > 52 │ 	<small onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    53 │ 	<source onClick={() => {}} />
+    54 │ 	<spacer onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:53:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    51 │ 	<section onClick={() => {}} />
+    52 │ 	<small onClick={() => {}} />
+  > 53 │ 	<source onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    54 │ 	<spacer onClick={() => {}} />
+    55 │ 	<span onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:54:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    52 │ 	<small onClick={() => {}} />
+    53 │ 	<source onClick={() => {}} />
+  > 54 │ 	<spacer onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    55 │ 	<span onClick={() => {}} />
+    56 │ 	<strike onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:55:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    53 │ 	<source onClick={() => {}} />
+    54 │ 	<spacer onClick={() => {}} />
+  > 55 │ 	<span onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    56 │ 	<strike onClick={() => {}} />
+    57 │ 	<style onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:56:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    54 │ 	<spacer onClick={() => {}} />
+    55 │ 	<span onClick={() => {}} />
+  > 56 │ 	<strike onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    57 │ 	<style onClick={() => {}} />
+    58 │ 	<summary onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:57:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    55 │ 	<span onClick={() => {}} />
+    56 │ 	<strike onClick={() => {}} />
+  > 57 │ 	<style onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    58 │ 	<summary onClick={() => {}} />
+    59 │ 	<title onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:58:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    56 │ 	<strike onClick={() => {}} />
+    57 │ 	<style onClick={() => {}} />
+  > 58 │ 	<summary onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    59 │ 	<title onClick={() => {}} />
+    60 │ 	<track onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:59:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    57 │ 	<style onClick={() => {}} />
+    58 │ 	<summary onClick={() => {}} />
+  > 59 │ 	<title onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    60 │ 	<track onClick={() => {}} />
+    61 │ 	<tt onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:60:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    58 │ 	<summary onClick={() => {}} />
+    59 │ 	<title onClick={() => {}} />
+  > 60 │ 	<track onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    61 │ 	<tt onClick={() => {}} />
+    62 │ 	<u onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:61:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    59 │ 	<title onClick={() => {}} />
+    60 │ 	<track onClick={() => {}} />
+  > 61 │ 	<tt onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^
+    62 │ 	<u onClick={() => {}} />
+    63 │ 	<var onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:62:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    60 │ 	<track onClick={() => {}} />
+    61 │ 	<tt onClick={() => {}} />
+  > 62 │ 	<u onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^
+    63 │ 	<var onClick={() => {}} />
+    64 │ 	<wbr onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:63:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    61 │ 	<tt onClick={() => {}} />
+    62 │ 	<u onClick={() => {}} />
+  > 63 │ 	<var onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^
+    64 │ 	<wbr onClick={() => {}} />
+    65 │ 	<xmp onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:64:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    62 │ 	<u onClick={() => {}} />
+    63 │ 	<var onClick={() => {}} />
+  > 64 │ 	<wbr onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^
+    65 │ 	<xmp onClick={() => {}} />
+    66 │ 	{/* // Handlers */}
+  
+
+```
+
+```
+invalid.jsx:65:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    63 │ 	<var onClick={() => {}} />
+    64 │ 	<wbr onClick={() => {}} />
+  > 65 │ 	<xmp onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^
+    66 │ 	{/* // Handlers */}
+    67 │ 	<div onKeyDown={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:67:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    65 │ 	<xmp onClick={() => {}} />
+    66 │ 	{/* // Handlers */}
+  > 67 │ 	<div onKeyDown={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    68 │ 	<div onKeyPress={() => {}} />
+    69 │ 	<div onKeyUp={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:68:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    66 │ 	{/* // Handlers */}
+    67 │ 	<div onKeyDown={() => {}} />
+  > 68 │ 	<div onKeyPress={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    69 │ 	<div onKeyUp={() => {}} />
+    70 │ 	<div onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:69:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    67 │ 	<div onKeyDown={() => {}} />
+    68 │ 	<div onKeyPress={() => {}} />
+  > 69 │ 	<div onKeyUp={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^
+    70 │ 	<div onClick={() => {}} />
+    71 │ 	<div onMouseDown={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:70:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    68 │ 	<div onKeyPress={() => {}} />
+    69 │ 	<div onKeyUp={() => {}} />
+  > 70 │ 	<div onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^
+    71 │ 	<div onMouseDown={() => {}} />
+    72 │ 	<div onMouseUp={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:71:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    69 │ 	<div onKeyUp={() => {}} />
+    70 │ 	<div onClick={() => {}} />
+  > 71 │ 	<div onMouseDown={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    72 │ 	<div onMouseUp={() => {}} />
+    73 │ 
+  
+
+```
+
+```
+invalid.jsx:72:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    70 │ 	<div onClick={() => {}} />
+    71 │ 	<div onMouseDown={() => {}} />
+  > 72 │ 	<div onMouseUp={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    73 │ 
+    74 │ 	{/* Presentation is a special case role that indicates intentional static semantics */}
+  
+
+```
+
+```
+invalid.jsx:75:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    74 │ 	{/* Presentation is a special case role that indicates intentional static semantics */}
+  > 75 │ 	<div role="presentation" onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    76 │ 	<div role="presentation" onKeyDown={() => {}} />
+    77 │ 	{/* HTML elements attributed with an abstract role */}
+  
+
+```
+
+```
+invalid.jsx:76:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    74 │ 	{/* Presentation is a special case role that indicates intentional static semantics */}
+    75 │ 	<div role="presentation" onClick={() => {}} />
+  > 76 │ 	<div role="presentation" onKeyDown={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    77 │ 	{/* HTML elements attributed with an abstract role */}
+    78 │ 	<div role="command" onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:78:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    76 │ 	<div role="presentation" onKeyDown={() => {}} />
+    77 │ 	{/* HTML elements attributed with an abstract role */}
+  > 78 │ 	<div role="command" onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    79 │ 	<div role="composite" onClick={() => {}} />
+    80 │ 	<div role="input" onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:79:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    77 │ 	{/* HTML elements attributed with an abstract role */}
+    78 │ 	<div role="command" onClick={() => {}} />
+  > 79 │ 	<div role="composite" onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    80 │ 	<div role="input" onClick={() => {}} />
+    81 │ 	<div role="landmark" onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:80:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    78 │ 	<div role="command" onClick={() => {}} />
+    79 │ 	<div role="composite" onClick={() => {}} />
+  > 80 │ 	<div role="input" onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    81 │ 	<div role="landmark" onClick={() => {}} />
+    82 │ 	<div role="range" onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:81:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    79 │ 	<div role="composite" onClick={() => {}} />
+    80 │ 	<div role="input" onClick={() => {}} />
+  > 81 │ 	<div role="landmark" onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    82 │ 	<div role="range" onClick={() => {}} />
+    83 │ 	<div role="roletype" onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:82:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    80 │ 	<div role="input" onClick={() => {}} />
+    81 │ 	<div role="landmark" onClick={() => {}} />
+  > 82 │ 	<div role="range" onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    83 │ 	<div role="roletype" onClick={() => {}} />
+    84 │ 	<div role="sectionhead" onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:83:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    81 │ 	<div role="landmark" onClick={() => {}} />
+    82 │ 	<div role="range" onClick={() => {}} />
+  > 83 │ 	<div role="roletype" onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    84 │ 	<div role="sectionhead" onClick={() => {}} />
+    85 │ 	<div role="select" onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:84:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    82 │ 	<div role="range" onClick={() => {}} />
+    83 │ 	<div role="roletype" onClick={() => {}} />
+  > 84 │ 	<div role="sectionhead" onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    85 │ 	<div role="select" onClick={() => {}} />
+    86 │ 	<div role="structure" onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:85:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    83 │ 	<div role="roletype" onClick={() => {}} />
+    84 │ 	<div role="sectionhead" onClick={() => {}} />
+  > 85 │ 	<div role="select" onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    86 │ 	<div role="structure" onClick={() => {}} />
+    87 │ 	<div role="widget" onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:86:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    84 │ 	<div role="sectionhead" onClick={() => {}} />
+    85 │ 	<div role="select" onClick={() => {}} />
+  > 86 │ 	<div role="structure" onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    87 │ 	<div role="widget" onClick={() => {}} />
+    88 │ 	<div role="window" onClick={() => {}} />
+  
+
+```
+
+```
+invalid.jsx:87:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    85 │ 	<div role="select" onClick={() => {}} />
+    86 │ 	<div role="structure" onClick={() => {}} />
+  > 87 │ 	<div role="widget" onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    88 │ 	<div role="window" onClick={() => {}} />
+    89 │ </>;
+  
+
+```
+
+```
+invalid.jsx:88:2 lint/nursery/noStaticElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element
+  
+    86 │ 	<div role="structure" onClick={() => {}} />
+    87 │ 	<div role="widget" onClick={() => {}} />
+  > 88 │ 	<div role="window" onClick={() => {}} />
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    89 │ </>;
+    90 │ 
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noStaticElementInteractions/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noStaticElementInteractions/valid.jsx
@@ -1,0 +1,229 @@
+<>
+	<TestComponent onClick={doFoo} />
+	<Button onClick={doFoo} />
+	<Button onClick={doFoo} />
+	<div />
+	<div className="foo" />
+	<div className="foo" {...props} />
+	<div onClick={() => void 0} aria-hidden />
+	<div onClick={() => void 0} aria-hidden={true} />
+	<div onClick={null} />
+	<input onClick={() => void 0} />
+	<input type="button" onClick={() => void 0} />
+	<input type="checkbox" onClick={() => void 0} />
+	<input type="color" onClick={() => void 0} />
+	<input type="date" onClick={() => void 0} />
+	<input type="datetime" onClick={() => void 0} />
+	<input type="datetime-local" onClick={() => void 0} />
+	<input type="email" onClick={() => void 0} />
+	<input type="file" onClick={() => void 0} />
+	<input type="hidden" onClick={() => void 0} />
+	<input type="image" onClick={() => void 0} />
+	<input type="month" onClick={() => void 0} />
+	<input type="number" onClick={() => void 0} />
+	<input type="password" onClick={() => void 0} />
+	<input type="radio" onClick={() => void 0} />
+	<input type="range" onClick={() => void 0} />
+	<input type="reset" onClick={() => void 0} />
+	<input type="search" onClick={() => void 0} />
+	<input type="submit" onClick={() => void 0} />
+	<input type="tel" onClick={() => void 0} />
+	<input type="text" onClick={() => void 0} />
+	<input type="time" onClick={() => void 0} />
+	<input type="url" onClick={() => void 0} />
+	<input type="week" onClick={() => void 0} />
+	<button onClick={() => void 0} className="foo" />
+	<datalist onClick={() => {}} />
+	<menuitem onClick={() => {}} />
+	<option onClick={() => void 0} className="foo" />
+	<select onClick={() => void 0} className="foo" />
+	<textarea onClick={() => void 0} className="foo" />
+	<a onClick={() => void 0} href="http://x.y.z" />
+	<a onClick={() => void 0} href="http://x.y.z" tabIndex="0" />
+	<audio onClick={() => {}} />
+	<form onClick={() => {}} />
+	<form onSubmit={() => {}} />
+
+	<div role="button" onClick={() => {}} />
+	<div role="checkbox" onClick={() => {}} />
+	<div role="columnheader" onClick={() => {}} />
+	<div role="combobox" onClick={() => {}} />
+	<div role="form" onClick={() => {}} />
+	<div role="gridcell" onClick={() => {}} />
+	<div role="link" onClick={() => {}} />
+	<div role="menuitem" onClick={() => {}} />
+	<div role="menuitemcheckbox" onClick={() => {}} />
+	<div role="menuitemradio" onClick={() => {}} />
+	<div role="option" onClick={() => {}} />
+	<div role="radio" onClick={() => {}} />
+	<div role="rowheader" onClick={() => {}} />
+	<div role="searchbox" onClick={() => {}} />
+	<div role="slider" onClick={() => {}} />
+	<div role="spinbutton" onClick={() => {}} />
+	<div role="switch" onClick={() => {}} />
+	<div role="tab" onClick={() => {}} />
+	<div role="textbox" onClick={() => {}} />
+	<div role="treeitem" onClick={() => {}} />
+
+	<div onCopy={() => {}} />
+	<div onCut={() => {}} />
+	<div onPaste={() => {}} />
+	<div onCompositionEnd={() => {}} />
+	<div onCompositionStart={() => {}} />
+	<div onCompositionUpdate={() => {}} />
+	<div onChange={() => {}} />
+	<div onInput={() => {}} />
+	<div onSubmit={() => {}} />
+	<div onSelect={() => {}} />
+	<div onTouchCancel={() => {}} />
+	<div onTouchEnd={() => {}} />
+	<div onTouchMove={() => {}} />
+	<div onTouchStart={() => {}} />
+	<div onScroll={() => {}} />
+	<div onWheel={() => {}} />
+	<div onAbort={() => {}} />
+	<div onCanPlay={() => {}} />
+	<div onCanPlayThrough={() => {}} />
+	<div onDurationChange={() => {}} />
+	<div onEmptied={() => {}} />
+	<div onEncrypted={() => {}} />
+	<div onEnded={() => {}} />
+	<div onError={() => {}} />
+	<div onLoadedData={() => {}} />
+	<div onLoadedMetadata={() => {}} />
+	<div onLoadStart={() => {}} />
+	<div onPause={() => {}} />
+	<div onPlay={() => {}} />
+	<div onPlaying={() => {}} />
+	<div onProgress={() => {}} />
+	<div onRateChange={() => {}} />
+	<div onSeeked={() => {}} />
+	<div onSeeking={() => {}} />
+	<div onStalled={() => {}} />
+	<div onSuspend={() => {}} />
+	<div onTimeUpdate={() => {}} />
+	<div onVolumeChange={() => {}} />
+	<div onWaiting={() => {}} />
+	<div onLoad={() => {}} />
+	<div onError={() => {}} />
+	<div onAnimationStart={() => {}} />
+	<div onAnimationEnd={() => {}} />
+	<div onAnimationIteration={() => {}} />
+	<div onTransitionEnd={() => {}} />
+
+	{/* HTML elements with an inherent, non-interactive role */}
+	<address onClick={() => {}} />
+	<article onClick={() => {}} />
+	<article onDblClick={() => void 0} />
+	<aside onClick={() => {}} />
+	<blockquote onClick={() => {}} />
+	<br onClick={() => {}} />
+	<canvas onClick={() => {}} />
+	<caption onClick={() => {}} />
+	<code onClick={() => {}} />
+	<details onClick={() => {}} />
+	<dd onClick={() => {}} />
+	<del onClick={() => {}} />
+	<dfn onClick={() => {}} />
+	<dir onClick={() => {}} />
+	<dl onClick={() => {}} />
+	<dt onClick={() => {}} />
+	<em onClick={() => {}} />
+	<embed onClick={() => {}} />
+	<fieldset onClick={() => {}} />
+	<figcaption onClick={() => {}} />
+	<figure onClick={() => {}} />
+	<footer onClick={() => {}} />
+	<h1 onClick={() => {}} />
+	<h2 onClick={() => {}} />
+	<h3 onClick={() => {}} />
+	<h4 onClick={() => {}} />
+	<h5 onClick={() => {}} />
+	<h6 onClick={() => {}} />
+	<hr onClick={() => {}} />
+	<html onClick={() => {}} />
+	<iframe onClick={() => {}} />
+	<img onClick={() => {}} />
+	<ins onClick={() => {}} />
+	<label onClick={() => {}} />
+	<legend onClick={() => {}} />
+	<li onClick={() => {}} />
+	<main onClick={() => void 0} />
+	<mark onClick={() => {}} />
+	<marquee onClick={() => {}} />
+	<menu onClick={() => {}} />
+	<meter onClick={() => {}} />
+	<nav onClick={() => {}} />
+	<ol onClick={() => {}} />
+	<optgroup onClick={() => {}} />
+	<output onClick={() => {}} />
+	<p onClick={() => {}} />
+	<pre onClick={() => {}} />
+	<progress onClick={() => {}} />
+	<ruby onClick={() => {}} />
+	<section onClick={() => {}} aria-label="Aa" />
+	<section onClick={() => {}} aria-labelledby="js_1" />
+	<strong onClick={() => {}} />
+	<sub onClick={() => {}} />
+	<sup onClick={() => {}} />
+	<table onClick={() => {}} />
+	<tbody onClick={() => {}} />
+	<tfoot onClick={() => {}} />
+	<th onClick={() => {}} />
+	<thead onClick={() => {}} />
+	<time onClick={() => {}} />
+	<tr onClick={() => {}} />
+	<video onClick={() => {}} />
+	<ul onClick={() => {}} />
+
+	{/* HTML elements attributed with a non-interactive role */}
+	<div role="alert" onClick={() => {}} />
+	<div role="alertdialog" onClick={() => {}} />
+	<div role="application" onClick={() => {}} />
+	<div role="article" onClick={() => {}} />
+	<div role="banner" onClick={() => {}} />
+	<div role="cell" onClick={() => {}} />
+	<div role="complementary" onClick={() => {}} />
+	<div role="contentinfo" onClick={() => {}} />
+	<div role="definition" onClick={() => {}} />
+	<div role="dialog" onClick={() => {}} />
+	<div role="directory" onClick={() => {}} />
+	<div role="document" onClick={() => {}} />
+	<div role="feed" onClick={() => {}} />
+	<div role="figure" onClick={() => {}} />
+	<div role="grid" onClick={() => {}} />
+	<div role="group" onClick={() => {}} />
+	<div role="heading" onClick={() => {}} />
+	<div role="img" onClick={() => {}} />
+	<div role="list" onClick={() => {}} />
+	<div role="listbox" onClick={() => {}} />
+	<div role="listitem" onClick={() => {}} />
+	<div role="log" onClick={() => {}} />
+	<div role="main" onClick={() => {}} />
+	<div role="marquee" onClick={() => {}} />
+	<div role="math" onClick={() => {}} />
+	<div role="menu" onClick={() => {}} />
+	<div role="menubar" onClick={() => {}} />
+	<div role="navigation" onClick={() => {}} />
+	<div role="note" onClick={() => {}} />
+	<div role="progressbar" onClick={() => {}} />
+	<div role="radiogroup" onClick={() => {}} />
+	<div role="region" onClick={() => {}} />
+	<div role="row" onClick={() => {}} />
+	<div role="rowgroup" onClick={() => {}} />
+	<div role="section" onClick={() => {}} />
+	<div role="search" onClick={() => {}} />
+	<div role="separator" onClick={() => {}} />
+	<div role="scrollbar" onClick={() => {}} />
+	<div role="status" onClick={() => {}} />
+	<div role="table" onClick={() => {}} />
+	<div role="tablist" onClick={() => {}} />
+	<div role="tabpanel" onClick={() => {}} />
+	<td onClick={() => {}} />
+	<div role="term" onClick={() => {}} />
+	<div role="timer" onClick={() => {}} />
+	<div role="toolbar" onClick={() => {}} />
+	<div role="tooltip" onClick={() => {}} />
+	<div role="tree" onClick={() => {}} />
+	<div role="treegrid" onClick={() => {}} />
+</>;

--- a/crates/biome_js_analyze/tests/specs/nursery/noStaticElementInteractions/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noStaticElementInteractions/valid.jsx.snap
@@ -1,0 +1,237 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.jsx
+---
+# Input
+```jsx
+<>
+	<TestComponent onClick={doFoo} />
+	<Button onClick={doFoo} />
+	<Button onClick={doFoo} />
+	<div />
+	<div className="foo" />
+	<div className="foo" {...props} />
+	<div onClick={() => void 0} aria-hidden />
+	<div onClick={() => void 0} aria-hidden={true} />
+	<div onClick={null} />
+	<input onClick={() => void 0} />
+	<input type="button" onClick={() => void 0} />
+	<input type="checkbox" onClick={() => void 0} />
+	<input type="color" onClick={() => void 0} />
+	<input type="date" onClick={() => void 0} />
+	<input type="datetime" onClick={() => void 0} />
+	<input type="datetime-local" onClick={() => void 0} />
+	<input type="email" onClick={() => void 0} />
+	<input type="file" onClick={() => void 0} />
+	<input type="hidden" onClick={() => void 0} />
+	<input type="image" onClick={() => void 0} />
+	<input type="month" onClick={() => void 0} />
+	<input type="number" onClick={() => void 0} />
+	<input type="password" onClick={() => void 0} />
+	<input type="radio" onClick={() => void 0} />
+	<input type="range" onClick={() => void 0} />
+	<input type="reset" onClick={() => void 0} />
+	<input type="search" onClick={() => void 0} />
+	<input type="submit" onClick={() => void 0} />
+	<input type="tel" onClick={() => void 0} />
+	<input type="text" onClick={() => void 0} />
+	<input type="time" onClick={() => void 0} />
+	<input type="url" onClick={() => void 0} />
+	<input type="week" onClick={() => void 0} />
+	<button onClick={() => void 0} className="foo" />
+	<datalist onClick={() => {}} />
+	<menuitem onClick={() => {}} />
+	<option onClick={() => void 0} className="foo" />
+	<select onClick={() => void 0} className="foo" />
+	<textarea onClick={() => void 0} className="foo" />
+	<a onClick={() => void 0} href="http://x.y.z" />
+	<a onClick={() => void 0} href="http://x.y.z" tabIndex="0" />
+	<audio onClick={() => {}} />
+	<form onClick={() => {}} />
+	<form onSubmit={() => {}} />
+
+	<div role="button" onClick={() => {}} />
+	<div role="checkbox" onClick={() => {}} />
+	<div role="columnheader" onClick={() => {}} />
+	<div role="combobox" onClick={() => {}} />
+	<div role="form" onClick={() => {}} />
+	<div role="gridcell" onClick={() => {}} />
+	<div role="link" onClick={() => {}} />
+	<div role="menuitem" onClick={() => {}} />
+	<div role="menuitemcheckbox" onClick={() => {}} />
+	<div role="menuitemradio" onClick={() => {}} />
+	<div role="option" onClick={() => {}} />
+	<div role="radio" onClick={() => {}} />
+	<div role="rowheader" onClick={() => {}} />
+	<div role="searchbox" onClick={() => {}} />
+	<div role="slider" onClick={() => {}} />
+	<div role="spinbutton" onClick={() => {}} />
+	<div role="switch" onClick={() => {}} />
+	<div role="tab" onClick={() => {}} />
+	<div role="textbox" onClick={() => {}} />
+	<div role="treeitem" onClick={() => {}} />
+
+	<div onCopy={() => {}} />
+	<div onCut={() => {}} />
+	<div onPaste={() => {}} />
+	<div onCompositionEnd={() => {}} />
+	<div onCompositionStart={() => {}} />
+	<div onCompositionUpdate={() => {}} />
+	<div onChange={() => {}} />
+	<div onInput={() => {}} />
+	<div onSubmit={() => {}} />
+	<div onSelect={() => {}} />
+	<div onTouchCancel={() => {}} />
+	<div onTouchEnd={() => {}} />
+	<div onTouchMove={() => {}} />
+	<div onTouchStart={() => {}} />
+	<div onScroll={() => {}} />
+	<div onWheel={() => {}} />
+	<div onAbort={() => {}} />
+	<div onCanPlay={() => {}} />
+	<div onCanPlayThrough={() => {}} />
+	<div onDurationChange={() => {}} />
+	<div onEmptied={() => {}} />
+	<div onEncrypted={() => {}} />
+	<div onEnded={() => {}} />
+	<div onError={() => {}} />
+	<div onLoadedData={() => {}} />
+	<div onLoadedMetadata={() => {}} />
+	<div onLoadStart={() => {}} />
+	<div onPause={() => {}} />
+	<div onPlay={() => {}} />
+	<div onPlaying={() => {}} />
+	<div onProgress={() => {}} />
+	<div onRateChange={() => {}} />
+	<div onSeeked={() => {}} />
+	<div onSeeking={() => {}} />
+	<div onStalled={() => {}} />
+	<div onSuspend={() => {}} />
+	<div onTimeUpdate={() => {}} />
+	<div onVolumeChange={() => {}} />
+	<div onWaiting={() => {}} />
+	<div onLoad={() => {}} />
+	<div onError={() => {}} />
+	<div onAnimationStart={() => {}} />
+	<div onAnimationEnd={() => {}} />
+	<div onAnimationIteration={() => {}} />
+	<div onTransitionEnd={() => {}} />
+
+	{/* HTML elements with an inherent, non-interactive role */}
+	<address onClick={() => {}} />
+	<article onClick={() => {}} />
+	<article onDblClick={() => void 0} />
+	<aside onClick={() => {}} />
+	<blockquote onClick={() => {}} />
+	<br onClick={() => {}} />
+	<canvas onClick={() => {}} />
+	<caption onClick={() => {}} />
+	<code onClick={() => {}} />
+	<details onClick={() => {}} />
+	<dd onClick={() => {}} />
+	<del onClick={() => {}} />
+	<dfn onClick={() => {}} />
+	<dir onClick={() => {}} />
+	<dl onClick={() => {}} />
+	<dt onClick={() => {}} />
+	<em onClick={() => {}} />
+	<embed onClick={() => {}} />
+	<fieldset onClick={() => {}} />
+	<figcaption onClick={() => {}} />
+	<figure onClick={() => {}} />
+	<footer onClick={() => {}} />
+	<h1 onClick={() => {}} />
+	<h2 onClick={() => {}} />
+	<h3 onClick={() => {}} />
+	<h4 onClick={() => {}} />
+	<h5 onClick={() => {}} />
+	<h6 onClick={() => {}} />
+	<hr onClick={() => {}} />
+	<html onClick={() => {}} />
+	<iframe onClick={() => {}} />
+	<img onClick={() => {}} />
+	<ins onClick={() => {}} />
+	<label onClick={() => {}} />
+	<legend onClick={() => {}} />
+	<li onClick={() => {}} />
+	<main onClick={() => void 0} />
+	<mark onClick={() => {}} />
+	<marquee onClick={() => {}} />
+	<menu onClick={() => {}} />
+	<meter onClick={() => {}} />
+	<nav onClick={() => {}} />
+	<ol onClick={() => {}} />
+	<optgroup onClick={() => {}} />
+	<output onClick={() => {}} />
+	<p onClick={() => {}} />
+	<pre onClick={() => {}} />
+	<progress onClick={() => {}} />
+	<ruby onClick={() => {}} />
+	<section onClick={() => {}} aria-label="Aa" />
+	<section onClick={() => {}} aria-labelledby="js_1" />
+	<strong onClick={() => {}} />
+	<sub onClick={() => {}} />
+	<sup onClick={() => {}} />
+	<table onClick={() => {}} />
+	<tbody onClick={() => {}} />
+	<tfoot onClick={() => {}} />
+	<th onClick={() => {}} />
+	<thead onClick={() => {}} />
+	<time onClick={() => {}} />
+	<tr onClick={() => {}} />
+	<video onClick={() => {}} />
+	<ul onClick={() => {}} />
+
+	{/* HTML elements attributed with a non-interactive role */}
+	<div role="alert" onClick={() => {}} />
+	<div role="alertdialog" onClick={() => {}} />
+	<div role="application" onClick={() => {}} />
+	<div role="article" onClick={() => {}} />
+	<div role="banner" onClick={() => {}} />
+	<div role="cell" onClick={() => {}} />
+	<div role="complementary" onClick={() => {}} />
+	<div role="contentinfo" onClick={() => {}} />
+	<div role="definition" onClick={() => {}} />
+	<div role="dialog" onClick={() => {}} />
+	<div role="directory" onClick={() => {}} />
+	<div role="document" onClick={() => {}} />
+	<div role="feed" onClick={() => {}} />
+	<div role="figure" onClick={() => {}} />
+	<div role="grid" onClick={() => {}} />
+	<div role="group" onClick={() => {}} />
+	<div role="heading" onClick={() => {}} />
+	<div role="img" onClick={() => {}} />
+	<div role="list" onClick={() => {}} />
+	<div role="listbox" onClick={() => {}} />
+	<div role="listitem" onClick={() => {}} />
+	<div role="log" onClick={() => {}} />
+	<div role="main" onClick={() => {}} />
+	<div role="marquee" onClick={() => {}} />
+	<div role="math" onClick={() => {}} />
+	<div role="menu" onClick={() => {}} />
+	<div role="menubar" onClick={() => {}} />
+	<div role="navigation" onClick={() => {}} />
+	<div role="note" onClick={() => {}} />
+	<div role="progressbar" onClick={() => {}} />
+	<div role="radiogroup" onClick={() => {}} />
+	<div role="region" onClick={() => {}} />
+	<div role="row" onClick={() => {}} />
+	<div role="rowgroup" onClick={() => {}} />
+	<div role="section" onClick={() => {}} />
+	<div role="search" onClick={() => {}} />
+	<div role="separator" onClick={() => {}} />
+	<div role="scrollbar" onClick={() => {}} />
+	<div role="status" onClick={() => {}} />
+	<div role="table" onClick={() => {}} />
+	<div role="tablist" onClick={() => {}} />
+	<div role="tabpanel" onClick={() => {}} />
+	<td onClick={() => {}} />
+	<div role="term" onClick={() => {}} />
+	<div role="timer" onClick={() => {}} />
+	<div role="toolbar" onClick={() => {}} />
+	<div role="tooltip" onClick={() => {}} />
+	<div role="tree" onClick={() => {}} />
+	<div role="treegrid" onClick={() => {}} />
+</>;
+
+```

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -985,6 +985,10 @@ export interface Nursery {
 	 */
 	noRestrictedImports?: RuleConfiguration_for_RestrictedImportsOptions;
 	/**
+	 * Enforce that non-interactive, visible elements (such as \<div>) that have click handlers use the role attribute.
+	 */
+	noStaticElementInteractions?: RuleConfiguration_for_Null;
+	/**
 	 * Disallow the use of dependencies that aren't specified in the package.json.
 	 */
 	noUndeclaredDependencies?: RuleConfiguration_for_Null;
@@ -2259,6 +2263,7 @@ export type Category =
 	| "lint/nursery/noNodejsModules"
 	| "lint/nursery/noReactSpecificProps"
 	| "lint/nursery/noRestrictedImports"
+	| "lint/nursery/noStaticElementInteractions"
 	| "lint/nursery/noTypeOnlyImportAttributes"
 	| "lint/nursery/noUndeclaredDependencies"
 	| "lint/nursery/noUnknownFunction"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1711,6 +1711,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noStaticElementInteractions": {
+					"description": "Enforce that non-interactive, visible elements (such as \\<div>) that have click handlers use the role attribute.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noUndeclaredDependencies": {
 					"description": "Disallow the use of dependencies that aren't specified in the package.json.",
 					"anyOf": [


### PR DESCRIPTION
## Summary

Enforce that non-interactive, visible elements (such as `<div>`) that have click handlers use the role attribute.

https://github.com/biomejs/biome/issues/527

## Test Plan

Added snaps for valid/invalid cases
