### PR TITLE
feat(configuration): integrate curly brace globs

### DIFF
--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -11,6 +11,7 @@ use biome_configuration::{
 };
 use biome_deserialize::Merge;
 use biome_service::configuration::PartialConfigurationExt;
+use biome_service::settings::{ConfigSource, ConfigurationBundle};
 use biome_service::workspace::RegisterProjectFolderParams;
 use biome_service::{
     configuration::{load_configuration, LoadedConfiguration},
@@ -165,12 +166,16 @@ pub(crate) fn check(
             set_as_current_workspace: true,
         })?;
 
+    let bundle = ConfigurationBundle {
+        config: fs_configuration,
+        source: ConfigSource::Biome,
+    };
     session
         .app
         .workspace
         .update_settings(UpdateSettingsParams {
             workspace_directory: session.app.fs.working_directory(),
-            configuration: fs_configuration,
+            configuration: vec![bundle],
             vcs_base_path,
             gitignore_matches,
         })?;

--- a/crates/biome_cli/src/commands/ci.rs
+++ b/crates/biome_cli/src/commands/ci.rs
@@ -8,6 +8,7 @@ use biome_deserialize::Merge;
 use biome_service::configuration::{
     load_configuration, LoadedConfiguration, PartialConfigurationExt,
 };
+use biome_service::settings::{ConfigSource, ConfigurationBundle};
 use biome_service::workspace::{RegisterProjectFolderParams, UpdateSettingsParams};
 use std::ffi::OsString;
 
@@ -115,11 +116,15 @@ pub(crate) fn ci(session: CliSession, payload: CiCommandPayload) -> Result<(), C
             set_as_current_workspace: true,
         })?;
 
+    let bundle = ConfigurationBundle {
+        config: fs_configuration,
+        source: ConfigSource::Biome,
+    };
     session
         .app
         .workspace
         .update_settings(UpdateSettingsParams {
-            configuration: fs_configuration,
+            configuration: vec![bundle],
             workspace_directory: session.app.fs.working_directory(),
             vcs_base_path,
             gitignore_matches,

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -17,6 +17,7 @@ use biome_diagnostics::PrintDiagnostic;
 use biome_service::configuration::{
     load_configuration, LoadedConfiguration, PartialConfigurationExt,
 };
+use biome_service::settings::{ConfigSource, ConfigurationBundle};
 use biome_service::workspace::{RegisterProjectFolderParams, UpdateSettingsParams};
 use std::ffi::OsString;
 
@@ -215,12 +216,16 @@ pub(crate) fn format(
             set_as_current_workspace: true,
         })?;
 
+    let bundle = ConfigurationBundle {
+        config: configuration,
+        source: ConfigSource::Biome,
+    };
     session
         .app
         .workspace
         .update_settings(UpdateSettingsParams {
             workspace_directory: session.app.fs.working_directory(),
-            configuration,
+            configuration: vec![bundle],
             vcs_base_path,
             gitignore_matches,
         })?;

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -17,6 +17,7 @@ use biome_deserialize::Merge;
 use biome_service::configuration::{
     load_configuration, LoadedConfiguration, PartialConfigurationExt,
 };
+use biome_service::settings::{ConfigSource, ConfigurationBundle};
 use biome_service::workspace::{RegisterProjectFolderParams, UpdateSettingsParams};
 use std::ffi::OsString;
 
@@ -149,12 +150,16 @@ pub(crate) fn lint(session: CliSession, payload: LintCommandPayload) -> Result<(
             set_as_current_workspace: true,
         })?;
 
+    let bundle = ConfigurationBundle {
+        config: fs_configuration,
+        source: ConfigSource::Biome,
+    };
     session
         .app
         .workspace
         .update_settings(UpdateSettingsParams {
             workspace_directory: session.app.fs.working_directory(),
-            configuration: fs_configuration,
+            configuration: vec![bundle],
             vcs_base_path,
             gitignore_matches,
         })?;

--- a/crates/biome_cli/src/commands/search.rs
+++ b/crates/biome_cli/src/commands/search.rs
@@ -8,6 +8,7 @@ use biome_deserialize::Merge;
 use biome_service::configuration::{
     load_configuration, LoadedConfiguration, PartialConfigurationExt,
 };
+use biome_service::settings::{ConfigSource, ConfigurationBundle};
 use biome_service::workspace::{
     ParsePatternParams, RegisterProjectFolderParams, UpdateSettingsParams,
 };
@@ -68,9 +69,13 @@ pub(crate) fn search(
             path: session.app.fs.working_directory(),
             set_as_current_workspace: true,
         })?;
+    let bundle = ConfigurationBundle {
+        config: configuration,
+        source: ConfigSource::Biome,
+    };
     workspace.update_settings(UpdateSettingsParams {
         workspace_directory: session.app.fs.working_directory(),
-        configuration,
+        configuration: vec![bundle],
         vcs_base_path,
         gitignore_matches,
     })?;

