### PR TITLE
fix(cli): improve reporter message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### CLI
 
+#### Enhancement
+
+- Reword the reporter message `No fixes needed` to `No fixes were applied`.
+
+  The former message is misleading when there're still errors or warnings in the files that should be taken care of manually. For example:
+
+  ```block
+  Checked 2 files in <TIME>. No fixes needed.
+  Found 2 errors.
+  ```
+
+  The new message suits better in these cases.
+
+  Contributed by @Sec-ant
+
 ### Configuration
 
 ### Editors

--- a/crates/biome_cli/src/reporter/terminal.rs
+++ b/crates/biome_cli/src/reporter/terminal.rs
@@ -93,7 +93,7 @@ impl fmt::Display for SummaryDetail {
             })
         } else {
             fmt.write_markup(markup! {
-                " No fixes needed."
+                " No fixes were applied."
             })
         }
     }

--- a/crates/biome_cli/tests/snapshots/main_cases_biome_json_support/always_disable_trailing_commas_biome_json.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_biome_json_support/always_disable_trailing_commas_biome_json.snap
@@ -21,5 +21,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_biome_json_support/biome_json_is_not_ignored.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_biome_json_support/biome_json_is_not_ignored.snap
@@ -28,5 +28,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
+Checked 2 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_biome_json_support/ci_biome_json.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_biome_json_support/ci_biome_json.snap
@@ -21,5 +21,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_biome_json_support/linter_biome_json.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_biome_json_support/linter_biome_json.snap
@@ -35,5 +35,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_formatter_no_linter.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_formatter_no_linter.snap
@@ -53,6 +53,6 @@ test.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_linter_not_formatter.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_linter_not_formatter.snap
@@ -78,7 +78,7 @@ test.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_resolves_when_using_config_path.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_resolves_when_using_config_path.snap
@@ -68,6 +68,6 @@ test.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_directory.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_directory.snap
@@ -55,6 +55,6 @@ src/index.js format ━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_file.snap
@@ -55,6 +55,6 @@ src/index.js format ━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_cts_files/should_allow_using_export_statements.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_cts_files/should_allow_using_export_statements.snap
@@ -11,5 +11,5 @@ export default { cjs: true };
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/diagnostic_level.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/diagnostic_level.snap
@@ -54,6 +54,6 @@ src/index.js organizeImports ━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/logs_the_appropriate_messages_according_to_set_diagnostics_level.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/logs_the_appropriate_messages_according_to_set_diagnostics_level.snap
@@ -28,5 +28,5 @@ debugger;
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_no_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_no_verbose.snap
@@ -34,6 +34,6 @@ src/file.js format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_verbose.snap
@@ -130,6 +130,6 @@ src/folder_0/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_have_biome_override_editorconfig.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_have_biome_override_editorconfig.snap
@@ -34,5 +34,5 @@ console.log(
 # Emitted Messages
 
 ```block
-Formatted 1 file in <TIME>. No fixes needed.
+Formatted 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/astro_global.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/astro_global.snap
@@ -14,5 +14,5 @@ const { some } = Astro.props
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/does_not_throw_parse_error_for_return.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/does_not_throw_parse_error_for_return.snap
@@ -18,5 +18,5 @@ if (foo) {
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_astro_carriage_return_line_feed_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_astro_carriage_return_line_feed_files.snap
@@ -39,6 +39,6 @@ file.astro format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_astro_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_astro_files.snap
@@ -46,6 +46,6 @@ file.astro format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_empty_astro_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_empty_astro_files_write.snap
@@ -11,5 +11,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Formatted 1 file in <TIME>. No fixes needed.
+Formatted 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_astro_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_astro_files.snap
@@ -44,6 +44,6 @@ file.astro:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
@@ -42,6 +42,6 @@ file.astro organizeImports ━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_format_files_by_when_opt_in.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_format_files_by_when_opt_in.snap
@@ -35,6 +35,6 @@ input.css format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_lint_files_by_when_enabled.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_lint_files_by_when_enabled.snap
@@ -43,6 +43,6 @@ input.css:1:6 lint/nursery/noEmptyBlock ━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_not_format_files_by_default.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_not_format_files_by_default.snap
@@ -22,5 +22,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_not_lint_files_by_default.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_css_files/should_not_lint_files_by_default.snap
@@ -30,5 +30,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_carriage_return_line_feed_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_carriage_return_line_feed_files.snap
@@ -39,6 +39,6 @@ file.svelte format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_ts_context_module_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_ts_context_module_files.snap
@@ -42,6 +42,6 @@ file.svelte format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
@@ -42,6 +42,6 @@ file.svelte organizeImports ━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_empty_vue_js_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_empty_vue_js_files_write.snap
@@ -11,5 +11,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Formatted 1 file in <TIME>. No fixes needed.
+Formatted 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_empty_vue_ts_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_empty_vue_ts_files_write.snap
@@ -11,5 +11,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Formatted 1 file in <TIME>. No fixes needed.
+Formatted 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_carriage_return_line_feed_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_carriage_return_line_feed_files.snap
@@ -39,6 +39,6 @@ file.vue format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_explicit_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_explicit_js_files.snap
@@ -42,6 +42,6 @@ file.vue format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_generic_component_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_generic_component_files.snap
@@ -37,6 +37,6 @@ file.vue format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_implicit_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_implicit_js_files.snap
@@ -42,6 +42,6 @@ file.vue format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_ts_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_ts_files.snap
@@ -42,6 +42,6 @@ file.vue format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_js_files.snap
@@ -102,6 +102,6 @@ file.vue:4:1 lint/style/noVar  FIXABLE  ━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 3 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_ts_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_ts_files.snap
@@ -124,6 +124,6 @@ file.vue:4:1 lint/style/noVar  FIXABLE  ━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 4 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
@@ -42,6 +42,6 @@ file.vue organizeImports ━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/vue_compiler_macros_as_globals.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/vue_compiler_macros_as_globals.snap
@@ -58,6 +58,6 @@ file.vue:16:36 lint/suspicious/noExplicitAny ━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_not_change_linting_settings.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_not_change_linting_settings.snap
@@ -40,5 +40,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
+Checked 2 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_preserve_group_recommended_when_override_global_recommened.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_preserve_group_recommended_when_override_global_recommened.snap
@@ -49,5 +49,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 3 files in <TIME>. No fixes needed.
+Checked 3 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_preserve_individually_diabled_rules_in_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/does_preserve_individually_diabled_rules_in_overrides.snap
@@ -49,5 +49,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 3 files in <TIME>. No fixes needed.
+Checked 3 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_cli.snap
@@ -22,5 +22,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_cli_verbose.snap
@@ -34,5 +34,5 @@ package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_linter_disabled_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_linter_disabled_from_cli_verbose.snap
@@ -46,6 +46,6 @@ other.json format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_ignored_file_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_ignored_file_from_cli_verbose.snap
@@ -46,6 +46,6 @@ other.json format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_check_command.snap
@@ -87,6 +87,6 @@ lint/suspicious/noDebugger                              8 (8 error(s), 0 warning
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
+Checked 2 files in <TIME>. No fixes were applied.
 Found 44 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_ci_command.snap
@@ -87,6 +87,6 @@ lint/suspicious/noDebugger                              8 (8 error(s), 0 warning
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
+Checked 2 files in <TIME>. No fixes were applied.
 Found 44 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_format_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_format_command.snap
@@ -74,6 +74,6 @@ index.ts
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
+Checked 2 files in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_lint_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_lint_command.snap
@@ -77,6 +77,6 @@ lint/suspicious/noDebugger                              8 (8 error(s), 0 warning
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
+Checked 2 files in <TIME>. No fixes were applied.
 Found 40 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_unknown_files/should_not_print_a_diagnostic_unknown_file_because_ignored.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_unknown_files/should_not_print_a_diagnostic_unknown_file_because_ignored.snap
@@ -46,6 +46,6 @@ format.js format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_unknown_files/should_print_a_diagnostic_unknown_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_unknown_files/should_print_a_diagnostic_unknown_file.snap
@@ -40,6 +40,6 @@ format.js format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/all_rules.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/all_rules.snap
@@ -63,6 +63,6 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/apply_bogus_argument.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/apply_bogus_argument.snap
@@ -60,6 +60,6 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 3 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/apply_noop.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/apply_noop.snap
@@ -20,5 +20,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_json_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_json_files.snap
@@ -66,6 +66,6 @@ test.json format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/config_recommended_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/config_recommended_group.snap
@@ -66,6 +66,6 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/deprecated_suppression_comment.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/deprecated_suppression_comment.snap
@@ -84,6 +84,6 @@ file.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/doesnt_error_if_no_files_were_processed.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/doesnt_error_if_no_files_were_processed.snap
@@ -5,5 +5,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/dont_applies_organize_imports_for_ignored_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/dont_applies_organize_imports_for_ignored_file.snap
@@ -27,5 +27,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/downgrade_severity.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/downgrade_severity.snap
@@ -64,7 +64,7 @@ file.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large.snap
@@ -46,6 +46,6 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large_cli_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large_cli_limit.snap
@@ -53,6 +53,6 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large_config_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large_config_limit.snap
@@ -63,6 +63,6 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/fix_noop.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/fix_noop.snap
@@ -12,5 +12,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/fs_error_dereferenced_symlink.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/fs_error_dereferenced_symlink.snap
@@ -26,6 +26,6 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/fs_error_infinite_symlink_expansion_to_dirs.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/fs_error_infinite_symlink_expansion_to_dirs.snap
@@ -16,5 +16,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/fs_error_read_only.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/fs_error_read_only.snap
@@ -34,5 +34,5 @@ test.js internalError/io  INTERNAL  ━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/fs_error_unknown.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/fs_error_unknown.snap
@@ -26,6 +26,6 @@ prefix/ci.js internalError/fs ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/ignore_configured_globals.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/ignore_configured_globals.snap
@@ -45,6 +45,6 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/ignore_vcs_ignored_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/ignore_vcs_ignored_file.snap
@@ -76,6 +76,6 @@ file1.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/ignore_vcs_ignored_file_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/ignore_vcs_ignored_file_via_cli.snap
@@ -70,6 +70,6 @@ file1.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/ignore_vcs_os_independent_parse.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/ignore_vcs_os_independent_parse.snap
@@ -66,6 +66,6 @@ file1.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/ignores_file_inside_directory.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/ignores_file_inside_directory.snap
@@ -50,5 +50,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/ignores_unknown_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/ignores_unknown_file.snap
@@ -41,6 +41,6 @@ test.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/lint_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/lint_error.snap
@@ -65,6 +65,6 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 3 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/lint_error_without_file_paths.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/lint_error_without_file_paths.snap
@@ -65,6 +65,6 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 3 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/maximum_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/maximum_diagnostics.snap
@@ -532,6 +532,6 @@ Diagnostics not shown: 77.
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 21 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/no_lint_if_linter_is_disabled.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/no_lint_if_linter_is_disabled.snap
@@ -47,6 +47,6 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/no_supported_file_found.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/no_supported_file_found.snap
@@ -16,5 +16,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/nursery_unstable.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/nursery_unstable.snap
@@ -49,6 +49,6 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/parse_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/parse_error.snap
@@ -67,6 +67,6 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 3 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/print_verbose.snap
@@ -65,6 +65,6 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 3 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_apply_correct_file_source.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_apply_correct_file_source.snap
@@ -50,6 +50,6 @@ file.ts format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_disable_a_rule.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_disable_a_rule.snap
@@ -35,5 +35,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_error_if_unchanged_files_only_with_changed_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_error_if_unchanged_files_only_with_changed_flag.snap
@@ -22,5 +22,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_error_if_unstaged_files_only_with_staged_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_error_if_unstaged_files_only_with_staged_flag.snap
@@ -22,5 +22,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_not_disable_recommended_rules_for_a_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_not_disable_recommended_rules_for_a_group.snap
@@ -76,6 +76,6 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_not_enable_all_recommended_rules.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_not_enable_all_recommended_rules.snap
@@ -76,6 +76,6 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_show_formatter_diagnostics_for_files_ignored_by_linter.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_show_formatter_diagnostics_for_files_ignored_by_linter.snap
@@ -56,6 +56,6 @@ build/file.js format ━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check.snap
@@ -37,6 +37,6 @@ check.js organizeImports ━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/suppression_syntax_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/suppression_syntax_error.snap
@@ -47,6 +47,6 @@ check.js:1:15 suppressions/parse ━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/top_level_all_down_level_not_all.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/top_level_all_down_level_not_all.snap
@@ -149,7 +149,7 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 Found 4 warnings.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/top_level_not_all_down_level_all.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/top_level_not_all_down_level_all.snap
@@ -125,6 +125,6 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 4 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/unsupported_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/unsupported_file.snap
@@ -23,5 +23,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/unsupported_file_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/unsupported_file_verbose.snap
@@ -35,6 +35,6 @@ check.txt files/missingHandler  VERBOSE  ━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/upgrade_severity.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/upgrade_severity.snap
@@ -69,6 +69,6 @@ file.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/write_noop.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/write_noop.snap
@@ -12,5 +12,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_organize_imports_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_organize_imports_via_cli.snap
@@ -13,5 +13,5 @@ import * as something from "../something";
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_formatter.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_formatter.snap
@@ -21,5 +21,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_formatter_biome_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_formatter_biome_jsonc.snap
@@ -22,5 +22,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_formatter_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_formatter_via_cli.snap
@@ -11,5 +11,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_linter.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_linter.snap
@@ -51,6 +51,6 @@ file.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_linter_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_linter_via_cli.snap
@@ -35,6 +35,6 @@ file.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_formatter_linter_organize_imports.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_formatter_linter_organize_imports.snap
@@ -80,6 +80,6 @@ file.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_lint_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_lint_error.snap
@@ -65,6 +65,6 @@ ci.js format ━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 3 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_ok.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_ok.snap
@@ -12,5 +12,5 @@ statement();
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_parse_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_parse_error.snap
@@ -67,6 +67,6 @@ ci.js format ━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 3 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_runs_linter_not_formatter_issue_3495.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_runs_linter_not_formatter_issue_3495.snap
@@ -53,6 +53,6 @@ file.js:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/correctly_handles_ignored_and_not_ignored_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/correctly_handles_ignored_and_not_ignored_files.snap
@@ -83,6 +83,6 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
+Checked 2 files in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/does_error_with_only_warnings.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/does_error_with_only_warnings.snap
@@ -60,6 +60,6 @@ file.js:2:1 lint/suspicious/noClassAssign ━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/does_formatting_error_without_file_paths.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/does_formatting_error_without_file_paths.snap
@@ -34,6 +34,6 @@ ci.js format ━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/doesnt_error_if_no_files_were_processed.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/doesnt_error_if_no_files_were_processed.snap
@@ -5,5 +5,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large.snap
@@ -46,6 +46,6 @@ ci.js format ━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large_cli_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large_cli_limit.snap
@@ -53,6 +53,6 @@ ci.js format ━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large_config_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large_config_limit.snap
@@ -63,6 +63,6 @@ ci.js format ━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/formatting_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/formatting_error.snap
@@ -34,6 +34,6 @@ ci.js format ━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ignore_vcs_ignored_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ignore_vcs_ignored_file.snap
@@ -76,6 +76,6 @@ file1.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ignore_vcs_ignored_file_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ignore_vcs_ignored_file_via_cli.snap
@@ -67,6 +67,6 @@ file1.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ignores_unknown_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ignores_unknown_file.snap
@@ -41,6 +41,6 @@ test.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/max_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/max_diagnostics.snap
@@ -16,6 +16,6 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-Checked 60 files in <TIME>. No fixes needed.
+Checked 60 files in <TIME>. No fixes were applied.
 Found 60 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/max_diagnostics_default.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/max_diagnostics_default.snap
@@ -16,6 +16,6 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-Checked 60 files in <TIME>. No fixes needed.
+Checked 60 files in <TIME>. No fixes were applied.
 Found 60 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/print_verbose.snap
@@ -65,6 +65,6 @@ ci.js format ━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 3 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/should_error_if_unchanged_files_only_with_changed_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/should_error_if_unchanged_files_only_with_changed_flag.snap
@@ -22,5 +22,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/applies_custom_configuration_over_config_file_issue_3175_v1.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/applies_custom_configuration_over_config_file_issue_3175_v1.snap
@@ -39,5 +39,5 @@ biome.json:4:5 deserialize  DEPRECATED  ━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/applies_custom_configuration_over_config_file_issue_3175_v2.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/applies_custom_configuration_over_config_file_issue_3175_v2.snap
@@ -26,5 +26,5 @@ function f() {
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/does_not_format_if_files_are_listed_in_ignore_option.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/does_not_format_if_files_are_listed_in_ignore_option.snap
@@ -42,5 +42,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Formatted 0 files in <TIME>. No fixes needed.
+Formatted 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_files.snap
@@ -33,5 +33,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Formatted 0 files in <TIME>. No fixes needed.
+Formatted 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/doesnt_error_if_no_files_were_processed.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/doesnt_error_if_no_files_were_processed.snap
@@ -5,5 +5,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large.snap
@@ -26,5 +26,5 @@ format.js format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Formatted 1 file in <TIME>. No fixes needed.
+Formatted 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large_cli_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large_cli_limit.snap
@@ -33,5 +33,5 @@ format.js format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large_config_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large_config_limit.snap
@@ -43,5 +43,5 @@ format.js format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_empty_svelte_js_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_empty_svelte_js_files_write.snap
@@ -11,5 +11,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Formatted 1 file in <TIME>. No fixes needed.
+Formatted 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_empty_svelte_ts_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_empty_svelte_ts_files_write.snap
@@ -11,5 +11,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Formatted 1 file in <TIME>. No fixes needed.
+Formatted 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_is_disabled.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_is_disabled.snap
@@ -36,5 +36,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Formatted 0 files in <TIME>. No fixes needed.
+Formatted 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_json_when_allow_trailing_commas.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_json_when_allow_trailing_commas.snap
@@ -53,6 +53,6 @@ file.json format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_jsonc_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_jsonc_files.snap
@@ -42,6 +42,6 @@ file.jsonc format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_shows_parse_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_shows_parse_diagnostics.snap
@@ -43,6 +43,6 @@ format.js format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_explicit_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_explicit_js_files.snap
@@ -42,6 +42,6 @@ file.svelte format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_implicit_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_implicit_js_files.snap
@@ -42,6 +42,6 @@ file.svelte format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_ts_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_ts_files.snap
@@ -42,6 +42,6 @@ file.svelte format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_without_file_paths.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_without_file_paths.snap
@@ -34,6 +34,6 @@ format.js format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/formatter_lint_warning.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/formatter_lint_warning.snap
@@ -33,6 +33,6 @@ format.js format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/formatter_print.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/formatter_print.snap
@@ -34,6 +34,6 @@ format.js format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/fs_error_read_only.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/fs_error_read_only.snap
@@ -26,5 +26,5 @@ test.js internalError/io  INTERNAL  ━━━━━━━━━━━━━━�
 ```
 
 ```block
-Formatted 1 file in <TIME>. No fixes needed.
+Formatted 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/ignore_comments_error_when_allow_comments.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/ignore_comments_error_when_allow_comments.snap
@@ -47,6 +47,6 @@ somefile.json format ━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/ignores_unknown_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/ignores_unknown_file.snap
@@ -41,6 +41,6 @@ test.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/max_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/max_diagnostics.snap
@@ -21,6 +21,6 @@ Diagnostics not shown: 50.
 ```
 
 ```block
-Checked 60 files in <TIME>. No fixes needed.
+Checked 60 files in <TIME>. No fixes were applied.
 Found 60 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/max_diagnostics_default.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/max_diagnostics_default.snap
@@ -21,6 +21,6 @@ Diagnostics not shown: 40.
 ```
 
 ```block
-Checked 60 files in <TIME>. No fixes needed.
+Checked 60 files in <TIME>. No fixes were applied.
 Found 60 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/no_supported_file_found.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/no_supported_file_found.snap
@@ -16,5 +16,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/print_verbose.snap
@@ -34,6 +34,6 @@ format.js format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/should_error_if_unchanged_files_only_with_changed_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/should_error_if_unchanged_files_only_with_changed_flag.snap
@@ -22,5 +22,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/should_error_if_unstaged_files_only_with_staged_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/should_error_if_unstaged_files_only_with_staged_flag.snap
@@ -22,5 +22,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/treat_known_json_files_as_jsonc_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/treat_known_json_files_as_jsonc_files.snap
@@ -94,6 +94,6 @@ files/.babelrc format ━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 3 files in <TIME>. No fixes needed.
+Checked 3 files in <TIME>. No fixes were applied.
 Found 3 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/apply_bogus_argument.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/apply_bogus_argument.snap
@@ -41,6 +41,6 @@ fix.js:1:22 parse ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/apply_noop.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/apply_noop.snap
@@ -19,5 +19,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/check_json_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/check_json_files.snap
@@ -54,6 +54,6 @@ test.json:1:3 lint/nursery/noDuplicateJsonKeys ━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/config_recommended_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/config_recommended_group.snap
@@ -54,6 +54,6 @@ check.js:1:1 lint/correctness/noInvalidNewBuiltin  FIXABLE  ━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/deprecated_suppression_comment.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/deprecated_suppression_comment.snap
@@ -30,5 +30,5 @@ file.js:1:1 suppressions/deprecatedSuppressionComment  FIXABLE   DEPRECATED  ━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/does_error_with_only_warnings.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/does_error_with_only_warnings.snap
@@ -67,6 +67,6 @@ file.js:2:1 lint/suspicious/noClassAssign ━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/doesnt_error_if_no_files_were_processed.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/doesnt_error_if_no_files_were_processed.snap
@@ -5,5 +5,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/downgrade_severity.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/downgrade_severity.snap
@@ -41,6 +41,6 @@ file.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/downgrade_severity_info.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/downgrade_severity_info.snap
@@ -41,5 +41,5 @@ file.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large.snap
@@ -26,5 +26,5 @@ check.js lint ━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large_cli_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large_cli_limit.snap
@@ -33,5 +33,5 @@ check.js lint ━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large_config_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large_config_limit.snap
@@ -43,5 +43,5 @@ check.js lint ━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/fix_noop.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/fix_noop.snap
@@ -11,5 +11,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/fs_error_dereferenced_symlink.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/fs_error_dereferenced_symlink.snap
@@ -26,6 +26,6 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/fs_error_infinite_symlink_expansion_to_dirs.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/fs_error_infinite_symlink_expansion_to_dirs.snap
@@ -16,5 +16,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/fs_error_read_only.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/fs_error_read_only.snap
@@ -34,5 +34,5 @@ test.js internalError/io  INTERNAL  ━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/fs_error_unknown.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/fs_error_unknown.snap
@@ -26,6 +26,6 @@ prefix/ci.js internalError/fs ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/group_level_recommended_false_enable_specific.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/group_level_recommended_false_enable_specific.snap
@@ -59,6 +59,6 @@ fix.jsx:3:16 lint/a11y/useButtonType ━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_configured_globals.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_configured_globals.snap
@@ -28,5 +28,5 @@ foo.call(); bar.call();
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_file_in_subdir_in_symlinked_dir.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_file_in_subdir_in_symlinked_dir.snap
@@ -5,5 +5,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_vcs_ignored_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_vcs_ignored_file.snap
@@ -64,6 +64,6 @@ file1.js:1:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_vcs_ignored_file_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_vcs_ignored_file_via_cli.snap
@@ -58,6 +58,6 @@ file1.js:1:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_vcs_os_independent_parse.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_vcs_os_independent_parse.snap
@@ -43,5 +43,5 @@ console.log('biome is cool');
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/ignores_unknown_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/ignores_unknown_file.snap
@@ -18,5 +18,5 @@ content
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_subdir.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_subdir.snap
@@ -64,6 +64,6 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
+Checked 2 files in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_symlinked_subdir.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_symlinked_subdir.snap
@@ -64,6 +64,6 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes needed.
+Checked 2 files in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_error.snap
@@ -55,6 +55,6 @@ check.js:1:6 lint/correctness/noConstantCondition ━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_error_without_file_paths.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_error_without_file_paths.snap
@@ -55,6 +55,6 @@ check.js:1:6 lint/correctness/noConstantCondition ━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_group.snap
@@ -62,6 +62,6 @@ check.js:3:9 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_group_skip_rule.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_group_skip_rule.snap
@@ -37,6 +37,6 @@ check.js:1:28 lint/suspicious/noCompareNegZero  FIXABLE  ━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_group_with_disabled_rule.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_group_with_disabled_rule.snap
@@ -62,6 +62,6 @@ check.js:3:9 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_multiple_rules.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_multiple_rules.snap
@@ -53,6 +53,6 @@ check.js:1:11 lint/performance/noDelete  FIXABLE  ━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule.snap
@@ -37,6 +37,6 @@ check.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_and_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_and_group.snap
@@ -53,6 +53,6 @@ check.js:1:11 lint/performance/noDelete  FIXABLE  ━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_ignore_suppression_comments.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_ignore_suppression_comments.snap
@@ -47,6 +47,6 @@ check.js:2:9 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_skip_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_skip_group.snap
@@ -11,5 +11,5 @@ debugger; delete obj.prop; a === -0;
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_with_config.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_with_config.snap
@@ -46,6 +46,6 @@ check.js:3:21 lint/style/useNamingConvention ━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_with_linter_disabled.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_with_linter_disabled.snap
@@ -34,5 +34,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_with_recommended_disabled.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_with_recommended_disabled.snap
@@ -37,6 +37,6 @@ check.js:2:21 lint/style/useNamingConvention ━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_skip_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_skip_group.snap
@@ -11,5 +11,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_skip_rule.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_skip_rule.snap
@@ -11,5 +11,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_skip_group_with_enabled_rule.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_skip_group_with_enabled_rule.snap
@@ -52,6 +52,6 @@ check.js:1:11 lint/performance/noDelete  FIXABLE  ━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_skip_multiple_rules.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_skip_multiple_rules.snap
@@ -37,6 +37,6 @@ check.js:1:28 lint/suspicious/noCompareNegZero  FIXABLE  ━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_skip_rule.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_skip_rule.snap
@@ -53,6 +53,6 @@ check.js:1:28 lint/suspicious/noCompareNegZero  FIXABLE  ━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_skip_rule_and_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_skip_rule_and_group.snap
@@ -37,6 +37,6 @@ check.js:1:28 lint/suspicious/noCompareNegZero  FIXABLE  ━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_syntax_rules.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_syntax_rules.snap
@@ -33,6 +33,6 @@ check.js:1:17 parse/noDuplicatePrivateClassMembers ━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/maximum_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/maximum_diagnostics.snap
@@ -532,6 +532,6 @@ Diagnostics not shown: 76.
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 20 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/no_lint_if_files_are_listed_in_ignore_option.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/no_lint_if_files_are_listed_in_ignore_option.snap
@@ -50,5 +50,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/no_lint_if_linter_is_disabled.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/no_lint_if_linter_is_disabled.snap
@@ -32,5 +32,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/no_lint_if_linter_is_disabled_when_run_apply.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/no_lint_if_linter_is_disabled_when_run_apply.snap
@@ -40,5 +40,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/no_lint_if_linter_is_disabled_when_run_apply_biome_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/no_lint_if_linter_is_disabled_when_run_apply_biome_jsonc.snap
@@ -41,5 +41,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/no_lint_when_file_is_ignored.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/no_lint_when_file_is_ignored.snap
@@ -41,5 +41,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/no_supported_file_found.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/no_supported_file_found.snap
@@ -16,5 +16,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/no_unused_dependencies.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/no_unused_dependencies.snap
@@ -65,6 +65,6 @@ fix.js:2:8 lint/nursery/noUndeclaredDependencies ━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/nursery_unstable.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/nursery_unstable.snap
@@ -36,6 +36,6 @@ check.js:1:4 lint/suspicious/noAssignInExpressions ━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/parse_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/parse_error.snap
@@ -41,6 +41,6 @@ check.js:2:1 parse ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/print_verbose.snap
@@ -55,6 +55,6 @@ check.js:1:6 lint/correctness/noConstantCondition ━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_apply_correct_file_source.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_apply_correct_file_source.snap
@@ -26,5 +26,5 @@ type A = { a: string }; type B = Partial<A>
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_disable_a_rule.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_disable_a_rule.snap
@@ -35,5 +35,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_disable_a_rule_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_disable_a_rule_group.snap
@@ -34,5 +34,5 @@ internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_unchanged_files_only_with_changed_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_unchanged_files_only_with_changed_flag.snap
@@ -22,5 +22,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_unstaged_files_only_with_staged_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_unstaged_files_only_with_staged_flag.snap
@@ -22,5 +22,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_disable_recommended_rules_for_a_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_disable_recommended_rules_for_a_group.snap
@@ -66,6 +66,6 @@ fix.js:3:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_enable_all_recommended_rules.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_enable_all_recommended_rules.snap
@@ -41,5 +41,5 @@ expression: content
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_error_for_no_changed_files_with_no_errors_on_unmatched.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_error_for_no_changed_files_with_no_errors_on_unmatched.snap
@@ -17,5 +17,5 @@ console.log('file2');
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_process_ignored_file_even_if_its_changed.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_process_ignored_file_even_if_its_changed.snap
@@ -41,5 +41,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_process_ignored_file_even_if_its_staged.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_process_ignored_file_even_if_its_staged.snap
@@ -41,5 +41,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_only_process_changed_file_if_its_included.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_only_process_changed_file_if_its_included.snap
@@ -30,5 +30,5 @@ console.log('file2');
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_only_process_staged_file_if_its_included.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_only_process_staged_file_if_its_included.snap
@@ -30,5 +30,5 @@ console.log('file2');
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_only_processes_changed_files_when_changed_flag_is_set.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_only_processes_changed_files_when_changed_flag_is_set.snap
@@ -17,5 +17,5 @@ console.log('file2');
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_only_processes_staged_files_when_staged_flag_is_set.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_only_processes_staged_files_when_staged_flag_is_set.snap
@@ -23,5 +23,5 @@ console.log('staged');
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_pass_if_there_are_only_warnings.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_pass_if_there_are_only_warnings.snap
@@ -56,6 +56,6 @@ file.js:2:1 lint/suspicious/noClassAssign ━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_process_changed_files_if_changed_flag_is_set_and_default_branch_is_configured.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_process_changed_files_if_changed_flag_is_set_and_default_branch_is_configured.snap
@@ -27,5 +27,5 @@ console.log('file2');
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/suppression_syntax_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/suppression_syntax_error.snap
@@ -35,6 +35,6 @@ check.js:1:15 suppressions/parse ━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_false_group_level_all_true.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_false_group_level_all_true.snap
@@ -105,6 +105,6 @@ fix.js:4:5 lint/style/noVar  FIXABLE  ━━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 3 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_true.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_true.snap
@@ -47,6 +47,6 @@ fix.js:1:2 lint/suspicious/noCompareNegZero  FIXABLE  ━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_true_group_level_all_false.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_true_group_level_all_false.snap
@@ -118,6 +118,6 @@ fix.js:4:12 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 4 warnings.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_true_group_level_empty.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_true_group_level_empty.snap
@@ -84,6 +84,6 @@ fix.js:3:11 lint/style/noShoutyConstants  FIXABLE  ━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 2 warnings.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_recommended_true_group_level_all_false.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_recommended_true_group_level_all_false.snap
@@ -26,5 +26,5 @@ let a = 0; let b = 0; a = (b = 1) + 1;
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/unsupported_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/unsupported_file.snap
@@ -23,5 +23,5 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/unsupported_file_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/unsupported_file_verbose.snap
@@ -35,6 +35,6 @@ check.txt files/missingHandler  VERBOSE  ━━━━━━━━━━━━━
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/upgrade_severity.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/upgrade_severity.snap
@@ -53,6 +53,6 @@ file.js:1:1 lint/style/noNegationElse  FIXABLE  ━━━━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_configuration/correct_root.snap
+++ b/crates/biome_cli/tests/snapshots/main_configuration/correct_root.snap
@@ -75,5 +75,5 @@ biome.json:6:5 deserialize  DEPRECATED  ━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes needed.
+Checked 0 files in <TIME>. No fixes were applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_configuration/override_globals.snap
+++ b/crates/biome_cli/tests/snapshots/main_configuration/override_globals.snap
@@ -70,6 +70,6 @@ tests/test.js:3:9 lint/correctness/noUndeclaredVariables ━━━━━━━�
 ```
 
 ```block
-Checked 1 file in <TIME>. No fixes needed.
+Checked 1 file in <TIME>. No fixes were applied.
 Found 1 error.
 ```


### PR DESCRIPTION
## Summary

This is a tiny PR to reword the reporter message `No fixes needed` to `No fixes were applied`.

The former message is misleading when there're still errors or warnings in the files that should be taken care of manually. For example:

```block
Checked 2 files in <TIME>. No fixes needed.
Found 2 errors.
```

The new message suits better in these cases.

## Test Plan

Many snapshots are updated.
