### PR TITLE
fix(cli): prevent overwriting paths when using `--staged` or `--changed` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ New entries must be placed in a section entitled `Unreleased`.
 Read
 our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
+## Unreleased
+
+### CLI
+
+#### Bug fixes
+
+- Fix  [#3069](https://github.com/biomejs/biome/issues/3069), prevent overwriting paths when using `--staged` or `--changed` options. Contributed by @unvalley
+
 ## 1.8.0 (2024-06-04)
 
 ### Analyzer

--- a/crates/biome_cli/examples/text_reporter.rs
+++ b/crates/biome_cli/examples/text_reporter.rs
@@ -1,4 +1,6 @@
-use biome_cli::{DiagnosticsPayload, Execution, Reporter, ReporterVisitor, TraversalSummary};
+use biome_cli::{
+    DiagnosticsPayload, Execution, Reporter, ReporterVisitor, TraversalSummary, VcsTargeted,
+};
 
 /// This will be the visitor, which where we **write** the data
 struct BufferVisitor(String);
@@ -10,7 +12,10 @@ struct TextReport {
 
 impl Reporter for TextReport {
     fn write(self, visitor: &mut dyn ReporterVisitor) -> std::io::Result<()> {
-        let execution = Execution::new_format();
+        let execution = Execution::new_format(VcsTargeted {
+            staged: false,
+            changed: false,
+        });
         visitor.report_summary(&execution, self.summary)?;
         Ok(())
     }

--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -2,6 +2,7 @@ use crate::cli_options::CliOptions;
 use crate::commands::{
     get_files_to_process, get_stdin, resolve_manifest, validate_configuration_diagnostics,
 };
+use crate::execute::VcsTargeted;
 use crate::{
     execute_mode, setup_cli_subscriber, CliDiagnostic, CliSession, Execution, TraversalMode,
 };
@@ -51,7 +52,7 @@ pub(crate) fn check(
         unsafe_,
         cli_options,
         configuration,
-        mut paths,
+        paths,
         stdin_file_path,
         linter_enabled,
         organize_imports_enabled,
@@ -151,11 +152,8 @@ pub(crate) fn check(
 
     let stdin = get_stdin(stdin_file_path, &mut *session.app.console, "check")?;
 
-    if let Some(_paths) =
-        get_files_to_process(since, changed, staged, &session.app.fs, &fs_configuration)?
-    {
-        paths = _paths;
-    }
+    let vcs_targeted_paths =
+        get_files_to_process(since, changed, staged, &session.app.fs, &fs_configuration)?;
 
     session
         .app
@@ -179,10 +177,11 @@ pub(crate) fn check(
         Execution::new(TraversalMode::Check {
             fix_file_mode,
             stdin,
+            vcs_targeted: VcsTargeted { staged, changed },
         })
         .set_report(&cli_options),
         session,
         &cli_options,
-        paths,
+        vcs_targeted_paths.unwrap_or(paths),
     )
 }

--- a/crates/biome_cli/src/commands/ci.rs
+++ b/crates/biome_cli/src/commands/ci.rs
@@ -1,6 +1,7 @@
 use crate::changed::get_changed_files;
 use crate::cli_options::CliOptions;
 use crate::commands::{resolve_manifest, validate_configuration_diagnostics};
+use crate::execute::VcsTargeted;
 use crate::{execute_mode, setup_cli_subscriber, CliDiagnostic, CliSession, Execution};
 use biome_configuration::{organize_imports::PartialOrganizeImports, PartialConfiguration};
 use biome_configuration::{PartialFormatterConfiguration, PartialLinterConfiguration};
@@ -126,7 +127,11 @@ pub(crate) fn ci(session: CliSession, payload: CiCommandPayload) -> Result<(), C
         })?;
 
     execute_mode(
-        Execution::new_ci().set_report(&cli_options),
+        Execution::new_ci(VcsTargeted {
+            staged: false,
+            changed,
+        })
+        .set_report(&cli_options),
         session,
         &cli_options,
         paths,

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -3,6 +3,7 @@ use crate::commands::{
     get_files_to_process, get_stdin, resolve_manifest, validate_configuration_diagnostics,
 };
 use crate::diagnostics::DeprecatedArgument;
+use crate::execute::VcsTargeted;
 use crate::{
     execute_mode, setup_cli_subscriber, CliDiagnostic, CliSession, Execution, TraversalMode,
 };
@@ -231,6 +232,7 @@ pub(crate) fn format(
         ignore_errors: cli_options.skip_errors,
         write: write || fix,
         stdin,
+        vcs_targeted: VcsTargeted { staged, changed },
     })
     .set_report(&cli_options);
 

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -43,7 +43,7 @@ pub(crate) fn traverse(
             | TraversalMode::Lint { .. }
             | TraversalMode::Format { .. }
             | TraversalMode::CI { .. } => {
-                // The `--staged` or `--changed` flags are intentionally empty, so we ignore them.
+                // If `--staged` or `--changed` is specified, it's acceptable for them to be empty, so ignore it.
                 if !execution.is_vcs_targeted() {
                     match current_dir() {
                         Ok(current_dir) => inputs.push(current_dir.into_os_string()),

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -31,7 +31,7 @@ use crate::commands::lint::LintCommandPayload;
 pub use crate::commands::{biome_command, BiomeCommand};
 pub use crate::logging::{setup_cli_subscriber, LoggingLevel};
 pub use diagnostics::CliDiagnostic;
-pub use execute::{execute_mode, Execution, TraversalMode};
+pub use execute::{execute_mode, Execution, TraversalMode, VcsTargeted};
 pub use panic::setup_panic_handler;
 pub use reporter::{DiagnosticsPayload, Reporter, ReporterVisitor, TraversalSummary};
 pub use service::{open_transport, SocketTransport};

--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -3293,3 +3293,52 @@ function f() {\n\targuments;\n}
         result,
     ));
 }
+
+#[test]
+fn should_error_if_unstaged_files_only_with_staged_flag() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    // Unstaged
+    fs.insert(
+        Path::new("file1.js").into(),
+        r#"console.log('file1');"#.as_bytes(),
+    );
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("check"), "--staged"].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_error_if_unstaged_files_only_with_staged_flag",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_error_if_unchanged_files_only_with_changed_flag() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    // Unchanged
+    fs.insert(
+        Path::new("file1.js").into(),
+        r#"console.log('file1');"#.as_bytes(),
+    );
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("check"), "--changed", "--since=main"].as_slice()),
+    );
+    assert!(result.is_err(), "run_cli returned {result:?}");
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_error_if_unchanged_files_only_with_changed_flag",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/commands/ci.rs
+++ b/crates/biome_cli/tests/commands/ci.rs
@@ -1050,3 +1050,27 @@ fn does_formatting_error_without_file_paths() {
         result,
     ));
 }
