### PR TITLE
fix(config): don't conceal a previous override with the base settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,46 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Configuration
 
+#### Bug fixes
+
+- Don't conceal previous overrides ([#3176](https://github.com/biomejs/biome/issues/3176)).
+
+  Previously, each override inherited the unset configuration of the base configuration.
+  This means that setting a configuration in an override can be concealed by a subsequent override that inherits of the value from the base configuration.
+
+  For example, in the next example, `noDebugger` was disabled for the `index.js` file.
+
+  ```json
+  {
+    "linter": {
+      "rules": {
+        "suspicious": { "noDebugger": "off" }
+      }
+    },
+    "overrides": [
+      {
+        "include": ["index.js"],
+        "linter": {
+          "rules": {
+            "suspicious": { "noDebugger": "warn" }
+          }
+        }
+      }, {
+        "include": ["index.js"],
+        "linter": {
+          "rules": {
+            "suspicious": { "noDoubleEquals": "off" }
+          }
+        }
+      }
+    ]
+  }
+  ```
+
+  The rule is now correctly enabled for the `index.js` file.
+
+  Contributed by @Conaclos
+
 ### Editors
 
 ### Formatter

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/does_not_conceal_previous_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/does_not_conceal_previous_overrides.snap
@@ -70,6 +70,6 @@ test2.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
+Checked 2 files in <TIME>. No fixes applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/does_not_conceal_previous_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/does_not_conceal_previous_overrides.snap
@@ -1,0 +1,75 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "javascript": { "formatter": { "quoteStyle": "single" } },
+  "overrides": [
+    {
+      "include": ["*.js"],
+      "javascript": { "formatter": { "quoteStyle": "double" } }
+    },
+    {
+      "include": ["test.js"],
+      "javascript": { "formatter": { "indentWidth": 4 } }
+    }
+  ]
+}
+```
+
+## `test.js`
+
+```js
+const a = ["loreum", "ipsum"]
+```
+
+## `test2.js`
+
+```js
+const a = ["loreum", "ipsum"]
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+test.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - const·a·=·["loreum",·"ipsum"]
+      1 │ + const·a·=·["loreum",·"ipsum"];
+      2 │ + 
+  
+
+```
+
+```block
+test2.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - const·a·=·["loreum",·"ipsum"]
+      1 │ + const·a·=·["loreum",·"ipsum"];
+      2 │ + 
+  
+
+```
+
+```block
+Checked 2 files in <TIME>. No fixes needed.
+Found 2 errors.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/takes_last_formatter_enabled_into_account.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/takes_last_formatter_enabled_into_account.snap
@@ -51,6 +51,6 @@ test.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/takes_last_formatter_enabled_into_account.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/takes_last_formatter_enabled_into_account.snap
@@ -1,0 +1,56 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "overrides": [
+    {
+      "include": ["*.js"],
+      "formatter": { "enabled": false }
+    },
+    {
+      "include": ["*.js"],
+      "formatter": { "enabled": true }
+    }
+  ]
+}
+```
+
+## `test.js`
+
+```js
+const a = ["loreum", "ipsum"]
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+test.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - const·a·=·["loreum",·"ipsum"]
+      1 │ + const·a·=·["loreum",·"ipsum"];
+      2 │ + 
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes needed.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_merge_all_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_merge_all_overrides.snap
@@ -33,6 +33,9 @@ expression: content
           }
         }
       }
+    },
+    {
+      "include": ["test3.js"]
     }
   ]
 }
@@ -47,19 +50,48 @@ debugger
 ## `test2.js`
 
 ```js
+debugger
+```
 
