### PR TITLE
fix(js_formatter): correctly handle line terminators in JSX string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Fix [#2470](https://github.com/biomejs/biome/issues/2470) by avoid introducing linebreaks in single line string interpolations. Contributed by @ah-yu
 - Resolve deadlocks by narrowing the scope of locks. Contributed by @mechairoi
 - Fix [#2782](https://github.com/biomejs/biome/issues/2782) by computing the enabled rules by taking the override settings into consideration. Contributed by @ematipico
+- Fix [https://github.com/biomejs/biome/issues/2877] by correctly handling line terminators in JSX string. Contributed by @ah-yu
 
 ### JavaScript APIs
 

--- a/crates/biome_formatter/src/token/string.rs
+++ b/crates/biome_formatter/src/token/string.rs
@@ -140,8 +140,13 @@ pub fn normalize_string(
 ) -> Cow<str> {
     let alternate_quote = preferred_quote.other();
 
-    // A string should be manipulated only if its raw content contains backslash or quotes
-    if !raw_content.contains(['\\', preferred_quote.as_char(), alternate_quote.as_char()]) {
+    // A string should be manipulated only if its raw content contains backslash, quotes or line terminators
+    if !raw_content.contains([
+        '\\',
+        '\r',
+        preferred_quote.as_char(),
+        alternate_quote.as_char(),
+    ]) {
         return Cow::Borrowed(raw_content);
     }
 
@@ -262,5 +267,22 @@ pub fn normalize_string(
         } else {
             Cow::Owned(reduced_string)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_newline() {
+        assert_eq!(
+            normalize_string("a\nb", Quote::Double, true),
+            Cow::Borrowed("a\nb")
+        );
+        assert_eq!(
+            normalize_string("a\r\nb", Quote::Double, false),
+            Cow::Borrowed("a\nb")
+        );
     }
 }

--- a/crates/biome_js_formatter/tests/specs/jsx/multiline_jsx_string/multiline_jsx_string.jsx
+++ b/crates/biome_js_formatter/tests/specs/jsx/multiline_jsx_string/multiline_jsx_string.jsx
@@ -1,0 +1,2 @@
+<div className="px-1 px-2
+px-3"/>;

--- a/crates/biome_js_formatter/tests/specs/jsx/multiline_jsx_string/multiline_jsx_string.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/multiline_jsx_string/multiline_jsx_string.jsx.snap
@@ -1,0 +1,66 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: jsx/multiline_jsx_string/multiline_jsx_string.jsx
+---
+# Input
+
+```jsx
+<div className="px-1 px-2
+px-3"/>;
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+-----
+
+```jsx
+<div
+	className="px-1 px-2
+px-3"
+/>;
+```
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: CRLF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+-----
+
+```jsx
+<div<CRLF>
+	className="px-1 px-2<CRLF>
+px-3"<CRLF>
+/>;<CRLF>
+```

--- a/crates/biome_js_formatter/tests/specs/jsx/multiline_jsx_string/options.json
+++ b/crates/biome_js_formatter/tests/specs/jsx/multiline_jsx_string/options.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "formatter": {
+    "lineEnding": "crlf"
+  }
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/2877

We manage line terminators in two steps:

1. Normalize line terminators during the IR generation phase by replacing `\r\n` with `\n`.
2. Replace `\n` with different line terminators based on the `line_ending` option.

It appears that the normalizing step is skipped for JSX strings.
## Test Plan

Add new test cases