+
+#[test]
+fn should_error_if_unchanged_files_only_with_changed_flag() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    // Unchanged
+    fs.insert(
+        Path::new("file1.js").into(),
+        r#"console.log('file1');"#.as_bytes(),
+    );
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("check"), "--changed", "--since=main"].as_slice()),
+    );
+    assert!(result.is_err(), "run_cli returned {result:?}");
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_error_if_unchanged_files_only_with_changed_flag",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -3719,3 +3719,52 @@ fn fix() {
         result,
     ));
 }
+
+#[test]
+fn should_error_if_unstaged_files_only_with_staged_flag() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    // Unstaged
+    fs.insert(
+        Path::new("file1.js").into(),
+        r#"console.log('file1');"#.as_bytes(),
+    );
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), "--staged"].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_error_if_unstaged_files_only_with_staged_flag",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_error_if_unchanged_files_only_with_changed_flag() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    // Unchanged
+    fs.insert(
+        Path::new("file1.js").into(),
+        r#"console.log('file1');"#.as_bytes(),
+    );
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), "--changed", "--since=main"].as_slice()),
+    );
+    assert!(result.is_err(), "run_cli returned {result:?}");
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_error_if_unchanged_files_only_with_changed_flag",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -4197,3 +4197,52 @@ function f() { arguments; }
         result,
     ));
 }
+
+#[test]
+fn should_error_if_unstaged_files_only_with_staged_flag() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    // Unstaged
+    fs.insert(
+        Path::new("file1.js").into(),
+        r#"console.log('file1');"#.as_bytes(),
+    );
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("lint"), "--staged"].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_error_if_unstaged_files_only_with_staged_flag",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_error_if_unchanged_files_only_with_changed_flag() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    // Unchanged
+    fs.insert(
+        Path::new("file1.js").into(),
+        r#"console.log('file1');"#.as_bytes(),
+    );
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("lint"), "--changed", "--since=main"].as_slice()),
+    );
+    assert!(result.is_err(), "run_cli returned {result:?}");
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_error_if_unchanged_files_only_with_changed_flag",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_error_if_unchanged_files_only_with_changed_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_error_if_unchanged_files_only_with_changed_flag.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file1.js`
+
+```js
+console.log('file1');
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × No files were processed in the specified paths.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Checked 0 files in <TIME>. No fixes needed.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_error_if_unstaged_files_only_with_staged_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_error_if_unstaged_files_only_with_staged_flag.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file1.js`
+
+```js
+console.log('file1');
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × No files were processed in the specified paths.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Checked 0 files in <TIME>. No fixes needed.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/should_error_if_unchanged_files_only_with_changed_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/should_error_if_unchanged_files_only_with_changed_flag.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file1.js`
+
+```js
+console.log('file1');
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × No files were processed in the specified paths.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Checked 0 files in <TIME>. No fixes needed.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/should_error_if_unchanged_files_only_with_changed_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/should_error_if_unchanged_files_only_with_changed_flag.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file1.js`
+
+```js
+console.log('file1');
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × No files were processed in the specified paths.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Checked 0 files in <TIME>. No fixes needed.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/should_error_if_unstaged_files_only_with_staged_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/should_error_if_unstaged_files_only_with_staged_flag.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file1.js`
+
+```js
+console.log('file1');
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × No files were processed in the specified paths.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Checked 0 files in <TIME>. No fixes needed.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_unchanged_files_only_with_changed_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_unchanged_files_only_with_changed_flag.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file1.js`
+
+```js
+console.log('file1');
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × No files were processed in the specified paths.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Checked 0 files in <TIME>. No fixes needed.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_unstaged_files_only_with_staged_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_unstaged_files_only_with_staged_flag.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file1.js`
+
+```js
+console.log('file1');
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × No files were processed in the specified paths.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Checked 0 files in <TIME>. No fixes needed.
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #3069 

### Context: 

The PR #2726 overwrite the `biome (lint|format|check|ci)` command's target path when the path is empty.
But, when using `--staged` and `--changed` options, the path would be **intentionally** empty. When there is no file in staging (`--staged`) or there is no difference from a certain branch (`--changed`), the file to be executed need not exist.


So, in this PR, make sure that paths are not overwritten when either `--staged` or `--changed` is used.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added snapshot cases.
And manually tested `--staged` and `--changed` commands.

<!-- What demonstrates that your implementation is correct? -->
