### PR TITLE
refactor(noUnusedTemplateLiteral): remove rule sources

### DIFF
--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -238,13 +238,6 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
-        "@typescript-eslint/no-useless-template-literals" => {
-            let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group
-                .no_unused_template_literal
-                .get_or_insert(Default::default());
-            rule.set_level(rule_severity.into());
-        }
         "@typescript-eslint/parameter-properties" => {
             if !options.include_inspired {
                 results.has_inspired_rules = true;

--- a/crates/biome_js_analyze/src/lint/style/no_unused_template_literal.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_unused_template_literal.rs
@@ -1,6 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
+use biome_analyze::{declare_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -41,7 +41,6 @@ declare_rule! {
         version: "1.0.0",
         name: "noUnusedTemplateLiteral",
         language: "ts",
-        sources: &[RuleSource::EslintTypeScript("no-useless-template-literals")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }


### PR DESCRIPTION
## Summary

Citing `no-useless-template-literals` (now renamed [no-unnecessary-template-expression](https://typescript-eslint.io/rules/no-unnecessary-template-expression)) was an error.

The rules are different.
The ESLint rule reports template literals that only use literals in interpolation. It doesn't report a template literal without interpolation.
Our rule outputs an opposite behavior.

## Test Plan

CI must pass.
