### PR TITLE
fix(noEmptyInterface): ignore empty interfaces in ambient modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [noEmptyInterface](https://biomejs.dev/linter/rules/no-empty-interface/) now ignores empty interfaces in ambient modules ([#3110](https://github.com/biomejs/biome/issues/3110)). Contributed by @Conaclos
+
 ### Parser
 
 ## 1.8.0 (2024-06-04)

--- a/crates/biome_js_analyze/src/lint/suspicious/no_empty_interface.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_empty_interface.rs
@@ -9,7 +9,8 @@ use biome_js_factory::{
     syntax::{AnyTsType, T},
 };
 use biome_js_syntax::{
-    AnyJsDeclarationClause, TriviaPieceKind, TsInterfaceDeclaration, TsTypeAliasDeclaration,
+    AnyJsDeclarationClause, JsSyntaxKind, TriviaPieceKind, TsInterfaceDeclaration,
+    TsTypeAliasDeclaration,
 };
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, SyntaxResult};
 
@@ -38,6 +39,11 @@ declare_rule! {
     ///
     /// // Allow empty interfaces that extend a type.
     /// interface B extends A {}
+    ///
+    /// // Allow empty interfaces in ambient modules
+    /// declare module "mod" {
+    ///   interface C {}
+    /// }
     /// ```
     pub NoEmptyInterface {
         version: "1.0.0",
@@ -58,6 +64,15 @@ impl Rule for NoEmptyInterface {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
+        let is_in_ambient_module = node.syntax().ancestors().skip(1).any(|ancestor| {
+            matches!(
+                ancestor.kind(),
+                JsSyntaxKind::TS_GLOBAL_DECLARATION | JsSyntaxKind::TS_EXTERNAL_MODULE_DECLARATION
+            )
+        });
+        if is_in_ambient_module {
+            return None;
+        }
         (node.members().is_empty() && node.extends_clause().is_none()).then_some(())
     }
 

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.d.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.d.ts
@@ -1,3 +1,6 @@
 declare global {
     export interface App extends Services {}
+    export namespace Ns {
+        export interface Empty {}
+    }
 }

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.d.ts.snap
@@ -6,8 +6,9 @@ expression: valid.d.ts
 ```ts
 declare global {
     export interface App extends Services {}
+    export namespace Ns {
+        export interface Empty {}
+    }
 }
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.ts
@@ -7,6 +7,7 @@ interface Baz extends Foo, Bar {}
 // See https://github.com/biomejs/biome/issues/959
 declare module "external" {
   export interface App extends Services {}
+  export interface Empty {}
 
   global {
     export interface App extends Services {}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyInterface/valid.ts.snap
@@ -13,6 +13,7 @@ interface Baz extends Foo, Bar {}
 // See https://github.com/biomejs/biome/issues/959
 declare module "external" {
   export interface App extends Services {}
+  export interface Empty {}
 
   global {
     export interface App extends Services {}
@@ -37,5 +38,3 @@ namespace Ns {
 }
 
 ```
-
-


### PR DESCRIPTION
## Summary

Fix #3110

We now accept empty interfaces in global declarations `declare global {}` and ambient modules `declare module "mod" {}`.

## Test Plan

I added tests.