### PR TITLE
fix(semantic_model): export of variable

### DIFF
--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -1,7 +1,10 @@
 //! Events emitted by the [SemanticEventExtractor] which are then constructed into the Semantic Model
 
 use biome_js_syntax::binding_ext::{AnyJsBindingDeclaration, AnyJsIdentifierBinding};
-use biome_js_syntax::{AnyJsIdentifierUsage, JsExportDefaultExpressionClause, JsLanguage, JsReferenceIdentifier, JsSyntaxKind, JsSyntaxNode, TextRange, TsTypeParameterName};
+use biome_js_syntax::{
+    AnyJsIdentifierUsage, JsExportDefaultExpressionClause, JsLanguage, JsReferenceIdentifier,
+    JsSyntaxKind, JsSyntaxNode, TextRange, TsTypeParameterName,
+};
 use biome_js_syntax::{AnyJsImportClause, AnyJsNamedImportSpecifier, AnyTsType};
 use biome_rowan::{syntax::Preorder, AstNode, SyntaxNodeOptionExt, TokenText};
 use rustc_hash::FxHashMap;
@@ -733,14 +736,13 @@ impl SemanticEventExtractor {
     fn leave_export_default_expression(&mut self, node: &JsExportDefaultExpressionClause) {
         for node in node.syntax().descendants().skip(1) {
             if let Some(identifier) = JsReferenceIdentifier::cast_ref(&node) {
-                for (_, info) in &self.bindings {
+                for info in self.bindings.values() {
                     let Ok(name) = identifier.name() else {
                         continue;
                     };
                     if name.text() == name.text() {
-                        self.stash.push_back(SemanticEvent::Exported {
-                            range: info.range
-                        })
+                        self.stash
+                            .push_back(SemanticEvent::Exported { range: info.range })
                     }
                 }
             }

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -331,6 +331,8 @@ impl SemanticModelBuilder {
                 }
             }
             Exported { range } => {
+                dbg!(&range);
+                // println!("Custom backtrace: {}", Backtrace::force_capture());
                 self.exported.insert(range.start());
             }
         }

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -331,8 +331,6 @@ impl SemanticModelBuilder {
                 }
             }
             Exported { range } => {
-                dbg!(&range);
-                // println!("Custom backtrace: {}", Backtrace::force_capture());
                 self.exported.insert(range.start());
             }
         }

--- a/crates/biome_js_semantic/src/semantic_model/model.rs
+++ b/crates/biome_js_semantic/src/semantic_model/model.rs
@@ -183,6 +183,32 @@ impl SemanticModel {
             index: x.id,
         })
     }
+    
+    /// Return an iterator over all the bindings that are exported from the current AST.
+    ///
+    /// ```rust
+    /// use biome_js_parser::JsParserOptions;
+    /// use biome_rowan::{AstNode, SyntaxNodeCast};
+    /// use biome_js_syntax::{JsFileSource, AnyJsFunction};
+    /// use biome_js_semantic::{semantic_model, CallsExtensions, SemanticModelOptions};
+    /// use biome_js_syntax::JsReferenceIdentifier;
+    ///
+    /// let r = biome_js_parser::parse("export const bar = 3; const foo = 10; export default { foo }", JsFileSource::js_module(), JsParserOptions::default());
+    /// let model = semantic_model(&r.tree(), SemanticModelOptions::default());
+    ///
+    /// let all_exported: Vec<_> = model.all_exported().collect();
+    /// 
+    /// assert_eq!(all_exported.len(), 2);
+    /// ```
+    pub fn all_exported(&self) -> impl Iterator<Item = Binding> + '_ {
+        self.data.exported.iter().map(|range| {
+            let id = &self.data.bindings_by_start[&range];
+            Binding {
+                data: self.data.clone(),
+                index: (*id).into(),
+            }
+        })
+    }
 
     /// Returns the [Binding] of a reference.
     /// Can also be called from "binding" extension method.

--- a/crates/biome_js_semantic/src/semantic_model/model.rs
+++ b/crates/biome_js_semantic/src/semantic_model/model.rs
@@ -183,7 +183,7 @@ impl SemanticModel {
             index: x.id,
         })
     }
-    
+
     /// Return an iterator over all the bindings that are exported from the current AST.
     ///
     /// ```rust
@@ -197,12 +197,12 @@ impl SemanticModel {
     /// let model = semantic_model(&r.tree(), SemanticModelOptions::default());
     ///
     /// let all_exported: Vec<_> = model.all_exported().collect();
-    /// 
+    ///
     /// assert_eq!(all_exported.len(), 2);
     /// ```
     pub fn all_exported(&self) -> impl Iterator<Item = Binding> + '_ {
         self.data.exported.iter().map(|range| {
-            let id = &self.data.bindings_by_start[&range];
+            let id = &self.data.bindings_by_start[range];
             Binding {
                 data: self.data.clone(),
                 index: (*id).into(),

--- a/crates/biome_js_semantic/src/semantic_model/tests.rs
+++ b/crates/biome_js_semantic/src/semantic_model/tests.rs
@@ -289,7 +289,7 @@ mod test {
         assert!(globals[0].is_read());
         assert_eq!(globals[0].syntax().text_trimmed(), "console");
     }
-    
+
     #[test]
     fn all_exported() {
         let r = biome_js_parser::parse(

--- a/crates/biome_js_semantic/src/semantic_model/tests.rs
+++ b/crates/biome_js_semantic/src/semantic_model/tests.rs
@@ -216,6 +216,7 @@ mod test {
         assert_is_exported(true, "A", "const A = 1; export {A}");
         assert_is_exported(false, "A", "const A = 1; export {type A}");
         assert_is_exported(false, "A", "const A = 1; export type {A}");
+        assert_is_exported(false, "A", "const A = 1; export default {A}");
 
         // Functions
         assert_is_exported(false, "f", "function f() {}");
@@ -287,5 +288,22 @@ mod test {
         assert_eq!(globals.len(), 1);
         assert!(globals[0].is_read());
         assert_eq!(globals[0].syntax().text_trimmed(), "console");
+    }
+    
+    #[test]
+    fn all_exported() {
+        let r = biome_js_parser::parse(
+            "export const bar = 3; const foo = 10; export default { foo }",
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+
+        let options = SemanticModelOptions::default();
+
+        let model = semantic_model(&r.tree(), options);
+
+        let exported: Vec<_> = model.all_exported().collect();
+
+        assert_eq!(exported.len(), 2);
     }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a new function called `all_exported` to the semantic model. This function will be useful for the project graph I am exploring.

In order to add this function, I had to fix an issue where some particular bindings were not marked as exported:

```js
const foo = 33;

export default { foo }
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added new test cases

<!-- What demonstrates that your implementation is correct? -->
