### PR TITLE
fix(biome_service): add Astro object to globals for .astro files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Enhancements
 
-- Assume `Astro` object is always a global when processing `.astro` files. ([#2771](https://github.com/biomejs/biome/pull/2771)) Contributed by @minht11
+- Assume `Astro` object is always a global when processing `.astro` files. Contributed by @minht11
 - Assume Vue compiler macros are globals when processing `.vue` files. ([#2771](https://github.com/biomejs/biome/pull/2771)) Contributed by @dyc3
 
 ### CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Enhancements
 
+- Assume `Astro` object is always a global when processing `.astro` files. ([#2771](https://github.com/biomejs/biome/pull/2771)) Contributed by @minht11
 - Assume Vue compiler macros are globals when processing `.vue` files. ([#2771](https://github.com/biomejs/biome/pull/2771)) Contributed by @dyc3
 
 ### CLI

--- a/crates/biome_cli/tests/cases/handle_astro_files.rs
+++ b/crates/biome_cli/tests/cases/handle_astro_files.rs
@@ -92,6 +92,11 @@ const foo = "";
 ---
 <div></div>"#;
 
+const ASTRO_FILE_ASTRO_GLOBAL_OBJECT: &str = r#"---
+const { some } = Astro.props
+---
+<div>{some}</div>"#;
+
 #[test]
 fn format_astro_files() {
     let mut fs = MemoryFileSystem::default();
@@ -680,6 +685,35 @@ fn check_stdin_write_unsafe_successfully() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "check_stdin_write_unsafe_successfully",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn astro_global_object() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let astro_file_path = Path::new("file.astro");
+    fs.insert(astro_file_path.into(), ASTRO_FILE_ASTRO_GLOBAL_OBJECT.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("lint"), astro_file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    dbg!("YEAH", &result);
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, astro_file_path, ASTRO_FILE_ASTRO_GLOBAL_OBJECT);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "astro_global",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/cases/handle_astro_files.rs
+++ b/crates/biome_cli/tests/cases/handle_astro_files.rs
@@ -697,7 +697,10 @@ fn astro_global_object() {
     let mut console = BufferConsole::default();
 
     let astro_file_path = Path::new("file.astro");
-    fs.insert(astro_file_path.into(), ASTRO_FILE_ASTRO_GLOBAL_OBJECT.as_bytes());
+    fs.insert(
+        astro_file_path.into(),
+        ASTRO_FILE_ASTRO_GLOBAL_OBJECT.as_bytes(),
+    );
 
     let result = run_cli(
         DynRef::Borrowed(&mut fs),

--- a/crates/biome_cli/tests/cases/handle_astro_files.rs
+++ b/crates/biome_cli/tests/cases/handle_astro_files.rs
@@ -708,8 +708,6 @@ fn astro_global_object() {
         Args::from([("lint"), astro_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
-    dbg!("YEAH", &result);
-
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
     assert_file_contents(&fs, astro_file_path, ASTRO_FILE_ASTRO_GLOBAL_OBJECT);

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/astro_global.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/astro_global.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.astro`
+
+```astro
+---
+const { some } = Astro.props
+---
+<div>{some}</div>
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+```

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -201,19 +201,26 @@ impl ServiceLanguage for JsLanguage {
             .override_js_globals(path, &global.languages.javascript.globals)
             .into_iter()
             .collect();
-        if path.extension().and_then(OsStr::to_str) == Some("vue") {
-            globals.extend(
-                [
-                    "defineEmits",
-                    "defineProps",
-                    "defineExpose",
-                    "defineModel",
-                    "defineOptions",
-                    "defineSlots",
-                ]
-                .map(ToOwned::to_owned),
-            );
-        }
+
+        match path.extension().and_then(OsStr::to_str) {
+            Some("vue") => {
+                globals.extend(
+                    [
+                        "defineEmits",
+                        "defineProps",
+                        "defineExpose",
+                        "defineModel",
+                        "defineOptions",
+                        "defineSlots",
+                    ]
+                    .map(ToOwned::to_owned),
+                );
+            }
+            Some("astro") => {
+                globals.extend(["Astro"].map(ToOwned::to_owned));
+            }
+            _ => {}
+        };
 
         let configuration = AnalyzerConfiguration {
             rules: to_analyzer_rules(global, path),


### PR DESCRIPTION
## Summary

The same idea as https://github.com/biomejs/biome/pull/2823
Add `Astro` object to globals list, so users don't have to.

## Test Plan
Added test and snapshot.
