### PR TITLE
chore(ci): use compact in pkg-pr-new command

### DIFF
--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -76,9 +76,7 @@ jobs:
 
       - name: Publish
         working-directory: packages/@biomejs/wasm-web
-        run: pnpx pkg-pr-new publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpx pkg-pr-new publish --compact
 
   repository-dispatch:
     name: Repository dispatch


### PR DESCRIPTION
## Summary

So we can have [shorter urls](https://github.com/stackblitz-labs/pkg.pr.new/?tab=readme-ov-file#setup).

Also, GITHUB_TOKEN is no longer needed.

## Test Plan

Merge to main.
