### PR TITLE
fix(config): default value for indent_width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,35 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ## Unreleased
 
+### Analyzer
+
 ### CLI
 
 #### Bug fixes
 
 - Fix [#3069](https://github.com/biomejs/biome/issues/3069), prevent overwriting paths when using `--staged` or `--changed` options. Contributed by @unvalley
 
+
+### Configuration
+
+#### Bug fixes
+
+- Fix [#3067](https://github.com/biomejs/biome/issues/3067), by assigning the correct default value to `indentWidth`. Contributed by @ematipico
+
+### Editors
+
+### Formatter
+
+### JavaScript APIs
+
 ### Linter
 
 #### Bug fixes
 
 - The `no-empty-block` css lint rule now treats empty blocks containing comments as valid ones. Contributed by @Sec-ant
+
+
+### Parser
 
 ## 1.8.0 (2024-06-04)
 
@@ -304,8 +322,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Resolve deadlocks by narrowing the scope of locks. Contributed by @mechairoi
 - Fix [#2782](https://github.com/biomejs/biome/issues/2782) by computing the enabled rules by taking the override settings into consideration. Contributed by @ematipico
 - Fix [https://github.com/biomejs/biome/issues/2877] by correctly handling line terminators in JSX string. Contributed by @ah-yu
-
-### JavaScript APIs
 
 ### Linter
 

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -215,7 +215,7 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("Indent style", markup!({DebugDisplay(formatter_configuration.indent_style)}))}
                             {KeyValuePair("Indent width", markup!({DebugDisplay(formatter_configuration.indent_width)}))}
                             {KeyValuePair("Line ending", markup!({DebugDisplay(formatter_configuration.line_ending)}))}
-                            {KeyValuePair("Line width", markup!({DebugDisplay(formatter_configuration.line_width.get())}))}
+                            {KeyValuePair("Line width", markup!({DebugDisplay(formatter_configuration.line_width.value())}))}
                             {KeyValuePair("Attribute position", markup!({DebugDisplay(formatter_configuration.attribute_position)}))}
                             {KeyValuePair("Ignore", markup!({DebugDisplay(formatter_configuration.ignore.iter().collect::<Vec<_>>())}))}
                             {KeyValuePair("Include", markup!({DebugDisplay(formatter_configuration.include.iter().collect::<Vec<_>>())}))}
@@ -237,7 +237,7 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("Indent style", markup!({DebugDisplayOption(javascript_formatter_configuration.indent_style)}))}
                             {KeyValuePair("Indent width", markup!({DebugDisplayOption(javascript_formatter_configuration.indent_width)}))}
                             {KeyValuePair("Line ending", markup!({DebugDisplayOption(javascript_formatter_configuration.line_ending)}))}
-                            {KeyValuePair("Line width", markup!({DebugDisplayOption(javascript_formatter_configuration.line_width.map(|lw| lw.get()))}))}
+                            {KeyValuePair("Line width", markup!({DebugDisplayOption(javascript_formatter_configuration.line_width.map(|lw| lw.value()))}))}
                             {KeyValuePair("Attribute position", markup!({DebugDisplay(javascript_formatter_configuration.attribute_position)}))}
                         )
                         .fmt(fmt)?;
@@ -250,7 +250,7 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("Indent style", markup!({DebugDisplayOption(json_formatter_configuration.indent_style)}))}
                             {KeyValuePair("Indent width", markup!({DebugDisplayOption(json_formatter_configuration.indent_width)}))}
                             {KeyValuePair("Line ending", markup!({DebugDisplayOption(json_formatter_configuration.line_ending)}))}
-                            {KeyValuePair("Line width", markup!({DebugDisplayOption(json_formatter_configuration.line_width.map(|lw| lw.get()))}))}
+                            {KeyValuePair("Line width", markup!({DebugDisplayOption(json_formatter_configuration.line_width.map(|lw| lw.value()))}))}
                             {KeyValuePair("Trailing Commas", markup!({DebugDisplayOption(json_formatter_configuration.trailing_commas)}))}
                         ).fmt(fmt)?;
 

--- a/crates/biome_cli/src/execute/migrate.rs
+++ b/crates/biome_cli/src/execute/migrate.rs
@@ -8,7 +8,7 @@ use biome_deserialize::json::deserialize_from_json_ast;
 use biome_deserialize::Merge;
 use biome_diagnostics::Diagnostic;
 use biome_diagnostics::{category, PrintDiagnostic};
-use biome_formatter::ParseLineWidthError;
+use biome_formatter::ParseFormatNumberError;
 use biome_fs::{BiomePath, ConfigName, FileSystemExt, OpenOptions};
 use biome_json_parser::{parse_json_with_cache, JsonParserOptions};
 use biome_json_syntax::{JsonFileSource, JsonRoot};
@@ -93,7 +93,7 @@ pub(crate) fn run(migrate_payload: MigratePayload) -> Result<(), CliDiagnostic> 
             let prettier_biome_config =
                 prettier_config
                     .try_into()
