### PR TITLE
feat: allow `"info"` severity for analyzer rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,20 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Add option `json.linter.enabled` to control the linter for JSON (and its super languages) files. Contributed by @ematipico
 - Add option `css.linter.enabled` to control the linter for CSS (and its super languages) files. Contributed by @ematipico
 - Add option `css.formatter`, to control the formatter options for CSS (and its super languages) files. Contributed by @ematipico
+- You can now change the severity of lint rules down to `"info"`. The `"info"` severity doesn't emit error codes, and it isn't affected by other options like `--error-on-warnings`:
+
+  ```json
+  {
+    "linter": {
+      "rules": {
+        "suspicious": {
+          "noDebugger": "info"
+        }
+      }
+    }
+  }
+  ```
+  Contributed by @ematipico
 
 #### Enhancements
 
@@ -301,7 +315,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   The rule now places inline comments after the declaration statement, instead of removing them.
   The code action is now safe to apply.
-  
+
   Contributed by @lutaok
 
 

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -11,7 +11,8 @@ use std::path::{Path, PathBuf};
 use crate::configs::{
     CONFIG_FILE_SIZE_LIMIT, CONFIG_IGNORE_SYMLINK, CONFIG_LINTER_AND_FILES_IGNORE,
     CONFIG_LINTER_DISABLED, CONFIG_LINTER_DISABLED_JSONC, CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC,
-    CONFIG_LINTER_IGNORED_FILES, CONFIG_LINTER_SUPPRESSED_GROUP, CONFIG_LINTER_SUPPRESSED_RULE,
+    CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC_INFO, CONFIG_LINTER_IGNORED_FILES,
+    CONFIG_LINTER_SUPPRESSED_GROUP, CONFIG_LINTER_SUPPRESSED_RULE,
     CONFIG_LINTER_UPGRADE_DIAGNOSTIC, CONFIG_RECOMMENDED_GROUP,
 };
 use crate::snap_test::{assert_file_contents, markup_to_string, SnapshotPayload};
@@ -622,6 +623,57 @@ fn downgrade_severity() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "downgrade_severity",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn downgrade_severity_info() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+    let file_path = Path::new("biome.json");
+    fs.insert(
+        file_path.into(),
+        CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC_INFO.as_bytes(),
+    );
+
+    let file_path = Path::new("file.js");
+    fs.insert(file_path.into(), NO_DEBUGGER.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("lint"),
+                "--error-on-warnings",
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    let messages = &console.out_buffer;
+
+    assert_eq!(
+        messages
+            .iter()
+            .filter(|m| m.level == LogLevel::Error)
+            .filter(|m| {
+                let content = format!("{:#?}", m.content);
+                content.contains("suspicious/noDebugger")
+            })
+            .count(),
+        1
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "downgrade_severity_info",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/configs.rs
+++ b/crates/biome_cli/tests/configs.rs
@@ -175,6 +175,17 @@ pub const CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC: &str = r#"{
   }
 }"#;
 
+pub const CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC_INFO: &str = r#"{
+  "linter": {
+    "rules": {
+        "recommended": true,
+        "suspicious": {
+            "noDebugger": "info"
+        }
+    }
+  }
+}"#;
+
 pub const CONFIG_LINTER_UPGRADE_DIAGNOSTIC: &str = r#"{
   "linter": {
     "rules": {

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/downgrade_severity_info.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/downgrade_severity_info.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noDebugger": "info"
+      }
+    }
+  }
+}
+```
+
+## `file.js`
+
+```js
+debugger;
+```
+
+# Emitted Messages
+
+```block
+file.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This is an unexpected use of the debugger statement.
+  
+  > 1 │ debugger;
+      │ ^^^^^^^^^
+  
+  i Unsafe fix: Remove debugger statement
+  
+    1 │ debugger;
+      │ ---------
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+```

--- a/crates/biome_configuration/src/linter/mod.rs
+++ b/crates/biome_configuration/src/linter/mod.rs
@@ -239,7 +239,10 @@ impl From<RulePlainConfiguration> for Severity {
         match conf {
             RulePlainConfiguration::Warn => Severity::Warning,
             RulePlainConfiguration::Error => Severity::Error,
-            _ => unreachable!("the rule is turned off, it should not step in here"),
+            RulePlainConfiguration::Info => Severity::Information,
+            RulePlainConfiguration::Off => {
+                unreachable!("the rule is turned off, it should not step in here")
+            }
         }
     }
 }
@@ -251,6 +254,7 @@ pub enum RulePlainConfiguration {
     #[default]
     Warn,
     Error,
+    Info,
     Off,
 }
 

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1693,7 +1693,7 @@ export type RuleConfiguration_for_FilenamingConventionOptions =
 export type RuleFixConfiguration_for_NamingConventionOptions =
 	| RulePlainConfiguration
 	| RuleWithFixOptions_for_NamingConventionOptions;
-export type RulePlainConfiguration = "warn" | "error" | "off";
+export type RulePlainConfiguration = "warn" | "error" | "info" | "off";
 export interface RuleWithFixOptions_for_Null {
 	/**
 	 * The kind of the code actions emitted by the rule

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2213,7 +2213,7 @@
 		},
 		"RulePlainConfiguration": {
 			"type": "string",
-			"enum": ["warn", "error", "off"]
+			"enum": ["warn", "error", "info", "off"]
 		},
 		"RuleWithComplexityOptions": {
 			"type": "object",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Now, rules can be downgraded to `"info"` severity

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test case

<!-- What demonstrates that your implementation is correct? -->