+## `test3.js`
+
+```js
+debugger
 ```
 
 # Emitted Messages
 
 ```block
-internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+test2.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The argument --apply-unsafe is deprecated, it will be removed in the next major release. Use --write --unsafe instead.
+  ! This is an unexpected use of the debugger statement.
   
+  > 1 │ debugger
+      │ ^^^^^^^^
+  
+  i Unsafe fix: Remove debugger statement
+  
+    1 │ debugger
+      │ --------
 
 ```
 
 ```block
-Checked 3 files in <TIME>. Fixed 1 file.
+test3.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This is an unexpected use of the debugger statement.
+  
+  > 1 │ debugger
+      │ ^^^^^^^^
+  
+  i Unsafe fix: Remove debugger statement
+  
+    1 │ debugger
+      │ --------
+
+```
+
+```block
+Checked 4 files in <TIME>. No fixes needed.
+Found 2 warnings.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_merge_all_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_merge_all_overrides.snap
@@ -92,6 +92,6 @@ test3.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━
 ```
 
 ```block
-Checked 4 files in <TIME>. No fixes needed.
+Checked 4 files in <TIME>. No fixes applied.
 Found 2 warnings.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_not_conceal_overrides_globals.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_not_conceal_overrides_globals.snap
@@ -34,5 +34,5 @@ export { GLOBAL_VAR };
 # Emitted Messages
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
+Checked 2 files in <TIME>. No fixes applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_not_conceal_overrides_globals.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_not_conceal_overrides_globals.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "correctness": {
+        "noUndeclaredVariables": "error"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "include": ["*.js"],
+      "javascript": { "globals": ["GLOBAL_VAR"] }
+    },
+    {
+      "include": ["*.js"]
+    }
+  ]
+}
+```
+
+## `test.js`
+
+```js
+export { GLOBAL_VAR };
+```
+
+# Emitted Messages
+
+```block
+Checked 2 files in <TIME>. No fixes needed.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/takes_last_linter_enabled_into_account.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/takes_last_linter_enabled_into_account.snap
@@ -1,0 +1,79 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "correctness": {
+        "noUndeclaredVariables": "error"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "include": ["*.js"],
+      "linter": { "enabled": false }
+    },
+    {
+      "include": ["*.js"],
+      "linter": { "enabled": true }
+    }
+  ]
+}
+```
+
+## `test.js`
+
+```js
+export { GLOBAL_VAR };
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+test.js:1:10 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The GLOBAL_VAR variable is undeclared.
+  
+  > 1 │ export { GLOBAL_VAR };
+      │          ^^^^^^^^^^
+  
+  i By default, Biome recognizes browser and Node.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
+
+```
+
+```block
+test.js:1:10 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The GLOBAL_VAR variable is undeclared.
+  
+  > 1 │ export { GLOBAL_VAR };
+      │          ^^^^^^^^^^
+  
+  i By default, Biome recognizes browser and Node.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
+
+```
+
+```block
+Checked 2 files in <TIME>. No fixes needed.
+Found 2 errors.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/takes_last_linter_enabled_into_account.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/takes_last_linter_enabled_into_account.snap
@@ -74,6 +74,6 @@ test.js:1:10 lint/correctness/noUndeclaredVariables ━━━━━━━━━�
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
+Checked 2 files in <TIME>. No fixes applied.
 Found 2 errors.
 ```

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -421,10 +421,10 @@ pub(crate) fn lint(params: LintParams) -> LintResults {
             let mut rules = None;
             let mut organize_imports_enabled = true;
             if let Some(settings) = params.workspace.settings() {
+                // Compute final rules (taking `overrides` into account)
                 rules = settings.as_rules(params.path.as_path());
                 organize_imports_enabled = settings.organize_imports.enabled;
             }
-            // Compute final rules (taking `overrides` into account)
 
             let has_only_filter = !params.only.is_empty();
             let enabled_rules = if has_only_filter {

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -300,10 +300,9 @@ impl Settings {
         let mut result = self.linter.rules.as_ref().map(Cow::Borrowed);
         let overrides = &self.override_settings;
         for pattern in overrides.patterns.iter() {
-            let excluded = pattern.exclude.matches_path(path);
-            if !excluded && !pattern.include.is_empty() && pattern.include.matches_path(path) {
-                let pattern_rules = pattern.linter.rules.as_ref();
-                if let Some(pattern_rules) = pattern_rules {
+            let pattern_rules = pattern.linter.rules.as_ref();
+            if let Some(pattern_rules) = pattern_rules {
+                if pattern.include.matches_path(path) && !pattern.exclude.matches_path(path) {
                     result = if let Some(mut result) = result.take() {
                         // Override rules
                         result.to_mut().merge_with(pattern_rules.clone());
@@ -753,22 +752,14 @@ impl OverrideSettings {
     pub fn override_js_format_options(
         &self,
         path: &Path,
-        options: JsFormatOptions,
+        mut options: JsFormatOptions,
     ) -> JsFormatOptions {
-        self.patterns.iter().fold(options, |mut options, pattern| {
-            let included = pattern.include.matches_path(path);
-            let excluded = pattern.exclude.matches_path(path);
-
-            if excluded {
-                return options;
-            }
-
-            if included {
+        for pattern in self.patterns.iter() {
+            if pattern.include.matches_path(path) && !pattern.exclude.matches_path(path) {
                 pattern.apply_overrides_to_js_format_options(&mut options);
             }
-
-            options
-        })
+        }
+        options
     }
 
     pub fn override_js_globals(
@@ -778,195 +769,158 @@ impl OverrideSettings {
     ) -> IndexSet<String> {
         self.patterns
             .iter()
-            .fold(base_set.as_ref(), |globals, pattern| {
-                let included = pattern.include.matches_path(path);
-                let excluded = pattern.exclude.matches_path(path);
-
-                if included && !excluded {
-                    pattern.languages.javascript.globals.as_ref()
+            // Reverse the traversal as only the last override takes effect
+            .rev()
+            .find_map(|pattern| {
+                if pattern.languages.javascript.globals.is_some()
+                    && pattern.include.matches_path(path)
+                    && !pattern.exclude.matches_path(path)
+                {
+                    pattern.languages.javascript.globals.clone()
                 } else {
-                    globals
+                    None
                 }
             })
-            .cloned()
+            .or_else(|| base_set.clone())
             .unwrap_or_default()
     }
 
     pub fn override_jsx_runtime(&self, path: &BiomePath, base_setting: JsxRuntime) -> JsxRuntime {
         self.patterns
             .iter()
-            .fold(base_setting, |jsx_runtime, pattern| {
-                let included = pattern.include.matches_path(path);
-                let excluded = pattern.exclude.matches_path(path);
-
-                if included && !excluded {
-                    pattern.languages.javascript.environment.jsx_runtime
+            // Reverse the traversal as only the last override takes effect
+            .rev()
+            .find_map(|pattern| {
+                if pattern.include.matches_path(path) && !pattern.exclude.matches_path(path) {
+                    Some(pattern.languages.javascript.environment.jsx_runtime)
                 } else {
-                    jsx_runtime
+                    None
                 }
             })
+            .unwrap_or(base_setting)
     }
 
     /// It scans the current override rules and return the json format that of the first override is matched
     pub fn to_override_json_format_options(
         &self,
         path: &Path,
-        options: JsonFormatOptions,
+        mut options: JsonFormatOptions,
     ) -> JsonFormatOptions {
-        self.patterns.iter().fold(options, |mut options, pattern| {
-            let included = !pattern.include.is_empty() && pattern.include.matches_path(path);
-            let excluded = !pattern.exclude.is_empty() && pattern.exclude.matches_path(path);
-            if excluded {
-                return options;
-            }
-            if included {
+        for pattern in self.patterns.iter() {
+            if pattern.include.matches_path(path) && !pattern.exclude.matches_path(path) {
                 pattern.apply_overrides_to_json_format_options(&mut options);
             }
-
-            options
-        })
+        }
+        options
     }
 
     /// It scans the current override rules and return the formatting options that of the first override is matched
     pub fn to_override_css_format_options(
         &self,
         path: &Path,
-        options: CssFormatOptions,
+        mut options: CssFormatOptions,
     ) -> CssFormatOptions {
-        self.patterns.iter().fold(options, |mut options, pattern| {
-            let included = !pattern.include.is_empty() && pattern.include.matches_path(path);
-            let excluded = !pattern.exclude.is_empty() && pattern.exclude.matches_path(path);
-            if excluded {
-                return options;
-            }
-            if included {
+        for pattern in self.patterns.iter() {
+            if pattern.include.matches_path(path) && !pattern.exclude.matches_path(path) {
                 pattern.apply_overrides_to_css_format_options(&mut options);
             }
-
-            options
-        })
+        }
+        options
     }
 
     pub fn to_override_js_parser_options(
         &self,
         path: &Path,
-        options: JsParserOptions,
+        mut options: JsParserOptions,
     ) -> JsParserOptions {
-        self.patterns.iter().fold(options, |mut options, pattern| {
-            let included = !pattern.include.is_empty() && pattern.include.matches_path(path);
-            let excluded = !pattern.exclude.is_empty() && pattern.exclude.matches_path(path);
-            if excluded {
-                return options;
+        for pattern in self.patterns.iter() {
+            if pattern.include.matches_path(path) && !pattern.exclude.matches_path(path) {
+                pattern.apply_overrides_to_js_parser_options(&mut options);
             }
-            if included {
-                pattern.apply_overrides_to_js_parser_options(&mut options)
-            }
-            options
-        })
+        }
+        options
     }
 
     pub fn to_override_json_parser_options(
         &self,
         path: &Path,
-        options: JsonParserOptions,
+        mut options: JsonParserOptions,
     ) -> JsonParserOptions {
-        self.patterns.iter().fold(options, |mut options, pattern| {
-            let included = !pattern.include.is_empty() && pattern.include.matches_path(path);
-            let excluded = !pattern.exclude.is_empty() && pattern.exclude.matches_path(path);
-            if excluded {
-                return options;
-            }
-            if included {
+        for pattern in self.patterns.iter() {
+            if pattern.include.matches_path(path) && !pattern.exclude.matches_path(path) {
                 pattern.apply_overrides_to_json_parser_options(&mut options);
             }
-            options
-        })
+        }
+        options
     }
 
     /// It scans the current override rules and return the parser options that of the first override is matched
     pub fn to_override_css_parser_options(
         &self,
         path: &Path,
-        options: CssParserOptions,
+        mut options: CssParserOptions,
     ) -> CssParserOptions {
-        self.patterns.iter().fold(options, |mut options, pattern| {
-            let included = !pattern.include.is_empty() && pattern.include.matches_path(path);
-            let excluded = !pattern.exclude.is_empty() && pattern.exclude.matches_path(path);
-
-            if included || !excluded {
-                pattern.apply_overrides_to_css_parser_options(&mut options)
+        for pattern in self.patterns.iter() {
+            if pattern.include.matches_path(path) && !pattern.exclude.matches_path(path) {
+                pattern.apply_overrides_to_css_parser_options(&mut options);
             }
-
-            options
-        })
+        }
+        options
     }
 
     /// Retrieves the options of lint rules that have been overridden
     pub fn override_analyzer_rules(
         &self,
         path: &Path,
-        analyzer_rules: AnalyzerRules,
+        mut analyzer_rules: AnalyzerRules,
     ) -> AnalyzerRules {
-        self.patterns
-            .iter()
-            .fold(analyzer_rules, |mut analyzer_rules, pattern| {
-                let excluded = !pattern.exclude.is_empty() && pattern.exclude.matches_path(path);
-                if !excluded && !pattern.include.is_empty() && pattern.include.matches_path(path) {
-                    if let Some(rules) = pattern.linter.rules.as_ref() {
-                        push_to_analyzer_rules(rules, metadata(), &mut analyzer_rules);
-                    }
+        for pattern in self.patterns.iter() {
+            if !pattern.exclude.matches_path(path) && pattern.include.matches_path(path) {
+                if let Some(rules) = pattern.linter.rules.as_ref() {
+                    push_to_analyzer_rules(rules, metadata(), &mut analyzer_rules);
                 }
-
-                analyzer_rules
-            })
+            }
+        }
+        analyzer_rules
     }
 
     /// Scans the overrides and checks if there's an override that disable the formatter for `path`
     pub fn formatter_disabled(&self, path: &Path) -> Option<bool> {
-        for pattern in &self.patterns {
-            if pattern.exclude.matches_path(path) {
-                continue;
-            }
-            if !pattern.include.is_empty() && pattern.include.matches_path(path) {
-                if let Some(enabled) = pattern.formatter.enabled {
+        // Reverse the traversal as only the last override takes effect
+        self.patterns.iter().rev().find_map(|pattern| {
+            if let Some(enabled) = pattern.formatter.enabled {
+                if pattern.include.matches_path(path) && !pattern.exclude.matches_path(path) {
                     return Some(!enabled);
                 }
-                continue;
             }
-        }
-        None
+            None
+        })
     }
 
     /// Scans the overrides and checks if there's an override that disable the linter for `path`
     pub fn linter_disabled(&self, path: &Path) -> Option<bool> {
-        for pattern in &self.patterns {
-            if pattern.exclude.matches_path(path) {
-                continue;
-            }
-            if !pattern.include.is_empty() && pattern.include.matches_path(path) {
-                if let Some(enabled) = pattern.linter.enabled {
+        // Reverse the traversal as only the last override takes effect
+        self.patterns.iter().rev().find_map(|pattern| {
+            if let Some(enabled) = pattern.linter.enabled {
+                if pattern.include.matches_path(path) && !pattern.exclude.matches_path(path) {
                     return Some(!enabled);
                 }
-                continue;
             }
-        }
-        None
+            None
+        })
     }
 
     /// Scans the overrides and checks if there's an override that disable the organize imports for `path`
     pub fn organize_imports_disabled(&self, path: &Path) -> Option<bool> {
-        for pattern in &self.patterns {
-            if pattern.exclude.matches_path(path) {
-                continue;
-            }
-            if !pattern.include.is_empty() && pattern.include.matches_path(path) {
-                if let Some(enabled) = pattern.organize_imports.enabled {
+        // Reverse the traversal as only the last override takes effect
+        self.patterns.iter().rev().find_map(|pattern| {
+            if let Some(enabled) = pattern.organize_imports.enabled {
+                if pattern.include.matches_path(path) && !pattern.exclude.matches_path(path) {
                     return Some(!enabled);
                 }
-                continue;
             }
-        }
-        None
+            None
+        })
     }
 }
 
@@ -1257,17 +1211,33 @@ pub fn to_override_settings(
 ) -> Result<OverrideSettings, WorkspaceError> {
     let mut override_settings = OverrideSettings::default();
     for mut pattern in overrides.0 {
-        let formatter = pattern.formatter.take().unwrap_or_default();
-        let formatter = to_override_format_settings(formatter, &current_settings.formatter);
-
-        let linter = pattern.linter.take().unwrap_or_default();
-        let linter = to_override_linter_settings(linter, &current_settings.linter);
-
-        let organize_imports = pattern.organize_imports.take().unwrap_or_default();
-        let organize_imports = to_override_organize_imports_settings(
-            organize_imports,
-            &current_settings.organize_imports,
-        );
+        let formatter = pattern
+            .formatter
+            .map(|formatter| OverrideFormatSettings {
+                enabled: formatter.enabled,
+                format_with_errors: formatter
+                    .format_with_errors
+                    .unwrap_or(current_settings.formatter.format_with_errors),
+                indent_style: formatter
+                    .indent_style
+                    .map(|indent_style| indent_style.into()),
+                indent_width: formatter.indent_width,
+                line_ending: formatter.line_ending,
+                line_width: formatter.line_width,
+            })
+            .unwrap_or_default();
+        let linter = pattern
+            .linter
+            .map(|linter| OverrideLinterSettings {
+                enabled: linter.enabled,
+                rules: linter.rules,
+            })
+            .unwrap_or_default();
+        let organize_imports = OverrideOrganizeImportsSettings {
+            enabled: pattern
+                .organize_imports
+                .and_then(|organize_imports| organize_imports.enabled),
+        };
 
         let mut languages = LanguageListSettings::default();
         let javascript = pattern.javascript.take().unwrap_or_default();
@@ -1295,94 +1265,29 @@ pub fn to_override_settings(
     Ok(override_settings)
 }
 
-pub(crate) fn to_override_format_settings(
-    conf: OverrideFormatterConfiguration,
-    format_settings: &FormatSettings,
-) -> OverrideFormatSettings {
-    let indent_style = conf
-        .indent_style
-        .map(Into::into)
-        .or(format_settings.indent_style);
-    let indent_width = conf
-        .indent_width
-        .map(Into::into)
-        .or(conf.indent_size.map(Into::into))
-        .or(format_settings.indent_width);
-
-    let line_ending = conf.line_ending.or(format_settings.line_ending);
-    let line_width = conf.line_width.or(format_settings.line_width);
-    let format_with_errors = conf
-        .format_with_errors
-        .unwrap_or(format_settings.format_with_errors);
-
-    OverrideFormatSettings {
-        enabled: conf.enabled.or(
-            if format_settings.enabled != FormatSettings::default().enabled {
-                Some(format_settings.enabled)
-            } else {
-                None
-            },
-        ),
-        indent_style,
-        indent_width,
-        line_ending,
-        line_width,
-        format_with_errors,
-    }
-}
-
-fn to_override_linter_settings(
-    conf: OverrideLinterConfiguration,
-    lint_settings: &LinterSettings,
-) -> OverrideLinterSettings {
-    OverrideLinterSettings {
-        enabled: conf.enabled.or(Some(lint_settings.enabled)),
-        rules: conf.rules.or(lint_settings.rules.clone()),
-    }
-}
-
 fn to_javascript_language_settings(
     mut conf: PartialJavascriptConfiguration,
     parent_settings: &LanguageSettings<JsLanguage>,
 ) -> LanguageSettings<JsLanguage> {
     let mut language_setting: LanguageSettings<JsLanguage> = LanguageSettings::default();
     let formatter = conf.formatter.take().unwrap_or_default();
-    let parent_formatter = &parent_settings.formatter;
-    language_setting.formatter.quote_style = formatter.quote_style.or(parent_formatter.quote_style);
-    language_setting.formatter.jsx_quote_style = formatter
-        .jsx_quote_style
-        .or(parent_formatter.jsx_quote_style);
-    language_setting.formatter.quote_properties = formatter
-        .quote_properties
-        .or(parent_formatter.quote_properties);
-    language_setting.formatter.trailing_commas = formatter
-        .trailing_commas
-        .or(formatter.trailing_comma)
-        .or(parent_formatter.trailing_commas);
-    language_setting.formatter.semicolons = formatter.semicolons.or(parent_formatter.semicolons);
-    language_setting.formatter.arrow_parentheses = formatter
-        .arrow_parentheses
-        .or(parent_formatter.arrow_parentheses);
-    language_setting.formatter.bracket_spacing = formatter
-        .bracket_spacing
-        .map(Into::into)
-        .or(parent_formatter.bracket_spacing);
-    language_setting.formatter.bracket_same_line = formatter
-        .bracket_same_line
-        .map(Into::into)
-        .or(parent_formatter.bracket_same_line);
-    language_setting.formatter.enabled = formatter.enabled.or(parent_formatter.enabled);
-    language_setting.formatter.line_width = formatter.line_width.or(parent_formatter.line_width);
-    language_setting.formatter.line_ending = formatter.line_ending.or(parent_formatter.line_ending);
+    language_setting.formatter.quote_style = formatter.quote_style;
+    language_setting.formatter.jsx_quote_style = formatter.jsx_quote_style;
+    language_setting.formatter.quote_properties = formatter.quote_properties;
+    language_setting.formatter.trailing_commas =
+        formatter.trailing_commas.or(formatter.trailing_comma);
+    language_setting.formatter.semicolons = formatter.semicolons;
+    language_setting.formatter.arrow_parentheses = formatter.arrow_parentheses;
+    language_setting.formatter.bracket_spacing = formatter.bracket_spacing.map(Into::into);
+    language_setting.formatter.bracket_same_line = formatter.bracket_same_line.map(Into::into);
+    language_setting.formatter.enabled = formatter.enabled;
+    language_setting.formatter.line_width = formatter.line_width;
+    language_setting.formatter.line_ending = formatter.line_ending;
     language_setting.formatter.indent_width = formatter
         .indent_width
         .map(Into::into)
-        .or(formatter.indent_size.map(Into::into))
-        .or(parent_formatter.indent_width);
-    language_setting.formatter.indent_style = formatter
-        .indent_style
-        .map(Into::into)
-        .or(parent_formatter.indent_style);
+        .or(formatter.indent_size.map(Into::into));
+    language_setting.formatter.indent_style = formatter.indent_style.map(Into::into);
 
     let parser = conf.parser.take().unwrap_or_default();
     let parent_parser = &parent_settings.parser;
@@ -1393,10 +1298,7 @@ fn to_javascript_language_settings(
     let organize_imports = conf.organize_imports;
     if let Some(_organize_imports) = organize_imports {}
 
-    language_setting.globals = conf
-        .globals
-        .map(StringSet::into_index_set)
-        .or_else(|| parent_settings.globals.clone());
+    language_setting.globals = conf.globals.map(StringSet::into_index_set);
 
     language_setting.environment.jsx_runtime = conf
         .jsx_runtime
@@ -1411,23 +1313,16 @@ fn to_json_language_settings(
 ) -> LanguageSettings<JsonLanguage> {
     let mut language_setting: LanguageSettings<JsonLanguage> = LanguageSettings::default();
     let formatter = conf.formatter.take().unwrap_or_default();
-    let parent_formatter = &parent_settings.formatter;
 
-    language_setting.formatter.enabled = formatter.enabled.or(parent_formatter.enabled);
-    language_setting.formatter.line_width = formatter.line_width.or(parent_formatter.line_width);
-    language_setting.formatter.line_ending = formatter.line_ending.or(parent_formatter.line_ending);
+    language_setting.formatter.enabled = formatter.enabled;
+    language_setting.formatter.line_width = formatter.line_width;
+    language_setting.formatter.line_ending = formatter.line_ending;
     language_setting.formatter.indent_width = formatter
         .indent_width
         .map(Into::into)
-        .or(formatter.indent_size.map(Into::into))
-        .or(parent_formatter.indent_width);
-    language_setting.formatter.indent_style = formatter
-        .indent_style
-        .map(Into::into)
-        .or(parent_formatter.indent_style);
-    language_setting.formatter.trailing_commas = formatter
-        .trailing_commas
-        .or(parent_formatter.trailing_commas);
+        .or(formatter.indent_size.map(Into::into));
+    language_setting.formatter.indent_style = formatter.indent_style.map(Into::into);
+    language_setting.formatter.trailing_commas = formatter.trailing_commas;
 
     let parser = conf.parser.take().unwrap_or_default();
     let parent_parser = &parent_settings.parser;
@@ -1448,20 +1343,13 @@ fn to_css_language_settings(
 ) -> LanguageSettings<CssLanguage> {
     let mut language_setting: LanguageSettings<CssLanguage> = LanguageSettings::default();
     let formatter = conf.formatter.take().unwrap_or_default();
-    let parent_formatter = &parent_settings.formatter;
 
-    language_setting.formatter.enabled = formatter.enabled.or(parent_formatter.enabled);
-    language_setting.formatter.line_width = formatter.line_width.or(parent_formatter.line_width);
-    language_setting.formatter.line_ending = formatter.line_ending.or(parent_formatter.line_ending);
-    language_setting.formatter.indent_width = formatter
-        .indent_width
-        .map(Into::into)
-        .or(parent_formatter.indent_width);
-    language_setting.formatter.indent_style = formatter
-        .indent_style
-        .map(Into::into)
-        .or(parent_formatter.indent_style);
-    language_setting.formatter.quote_style = formatter.quote_style.or(parent_formatter.quote_style);
+    language_setting.formatter.enabled = formatter.enabled;
+    language_setting.formatter.line_width = formatter.line_width;
+    language_setting.formatter.line_ending = formatter.line_ending;
+    language_setting.formatter.indent_width = formatter.indent_width.map(Into::into);
+    language_setting.formatter.indent_style = formatter.indent_style.map(Into::into);
+    language_setting.formatter.quote_style = formatter.quote_style;
 
     let parser = conf.parser.take().unwrap_or_default();
     let parent_parser = &parent_settings.parser;
@@ -1471,15 +1359,6 @@ fn to_css_language_settings(
     language_setting.parser.css_modules = parser.css_modules.unwrap_or(parent_parser.css_modules);
 
     language_setting
-}
-
-fn to_override_organize_imports_settings(
-    conf: OverrideOrganizeImportsConfiguration,
-    settings: &OrganizeImportsSettings,
-) -> OverrideOrganizeImportsSettings {
-    OverrideOrganizeImportsSettings {
-        enabled: conf.enabled.or(Some(settings.enabled)),
-    }
 }
 
 pub fn to_format_settings(


### PR DESCRIPTION
## Summary

Fix #3176

When we convert the Biome Configuration to Workspace settings, we use the base settings to set the missing settings in every override. This results in overrides that conceal previous overrides.

For example, the following config:

```json
  {
    "linter": {
      "rules": {
        "suspicious": { "noDebugger": "off" }
      }
    },
    "overrides": [
      {
        "include": ["index.js"],
        "linter": {
          "rules": {
            "suspicious": { "noDebugger": "warn" }
          }
        }
      }, {
        "include": ["index.js"]
      }
    ]
  }
```

was resolved to:

```json
  {
    "linter": {
      "rules": {
        "suspicious": { "noDebugger": "off" }
      }
    },
    "overrides": [
      {
        "include": ["index.js"],
        "linter": {
          "rules": {
            "suspicious": { "noDebugger": "warn" }
          }
        }
      }, {
        "include": ["index.js"],
        "linter": {
          "rules": {
            "suspicious": { "noDebugger": "off" }
          }
        }
      }
    ]
  }
```

The current PR fixes the issue by removing the propagation of the base configuration to every override.

I also fixed several erroneous implementations.
For example, we took the first `override.{linter.formatter.organizeImports}.enabled` into account, while we have to take the last one.

I think there are still some issues. Some fields such as `jsx_runtime` are not behind an `Option` in `overrides`.
This means that every `overrides` has a default value for this field.
This is a change for a future PR.

## Test Plan

I added new tests to avoid any regressions.
