### PR TITLE
feat(analyzer): suppress individual dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### New features
 
-- Allow passing values to suppression comments. This is used for the lint rule
-  `useExhaustiveDependencies`, which is now able to suppress specific
-  dependencies. Fixes #2509. Contributed by @arendjr
+- Allow suppression comments to suppress individual instances of rules. This is
+  used for the lint rule `useExhaustiveDependencies`, which is now able to
+  suppress specific dependencies. Fixes #2509. Contributed by @arendjr
 
 #### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Analyzer
 
+#### New features
+
+- Allow passing values to suppression comments. This is used for the lint rule
+  `useExhaustiveDependencies`, which is now able to suppress specific
+  dependencies. Fixes #2509. Contributed by @arendjr
+
 #### Enhancements
 
 - Assume `Astro` object is always a global when processing `.astro` files. Contributed by @minht11

--- a/crates/biome_analyze/src/matcher.rs
+++ b/crates/biome_analyze/src/matcher.rs
@@ -137,6 +137,8 @@ pub struct SignalEntry<'phase, L: Language> {
     pub signal: Box<dyn AnalyzerSignal<L> + 'phase>,
     /// Unique identifier for the rule that emitted this signal
     pub rule: RuleKey,
+    /// Optional rule-specific values being suppressed
+    pub values: Vec<String>,
     /// Text range in the document this signal covers
     pub text_range: TextRange,
 }
@@ -233,6 +235,7 @@ mod tests {
             params.signal_queue.push(SignalEntry {
                 signal: Box::new(DiagnosticSignal::new(move || TestDiagnostic { span })),
                 rule: RuleKey::new("group", "rule"),
+                values: Default::default(),
                 text_range: span,
             });
         }

--- a/crates/biome_analyze/src/matcher.rs
+++ b/crates/biome_analyze/src/matcher.rs
@@ -137,8 +137,8 @@ pub struct SignalEntry<'phase, L: Language> {
     pub signal: Box<dyn AnalyzerSignal<L> + 'phase>,
     /// Unique identifier for the rule that emitted this signal
     pub rule: RuleKey,
-    /// Optional rule-specific values being suppressed
-    pub values: Vec<String>,
+    /// Optional rule instances being suppressed
+    pub instances: Vec<String>,
     /// Text range in the document this signal covers
     pub text_range: TextRange,
 }
@@ -235,7 +235,7 @@ mod tests {
             params.signal_queue.push(SignalEntry {
                 signal: Box::new(DiagnosticSignal::new(move || TestDiagnostic { span })),
                 rule: RuleKey::new("group", "rule"),
-                values: Default::default(),
+                instances: Default::default(),
                 text_range: span,
             });
         }

