### PR TITLE
feat(grit): parse Grit literal snippets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ dependencies = [
  "biome_diagnostics",
  "biome_grit_parser",
  "biome_grit_syntax",
+ "biome_js_parser",
  "biome_js_syntax",
  "biome_parser",
  "biome_rowan",
@@ -1878,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "grit-pattern-matcher"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ca790933b1ae99fbb0caf4b90255bbcdc6507b893d5bbd8d0552bbb48018c2"
+checksum = "eb91ad25bb8557f3be40899becf5db27e8431e359d69d5b67104f1d1a12c8d9a"
 dependencies = [
  "anyhow",
  "elsa",
@@ -1893,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "grit-util"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b466e27499052b6206a3fe31eff49c5c55586ea23f9d73b2df41c0de8057ef"
+checksum = "e4d302f12945a38d464183a6ffe49b8b778876f82ab753174324cd7aae74b24a"
 dependencies = [
  "derive_builder",
  "once_cell",

--- a/crates/biome_diagnostics/src/display.rs
+++ b/crates/biome_diagnostics/src/display.rs
@@ -10,7 +10,7 @@ mod diff;
 pub(super) mod frame;
 mod message;
 
-pub use crate::display::frame::SourceFile;
+pub use crate::display::frame::{SourceFile, SourceLocation};
 use crate::{
     diagnostic::internal::AsDiagnostic, Advices, Diagnostic, DiagnosticTags, Location, LogCategory,
     Resource, Severity, Visit,

--- a/crates/biome_grit_patterns/Cargo.toml
+++ b/crates/biome_grit_patterns/Cargo.toml
@@ -17,11 +17,12 @@ biome_console        = { workspace = true }
 biome_diagnostics    = { workspace = true }
 biome_grit_parser    = { workspace = true }
 biome_grit_syntax    = { workspace = true }
+biome_js_parser      = { workspace = true }
 biome_js_syntax      = { workspace = true }
 biome_parser         = { workspace = true }
 biome_rowan          = { workspace = true }
-grit-pattern-matcher = { version = "0.2" }
-grit-util            = { version = "0.2" }
+grit-pattern-matcher = { version = "0.3" }
+grit-util            = { version = "0.3" }
 im                   = { version = "15.1.0" }
 rustc-hash           = { workspace = true }
 serde                = { workspace = true, features = ["derive"] }

--- a/crates/biome_grit_patterns/src/errors.rs
+++ b/crates/biome_grit_patterns/src/errors.rs
@@ -51,6 +51,13 @@ pub enum CompileError {
 
     /// A pattern is required to compile a Grit query.
     MissingPattern,
+
+    /// Bracketed metavariables are only allowed on the right-hand side of
+    /// rewrite.
+    InvalidBracketedMetavariable,
+
+    /// Unknown variable.
+    UnknownVariable(String),
 }
 
 impl Diagnostic for CompileError {}

--- a/crates/biome_grit_patterns/src/grit_analysis_ext.rs
+++ b/crates/biome_grit_patterns/src/grit_analysis_ext.rs
@@ -1,0 +1,69 @@
+use biome_diagnostics::{Diagnostic, PrintDescription, Severity};
+use grit_util::{AnalysisLog, Position, Range};
+use std::path::{Path, PathBuf};
+
+pub trait GritAnalysisExt {
+    fn to_log(&self, path: Option<&Path>) -> AnalysisLog;
+}
+
+impl<T> GritAnalysisExt for T
+where
+    T: Diagnostic,
+{
+    fn to_log(&self, path: Option<&Path>) -> AnalysisLog {
+        let location = self.location();
+        let source = location.source_code;
+        let range =
+            match (location.span, source) {
+                (Some(range), Some(source)) => source.text[..range.start().into()]
+                    .lines()
+                    .enumerate()
+                    .last()
+                    .map(|(i, line)| {
+                        let start = Position {
+                            line: (i + 1) as u32,
+                            column: line.len() as u32,
+                        };
+                        let end = source.text[range].lines().enumerate().last().map_or(
+                            start,
+                            |(j, line)| Position {
+                                line: start.line + j as u32,
+                                column: if j == 0 {
+                                    start.column + line.len() as u32
+                                } else {
+                                    line.len() as u32
+                                },
+                            },
+                        );
+                        Range {
+                            start,
+                            end,
+                            start_byte: range.start().into(),
+                            end_byte: range.end().into(),
+                        }
+                    }),
+                _ => None,
+            };
+
+        AnalysisLog {
+            engine_id: Some("biome".to_owned()),
+            file: path.map(Path::to_path_buf).or_else(|| {
+                location
+                    .resource
+                    .and_then(|r| r.as_file().map(PathBuf::from))
+            }),
+            level: Some(match self.severity() {
+                Severity::Hint => 1,
+                Severity::Information => 2,
+                Severity::Warning => 3,
+                Severity::Error => 4,
+                Severity::Fatal => 5,
+            }),
+            message: PrintDescription(self).to_string(),
+            position: range.as_ref().map(|r| r.start),
+            range,
+            syntax_tree: None,
+            source: source.map(|s| s.text.to_owned()),
+        }
+    }
+}

--- a/crates/biome_grit_patterns/src/grit_context.rs
+++ b/crates/biome_grit_patterns/src/grit_context.rs
@@ -27,7 +27,7 @@ impl QueryContext for GritQueryContext {
     type ResolvedPattern<'a> = GritResolvedPattern;
     type Language<'a> = GritTargetLanguage;
     type File<'a> = GritFile;
-    type Tree = GritTree;
+    type Tree<'a> = GritTree;
 }
 
 #[derive(Debug)]
@@ -79,6 +79,15 @@ impl<'a> ExecContext<'a, GritQueryContext> for GritExecContext {
     }
 
     fn name(&self) -> Option<&str> {
+        todo!()
+    }
+
+    fn load_file(
+        &self,
+        _file: &<GritQueryContext as QueryContext>::File<'a>,
+        _state: &mut State<'a, GritQueryContext>,
+        _logs: &mut AnalysisLogs,
+    ) -> Result<bool> {
         todo!()
     }
 }

--- a/crates/biome_grit_patterns/src/grit_js_parser.rs
+++ b/crates/biome_grit_patterns/src/grit_js_parser.rs
@@ -1,0 +1,53 @@
+use crate::{grit_analysis_ext::GritAnalysisExt, grit_tree::GritTree};
+use biome_js_parser::{parse, JsParserOptions};
+use biome_js_syntax::JsFileSource;
+use grit_util::{AnalysisLogs, FileOrigin, Parser, SnippetTree};
+use std::path::Path;
+
+pub struct GritJsParser;
+
+impl Parser for GritJsParser {
+    type Tree = GritTree;
+
+    fn parse_file(
+        &mut self,
+        body: &str,
+        path: Option<&Path>,
+        logs: &mut AnalysisLogs,
+        _old_tree: FileOrigin<'_, GritTree>,
+    ) -> Option<GritTree> {
+        let parse_result = parse(body, JsFileSource::tsx(), JsParserOptions::default());
+
+        for diagnostic in parse_result.diagnostics() {
+            logs.push(diagnostic.to_log(path));
+        }
+
+        Some(GritTree::new(parse_result.syntax().into()))
+    }
+
+    fn parse_snippet(
+        &mut self,
+        prefix: &'static str,
+        source: &str,
+        postfix: &'static str,
+    ) -> SnippetTree<GritTree> {
+        let context = format!("{prefix}{source}{postfix}");
+
+        let len = if cfg!(target_arch = "wasm32") {
+            |src: &str| src.chars().count() as u32
+        } else {
+            |src: &str| src.len() as u32
+        };
+
+        let parse_result = parse(&context, JsFileSource::tsx(), JsParserOptions::default());
+
+        SnippetTree {
+            tree: GritTree::new(parse_result.syntax().into()),
+            source: source.to_owned(),
+            prefix,
+            postfix,
+            snippet_start: (len(prefix) + len(source) - len(source.trim_start())),
+            snippet_end: (len(prefix) + len(source.trim_end())),
+        }
+    }
+}

--- a/crates/biome_grit_patterns/src/grit_node.rs
+++ b/crates/biome_grit_patterns/src/grit_node.rs
@@ -94,12 +94,6 @@ impl GritAstNode for GritNode {
         }
     }
 
-    fn full_source(&self) -> &str {
-        // This should not be a problem anytime soon, though we may want to
-        // reconsider when we implement rewrites.
-        unimplemented!("Full source of file not available")
-    }
-
     fn walk(&self) -> impl AstCursor<Node = Self> {
         GritNodeCursor::new(self)
     }

--- a/crates/biome_grit_patterns/src/grit_node_patterns.rs
+++ b/crates/biome_grit_patterns/src/grit_node_patterns.rs
@@ -11,6 +11,8 @@ use grit_util::AnalysisLogs;
 pub(crate) struct GritNodePattern;
 
 impl AstNodePattern<GritQueryContext> for GritNodePattern {
+    const INCLUDES_TRIVIA: bool = true;
+
     fn children(&self) -> Vec<PatternOrPredicate<GritQueryContext>> {
         todo!()
     }

--- a/crates/biome_grit_patterns/src/grit_query.rs
+++ b/crates/biome_grit_patterns/src/grit_query.rs
@@ -10,7 +10,7 @@ use crate::variables::{VarRegistry, VariableLocations};
 use crate::CompileError;
 use anyhow::Result;
 use biome_grit_syntax::{GritRoot, GritRootExt};
-use grit_pattern_matcher::pattern::{Matcher, Pattern, State};
+use grit_pattern_matcher::pattern::{FileRegistry, Matcher, Pattern, State};
 use std::collections::BTreeMap;
 
 /// Represents a top-level Grit query.
@@ -32,7 +32,10 @@ impl GritQuery {
 
         let binding = GritResolvedPattern;
         let context = GritExecContext;
-        let mut state = State::new(var_registry.into(), Vec::new());
+        let mut state = State::new(
+            var_registry.into(),
+            FileRegistry::new_from_paths(Vec::new()),
+        );
         let mut logs = Vec::new().into();
 
         self.pattern

--- a/crates/biome_grit_patterns/src/grit_target_node.rs
+++ b/crates/biome_grit_patterns/src/grit_target_node.rs
@@ -1,6 +1,6 @@
 use crate::util::TextRangeGritExt;
 use biome_js_syntax::{JsSyntaxKind, JsSyntaxNode, JsSyntaxToken};
-use biome_rowan::{SyntaxNodeText, TextRange};
+use biome_rowan::{SyntaxKind, SyntaxNodeText, TextRange};
 use grit_util::{AstCursor, AstNode as GritAstNode, ByteRange, CodeRange};
 use std::{borrow::Cow, str::Utf8Error};
 
@@ -73,6 +73,14 @@ macro_rules! generate_target_node {
                     $(Self::$lang_node(node) => node.text_trimmed_range()),+
                 }
             }
+
+            pub fn start_byte(&self) -> u32 {
+                self.text_trimmed_range().start().into()
+            }
+
+            pub fn end_byte(&self) -> u32 {
+                self.text_trimmed_range().end().into()
+            }
         }
 
         impl GritAstNode for GritTargetNode {
@@ -144,12 +152,6 @@ macro_rules! generate_target_node {
                 }
             }
 
-            fn full_source(&self) -> &str {
-                // This should not be a problem anytime soon, though we may want to
-                // reconsider when we implement rewrites.
-                unimplemented!("Full source of file not available")
-            }
-
             fn walk(&self) -> impl AstCursor<Node = Self> {
                 GritTargetNodeCursor::new(self)
             }
@@ -184,6 +186,14 @@ macro_rules! generate_target_node {
                 Self::$lang_kind(value)
             }
         })+
