### PR TITLE
fix(css_formatter): fix CSS formatter converts variable declarations and function calls to lowercase #3068

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Fix [#3069](https://github.com/biomejs/biome/issues/3069), prevent overwriting paths when using `--staged` or `--changed` options. Contributed by @unvalley
 - Fix the bug where whitespace after the & character in CSS nesting was incorrectly trimmed, ensuring proper targeting of child classes [#3061](https://github.com/biomejs/biome/issues/3061). Contributed by @denbezrukov
-
+- Fix [#3068](https://github.com/biomejs/biome/issues/3068) where the CSS formatter was inadvertently converting variable declarations and function calls to lowercase. Contributed by @denbezrukov
 
 ### Configuration
 

--- a/crates/biome_css_formatter/src/comments.rs
+++ b/crates/biome_css_formatter/src/comments.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_css_syntax::{AnyCssDeclarationName, CssFunction, CssLanguage, TextLen};
+use biome_css_syntax::{AnyCssDeclarationName, CssFunction, CssIdentifier, CssLanguage, TextLen};
 use biome_diagnostics::category;
 use biome_formatter::comments::{
     is_doc_comment, CommentKind, CommentPlacement, CommentStyle, CommentTextPosition, Comments,
@@ -123,7 +123,7 @@ fn handle_function_comment(
     };
 
     let is_inside_function = CssFunction::can_cast(comment.enclosing_node().kind());
-    let is_after_name = AnyCssDeclarationName::can_cast(preceding_node.kind());
+    let is_after_name = CssIdentifier::can_cast(preceding_node.kind());
     if is_inside_function && is_after_name {
         CommentPlacement::leading(following_node.clone(), comment)
     } else {

--- a/crates/biome_css_formatter/src/css/auxiliary/function.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/function.rs
@@ -1,6 +1,8 @@
+use crate::css::value::identifier::FormatCssIdentifierOptions;
 use crate::prelude::*;
 use biome_css_syntax::{CssFunction, CssFunctionFields};
 use biome_formatter::{format_args, write};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssFunction;
 impl FormatNodeRule<CssFunction> for FormatCssFunction {
@@ -12,16 +14,22 @@ impl FormatNodeRule<CssFunction> for FormatCssFunction {
             r_paren_token,
         } = node.as_fields();
 
+        if let Ok(name) = name {
+            write!(
+                f,
+                [name
+                    .format()
+                    .with_options(FormatCssIdentifierOptions::default().prevent_lowercase(true))]
+            )?;
+        }
+
         write!(
             f,
-            [
-                name.format(),
-                group(&format_args![
-                    l_paren_token.format(),
-                    soft_block_indent(&items.format()),
-                    r_paren_token.format()
-                ])
-            ]
+            [group(&format_args![
+                l_paren_token.format(),
+                soft_block_indent(&items.format()),
+                r_paren_token.format()
+            ])]
         )
     }
 }

--- a/crates/biome_css_formatter/src/css/lists/layer_name_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/layer_name_list.rs
@@ -1,10 +1,18 @@
+use crate::css::value::identifier::FormatCssIdentifierOptions;
 use crate::prelude::*;
+use crate::separated::FormatAstSeparatedListWithOptionsExtension;
 use biome_css_syntax::CssLayerNameList;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssLayerNameList;
 impl FormatRule<CssLayerNameList> for FormatCssLayerNameList {
     type Context = CssFormatContext;
     fn fmt(&self, node: &CssLayerNameList, f: &mut CssFormatter) -> FormatResult<()> {
-        f.join().entries(node.format_separated(".")).finish()
+        f.join()
+            .entries(node.format_separated_with_options1(
+                ".",
+                FormatCssIdentifierOptions::default().prevent_lowercase(true),
+            ))
+            .finish()
     }
 }

--- a/crates/biome_css_formatter/src/css/lists/layer_name_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/layer_name_list.rs
@@ -9,7 +9,7 @@ impl FormatRule<CssLayerNameList> for FormatCssLayerNameList {
     type Context = CssFormatContext;
     fn fmt(&self, node: &CssLayerNameList, f: &mut CssFormatter) -> FormatResult<()> {
         f.join()
-            .entries(node.format_separated_with_options1(
+            .entries(node.format_separated_with_options(
                 ".",
                 FormatCssIdentifierOptions::default().prevent_lowercase(true),
             ))

--- a/crates/biome_css_formatter/src/css/value/identifier.rs
+++ b/crates/biome_css_formatter/src/css/value/identifier.rs
@@ -1,13 +1,40 @@
 use crate::{prelude::*, utils::string_utils::FormatTokenAsLowercase};
 use biome_css_syntax::{CssIdentifier, CssIdentifierFields};
-use biome_formatter::write;
+use biome_formatter::{write, FormatRuleWithOptions};
 
-#[derive(Debug, Clone, Default)]
-pub(crate) struct FormatCssIdentifier;
+#[derive(Default, Debug, Clone, Copy)]
+pub(crate) struct FormatCssIdentifier {
+    prevent_lowercase: bool,
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub(crate) struct FormatCssIdentifierOptions {
+    pub(crate) prevent_lowercase: bool,
+}
+
+impl FormatCssIdentifierOptions {
+    pub(crate) fn prevent_lowercase(mut self, prevent_lowercase: bool) -> Self {
+        self.prevent_lowercase = prevent_lowercase;
+        self
+    }
+}
+
+impl FormatRuleWithOptions<CssIdentifier> for FormatCssIdentifier {
+    type Options = FormatCssIdentifierOptions;
+
+    fn with_options(mut self, options: Self::Options) -> Self {
+        self.prevent_lowercase = options.prevent_lowercase;
+        self
+    }
+}
 
 impl FormatNodeRule<CssIdentifier> for FormatCssIdentifier {
     fn fmt_fields(&self, node: &CssIdentifier, f: &mut CssFormatter) -> FormatResult<()> {
         let CssIdentifierFields { value_token } = node.as_fields();
+
+        if self.prevent_lowercase {
+            return write!(f, [value_token.format()]);
+        }
 
         // Identifiers in CSS are used all over the place. Type selectors,
         // declaration names, value definitions, and plenty more. For the most

--- a/crates/biome_css_formatter/src/separated.rs
+++ b/crates/biome_css_formatter/src/separated.rs
@@ -110,7 +110,7 @@ pub(crate) trait FormatAstSeparatedListWithOptionsExtension<O>:
     /// calling the `separator_factory` function. The last trailing separator
     /// will not be printed by default. Use `with_trailing_separator` to add it
     /// in where necessary.
-    fn format_separated_with_options1(
+    fn format_separated_with_options(
         &self,
         separator: &'static str,
         options: O,

--- a/crates/biome_css_formatter/src/separated.rs
+++ b/crates/biome_css_formatter/src/separated.rs
@@ -1,10 +1,10 @@
 use crate::prelude::*;
 use crate::FormatCssSyntaxToken;
-use biome_css_syntax::{CssLanguage, CssSyntaxToken};
+use biome_css_syntax::{CssIdentifier, CssLanguage, CssSyntaxToken};
 use biome_formatter::separated::{
     FormatSeparatedElementRule, FormatSeparatedIter, TrailingSeparator,
 };
-use biome_formatter::FormatRefWithRule;
+use biome_formatter::{FormatRefWithRule, FormatRuleWithOptions};
 use biome_rowan::{AstNode, AstSeparatedList, AstSeparatedListElementsIterator};
 use std::marker::PhantomData;
 
@@ -30,8 +30,6 @@ where
     }
 }
 
-// Unused currently because CSS formatting is very barebones for now
-#[allow(unused)]
 type CssFormatSeparatedIter<Node> = FormatSeparatedIter<
     AstSeparatedListElementsIterator<CssLanguage, Node>,
     Node,
@@ -59,3 +57,74 @@ pub(crate) trait FormatAstSeparatedListExtension:
 }
 
 impl<T> FormatAstSeparatedListExtension for T where T: AstSeparatedList<Language = CssLanguage> {}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub(crate) struct CssFormatSeparatedElementRuleWithOptions<N, O> {
+    node: PhantomData<N>,
+    options: O,
+}
+
+impl<N, O> CssFormatSeparatedElementRuleWithOptions<N, O> {
+    pub(crate) fn new(options: O) -> Self {
+        Self {
+            node: PhantomData,
+            options,
+        }
+    }
+}
+
+impl<N, O, R> FormatSeparatedElementRule<N> for CssFormatSeparatedElementRuleWithOptions<N, O>
+where
+    O: Clone + Copy,
+    R: FormatNodeRule<N> + FormatRuleWithOptions<N, Context = CssFormatContext, Options = O>,
+    N: AstNode<Language = CssLanguage>
+        + for<'a> AsFormat<CssFormatContext, Format<'a> = FormatRefWithRule<'a, N, R>>
+        + 'static,
+{
+    type Context = CssFormatContext;
+    type FormatNode<'a> = FormatRefWithRule<'a, N, R>;
+    type FormatSeparator<'a> = FormatRefWithRule<'a, CssSyntaxToken, FormatCssSyntaxToken>;
+
+    fn format_node<'a>(&self, node: &'a N) -> Self::FormatNode<'a> {
+        node.format().with_options(self.options)
+    }
+
+    fn format_separator<'a>(&self, separator: &'a CssSyntaxToken) -> Self::FormatSeparator<'a> {
+        separator.format()
+    }
+}
+
+type CssFormatSeparatedIterWithOptions<Node, Options> = FormatSeparatedIter<
+    AstSeparatedListElementsIterator<CssLanguage, Node>,
+    Node,
+    CssFormatSeparatedElementRuleWithOptions<Node, Options>,
+>;
+
+/// AST Separated list formatting extension methods with options
+pub(crate) trait FormatAstSeparatedListWithOptionsExtension<O>:
+    AstSeparatedList<Language = CssLanguage>
+{
+    /// Prints a separated list of nodes with options
+    ///
+    /// Trailing separators will be reused from the original list or created by
+    /// calling the `separator_factory` function. The last trailing separator
+    /// will not be printed by default. Use `with_trailing_separator` to add it
+    /// in where necessary.
+    fn format_separated_with_options1(
+        &self,
+        separator: &'static str,
+        options: O,
+    ) -> CssFormatSeparatedIterWithOptions<Self::Node, O> {
+        FormatSeparatedIter::new(
+            self.elements(),
+            separator,
+            CssFormatSeparatedElementRuleWithOptions::new(options),
+        )
+        .with_trailing_separator(TrailingSeparator::Disallowed)
+    }
+}
+
+impl<T, O> FormatAstSeparatedListWithOptionsExtension<O> for T where
+    T: AstSeparatedList<Language = CssLanguage, Node = CssIdentifier>
+{
+}

--- a/crates/biome_css_formatter/tests/specs/css/atrule/import.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/import.css.snap
@@ -335,7 +335,7 @@ st.css");
 @import url("./test.css") screen and (min-width: 400px);
 @import url("./test.css") layer(default) supports(display: flex)
 	screen and (min-width: 400px);
-@import url("./test.css") layer(default) supports(display: flex)
+@import url("./test.css") layer(DEFAULT) supports(display: flex)
 	screen and (min-width: 400px);
 @import url("./test.css") /* Comment */
 	layer(/* Comment */ /* Comment */ default) /* Comment */

--- a/crates/biome_css_formatter/tests/specs/css/atrule/layer.css
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/layer.css
@@ -18,7 +18,7 @@ framework
 }
 
 @layer   {}
-@layer { 
+@layer {
     }
 
 @layer
@@ -64,5 +64,14 @@ reset.type
 
 	@layer theme {
 		h1, h2 { color: maroon; }
+	}
+}
+
+@layer reSet, MyLayer;
+
+@layer reSet, MyLayer {
+	audio[controls] {
+		/* specificity of 0,1,1 - explicit "reset" layer */
+		display: block;
 	}
 }

--- a/crates/biome_css_formatter/tests/specs/css/atrule/layer.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/layer.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/atrule/layer.css
 ---
-
 # Input
 
 ```css
@@ -26,7 +25,7 @@ framework
 }
 
 @layer   {}
-@layer { 
+@layer {
     }
 
 @layer
@@ -72,6 +71,15 @@ reset.type
 
 	@layer theme {
 		h1, h2 { color: maroon; }
+	}
+}
+
+@layer reSet, MyLayer;
+
+@layer reSet, MyLayer {
+	audio[controls] {
+		/* specificity of 0,1,1 - explicit "reset" layer */
+		display: block;
 	}
 }
 
@@ -185,6 +193,13 @@ Quote style: Double Quotes
 		}
 	}
 }
+
+@layer reSet, MyLayer;
+
+@layer reSet, MyLayer {
+	audio[controls] {
+		/* specificity of 0,1,1 - explicit "reset" layer */
+		display: block;
+	}
+}
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/css/casing.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/casing.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/casing.css
 ---
-
 # Input
 
 ```css
@@ -72,8 +71,8 @@ div.classNames#AND_Ids.ArePreserved {
 }
 
 div {
-	--preserved-casing: blue;
-	color: var(--Preserved-Casing);
+	--Preserved-Casing: blue;
+	color: VAR(--Preserved-Casing);
 }
 
 @font-palette-values --AnyCASInG-works {
@@ -88,5 +87,3 @@ div {
 @page ThisIsPreserved:first {
 }
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/css/properties/all.css
+++ b/crates/biome_css_formatter/tests/specs/css/properties/all.css
@@ -22,3 +22,12 @@ div {
 		180deg
 	);
 }
+
+.variable {
+	--myVariableName: 10px;
+	margin: var(--myVariableName);
+}
+
+.function {
+	transform: translateX(10px) translateY(10px);
+}

--- a/crates/biome_css_formatter/tests/specs/css/properties/all.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/properties/all.css.snap
@@ -30,6 +30,15 @@ div {
 	);
 }
 
+.variable {
+	--myVariableName: 10px;
+	margin: var(--myVariableName);
+}
+
+.function {
+	transform: translateX(10px) translateY(10px);
+}
+
 ```
 
 
@@ -67,5 +76,14 @@ div {
 		180deg,
 		180deg
 	);
+}
+
+.variable {
+	--myVariableName: 10px;
+	margin: var(--myVariableName);
+}
+
+.function {
+	transform: translateX(10px) translateY(10px);
 }
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/css/case/case.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/case/case.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/case/case.css
 ---
-
 # Input
 
 ```css
@@ -326,5 +325,3 @@ case.css:1:44 parse ━━━━━━━━━━━━━━━━━━━━
   
 
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/color/color-adjuster.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/color/color-adjuster.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/color/color-adjuster.css
 ---
-
 # Input
 
 ```css
@@ -1837,5 +1836,3 @@ color-adjuster.css:120:52 parse ━━━━━━━━━━━━━━━━
 ```
   109:   color: color(color-mod(0deg blue(10%)) rgb(+ 0 10 0) hue(+ 10deg) tint(10%) lightness(+ 10%) saturation(+ 10%) blend(rebeccapurple 50%));
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/loose/loose.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/loose/loose.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/loose/loose.css
 ---
-
 # Input
 
 ```css
@@ -52,5 +51,3 @@ div {
   background-image: url() center center no-repeat black;
 }
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/parens/parens.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/parens/parens.css.snap
@@ -267,12 +267,7 @@ a {
 ```diff
 --- Prettier
 +++ Biome
-@@ -53,14 +53,14 @@
- }
- 
- .foo {
--  --paddingC: calc(var(--widthB) / 2);
-+  --paddingc: calc(var(--widthB) / 2);
+@@ -57,10 +57,10 @@
    content: attr(data-title);
    color: var(--main-bg-color);
    background-color: rgb(255, 0, 0);
@@ -425,7 +420,7 @@ a {
 }
 
 .foo {
-  --paddingc: calc(var(--widthB) / 2);
+  --paddingC: calc(var(--widthB) / 2);
   content: attr(data-title);
   color: var(--main-bg-color);
   background-color: rgb(255, 0, 0);

--- a/crates/biome_css_parser/src/syntax/property/mod.rs
+++ b/crates/biome_css_parser/src/syntax/property/mod.rs
@@ -5,8 +5,9 @@ use crate::syntax::css_modules::{
 };
 use crate::syntax::parse_error::{expected_component_value, expected_identifier};
 use crate::syntax::{
-    is_at_any_value, is_at_identifier, is_at_string, parse_any_value,
-    parse_custom_identifier_with_keywords, parse_regular_identifier, parse_string,
+    is_at_any_value, is_at_dashed_identifier, is_at_identifier, is_at_string, parse_any_value,
+    parse_custom_identifier_with_keywords, parse_dashed_identifier, parse_regular_identifier,
+    parse_string,
 };
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
@@ -165,7 +166,12 @@ fn parse_generic_property(p: &mut CssParser) -> ParsedSyntax {
     }
 
     let m = p.start();
-    parse_regular_identifier(p).ok();
+
+    if is_at_dashed_identifier(p) {
+        parse_dashed_identifier(p).ok();
+    } else {
+        parse_regular_identifier(p).ok();
+    }
 
     p.expect(T![:]);
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/property/property_generic_error.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/property/property_generic_error.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_css_parser/tests/spec_test.rs
 expression: snapshot
 ---
-
 ## Input
 
 ```css
@@ -83,7 +82,7 @@ CssRoot {
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
-                                name: CssIdentifier {
+                                name: CssDashedIdentifier {
                                     value_token: IDENT@43..56 "--custom" [Newline("\n"), Whitespace("    ")] [],
                                 },
                                 colon_token: COLON@56..58 ":" [] [Whitespace(" ")],
@@ -162,7 +161,7 @@ CssRoot {
           2: CSS_DECLARATION_WITH_SEMICOLON@43..64
             0: CSS_DECLARATION@43..63
               0: CSS_GENERIC_PROPERTY@43..63
-                0: CSS_IDENTIFIER@43..56
+                0: CSS_DASHED_IDENTIFIER@43..56
                   0: IDENT@43..56 "--custom" [Newline("\n"), Whitespace("    ")] []
                 1: COLON@56..58 ":" [] [Whitespace(" ")]
                 2: CSS_GENERIC_COMPONENT_VALUE_LIST@58..63
@@ -239,5 +238,3 @@ property_generic_error.css:4:20 parse ━━━━━━━━━━━━━━
     5 │ }
   
 ```
-
-

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_container.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_container.css.snap
@@ -141,7 +141,7 @@ CssRoot {
                         l_paren_token: L_PAREN@136..137 "(" [] [],
                         query: CssDeclaration {
                             property: CssGenericProperty {
-                                name: CssIdentifier {
+                                name: CssDashedIdentifier {
                                     value_token: IDENT@137..149 "--responsive" [] [],
                                 },
                                 colon_token: COLON@149..151 ":" [] [Whitespace(" ")],
@@ -408,7 +408,7 @@ CssRoot {
                     l_paren_token: L_PAREN@486..487 "(" [] [],
                     query: CssDeclaration {
                         property: CssGenericProperty {
-                            name: CssIdentifier {
+                            name: CssDashedIdentifier {
                                 value_token: IDENT@487..499 "--responsive" [] [],
                             },
                             colon_token: COLON@499..501 ":" [] [Whitespace(" ")],
@@ -724,7 +724,7 @@ CssRoot {
             1: L_PAREN@136..137 "(" [] []
             2: CSS_DECLARATION@137..155
               0: CSS_GENERIC_PROPERTY@137..155
-                0: CSS_IDENTIFIER@137..149
+                0: CSS_DASHED_IDENTIFIER@137..149
                   0: IDENT@137..149 "--responsive" [] []
                 1: COLON@149..151 ":" [] [Whitespace(" ")]
                 2: CSS_GENERIC_COMPONENT_VALUE_LIST@151..155
@@ -913,7 +913,7 @@ CssRoot {
           1: L_PAREN@486..487 "(" [] []
           2: CSS_DECLARATION@487..505
             0: CSS_GENERIC_PROPERTY@487..505
-              0: CSS_IDENTIFIER@487..499
+              0: CSS_DASHED_IDENTIFIER@487..499
                 0: IDENT@487..499 "--responsive" [] []
               1: COLON@499..501 ":" [] [Whitespace(" ")]
               2: CSS_GENERIC_COMPONENT_VALUE_LIST@501..505

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_container_complex.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_container_complex.css.snap
@@ -564,7 +564,7 @@ CssRoot {
                             l_paren_token: L_PAREN@633..634 "(" [] [],
                             query: CssDeclaration {
                                 property: CssGenericProperty {
-                                    name: CssIdentifier {
+                                    name: CssDashedIdentifier {
                                         value_token: IDENT@634..637 "--a" [] [],
                                     },
                                     colon_token: COLON@637..639 ":" [] [Whitespace(" ")],
@@ -630,7 +630,7 @@ CssRoot {
                             l_paren_token: L_PAREN@715..716 "(" [] [],
                             query: CssDeclaration {
                                 property: CssGenericProperty {
-                                    name: CssIdentifier {
+                                    name: CssDashedIdentifier {
                                         value_token: IDENT@716..719 "--a" [] [],
                                     },
                                     colon_token: COLON@719..721 ":" [] [Whitespace(" ")],
@@ -649,7 +649,7 @@ CssRoot {
                             l_paren_token: L_PAREN@731..732 "(" [] [],
                             query: CssDeclaration {
                                 property: CssGenericProperty {
-                                    name: CssIdentifier {
+                                    name: CssDashedIdentifier {
                                         value_token: IDENT@732..735 "--b" [] [],
                                     },
                                     colon_token: COLON@735..737 ":" [] [Whitespace(" ")],
@@ -688,7 +688,7 @@ CssRoot {
                             l_paren_token: L_PAREN@770..771 "(" [] [],
                             query: CssDeclaration {
                                 property: CssGenericProperty {
-                                    name: CssIdentifier {
+                                    name: CssDashedIdentifier {
                                         value_token: IDENT@771..774 "--a" [] [],
                                     },
                                     colon_token: COLON@774..776 ":" [] [Whitespace(" ")],
@@ -710,7 +710,7 @@ CssRoot {
                                     l_paren_token: L_PAREN@787..788 "(" [] [],
                                     query: CssDeclaration {
                                         property: CssGenericProperty {
-                                            name: CssIdentifier {
+                                            name: CssDashedIdentifier {
                                                 value_token: IDENT@788..791 "--b" [] [],
                                             },
                                             colon_token: COLON@791..793 ":" [] [Whitespace(" ")],
@@ -729,7 +729,7 @@ CssRoot {
                                     l_paren_token: L_PAREN@801..802 "(" [] [],
                                     query: CssDeclaration {
                                         property: CssGenericProperty {
-                                            name: CssIdentifier {
+                                            name: CssDashedIdentifier {
                                                 value_token: IDENT@802..805 "--c" [] [],
                                             },
                                             colon_token: COLON@805..807 ":" [] [Whitespace(" ")],
@@ -775,7 +775,7 @@ CssRoot {
                                     l_paren_token: L_PAREN@848..849 "(" [] [],
                                     query: CssDeclaration {
                                         property: CssGenericProperty {
-                                            name: CssIdentifier {
+                                            name: CssDashedIdentifier {
                                                 value_token: IDENT@849..852 "--b" [] [],
                                             },
                                             colon_token: COLON@852..854 ":" [] [Whitespace(" ")],
@@ -797,7 +797,7 @@ CssRoot {
                             l_paren_token: L_PAREN@863..864 "(" [] [],
                             query: CssDeclaration {
                                 property: CssGenericProperty {
-                                    name: CssIdentifier {
+                                    name: CssDashedIdentifier {
                                         value_token: IDENT@864..867 "--c" [] [],
                                     },
                                     colon_token: COLON@867..869 ":" [] [Whitespace(" ")],
@@ -840,7 +840,7 @@ CssRoot {
                                     l_paren_token: L_PAREN@909..910 "(" [] [],
                                     query: CssDeclaration {
                                         property: CssGenericProperty {
-                                            name: CssIdentifier {
+                                            name: CssDashedIdentifier {
                                                 value_token: IDENT@910..913 "--b" [] [],
                                             },
                                             colon_token: COLON@913..915 ":" [] [Whitespace(" ")],
@@ -866,7 +866,7 @@ CssRoot {
                                     l_paren_token: L_PAREN@929..930 "(" [] [],
                                     query: CssDeclaration {
                                         property: CssGenericProperty {
-                                            name: CssIdentifier {
+                                            name: CssDashedIdentifier {
                                                 value_token: IDENT@930..933 "--c" [] [],
                                             },
                                             colon_token: COLON@933..935 ":" [] [Whitespace(" ")],
@@ -912,7 +912,7 @@ CssRoot {
                                     l_paren_token: L_PAREN@976..977 "(" [] [],
                                     query: CssDeclaration {
                                         property: CssGenericProperty {
-                                            name: CssIdentifier {
+                                            name: CssDashedIdentifier {
                                                 value_token: IDENT@977..980 "--b" [] [],
                                             },
                                             colon_token: COLON@980..982 ":" [] [Whitespace(" ")],
@@ -941,7 +941,7 @@ CssRoot {
                                             l_paren_token: L_PAREN@997..998 "(" [] [],
                                             query: CssDeclaration {
                                                 property: CssGenericProperty {
-                                                    name: CssIdentifier {
+                                                    name: CssDashedIdentifier {
                                                         value_token: IDENT@998..1001 "--c" [] [],
                                                     },
                                                     colon_token: COLON@1001..1003 ":" [] [Whitespace(" ")],
@@ -1010,7 +1010,7 @@ CssRoot {
                                     l_paren_token: L_PAREN@1071..1072 "(" [] [],
                                     query: CssDeclaration {
                                         property: CssGenericProperty {
-                                            name: CssIdentifier {
+                                            name: CssDashedIdentifier {
                                                 value_token: IDENT@1072..1075 "--b" [] [],
                                             },
                                             colon_token: COLON@1075..1077 ":" [] [Whitespace(" ")],
@@ -1074,7 +1074,7 @@ CssRoot {
                                         l_paren_token: L_PAREN@1138..1139 "(" [] [],
                                         query: CssDeclaration {
                                             property: CssGenericProperty {
-                                                name: CssIdentifier {
+                                                name: CssDashedIdentifier {
                                                     value_token: IDENT@1139..1142 "--b" [] [],
                                                 },
                                                 colon_token: COLON@1142..1144 ":" [] [Whitespace(" ")],
@@ -1103,7 +1103,7 @@ CssRoot {
                                                 l_paren_token: L_PAREN@1159..1160 "(" [] [],
                                                 query: CssDeclaration {
                                                     property: CssGenericProperty {
-                                                        name: CssIdentifier {
+                                                        name: CssDashedIdentifier {
                                                             value_token: IDENT@1160..1163 "--c" [] [],
                                                         },
                                                         colon_token: COLON@1163..1165 ":" [] [Whitespace(" ")],
@@ -1639,7 +1639,7 @@ CssRoot {
               0: L_PAREN@633..634 "(" [] []
               1: CSS_DECLARATION@634..643
                 0: CSS_GENERIC_PROPERTY@634..643
-                  0: CSS_IDENTIFIER@634..637
+                  0: CSS_DASHED_IDENTIFIER@634..637
                     0: IDENT@634..637 "--a" [] []
                   1: COLON@637..639 ":" [] [Whitespace(" ")]
                   2: CSS_GENERIC_COMPONENT_VALUE_LIST@639..643
@@ -1685,7 +1685,7 @@ CssRoot {
               0: L_PAREN@715..716 "(" [] []
               1: CSS_DECLARATION@716..725
                 0: CSS_GENERIC_PROPERTY@716..725
-                  0: CSS_IDENTIFIER@716..719
+                  0: CSS_DASHED_IDENTIFIER@716..719
                     0: IDENT@716..719 "--a" [] []
                   1: COLON@719..721 ":" [] [Whitespace(" ")]
                   2: CSS_GENERIC_COMPONENT_VALUE_LIST@721..725
@@ -1698,7 +1698,7 @@ CssRoot {
               0: L_PAREN@731..732 "(" [] []
               1: CSS_DECLARATION@732..740
                 0: CSS_GENERIC_PROPERTY@732..740
-                  0: CSS_IDENTIFIER@732..735
+                  0: CSS_DASHED_IDENTIFIER@732..735
                     0: IDENT@732..735 "--b" [] []
                   1: COLON@735..737 ":" [] [Whitespace(" ")]
                   2: CSS_GENERIC_COMPONENT_VALUE_LIST@737..740
@@ -1725,7 +1725,7 @@ CssRoot {
               0: L_PAREN@770..771 "(" [] []
               1: CSS_DECLARATION@771..780
                 0: CSS_GENERIC_PROPERTY@771..780
-                  0: CSS_IDENTIFIER@771..774
+                  0: CSS_DASHED_IDENTIFIER@771..774
                     0: IDENT@771..774 "--a" [] []
                   1: COLON@774..776 ":" [] [Whitespace(" ")]
                   2: CSS_GENERIC_COMPONENT_VALUE_LIST@776..780
@@ -1741,7 +1741,7 @@ CssRoot {
                   0: L_PAREN@787..788 "(" [] []
                   1: CSS_DECLARATION@788..796
                     0: CSS_GENERIC_PROPERTY@788..796
-                      0: CSS_IDENTIFIER@788..791
+                      0: CSS_DASHED_IDENTIFIER@788..791
                         0: IDENT@788..791 "--b" [] []
                       1: COLON@791..793 ":" [] [Whitespace(" ")]
                       2: CSS_GENERIC_COMPONENT_VALUE_LIST@793..796
@@ -1754,7 +1754,7 @@ CssRoot {
                   0: L_PAREN@801..802 "(" [] []
                   1: CSS_DECLARATION@802..812
                     0: CSS_GENERIC_PROPERTY@802..812
-                      0: CSS_IDENTIFIER@802..805
+                      0: CSS_DASHED_IDENTIFIER@802..805
                         0: IDENT@802..805 "--c" [] []
                       1: COLON@805..807 ":" [] [Whitespace(" ")]
                       2: CSS_GENERIC_COMPONENT_VALUE_LIST@807..812
@@ -1786,7 +1786,7 @@ CssRoot {
                   0: L_PAREN@848..849 "(" [] []
                   1: CSS_DECLARATION@849..857
                     0: CSS_GENERIC_PROPERTY@849..857
-                      0: CSS_IDENTIFIER@849..852
+                      0: CSS_DASHED_IDENTIFIER@849..852
                         0: IDENT@849..852 "--b" [] []
                       1: COLON@852..854 ":" [] [Whitespace(" ")]
                       2: CSS_GENERIC_COMPONENT_VALUE_LIST@854..857
@@ -1800,7 +1800,7 @@ CssRoot {
               0: L_PAREN@863..864 "(" [] []
               1: CSS_DECLARATION@864..874
                 0: CSS_GENERIC_PROPERTY@864..874
-                  0: CSS_IDENTIFIER@864..867
+                  0: CSS_DASHED_IDENTIFIER@864..867
                     0: IDENT@864..867 "--c" [] []
                   1: COLON@867..869 ":" [] [Whitespace(" ")]
                   2: CSS_GENERIC_COMPONENT_VALUE_LIST@869..874
@@ -1831,7 +1831,7 @@ CssRoot {
                   0: L_PAREN@909..910 "(" [] []
                   1: CSS_DECLARATION@910..918
                     0: CSS_GENERIC_PROPERTY@910..918
-                      0: CSS_IDENTIFIER@910..913
+                      0: CSS_DASHED_IDENTIFIER@910..913
                         0: IDENT@910..913 "--b" [] []
                       1: COLON@913..915 ":" [] [Whitespace(" ")]
                       2: CSS_GENERIC_COMPONENT_VALUE_LIST@915..918
@@ -1849,7 +1849,7 @@ CssRoot {
                   0: L_PAREN@929..930 "(" [] []
                   1: CSS_DECLARATION@930..940
                     0: CSS_GENERIC_PROPERTY@930..940
-                      0: CSS_IDENTIFIER@930..933
+                      0: CSS_DASHED_IDENTIFIER@930..933
                         0: IDENT@930..933 "--c" [] []
                       1: COLON@933..935 ":" [] [Whitespace(" ")]
                       2: CSS_GENERIC_COMPONENT_VALUE_LIST@935..940
@@ -1881,7 +1881,7 @@ CssRoot {
                   0: L_PAREN@976..977 "(" [] []
                   1: CSS_DECLARATION@977..985
                     0: CSS_GENERIC_PROPERTY@977..985
-                      0: CSS_IDENTIFIER@977..980
+                      0: CSS_DASHED_IDENTIFIER@977..980
                         0: IDENT@977..980 "--b" [] []
                       1: COLON@980..982 ":" [] [Whitespace(" ")]
                       2: CSS_GENERIC_COMPONENT_VALUE_LIST@982..985
@@ -1902,7 +1902,7 @@ CssRoot {
                       0: L_PAREN@997..998 "(" [] []
                       1: CSS_DECLARATION@998..1008
                         0: CSS_GENERIC_PROPERTY@998..1008
-                          0: CSS_IDENTIFIER@998..1001
+                          0: CSS_DASHED_IDENTIFIER@998..1001
                             0: IDENT@998..1001 "--c" [] []
                           1: COLON@1001..1003 ":" [] [Whitespace(" ")]
                           2: CSS_GENERIC_COMPONENT_VALUE_LIST@1003..1008
@@ -1949,7 +1949,7 @@ CssRoot {
                   0: L_PAREN@1071..1072 "(" [] []
                   1: CSS_DECLARATION@1072..1080
                     0: CSS_GENERIC_PROPERTY@1072..1080
-                      0: CSS_IDENTIFIER@1072..1075
+                      0: CSS_DASHED_IDENTIFIER@1072..1075
                         0: IDENT@1072..1075 "--b" [] []
                       1: COLON@1075..1077 ":" [] [Whitespace(" ")]
                       2: CSS_GENERIC_COMPONENT_VALUE_LIST@1077..1080
@@ -1994,7 +1994,7 @@ CssRoot {
                     0: L_PAREN@1138..1139 "(" [] []
                     1: CSS_DECLARATION@1139..1147
                       0: CSS_GENERIC_PROPERTY@1139..1147
-                        0: CSS_IDENTIFIER@1139..1142
+                        0: CSS_DASHED_IDENTIFIER@1139..1142
                           0: IDENT@1139..1142 "--b" [] []
                         1: COLON@1142..1144 ":" [] [Whitespace(" ")]
                         2: CSS_GENERIC_COMPONENT_VALUE_LIST@1144..1147
@@ -2015,7 +2015,7 @@ CssRoot {
                         0: L_PAREN@1159..1160 "(" [] []
                         1: CSS_DECLARATION@1160..1170
                           0: CSS_GENERIC_PROPERTY@1160..1170
-                            0: CSS_IDENTIFIER@1160..1163
+                            0: CSS_DASHED_IDENTIFIER@1160..1163
                               0: IDENT@1160..1163 "--c" [] []
                             1: COLON@1163..1165 ":" [] [Whitespace(" ")]
                             2: CSS_GENERIC_COMPONENT_VALUE_LIST@1165..1170

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_supports.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_supports.css.snap
@@ -2301,7 +2301,7 @@ CssRoot {
                     l_paren_token: L_PAREN@2191..2192 "(" [] [],
                     declaration: CssDeclaration {
                         property: CssGenericProperty {
-                            name: CssIdentifier {
+                            name: CssDashedIdentifier {
                                 value_token: IDENT@2192..2197 "--foo" [] [],
                             },
                             colon_token: COLON@2197..2199 ":" [] [Whitespace(" ")],
@@ -3215,7 +3215,7 @@ CssRoot {
                     l_paren_token: L_PAREN@2939..2943 "(" [] [Whitespace("   ")],
                     declaration: CssDeclaration {
                         property: CssGenericProperty {
-                            name: CssIdentifier {
+                            name: CssDashedIdentifier {
                                 value_token: IDENT@2943..2948 "--var" [] [],
                             },
                             colon_token: COLON@2948..2952 ":" [] [Whitespace("   ")],
@@ -4830,7 +4830,7 @@ CssRoot {
           0: L_PAREN@2191..2192 "(" [] []
           1: CSS_DECLARATION@2192..2204
             0: CSS_GENERIC_PROPERTY@2192..2204
-              0: CSS_IDENTIFIER@2192..2197
+              0: CSS_DASHED_IDENTIFIER@2192..2197
                 0: IDENT@2192..2197 "--foo" [] []
               1: COLON@2197..2199 ":" [] [Whitespace(" ")]
               2: CSS_GENERIC_COMPONENT_VALUE_LIST@2199..2204
@@ -5439,7 +5439,7 @@ CssRoot {
           0: L_PAREN@2939..2943 "(" [] [Whitespace("   ")]
           1: CSS_DECLARATION@2943..2961
             0: CSS_GENERIC_PROPERTY@2943..2961
-              0: CSS_IDENTIFIER@2943..2948
+              0: CSS_DASHED_IDENTIFIER@2943..2948
                 0: IDENT@2943..2948 "--var" [] []
               1: COLON@2948..2952 ":" [] [Whitespace("   ")]
               2: CSS_GENERIC_COMPONENT_VALUE_LIST@2952..2961

--- a/crates/biome_css_parser/tests/css_test_suite/ok/declaration_list.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/declaration_list.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_css_parser/tests/spec_test.rs
 expression: snapshot
 ---
-
 ## Input
 
 ```css
@@ -575,7 +574,7 @@ CssRoot {
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
-                                name: CssIdentifier {
+                                name: CssDashedIdentifier {
                                     value_token: IDENT@337..364 "--bs-btn-focus-shadow-rgb" [Newline("\n"), Whitespace("\t")] [],
                                 },
                                 colon_token: COLON@364..366 ":" [] [Whitespace(" ")],
@@ -1000,7 +999,7 @@ CssRoot {
           0: CSS_DECLARATION_WITH_SEMICOLON@337..377
             0: CSS_DECLARATION@337..376
               0: CSS_GENERIC_PROPERTY@337..376
-                0: CSS_IDENTIFIER@337..364
+                0: CSS_DASHED_IDENTIFIER@337..364
                   0: IDENT@337..364 "--bs-btn-focus-shadow-rgb" [Newline("\n"), Whitespace("\t")] []
                 1: COLON@364..366 ":" [] [Whitespace(" ")]
                 2: CSS_GENERIC_COMPONENT_VALUE_LIST@366..376
@@ -1053,5 +1052,3 @@ CssRoot {
   2: EOF@455..456 "" [Newline("\n")] []
 
 ```
-
-

--- a/crates/biome_css_parser/tests/css_test_suite/ok/function/calc.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/function/calc.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_css_parser/tests/spec_test.rs
 expression: snapshot
 ---
-
 ## Input
 
 ```css
@@ -250,7 +249,7 @@ CssRoot {
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
-                                name: CssIdentifier {
+                                name: CssDashedIdentifier {
                                     value_token: IDENT@49..61 "--width" [Newline("\n"), Whitespace("    ")] [],
                                 },
                                 colon_token: COLON@61..63 ":" [] [Whitespace(" ")],
@@ -5062,7 +5061,7 @@ CssRoot {
           0: CSS_DECLARATION_WITH_SEMICOLON@49..80
             0: CSS_DECLARATION@49..79
               0: CSS_GENERIC_PROPERTY@49..79
-                0: CSS_IDENTIFIER@49..61
+                0: CSS_DASHED_IDENTIFIER@49..61
                   0: IDENT@49..61 "--width" [Newline("\n"), Whitespace("    ")] []
                 1: COLON@61..63 ":" [] [Whitespace(" ")]
                 2: CSS_GENERIC_COMPONENT_VALUE_LIST@63..79
@@ -8040,5 +8039,3 @@ CssRoot {
   2: EOF@3559..3559 "" [] []
 
 ```
-
-

--- a/crates/biome_css_parser/tests/css_test_suite/ok/property/property_generic.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/property/property_generic.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_css_parser/tests/spec_test.rs
 expression: snapshot
 ---
-
 ## Input
 
 ```css
@@ -207,7 +206,7 @@ CssRoot {
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
-                                name: CssIdentifier {
+                                name: CssDashedIdentifier {
                                     value_token: IDENT@298..363 "--custom-property" [Newline("\n"), Newline("\n"), Whitespace("    "), Comments("/* Custom property, a ..."), Newline("\n"), Whitespace("    ")] [],
                                 },
                                 colon_token: COLON@363..365 ":" [] [Whitespace(" ")],
@@ -227,7 +226,7 @@ CssRoot {
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
-                                name: CssIdentifier {
+                                name: CssDashedIdentifier {
                                     value_token: IDENT@373..395 "--custom-property" [Newline("\n"), Whitespace("    ")] [],
                                 },
                                 colon_token: COLON@395..397 ":" [] [Whitespace(" ")],
@@ -244,7 +243,7 @@ CssRoot {
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
-                                name: CssIdentifier {
+                                name: CssDashedIdentifier {
                                     value_token: IDENT@407..429 "--custom-property" [Newline("\n"), Whitespace("    ")] [],
                                 },
                                 colon_token: COLON@429..431 ":" [] [Whitespace(" ")],
@@ -264,7 +263,7 @@ CssRoot {
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
-                                name: CssIdentifier {
+                                name: CssDashedIdentifier {
                                     value_token: IDENT@447..469 "--custom-property" [Newline("\n"), Whitespace("    ")] [],
                                 },
                                 colon_token: COLON@469..471 ":" [] [Whitespace(" ")],
@@ -287,7 +286,7 @@ CssRoot {
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
-                                name: CssIdentifier {
+                                name: CssDashedIdentifier {
                                     value_token: IDENT@489..511 "--custom-property" [Newline("\n"), Whitespace("    ")] [],
                                 },
                                 colon_token: COLON@511..513 ":" [] [Whitespace(" ")],
@@ -316,7 +315,7 @@ CssRoot {
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
-                                name: CssIdentifier {
+                                name: CssDashedIdentifier {
                                     value_token: IDENT@540..562 "--custom-property" [Newline("\n"), Whitespace("    ")] [],
                                 },
                                 colon_token: COLON@562..564 ":" [] [Whitespace(" ")],
@@ -622,7 +621,7 @@ CssRoot {
           6: CSS_DECLARATION_WITH_SEMICOLON@298..373
             0: CSS_DECLARATION@298..372
               0: CSS_GENERIC_PROPERTY@298..372
-                0: CSS_IDENTIFIER@298..363
+                0: CSS_DASHED_IDENTIFIER@298..363
                   0: IDENT@298..363 "--custom-property" [Newline("\n"), Newline("\n"), Whitespace("    "), Comments("/* Custom property, a ..."), Newline("\n"), Whitespace("    ")] []
                 1: COLON@363..365 ":" [] [Whitespace(" ")]
                 2: CSS_GENERIC_COMPONENT_VALUE_LIST@365..372
@@ -635,7 +634,7 @@ CssRoot {
           7: CSS_DECLARATION_WITH_SEMICOLON@373..407
             0: CSS_DECLARATION@373..406
               0: CSS_GENERIC_PROPERTY@373..406
-                0: CSS_IDENTIFIER@373..395
+                0: CSS_DASHED_IDENTIFIER@373..395
                   0: IDENT@373..395 "--custom-property" [Newline("\n"), Whitespace("    ")] []
                 1: COLON@395..397 ":" [] [Whitespace(" ")]
                 2: CSS_GENERIC_COMPONENT_VALUE_LIST@397..406
@@ -646,7 +645,7 @@ CssRoot {
           8: CSS_DECLARATION_WITH_SEMICOLON@407..447
             0: CSS_DECLARATION@407..446
               0: CSS_GENERIC_PROPERTY@407..446
-                0: CSS_IDENTIFIER@407..429
+                0: CSS_DASHED_IDENTIFIER@407..429
                   0: IDENT@407..429 "--custom-property" [Newline("\n"), Whitespace("    ")] []
                 1: COLON@429..431 ":" [] [Whitespace(" ")]
                 2: CSS_GENERIC_COMPONENT_VALUE_LIST@431..446
@@ -659,7 +658,7 @@ CssRoot {
           9: CSS_DECLARATION_WITH_SEMICOLON@447..489
             0: CSS_DECLARATION@447..488
               0: CSS_GENERIC_PROPERTY@447..488
-                0: CSS_IDENTIFIER@447..469
+                0: CSS_DASHED_IDENTIFIER@447..469
                   0: IDENT@447..469 "--custom-property" [Newline("\n"), Whitespace("    ")] []
                 1: COLON@469..471 ":" [] [Whitespace(" ")]
                 2: CSS_GENERIC_COMPONENT_VALUE_LIST@471..488
@@ -674,7 +673,7 @@ CssRoot {
           10: CSS_DECLARATION_WITH_SEMICOLON@489..540
             0: CSS_DECLARATION@489..539
               0: CSS_GENERIC_PROPERTY@489..539
-                0: CSS_IDENTIFIER@489..511
+                0: CSS_DASHED_IDENTIFIER@489..511
                   0: IDENT@489..511 "--custom-property" [Newline("\n"), Whitespace("    ")] []
                 1: COLON@511..513 ":" [] [Whitespace(" ")]
                 2: CSS_GENERIC_COMPONENT_VALUE_LIST@513..539
@@ -693,7 +692,7 @@ CssRoot {
           11: CSS_DECLARATION_WITH_SEMICOLON@540..597
             0: CSS_DECLARATION@540..596
               0: CSS_GENERIC_PROPERTY@540..596
-                0: CSS_IDENTIFIER@540..562
+                0: CSS_DASHED_IDENTIFIER@540..562
                   0: IDENT@540..562 "--custom-property" [Newline("\n"), Whitespace("    ")] []
                 1: COLON@562..564 ":" [] [Whitespace(" ")]
                 2: CSS_GENERIC_COMPONENT_VALUE_LIST@564..596
@@ -814,5 +813,3 @@ CssRoot {
   2: EOF@827..827 "" [] []
 
 ```
-
-

--- a/crates/biome_css_parser/tests/css_test_suite/ok/values/url_value.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/values/url_value.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_css_parser/tests/spec_test.rs
 expression: snapshot
 ---
-
 ## Input
 
 ```css
@@ -487,7 +486,7 @@ CssRoot {
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
-                                name: CssIdentifier {
+                                name: CssDashedIdentifier {
                                     value_token: IDENT@769..777 "--foo" [Newline("\n"), Newline("\n"), Whitespace("\t")] [],
                                 },
                                 colon_token: COLON@777..779 ":" [] [Whitespace(" ")],
@@ -1035,7 +1034,7 @@ CssRoot {
           15: CSS_DECLARATION_WITH_SEMICOLON@769..816
             0: CSS_DECLARATION@769..815
               0: CSS_GENERIC_PROPERTY@769..815
-                0: CSS_IDENTIFIER@769..777
+                0: CSS_DASHED_IDENTIFIER@769..777
                   0: IDENT@769..777 "--foo" [Newline("\n"), Newline("\n"), Whitespace("\t")] []
                 1: COLON@777..779 ":" [] [Whitespace(" ")]
                 2: CSS_GENERIC_COMPONENT_VALUE_LIST@779..815
@@ -1201,5 +1200,3 @@ CssRoot {
   2: EOF@1290..1291 "" [Newline("\n")] []
 
 ```
-
-


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/3068

We have several ways to prevent case changes while formatting:

1. We use custom identifiers during parsing.
2. We pass parameters to the identifier formatter to prevent parsing.

However, using custom identifiers in places where they aren't specified as part of the specification may not be ideal. So I avoid that places and pass a parameter for a formatter.

## Test Plan

`cargo test`
