### PR TITLE
fix: remove unnecessary example

### DIFF
--- a/crates/biome_js_analyze/src/lint/a11y/use_key_with_click_events.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_key_with_click_events.rs
@@ -17,10 +17,6 @@ declare_rule! {
     /// <div onClick={() => {}} />
     /// ```
     ///
-    /// ```jsx,expect_diagnostic
-    /// <div onClick={() => {}} ></div>
-    /// ```
-    ///
     /// ### Valid
     ///
     /// ```jsx


### PR DESCRIPTION
The two examples given only differed on how the div element was closed (self-closing vs non-self-closing), which is not relevant to the rule at hand. To avoid confusing the reader, let's keep only one of the examples.

The non-self-closing case is tested explicitly in the dedicated test cases for useKeyWithClickEvents, so we don't loose any test coverage with this change.

Moved here from https://github.com/biomejs/website/pull/591
