### PR TITLE
fix(cli): `biome init` won't generate config file if `biome.jsonc` already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,7 +187,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
-- Fix issue where running `biome init` would create `biome.json` even if `biome.jsonc` already exists. [#3024](https://github.com/biomejs/biome/issues/3024) Contributed by @minht11
+- Fix  [#3024](https://github.com/biomejs/biome/issues/3024), where running `biome init` would create `biome.json` even if `biome.jsonc` already exists.  Contributed by @minht11
 
 ### Configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,9 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   ```
   Contributed by @ematipico
 
+#### Bug fixes
+
+- Fix issue where running `biome init` would create `biome.json` even if `biome.jsonc` already exists. [#3024](https://github.com/biomejs/biome/issues/3024) Contributed by @minht11
 
 ### Configuration
 

--- a/crates/biome_cli/tests/commands/init.rs
+++ b/crates/biome_cli/tests/commands/init.rs
@@ -135,3 +135,53 @@ fn creates_config_file_when_biome_installed_via_package_manager() {
         result,
     ));
 }
+
+#[test]
+fn does_not_create_config_file_if_json_exists() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("biome.json");
+    fs.insert(file_path.into(), *b"{}");
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("init")].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "does_not_create_config_file_if_json_exists",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn does_not_create_config_file_if_jsonc_exists() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("biome.jsonc");
+    fs.insert(file_path.into(), *b"{}");
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("init")].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "does_not_create_config_file_if_jsonc_exists",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_commands_init/does_not_create_config_file_if_json_exists.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_init/does_not_create_config_file_if_json_exists.snap
@@ -1,0 +1,20 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{}
+```
+
+# Termination Message
+
+```block
+configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × It seems that a configuration file already exists
+  
+
+
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_init/does_not_create_config_file_if_jsonc_exists.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_init/does_not_create_config_file_if_jsonc_exists.snap
@@ -1,0 +1,20 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.jsonc`
+
+```json
+{}
+```
+
+# Termination Message
+
+```block
+configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × It seems that a configuration file already exists
+  
+
+
+```

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -293,11 +293,14 @@ pub fn create_config(
     mut configuration: PartialConfiguration,
     emit_jsonc: bool,
 ) -> Result<(), WorkspaceError> {
-    let path = if emit_jsonc {
-        PathBuf::from(ConfigName::biome_jsonc())
-    } else {
-        PathBuf::from(ConfigName::biome_json())
-    };
+    let json_path = PathBuf::from(ConfigName::biome_json());
+    let jsonc_path = PathBuf::from(ConfigName::biome_jsonc());
+
+    if fs.path_exists(&json_path) || fs.path_exists(&jsonc_path) {
+        return Err(BiomeDiagnostic::new_already_exists().into());
+    }
+
+    let path = if emit_jsonc { jsonc_path } else { json_path };
 
     let options = OpenOptions::default().write(true).create_new(true);
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fix https://github.com/biomejs/biome/issues/3024
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added tests