--- a/crates/biome_analyze/src/registry.rs
+++ b/crates/biome_analyze/src/registry.rs
@@ -434,6 +434,7 @@ impl<L: Language + Default> RegistryRule<L> {
 
                 R::suppressed_nodes(&ctx, &result, &mut state.suppressions);
 
+                let values = R::values_for_signal(&result);
                 let signal = Box::new(RuleSignal::<R>::new(
                     params.root,
                     query_result.clone(),
@@ -446,6 +447,7 @@ impl<L: Language + Default> RegistryRule<L> {
                 params.signal_queue.push(SignalEntry {
                     signal,
                     rule: RuleKey::rule::<R>(),
+                    values,
                     text_range,
                 });
             }

--- a/crates/biome_analyze/src/registry.rs
+++ b/crates/biome_analyze/src/registry.rs
@@ -434,7 +434,7 @@ impl<L: Language + Default> RegistryRule<L> {
 
                 R::suppressed_nodes(&ctx, &result, &mut state.suppressions);
 
-                let values = R::values_for_signal(&result);
+                let instances = R::instances_for_signal(&result);
                 let signal = Box::new(RuleSignal::<R>::new(
                     params.root,
                     query_result.clone(),
@@ -447,7 +447,7 @@ impl<L: Language + Default> RegistryRule<L> {
                 params.signal_queue.push(SignalEntry {
                     signal,
                     rule: RuleKey::rule::<R>(),
-                    values,
+                    instances,
                     text_range,
                 });
             }

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -543,6 +543,14 @@ pub trait Rule: RuleMeta + Sized {
     /// `diagnostic` or `action` on it
     fn run(ctx: &RuleContext<Self>) -> Self::Signals;
 
+    /// Returns the value associated with the given signal.
+    ///
+    /// This allows suppression of specific values for a given rule, without
+    /// suppressing other values for the same rule.
+    fn values_for_signal(_signal: &Self::State) -> Vec<String> {
+        Vec::new()
+    }
+
     /// Used by the analyzer to associate a range of source text to a signal in
     /// order to support suppression comments.
     ///

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -543,11 +543,33 @@ pub trait Rule: RuleMeta + Sized {
     /// `diagnostic` or `action` on it
     fn run(ctx: &RuleContext<Self>) -> Self::Signals;
 
-    /// Returns the value associated with the given signal.
+    /// Returns the instances associated with the given signal.
     ///
-    /// This allows suppression of specific values for a given rule, without
-    /// suppressing other values for the same rule.
-    fn values_for_signal(_signal: &Self::State) -> Vec<String> {
+    /// This allows suppression of specific instances of a given rule, without
+    /// suppressing other instances of the same rule.
+    ///
+    /// ## Example
+    ///
+    /// Consider the situation where the following two variables are unused:
+    ///
+    /// ```js
+    /// let a, b;
+    /// ```
+    ///
+    /// The rule `noUnusedVariables` will report a diagnostic about it, which we
+    /// can suppress with `// biome-ignore lint/correctness/noUnusedVariables`.
+    ///
+    /// But what if we wanted to suppress the rule for `a`, but not for `b`?
+    ///
+    /// We would need to recognize there are actually two separate instances
+    /// that the rule is reporting on, identified as "a" and "b". This allows
+    /// the user to suppress a specific instance using
+    /// `// biome-ignore lint/correctness/noUnusedVariables(a)`.
+    ///
+    /// *Note: For `noUnusedVariables` the above may not seem very useful (and
+    /// indeed it's not implemented), but for rules such as
+    /// `useExhaustiveDependencies` this is actually desirable.*
+    fn instances_for_signal(_signal: &Self::State) -> Vec<String> {
         Vec::new()
     }
 

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -94,7 +94,11 @@ where
                 } else {
                     let category = key.name();
                     if let Some(rule) = category.strip_prefix("lint/") {
-                        result.push(Ok(SuppressionKind::Rule(rule)));
+                        if let Some(value) = value {
+                            result.push(Ok(SuppressionKind::RuleWithValue(rule, value)));
+                        } else {
+                            result.push(Ok(SuppressionKind::Rule(rule)));
+                        }
                     }
                 }
             }

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -94,8 +94,8 @@ where
                 } else {
                     let category = key.name();
                     if let Some(rule) = category.strip_prefix("lint/") {
-                        if let Some(value) = value {
-                            result.push(Ok(SuppressionKind::RuleWithValue(rule, value)));
+                        if let Some(instance) = value {
+                            result.push(Ok(SuppressionKind::RuleInstance(rule, instance)));
                         } else {
                             result.push(Ok(SuppressionKind::Rule(rule)));
                         }

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -142,7 +142,7 @@ declare_rule! {
     ///
     /// Sometimes you may wish to ignore a diagnostic about a specific
     /// dependency without disabling *all* linting for that hook. To do so,
-    /// you may specify the name of a specific dependency between brackets,
+    /// you may specify the name of a specific dependency between parentheses,
     /// like this:
     ///
     /// ```js
@@ -150,7 +150,7 @@ declare_rule! {
     ///
     /// function component() {
     ///     let a = 1;
-    ///     // biome-ignore lint/correctness/useExhaustiveDependencies(a): *insert good reason*
+    ///     // biome-ignore lint/correctness/useExhaustiveDependencies(a): <explanation>
     ///     useEffect(() => {
     ///         console.log(a);
     ///     }, []);
@@ -839,7 +839,7 @@ impl Rule for UseExhaustiveDependencies {
         signals
     }
 
-    fn values_for_signal(signal: &Self::State) -> Vec<String> {
+    fn instances_for_signal(signal: &Self::State) -> Vec<String> {
         match signal {
             Fix::AddDependency { captures, .. } => vec![captures.0.clone()],
             Fix::RemoveDependency { dependencies, .. } => dependencies

--- a/crates/biome_js_analyze/tests/quick_test.rs
+++ b/crates/biome_js_analyze/tests/quick_test.rs
@@ -1,0 +1,98 @@
+use biome_analyze::{AnalysisFilter, ControlFlow, Never, RuleFilter};
+use biome_diagnostics::advice::CodeSuggestionAdvice;
+use biome_diagnostics::{DiagnosticExt, Severity};
+use biome_js_parser::{parse, JsParserOptions};
+use biome_js_syntax::JsFileSource;
+use biome_test_utils::{
+    code_fix_to_string, create_analyzer_options, diagnostic_to_string, load_manifest,
+    parse_test_path, scripts_from_json,
+};
+use std::{ffi::OsStr, fs::read_to_string, path::Path, slice};
+
+// use this test check if your snippet produces the diagnostics you wish, without using a snapshot
+#[ignore]
+#[test]
+fn run_test() {
+    let input_file =
+        Path::new("tests/specs/correctness/useExhaustiveDependencies/ignoredDependencies.js");
+    let file_name = input_file.file_name().and_then(OsStr::to_str).unwrap();
+
+    let (group, rule) = parse_test_path(input_file);
+    if rule == "specs" || rule == "suppression" {
+        panic!("the test file must be placed in the {rule}/<group-name>/<rule-name>/ directory");
+    }
+    if group == "specs" || group == "suppression" {
+        panic!("the test file must be placed in the {group}/{rule}/<rule-name>/ directory");
+    }
+    if biome_js_analyze::metadata()
+        .find_rule(group, rule)
+        .is_none()
+    {
+        panic!("could not find rule {group}/{rule}");
+    }
+
+    let rule_filter = RuleFilter::Rule(group, rule);
+    let filter = AnalysisFilter {
+        enabled_rules: Some(slice::from_ref(&rule_filter)),
+        ..AnalysisFilter::default()
+    };
+
+    let extension = input_file.extension().unwrap_or_default();
+
+    let input_code = read_to_string(input_file)
+        .unwrap_or_else(|err| panic!("failed to read {:?}: {:?}", input_file, err));
+    if let Some(scripts) = scripts_from_json(extension, &input_code) {
+        for script in scripts {
+            analyze(
+                &script,
+                JsFileSource::js_script(),
+                filter,
+                file_name,
+                input_file,
+            );
+        }
+    } else if let Ok(source_type) = input_file.try_into() {
+        analyze(&input_code, source_type, filter, file_name, input_file);
+    }
+}
+
+fn analyze(
+    input_code: &str,
+    source_type: JsFileSource,
+    filter: AnalysisFilter,
+    file_name: &str,
+    input_file: &Path,
+) {
+    let parsed = parse(input_code, source_type, JsParserOptions::default());
+    let root = parsed.tree();
+
+    let mut diagnostics = Vec::new();
+    let mut code_fixes = Vec::new();
+    let options = create_analyzer_options(input_file, &mut diagnostics);
+    let manifest = load_manifest(input_file, &mut diagnostics);
+
+    let (_, errors) =
+        biome_js_analyze::analyze(&root, filter, &options, source_type, manifest, |event| {
+            if let Some(mut diag) = event.diagnostic() {
+                for action in event.actions() {
+                    diag = diag.add_code_suggestion(CodeSuggestionAdvice::from(action));
+                }
+
+                let error = diag.with_severity(Severity::Warning);
+                diagnostics.push(diagnostic_to_string(file_name, input_code, error));
+                return ControlFlow::Continue(());
+            }
+
+            for action in event.actions() {
+                code_fixes.push(code_fix_to_string(input_code, action));
+            }
+
+            ControlFlow::<Never>::Continue(())
+        });
+
+    for error in errors {
+        diagnostics.push(diagnostic_to_string(file_name, input_code, error));
+    }
+
+    println!("Diagnostics:\n{}", diagnostics.join("\n"));
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/ignoredDependencies.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/ignoredDependencies.js
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+
+// Make sure disabling a single dependency doesn't disable all.
+function IgnoredDependencies1() {
+    let a = 1;
+    let b = 2;
+    // biome-ignore lint/correctness/useExhaustiveDependencies(b): `b` is ignored, but there should still be a diagnostic for `a`
+    useEffect(() => {
+        console.log(a + b);
+    }, []);
+}
+
+// Make sure an unnecessarily ignored dependency triggers a diagnostic.
+function IgnoredDependencies2() {
+    let a = 1;
+    // biome-ignore lint/correctness/useExhaustiveDependencies(a): `a` is correctly specified, so we shouldn't ignore it
+    useEffect(() => {
+        console.log(a);
+    }, [a]);
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/ignoredDependencies.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/ignoredDependencies.js.snap
@@ -1,0 +1,70 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ignoredDependencies.js
+---
+# Input
+```jsx
+import { useEffect } from "react";
+
+// Make sure disabling a single dependency doesn't disable all.
+function IgnoredDependencies1() {
+    let a = 1;
+    let b = 2;
+    // biome-ignore lint/correctness/useExhaustiveDependencies(b): `b` is ignored, but there should still be a diagnostic for `a`
+    useEffect(() => {
+        console.log(a + b);
+    }, []);
+}
+
+// Make sure an unnecessarily ignored dependency triggers a diagnostic.
+function IgnoredDependencies2() {
+    let a = 1;
+    // biome-ignore lint/correctness/useExhaustiveDependencies(a): `a` is correctly specified, so we shouldn't ignore it
+    useEffect(() => {
+        console.log(a);
+    }, [a]);
+}
+
+```
+
+# Diagnostics
+```
+ignoredDependencies.js:8:5 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook does not specify all of its dependencies: a
+  
+     6 │     let b = 2;
+     7 │     // biome-ignore lint/correctness/useExhaustiveDependencies(b): `b` is ignored, but there should still be a diagnostic for `a`
+   > 8 │     useEffect(() => {
+       │     ^^^^^^^^^
+     9 │         console.log(a + b);
+    10 │     }, []);
+  
+  i This dependency is not specified in the hook dependency list.
+  
+     7 │     // biome-ignore lint/correctness/useExhaustiveDependencies(b): `b` is ignored, but there should still be a diagnostic for `a`
+     8 │     useEffect(() => {
+   > 9 │         console.log(a + b);
+       │                     ^
+    10 │     }, []);
+    11 │ }
+  
+  i Either include it or remove the dependency array
+  
+
+```
+
+```
+ignoredDependencies.js:16:5 suppressions/unused ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Suppression comment is not being used
+  
+    14 │ function IgnoredDependencies2() {
+    15 │     let a = 1;
+  > 16 │     // biome-ignore lint/correctness/useExhaustiveDependencies(a): `a` is correctly specified, so we shouldn't ignore it
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    17 │     useEffect(() => {
+    18 │         console.log(a);
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/valid.js
@@ -255,7 +255,7 @@ function MyComponent23 ({ arr })  {
 }
 
 // https://github.com/biomejs/biome/issues/2361
-function ComponentWithRecursiveCallback() {  
+function ComponentWithRecursiveCallback() {
     const fib = useCallback((num) => {
       if (num < 2) {
         return num;
@@ -273,4 +273,23 @@ function OutsideFunctionDeclaration() {
       func()
     }, [])
 }
-  
+
+// Specific ignored dependencies
+// https://github.com/biomejs/biome/discussions/2509
+function IgnoredDependencies() {
+    const [foo, setFoo] = useState(1);
+    // biome-ignore lint/correctness/useExhaustiveDependencies(foo): foo should be listed, but we override it
+    // biome-ignore lint/correctness/useExhaustiveDependencies(setFoo): setFoo shouldn't be listed, but we override it
+    useEffect(() => {
+        setFoo(foo + 1);
+    }, [setFoo]);
+}
+
+// Make sure ignoring without specific value also works for this rule.
+function IgnoredDependencies2() {
+    const [foo, setFoo] = useState(1);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: both are ignored.
+    useEffect(() => {
+        setFoo(foo + 1);
+    }, [setFoo]);
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/valid.js.snap
@@ -261,7 +261,7 @@ function MyComponent23 ({ arr })  {
 }
 
 // https://github.com/biomejs/biome/issues/2361
-function ComponentWithRecursiveCallback() {  
+function ComponentWithRecursiveCallback() {
     const fib = useCallback((num) => {
       if (num < 2) {
         return num;
@@ -279,5 +279,25 @@ function OutsideFunctionDeclaration() {
       func()
     }, [])
 }
-  
+
+// Specific ignored dependencies
+// https://github.com/biomejs/biome/discussions/2509
+function IgnoredDependencies() {
+    const [foo, setFoo] = useState(1);
+    // biome-ignore lint/correctness/useExhaustiveDependencies(foo): foo should be listed, but we override it
+    // biome-ignore lint/correctness/useExhaustiveDependencies(setFoo): setFoo shouldn't be listed, but we override it
+    useEffect(() => {
+        setFoo(foo + 1);
+    }, [setFoo]);
+}
+
+// Make sure ignoring without specific value also works for this rule.
+function IgnoredDependencies2() {
+    const [foo, setFoo] = useState(1);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: both are ignored.
+    useEffect(() => {
+        setFoo(foo + 1);
+    }, [setFoo]);
+}
+
 ```

--- a/crates/biome_suppression/src/lib.rs
+++ b/crates/biome_suppression/src/lib.rs
@@ -3,7 +3,7 @@ use biome_rowan::{TextRange, TextSize};
 
 /// Single instance of a suppression comment, with the following syntax:
 ///
-/// `// rome-ignore { <category> { (<value>) }? }+: <reason>`
+/// `// biome-ignore { <category> { (<value>) }? }+: <reason>`
 ///
 /// The category broadly describes what feature is being suppressed (formatting,
 /// linting, ...) with the value being and optional, category-specific name of
@@ -23,7 +23,7 @@ pub struct Suppression<'a> {
     pub categories: Vec<(&'a Category, Option<&'a str>)>,
     /// Reason for this suppression comment to exist
     pub reason: &'a str,
-    /// If the comment is `// rome-ignore`
+    /// If the comment is `// biome-ignore`
     pub is_legacy: bool,
 }
 


### PR DESCRIPTION
## Summary

Allow suppression comments to suppress individual instances of rules. This is used for the lint rule `useExhaustiveDependencies`, which is now able to suppress specific dependencies.

The syntax for passing instances to suppress is `// biome-ignore lint/correctness/useExhaustiveDependencies(a): <explanation>` as documented in the `useExhaustiveDependencies` rule. The reason I opted for this syntax was pragmatic; our suppression parser already supported it. This does mean I'm kinda reusing a legacy syntax for a new purpose, though I see no clear conflicts in this approach. Let me know if you prefer a different approach though.

Fixes #2509.

## Test Plan

Tests added.

I have also added a `quick_test.rs` in `biome_js_analyze` which helps with debugging lint rules a bit more easily.
