### PR TITLE
fix(useLiteralKeys): don't report quoted member names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,23 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
-- The `no-empty-block` css lint rule now treats empty blocks containing comments as valid ones. Contributed by @Sec-ant
+- The `noEmptyBlock` css lint rule now treats empty blocks containing comments as valid ones. Contributed by @Sec-ant
 
+- [useLiteralKeys](https://biomejs.dev/linter/rules/use-literal-keys/) no longer reports quoted member names ([#3085](https://github.com/biomejs/biome/issues/3085)).
+
+  Previously [useLiteralKeys](https://biomejs.dev/linter/rules/use-literal-keys/) reported quoted member names that can be unquoted.
+  For example, the rule suggested the following fix:
+
+  ```diff
+  - const x = { "prop": 0 };
+  + const x = { prop: 0 };
+  ```
+
+  This conflicted with the option [quoteProperties](https://biomejs.dev/reference/configuration/#javascriptformatterquoteproperties) of our formatter.
+
+  The rule now ignores quoted member names.
+
+  Contributed by @Conaclos
 
 ### Parser
 

--- a/crates/biome_formatter/src/builders.rs
+++ b/crates/biome_formatter/src/builders.rs
@@ -1081,7 +1081,7 @@ where
 /// # fn main() -> FormatResult<()> {
 /// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     indent_style: IndentStyle::Space,
-///     indent_width: 4.into(),
+///     indent_width: 4.try_into().unwrap(),
 ///     ..SimpleFormatOptions::default()
 /// });
 ///

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js
@@ -14,19 +14,12 @@ a = {
 a = {
 	[`b`]: d
 };
-a = {
-	"b": d
-};
 a.b[`$c`];
 a.b["_d"];
 class C { ["a"] = 0 }
-class C { "a" = 0 }
 class C { ["a"](){} }
-class C { "a"(){} }
 class C { get ["a"](){} }
-class C { get "a"(){} }
 class C { set ["a"](x){} }
-class C { set "a"(x){} }
 a = {
 	["1+1"]: 2
 }
@@ -35,9 +28,6 @@ a = {
 }
 a = {
 	[""]: 2
-}
-a = {
-	"__proto__": null,
 }
 
 // optional chain

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js.snap
@@ -20,19 +20,12 @@ a = {
 a = {
 	[`b`]: d
 };
-a = {
-	"b": d
-};
 a.b[`$c`];
 a.b["_d"];
 class C { ["a"] = 0 }
-class C { "a" = 0 }
 class C { ["a"](){} }
-class C { "a"(){} }
 class C { get ["a"](){} }
-class C { get "a"(){} }
 class C { set ["a"](x){} }
-class C { set "a"(x){} }
 a = {
 	["1+1"]: 2
 }
@@ -41,9 +34,6 @@ a = {
 }
 a = {
 	[""]: 2
-}
-a = {
-	"__proto__": null,
 }
 
 // optional chain
@@ -348,8 +338,13 @@ invalid.js:12:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
   
   i Unsafe fix: Use a literal key instead.
   
-    12 │ → ['b']:·d
-       │   -- --   
+    10 10 │   a.b[c["d"]] = "something";
+    11 11 │   a = {
+    12    │ - → ['b']:·d
+       12 │ + → "b":·d
+    13 13 │   };
+    14 14 │   a = {
+  
 
 ```
 
@@ -363,362 +358,253 @@ invalid.js:15:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
   > 15 │ 	[`b`]: d
        │ 	 ^^^
     16 │ };
-    17 │ a = {
+    17 │ a.b[`$c`];
   
   i Unsafe fix: Use a literal key instead.
   
-    15 │ → [`b`]:·d
-       │   -- --   
+    13 13 │   };
+    14 14 │   a = {
+    15    │ - → [`b`]:·d
+       15 │ + → "b":·d
+    16 16 │   };
+    17 17 │   a.b[`$c`];
+  
 
 ```
 
 ```
-invalid.js:18:2 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:17:5 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The computed expression can be simplified without the use of a string literal.
+  
+    15 │ 	[`b`]: d
+    16 │ };
+  > 17 │ a.b[`$c`];
+       │     ^^^^
+    18 │ a.b["_d"];
+    19 │ class C { ["a"] = 0 }
+  
+  i Unsafe fix: Use a literal key instead.
+  
+    15 15 │   	[`b`]: d
+    16 16 │   };
+    17    │ - a.b[`$c`];
+       17 │ + a.b.$c;
+    18 18 │   a.b["_d"];
+    19 19 │   class C { ["a"] = 0 }
+  
+
+```
+
+```
+invalid.js:18:5 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
     16 │ };
-    17 │ a = {
-  > 18 │ 	"b": d
-       │ 	^^^
-    19 │ };
-    20 │ a.b[`$c`];
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    18 │ → "b":·d
-       │   - -   
-
-```
-
-```
-invalid.js:20:5 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    18 │ 	"b": d
-    19 │ };
-  > 20 │ a.b[`$c`];
+    17 │ a.b[`$c`];
+  > 18 │ a.b["_d"];
        │     ^^^^
-    21 │ a.b["_d"];
-    22 │ class C { ["a"] = 0 }
+    19 │ class C { ["a"] = 0 }
+    20 │ class C { ["a"](){} }
   
   i Unsafe fix: Use a literal key instead.
   
-    18 18 │   	"b": d
-    19 19 │   };
-    20    │ - a.b[`$c`];
-       20 │ + a.b.$c;
-    21 21 │   a.b["_d"];
-    22 22 │   class C { ["a"] = 0 }
+    16 16 │   };
+    17 17 │   a.b[`$c`];
+    18    │ - a.b["_d"];
+       18 │ + a.b._d;
+    19 19 │   class C { ["a"] = 0 }
+    20 20 │   class C { ["a"](){} }
   
 
 ```
 
 ```
-invalid.js:21:5 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:19:12 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    19 │ };
-    20 │ a.b[`$c`];
-  > 21 │ a.b["_d"];
-       │     ^^^^
-    22 │ class C { ["a"] = 0 }
-    23 │ class C { "a" = 0 }
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    19 19 │   };
-    20 20 │   a.b[`$c`];
-    21    │ - a.b["_d"];
-       21 │ + a.b._d;
-    22 22 │   class C { ["a"] = 0 }
-    23 23 │   class C { "a" = 0 }
-  
-
-```
-
-```
-invalid.js:22:12 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    20 │ a.b[`$c`];
-    21 │ a.b["_d"];
-  > 22 │ class C { ["a"] = 0 }
+    17 │ a.b[`$c`];
+    18 │ a.b["_d"];
+  > 19 │ class C { ["a"] = 0 }
        │            ^^^
-    23 │ class C { "a" = 0 }
-    24 │ class C { ["a"](){} }
+    20 │ class C { ["a"](){} }
+    21 │ class C { get ["a"](){} }
   
   i Unsafe fix: Use a literal key instead.
   
-    22 │ class·C·{·["a"]·=·0·}
-       │           -- --      
+    19 │ class·C·{·["a"]·=·0·}
+       │           -   -      
 
 ```
 
 ```
-invalid.js:23:11 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:20:12 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    21 │ a.b["_d"];
-    22 │ class C { ["a"] = 0 }
-  > 23 │ class C { "a" = 0 }
-       │           ^^^
-    24 │ class C { ["a"](){} }
-    25 │ class C { "a"(){} }
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    23 │ class·C·{·"a"·=·0·}
-       │           - -      
-
-```
-
-```
-invalid.js:24:12 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    22 │ class C { ["a"] = 0 }
-    23 │ class C { "a" = 0 }
-  > 24 │ class C { ["a"](){} }
+    18 │ a.b["_d"];
+    19 │ class C { ["a"] = 0 }
+  > 20 │ class C { ["a"](){} }
        │            ^^^
-    25 │ class C { "a"(){} }
-    26 │ class C { get ["a"](){} }
+    21 │ class C { get ["a"](){} }
+    22 │ class C { set ["a"](x){} }
   
   i Unsafe fix: Use a literal key instead.
   
-    24 │ class·C·{·["a"](){}·}
-       │           -- --      
+    20 │ class·C·{·["a"](){}·}
+       │           -   -      
 
 ```
 
 ```
-invalid.js:25:11 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:21:16 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    23 │ class C { "a" = 0 }
-    24 │ class C { ["a"](){} }
-  > 25 │ class C { "a"(){} }
-       │           ^^^
-    26 │ class C { get ["a"](){} }
-    27 │ class C { get "a"(){} }
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    25 │ class·C·{·"a"(){}·}
-       │           - -      
-
-```
-
-```
-invalid.js:26:16 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    24 │ class C { ["a"](){} }
-    25 │ class C { "a"(){} }
-  > 26 │ class C { get ["a"](){} }
+    19 │ class C { ["a"] = 0 }
+    20 │ class C { ["a"](){} }
+  > 21 │ class C { get ["a"](){} }
        │                ^^^
-    27 │ class C { get "a"(){} }
-    28 │ class C { set ["a"](x){} }
+    22 │ class C { set ["a"](x){} }
+    23 │ a = {
   
   i Unsafe fix: Use a literal key instead.
   
-    26 │ class·C·{·get·["a"](){}·}
-       │               -- --      
+    21 │ class·C·{·get·["a"](){}·}
+       │               -   -      
 
 ```
 
 ```
-invalid.js:27:15 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:22:16 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    25 │ class C { "a"(){} }
-    26 │ class C { get ["a"](){} }
-  > 27 │ class C { get "a"(){} }
-       │               ^^^
-    28 │ class C { set ["a"](x){} }
-    29 │ class C { set "a"(x){} }
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    27 │ class·C·{·get·"a"(){}·}
-       │               - -      
-
-```
-
-```
-invalid.js:28:16 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    26 │ class C { get ["a"](){} }
-    27 │ class C { get "a"(){} }
-  > 28 │ class C { set ["a"](x){} }
+    20 │ class C { ["a"](){} }
+    21 │ class C { get ["a"](){} }
+  > 22 │ class C { set ["a"](x){} }
        │                ^^^
-    29 │ class C { set "a"(x){} }
-    30 │ a = {
+    23 │ a = {
+    24 │ 	["1+1"]: 2
   
   i Unsafe fix: Use a literal key instead.
   
-    28 │ class·C·{·set·["a"](x){}·}
-       │               -- --       
+    22 │ class·C·{·set·["a"](x){}·}
+       │               -   -       
 
 ```
 
 ```
-invalid.js:29:15 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:24:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    27 │ class C { get "a"(){} }
-    28 │ class C { set ["a"](x){} }
-  > 29 │ class C { set "a"(x){} }
-       │               ^^^
-    30 │ a = {
-    31 │ 	["1+1"]: 2
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    29 │ class·C·{·set·"a"(x){}·}
-       │               - -       
-
-```
-
-```
-invalid.js:31:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    29 │ class C { set "a"(x){} }
-    30 │ a = {
-  > 31 │ 	["1+1"]: 2
+    22 │ class C { set ["a"](x){} }
+    23 │ a = {
+  > 24 │ 	["1+1"]: 2
        │ 	 ^^^^^
-    32 │ }
-    33 │ a = {
+    25 │ }
+    26 │ a = {
   
   i Unsafe fix: Use a literal key instead.
   
-    31 │ → ["1+1"]:·2
+    24 │ → ["1+1"]:·2
        │   -     -   
 
 ```
 
 ```
-invalid.js:34:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:27:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    32 │ }
-    33 │ a = {
-  > 34 │ 	[`1+1`]: 2
+    25 │ }
+    26 │ a = {
+  > 27 │ 	[`1+1`]: 2
        │ 	 ^^^^^
-    35 │ }
-    36 │ a = {
+    28 │ }
+    29 │ a = {
   
   i Unsafe fix: Use a literal key instead.
   
-    32 32 │   }
-    33 33 │   a = {
-    34    │ - → [`1+1`]:·2
-       34 │ + → "1+1":·2
-    35 35 │   }
-    36 36 │   a = {
+    25 25 │   }
+    26 26 │   a = {
+    27    │ - → [`1+1`]:·2
+       27 │ + → "1+1":·2
+    28 28 │   }
+    29 29 │   a = {
   
 
 ```
 
 ```
-invalid.js:37:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:30:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    35 │ }
-    36 │ a = {
-  > 37 │ 	[""]: 2
+    28 │ }
+    29 │ a = {
+  > 30 │ 	[""]: 2
        │ 	 ^^
-    38 │ }
-    39 │ a = {
+    31 │ }
+    32 │ 
   
   i Unsafe fix: Use a literal key instead.
   
-    37 │ → [""]:·2
+    30 │ → [""]:·2
        │   -  -   
 
 ```
 
 ```
-invalid.js:40:2 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:34:5 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    38 │ }
-    39 │ a = {
-  > 40 │ 	"__proto__": null,
-       │ 	^^^^^^^^^^^
-    41 │ }
-    42 │ 
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    40 │ → "__proto__":·null,
-       │   -         -       
-
-```
-
-```
-invalid.js:44:5 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    43 │ // optional chain
-  > 44 │ a?.["b"]?.['c']?.d?.e?.["f"]
+    33 │ // optional chain
+  > 34 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │     ^^^
-    45 │ 
+    35 │ 
   
   i Unsafe fix: Use a literal key instead.
   
-    44 │ a?.["b"]?.['c']?.d?.e?.["f"]
+    34 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │    -- --                    
 
 ```
 
 ```
-invalid.js:44:12 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:34:12 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    43 │ // optional chain
-  > 44 │ a?.["b"]?.['c']?.d?.e?.["f"]
+    33 │ // optional chain
+  > 34 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │            ^^^
-    45 │ 
+    35 │ 
   
   i Unsafe fix: Use a literal key instead.
   
-    44 │ a?.["b"]?.['c']?.d?.e?.["f"]
+    34 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │           -- --             
 
 ```
 
 ```
-invalid.js:44:25 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:34:25 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    43 │ // optional chain
-  > 44 │ a?.["b"]?.['c']?.d?.e?.["f"]
+    33 │ // optional chain
+  > 34 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │                         ^^^
-    45 │ 
+    35 │ 
   
   i Unsafe fix: Use a literal key instead.
   
-    44 │ a?.["b"]?.['c']?.d?.e?.["f"]
+    34 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │                        -- --
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.ts
@@ -1,19 +1,11 @@
 export interface I {
 	["p1"]: number
 
-	"p2": number
+	get ["p2"](): number
 
-	get ["p3"](): number
-
-	get "p4"(): number
-
-	set ["p3"](x: number)
-
-	set "p4"(x: number)
+	set ["p2"](x: number)
 
 	["m1"](): void
-
-	"m2"(): void
 
 	[""]: number
 }
@@ -21,19 +13,11 @@ export interface I {
 export type T = {
 	["p1"]: number
 
-	"p2": number
+	get ["p2"](): number
 
-	get ["p3"](): number
-
-	get "p4"(): number
-
-	set ["p3"](x: number)
-
-	set "p4"(x: number)
+	set ["p2"](x: number)
 
 	["m1"](): void
-
-	"m2"(): void
 
 	[""]: number
 }

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.ts.snap
@@ -7,19 +7,11 @@ expression: invalid.ts
 export interface I {
 	["p1"]: number
 
-	"p2": number
+	get ["p2"](): number
 
-	get ["p3"](): number
-
-	get "p4"(): number
-
-	set ["p3"](x: number)
-
-	set "p4"(x: number)
+	set ["p2"](x: number)
 
 	["m1"](): void
-
-	"m2"(): void
 
 	[""]: number
 }
@@ -27,19 +19,11 @@ export interface I {
 export type T = {
 	["p1"]: number
 
-	"p2": number
+	get ["p2"](): number
 
-	get ["p3"](): number
-
-	get "p4"(): number
-
-	set ["p3"](x: number)
-
-	set "p4"(x: number)
+	set ["p2"](x: number)
 
 	["m1"](): void
-
-	"m2"(): void
 
 	[""]: number
 }
@@ -56,31 +40,31 @@ invalid.ts:2:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━
   > 2 │ 	["p1"]: number
       │ 	 ^^^^
     3 │ 
-    4 │ 	"p2": number
+    4 │ 	get ["p2"](): number
   
   i Unsafe fix: Use a literal key instead.
   
     2 │ → ["p1"]:·number
-      │   --  --        
+      │   -    -        
 
 ```
 
 ```
-invalid.ts:4:2 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:4:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
     2 │ 	["p1"]: number
     3 │ 
-  > 4 │ 	"p2": number
-      │ 	^^^^
+  > 4 │ 	get ["p2"](): number
+      │ 	     ^^^^
     5 │ 
-    6 │ 	get ["p3"](): number
+    6 │ 	set ["p2"](x: number)
   
   i Unsafe fix: Use a literal key instead.
   
-    4 │ → "p2":·number
-      │   -  -        
+    4 │ → get·["p2"]():·number
+      │       -    -          
 
 ```
 
@@ -89,74 +73,55 @@ invalid.ts:6:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    4 │ 	"p2": number
+    4 │ 	get ["p2"](): number
     5 │ 
-  > 6 │ 	get ["p3"](): number
+  > 6 │ 	set ["p2"](x: number)
       │ 	     ^^^^
     7 │ 
-    8 │ 	get "p4"(): number
+    8 │ 	["m1"](): void
   
   i Unsafe fix: Use a literal key instead.
   
-    6 │ → get·["p3"]():·number
-      │       --  --          
+    6 │ → set·["p2"](x:·number)
+      │       -    -           
 
 ```
 
 ```
-invalid.ts:8:6 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:8:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-     6 │ 	get ["p3"](): number
+     6 │ 	set ["p2"](x: number)
      7 │ 
-   > 8 │ 	get "p4"(): number
-       │ 	    ^^^^
+   > 8 │ 	["m1"](): void
+       │ 	 ^^^^
      9 │ 
-    10 │ 	set ["p3"](x: number)
+    10 │ 	[""]: number
   
   i Unsafe fix: Use a literal key instead.
   
-    8 │ → get·"p4"():·number
-      │       -  -          
+    8 │ → ["m1"]():·void
+      │   -    -        
 
 ```
 
 ```
-invalid.ts:10:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:10:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-     8 │ 	get "p4"(): number
+     8 │ 	["m1"](): void
      9 │ 
-  > 10 │ 	set ["p3"](x: number)
-       │ 	     ^^^^
-    11 │ 
-    12 │ 	set "p4"(x: number)
+  > 10 │ 	[""]: number
+       │ 	 ^^
+    11 │ }
+    12 │ 
   
   i Unsafe fix: Use a literal key instead.
   
-    10 │ → set·["p3"](x:·number)
-       │       --  --           
-
-```
-
-```
-invalid.ts:12:6 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    10 │ 	set ["p3"](x: number)
-    11 │ 
-  > 12 │ 	set "p4"(x: number)
-       │ 	    ^^^^
-    13 │ 
-    14 │ 	["m1"](): void
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    12 │ → set·"p4"(x:·number)
-       │       -  -           
+    10 │ → [""]:·number
+       │   -  -        
 
 ```
 
@@ -165,55 +130,73 @@ invalid.ts:14:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    12 │ 	set "p4"(x: number)
-    13 │ 
-  > 14 │ 	["m1"](): void
+    13 │ export type T = {
+  > 14 │ 	["p1"]: number
        │ 	 ^^^^
     15 │ 
-    16 │ 	"m2"(): void
+    16 │ 	get ["p2"](): number
   
   i Unsafe fix: Use a literal key instead.
   
-    14 │ → ["m1"]():·void
-       │   --  --        
+    14 │ → ["p1"]:·number
+       │   -    -        
 
 ```
 
 ```
-invalid.ts:16:2 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:16:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    14 │ 	["m1"](): void
+    14 │ 	["p1"]: number
     15 │ 
-  > 16 │ 	"m2"(): void
-       │ 	^^^^
+  > 16 │ 	get ["p2"](): number
+       │ 	     ^^^^
     17 │ 
-    18 │ 	[""]: number
+    18 │ 	set ["p2"](x: number)
   
   i Unsafe fix: Use a literal key instead.
   
-    16 │ → "m2"():·void
-       │   -  -        
+    16 │ → get·["p2"]():·number
+       │       -    -          
 
 ```
 
 ```
-invalid.ts:18:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:18:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    16 │ 	"m2"(): void
+    16 │ 	get ["p2"](): number
     17 │ 
-  > 18 │ 	[""]: number
-       │ 	 ^^
-    19 │ }
-    20 │ 
+  > 18 │ 	set ["p2"](x: number)
+       │ 	     ^^^^
+    19 │ 
+    20 │ 	["m1"](): void
   
   i Unsafe fix: Use a literal key instead.
   
-    18 │ → [""]:·number
-       │   -  -        
+    18 │ → set·["p2"](x:·number)
+       │       -    -           
+
+```
+
+```
+invalid.ts:20:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The computed expression can be simplified without the use of a string literal.
+  
+    18 │ 	set ["p2"](x: number)
+    19 │ 
+  > 20 │ 	["m1"](): void
+       │ 	 ^^^^
+    21 │ 
+    22 │ 	[""]: number
+  
+  i Unsafe fix: Use a literal key instead.
+  
+    20 │ → ["m1"]():·void
+       │   -    -        
 
 ```
 
@@ -222,169 +205,16 @@ invalid.ts:22:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 
   ! The computed expression can be simplified without the use of a string literal.
   
-    21 │ export type T = {
-  > 22 │ 	["p1"]: number
-       │ 	 ^^^^
-    23 │ 
-    24 │ 	"p2": number
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    22 │ → ["p1"]:·number
-       │   --  --        
-
-```
-
-```
-invalid.ts:24:2 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    22 │ 	["p1"]: number
-    23 │ 
-  > 24 │ 	"p2": number
-       │ 	^^^^
-    25 │ 
-    26 │ 	get ["p3"](): number
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    24 │ → "p2":·number
-       │   -  -        
-
-```
-
-```
-invalid.ts:26:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    24 │ 	"p2": number
-    25 │ 
-  > 26 │ 	get ["p3"](): number
-       │ 	     ^^^^
-    27 │ 
-    28 │ 	get "p4"(): number
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    26 │ → get·["p3"]():·number
-       │       --  --          
-
-```
-
-```
-invalid.ts:28:6 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    26 │ 	get ["p3"](): number
-    27 │ 
-  > 28 │ 	get "p4"(): number
-       │ 	    ^^^^
-    29 │ 
-    30 │ 	set ["p3"](x: number)
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    28 │ → get·"p4"():·number
-       │       -  -          
-
-```
-
-```
-invalid.ts:30:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    28 │ 	get "p4"(): number
-    29 │ 
-  > 30 │ 	set ["p3"](x: number)
-       │ 	     ^^^^
-    31 │ 
-    32 │ 	set "p4"(x: number)
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    30 │ → set·["p3"](x:·number)
-       │       --  --           
-
-```
-
-```
-invalid.ts:32:6 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    30 │ 	set ["p3"](x: number)
-    31 │ 
-  > 32 │ 	set "p4"(x: number)
-       │ 	    ^^^^
-    33 │ 
-    34 │ 	["m1"](): void
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    32 │ → set·"p4"(x:·number)
-       │       -  -           
-
-```
-
-```
-invalid.ts:34:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    32 │ 	set "p4"(x: number)
-    33 │ 
-  > 34 │ 	["m1"](): void
-       │ 	 ^^^^
-    35 │ 
-    36 │ 	"m2"(): void
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    34 │ → ["m1"]():·void
-       │   --  --        
-
-```
-
-```
-invalid.ts:36:2 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    34 │ 	["m1"](): void
-    35 │ 
-  > 36 │ 	"m2"(): void
-       │ 	^^^^
-    37 │ 
-    38 │ 	[""]: number
-  
-  i Unsafe fix: Use a literal key instead.
-  
-    36 │ → "m2"():·void
-       │   -  -        
-
-```
-
-```
-invalid.ts:38:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The computed expression can be simplified without the use of a string literal.
-  
-    36 │ 	"m2"(): void
-    37 │ 
-  > 38 │ 	[""]: number
+    20 │ 	["m1"](): void
+    21 │ 
+  > 22 │ 	[""]: number
        │ 	 ^^
-    39 │ }
-    40 │ 
+    23 │ }
+    24 │ 
   
   i Unsafe fix: Use a literal key instead.
   
-    38 │ → [""]:·number
+    22 │ → [""]:·number
        │   -  -        
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js
@@ -19,5 +19,16 @@ class C { a(){} }
 class C { get a(){} }
 class C { set a(x){} }
 a = {
+	"b": d
+};
+class C { "a" = 0 }
+class C { "a"(){} }
+class C { get "a"(){} }
+class C { set "a"(x){} }
+a = {
+	"__proto__": null,
+}
+// Exception
+a = {
 	["__proto__"]: null,
 }

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js.snap
@@ -25,6 +25,17 @@ class C { a(){} }
 class C { get a(){} }
 class C { set a(x){} }
 a = {
+	"b": d
+};
+class C { "a" = 0 }
+class C { "a"(){} }
+class C { get "a"(){} }
+class C { set "a"(x){} }
+a = {
+	"__proto__": null,
+}
+// Exception
+a = {
 	["__proto__"]: null,
 }
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.ts
@@ -6,6 +6,14 @@ export interface I {
 	set p2(x: number)
 
 	m1(): void
+
+	"p3": number
+
+	get "p4"(): number
+
+	set "p4"(x: number)
+
+	"m2"(): void
 }
 
 export type T = {
@@ -16,4 +24,12 @@ export type T = {
 	set p2(x: number)
 
 	m1(): void
+
+	"p3": number
+
+	get "p4"(): number
+
+	set "p4"(x: number)
+
+	"m2"(): void
 }

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.ts.snap
@@ -12,6 +12,14 @@ export interface I {
 	set p2(x: number)
 
 	m1(): void
+
+	"p3": number
+
+	get "p4"(): number
+
+	set "p4"(x: number)
+
+	"m2"(): void
 }
 
 export type T = {
@@ -22,8 +30,14 @@ export type T = {
 	set p2(x: number)
 
 	m1(): void
+
+	"p3": number
+
+	get "p4"(): number
+
+	set "p4"(x: number)
+
+	"m2"(): void
 }
 
 ```
-
-


### PR DESCRIPTION
## Summary

Fix #3085

Note that we still report computed member names that can be simplified. Instead of simplifying to an identifier, we always simplify to a quoted property leaving the removal of the quotes to the formatter.

## Test Plan

I updated the tests.