### PR TITLE
fix(graphql_parser): allow backlash in block string

### DIFF
--- a/crates/biome_graphql_parser/src/lexer/mod.rs
+++ b/crates/biome_graphql_parser/src/lexer/mod.rs
@@ -656,16 +656,8 @@ impl<'src> GraphqlLexer<'src> {
                     && self.byte_at(2) == Some(b'"')
                 {
                     self.advance(3);
-                    (state, None)
-                } else {
-                    let c = self.current_char_unchecked();
-                    let diagnostic = ParseDiagnostic::new(
-                        "Invalid escape sequence",
-                        escape_start..self.text_position() + c.text_len(),
-                    )
-                    .with_hint(r#"For block string the only valid escape sequences is `\"""`. "#);
-                    (state, Some(diagnostic))
                 }
+                (state, None)
             }
             // should never happen
             _ => (

--- a/crates/biome_graphql_parser/src/lexer/tests.rs
+++ b/crates/biome_graphql_parser/src/lexer/tests.rs
@@ -219,11 +219,10 @@ fn string() {
         WHITESPACE:1,
     }
 
-    // invalid escape sequence
+    // unescaped backslash
     assert_lex! {
-        r#"""" \" \r \n \"" """ "#,
-        ERROR_TOKEN:20,
-        WHITESPACE:1,
+        r#"""" \" \r \n \"" """"#,
+        GRAPHQL_STRING_LITERAL:20,
     }
 
     // empty


### PR DESCRIPTION
## Summary

According to the GraphQL documentation, backslash characters can be used unescaped within a block string ([link](https://spec.graphql.org/October2021/#sec-String-Value.Block-Strings)).

## Test Plan

All tests should pass.
