### PR TITLE
fix(formatter): never format biome.json with trailing commas

### DIFF
--- a/crates/biome_cli/tests/cases/biome_json_support.rs
+++ b/crates/biome_cli/tests/cases/biome_json_support.rs
@@ -253,3 +253,41 @@ fn biome_json_is_not_ignored() {
         result,
     ));
 }
+
+#[test]
+fn always_disable_trailing_commas_biome_json() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("biome.json");
+    let config = r#"{
+    "formatter": {
+        "indentStyle": "space",
+        "indentWidth": 4
+    },
+    "json": {
+        "formatter": {
+            "trailingCommas": "all"
+        }
+    }
+}
+"#;
+    fs.insert(file_path.into(), config);
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(["check", "--write", "."].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, file_path, config);
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "always_disable_trailing_commas_biome_json",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_biome_json_support/always_disable_trailing_commas_biome_json.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_biome_json_support/always_disable_trailing_commas_biome_json.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 4
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "all"
+    }
+  }
+}
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+```

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsStr;
+
 use super::{CodeActionsParams, DocumentFileSource, ExtensionHandler, ParseResult};
 use crate::configuration::to_analyzer_rules;
 use crate::file_handlers::DebugCapabilities;
@@ -96,6 +98,14 @@ impl ServiceLanguage for JsonLanguage {
             global.line_ending.unwrap_or_default()
         };
 
+        // ensure it never formats biome.json into a form it can't parse
+        let trailing_commas =
+            if matches!(path.file_name().and_then(OsStr::to_str), Some("biome.json")) {
+                TrailingCommas::None
+            } else {
+                language.trailing_commas.unwrap_or_default()
+            };
+
         overrides.to_override_json_format_options(
             path,
             JsonFormatOptions::new()
@@ -103,7 +113,7 @@ impl ServiceLanguage for JsonLanguage {
                 .with_indent_style(indent_style)
                 .with_indent_width(indent_width)
                 .with_line_width(line_width)
-                .with_trailing_commas(language.trailing_commas.unwrap_or_default()),
+                .with_trailing_commas(trailing_commas),
         )
     }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This ensures that trailing commas is always disabled when formatting `biome.json` or `biome.jsonc`. Failing to do so could result in biome formatting it's own configuration such that it's no longer valid json, and would not get parsed. The full context is in #2990.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #2990


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
I added a cli test for this scenario.
```bash
cargo test -p biome_cli always_disable_trailing_commas_biome_json
```
