### PR TITLE
fix(ci): rule check error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ New entries must be placed in a section entitled `Unreleased`.
 Read
 our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
+## Unreleased
+
+### Analyzer
+
+### CLI
+
+### Configuration
+
+### Editors
+
+### Formatter
+
+### JavaScript APIs
+
+### Linter
+
+#### Bug fixes
+
+- The [`noUnmatchableAnbSelector`](https://biomejs.dev/linter/rules/no-unmatchable-anb-selector/) rule is now able to catch unmatchable `an+b` selectors like `0n+0` or `-0n+0`. Contributed by @Sec-ant.
+
+### Parser
+
 ## v1.8.1 (2024-06-10)
 
 ### Analyzer

--- a/crates/biome_configuration/src/linter/rules.rs
+++ b/crates/biome_configuration/src/linter/rules.rs
@@ -2905,7 +2905,7 @@ pub struct Nursery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_consistent_builtin_instantiation:
         Option<RuleFixConfiguration<UseConsistentBuiltinInstantiation>>,
-    #[doc = "Disallowing invalid named grid areas in CSS Grid Layouts."]
+    #[doc = "Disallows invalid named grid areas in CSS Grid Layouts."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_consistent_grid_areas: Option<RuleConfiguration<UseConsistentGridAreas>>,
     #[doc = "Use Date.now() to get the number of milliseconds since the Unix Epoch."]

--- a/crates/biome_css_analyze/src/lint/nursery/no_unmatchable_anb_selector.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unmatchable_anb_selector.rs
@@ -98,7 +98,8 @@ fn is_unmatchable(nth: &AnyCssPseudoClassNth) -> bool {
         AnyCssPseudoClassNth::CssPseudoClassNthIdentifier(_) => false,
         AnyCssPseudoClassNth::CssPseudoClassNth(nth) => {
             let coefficient = nth.value();
-            let constant = nth.offset();
+            let constant = nth.offset().and_then(|offset| offset.value().ok());
+
             match (coefficient, constant) {
                 (Some(a), Some(b)) => a.text() == "0" && b.text() == "0",
                 (Some(a), None) => a.text() == "0",

--- a/crates/biome_css_analyze/tests/specs/nursery/noUnmatchableAnbSelector/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noUnmatchableAnbSelector/invalid.css.snap
@@ -96,6 +96,63 @@ invalid.css:4:13 lint/nursery/noUnmatchableAnbSelector ━━━━━━━━�
 ```
 
 ```
+invalid.css:5:13 lint/nursery/noUnmatchableAnbSelector ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This selector will never match any elements.
+  
+    3 │ a:nth-child(+0n) {}
+    4 │ a:nth-child(-0n) {}
+  > 5 │ a:nth-child(0n+0) {}
+      │             ^^^^
+    6 │ a:nth-child(0n-0) {}
+    7 │ a:nth-child(-0n-0) {}
+  
+  i Avoid using An+B selectors that always evaluate to 0.
+  
+  i For more details, see the official spec for An+B selectors.
+  
+
+```
+
+```
+invalid.css:6:13 lint/nursery/noUnmatchableAnbSelector ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This selector will never match any elements.
+  
+    4 │ a:nth-child(-0n) {}
+    5 │ a:nth-child(0n+0) {}
+  > 6 │ a:nth-child(0n-0) {}
+      │             ^^^^
+    7 │ a:nth-child(-0n-0) {}
+    8 │ a:nth-child(0 of a) {}
+  
+  i Avoid using An+B selectors that always evaluate to 0.
+  
+  i For more details, see the official spec for An+B selectors.
+  
+
+```
+
+```
+invalid.css:7:13 lint/nursery/noUnmatchableAnbSelector ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This selector will never match any elements.
+  
+    5 │ a:nth-child(0n+0) {}
+    6 │ a:nth-child(0n-0) {}
+  > 7 │ a:nth-child(-0n-0) {}
+      │             ^^^^^
+    8 │ a:nth-child(0 of a) {}
+    9 │ a:nth-child(0), a:nth-child(1) {}
+  
+  i Avoid using An+B selectors that always evaluate to 0.
+  
+  i For more details, see the official spec for An+B selectors.
+  
+
+```
+
+```
 invalid.css:8:13 lint/nursery/noUnmatchableAnbSelector ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This selector will never match any elements.

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1099,7 +1099,7 @@ export interface Nursery {
 	 */
 	useConsistentBuiltinInstantiation?: RuleFixConfiguration_for_Null;
 	/**
-	 * Disallowing invalid named grid areas in CSS Grid Layouts.
+	 * Disallows invalid named grid areas in CSS Grid Layouts.
 	 */
 	useConsistentGridAreas?: RuleConfiguration_for_Null;
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1879,7 +1879,7 @@
 					]
 				},
 				"useConsistentGridAreas": {
-					"description": "Disallowing invalid named grid areas in CSS Grid Layouts.",
+					"description": "Disallows invalid named grid areas in CSS Grid Layouts.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }


### PR DESCRIPTION
## Summary

- The file name `format!("{group}/{rule}.js")` displayed in the code block diagnostics is misleading, I changed it to `rule-doc-code-block`.
- When diagnostics are unexpected or the number of them is greater than 2, only the diagnostics themselves were printed, but the error messages were not. I printed them before `ControlFlow::Break`.
- For JSON and CSS rules, we didn't check them when diagnostices were expected but none were printed. This fix helps us catch a failure codeblock in `nursery/noUnmatchableAnbSelector`.
- `Fixkind` mismatch can be catched by the compiler, so I removed the check.

## Test Plan

CI should pass when the rule `nursery/noUnmatchableAnbSelector` is fixed.