### PR TITLE
chore(ci): try enable `--compact` flag for `pkg.pr.new`

### DIFF
--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Publish
         working-directory: packages/@biomejs/wasm-web
-        run: pnpx pkg-pr-new publish
+        run: pnpx pkg-pr-new publish --compact
 
   repository-dispatch:
     name: Repository dispatch


### PR DESCRIPTION
## Summary

We fixed the manifest files in #3155, let's try enabling `--compact` again.

## Test Plan

Merge to main.
