### PR TITLE
chore(ci): remove `--compact` flag

### DIFF
--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Publish
         working-directory: packages/@biomejs/wasm-web
-        run: pnpx pkg-pr-new publish --compact
+        run: pnpx pkg-pr-new publish
 
   repository-dispatch:
     name: Repository dispatch


### PR DESCRIPTION
## Summary

It doesn't work for 2 reasons:

1. We haven't published the fix.
2. The `sideEffect` field fails the zod validation.

I'll report the issue to upstream.

## Test Plan


