### PR TITLE
fix(lint/useJsxKeyInIterable): fix a false positive when key is in the return statement, but not any variable declarations

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -197,7 +197,7 @@ fn handle_function_body(
                 returned_value.syntax().kind(),
             ))
         })
-        .unwrap_or(false);
+        .unwrap_or_default();
     let ranges = return_statement.and_then(|ret| {
         let returned_value = ret.argument()?;
         handle_potential_react_component(returned_value, model, is_inside_jsx)

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx
@@ -91,3 +91,8 @@ React.Children.map(c => React.cloneElement(c, {key: c}));
 	const div = <div key={item.id}>{x}</div>;
 	return div;
 });
+
+[].map((item) => {
+	const node = <button type="button">{item.label}</button>;
+	return <Fragment key={item.label}>{node}</Fragment>;
+})

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx.snap
@@ -98,4 +98,9 @@ React.Children.map(c => React.cloneElement(c, {key: c}));
 	return div;
 });
 
+[].map((item) => {
+	const node = <button type="button">{item.label}</button>;
+	return <Fragment key={item.label}>{node}</Fragment>;
+})
+
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR fixes a false positive where the rule would flag variable declaration statements even if the return statement had a component with the `key` prop set.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #3020

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added snapshot test