+
+        impl GritTargetSyntaxKind {
+            pub fn is_bogus(&self) -> bool {
+                match self {
+                    $(Self::$lang_kind(kind) => kind.is_bogus()),+
+                }
+            }
+        }
     };
 }
 

--- a/crates/biome_grit_patterns/src/grit_tree.rs
+++ b/crates/biome_grit_patterns/src/grit_tree.rs
@@ -1,9 +1,16 @@
 use crate::grit_target_node::GritTargetNode;
 use grit_util::Ast;
+use std::borrow::Cow;
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct GritTree {
+pub struct GritTree {
     root: GritTargetNode,
+}
+
+impl GritTree {
+    pub fn new(root: GritTargetNode) -> Self {
+        Self { root }
+    }
 }
 
 impl Ast for GritTree {
@@ -13,5 +20,9 @@ impl Ast for GritTree {
 
     fn root_node(&self) -> GritTargetNode {
         self.root.clone()
+    }
+
+    fn source(&self) -> Cow<str> {
+        self.root.text().to_string().into()
     }
 }

--- a/crates/biome_grit_patterns/src/lib.rs
+++ b/crates/biome_grit_patterns/src/lib.rs
@@ -15,6 +15,7 @@ mod grit_target_node;
 mod grit_tree;
 mod pattern_compiler;
 mod resolved_pattern;
+mod source_location_ext;
 mod util;
 mod variables;
 

--- a/crates/biome_grit_patterns/src/lib.rs
+++ b/crates/biome_grit_patterns/src/lib.rs
@@ -1,10 +1,12 @@
 #![allow(dead_code)] // FIXME: Remove when more stuff is ready
 mod diagnostics;
 mod errors;
+mod grit_analysis_ext;
 mod grit_binding;
 mod grit_code_snippet;
 mod grit_context;
 mod grit_file;
+mod grit_js_parser;
 mod grit_node;
 mod grit_node_patterns;
 mod grit_query;

--- a/crates/biome_grit_patterns/src/pattern_compiler/literal_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/literal_compiler.rs
@@ -26,6 +26,7 @@ impl LiteralCompiler {
                     let token = node.value_token()?;
                     let text = token.text_trimmed();
                     let range = node.syntax().text_trimmed_range().to_byte_range();
+                    debug_assert!(text.len() >= 2, "Literals must have quotes");
                     parse_snippet_content(&text[1..text.len() - 1], range, context, is_rhs)
                 }
                 AnyGritCodeSnippetSource::GritLanguageSpecificSnippet(_) => todo!(),

--- a/crates/biome_grit_patterns/src/pattern_compiler/snippet_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/snippet_compiler.rs
@@ -1,5 +1,190 @@
-use grit_util::{ByteRange, Language};
+use super::compilation_context::NodeCompilationContext;
+use crate::{
+    grit_code_snippet::GritCodeSnippet, grit_context::GritQueryContext,
+    grit_target_node::GritTargetNode, grit_tree::GritTree, CompileError,
+};
+use grit_pattern_matcher::{
+    constants::GLOBAL_VARS_SCOPE_INDEX,
+    pattern::{DynamicPattern, DynamicSnippet, DynamicSnippetPart, Pattern, Variable},
+};
+use grit_util::{Ast, AstNode, ByteRange, Language, SnippetTree};
 use std::borrow::Cow;
+
+pub(crate) fn parse_snippet_content(
+    source: &str,
+    range: ByteRange,
+    context: &mut NodeCompilationContext,
+    is_rhs: bool,
+) -> Result<Pattern<GritQueryContext>, CompileError> {
+    // we check for BRACKET_VAR_REGEX in the content, and if found
+    // compile into a DynamicPattern, rather than a CodeSnippet.
+    // This is because the syntax should only ever be necessary
+    // when treating a metavariable as a string to substitute
+    // rather than an AST node to match on. eg. in the following
+    // `const ${name}Handler = useCallback(async () => $body, []);`
+    // $name does not correspond to a node, but rather prepends a
+    // string to "Handler", which will together combine into an
+    // identifier.
+    if context
+        .compilation
+        .lang
+        .metavariable_bracket_regex()
+        .is_match(source)
+    {
+        return if is_rhs {
+            Ok(Pattern::Dynamic(
+                dynamic_snippet_from_source(source, range, context).map(DynamicPattern::Snippet)?,
+            ))
+        } else {
+            Err(CompileError::InvalidBracketedMetavariable)
+        };
+    }
+
+    if context
+        .compilation
+        .lang
+        .exact_variable_regex()
+        .is_match(source.trim())
+    {
+        return match source.trim() {
+            "$_" => Ok(Pattern::Underscore),
+            "^_" => Ok(Pattern::Underscore),
+            name => {
+                let var = context.register_variable(name.to_owned(), range)?;
+                Ok(Pattern::Variable(var))
+            }
+        };
+    }
+
+    let snippet_trees = context.compilation.lang.parse_snippet_contexts(source);
+    let snippet_nodes = nodes_from_indices(&snippet_trees);
+    if snippet_nodes.is_empty() {
+        // not checking if is_rhs. So could potentially
+        // be harder to find bugs where we expect the pattern
+        // to parse. unfortunately got rid of check to support
+        // passing non-node snippets as args.
+        return Ok(Pattern::Dynamic(
+            dynamic_snippet_from_source(source, range, context).map(DynamicPattern::Snippet)?,
+        ));
+    }
+
+    let dynamic_snippet = dynamic_snippet_from_source(source, range, context)
+        .map_or(None, |s| Some(DynamicPattern::Snippet(s)));
+    Ok(Pattern::CodeSnippet(GritCodeSnippet {
+        dynamic_snippet,
+        source: source.to_owned(),
+    }))
+}
+
+pub(crate) fn dynamic_snippet_from_source(
+    raw_source: &str,
+    source_range: ByteRange,
+    context: &mut NodeCompilationContext,
+) -> Result<DynamicSnippet, CompileError> {
+    let source_string = raw_source
+        .replace("\\n", "\n")
+        .replace("\\$", "$")
+        .replace("\\^", "^")
+        .replace("\\`", "`")
+        .replace("\\\"", "\"")
+        .replace("\\\\", "\\");
+    let source = source_string.as_str();
+    let metavariables = split_snippet(source, &context.compilation.lang);
+    let mut parts = Vec::with_capacity(2 * metavariables.len() + 1);
+    let mut last = 0;
+    // Reverse the iterator so we go over the variables in ascending order.
+    for (byte_range, var) in metavariables.into_iter().rev() {
+        parts.push(DynamicSnippetPart::String(
+            source[last..byte_range.start].to_string(),
+        ));
+        let range = ByteRange::new(
+            source_range.start + byte_range.start,
+            source_range.start + byte_range.start + var.len(),
+        );
+        if let Some(var) = context.vars.get(var.as_ref()) {
+            context.vars_array[context.scope_index][*var]
+                .locations
+                .insert(range);
+            parts.push(DynamicSnippetPart::Variable(Variable::new(
+                context.scope_index,
+                *var,
+            )));
+        } else if let Some(var) = context.global_vars.get(var.as_ref()) {
+            parts.push(DynamicSnippetPart::Variable(Variable::new(
+                GLOBAL_VARS_SCOPE_INDEX,
+                *var,
+            )));
+        } else if var.starts_with("$GLOBAL_") {
+            let variable = context.register_variable(var.to_string(), range)?;
+            parts.push(DynamicSnippetPart::Variable(variable));
+        } else {
+            return Err(CompileError::UnknownVariable(var.to_string()));
+        }
+        last = byte_range.end;
+    }
+    parts.push(DynamicSnippetPart::String(source[last..].to_string()));
+
+    Ok(DynamicSnippet { parts })
+}
+
+pub fn nodes_from_indices(indices: &[SnippetTree<GritTree>]) -> Vec<GritTargetNode> {
+    indices
+        .iter()
+        .filter_map(snippet_nodes_from_index)
+        .collect()
+}
+
+fn snippet_nodes_from_index(snippet: &SnippetTree<GritTree>) -> Option<GritTargetNode> {
+    let mut snippet_root = snippet.tree.root_node();
+
+    // find the outermost node with the same index as the snippet
+    'outer: while snippet_root.start_byte() < snippet.snippet_start
+        || snippet_root.end_byte() > snippet.snippet_end
+    {
+        let mut has_children = false;
+        for child in snippet_root.clone().children() {
+            has_children = true;
+
+            if child.start_byte() <= snippet.snippet_start
+                && child.end_byte() >= snippet.snippet_end
+            {
+                snippet_root = child;
+                continue 'outer;
+            }
+        }
+
+        if snippet_root.text() != snippet.source.trim() {
+            return None;
+        }
+
+        if !has_children {
+            return Some(snippet_root);
+        }
+
+        break;
+    }
+
+    // in order to handle white space and other superfluous
+    // stuff in the snippet we assume the root
+    // is correct as long as it's the largest node within
+    // the snippet length. Maybe this is too permissive?
+    let mut nodes = Vec::new();
+    let root_start = snippet_root.start_byte();
+    let root_end = snippet_root.end_byte();
+    if root_start > snippet.snippet_start || root_end < snippet.snippet_end {
+        return None;
+    }
+    while snippet_root.start_byte() == root_start && snippet_root.end_byte() == root_end {
+        let first_child = snippet_root.children().next();
+        nodes.push(snippet_root);
+        if let Some(child) = first_child {
+            snippet_root = child
+        } else {
+            break;
+        }
+    }
+    nodes.last().cloned()
+}
 
 /// Takes a snippet with metavariables and returns a list of ranges and the
 /// corresponding metavariables.

--- a/crates/biome_grit_patterns/src/source_location_ext.rs
+++ b/crates/biome_grit_patterns/src/source_location_ext.rs
@@ -1,0 +1,34 @@
+use biome_diagnostics::display::{SourceFile, SourceLocation};
+use biome_rowan::TextRange;
+use grit_util::{Position, Range};
+
+pub trait SourceFileExt {
+    fn to_grit_range(&self, range: TextRange) -> Option<Range>;
+}
+
+impl<'d> SourceFileExt for SourceFile<'d> {
+    fn to_grit_range(&self, range: TextRange) -> Option<Range> {
+        let start = self.location(range.start()).ok()?;
+        let end = self.location(range.end()).ok()?;
+
+        Some(Range {
+            start: start.to_grit_position(),
+            end: end.to_grit_position(),
+            start_byte: range.start().into(),
+            end_byte: range.end().into(),
+        })
+    }
+}
+
+pub trait SourceLocationExt {
+    fn to_grit_position(&self) -> Position;
+}
+
+impl SourceLocationExt for SourceLocation {
+    fn to_grit_position(&self) -> Position {
+        Position {
+            column: self.column_number.get() as u32,
+            line: self.line_number.get() as u32,
+        }
+    }
+}

--- a/crates/biome_grit_patterns/tests/quick_test.rs
+++ b/crates/biome_grit_patterns/tests/quick_test.rs
@@ -1,0 +1,23 @@
+use biome_grit_parser::parse_grit;
+use biome_grit_patterns::{GritQuery, GritTargetLanguage, JsTargetLanguage};
+
+// Use this test to quickly execute a Grit query against an source snippet.
+#[ignore]
+#[test]
+fn test_query() {
+    let parse_result = parse_grit("`console.log('hello')`");
+    if !parse_result.diagnostics().is_empty() {
+        println!(
+            "Diagnostics from parsing query:\n{:?}",
+            parse_result.diagnostics()
+        );
+    }
+
+    let query = GritQuery::from_node(
+        parse_result.tree(),
+        GritTargetLanguage::JsTargetLanguage(JsTargetLanguage),
+    )
+    .expect("could not construct query");
+
+    query.execute().expect("could not execute query");
+}


### PR DESCRIPTION
## Summary

Grit patterns can contain [snippet literals](https://docs.grit.io/language/patterns#code-snippets) like such:

```
`console.log("foo");`
```

The part inside the backticks is a structural pattern that matches any function call node where the callee matches `console.log` and which has a single string argument with the content `foo`.

This PR updates the Grit crates and implements the parsing for snippet literals, so that our own Grit bindings invoke the Biome JS parser when a snippet like the above is encountered.

## Test Plan

Added a quick test that helps with testing Grit patterns, although it still fails in the execution part. But at least it parses the query with a literal snippet now.
