### PR TITLE
fix(javascript/vue): missing withDefaults macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Sec-ant
 
+- Fix missing `withDefaults` macro in vue files for globals variables. Contributed by @Shyam-Chen
+
 ### Parser
 
 #### Bug fixes

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -232,12 +232,13 @@ impl ServiceLanguage for JsLanguage {
             Some("vue") => {
                 globals.extend(
                     [
-                        "defineEmits",
-                        "defineProps",
-                        "defineExpose",
-                        "defineModel",
                         "defineOptions",
+                        "defineModel",
+                        "withDefaults",
+                        "defineProps",
+                        "defineEmits",
                         "defineSlots",
+                        "defineExpose",
                     ]
                     .map(ToOwned::to_owned),
                 );


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Ref: https://vuejs.org/api/sfc-script-setup.html#default-props-values-when-using-type-declaration

Besides that, I also sorted the positions based on [`vue/define-macros-order`](https://eslint.vuejs.org/rules/define-macros-order.html).

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