--- a/crates/biome_css_parser/tests/spec_test.rs
+++ b/crates/biome_css_parser/tests/spec_test.rs
@@ -8,7 +8,7 @@ use biome_diagnostics::DiagnosticExt;
 use biome_diagnostics::{print_diagnostic_to_string, termcolor};
 use biome_fs::BiomePath;
 use biome_rowan::SyntaxKind;
-use biome_service::settings::Settings;
+use biome_service::settings::{ConfigSource, ConfigurationBundle, Settings};
 use biome_test_utils::has_bogus_nodes_or_empty_slots;
 use std::fmt::Write;
 use std::fs;
@@ -54,8 +54,12 @@ pub fn run(test_case: &str, _snapshot_name: &str, test_directory: &str, outcome_
         )
         .consume();
 
+        let bundle = ConfigurationBundle {
+            config: test_options.unwrap_or_default(),
+            source: ConfigSource::EditorConfig,
+        };
         settings
-            .merge_with_configuration(test_options.unwrap_or_default(), None, None, &[])
+            .merge_with_configuration(bundle, None, None, &[])
             .unwrap();
 
         let settings = settings.languages.css.parser;

--- a/crates/biome_formatter_test/src/spec.rs
+++ b/crates/biome_formatter_test/src/spec.rs
@@ -10,7 +10,7 @@ use biome_formatter::{FormatOptions, Printed};
 use biome_fs::BiomePath;
 use biome_parser::AnyParse;
 use biome_rowan::{TextRange, TextSize};
-use biome_service::settings::{ServiceLanguage, Settings};
+use biome_service::settings::{ConfigSource, ConfigurationBundle, ServiceLanguage, Settings};
 use biome_service::workspace::{
     DocumentFileSource, FeaturesBuilder, RegisterProjectFolderParams, SupportsFeatureParams,
 };
@@ -236,8 +236,12 @@ where
                 options_path.get_buffer_from_file().as_str(),
             )
             .consume();
+            let bundle = ConfigurationBundle {
+                config: test_options.unwrap(),
+                source: ConfigSource::Biome,
+            };
             settings
-                .merge_with_configuration(test_options.unwrap_or_default(), None, None, &[])
+                .merge_with_configuration(bundle, None, None, &[])
                 .unwrap();
 
             if !diagnostics.is_empty() {

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -13,6 +13,7 @@ use biome_service::configuration::{
     load_configuration, LoadedConfiguration, PartialConfigurationExt,
 };
 use biome_service::file_handlers::{AstroFileHandler, SvelteFileHandler, VueFileHandler};
+use biome_service::settings::{ConfigSource, ConfigurationBundle};
 use biome_service::workspace::{
     FeaturesBuilder, GetFileContentParams, OpenProjectParams, PullDiagnosticsParams,
     RegisterProjectFolderParams, SupportsFeatureParams, UpdateProjectParams,
@@ -498,9 +499,13 @@ impl Session {
                                     },
                                 );
                             }
+                            let bundle = ConfigurationBundle {
+                                config: configuration,
+                                source: ConfigSource::Biome,
+                            };
                             let result = self.workspace.update_settings(UpdateSettingsParams {
                                 workspace_directory: fs.working_directory(),
-                                configuration,
+                                configuration: vec![bundle],
                                 vcs_base_path,
                                 gitignore_matches,
                             });

--- a/crates/biome_service/src/matcher/mod.rs
+++ b/crates/biome_service/src/matcher/mod.rs
@@ -51,6 +51,11 @@ impl Matcher {
         Ok(())
     }
 
+    /// It adds a unix shell style pattern that has already been parsed
+    pub fn add_pattern_parsed(&mut self, pattern: Pattern) {
+        self.patterns.push(pattern);
+    }
+
     /// It matches the given string against the stored patterns.
     ///
     /// It returns [true] if there's at least a match

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1,7 +1,9 @@
+use crate::matcher::Pattern;
 use crate::workspace::{DocumentFileSource, ProjectKey, WorkspaceData};
 use crate::{Matcher, WorkspaceError};
 use biome_analyze::{AnalyzerOptions, AnalyzerRules};
 use biome_configuration::diagnostics::InvalidIgnorePattern;
+use biome_configuration::editorconfig::EditorConfig;
 use biome_configuration::javascript::JsxRuntime;
 use biome_configuration::organize_imports::OrganizeImports;
 use biome_configuration::{
@@ -1551,5 +1553,15 @@ impl TryFrom<OverrideLinterConfiguration> for LinterSettings {
             ignored_files: Matcher::empty(),
             included_files: Matcher::empty(),
         })
