### PR TITLE
fix(lint/useExhaustiveDependencies): false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,24 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - The [noUnknownProperty](https://biomejs.dev/linter/rules/no-unknown-property/) rule now ignores the `composes` property often used in css modules. [#3000](https://github.com/biomejs/biome/issues/3000) Contributed by @chansuke
 
+- Fix false positives of the [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) rule.
+
+  The component itself is considered stable when it is used recursively inside a hook closure defined inside of it:
+
+  ```jsx
+  import { useMemo } from "react";
+
+  function MyRecursiveComponent() {
+    // MyRecursiveComponent is stable, we don't need to add it to the dependencies list.
+    const children = useMemo(() => <MyRecursiveComponent />, []);
+    return <div>{children}</div>;
+  }
+  ```
+
+  Also, `export default function` and `export default class` are considered stable now because they can only appear at the top level of a module.
+
+  Contributed by @Sec-ant
+
 ### Parser
 
 ## v1.8.1 (2024-06-10)

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -467,6 +467,8 @@ fn capture_needs_to_be_in_the_dependency_list(
     match decl.parent_binding_pattern_declaration().unwrap_or(decl) {
         // These declarations are always stable
         AnyJsBindingDeclaration::JsClassDeclaration(_)
+        | AnyJsBindingDeclaration::JsClassExportDefaultDeclaration(_)
+        | AnyJsBindingDeclaration::JsFunctionExportDefaultDeclaration(_)
         | AnyJsBindingDeclaration::TsEnumDeclaration(_)
         | AnyJsBindingDeclaration::TsTypeAliasDeclaration(_)
         | AnyJsBindingDeclaration::TsInterfaceDeclaration(_)
@@ -474,14 +476,34 @@ fn capture_needs_to_be_in_the_dependency_list(
         | AnyJsBindingDeclaration::TsInferType(_)
         | AnyJsBindingDeclaration::TsMappedType(_)
         | AnyJsBindingDeclaration::TsTypeParameter(_) => false,
-        // Function declarations are unstable if ...
+        // Function declarations are stable if ...
         AnyJsBindingDeclaration::JsFunctionDeclaration(declaration) => {
             let declaration_range = declaration.syntax().text_range();
 
-            // ... they are declared inside the component function
-            component_function_range
+            // ... they are declared outside of the component function
+            if component_function_range
                 .intersect(declaration_range)
-                .map_or(false, |range| !range.is_empty())
+                .map_or(true, TextRange::is_empty)
+            {
+                return false;
+            }
+
+            // ... they are recursively used by the binding being created:
+            //
+            // function MyRecursiveElement() {
+            // 	 const children = useMemo(() => <MyRecursiveElement />, []);
+            // 	 return <div>{children}</div>;
+            // }
+            //
+            if capture
+                .node()
+                .ancestors()
+                .any(|ancestor| &ancestor == declaration.syntax())
+            {
+                return false;
+            }
+
+            true
         }
         // Variable declarators are stable if ...
         AnyJsBindingDeclaration::JsVariableDeclarator(declarator) => {
@@ -536,8 +558,6 @@ fn capture_needs_to_be_in_the_dependency_list(
         | AnyJsBindingDeclaration::JsFunctionExpression(_)
         | AnyJsBindingDeclaration::TsDeclareFunctionDeclaration(_)
         | AnyJsBindingDeclaration::JsClassExpression(_)
-        | AnyJsBindingDeclaration::JsClassExportDefaultDeclaration(_)
-        | AnyJsBindingDeclaration::JsFunctionExportDefaultDeclaration(_)
         | AnyJsBindingDeclaration::TsDeclareFunctionExportDefaultDeclaration(_)
         | AnyJsBindingDeclaration::JsCatchDeclaration(_) => true,
 

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/exportDefaultClass.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/exportDefaultClass.js
@@ -1,0 +1,12 @@
+import { Component, useMemo } from "react";
+
+export default class ClassComponent extends Component {
+  render() {
+    return <h2>Hi, I am a Class component!</h2>;
+  }
+}
+
+function FunctionComponent() {
+	const children = useMemo(() => <ClassComponent />, []);
+	return <div>{children}</div>;
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/exportDefaultClass.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/exportDefaultClass.js.snap
@@ -1,0 +1,20 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: exportDefaultClass.js
+---
+# Input
+```jsx
+import { Component, useMemo } from "react";
+
+export default class ClassComponent extends Component {
+  render() {
+    return <h2>Hi, I am a Class component!</h2>;
+  }
+}
+
+function FunctionComponent() {
+	const children = useMemo(() => <ClassComponent />, []);
+	return <div>{children}</div>;
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/recursiveComponents.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/recursiveComponents.js
@@ -1,0 +1,33 @@
+// issue: https://github.com/biomejs/biome/issues/3212
+
+import { useMemo } from "react";
+
+function MyRecursiveComponent1() {
+	const children = useMemo(() => <MyRecursiveComponent1 />, []);
+	return <div>{children}</div>;
+}
+
+export function MyRecursiveComponent2() {
+	const children = useMemo(() => <MyRecursiveComponent2 />, []);
+	return <div>{children}</div>;
+}
+
+export default function MyRecursiveComponent3() {
+	const children = useMemo(() => <MyRecursiveComponent3 />, []);
+	return <div>{children}</div>;
+}
+
+const MyRecursiveComponent4 = () => {
+	const children = useMemo(() => <MyRecursiveComponent4 />, []);
+	return <div>{children}</div>;
+}
+
+const MyRecursiveComponent5 = function() {
+	const children = useMemo(() => <MyRecursiveComponent5 />, []);
+	return <div>{children}</div>;
+}
+
+const MyRecursiveComponent6 = function f() {
+	const children = useMemo(() => <MyRecursiveComponent6 />, []);
+	return <div>{children}</div>;
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/recursiveComponents.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/recursiveComponents.js.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: recursiveComponents.js
+---
+# Input
+```jsx
+// issue: https://github.com/biomejs/biome/issues/3212
+
+import { useMemo } from "react";
+
+function MyRecursiveComponent1() {
+	const children = useMemo(() => <MyRecursiveComponent1 />, []);
+	return <div>{children}</div>;
+}
+
+export function MyRecursiveComponent2() {
+	const children = useMemo(() => <MyRecursiveComponent2 />, []);
+	return <div>{children}</div>;
+}
+
+export default function MyRecursiveComponent3() {
+	const children = useMemo(() => <MyRecursiveComponent3 />, []);
+	return <div>{children}</div>;
+}
+
+const MyRecursiveComponent4 = () => {
+	const children = useMemo(() => <MyRecursiveComponent4 />, []);
+	return <div>{children}</div>;
+}
+
+const MyRecursiveComponent5 = function() {
+	const children = useMemo(() => <MyRecursiveComponent5 />, []);
+	return <div>{children}</div>;
+}
+
+const MyRecursiveComponent6 = function f() {
+	const children = useMemo(() => <MyRecursiveComponent6 />, []);
+	return <div>{children}</div>;
+}
+
+```


### PR DESCRIPTION
## Summary

Fix false positives of the [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) rule:

- The component itself is considered stable when it is used recursively inside a hook closure defined inside of it:

  ```jsx
  import { useMemo } from "react";
  
  function MyRecursiveComponent() {
    // MyRecursiveComponent is stable, we don't need to add it to the dependencies list.
    const children = useMemo(() => <MyRecursiveComponent />, []);
    return <div>{children}</div>;
  }
  ```

- Also, `export default function` and `export default class` are considered stable now because they can only appear at the top level of a module.

Closes #3212

## Test Plan

Added several valid test cases.