### PR TITLE
chore: fix JSON schema for biome config file

### DIFF
--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -83,77 +83,77 @@
 				"noAccessKey": {
 					"description": "Enforce that the accessKey attribute is not used on any HTML element.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noAriaHiddenOnFocusable": {
 					"description": "Enforce that aria-hidden=\"true\" is not set on focusable elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noAriaUnsupportedElements": {
 					"description": "Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noAutofocus": {
 					"description": "Enforce that autoFocus prop is not used on elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noBlankTarget": {
 					"description": "Disallow target=\"_blank\" attribute without rel=\"noreferrer\"",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDistractingElements": {
 					"description": "Enforces that no distracting elements are used.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noHeaderScope": {
 					"description": "The scope prop should be used only on \\<th> elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noInteractiveElementToNoninteractiveRole": {
 					"description": "Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noNoninteractiveElementToInteractiveRole": {
 					"description": "Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noNoninteractiveTabindex": {
 					"description": "Enforce that tabIndex is not assigned to non-interactive HTML elements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noPositiveTabindex": {
 					"description": "Prevent the usage of positive integers on tabIndex property",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -167,7 +167,7 @@
 				"noRedundantRoles": {
 					"description": "Enforce explicit role property is not the same as implicit/default role property on an element.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -192,14 +192,14 @@
 				"useAnchorContent": {
 					"description": "Enforce that anchors have content and that the content is accessible to screen readers.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useAriaActivedescendantWithTabindex": {
 					"description": "Enforce that tabIndex is assigned to non-interactive HTML elements with aria-activedescendant.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -269,16 +269,14 @@
 				"useValidAriaProps": {
 					"description": "Ensures that ARIA properties aria-* are all valid.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useValidAriaRole": {
 					"description": "Elements with ARIA roles must use a valid, non-abstract ARIA role.",
 					"anyOf": [
-						{
-							"$ref": "#/definitions/RuleFixConfiguration_for_ValidAriaRoleOptions"
-						},
+						{ "$ref": "#/definitions/ValidAriaRoleConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -312,7 +310,7 @@
 				"noBannedTypes": {
 					"description": "Disallow primitive type aliases and misleading types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -340,7 +338,7 @@
 				"noExtraBooleanCast": {
 					"description": "Disallow unnecessary boolean casts",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -354,7 +352,7 @@
 				"noMultipleSpacesInRegularExpressionLiterals": {
 					"description": "Disallow unclear usage of consecutive space characters in regular expression literals",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -368,7 +366,7 @@
 				"noThisInStatic": {
 					"description": "Disallow this and super in static contexts.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -382,70 +380,70 @@
 				"noUselessConstructor": {
 					"description": "Disallow unnecessary constructors.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessEmptyExport": {
 					"description": "Disallow empty exports that don't change anything in a module file.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessFragments": {
 					"description": "Disallow unnecessary fragments",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessLabel": {
 					"description": "Disallow unnecessary labels.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessLoneBlockStatements": {
 					"description": "Disallow unnecessary nested block statements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessRename": {
 					"description": "Disallow renaming import, export, and destructured assignments to the same name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessSwitchCase": {
 					"description": "Disallow useless case in switch statements.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessTernary": {
 					"description": "Disallow ternary operators when simpler alternatives exist.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessThisAlias": {
 					"description": "Disallow useless this aliasing.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessTypeConstraint": {
 					"description": "Disallow using any or unknown as type constraint.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -470,49 +468,49 @@
 				"useArrowFunction": {
 					"description": "Use arrow functions over function expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useFlatMap": {
 					"description": "Promotes the use of .flatMap() when map().flat() are used together.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useLiteralKeys": {
 					"description": "Enforce the usage of a literal access to properties over computed property access.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useOptionalChain": {
 					"description": "Enforce using concise optional chain instead of chained logical expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useRegexLiterals": {
 					"description": "Enforce the use of the regular expression literals instead of the RegExp constructor if possible.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useSimpleNumberKeys": {
 					"description": "Disallow number literal object member names which are not base10 or uses underscore as separator",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useSimplifiedLogicExpression": {
 					"description": "Discard redundant terms from logical expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				}
@@ -551,6 +549,12 @@
 					"type": "string",
 					"enum": ["generic"]
 				}
+			]
+		},
+		"ConsistentArrayTypeConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithConsistentArrayTypeOptions" }
 			]
 		},
 		"ConsistentArrayTypeOptions": {
@@ -597,7 +601,7 @@
 				"noConstAssign": {
 					"description": "Prevents from having const variables being re-assigned.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -611,7 +615,7 @@
 				"noConstantMathMinMaxClamp": {
 					"description": "Disallow the use of Math.min and Math.max to clamp a value where the result itself is constant.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -639,7 +643,7 @@
 				"noFlatMapIdentity": {
 					"description": "Disallow to use unnecessary callback on flatMap.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -667,7 +671,7 @@
 				"noInvalidNewBuiltin": {
 					"description": "Disallow new operators with global non-constructor functions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -681,7 +685,7 @@
 				"noNewSymbol": {
 					"description": "Disallow new operators with the Symbol object.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -695,7 +699,7 @@
 				"noNonoctalDecimalEscape": {
 					"description": "Disallow \\8 and \\9 escape sequences in string literals.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -730,14 +734,14 @@
 				"noStringCaseMismatch": {
 					"description": "Disallow comparison of expressions modifying the string case with non-compliant value.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noSwitchDeclarations": {
 					"description": "Disallow lexical declarations in switch clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -751,7 +755,7 @@
 				"noUnnecessaryContinue": {
 					"description": "Avoid using unnecessary continue.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -786,35 +790,35 @@
 				"noUnusedImports": {
 					"description": "Disallow unused imports.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedLabels": {
 					"description": "Disallow unused labels.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedPrivateClassMembers": {
 					"description": "Disallow unused private class members",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedVariables": {
 					"description": "Disallow unused variables.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noVoidElementsWithChildren": {
 					"description": "This rules prevents void elements (AKA self-closing elements) from having children.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -832,7 +836,7 @@
 				"useArrayLiterals": {
 					"description": "Disallow Array constructors.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -853,7 +857,7 @@
 				"useIsNan": {
 					"description": "Require calls to isNaN() when checking for NaN.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1594,6 +1598,12 @@
 			"items": { "$ref": "#/definitions/RestrictedModifier" },
 			"uniqueItems": true
 		},
+		"NamingConventionConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithNamingConventionOptions" }
+			]
+		},
 		"NamingConventionOptions": {
 			"description": "Rule's options.",
 			"type": "object",
@@ -1657,7 +1667,7 @@
 				"noConsole": {
 					"description": "Disallow the use of console.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1748,7 +1758,7 @@
 				"noReactSpecificProps": {
 					"description": "Prevents React-specific JSX properties from being used.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1811,28 +1821,28 @@
 				"noUnusedFunctionParameters": {
 					"description": "Disallow unused function parameters.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessStringConcat": {
 					"description": "Disallow unnecessary concatenation of string or template literals.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessUndefinedInitialization": {
 					"description": "Disallow initializing variables to undefined.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noYodaExpression": {
 					"description": "Disallow the use of yoda expressions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1850,14 +1860,14 @@
 				"useConsistentBuiltinInstantiation": {
 					"description": "Enforce the use of new for all builtins, except String, Number, Boolean, Symbol and BigInt.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useDateNow": {
 					"description": "Use Date.now() to get the number of milliseconds since the Unix Epoch.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1878,7 +1888,7 @@
 				"useExplicitLengthCheck": {
 					"description": "Enforce explicitly comparing the length, size, byteLength or byteOffset property of a value.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1899,7 +1909,7 @@
 				"useImportExtensions": {
 					"description": "Enforce file extensions for relative imports.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1913,7 +1923,7 @@
 				"useNumberToFixedDigitsArgument": {
 					"description": "Enforce using the digits argument with Number#toFixed().",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -1927,16 +1937,14 @@
 				"useSortedClasses": {
 					"description": "Enforce the sorting of CSS utility classes.",
 					"anyOf": [
-						{
-							"$ref": "#/definitions/RuleFixConfiguration_for_UtilityClassSortingOptions"
-						},
+						{ "$ref": "#/definitions/UtilityClassSortingConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useThrowNewError": {
 					"description": "Require new when throwing an error.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2125,7 +2133,7 @@
 				"noDelete": {
 					"description": "Disallow the use of the delete operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2200,40 +2208,10 @@
 				{ "$ref": "#/definitions/RuleWithNoOptions" }
 			]
 		},
-		"RuleFixConfiguration_for_ConsistentArrayTypeOptions": {
+		"RuleFixConfiguration": {
 			"anyOf": [
 				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{
-					"$ref": "#/definitions/RuleWithFixOptions_for_ConsistentArrayTypeOptions"
-				}
-			]
-		},
-		"RuleFixConfiguration_for_NamingConventionOptions": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{
-					"$ref": "#/definitions/RuleWithFixOptions_for_NamingConventionOptions"
-				}
-			]
-		},
-		"RuleFixConfiguration_for_Null": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithFixOptions_for_Null" }
-			]
-		},
-		"RuleFixConfiguration_for_UtilityClassSortingOptions": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{
-					"$ref": "#/definitions/RuleWithFixOptions_for_UtilityClassSortingOptions"
-				}
-			]
-		},
-		"RuleFixConfiguration_for_ValidAriaRoleOptions": {
-			"anyOf": [
-				{ "$ref": "#/definitions/RulePlainConfiguration" },
-				{ "$ref": "#/definitions/RuleWithFixOptions_for_ValidAriaRoleOptions" }
+				{ "$ref": "#/definitions/RuleWithFixNoOptions" }
 			]
 		},
 		"RulePlainConfiguration": {
@@ -2251,6 +2229,25 @@
 				"options": {
 					"description": "Rule's options",
 					"allOf": [{ "$ref": "#/definitions/ComplexityOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithConsistentArrayTypeOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/ConsistentArrayTypeOptions" }]
 				}
 			},
 			"additionalProperties": false
@@ -2285,9 +2282,9 @@
 			},
 			"additionalProperties": false
 		},
-		"RuleWithFixOptions_for_ConsistentArrayTypeOptions": {
+		"RuleWithFixNoOptions": {
 			"type": "object",
-			"required": ["level", "options"],
+			"required": ["level"],
 			"properties": {
 				"fix": {
 					"description": "The kind of the code actions emitted by the rule",
@@ -2296,83 +2293,6 @@
 				"level": {
 					"description": "The severity of the emitted diagnostics by the rule",
 					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
-				},
-				"options": {
-					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/ConsistentArrayTypeOptions" }]
-				}
-			},
-			"additionalProperties": false
-		},
-		"RuleWithFixOptions_for_NamingConventionOptions": {
-			"type": "object",
-			"required": ["level", "options"],
-			"properties": {
-				"fix": {
-					"description": "The kind of the code actions emitted by the rule",
-					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
-				},
-				"level": {
-					"description": "The severity of the emitted diagnostics by the rule",
-					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
-				},
-				"options": {
-					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NamingConventionOptions" }]
-				}
-			},
-			"additionalProperties": false
-		},
-		"RuleWithFixOptions_for_Null": {
-			"type": "object",
-			"required": ["level", "options"],
-			"properties": {
-				"fix": {
-					"description": "The kind of the code actions emitted by the rule",
-					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
-				},
-				"level": {
-					"description": "The severity of the emitted diagnostics by the rule",
-					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
-				},
-				"options": { "description": "Rule's options", "type": "null" }
-			},
-			"additionalProperties": false
-		},
-		"RuleWithFixOptions_for_UtilityClassSortingOptions": {
-			"type": "object",
-			"required": ["level", "options"],
-			"properties": {
-				"fix": {
-					"description": "The kind of the code actions emitted by the rule",
-					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
-				},
-				"level": {
-					"description": "The severity of the emitted diagnostics by the rule",
-					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
-				},
-				"options": {
-					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UtilityClassSortingOptions" }]
-				}
-			},
-			"additionalProperties": false
-		},
-		"RuleWithFixOptions_for_ValidAriaRoleOptions": {
-			"type": "object",
-			"required": ["level", "options"],
-			"properties": {
-				"fix": {
-					"description": "The kind of the code actions emitted by the rule",
-					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
-				},
-				"level": {
-					"description": "The severity of the emitted diagnostics by the rule",
-					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
-				},
-				"options": {
-					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/ValidAriaRoleOptions" }]
 				}
 			},
 			"additionalProperties": false
@@ -2388,6 +2308,25 @@
 				"options": {
 					"description": "Rule's options",
 					"allOf": [{ "$ref": "#/definitions/HooksOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNamingConventionOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/NamingConventionOptions" }]
 				}
 			},
 			"additionalProperties": false
@@ -2444,6 +2383,44 @@
 				"options": {
 					"description": "Rule's options",
 					"allOf": [{ "$ref": "#/definitions/RestrictedImportsOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithUtilityClassSortingOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/UtilityClassSortingOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithValidAriaRoleOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/ValidAriaRoleOptions" }]
 				}
 			},
 			"additionalProperties": false
@@ -2598,14 +2575,14 @@
 				"noImplicitBoolean": {
 					"description": "Disallow implicit true values on JSX boolean attributes",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noInferrableTypes": {
 					"description": "Disallow type annotations for variables, parameters, and class properties initialized with a literal expression.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2626,14 +2603,14 @@
 				"noNegationElse": {
 					"description": "Disallow negation in the condition of an if statement if it has an else clause.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noNonNullAssertion": {
 					"description": "Disallow non-null assertions using the ! postfix operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2661,28 +2638,28 @@
 				"noShoutyConstants": {
 					"description": "Disallow the use of constants which its value is the upper-case version of its name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUnusedTemplateLiteral": {
 					"description": "Disallow template literals if interpolation and special-character handling are not needed",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noUselessElse": {
 					"description": "Disallow else block when the if block breaks early.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noVar": {
 					"description": "Disallow the use of var",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2693,65 +2670,63 @@
 				"useAsConstAssertion": {
 					"description": "Enforce the use of as const over literal type and type annotation.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useBlockStatements": {
 					"description": "Requires following curly brace conventions.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useCollapsedElseIf": {
 					"description": "Enforce using else if instead of nested if in else clauses.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useConsistentArrayType": {
 					"description": "Require consistently using either T\\[] or Array\\<T>",
 					"anyOf": [
-						{
-							"$ref": "#/definitions/RuleFixConfiguration_for_ConsistentArrayTypeOptions"
-						},
+						{ "$ref": "#/definitions/ConsistentArrayTypeConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useConst": {
 					"description": "Require const declarations for variables that are only assigned once.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useDefaultParameterLast": {
 					"description": "Enforce default function parameters and optional function parameters to be last.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useEnumInitializers": {
 					"description": "Require that each enum member value be explicitly initialized.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useExponentiationOperator": {
 					"description": "Disallow the use of Math.pow in favor of the ** operator.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useExportType": {
 					"description": "Promotes the use of export type for types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2772,14 +2747,14 @@
 				"useFragmentSyntax": {
 					"description": "This rule enforces the use of \\<>...\\</> over \\<Fragment>...\\</Fragment>.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useImportType": {
 					"description": "Promotes the use of import type for types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2793,93 +2768,91 @@
 				"useNamingConvention": {
 					"description": "Enforce naming conventions for everything across a codebase.",
 					"anyOf": [
-						{
-							"$ref": "#/definitions/RuleFixConfiguration_for_NamingConventionOptions"
-						},
+						{ "$ref": "#/definitions/NamingConventionConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useNodeAssertStrict": {
 					"description": "Promotes the usage of node:assert/strict over node:assert.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useNodejsImportProtocol": {
 					"description": "Enforces using the node: protocol for Node.js builtin modules.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useNumberNamespace": {
 					"description": "Use the Number properties instead of global ones.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useNumericLiterals": {
 					"description": "Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useSelfClosingElements": {
 					"description": "Prevent extra closing tags for components without children",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useShorthandArrayType": {
 					"description": "When expressing array types, this rule promotes the usage of T\\[] shorthand instead of Array\\<T>.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useShorthandAssign": {
 					"description": "Require assignment operator shorthand where possible.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useShorthandFunctionType": {
 					"description": "Enforce using function types instead of object type with call signatures.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useSingleCaseStatement": {
 					"description": "Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useSingleVarDeclarator": {
 					"description": "Disallow multiple variable declarations in the same variable statement",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useTemplate": {
 					"description": "Prefer template literals over string concatenation.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useWhile": {
 					"description": "Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				}
@@ -2897,7 +2870,7 @@
 				"noApproximativeNumericConstant": {
 					"description": "Use standard constants instead of approximated literals.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2939,14 +2912,14 @@
 				"noCommentText": {
 					"description": "Prevent comments from being inserted as text nodes",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noCompareNegZero": {
 					"description": "Disallow comparing against -0",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2960,21 +2933,21 @@
 				"noConfusingVoidType": {
 					"description": "Disallow void type outside of generic or return types.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noConsoleLog": {
 					"description": "Disallow the use of console.log",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noConstEnum": {
 					"description": "Disallow TypeScript const enum",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2988,14 +2961,14 @@
 				"noDebugger": {
 					"description": "Disallow the use of debugger",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noDoubleEquals": {
 					"description": "Require the use of === and !==",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -3023,7 +2996,7 @@
 				"noDuplicateObjectKeys": {
 					"description": "Prevents object literals having more than one property declaration for the same name.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -3051,7 +3024,7 @@
 				"noEmptyInterface": {
 					"description": "Disallow the declaration of empty interfaces.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -3072,7 +3045,7 @@
 				"noExtraNonNullAssertion": {
 					"description": "Prevents the wrong usage of the non-null assertion operator (!) in TypeScript files.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -3086,7 +3059,7 @@
 				"noFocusedTests": {
 					"description": "Disallow focused tests.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -3107,14 +3080,14 @@
 				"noGlobalIsFinite": {
 					"description": "Use Number.isFinite instead of global isFinite.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noGlobalIsNan": {
 					"description": "Use Number.isNaN instead of global isNaN.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -3142,7 +3115,7 @@
 				"noMisleadingCharacterClass": {
 					"description": "Disallow characters made with multiple code points in character class syntax.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -3156,7 +3129,7 @@
 				"noMisrefactoredShorthandAssign": {
 					"description": "Disallow shorthand assign when variable appears on both sides.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -3177,7 +3150,7 @@
 				"noRedundantUseStrict": {
 					"description": "Prevents from having redundant \"use strict\".",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -3198,14 +3171,14 @@
 				"noSkippedTests": {
 					"description": "Disallow disabled tests.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"noSparseArray": {
 					"description": "Disallow sparse arrays",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -3233,7 +3206,7 @@
 				"noUnsafeNegation": {
 					"description": "Disallow using unsafe negation.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -3265,21 +3238,21 @@
 				"useIsArray": {
 					"description": "Use Array.isArray() instead of instanceof Array.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useNamespaceKeyword": {
 					"description": "Require using the namespace keyword over the module keyword to declare TypeScript namespaces.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},
 				"useValidTypeof": {
 					"description": "This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration_for_Null" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				}
@@ -3320,6 +3293,12 @@
 				}
 			]
 		},
+		"UtilityClassSortingConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithUtilityClassSortingOptions" }
+			]
+		},
 		"UtilityClassSortingOptions": {
 			"type": "object",
 			"properties": {
@@ -3335,6 +3314,12 @@
 				}
 			},
 			"additionalProperties": false
+		},
+		"ValidAriaRoleConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithValidAriaRoleOptions" }
+			]
 		},
 		"ValidAriaRoleOptions": {
 			"type": "object",

--- a/xtask/codegen/src/generate_schema.rs
+++ b/xtask/codegen/src/generate_schema.rs
@@ -36,12 +36,23 @@ fn rename_partial_references_in_schema(mut schema: RootSchema) -> RootSchema {
                 meta.title = Some(stripped.to_string());
             } else if title == "RuleWithOptions_for_Null" {
                 meta.title = Some("RuleWithNoOptions".to_string());
+            } else if title == "RuleWithFixOptions_for_Null" {
+                meta.title = Some("RuleWithFixNoOptions".to_string());
             } else if title == "RuleConfiguration_for_Null" {
                 meta.title = Some("RuleConfiguration".to_string());
+            } else if title == "RuleFixConfiguration_for_Null" {
+                meta.title = Some("RuleFixConfiguration".to_string());
             } else if let Some(stripped) = title.strip_prefix("RuleWithOptions_for_") {
+                meta.title = Some(format!("RuleWith{stripped}"));
+            } else if let Some(stripped) = title.strip_prefix("RuleWithFixOptions_for_") {
                 meta.title = Some(format!("RuleWith{stripped}"));
             } else if let Some(stripped) = title
                 .strip_prefix("RuleConfiguration_for_")
+                .map(|x| x.strip_suffix("Options").unwrap_or(x))
+            {
+                meta.title = Some(format!("{stripped}Configuration"));
+            } else if let Some(stripped) = title
+                .strip_prefix("RuleFixConfiguration_for_")
                 .map(|x| x.strip_suffix("Options").unwrap_or(x))
             {
                 meta.title = Some(format!("{stripped}Configuration"));
@@ -57,8 +68,12 @@ fn rename_partial_references_in_schema(mut schema: RootSchema) -> RootSchema {
         .map(|(mut key, mut schema)| {
             if let Some(stripped) = key.strip_prefix("Partial") {
                 key = stripped.to_string();
-            } else if key == "RuleWithOptions_for_Null" {
-                key = "RuleWithNoOptions".to_string();
+            } else if key == "RuleWithOptions_for_Null" || key == "RuleWithFixOptions_for_Null" {
+                key = if key == "RuleWithOptions_for_Null" {
+                    "RuleWithNoOptions".to_string()
+                } else {
+                    "RuleWithFixNoOptions".to_string()
+                };
                 if let Schema::Object(schema_object) = &mut schema {
                     if let Some(object) = &mut schema_object.object {
                         object.required.remove("options");
@@ -67,10 +82,19 @@ fn rename_partial_references_in_schema(mut schema: RootSchema) -> RootSchema {
                 }
             } else if key == "RuleConfiguration_for_Null" {
                 key = "RuleConfiguration".to_string();
+            } else if key == "RuleFixConfiguration_for_Null" {
+                key = "RuleFixConfiguration".to_string();
             } else if let Some(stripped) = key.strip_prefix("RuleWithOptions_for_") {
+                key = format!("RuleWith{stripped}");
+            } else if let Some(stripped) = key.strip_prefix("RuleWithFixOptions_for_") {
                 key = format!("RuleWith{stripped}");
             } else if let Some(stripped) = key
                 .strip_prefix("RuleConfiguration_for_")
+                .map(|x| x.strip_suffix("Options").unwrap_or(x))
+            {
+                key = format!("{stripped}Configuration");
+            } else if let Some(stripped) = key
+                .strip_prefix("RuleFixConfiguration_for_")
                 .map(|x| x.strip_suffix("Options").unwrap_or(x))
             {
                 key = format!("{stripped}Configuration");
@@ -101,13 +125,26 @@ fn rename_partial_references_in_schema_object(object: &mut SchemaObject) {
             *reference = format!("#/definitions/{stripped}");
         } else if reference == "#/definitions/RuleWithOptions_for_Null" {
             *reference = "#/definitions/RuleWithNoOptions".to_string();
+        } else if reference == "#/definitions/RuleWithFixOptions_for_Null" {
+            *reference = "#/definitions/RuleWithFixNoOptions".to_string();
         } else if reference == "#/definitions/RuleConfiguration_for_Null" {
             *reference = "#/definitions/RuleConfiguration".to_string();
+        } else if reference == "#/definitions/RuleFixConfiguration_for_Null" {
+            *reference = "#/definitions/RuleFixConfiguration".to_string();
         } else if let Some(stripped) = reference.strip_prefix("#/definitions/RuleWithOptions_for_")
+        {
+            *reference = format!("#/definitions/RuleWith{stripped}");
+        } else if let Some(stripped) =
+            reference.strip_prefix("#/definitions/RuleWithFixOptions_for_")
         {
             *reference = format!("#/definitions/RuleWith{stripped}");
         } else if let Some(stripped) = reference
             .strip_prefix("#/definitions/RuleConfiguration_for_")
+            .map(|x| x.strip_suffix("Options").unwrap_or(x))
+        {
+            *reference = format!("#/definitions/{stripped}Configuration");
+        } else if let Some(stripped) = reference
+            .strip_prefix("#/definitions/RuleFixConfiguration_for_")
             .map(|x| x.strip_suffix("Options").unwrap_or(x))
         {
             *reference = format!("#/definitions/{stripped}Configuration");


### PR DESCRIPTION
## Summary

Fix #3098

I really don't like the way we generate the schema for the rules. It is prone to errors. In the future, we should try a different approach: we could try to edit the schema directly in the code, instead of modifying the generated schema by traversing and patching it.

- [ ] Update the schema on the website

## Test Plan

Locally tested.
