### PR TITLE
fix(lint/useJsxKeyInIterable): fix a false positive when key is in parenthesized return statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Add [nursery/noShorthandPropertyOverrides](https://biomejs.dev/linter/rules/no-shorthand-property-overrides). [#2958](https://github.com/biomejs/biome/issues/2958) Contributed by @neokidev
 
+#### Bug fixes
+
+- Fix [[#3084](https://github.com/biomejs/biome/issues/3084)] false positive by correctly recognize parenthesized return statement. Contributed by @unvalley
+
 ### CLI
 
 ### Configuration

--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -210,8 +210,6 @@ fn handle_function_body(
     node.statements()
         .iter()
         .filter_map(|statement| {
-            // dbg!(statement.syntax().kind());
-            // dbg!(statement.syntax().text());
             if let Some(statement) = statement.as_js_variable_statement() {
                 let declaration = statement.declaration().ok()?;
                 Some(

--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -193,6 +193,7 @@ fn handle_function_body(
         .as_ref()
         .and_then(|ret| {
             let returned_value = ret.argument()?;
+            let returned_value = unwrap_parenthesis(returned_value)?;
             Some(ReactComponentExpression::can_cast(
                 returned_value.syntax().kind(),
             ))
@@ -209,6 +210,8 @@ fn handle_function_body(
     node.statements()
         .iter()
         .filter_map(|statement| {
+            // dbg!(statement.syntax().kind());
+            // dbg!(statement.syntax().text());
             if let Some(statement) = statement.as_js_variable_statement() {
                 let declaration = statement.declaration().ok()?;
                 Some(

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx
@@ -95,4 +95,9 @@ React.Children.map(c => React.cloneElement(c, {key: c}));
 [].map((item) => {
 	const node = <button type="button">{item.label}</button>;
 	return <Fragment key={item.label}>{node}</Fragment>;
-})
+});
+
+[].map((el) => {
+  const content = <p>Paragraph</p>
+  return (<div key={el}>{content}</div>);
+});

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx.snap
@@ -101,6 +101,11 @@ React.Children.map(c => React.cloneElement(c, {key: c}));
 [].map((item) => {
 	const node = <button type="button">{item.label}</button>;
 	return <Fragment key={item.label}>{node}</Fragment>;
-})
+});
+
+[].map((el) => {
+  const content = <p>Paragraph</p>
+  return (<div key={el}>{content}</div>);
+});
 
 ```


### PR DESCRIPTION
## Summary

Closes #3084 by fixing the cast when the returned component is parenthesized.

```js
[].map((el) => {
  const content = <p>Paragraph</p>
  return (<div key={el}>{content}</div>); // will cast successfully
});
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a snapshot case.

<!-- What demonstrates that your implementation is correct? -->
