### PR TITLE
fix(lint/useLiteralKeys): unescaped newline false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,18 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - The [`noUnmatchableAnbSelector`](https://biomejs.dev/linter/rules/no-unmatchable-anb-selector/) rule is now able to catch unmatchable `an+b` selectors like `0n+0` or `-0n+0`. Contributed by @Sec-ant.
 - The [`useHookAtTopLevel`](https://biomejs.dev/linter/rules/use-hook-at-top-level/) rule now recognizes properties named as hooks like `foo.useFoo()`. Contributed by @ksnyder9801
 - Fix [#3092](https://github.com/biomejs/biome/issues/3092), prevent warning for `Custom properties (--*)`. Contributed by @chansuke
+- Fix a false positive in the [`useLiteralKeys`](https://biomejs.dev/linter/rules/use-literal-keys/) rule. ([#3160](https://github.com/biomejs/biome/issues/3160))
+
+  This rule now ignores the following kind of computed member name:
+
+  ```js
+  const a = {
+    [`line1
+    line2`]: true,
+  };
+  ```
+
+  Contributed by @Sec-ant
 
 ### Parser
 

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js
@@ -32,3 +32,17 @@ a = {
 
 // optional chain
 a?.["b"]?.['c']?.d?.e?.["f"]
+a = {
+  ["line1\
+  line2"]: true,
+};
+a = {
+  [`line1\
+  line2`]: true,
+};
+a = {
+  ["line1\nline2"]: true,
+};
+a = {
+  [`line1\nline2`]: true,
+};

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js.snap
@@ -38,7 +38,20 @@ a = {
 
 // optional chain
 a?.["b"]?.['c']?.d?.e?.["f"]
-
+a = {
+  ["line1\
+  line2"]: true,
+};
+a = {
+  [`line1\
+  line2`]: true,
+};
+a = {
+  ["line1\nline2"]: true,
+};
+a = {
+  [`line1\nline2`]: true,
+};
 ```
 
 # Diagnostics
@@ -566,7 +579,8 @@ invalid.js:34:5 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
     33 │ // optional chain
   > 34 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │     ^^^
-    35 │ 
+    35 │ a = {
+    36 │   ["line1\
   
   i Unsafe fix: Use a literal key instead.
   
@@ -583,7 +597,8 @@ invalid.js:34:12 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
     33 │ // optional chain
   > 34 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │            ^^^
-    35 │ 
+    35 │ a = {
+    36 │   ["line1\
   
   i Unsafe fix: Use a literal key instead.
   
@@ -600,11 +615,109 @@ invalid.js:34:25 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
     33 │ // optional chain
   > 34 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │                         ^^^
-    35 │ 
+    35 │ a = {
+    36 │   ["line1\
   
   i Unsafe fix: Use a literal key instead.
   
     34 │ a?.["b"]?.['c']?.d?.e?.["f"]
        │                        -- --
+
+```
+
+```
+invalid.js:36:4 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The computed expression can be simplified without the use of a string literal.
+  
+    34 │ a?.["b"]?.['c']?.d?.e?.["f"]
+    35 │ a = {
+  > 36 │   ["line1\
+       │    ^^^^^^^
+  > 37 │   line2"]: true,
+       │   ^^^^^^
+    38 │ };
+    39 │ a = {
+  
+  i Unsafe fix: Use a literal key instead.
+  
+    34 34 │   a?.["b"]?.['c']?.d?.e?.["f"]
+    35 35 │   a = {
+    36    │ - ··["line1\
+    37    │ - ··line2"]:·true,
+       36 │ + ··"line1\
+       37 │ + ··line2":·true,
+    38 38 │   };
+    39 39 │   a = {
+  
+
+```
+
+```
+invalid.js:40:4 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The computed expression can be simplified without the use of a string literal.
+  
+    38 │ };
+    39 │ a = {
+  > 40 │   [`line1\
+       │    ^^^^^^^
+  > 41 │   line2`]: true,
+       │   ^^^^^^
+    42 │ };
+    43 │ a = {
+  
+  i Unsafe fix: Use a literal key instead.
+  
+    38 38 │   };
+    39 39 │   a = {
+    40    │ - ··[`line1\
+    41    │ - ··line2`]:·true,
+       40 │ + ··"line1\
+       41 │ + ··line2":·true,
+    42 42 │   };
+    43 43 │   a = {
+  
+
+```
+
+```
+invalid.js:44:4 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The computed expression can be simplified without the use of a string literal.
+  
+    42 │ };
+    43 │ a = {
+  > 44 │   ["line1\nline2"]: true,
+       │    ^^^^^^^^^^^^^^
+    45 │ };
+    46 │ a = {
+  
+  i Unsafe fix: Use a literal key instead.
+  
+    44 │ ··["line1\nline2"]:·true,
+       │   -              -       
+
+```
+
+```
+invalid.js:47:4 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The computed expression can be simplified without the use of a string literal.
+  
+    45 │ };
+    46 │ a = {
+  > 47 │   [`line1\nline2`]: true,
+       │    ^^^^^^^^^^^^^^
+    48 │ };
+  
+  i Unsafe fix: Use a literal key instead.
+  
+    45 45 │   };
+    46 46 │   a = {
+    47    │ - ··[`line1\nline2`]:·true,
+       47 │ + ··"line1\nline2":·true,
+    48 48 │   };
+  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.js.snap
@@ -340,7 +340,7 @@ invalid.js:10:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.js:12:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     10 │ a.b[c["d"]] = "something";
     11 │ a = {
@@ -364,7 +364,7 @@ invalid.js:12:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.js:15:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     13 │ };
     14 │ a = {
@@ -436,7 +436,7 @@ invalid.js:18:5 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.js:19:12 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     17 │ a.b[`$c`];
     18 │ a.b["_d"];
@@ -455,7 +455,7 @@ invalid.js:19:12 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.js:20:12 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     18 │ a.b["_d"];
     19 │ class C { ["a"] = 0 }
@@ -474,7 +474,7 @@ invalid.js:20:12 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.js:21:16 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     19 │ class C { ["a"] = 0 }
     20 │ class C { ["a"](){} }
@@ -493,7 +493,7 @@ invalid.js:21:16 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.js:22:16 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     20 │ class C { ["a"](){} }
     21 │ class C { get ["a"](){} }
@@ -512,7 +512,7 @@ invalid.js:22:16 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.js:24:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     22 │ class C { set ["a"](x){} }
     23 │ a = {
@@ -531,7 +531,7 @@ invalid.js:24:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.js:27:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     25 │ }
     26 │ a = {
@@ -555,7 +555,7 @@ invalid.js:27:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.js:30:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     28 │ }
     29 │ a = {
@@ -628,7 +628,7 @@ invalid.js:34:25 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.js:36:4 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     34 │ a?.["b"]?.['c']?.d?.e?.["f"]
     35 │ a = {
@@ -656,7 +656,7 @@ invalid.js:36:4 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.js:40:4 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     38 │ };
     39 │ a = {
@@ -684,7 +684,7 @@ invalid.js:40:4 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.js:44:4 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     42 │ };
     43 │ a = {
@@ -703,7 +703,7 @@ invalid.js:44:4 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.js:47:4 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     45 │ };
     46 │ a = {

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/invalid.ts.snap
@@ -34,7 +34,7 @@ export type T = {
 ```
 invalid.ts:2:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     1 │ export interface I {
   > 2 │ 	["p1"]: number
@@ -52,7 +52,7 @@ invalid.ts:2:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━
 ```
 invalid.ts:4:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     2 │ 	["p1"]: number
     3 │ 
@@ -71,7 +71,7 @@ invalid.ts:4:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━
 ```
 invalid.ts:6:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     4 │ 	get ["p2"](): number
     5 │ 
@@ -90,7 +90,7 @@ invalid.ts:6:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━
 ```
 invalid.ts:8:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
      6 │ 	set ["p2"](x: number)
      7 │ 
@@ -109,7 +109,7 @@ invalid.ts:8:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━
 ```
 invalid.ts:10:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
      8 │ 	["m1"](): void
      9 │ 
@@ -128,7 +128,7 @@ invalid.ts:10:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.ts:14:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     13 │ export type T = {
   > 14 │ 	["p1"]: number
@@ -146,7 +146,7 @@ invalid.ts:14:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.ts:16:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     14 │ 	["p1"]: number
     15 │ 
@@ -165,7 +165,7 @@ invalid.ts:16:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.ts:18:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     16 │ 	get ["p2"](): number
     17 │ 
@@ -184,7 +184,7 @@ invalid.ts:18:7 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.ts:20:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     18 │ 	set ["p2"](x: number)
     19 │ 
@@ -203,7 +203,7 @@ invalid.ts:20:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━�
 ```
 invalid.ts:22:3 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The computed expression can be simplified without the use of a string literal.
+  ! The computed expression can be simplified to a string literal.
   
     20 │ 	["m1"](): void
     21 │ 

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js
@@ -32,3 +32,7 @@ a = {
 a = {
 	["__proto__"]: null,
 }
+a = {
+  [`line1
+  line2`]: true,
+};

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js.snap
@@ -38,4 +38,9 @@ a = {
 a = {
 	["__proto__"]: null,
 }
+a = {
+  [`line1
+  line2`]: true,
+};
+
 ```


### PR DESCRIPTION
## Summary

Fixes #3160. This rule now ignores the following kind of computed member name:

```js
const a = {
  [`line1
  line2`]: true,
};
```

## Test Plan

Test cases added.