-                    .map_err(|err: ParseLineWidthError| {
+                    .map_err(|err: ParseFormatNumberError| {
                         CliDiagnostic::MigrateError(MigrationDiagnostic {
                             reason: err.to_string(),
                         })

--- a/crates/biome_cli/src/execute/migrate.rs
+++ b/crates/biome_cli/src/execute/migrate.rs
@@ -8,7 +8,7 @@ use biome_deserialize::json::deserialize_from_json_ast;
 use biome_deserialize::Merge;
 use biome_diagnostics::Diagnostic;
 use biome_diagnostics::{category, PrintDiagnostic};
-use biome_formatter::LineWidthFromIntError;
+use biome_formatter::ParseLineWidthError;
 use biome_fs::{BiomePath, ConfigName, FileSystemExt, OpenOptions};
 use biome_json_parser::{parse_json_with_cache, JsonParserOptions};
 use biome_json_syntax::{JsonFileSource, JsonRoot};
@@ -93,7 +93,7 @@ pub(crate) fn run(migrate_payload: MigratePayload) -> Result<(), CliDiagnostic> 
             let prettier_biome_config =
                 prettier_config
                     .try_into()
-                    .map_err(|err: LineWidthFromIntError| {
+                    .map_err(|err: ParseLineWidthError| {
                         CliDiagnostic::MigrateError(MigrationDiagnostic {
                             reason: err.to_string(),
                         })

--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -5,7 +5,7 @@ use biome_deserialize::{json::deserialize_from_json_str, StringSet};
 use biome_deserialize_macros::Deserializable;
 use biome_diagnostics::{DiagnosticExt, PrintDiagnostic};
 use biome_formatter::{
-    AttributePosition, IndentWidth, LineEnding, LineWidth, ParseLineWidthError, QuoteStyle,
+    AttributePosition, IndentWidth, LineEnding, LineWidth, ParseFormatNumberError, QuoteStyle,
 };
 use biome_fs::{FileSystem, OpenOptions};
 use biome_js_formatter::context::{ArrowParentheses, QuoteProperties, Semicolons, TrailingCommas};
@@ -187,7 +187,7 @@ impl From<QuoteProps> for QuoteProperties {
 }
 
 impl TryFrom<PrettierConfiguration> for biome_configuration::PartialConfiguration {
-    type Error = ParseLineWidthError;
+    type Error = ParseFormatNumberError;
     fn try_from(value: PrettierConfiguration) -> Result<Self, Self::Error> {
         let mut result = biome_configuration::PartialConfiguration::default();
 
@@ -267,7 +267,7 @@ impl TryFrom<PrettierConfiguration> for biome_configuration::PartialConfiguratio
 }
 
 impl TryFrom<Override> for biome_configuration::OverridePattern {
-    type Error = ParseLineWidthError;
+    type Error = ParseFormatNumberError;
     fn try_from(Override { files, options }: Override) -> Result<Self, Self::Error> {
         let mut result = biome_configuration::OverridePattern {
             include: Some(StringSet::new(files.into_iter().collect())),

--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -5,7 +5,7 @@ use biome_deserialize::{json::deserialize_from_json_str, StringSet};
 use biome_deserialize_macros::Deserializable;
 use biome_diagnostics::{DiagnosticExt, PrintDiagnostic};
 use biome_formatter::{
-    AttributePosition, LineEnding, LineWidth, LineWidthFromIntError, QuoteStyle,
+    AttributePosition, IndentWidth, LineEnding, LineWidth, ParseLineWidthError, QuoteStyle,
 };
 use biome_fs::{FileSystem, OpenOptions};
 use biome_js_formatter::context::{ArrowParentheses, QuoteProperties, Semicolons, TrailingCommas};
@@ -187,18 +187,19 @@ impl From<QuoteProps> for QuoteProperties {
 }
 
 impl TryFrom<PrettierConfiguration> for biome_configuration::PartialConfiguration {
-    type Error = LineWidthFromIntError;
+    type Error = ParseLineWidthError;
     fn try_from(value: PrettierConfiguration) -> Result<Self, Self::Error> {
         let mut result = biome_configuration::PartialConfiguration::default();
 
         let line_width = LineWidth::try_from(value.print_width)?;
+        let indent_width = IndentWidth::try_from(value.tab_width)?;
         let indent_style = if value.use_tabs {
             biome_configuration::PlainIndentStyle::Tab
         } else {
             biome_configuration::PlainIndentStyle::Space
         };
         let formatter = biome_configuration::PartialFormatterConfiguration {
-            indent_width: Some(value.tab_width),
+            indent_width: Some(indent_width),
             line_width: Some(line_width),
             indent_style: Some(indent_style),
             line_ending: Some(value.end_of_line.into()),
@@ -266,7 +267,7 @@ impl TryFrom<PrettierConfiguration> for biome_configuration::PartialConfiguratio
 }
 
 impl TryFrom<Override> for biome_configuration::OverridePattern {
-    type Error = LineWidthFromIntError;
+    type Error = ParseLineWidthError;
     fn try_from(Override { files, options }: Override) -> Result<Self, Self::Error> {
         let mut result = biome_configuration::OverridePattern {
             include: Some(StringSet::new(files.into_iter().collect())),
@@ -283,6 +284,12 @@ impl TryFrom<Override> for biome_configuration::OverridePattern {
             } else {
                 None
             };
+            // are global options are set
+            let indent_width = if let Some(indent_width) = options.tab_width {
+                Some(IndentWidth::try_from(indent_width)?)
+            } else {
+                None
+            };
             let indent_style = options.use_tabs.map(|use_tabs| {
                 if use_tabs {
                     biome_configuration::PlainIndentStyle::Tab
@@ -291,7 +298,7 @@ impl TryFrom<Override> for biome_configuration::OverridePattern {
                 }
             });
             let formatter = biome_configuration::OverrideFormatterConfiguration {
-                indent_width: options.tab_width,
+                indent_width,
                 line_width,
                 indent_style,
                 line_ending: options.end_of_line.map(|end_of_line| end_of_line.into()),

--- a/crates/biome_cli/tests/cases/config_extends.rs
+++ b/crates/biome_cli/tests/cases/config_extends.rs
@@ -325,7 +325,7 @@ fn allows_reverting_fields_in_extended_config_to_default() {
         rome_json.into(),
         format!(
             r#"{{ "extends": ["format.json"], "formatter": {{ "lineWidth": {} }} }}"#,
-            LineWidth::default().get()
+            LineWidth::default().value()
         ),
     );
 

--- a/crates/biome_cli/tests/snap_test.rs
+++ b/crates/biome_cli/tests/snap_test.rs
@@ -3,7 +3,7 @@ use biome_console::fmt::{Formatter, Termcolor};
 use biome_console::{markup, BufferConsole, Markup};
 use biome_diagnostics::termcolor::NoColor;
 use biome_diagnostics::{print_diagnostic_to_string, Error};
-use biome_formatter::IndentStyle;
+use biome_formatter::{IndentStyle, IndentWidth};
 use biome_fs::{ConfigName, FileSystemExt, MemoryFileSystem};
 use biome_json_formatter::context::JsonFormatOptions;
 use biome_json_formatter::format_node;
@@ -69,7 +69,7 @@ impl CliSnapshot {
             let formatted = format_node(
                 JsonFormatOptions::default()
                     .with_indent_style(IndentStyle::Space)
-                    .with_indent_width(2.into()),
+                    .with_indent_width(IndentWidth::default()),
                 &parsed.syntax(),
             )
             .expect("formatted JSON")

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
@@ -78,7 +78,7 @@ Biome Configuration:
 Formatter:
   Format with errors:           true
   Indent style:                 Space
-  Indent width:                 IndentWidth(2)
+  Indent width:                 2
   Line ending:                  Lf
   Line width:                   120
   Attribute position:           Multiline
@@ -96,7 +96,7 @@ JavaScript Formatter:
   Bracket same line:            false
   Quote style:                  Double
   Indent style:                 Tab
-  Indent width:                 IndentWidth(2)
+  Indent width:                 2
   Line ending:                  Lf
   Line width:                   100
   Attribute position:           Auto
@@ -104,7 +104,7 @@ JavaScript Formatter:
 JSON Formatter:
   Enabled:                      true
   Indent style:                 Space
-  Indent width:                 IndentWidth(2)
+  Indent width:                 2
   Line ending:                  Lf
   Line width:                   100
   Trailing Commas:              unset
@@ -112,9 +112,9 @@ JSON Formatter:
 CSS Formatter:
   Enabled:                      false
   Indent style:                 Tab
-  Indent width:                 IndentWidth(2)
+  Indent width:                 2
   Line ending:                  Lf
-  Line width:                   LineWidth(80)
+  Line width:                   80
   Quote style:                  Double
 
 Server:

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
@@ -78,7 +78,7 @@ Biome Configuration:
 Formatter:
   Format with errors:           true
   Indent style:                 Space
-  Indent width:                 2
+  Indent width:                 IndentWidth(2)
   Line ending:                  Lf
   Line width:                   120
   Attribute position:           Multiline
@@ -96,7 +96,7 @@ JavaScript Formatter:
   Bracket same line:            false
   Quote style:                  Double
   Indent style:                 Tab
-  Indent width:                 2
+  Indent width:                 IndentWidth(2)
   Line ending:                  Lf
   Line width:                   100
   Attribute position:           Auto
@@ -104,7 +104,7 @@ JavaScript Formatter:
 JSON Formatter:
   Enabled:                      true
   Indent style:                 Space
-  Indent width:                 2
+  Indent width:                 IndentWidth(2)
   Line ending:                  Lf
   Line width:                   100
   Trailing Commas:              unset
@@ -112,7 +112,7 @@ JSON Formatter:
 CSS Formatter:
   Enabled:                      false
   Indent style:                 Tab
-  Indent width:                 0
+  Indent width:                 IndentWidth(2)
   Line ending:                  Lf
   Line width:                   LineWidth(80)
   Quote style:                  Double

--- a/crates/biome_configuration/src/css.rs
+++ b/crates/biome_configuration/src/css.rs
@@ -1,6 +1,6 @@
 use crate::PlainIndentStyle;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
-use biome_formatter::{LineEnding, LineWidth, QuoteStyle};
+use biome_formatter::{IndentWidth, LineEnding, LineWidth, QuoteStyle};
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 
@@ -54,7 +54,7 @@ pub struct CssFormatter {
 
     /// The size of the indentation applied to CSS (and its super languages) files. Default to 2.
     #[partial(bpaf(long("css-formatter-indent-width"), argument("NUMBER"), optional))]
-    pub indent_width: u8,
+    pub indent_width: IndentWidth,
 
     /// The type of line ending applied to CSS (and its super languages) files.
     #[partial(bpaf(long("css-formatter-line-ending"), argument("lf|crlf|cr"), optional))]
@@ -99,4 +99,12 @@ impl PartialCssLinter {
             enabled: self.enabled.unwrap_or_default(),
         }
     }
+}
+
+#[test]
+fn default_css() {
+    let css_configuration = CssFormatter::default();
+
+    assert_eq!(css_configuration.indent_width, IndentWidth::default());
+    assert_eq!(css_configuration.indent_width.value(), 2);
 }

--- a/crates/biome_configuration/src/editorconfig.rs
+++ b/crates/biome_configuration/src/editorconfig.rs
@@ -13,7 +13,7 @@ use std::{collections::HashMap, str::FromStr};
 
 use biome_deserialize::StringSet;
 use biome_diagnostics::{adapters::IniError, Error};
-use biome_formatter::{LineEnding, LineWidth};
+use biome_formatter::{IndentWidth, LineEnding, LineWidth};
 use indexmap::IndexSet;
 use serde::{Deserialize, Deserializer};
 
@@ -83,8 +83,8 @@ impl EditorConfig {
 #[serde(default)]
 pub struct EditorConfigOptions {
     indent_style: Option<PlainIndentStyle>,
-    #[serde(deserialize_with = "deserialize_optional_u8_from_string")]
-    indent_size: Option<u8>,
+    #[serde(deserialize_with = "deserialize_optional_indent_width_from_string")]
+    indent_size: Option<IndentWidth>,
     end_of_line: Option<LineEnding>,
     #[serde(deserialize_with = "deserialize_optional_line_width_from_string")]
     max_line_length: Option<LineWidth>,
@@ -146,17 +146,16 @@ where
     deserialize_bool_from_string(deserializer).map(Some)
 }
 
-fn deserialize_optional_u8_from_string<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
+fn deserialize_optional_indent_width_from_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<IndentWidth>, D::Error>
 where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    match s.parse() {
-        Ok(n) => Ok(Some(n)),
-        Err(_) => Err(serde::de::Error::custom(
-            "expected a number between 0 and 255",
-        )),
-    }
+    IndentWidth::from_str(s.as_str())
+        .map_err(serde::de::Error::custom)
+        .map(Some)
 }
 
 fn deserialize_optional_line_width_from_string<'de, D>(
@@ -225,20 +224,20 @@ root = true
 
 [*]
 insert_final_newline = true
-end_of_line = lf
-indent_style = tab
+end_of_line = crlf
+indent_style = space
 indent_size = 4
-max_line_length = 120
+max_line_length = 80
 "#;
 
         let conf = parse_str(input).expect("Failed to parse editorconfig");
         let (conf, _) = conf.to_biome();
         let conf = conf.expect("Failed to convert editorconfig to biome");
         let formatter = conf.formatter.expect("Formatter not set");
-        assert_eq!(formatter.indent_style, Some(PlainIndentStyle::Tab));
-        assert_eq!(formatter.indent_width, Some(4));
-        assert_eq!(formatter.line_ending, Some(LineEnding::Lf));
-        assert_eq!(formatter.line_width.map(|v| v.get()), Some(120));
+        assert_eq!(formatter.indent_style, Some(PlainIndentStyle::Space));
+        assert_eq!(formatter.indent_width.unwrap().value(), 4);
+        assert_eq!(formatter.line_ending, Some(LineEnding::Crlf));
+        assert_eq!(formatter.line_width.map(|v| v.get()), Some(80));
     }
 
     #[test]

--- a/crates/biome_configuration/src/editorconfig.rs
+++ b/crates/biome_configuration/src/editorconfig.rs
@@ -237,7 +237,7 @@ max_line_length = 80
         assert_eq!(formatter.indent_style, Some(PlainIndentStyle::Space));
         assert_eq!(formatter.indent_width.unwrap().value(), 4);
         assert_eq!(formatter.line_ending, Some(LineEnding::Crlf));
-        assert_eq!(formatter.line_width.map(|v| v.get()), Some(80));
+        assert_eq!(formatter.line_width.map(|v| v.value()), Some(80));
     }
 
     #[test]

--- a/crates/biome_configuration/src/formatter.rs
+++ b/crates/biome_configuration/src/formatter.rs
@@ -1,6 +1,6 @@
 use biome_deserialize::StringSet;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
-use biome_formatter::{AttributePosition, IndentStyle, LineEnding, LineWidth};
+use biome_formatter::{AttributePosition, IndentStyle, IndentWidth, LineEnding, LineWidth};
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -27,11 +27,11 @@ pub struct FormatterConfiguration {
     /// The size of the indentation, 2 by default (deprecated, use `indent-width`)
     #[partial(bpaf(long("indent-size"), argument("NUMBER"), optional))]
     #[partial(deserializable(deprecated(use_instead = "formatter.indentWidth")))]
-    pub indent_size: u8,
+    pub indent_size: IndentWidth,
 
     /// The size of the indentation, 2 by default
     #[partial(bpaf(long("indent-width"), argument("NUMBER"), optional))]
-    pub indent_width: u8,
+    pub indent_width: IndentWidth,
 
     /// The type of line ending.
     #[partial(bpaf(long("line-ending"), argument("lf|crlf|cr"), optional))]
@@ -82,8 +82,8 @@ impl Default for FormatterConfiguration {
         Self {
             enabled: true,
             format_with_errors: false,
-            indent_size: 2,
-            indent_width: 2,
+            indent_size: IndentWidth::default(),
+            indent_width: IndentWidth::default(),
             indent_style: PlainIndentStyle::default(),
             line_ending: LineEnding::default(),
             line_width: LineWidth::default(),

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -1,6 +1,6 @@
 use crate::PlainIndentStyle;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
-use biome_formatter::{AttributePosition, LineEnding, LineWidth, QuoteStyle};
+use biome_formatter::{AttributePosition, IndentWidth, LineEnding, LineWidth, QuoteStyle};
 use biome_js_formatter::context::{
     trailing_commas::TrailingCommas, ArrowParentheses, QuoteProperties, Semicolons,
 };
@@ -63,7 +63,7 @@ pub struct JavascriptFormatter {
     /// The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.
     #[partial(deserializable(deprecated(use_instead = "javascript.formatter.indentWidth")))]
     #[partial(bpaf(long("javascript-formatter-indent-size"), argument("NUMBER"), optional))]
-    pub indent_size: Option<u8>,
+    pub indent_size: Option<IndentWidth>,
 
     /// The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.
     #[partial(bpaf(
@@ -71,7 +71,7 @@ pub struct JavascriptFormatter {
         argument("NUMBER"),
         optional
     ))]
-    pub indent_width: Option<u8>,
+    pub indent_width: Option<IndentWidth>,
 
     /// The type of line ending applied to JavaScript (and its super languages) files.
     #[partial(bpaf(

--- a/crates/biome_configuration/src/json.rs
+++ b/crates/biome_configuration/src/json.rs
@@ -1,6 +1,6 @@
 use crate::PlainIndentStyle;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
-use biome_formatter::{LineEnding, LineWidth};
+use biome_formatter::{IndentWidth, LineEnding, LineWidth};
 use biome_json_formatter::context::TrailingCommas;
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
@@ -54,12 +54,12 @@ pub struct JsonFormatter {
 
     /// The size of the indentation applied to JSON (and its super languages) files. Default to 2.
     #[partial(bpaf(long("json-formatter-indent-width"), argument("NUMBER"), optional))]
-    pub indent_width: Option<u8>,
+    pub indent_width: Option<IndentWidth>,
 
     /// The size of the indentation applied to JSON (and its super languages) files. Default to 2.
     #[partial(bpaf(long("json-formatter-indent-size"), argument("NUMBER"), optional))]
     #[partial(deserializable(deprecated(use_instead = "json.formatter.indentWidth")))]
-    pub indent_size: Option<u8>,
+    pub indent_size: Option<IndentWidth>,
 
     /// The type of line ending applied to JSON (and its super languages) files.
     #[partial(bpaf(long("json-formatter-line-ending"), argument("lf|crlf|cr"), optional))]

--- a/crates/biome_configuration/src/linter/mod.rs
+++ b/crates/biome_configuration/src/linter/mod.rs
@@ -370,6 +370,7 @@ impl<'de> serde::Deserialize<'de> for RuleSelector {
     }
 }
 
+#[cfg(feature = "schema")]
 impl schemars::JsonSchema for RuleSelector {
     fn schema_name() -> String {
         "RuleCode".to_string()

--- a/crates/biome_configuration/src/overrides.rs
+++ b/crates/biome_configuration/src/overrides.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use biome_deserialize::StringSet;
 use biome_deserialize_macros::{Deserializable, Merge};
-use biome_formatter::{AttributePosition, LineEnding, LineWidth};
+use biome_formatter::{AttributePosition, IndentWidth, LineEnding, LineWidth};
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -110,12 +110,12 @@ pub struct OverrideFormatterConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[deserializable(deprecated(use_instead = "formatter.indentWidth"))]
     #[bpaf(long("indent-size"), argument("NUMBER"), optional)]
-    pub indent_size: Option<u8>,
+    pub indent_size: Option<IndentWidth>,
 
     /// The size of the indentation, 2 by default
     #[serde(skip_serializing_if = "Option::is_none")]
     #[bpaf(long("indent-width"), argument("NUMBER"), optional)]
-    pub indent_width: Option<u8>,
+    pub indent_width: Option<IndentWidth>,
 
     /// The type of line ending.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/biome_css_formatter/src/context.rs
+++ b/crates/biome_css_formatter/src/context.rs
@@ -160,7 +160,7 @@ impl fmt::Display for CssFormatOptions {
         writeln!(f, "Indent style: {}", self.indent_style)?;
         writeln!(f, "Indent width: {}", self.indent_width.value())?;
         writeln!(f, "Line ending: {}", self.line_ending)?;
-        writeln!(f, "Line width: {}", self.line_width.get())?;
+        writeln!(f, "Line width: {}", self.line_width.value())?;
         writeln!(f, "Quote style: {}", self.quote_style)
     }
 }

--- a/crates/biome_css_formatter/tests/prettier_tests.rs
+++ b/crates/biome_css_formatter/tests/prettier_tests.rs
@@ -1,7 +1,7 @@
 use std::{env, path::Path};
 
 use biome_css_formatter::context::CssFormatOptions;
-use biome_formatter::IndentStyle;
+use biome_formatter::{IndentStyle, IndentWidth};
 use biome_formatter_test::test_prettier_snapshot::{PrettierSnapshot, PrettierTestFile};
 
 mod language;
@@ -19,7 +19,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
     let test_file = PrettierTestFile::new(input, root_path);
     let options = CssFormatOptions::default()
         .with_indent_style(IndentStyle::Space)
-        .with_indent_width(2.into());
+        .with_indent_width(IndentWidth::default());
     let language = language::CssTestFormatLanguage::default();
     let snapshot = PrettierSnapshot::new(test_file, language, options);
 

--- a/crates/biome_css_formatter/tests/specs/css/quote_style/normalize_quotes.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/quote_style/normalize_quotes.css.snap
@@ -71,7 +71,7 @@ div {
 
 -----
 Indent style: Tab
-Indent width: 0
+Indent width: 2
 Line ending: LF
 Line width: 80
 Quote style: Single Quotes

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -44,7 +44,7 @@ mod verbatim;
 use crate::formatter::Formatter;
 use crate::group_id::UniqueGroupIdBuilder;
 use crate::prelude::TagKind;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 
 use crate::builders::syntax_token_cow_slice;
 use crate::comments::{CommentStyle, Comments, SourceComment};
@@ -55,6 +55,7 @@ use crate::printed_tokens::PrintedTokens;
 use crate::printer::{Printer, PrinterOptions};
 use crate::trivia::{format_skipped_token_trivia, format_trimmed_token};
 pub use arguments::{Argument, Arguments};
+use biome_console::markup;
 use biome_deserialize::{
     Deserializable, DeserializableValue, DeserializationDiagnostic, TextNumber,
 };
@@ -119,7 +120,7 @@ impl FromStr for IndentStyle {
     }
 }
 
-impl std::fmt::Display for IndentStyle {
+impl Display for IndentStyle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             IndentStyle::Tab => std::write!(f, "Tab"),
@@ -197,7 +198,7 @@ impl std::fmt::Display for LineEnding {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Merge, Hash, PartialEq)]
+#[derive(Clone, Copy, Eq, Merge, Hash, PartialEq)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, schemars::JsonSchema),
@@ -206,9 +207,9 @@ impl std::fmt::Display for LineEnding {
 pub struct IndentWidth(u8);
 
 impl IndentWidth {
-    pub const MIN: u8 = 2;
+    pub const MIN: u8 = 0;
 
-    pub const MAX: u8 = 80;
+    pub const MAX: u8 = 24;
 
     /// Return the numeric value for this [IndentWidth]
     pub fn value(&self) -> u8 {
@@ -254,11 +255,11 @@ impl<'de> serde::Deserialize<'de> for IndentWidth {
 }
 
 impl FromStr for IndentWidth {
-    type Err = ParseLineWidthError;
+    type Err = ParseFormatNumberError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let value = u8::from_str(s).map_err(ParseLineWidthError::ParseError)?;
-        let value = Self::try_from(value).map_err(ParseLineWidthError::TryFromU8Error)?;
+        let value = u8::from_str(s).map_err(ParseFormatNumberError::ParseError)?;
+        let value = Self::try_from(value).map_err(ParseFormatNumberError::TryFromU8Error)?;
         Ok(value)
     }
 }
@@ -275,10 +276,29 @@ impl TryFrom<u8> for IndentWidth {
     }
 }
 
+impl biome_console::fmt::Display for IndentWidth {
+    fn fmt(&self, fmt: &mut biome_console::fmt::Formatter) -> std::io::Result<()> {
+        fmt.write_markup(markup! {{self.value()}})
+    }
+}
+
+impl Display for IndentWidth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = self.value();
+        f.write_str(&std::format!("{}", value))
+    }
+}
+
+impl Debug for IndentWidth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
 /// Validated value for the `line_width` formatter options
 ///
 /// The allowed range of values is 1..=320
-#[derive(Clone, Copy, Debug, Eq, Merge, PartialEq)]
+#[derive(Clone, Copy, Eq, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, schemars::JsonSchema),
@@ -293,7 +313,7 @@ impl LineWidth {
     pub const MAX: u16 = 320;
 
     /// Return the numeric value for this [LineWidth]
-    pub fn get(&self) -> u16 {
+    pub fn value(&self) -> u16 {
         self.0
     }
 }
@@ -335,9 +355,28 @@ impl<'de> serde::Deserialize<'de> for LineWidth {
     }
 }
 
-/// Error type returned when parsing a [LineWidth] from a string fails
-pub enum ParseLineWidthError {
-    /// The string could not be parsed as a valid [u16]
+impl biome_console::fmt::Display for LineWidth {
+    fn fmt(&self, fmt: &mut biome_console::fmt::Formatter) -> std::io::Result<()> {
+        fmt.write_markup(markup! {{self.0}})
+    }
+}
+
+impl Display for LineWidth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = self.value();
+        f.write_str(&std::format!("{}", value))
+    }
+}
+
+impl Debug for LineWidth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
+/// Error type returned when parsing a [LineWidth] or [IndentWidth] from a string fails
+pub enum ParseFormatNumberError {
+    /// The string could not be parsed to a number
     ParseError(ParseIntError),
     /// The `u16` value of the string is not a valid [LineWidth]
     TryFromU16Error(LineWidthFromIntError),
@@ -345,36 +384,36 @@ pub enum ParseLineWidthError {
     TryFromU8Error(IndentWidthFromIntError),
 }
 
-impl From<IndentWidthFromIntError> for ParseLineWidthError {
+impl From<IndentWidthFromIntError> for ParseFormatNumberError {
     fn from(value: IndentWidthFromIntError) -> Self {
         Self::TryFromU8Error(value)
     }
 }
 
-impl From<LineWidthFromIntError> for ParseLineWidthError {
+impl From<LineWidthFromIntError> for ParseFormatNumberError {
     fn from(value: LineWidthFromIntError) -> Self {
         Self::TryFromU16Error(value)
     }
 }
 
-impl From<ParseIntError> for ParseLineWidthError {
+impl From<ParseIntError> for ParseFormatNumberError {
     fn from(value: ParseIntError) -> Self {
         Self::ParseError(value)
     }
 }
 
-impl Debug for ParseLineWidthError {
+impl Debug for ParseFormatNumberError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self, f)
     }
 }
 
-impl std::fmt::Display for ParseLineWidthError {
+impl std::fmt::Display for ParseFormatNumberError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ParseLineWidthError::ParseError(err) => std::fmt::Display::fmt(err, fmt),
-            ParseLineWidthError::TryFromU16Error(err) => std::fmt::Display::fmt(err, fmt),
-            ParseLineWidthError::TryFromU8Error(err) => std::fmt::Display::fmt(err, fmt),
+            ParseFormatNumberError::ParseError(err) => std::fmt::Display::fmt(err, fmt),
+            ParseFormatNumberError::TryFromU16Error(err) => std::fmt::Display::fmt(err, fmt),
+            ParseFormatNumberError::TryFromU8Error(err) => std::fmt::Display::fmt(err, fmt),
         }
     }
 }
@@ -392,11 +431,11 @@ impl TryFrom<u16> for LineWidth {
 }
 
 impl FromStr for LineWidth {
-    type Err = ParseLineWidthError;
+    type Err = ParseFormatNumberError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let value = u16::from_str(s).map_err(ParseLineWidthError::ParseError)?;
-        let value = Self::try_from(value).map_err(ParseLineWidthError::TryFromU16Error)?;
+        let value = u16::from_str(s).map_err(ParseFormatNumberError::ParseError)?;
+        let value = Self::try_from(value).map_err(ParseFormatNumberError::TryFromU16Error)?;
         Ok(value)
     }
 }

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -339,9 +339,9 @@ impl<'de> serde::Deserialize<'de> for LineWidth {
 pub enum ParseLineWidthError {
     /// The string could not be parsed as a valid [u16]
     ParseError(ParseIntError),
-    /// The [u16] value of the string is not a valid [LineWidth]
+    /// The `u16` value of the string is not a valid [LineWidth]
     TryFromU16Error(LineWidthFromIntError),
-    /// The [u8] value of the string is not a valid [IndentWidth]
+    /// The `u8 value of the string is not a valid [IndentWidth]
     TryFromU8Error(IndentWidthFromIntError),
 }
 

--- a/crates/biome_formatter/src/printer/mod.rs
+++ b/crates/biome_formatter/src/printer/mod.rs
@@ -1400,7 +1400,7 @@ mod tests {
             root,
             PrinterOptions {
                 indent_style: IndentStyle::Space,
-                indent_width: 2.into(),
+                indent_width: 2.try_into().unwrap(),
                 line_ending: LineEnding::Lf,
                 ..PrinterOptions::default()
             },
@@ -1568,7 +1568,7 @@ two lines`,
     fn it_use_the_indent_character_specified_in_the_options() {
         let options = PrinterOptions {
             indent_style: IndentStyle::Tab,
-            indent_width: 4.into(),
+            indent_width: 2.try_into().unwrap(),
             print_width: PrintWidth::new(19),
             ..PrinterOptions::default()
         };

--- a/crates/biome_formatter/src/printer/printer_options/mod.rs
+++ b/crates/biome_formatter/src/printer/printer_options/mod.rs
@@ -112,7 +112,7 @@ impl PrinterOptions {
 impl Default for PrinterOptions {
     fn default() -> Self {
         PrinterOptions {
-            indent_width: 2.into(),
+            indent_width: IndentWidth::default(),
             print_width: PrintWidth::default(),
             indent_style: Default::default(),
             line_ending: LineEnding::Lf,

--- a/crates/biome_formatter_test/src/spec.rs
+++ b/crates/biome_formatter_test/src/spec.rs
@@ -225,7 +225,7 @@ where
 
         let (output_code, printed) = self.formatted(&parsed, self.options.clone());
 
-        let max_width = self.options.line_width().get() as usize;
+        let max_width = self.options.line_width().value() as usize;
 
         snapshot_builder = snapshot_builder
             .with_output_and_options(
@@ -263,7 +263,7 @@ where
 
             let (mut output_code, printed) = self.formatted(&parsed, options.clone());
 
-            let max_width = options.line_width().get() as usize;
+            let max_width = options.line_width().value() as usize;
 
             // There are some logs that print different line endings, and we can't snapshot those
             // otherwise we risk automatically having them replaced with LF by git.

--- a/crates/biome_formatter_test/src/test_prettier_snapshot.rs
+++ b/crates/biome_formatter_test/src/test_prettier_snapshot.rs
@@ -203,7 +203,7 @@ where
             .with_output(SnapshotOutput::new(&formatted))
             .with_errors(&parsed, &self.test_file().parse_input);
 
-        let max_width = self.options.line_width().get() as usize;
+        let max_width = self.options.line_width().value() as usize;
         builder = builder.with_lines_exceeding_max_width(&formatted, max_width);
 
         builder.finish(relative_file_name);

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -386,7 +386,7 @@ impl fmt::Display for JsFormatOptions {
         writeln!(f, "Indent style: {}", self.indent_style)?;
         writeln!(f, "Indent width: {}", self.indent_width.value())?;
         writeln!(f, "Line ending: {}", self.line_ending)?;
-        writeln!(f, "Line width: {}", self.line_width.get())?;
+        writeln!(f, "Line width: {}", self.line_width.value())?;
         writeln!(f, "Quote style: {}", self.quote_style)?;
         writeln!(f, "JSX quote style: {}", self.jsx_quote_style)?;
         writeln!(f, "Quote properties: {}", self.quote_properties)?;

--- a/crates/biome_js_formatter/src/lib.rs
+++ b/crates/biome_js_formatter/src/lib.rs
@@ -600,7 +600,7 @@ while(
         let result = format_range(
             JsFormatOptions::new(JsFileSource::js_script())
                 .with_indent_style(IndentStyle::Space)
-                .with_indent_width(4.into()),
+                .with_indent_width(4.try_into().unwrap()),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -634,7 +634,7 @@ function() {
         let result = format_range(
             JsFormatOptions::new(JsFileSource::js_script())
                 .with_indent_style(IndentStyle::Space)
-                .with_indent_width(4.into()),
+                .with_indent_width(4.try_into().unwrap()),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -663,7 +663,7 @@ function() {
         let result = format_range(
             JsFormatOptions::new(JsFileSource::js_script())
                 .with_indent_style(IndentStyle::Space)
-                .with_indent_width(4.into()),
+                .with_indent_width(4.try_into().unwrap()),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -693,7 +693,7 @@ function() {
         let result = format_range(
             JsFormatOptions::new(JsFileSource::js_script())
                 .with_indent_style(IndentStyle::Space)
-                .with_indent_width(4.into()),
+                .with_indent_width(4.try_into().unwrap()),
             &tree.syntax(),
             range,
         )
@@ -726,7 +726,7 @@ function() {
         let result = format_range(
             JsFormatOptions::new(JsFileSource::js_script())
                 .with_indent_style(IndentStyle::Space)
-                .with_indent_width(4.into()),
+                .with_indent_width(4.try_into().unwrap()),
             &tree.syntax(),
             range,
         )

--- a/crates/biome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/biome_js_formatter/src/utils/assignment_like.rs
@@ -1154,7 +1154,7 @@ fn is_poorly_breakable_member_or_call_chain(
     expression: &AnyJsExpression,
     f: &Formatter<JsFormatContext>,
 ) -> SyntaxResult<bool> {
-    let threshold = f.options().line_width().get() / 4;
+    let threshold = f.options().line_width().value() / 4;
 
     // Only call and member chains are poorly breakable
     // - `obj.member.prop`

--- a/crates/biome_js_formatter/tests/prettier_tests.rs
+++ b/crates/biome_js_formatter/tests/prettier_tests.rs
@@ -1,6 +1,6 @@
 use std::{env, path::Path};
 
-use biome_formatter::IndentStyle;
+use biome_formatter::{IndentStyle, IndentWidth};
 use biome_formatter_test::test_prettier_snapshot::{PrettierSnapshot, PrettierTestFile};
 use biome_js_formatter::context::JsFormatOptions;
 use biome_js_syntax::{JsFileSource, LanguageVariant, ModuleKind};
@@ -41,7 +41,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
 
     let options = JsFormatOptions::new(source_type)
         .with_indent_style(IndentStyle::Space)
-        .with_indent_width(2.into());
+        .with_indent_width(IndentWidth::default());
 
     let language = language::JsTestFormatLanguage::new(source_type);
 

--- a/crates/biome_json_formatter/src/context.rs
+++ b/crates/biome_json_formatter/src/context.rs
@@ -195,7 +195,7 @@ impl fmt::Display for JsonFormatOptions {
         writeln!(f, "Indent style: {}", self.indent_style)?;
         writeln!(f, "Indent width: {}", self.indent_width.value())?;
         writeln!(f, "Line ending: {}", self.line_ending)?;
-        writeln!(f, "Line width: {}", self.line_width.get())?;
+        writeln!(f, "Line width: {}", self.line_width.value())?;
         writeln!(f, "Trailing commas: {}", self.trailing_commas)
     }
 }

--- a/crates/biome_json_formatter/tests/language.rs
+++ b/crates/biome_json_formatter/tests/language.rs
@@ -1,4 +1,6 @@
-use biome_formatter::{FormatResult, Formatted, IndentStyle, LineEnding, LineWidth, Printed};
+use biome_formatter::{
+    FormatResult, Formatted, IndentStyle, IndentWidth, LineEnding, LineWidth, Printed,
+};
 use biome_formatter_test::TestFormatLanguage;
 use biome_json_formatter::context::{JsonFormatContext, JsonFormatOptions};
 use biome_json_formatter::{format_node, format_range, JsonFormatLanguage};
@@ -112,7 +114,11 @@ impl From<JsonSerializableFormatOptions> for JsonFormatOptions {
     fn from(test: JsonSerializableFormatOptions) -> Self {
         JsonFormatOptions::default()
             .with_indent_style(test.indent_style.map(Into::into).unwrap_or_default())
-            .with_indent_width(test.indent_width.map(Into::into).unwrap_or_default())
+            .with_indent_width(
+                test.indent_width
+                    .and_then(|width| IndentWidth::try_from(width).ok())
+                    .unwrap_or_default(),
+            )
             .with_line_width(
                 test.line_width
                     .and_then(|width| LineWidth::try_from(width).ok())

--- a/crates/biome_json_formatter/tests/prettier_tests.rs
+++ b/crates/biome_json_formatter/tests/prettier_tests.rs
@@ -1,6 +1,6 @@
 use std::{env, path::Path};
 
-use biome_formatter::IndentStyle;
+use biome_formatter::{IndentStyle, IndentWidth};
 use biome_formatter_test::test_prettier_snapshot::{PrettierSnapshot, PrettierTestFile};
 use biome_json_formatter::context::JsonFormatOptions;
 
@@ -19,7 +19,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
     let test_file = PrettierTestFile::new(input, root_path);
     let options = JsonFormatOptions::default()
         .with_indent_style(IndentStyle::Space)
-        .with_indent_width(2.into());
+        .with_indent_width(IndentWidth::default());
     let language = language::JsonTestFormatLanguage::default();
     let snapshot = PrettierSnapshot::new(test_file, language, options);
 

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -496,7 +496,7 @@ impl From<CssConfiguration> for LanguageSettings<CssLanguage> {
 
         language_setting.formatter.enabled = Some(css.formatter.enabled);
         language_setting.formatter.line_width = Some(css.formatter.line_width);
-        language_setting.formatter.indent_width = Some(css.formatter.indent_width.into());
+        language_setting.formatter.indent_width = Some(css.formatter.indent_width);
         language_setting.formatter.indent_style = Some(css.formatter.indent_style.into());
         language_setting.formatter.quote_style = Some(css.formatter.quote_style);
         language_setting.linter.enabled = Some(css.linter.enabled);
@@ -1489,7 +1489,7 @@ pub fn to_format_settings(
         PlainIndentStyle::Tab => IndentStyle::Tab,
         PlainIndentStyle::Space => IndentStyle::Space,
     };
-    let indent_width = conf.indent_width.into();
+    let indent_width = conf.indent_width;
 
     Ok(FormatSettings {
         enabled: conf.enabled,

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -135,7 +135,7 @@ export interface PartialFormatterConfiguration {
 	/**
 	 * The size of the indentation, 2 by default (deprecated, use `indent-width`)
 	 */
-	indentSize?: number;
+	indentSize?: IndentWidth;
 	/**
 	 * The indent style.
 	 */
@@ -143,7 +143,7 @@ export interface PartialFormatterConfiguration {
 	/**
 	 * The size of the indentation, 2 by default
 	 */
-	indentWidth?: number;
+	indentWidth?: IndentWidth;
 	/**
 	 * The type of line ending.
 	 */
@@ -273,7 +273,7 @@ export interface PartialCssFormatter {
 	/**
 	 * The size of the indentation applied to CSS (and its super languages) files. Default to 2.
 	 */
-	indentWidth?: number;
+	indentWidth?: IndentWidth;
 	/**
 	 * The type of line ending applied to CSS (and its super languages) files.
 	 */
@@ -310,6 +310,7 @@ export interface PartialCssParser {
 	cssModules?: boolean;
 }
 export type AttributePosition = "auto" | "multiline";
+export type IndentWidth = number;
 export type PlainIndentStyle = "tab" | "space";
 export type LineEnding = "lf" | "crlf" | "cr";
 /**
@@ -345,7 +346,7 @@ export interface PartialJavascriptFormatter {
 	/**
 	 * The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.
 	 */
-	indentSize?: number;
+	indentSize?: IndentWidth;
 	/**
 	 * The indent style applied to JavaScript (and its super languages) files.
 	 */
@@ -353,7 +354,7 @@ export interface PartialJavascriptFormatter {
 	/**
 	 * The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.
 	 */
-	indentWidth?: number;
+	indentWidth?: IndentWidth;
 	/**
 	 * The type of quotes used in JSX. Defaults to double.
 	 */
@@ -420,7 +421,7 @@ export interface PartialJsonFormatter {
 	/**
 	 * The size of the indentation applied to JSON (and its super languages) files. Default to 2.
 	 */
-	indentSize?: number;
+	indentSize?: IndentWidth;
 	/**
 	 * The indent style applied to JSON (and its super languages) files.
 	 */
@@ -428,7 +429,7 @@ export interface PartialJsonFormatter {
 	/**
 	 * The size of the indentation applied to JSON (and its super languages) files. Default to 2.
 	 */
-	indentWidth?: number;
+	indentWidth?: IndentWidth;
 	/**
 	 * The type of line ending applied to JSON (and its super languages) files.
 	 */
@@ -1631,7 +1632,7 @@ export interface OverrideFormatterConfiguration {
 	/**
 	 * The size of the indentation, 2 by default (deprecated, use `indent-width`)
 	 */
-	indentSize?: number;
+	indentSize?: IndentWidth;
 	/**
 	 * The indent style.
 	 */
@@ -1639,7 +1640,7 @@ export interface OverrideFormatterConfiguration {
 	/**
 	 * The size of the indentation, 2 by default
 	 */
-	indentWidth?: number;
+	indentWidth?: IndentWidth;
 	/**
 	 * The type of line ending.
 	 */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -920,9 +920,7 @@
 				},
 				"indentWidth": {
 					"description": "The size of the indentation applied to CSS (and its super languages) files. Default to 2.",
-					"type": ["integer", "null"],
-					"format": "uint8",
-					"minimum": 0.0
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
 				},
 				"lineEnding": {
 					"description": "The type of line ending applied to CSS (and its super languages) files.",
@@ -1113,9 +1111,7 @@
 				},
 				"indentSize": {
 					"description": "The size of the indentation, 2 by default (deprecated, use `indent-width`)",
-					"type": ["integer", "null"],
-					"format": "uint8",
-					"minimum": 0.0
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
 				},
 				"indentStyle": {
 					"description": "The indent style.",
@@ -1126,9 +1122,7 @@
 				},
 				"indentWidth": {
 					"description": "The size of the indentation, 2 by default",
-					"type": ["integer", "null"],
-					"format": "uint8",
-					"minimum": 0.0
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
 				},
 				"lineEnding": {
 					"description": "The type of line ending.",
@@ -1184,6 +1178,7 @@
 			},
 			"additionalProperties": false
 		},
+		"IndentWidth": { "type": "integer", "format": "uint8", "minimum": 0.0 },
 		"JavascriptConfiguration": {
 			"description": "A set of options applied to the JavaScript files",
 			"type": "object",
@@ -1258,9 +1253,7 @@
 				},
 				"indentSize": {
 					"description": "The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.",
-					"type": ["integer", "null"],
-					"format": "uint8",
-					"minimum": 0.0
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
 				},
 				"indentStyle": {
 					"description": "The indent style applied to JavaScript (and its super languages) files.",
@@ -1271,9 +1264,7 @@
 				},
 				"indentWidth": {
 					"description": "The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.",
-					"type": ["integer", "null"],
-					"format": "uint8",
-					"minimum": 0.0
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
 				},
 				"jsxQuoteStyle": {
 					"description": "The type of quotes used in JSX. Defaults to double.",
@@ -1376,9 +1367,7 @@
 				},
 				"indentSize": {
 					"description": "The size of the indentation applied to JSON (and its super languages) files. Default to 2.",
-					"type": ["integer", "null"],
-					"format": "uint8",
-					"minimum": 0.0
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
 				},
 				"indentStyle": {
 					"description": "The indent style applied to JSON (and its super languages) files.",
@@ -1389,9 +1378,7 @@
 				},
 				"indentWidth": {
 					"description": "The size of the indentation applied to JSON (and its super languages) files. Default to 2.",
-					"type": ["integer", "null"],
-					"format": "uint8",
-					"minimum": 0.0
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
 				},
 				"lineEnding": {
 					"description": "The type of line ending applied to JSON (and its super languages) files.",
@@ -2005,9 +1992,7 @@
 				},
 				"indentSize": {
 					"description": "The size of the indentation, 2 by default (deprecated, use `indent-width`)",
-					"type": ["integer", "null"],
-					"format": "uint8",
-					"minimum": 0.0
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
 				},
 				"indentStyle": {
 					"description": "The indent style.",
@@ -2018,9 +2003,7 @@
 				},
 				"indentWidth": {
 					"description": "The size of the indentation, 2 by default",
-					"type": ["integer", "null"],
-					"format": "uint8",
-					"minimum": 0.0
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
 				},
 				"lineEnding": {
 					"description": "The type of line ending.",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

The issue is that we had `IndentWidth`, but we weren't using it at all 😆 

Now we use it, and I took the chance to add a max value that we cant' exceed. It behaves the same way `LineWidth` does.

Closes https://github.com/biomejs/biome/issues/3067

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added a new test case

<!-- What demonstrates that your implementation is correct? -->
