### PR TITLE
chore(ci): improve rules_check task

### DIFF
--- a/crates/biome_json_parser/src/parser.rs
+++ b/crates/biome_json_parser/src/parser.rs
@@ -1,5 +1,5 @@
 use crate::token_source::JsonTokenSource;
-use biome_json_syntax::JsonSyntaxKind;
+use biome_json_syntax::{JsonFileSource, JsonSyntaxKind};
 use biome_parser::diagnostic::merge_diagnostics;
 use biome_parser::event::Event;
 use biome_parser::prelude::*;
@@ -27,6 +27,19 @@ impl JsonParserOptions {
     pub fn with_allow_trailing_commas(mut self) -> Self {
         self.allow_trailing_commas = true;
         self
+    }
+}
+
+impl From<&JsonFileSource> for JsonParserOptions {
+    fn from(file_source: &JsonFileSource) -> Self {
+        let options = Self::default();
+        if file_source.allow_comments() {
+            options.with_allow_comments();
+        }
+        if file_source.allow_trailing_commas() {
+            options.with_allow_trailing_commas();
+        }
+        options
     }
 }
 

--- a/xtask/rules_check/src/lib.rs
+++ b/xtask/rules_check/src/lib.rs
@@ -137,15 +137,11 @@ impl FromStr for CodeBlockTest {
 
         for token in tokens {
             match token {
-                // language tags
-                "cjs" | "js" | "mjs" | "jsx" | "ts" | "mts" | "cts" | "tsx" | "svelte"
-                | "astro" | "vue" | "json" | "jsonc" | "css" => test.tag = token.to_string(),
                 // Other attributes
                 "expect_diagnostic" => test.expect_diagnostic = true,
                 "ignore" => test.ignore = true,
-                // A catch-all to regard unknown tokens as foreign languages,
-                // and do not run tests on these code blocks.
-                _ => test.ignore = true,
+                // Regard as language tags, last one wins
+                _ => test.tag = token.to_string(),
             }
         }
 
@@ -370,7 +366,7 @@ fn assert_lint(
                 });
             }
         }
-        // Unknown code blocks should be already ignored by tests
+        // Unknown code blocks should be ignored by tests
         DocumentFileSource::Unknown => {}
     }
 

--- a/xtask/rules_check/src/lib.rs
+++ b/xtask/rules_check/src/lib.rs
@@ -107,14 +107,14 @@ pub fn check_rules() -> anyhow::Result<()> {
     Ok(())
 }
 struct CodeBlockTest {
-    lang: String,
+    tag: String,
     expect_diagnostic: bool,
     ignore: bool,
 }
 
 impl CodeBlockTest {
     fn document_file_source(&self) -> DocumentFileSource {
-        DocumentFileSource::from_extension(&self.lang)
+        DocumentFileSource::from_extension(&self.tag)
     }
 }
 
@@ -130,16 +130,16 @@ impl FromStr for CodeBlockTest {
             .filter(|token| !token.is_empty());
 
         let mut test = CodeBlockTest {
-            lang: "".to_string(),
+            tag: "".to_string(),
             expect_diagnostic: false,
             ignore: false,
         };
 
         for token in tokens {
             match token {
-                // languages
+                // language tags
                 "cjs" | "js" | "mjs" | "jsx" | "ts" | "mts" | "cts" | "tsx" | "svelte"
-                | "astro" | "vue" | "json" | "jsonc" | "css" => test.lang = token.to_string(),
+                | "astro" | "vue" | "json" | "jsonc" | "css" => test.tag = token.to_string(),
                 // Other attributes
                 "expect_diagnostic" => test.expect_diagnostic = true,
                 "ignore" => test.ignore = true,
@@ -162,7 +162,7 @@ fn assert_lint(
     test: &CodeBlockTest,
     code: &str,
 ) -> anyhow::Result<()> {
-    let file_path = format!("code-block.{}", test.lang);
+    let file_path = format!("code-block.{}", test.tag);
 
     let mut diagnostic_count = 0;
     let mut all_diagnostics = vec![];

--- a/xtask/rules_check/src/lib.rs
+++ b/xtask/rules_check/src/lib.rs
@@ -130,7 +130,7 @@ impl FromStr for CodeBlockTest {
             .filter(|token| !token.is_empty());
 
         let mut test = CodeBlockTest {
-            tag: "".to_string(),
+            tag: String::new(),
             expect_diagnostic: false,
             ignore: false,
         };


### PR DESCRIPTION
## Summary

- Discard `BlockType` and use `DocumentFileSource` as the single source of truth.
- Retain the code block tag from the input instead of regenerating it.
- Use `code-block.{js,css,json...}` as the file path displayed in code block diagnostics.

I will apply the same modifications to the codegen task in the website repo after this is merged.

## Test Plan

CI should pass.