### PR TITLE
fix(noUnusedFunctionParameters): fix typo in documentation code example

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_unused_function_parameters.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_unused_function_parameters.rs
@@ -34,7 +34,7 @@ declare_rule! {
     /// ```
     ///
     /// ```js,expect_diagnostic
-    /// const squares = [[1, 1], [2, 4], [3, 9], 4, 16]];
+    /// const squares = [[1, 1], [2, 4], [3, 9], [4, 16]];
     /// squares.filter(([k, v]) => v > 5);
     /// ```
     ///


### PR DESCRIPTION
## Summary

Fixing a typo in the documentation code example

## Test Plan

Manually checked that it's correct