### PR TITLE
feat(lsp): improve DX when the configuration has syntax errors

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,5 @@
 {
   "$schema": "./packages/@biomejs/biome/configuration_schema.json",
-  "extends": ["@biomejs/shared/biome"],
   "files": {
     "ignore": [
       "crates/**",
@@ -11,15 +10,39 @@
       "public/**",
       "**/__snapshots__",
       "**/undefined/**",
-      "_fonts/**"
+      "_fonts/**",
+      "packages/@biomejs/wasm-*"
+    ],
+    "include": [
+      "packages/@biomejs/**",
+      "packages/tailwindcss-config-analyzer"
     ]
   },
   "formatter": {
-    "ignore": ["configuration_schema.json"]
+    "ignore": [
+      "configuration_schema.json"
+    ]
   },
   "json": {
     "formatter": {
       "indentStyle": "space"
     }
+  },
+  "vcs": {
+    "clientKind": "git",
+    "enabled": true,
+    "useIgnoreFile": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": {
+        "noNonNullAssertion": "off"
+      }
+    }
+  },
+  "organizeImports": {
+    "enabled": true
   }
 }

--- a/crates/biome_formatter_test/src/lib.rs
+++ b/crates/biome_formatter_test/src/lib.rs
@@ -50,9 +50,9 @@ pub trait TestFormatLanguage {
     ) -> <Self::ServiceLanguage as ServiceLanguage>::FormatOptions {
         let language_settings = self.to_language_settings(settings);
         Self::ServiceLanguage::resolve_format_options(
-            &settings.formatter,
-            &settings.override_settings,
-            language_settings,
+            Some(&settings.formatter),
+            Some(&settings.override_settings),
+            Some(language_settings),
             &BiomePath::new(""),
             file_source,
         )

--- a/crates/biome_service/src/file_handlers/astro.rs
+++ b/crates/biome_service/src/file_handlers/astro.rs
@@ -3,7 +3,7 @@ use crate::file_handlers::{
     ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults, ParseResult,
     ParserCapabilities,
 };
-use crate::settings::WorkspaceSettingsHandle;
+use crate::settings::{Settings, WorkspaceSettingsHandle};
 use crate::workspace::{
     DocumentFileSource, FixFileResult, OrganizeImportsResult, PullActionsResult,
 };
@@ -94,7 +94,7 @@ fn parse(
     _rome_path: &BiomePath,
     file_source: DocumentFileSource,
     text: &str,
-    _settings: WorkspaceSettingsHandle,
+    _settings: Option<&Settings>,
     cache: &mut NodeCache,
 ) -> ParseResult {
     let frontmatter = AstroFileHandler::input(text);

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -31,6 +31,7 @@ use biome_formatter::{
 };
 use biome_fs::BiomePath;
 use biome_js_analyze::RuleError;
+use biome_js_syntax::AnyJsRoot;
 use biome_parser::AnyParse;
 use biome_rowan::{AstNode, NodeCache};
 use biome_rowan::{TextRange, TextSize, TokenAtOffset};
@@ -96,66 +97,76 @@ impl ServiceLanguage for CssLanguage {
     }
 
     fn resolve_format_options(
-        global: &FormatSettings,
-        overrides: &OverrideSettings,
-        language: &Self::FormatterSettings,
+        global: Option<&FormatSettings>,
+        overrides: Option<&OverrideSettings>,
+        language: Option<&Self::FormatterSettings>,
         path: &BiomePath,
         document_file_source: &DocumentFileSource,
     ) -> Self::FormatOptions {
-        let indent_style = if let Some(indent_style) = language.indent_style {
-            indent_style
-        } else {
-            global.indent_style.unwrap_or_default()
-        };
-        let line_width = if let Some(line_width) = language.line_width {
-            line_width
-        } else {
-            global.line_width.unwrap_or_default()
-        };
-        let indent_width = if let Some(indent_width) = language.indent_width {
-            indent_width
-        } else {
-            global.indent_width.unwrap_or_default()
-        };
+        let indent_style = language
+            .and_then(|l| l.indent_style)
+            .or(global.and_then(|g| g.indent_style))
+            .unwrap_or_default();
+        let line_width = language
+            .and_then(|l| l.line_width)
+            .or(global.and_then(|g| g.line_width))
+            .unwrap_or_default();
+        let indent_width = language
+            .and_then(|l| l.indent_width)
+            .or(global.and_then(|g| g.indent_width))
+            .unwrap_or_default();
 
-        overrides.to_override_css_format_options(
-            path,
-            CssFormatOptions::new(
-                document_file_source
-                    .to_css_file_source()
-                    .unwrap_or_default(),
-            )
-            .with_indent_style(indent_style)
-            .with_indent_width(indent_width)
-            .with_line_width(line_width)
-            .with_quote_style(language.quote_style.unwrap_or_default()),
+        let line_ending = language
+            .and_then(|l| l.line_ending)
+            .or(global.and_then(|g| g.line_ending))
+            .unwrap_or_default();
+
+        let options = CssFormatOptions::new(
+            document_file_source
+                .to_css_file_source()
+                .unwrap_or_default(),
         )
+        .with_indent_style(indent_style)
+        .with_indent_width(indent_width)
+        .with_line_width(line_width)
+        .with_line_ending(line_ending)
+        .with_quote_style(language.and_then(|l| l.quote_style).unwrap_or_default());
+        if let Some(overrides) = overrides {
+            overrides.to_override_css_format_options(path, options)
+        } else {
+            options
+        }
     }
 
     fn resolve_analyzer_options(
-        global: &Settings,
-        _linter: &LinterSettings,
-        _overrides: &OverrideSettings,
-        _language: &Self::LinterSettings,
+        global: Option<&Settings>,
+        _linter: Option<&LinterSettings>,
+        _overrides: Option<&OverrideSettings>,
+        _language: Option<&Self::LinterSettings>,
         file_path: &BiomePath,
         _file_source: &DocumentFileSource,
     ) -> AnalyzerOptions {
         let preferred_quote = global
-            .languages
-            .css
-            .formatter
-            .quote_style
-            .map(|quote_style: QuoteStyle| {
-                if quote_style == QuoteStyle::Single {
-                    PreferredQuote::Single
-                } else {
-                    PreferredQuote::Double
-                }
+            .and_then(|global| {
+                global
+                    .languages
+                    .css
+                    .formatter
+                    .quote_style
+                    .map(|quote_style: QuoteStyle| {
+                        if quote_style == QuoteStyle::Single {
+                            PreferredQuote::Single
+                        } else {
+                            PreferredQuote::Double
+                        }
+                    })
             })
             .unwrap_or_default();
 
         let configuration = AnalyzerConfiguration {
-            rules: to_analyzer_rules(global, file_path.as_path()),
+            rules: global
+                .map(|g| to_analyzer_rules(g, file_path.as_path()))
+                .unwrap_or_default(),
             globals: vec![],
             preferred_quote,
             jsx_runtime: None,
@@ -200,9 +211,22 @@ fn parse(
     biome_path: &BiomePath,
     _file_source: DocumentFileSource,
     text: &str,
-    settings: WorkspaceSettingsHandle,
+    settings: Option<&Settings>,
     cache: &mut NodeCache,
 ) -> ParseResult {
+    let mut options = CssParserOptions {
+        allow_wrong_line_comments: settings
+            .map(|s| s.languages.css.parser.allow_wrong_line_comments)
+            .unwrap_or_default(),
+        css_modules: settings
+            .map(|s| s.languages.css.parser.css_modules)
+            .unwrap_or_default(),
+    };
+    if let Some(settings) = settings {
+        options = settings
+            .override_settings
+            .to_override_css_parser_options(biome_path, options);
+    }
     let parser = &settings.settings().languages.css.parser;
     let overrides = &settings.settings().override_settings;
     let options: CssParserOptions = overrides.to_override_css_parser_options(
@@ -323,36 +347,43 @@ fn format_on_type(
 fn lint(params: LintParams) -> LintResults {
     debug_span!("Linting CSS file", path =? params.path, language =? params.language).in_scope(
         move || {
-            let workspace_settings = &params.settings;
+            let workspace_settings = &params.workspace;
             let analyzer_options =
                 workspace_settings.analyzer_options::<CssLanguage>(params.path, &params.language);
-            let settings = workspace_settings.settings();
             let tree = params.parse.tree();
             let mut diagnostics = params.parse.into_diagnostics();
 
-            // Compute final rules (taking `overrides` into account)
-            let rules = settings.as_rules(params.path.as_path());
-
             let has_only_filter = !params.only.is_empty();
-            let enabled_rules = if has_only_filter {
-                params
-                    .only
-                    .into_iter()
-                    .map(|selector| selector.into())
-                    .collect::<Vec<_>>()
+            let mut rules = None;
+
+            let enabled_rules = if let Some(settings) = params.workspace.settings() {
+                // Compute final rules (taking `overrides` into account)
+                rules = settings.as_rules(params.path.as_path());
+
+                if has_only_filter {
+                    params
+                        .only
+                        .into_iter()
+                        .map(|selector| selector.into())
+                        .collect::<Vec<_>>()
+                } else {
+                    rules
+                        .as_ref()
+                        .map(|rules| rules.as_enabled_rules())
+                        .unwrap_or_default()
+                        .into_iter()
+                        .collect::<Vec<_>>()
+                }
             } else {
-                rules
-                    .as_ref()
-                    .map(|rules| rules.as_enabled_rules())
-                    .unwrap_or_default()
-                    .into_iter()
-                    .collect::<Vec<_>>()
+                vec![]
             };
+
             let disabled_rules = params
                 .skip
                 .into_iter()
                 .map(|selector| selector.into())
                 .collect::<Vec<_>>();
+
             let filter = AnalysisFilter {
                 categories: params.categories,
                 enabled_rules: Some(enabled_rules.as_slice()),
@@ -451,11 +482,11 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         path,
         manifest: _,
         language,
+        settings,
     } = params;
     debug_span!("Code actions JavaScript", range =? range, path =? path).in_scope(move || {
         let tree = parse.tree();
         trace_span!("Parsed file", tree =? tree).in_scope(move || {
-            let settings = workspace.settings();
             let rules = settings.as_rules(params.path.as_path());
             let filter = rules
                 .as_ref()
@@ -505,31 +536,49 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
 pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
     let FixAllParams {
         parse,
-        rules,
         fix_file_mode,
-        settings,
+        workspace,
         should_format,
         biome_path,
-        mut filter,
         manifest: _,
         document_file_source,
     } = params;
 
+    let settings = workspace.settings();
+    let Some(settings) = settings else {
+        let tree: AnyJsRoot = parse.tree();
+
+        return Ok(FixFileResult {
+            actions: vec![],
+            errors: 0,
+            skipped_suggested_fixes: 0,
+            code: tree.syntax().to_string(),
+        });
+    };
+
     let mut tree: CssRoot = parse.tree();
     let mut actions = Vec::new();
 
-    filter.categories = RuleCategories::SYNTAX | RuleCategories::LINT;
+    // Compute final rules (taking `overrides` into account)
+    let rules = settings.as_rules(params.biome_path.as_path());
+    let rule_filter_list = rules
+        .as_ref()
+        .map(|rules| rules.as_enabled_rules())
+        .unwrap_or_default()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let filter = AnalysisFilter::from_enabled_rules(rule_filter_list.as_slice());
 
     let mut skipped_suggested_fixes = 0;
     let mut errors: u16 = 0;
     let analyzer_options =
-        settings.analyzer_options::<CssLanguage>(biome_path, &document_file_source);
+        workspace.analyzer_options::<CssLanguage>(biome_path, &document_file_source);
     loop {
         let (action, _) = analyze(&tree, filter, &analyzer_options, |signal| {
             let current_diagnostic = signal.diagnostic();
 
             if let Some(diagnostic) = current_diagnostic.as_ref() {
-                if is_diagnostic_error(diagnostic, rules) {
+                if is_diagnostic_error(diagnostic, rules.as_deref()) {
                     errors += 1;
                 }
             }
@@ -593,7 +642,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
             None => {
                 let code = if should_format {
                     format_node(
-                        settings.format_options::<CssLanguage>(biome_path, &document_file_source),
+                        workspace.format_options::<CssLanguage>(biome_path, &document_file_source),
                         tree.syntax(),
                     )?
                     .print()?

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -219,7 +219,7 @@ fn parse(
             .map(|s| s.languages.css.parser.allow_wrong_line_comments)
             .unwrap_or_default(),
         css_modules: settings
-            .map(|s| s.languages.css.parser.css_modules)
+            .map(|s| s.languages.css.parser.allow_wrong_line_comments)
             .unwrap_or_default(),
     };
     if let Some(settings) = settings {
@@ -227,15 +227,6 @@ fn parse(
             .override_settings
             .to_override_css_parser_options(biome_path, options);
     }
-    let parser = &settings.settings().languages.css.parser;
-    let overrides = &settings.settings().override_settings;
-    let options: CssParserOptions = overrides.to_override_css_parser_options(
-        biome_path,
-        CssParserOptions {
-            allow_wrong_line_comments: parser.allow_wrong_line_comments,
-            css_modules: parser.css_modules,
-        },
-    );
     let parse = biome_css_parser::parse_css_with_cache(text, cache, options);
     let root = parse.syntax();
     let diagnostics = parse.into_diagnostics();

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -112,9 +112,9 @@ impl ServiceLanguage for JsLanguage {
     }
 
     fn resolve_format_options(
-        global: &FormatSettings,
-        overrides: &OverrideSettings,
-        language: &JsFormatterSettings,
+        global: Option<&FormatSettings>,
+        overrides: Option<&OverrideSettings>,
+        language: Option<&JsFormatterSettings>,
         path: &BiomePath,
         document_file_source: &DocumentFileSource,
     ) -> JsFormatOptions {
@@ -126,81 +126,108 @@ impl ServiceLanguage for JsLanguage {
         )
         .with_indent_style(
             language
-                .indent_style
-                .or(global.indent_style)
+                .and_then(|l| l.indent_style)
+                .or(global.and_then(|g| g.indent_style))
                 .unwrap_or_default(),
         )
         .with_indent_width(
             language
-                .indent_width
-                .or(global.indent_width)
+                .and_then(|l| l.indent_width)
+                .or(global.and_then(|g| g.indent_width))
                 .unwrap_or_default(),
         )
         .with_line_width(
             language
-                .line_width
-                .or(global.line_width)
+                .and_then(|l| l.line_width)
+                .or(global.and_then(|g| g.line_width))
                 .unwrap_or_default(),
         )
         .with_line_ending(
             language
-                .line_ending
-                .or(global.line_ending)
+                .and_then(|l| l.line_ending)
+                .or(global.and_then(|g| g.line_ending))
                 .unwrap_or_default(),
         )
-        .with_quote_style(language.quote_style.unwrap_or_default())
-        .with_jsx_quote_style(language.jsx_quote_style.unwrap_or_default())
-        .with_quote_properties(language.quote_properties.unwrap_or_default())
-        .with_trailing_commas(language.trailing_commas.unwrap_or_default())
-        .with_semicolons(language.semicolons.unwrap_or_default())
-        .with_arrow_parentheses(language.arrow_parentheses.unwrap_or_default())
-        .with_bracket_spacing(language.bracket_spacing.unwrap_or_default())
-        .with_bracket_same_line(language.bracket_same_line.unwrap_or_default())
+        .with_quote_style(language.and_then(|l| l.quote_style).unwrap_or_default())
+        .with_jsx_quote_style(language.and_then(|l| l.jsx_quote_style).unwrap_or_default())
+        .with_quote_properties(
+            language
+                .and_then(|l| l.quote_properties)
+                .unwrap_or_default(),
+        )
+        .with_trailing_commas(language.and_then(|l| l.trailing_commas).unwrap_or_default())
+        .with_semicolons(language.and_then(|l| l.semicolons).unwrap_or_default())
+        .with_arrow_parentheses(
+            language
+                .and_then(|l| l.arrow_parentheses)
+                .unwrap_or_default(),
+        )
+        .with_bracket_spacing(language.and_then(|l| l.bracket_spacing).unwrap_or_default())
+        .with_bracket_same_line(
+            language
+                .and_then(|l| l.bracket_same_line)
+                .unwrap_or_default(),
+        )
         .with_attribute_position(
             language
-                .attribute_position
-                .or(global.attribute_position)
+                .and_then(|l| l.attribute_position)
+                .or(global.and_then(|g| g.attribute_position))
                 .unwrap_or_default(),
         );
 
-        overrides.override_js_format_options(path, options)
+        if let Some(overrides) = overrides {
+            overrides.override_js_format_options(path, options)
+        } else {
+            options
+        }
     }
 
     fn resolve_analyzer_options(
-        global: &Settings,
-        _linter: &LinterSettings,
-        overrides: &OverrideSettings,
-        _language: &Self::LinterSettings,
+        global: Option<&Settings>,
+        _linter: Option<&LinterSettings>,
+        overrides: Option<&OverrideSettings>,
+        _language: Option<&Self::LinterSettings>,
         path: &BiomePath,
         _file_source: &DocumentFileSource,
     ) -> AnalyzerOptions {
-        let preferred_quote = global
-            .languages
-            .javascript
-            .formatter
-            .quote_style
-            .map(|quote_style: QuoteStyle| {
-                if quote_style == QuoteStyle::Single {
-                    PreferredQuote::Single
-                } else {
-                    PreferredQuote::Double
-                }
-            })
-            .unwrap_or_default();
+        let preferred_quote =
+            global
+                .and_then(|global| {
+                    global.languages.javascript.formatter.quote_style.map(
+                        |quote_style: QuoteStyle| {
+                            if quote_style == QuoteStyle::Single {
+                                PreferredQuote::Single
+                            } else {
+                                PreferredQuote::Double
+                            }
+                        },
+                    )
+                })
+                .unwrap_or_default();
 
-        let jsx_runtime = match overrides
-            .override_jsx_runtime(path, global.languages.javascript.environment.jsx_runtime)
-        {
-            // In the future, we may wish to map an `Auto` variant to a concrete
-            // analyzer value for easy access by the analyzer.
-            JsxRuntime::Transparent => biome_analyze::options::JsxRuntime::Transparent,
-            JsxRuntime::ReactClassic => biome_analyze::options::JsxRuntime::ReactClassic,
-        };
+        let mut jsx_runtime = None;
+        let mut globals = vec![];
 
-        let mut globals: Vec<_> = overrides
-            .override_js_globals(path, &global.languages.javascript.globals)
-            .into_iter()
-            .collect();
+        if let (Some(overrides), Some(global)) = (overrides, global) {
+            jsx_runtime = Some(
+                match overrides
+                    .override_jsx_runtime(path, global.languages.javascript.environment.jsx_runtime)
+                {
+                    // In the future, we may wish to map an `Auto` variant to a concrete
+                    // analyzer value for easy access by the analyzer.
+                    JsxRuntime::Transparent => biome_analyze::options::JsxRuntime::Transparent,
+                    JsxRuntime::ReactClassic => biome_analyze::options::JsxRuntime::ReactClassic,
+                },
+            );
+
+            globals.extend(
+                overrides
+                    .override_js_globals(path, &global.languages.javascript.globals)
+                    .into_iter()
+                    .collect::<Vec<_>>(),
+            );
+        }
+
 
         match path.extension().and_then(OsStr::to_str) {
             Some("vue") => {
@@ -223,10 +250,12 @@ impl ServiceLanguage for JsLanguage {
         };
 
         let configuration = AnalyzerConfiguration {
-            rules: to_analyzer_rules(global, path),
+            rules: global
+                .map(|g| to_analyzer_rules(g, path.as_path()))
+                .unwrap_or_default(),
             globals,
             preferred_quote,
-            jsx_runtime: Some(jsx_runtime),
+            jsx_runtime,
         };
 
         AnalyzerOptions {
@@ -268,17 +297,26 @@ fn parse(
     biome_path: &BiomePath,
     file_source: DocumentFileSource,
     text: &str,
-    settings: WorkspaceSettingsHandle,
+    settings: Option<&Settings>,
     cache: &mut NodeCache,
 ) -> ParseResult {
-    let parser_settings = &settings.settings().languages.javascript.parser;
-    let overrides = &settings.settings().override_settings;
-    let options = overrides.to_override_js_parser_options(
-        biome_path,
-        JsParserOptions {
-            parse_class_parameter_decorators: parser_settings.parse_class_parameter_decorators,
-        },
-    );
+    let mut options = JsParserOptions {
+        parse_class_parameter_decorators: settings
+            .map(|settings| {
+                settings
+                    .languages
+                    .javascript
+                    .parser
+                    .parse_class_parameter_decorators
+            })
+            .unwrap_or_default(),
+    };
+    if let Some(settings) = settings {
+        options = settings
+            .override_settings
+            .to_override_js_parser_options(biome_path, options);
+    }
+
     let file_source = file_source.to_js_file_source().unwrap_or_default();
     let parse = biome_js_parser::parse_js_with_cache(text, file_source, options, cache);
     let root = parse.syntax();
@@ -364,7 +402,6 @@ fn debug_formatter_ir(
 pub(crate) fn lint(params: LintParams) -> LintResults {
     debug_span!("Linting JavaScript file", path =? params.path, language =? params.language)
         .in_scope(move || {
-            let settings = params.settings.settings();
             let Some(file_source) = params
                 .language
                 .to_js_file_source()
@@ -379,11 +416,16 @@ pub(crate) fn lint(params: LintParams) -> LintResults {
             let tree = params.parse.tree();
             let mut diagnostics = params.parse.into_diagnostics();
             let analyzer_options = &params
-                .settings
+                .workspace
                 .analyzer_options::<JsLanguage>(params.path, &params.language);
 
+            let mut rules = None;
+            let mut organize_imports_enabled = true;
+            if let Some(settings) = params.workspace.settings() {
+                rules = settings.as_rules(params.path.as_path());
+                organize_imports_enabled = settings.organize_imports.enabled;
+            }
             // Compute final rules (taking `overrides` into account)
-            let rules = settings.as_rules(params.path.as_path());
 
             let has_only_filter = !params.only.is_empty();
             let enabled_rules = if has_only_filter {
@@ -399,7 +441,7 @@ pub(crate) fn lint(params: LintParams) -> LintResults {
                     .unwrap_or_default()
                     .into_iter()
                     .collect::<Vec<_>>();
-                if settings.organize_imports.enabled && !params.categories.is_syntax() {
+                if organize_imports_enabled && !params.categories.is_syntax() {
                     rule_filter_list.push(RuleFilter::Rule("correctness", "organizeImports"));
                 }
                 rule_filter_list.push(RuleFilter::Rule(
@@ -541,13 +583,13 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         path,
         manifest,
         language,
+        settings,
     } = params;
     debug_span!("Code actions JavaScript", range =? range, path =? path).in_scope(move || {
         let tree = parse.tree();
         trace_span!("Parsed file", tree =? tree).in_scope(move || {
             let analyzer_options =
                 workspace.analyzer_options::<JsLanguage>(params.path, &params.language);
-            let settings = workspace.settings();
             let rules = settings.as_rules(params.path);
             let mut actions = Vec::new();
             let mut enabled_rules = vec![];
@@ -615,15 +657,36 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
 pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
     let FixAllParams {
         parse,
-        rules,
+        // rules,
         fix_file_mode,
-        settings,
         should_format,
         biome_path,
-        mut filter,
+        // mut filter,
         manifest,
         document_file_source,
+        workspace,
     } = params;
+
+    let settings = workspace.settings();
+    let Some(settings) = settings else {
+        let tree: AnyJsRoot = parse.tree();
+
+        return Ok(FixFileResult {
+            actions: vec![],
+            errors: 0,
+            skipped_suggested_fixes: 0,
+            code: tree.syntax().to_string(),
+        });
+    };
+    // Compute final rules (taking `overrides` into account)
+    let rules = settings.as_rules(params.biome_path.as_path());
+    let rule_filter_list = rules
+        .as_ref()
+        .map(|rules| rules.as_enabled_rules())
+        .unwrap_or_default()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let mut filter = AnalysisFilter::from_enabled_rules(rule_filter_list.as_slice());
 
     let Some(file_source) = document_file_source
         .to_js_file_source()
@@ -639,7 +702,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
     let mut skipped_suggested_fixes = 0;
     let mut errors: u16 = 0;
     let analyzer_options =
-        settings.analyzer_options::<JsLanguage>(biome_path, &document_file_source);
+        workspace.analyzer_options::<JsLanguage>(biome_path, &document_file_source);
     loop {
         let (action, _) = analyze(
             &tree,
@@ -651,7 +714,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
                 let current_diagnostic = signal.diagnostic();
 
                 if let Some(diagnostic) = current_diagnostic.as_ref() {
-                    if is_diagnostic_error(diagnostic, rules) {
+                    if is_diagnostic_error(diagnostic, rules.as_deref()) {
                         errors += 1;
                     }
                 }
@@ -716,7 +779,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
             None => {
                 let code = if should_format {
                     format_node(
-                        settings.format_options::<JsLanguage>(biome_path, &document_file_source),
+                        workspace.format_options::<JsLanguage>(biome_path, &document_file_source),
                         tree.syntax(),
                     )?
                     .print()?

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -70,33 +70,29 @@ impl ServiceLanguage for JsonLanguage {
     }
 
     fn resolve_format_options(
-        global: &FormatSettings,
-        overrides: &OverrideSettings,
-        language: &JsonFormatterSettings,
+        global: Option<&FormatSettings>,
+        overrides: Option<&OverrideSettings>,
+        language: Option<&JsonFormatterSettings>,
         path: &BiomePath,
         _document_file_source: &DocumentFileSource,
     ) -> Self::FormatOptions {
-        let indent_style = if let Some(indent_style) = language.indent_style {
-            indent_style
-        } else {
-            global.indent_style.unwrap_or_default()
-        };
-        let line_width = if let Some(line_width) = language.line_width {
-            line_width
-        } else {
-            global.line_width.unwrap_or_default()
-        };
-        let indent_width = if let Some(indent_width) = language.indent_width {
-            indent_width
-        } else {
-            global.indent_width.unwrap_or_default()
-        };
+        let indent_style = language
+            .and_then(|l| l.indent_style)
+            .or(global.and_then(|g| g.indent_style))
+            .unwrap_or_default();
+        let line_width = language
+            .and_then(|l| l.line_width)
+            .or(global.and_then(|g| g.line_width))
+            .unwrap_or_default();
+        let indent_width = language
+            .and_then(|l| l.indent_width)
+            .or(global.and_then(|g| g.indent_width))
+            .unwrap_or_default();
 
-        let line_ending = if let Some(line_ending) = language.line_ending {
-            line_ending
-        } else {
-            global.line_ending.unwrap_or_default()
-        };
+        let line_ending = language
+            .and_then(|l| l.line_ending)
+            .or(global.and_then(|g| g.line_ending))
+            .unwrap_or_default();
 
         // ensure it never formats biome.json into a form it can't parse
         let trailing_commas =
@@ -106,27 +102,32 @@ impl ServiceLanguage for JsonLanguage {
                 language.trailing_commas.unwrap_or_default()
             };
 
-        overrides.to_override_json_format_options(
-            path,
-            JsonFormatOptions::new()
-                .with_line_ending(line_ending)
-                .with_indent_style(indent_style)
-                .with_indent_width(indent_width)
-                .with_line_width(line_width)
-                .with_trailing_commas(trailing_commas),
-        )
+        let options = JsonFormatOptions::new()
+            .with_line_ending(line_ending)
+            .with_indent_style(indent_style)
+            .with_indent_width(indent_width)
+            .with_line_width(line_width)
+            .with_trailing_commas(trailing_commas);
+
+        if let Some(overrides) = overrides {
+            overrides.to_override_json_format_options(path, options)
+        } else {
+            options
+        }
     }
 
     fn resolve_analyzer_options(
-        global: &Settings,
-        _linter: &LinterSettings,
-        _overrides: &OverrideSettings,
-        _language: &Self::LinterSettings,
+        global: Option<&Settings>,
+        _linter: Option<&LinterSettings>,
+        _overrides: Option<&OverrideSettings>,
+        _language: Option<&Self::LinterSettings>,
         path: &BiomePath,
         _file_source: &DocumentFileSource,
     ) -> AnalyzerOptions {
         let configuration = AnalyzerConfiguration {
-            rules: to_analyzer_rules(global, path.as_path()),
+            rules: global
+                .map(|g| to_analyzer_rules(g, path.as_path()))
+                .unwrap_or_default(),
             globals: vec![],
             preferred_quote: PreferredQuote::Double,
             jsx_runtime: Default::default(),
@@ -170,21 +171,23 @@ fn parse(
     biome_path: &BiomePath,
     file_source: DocumentFileSource,
     text: &str,
-    settings: WorkspaceSettingsHandle,
+    settings: Option<&Settings>,
     cache: &mut NodeCache,
 ) -> ParseResult {
-    let parser = &settings.settings().languages.json.parser;
-    let overrides = &settings.settings().override_settings;
+    let parser = settings.map(|s| &s.languages.json.parser);
+    let overrides = settings.map(|s| &s.override_settings);
     let optional_json_file_source = file_source.to_json_file_source();
-    let options: JsonParserOptions = overrides.to_override_json_parser_options(
-        biome_path,
-        JsonParserOptions {
-            allow_comments: parser.allow_comments
-                || optional_json_file_source.map_or(false, |x| x.allow_comments()),
-            allow_trailing_commas: parser.allow_trailing_commas
-                || optional_json_file_source.map_or(false, |x| x.allow_trailing_commas()),
-        },
-    );
+    let options = JsonParserOptions {
+        allow_comments: parser.map(|p| p.allow_comments).unwrap_or_default()
+            || optional_json_file_source.map_or(false, |x| x.allow_comments()),
+        allow_trailing_commas: parser.map(|p| p.allow_trailing_commas).unwrap_or_default()
+            || optional_json_file_source.map_or(false, |x| x.allow_trailing_commas()),
+    };
+    let options = if let Some(overrides) = overrides {
+        overrides.to_override_json_parser_options(biome_path, options)
+    } else {
+        options
+    };
     let parse = biome_json_parser::parse_json_with_cache(text, cache, options);
     let root = parse.syntax();
     let diagnostics = parse.into_diagnostics();
@@ -299,7 +302,6 @@ fn lint(params: LintParams) -> LintResults {
         .in_scope(move || {
             let root: JsonRoot = params.parse.tree();
             let mut diagnostics = params.parse.into_diagnostics();
-            let settings = params.settings.settings();
 
             // if we're parsing the `biome.json` file, we deserialize it, so we can emit diagnostics for
             // malformed configuration
@@ -318,10 +320,13 @@ fn lint(params: LintParams) -> LintResults {
             }
 
             let analyzer_options = &params
-                .settings
+                .workspace
                 .analyzer_options::<JsonLanguage>(params.path, &params.language);
 
-            let rules = settings.as_rules(params.path.as_path());
+            let mut rules = None;
+            if let Some(settings) = params.workspace.settings() {
+                rules = settings.as_rules(params.path.as_path());
+            }
 
             let has_only_filter = !params.only.is_empty();
             let enabled_rules = if has_only_filter {

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -99,7 +99,7 @@ impl ServiceLanguage for JsonLanguage {
             if matches!(path.file_name().and_then(OsStr::to_str), Some("biome.json")) {
                 TrailingCommas::None
             } else {
-                language.trailing_commas.unwrap_or_default()
+                language.and_then(|l| l.trailing_commas).unwrap_or_default()
             };
 
         let options = JsonFormatOptions::new()

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -5,13 +5,14 @@ use self::{
 pub use crate::file_handlers::astro::{AstroFileHandler, ASTRO_FENCE};
 pub use crate::file_handlers::svelte::{SvelteFileHandler, SVELTE_FENCE};
 pub use crate::file_handlers::vue::{VueFileHandler, VUE_FENCE};
+use crate::settings::Settings;
 use crate::workspace::{FixFileMode, OrganizeImportsResult};
 use crate::{
     settings::WorkspaceSettingsHandle,
     workspace::{FixFileResult, GetSyntaxTreeResult, PullActionsResult, RenameResult},
     WorkspaceError,
 };
-use biome_analyze::{AnalysisFilter, AnalyzerDiagnostic, RuleCategories};
+use biome_analyze::{AnalyzerDiagnostic, RuleCategories};
 use biome_configuration::linter::RuleSelector;
 use biome_configuration::Rules;
 use biome_console::fmt::Formatter;
@@ -301,10 +302,10 @@ impl biome_console::fmt::Display for DocumentFileSource {
 
 pub struct FixAllParams<'a> {
     pub(crate) parse: AnyParse,
-    pub(crate) rules: Option<&'a Rules>,
-    pub(crate) filter: AnalysisFilter<'a>,
+    // pub(crate) rules: Option<&'a Rules>,
+    // pub(crate) filter: AnalysisFilter<'a>,
     pub(crate) fix_file_mode: FixFileMode,
-    pub(crate) settings: WorkspaceSettingsHandle<'a>,
+    pub(crate) workspace: WorkspaceSettingsHandle<'a>,
     /// Whether it should format the code action
     pub(crate) should_format: bool,
     pub(crate) biome_path: &'a BiomePath,
@@ -327,13 +328,8 @@ pub struct ParseResult {
     pub(crate) language: Option<DocumentFileSource>,
 }
 
-type Parse = fn(
-    &BiomePath,
-    DocumentFileSource,
-    &str,
-    WorkspaceSettingsHandle,
-    &mut NodeCache,
-) -> ParseResult;
+type Parse =
+    fn(&BiomePath, DocumentFileSource, &str, Option<&Settings>, &mut NodeCache) -> ParseResult;
 
 #[derive(Default)]
 pub struct ParserCapabilities {
@@ -362,7 +358,7 @@ pub struct DebugCapabilities {
 
 pub(crate) struct LintParams<'a> {
     pub(crate) parse: AnyParse,
-    pub(crate) settings: WorkspaceSettingsHandle<'a>,
+    pub(crate) workspace: &'a WorkspaceSettingsHandle<'a>,
     pub(crate) language: DocumentFileSource,
     pub(crate) max_diagnostics: u32,
     pub(crate) path: &'a BiomePath,
@@ -381,10 +377,11 @@ pub(crate) struct LintResults {
 pub(crate) struct CodeActionsParams<'a> {
     pub(crate) parse: AnyParse,
     pub(crate) range: TextRange,
-    pub(crate) workspace: WorkspaceSettingsHandle<'a>,
+    pub(crate) workspace: &'a WorkspaceSettingsHandle<'a>,
     pub(crate) path: &'a BiomePath,
     pub(crate) manifest: Option<PackageJson>,
     pub(crate) language: DocumentFileSource,
+    pub(crate) settings: &'a Settings,
 }
 
 type Lint = fn(LintParams) -> LintResults;

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -3,7 +3,7 @@ use crate::file_handlers::{
     ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults, ParseResult,
     ParserCapabilities,
 };
-use crate::settings::WorkspaceSettingsHandle;
+use crate::settings::{Settings, WorkspaceSettingsHandle};
 use crate::workspace::{
     DocumentFileSource, FixFileResult, OrganizeImportsResult, PullActionsResult,
 };
@@ -114,7 +114,7 @@ fn parse(
     _rome_path: &BiomePath,
     _file_source: DocumentFileSource,
     text: &str,
-    _settings: WorkspaceSettingsHandle,
+    _settings: Option<&Settings>,
     cache: &mut NodeCache,
 ) -> ParseResult {
     let script = SvelteFileHandler::input(text);

--- a/crates/biome_service/src/file_handlers/vue.rs
+++ b/crates/biome_service/src/file_handlers/vue.rs
@@ -3,7 +3,7 @@ use crate::file_handlers::{
     ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults, ParseResult,
     ParserCapabilities,
 };
-use crate::settings::WorkspaceSettingsHandle;
+use crate::settings::{Settings, WorkspaceSettingsHandle};
 use crate::workspace::{
     DocumentFileSource, FixFileResult, OrganizeImportsResult, PullActionsResult,
 };
@@ -114,7 +114,7 @@ fn parse(
     _rome_path: &BiomePath,
     _file_source: DocumentFileSource,
     text: &str,
-    _settings: WorkspaceSettingsHandle,
+    _settings: Option<&Settings>,
     cache: &mut NodeCache,
 ) -> ParseResult {
     let script = VueFileHandler::input(text);

--- a/package.json
+++ b/package.json
@@ -1,17 +1,14 @@
 {
-	"name": "@biomejs/monorepo",
-	"version": "0.0.0",
-	"private": true,
-	"scripts": {
-		"check:apply": "cargo biome-cli-dev check --apply-unsafe .",
-		"check": "cargo biome-cli-dev check .",
-		"ci": "cargo biome-cli-dev ci ."
-	},
-	"keywords": [],
-	"author": "Biome Developers and Contributors",
-	"license": "MIT OR Apache-2.0",
-	"devDependencies": {
-		"@biomejs/shared": "workspace:^"
-	},
-	"packageManager": "pnpm@8.15.8"
+  "name": "@biomejs/monorepo",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "check:apply": "cargo biome-cli-dev check --apply-unsafe .",
+    "check": "cargo biome-cli-dev check .",
+    "ci": "cargo biome-cli-dev ci ."
+  },
+  "keywords": [],
+  "author": "Biome Developers and Contributors",
+  "license": "MIT OR Apache-2.0",
+  "packageManager": "pnpm@8.15.8"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,7 @@ settings:
 
 importers:
 
-  .:
-    devDependencies:
-      '@biomejs/shared':
-        specifier: workspace:^
-        version: link:shared
+  .: {}
 
   packages/@biomejs/backend-jsonrpc:
     optionalDependencies:
@@ -137,8 +133,6 @@ importers:
       typescript:
         specifier: 5.4.5
         version: 5.4.5
-
-  shared: {}
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
 packages:
   - "packages/**"
-  - "shared"

--- a/shared/biome.json
+++ b/shared/biome.json
@@ -1,24 +1,2 @@
 {
-  "$schema": "../packages/@biomejs/biome/configuration_schema.json",
-  "vcs": {
-    "clientKind": "git",
-    "enabled": true,
-    "useIgnoreFile": true
-  },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true,
-      "style": {
-        "noNonNullAssertion": "off"
-      }
-    }
-  },
-  "organizeImports": {
-    "enabled": true
-  },
-  "files": {
-    "ignore": ["packages/@biomejs/wasm-*"],
-    "include": ["packages/@biomejs/**", "packages/tailwindcss-config-analyzer"]
-  }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/2976

This PR is an overhaul of our LSP's user experience. I baked this PR while flying 😛 

The fundamental issue we were having was the assumption that we always have valid **settings** - and when I say settings, I mean the ones that we store inside the `WorkspaceServer`. The settings come from different sources and clients: CLI, biome.json, LSP settings, etc. However, this was an incorrect assumption because sometimes the configuration can contain errors, hence we can't push settings into the `WorkspaceSettings`; we could push the default settings, but this is a mistake because otherwise Biome will format/lint with incorrect settings.

On the other hand, having defaults can come handy in some instances.

In this PR I applied the following changes:
- `&Settings` -> `Option<&Settings>` inside the `WorkspaceServer`. This has many repercussions on the code, but it was mostly grunt work thanks to the type system.
- Parsing always works now, even when there's a broken configuration. If the configuration is broken, the parsing uses the default settings.
- The rest of the operations (lint rules, code actions, formatting, etc.) stop working if the `Settings` are absent. The diagnostics pulled by the analyzer are only syntax (parsing and syntax rules)
- The LSP sends a warning if the configuration is broken, and the user tries to format/apply a code action.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Tested locally

 https://imgur.com/a/cva1qzA

<!-- What demonstrates that your implementation is correct? -->
