### PR TITLE
fix(noUnknownProperty): prevent warning on CSS custom property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Linter
 
-
 #### New features
 
 - Add [nursery/useValidAutocomplete](https://biomejs.dev/linter/rules/use-valid-autocomplete/). Contributed by @unvalley
@@ -98,8 +97,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - [useImportExtensions](https://biomejs.dev/linter/rules/use-import-extensions/) now suggests a correct fix for `import '.'` and `import './.'`. Contributed by @minht11
 - Fix [useDateNow](https://biomejs.dev/linter/rules/use-date-now/) false positive when new Date object has arguments `new Date(0).getTime()`. Contributed by @minht11.
 - The [`noUnmatchableAnbSelector`](https://biomejs.dev/linter/rules/no-unmatchable-anb-selector/) rule is now able to catch unmatchable `an+b` selectors like `0n+0` or `-0n+0`. Contributed by @Sec-ant.
-
 - The [`useHookAtTopLevel`](https://biomejs.dev/linter/rules/use-hook-at-top-level/) rule now recognizes properties named as hooks like `foo.useFoo()`. Contributed by @ksnyder9801
+- Fix [#3092](https://github.com/biomejs/biome/issues/3092), prevent warning for `Custom properties (--*)`. Contributed by @chansuke
 
 ### Parser
 

--- a/crates/biome_css_analyze/src/lint/nursery/no_unknown_property.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unknown_property.rs
@@ -54,7 +54,7 @@ declare_rule! {
     /// ```
     ///
     pub NoUnknownProperty {
-        version: "next",
+        version: "1.8.0",
         name: "noUnknownProperty",
         language: "css",
         recommended: false,

--- a/crates/biome_css_analyze/src/lint/nursery/no_unknown_property.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unknown_property.rs
@@ -54,7 +54,7 @@ declare_rule! {
     /// ```
     ///
     pub NoUnknownProperty {
-        version: "1.8.0",
+        version: "next",
         name: "noUnknownProperty",
         language: "css",
         recommended: false,
@@ -70,7 +70,10 @@ impl Rule for NoUnknownProperty {
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let node = ctx.query();
         let property_name = node.name().ok()?.text().to_lowercase();
-        if !is_known_properties(&property_name) && !vendor_prefixed(&property_name) {
+        if !is_known_properties(&property_name)
+            && !vendor_prefixed(&property_name)
+            && !property_name.starts_with("--")
+        {
             return Some(node.name().ok()?.range());
         }
         None

--- a/crates/biome_css_analyze/src/lint/nursery/no_unknown_property.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unknown_property.rs
@@ -70,9 +70,9 @@ impl Rule for NoUnknownProperty {
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let node = ctx.query();
         let property_name = node.name().ok()?.text().to_lowercase();
-        if !is_known_properties(&property_name)
+        if !property_name.starts_with("--")
+            && !is_known_properties(&property_name)
             && !vendor_prefixed(&property_name)
-            && !property_name.starts_with("--")
         {
             return Some(node.name().ok()?.range());
         }

--- a/crates/biome_css_analyze/tests/specs/nursery/noUnknownProperty/valid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noUnknownProperty/valid.css
@@ -42,3 +42,16 @@ a {
 a {
   -webkit-mask-image: url(mask.png);
 }
+
+/* Custom property */
+a {
+  --custom-color: #1234560;
+}
+
+a {
+  --custom-margin: 100px;
+}
+
+a {
+  --custom-property: 10px;
+}

--- a/crates/biome_css_analyze/tests/specs/nursery/noUnknownProperty/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noUnknownProperty/valid.css.snap
@@ -49,4 +49,17 @@ a {
   -webkit-mask-image: url(mask.png);
 }
 
+/* Custom property */
+a {
+  --custom-color: #1234560;
+}
+
+a {
+  --custom-margin: 100px;
+}
+
+a {
+  --custom-property: 10px;
+}
+
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #3092.

Prevent warnings from being thrown for [Custom properties (--*)](https://developer.mozilla.org/en-US/docs/Web/CSS/--*).
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