+    }
+}
+
+pub fn overrides_from_editorconfig(editorconfig: EditorConfig) -> Result<Vec<OverrideSettingPattern>, PatternError> {
+    let (biome, _) = editorconfig.to_biome();
+    if let Some(overrides) = biome.and_then(|biome| biome.overrides) {
+
+        Ok(overrides)
+    } else {
+        Ok(vec![])
     }
 }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -172,11 +172,12 @@ impl Settings {
     #[tracing::instrument(level = "trace", skip(self))]
     pub fn merge_with_configuration(
         &mut self,
-        configuration: PartialConfiguration,
+        bundle: ConfigurationBundle,
         working_directory: Option<PathBuf>,
         vcs_path: Option<PathBuf>,
         gitignore_matches: &[String],
     ) -> Result<(), WorkspaceError> {
+        let configuration = bundle.config;
         // formatter part
         if let Some(formatter) = configuration.formatter {
             self.formatter = to_format_settings(
@@ -1612,4 +1613,19 @@ pub fn overrides_from_editorconfig(
     } else {
         Ok(vec![])
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ConfigSource {
+    Biome,
+    EditorConfig,
+}
+
+/// A simple wrapper around the configuration and the source of the configuration so  that we can gate certain features based on where the configuration came from.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct ConfigurationBundle {
+    pub config: PartialConfiguration,
+    pub source: ConfigSource,
 }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1281,7 +1281,6 @@ fn to_override_setting_pattern(
     let include = to_matcher(working_directory.clone(), pattern.include.as_ref(), is_editorconfig)?;
     let exclude = to_matcher(working_directory.clone(), pattern.ignore.as_ref(), is_editorconfig)?;
     to_override_setting_pattern_with_matchers(
-        working_directory,
         pattern,
         current_settings,
         include,
@@ -1290,7 +1289,6 @@ fn to_override_setting_pattern(
 }
 
 fn to_override_setting_pattern_with_matchers(
-    working_directory: Option<PathBuf>,
     mut pattern: OverridePattern,
     current_settings: &Settings,
     include: Matcher,

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -56,7 +56,6 @@ use crate::{Deserialize, Serialize, WorkspaceError};
 use biome_analyze::ActionCategory;
 pub use biome_analyze::RuleCategories;
 use biome_configuration::linter::RuleSelector;
-use biome_configuration::PartialConfiguration;
 use biome_console::{markup, Markup, MarkupBuf};
 use biome_diagnostics::CodeSuggestion;
 use biome_formatter::Printed;

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -74,7 +74,7 @@ use tracing::debug;
 
 pub use self::client::{TransportRequest, WorkspaceClient, WorkspaceTransport};
 pub use crate::file_handlers::DocumentFileSource;
-use crate::settings::Settings;
+use crate::settings::{ConfigurationBundle, Settings};
 
 mod client;
 mod server;
@@ -410,7 +410,7 @@ impl FeaturesBuilder {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct UpdateSettingsParams {
-    pub configuration: PartialConfiguration,
+    pub configuration: Vec<ConfigurationBundle>,
     // @ematipico TODO: have a better data structure for this
     pub vcs_base_path: Option<PathBuf>,
     // @ematipico TODO: have a better data structure for this

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -393,15 +393,16 @@ impl Workspace for WorkspaceServer {
     #[tracing::instrument(level = "trace", skip(self))]
     fn update_settings(&self, params: UpdateSettingsParams) -> Result<(), WorkspaceError> {
         let mut workspace = self.workspaces_mut();
-        workspace
-            .as_mut()
-            .get_current_settings_mut()
-            .merge_with_configuration(
-                params.configuration,
-                params.workspace_directory,
-                params.vcs_base_path,
+        let settings = workspace.as_mut().get_current_settings_mut();
+
+        for bundle in params.configuration {
+            settings.merge_with_configuration(
+                bundle,
+                params.workspace_directory.clone(),
+                params.vcs_base_path.clone(),
                 params.gitignore_matches.as_slice(),
             )?;
+        }
 
         Ok(())
     }

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -9,7 +9,7 @@ use biome_json_parser::{JsonParserOptions, ParseDiagnostic};
 use biome_project::PackageJson;
 use biome_rowan::{SyntaxKind, SyntaxNode, SyntaxSlot};
 use biome_service::configuration::to_analyzer_rules;
-use biome_service::settings::{ServiceLanguage, Settings};
+use biome_service::settings::{ConfigSource, ConfigurationBundle, ServiceLanguage, Settings};
 use json_comments::StripComments;
 use similar::TextDiff;
 use std::ffi::{c_int, OsStr};
@@ -94,8 +94,12 @@ pub fn create_analyzer_options(
                 Transparent => Some(JsxRuntime::Transparent),
             };
 
+            let bundle = ConfigurationBundle {
+                config: configuration,
+                source: ConfigSource::Biome,
+            };
             settings
-                .merge_with_configuration(configuration, None, None, &[])
+                .merge_with_configuration(bundle, None, None, &[])
                 .unwrap();
             analyzer_configuration.rules = to_analyzer_rules(&settings, input_file);
         }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
In order to fully support `.editorconfig`, we need to enable certain glob matching expressions only if the configuration came from `.editorconfig` to avoid breaking changes (discussed in #2986). When biome turns "Configuration" into "Settings", that's when the glob patterns are actually evaluated. However, by that point, the source of the configuration can no longer be derived, as all the configuration has already been combined and merged into one configuration. 

This PR primarily introduces the `ConfigurationBundle` and `ConfigSource` types to address this problem. It will also reenable `.editorconfig` loading (not currently implemented).

This PR is very WIP. I'm not entirely sure if this approach is the best because of the large amount of changes required.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
related to: #1724


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
