### PR TITLE
fix(cli): correctly compute the color mode in `ci`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Fix [#3201](https://github.com/biomejs/biome/issues/3201) by correctly injecting the source code of the file when printing the diagnostics. Contributed by @ematipico
 - Fix [#3179](https://github.com/biomejs/biome/issues/3179) where comma separators are not correctly removed after running `biome migrate` and thus choke the parser. Contributed by @Sec-ant
-
+- Fix [#3232](https://github.com/biomejs/biome/issues/3232) by correctly using the colors set by the user. Contributed by @ematipico
 #### Enhancement
 
 - Reword the reporter message `No fixes needed` to `No fixes applied`.

--- a/crates/biome_cli/src/main.rs
+++ b/crates/biome_cli/src/main.rs
@@ -39,8 +39,12 @@ fn main() -> ExitCode {
 
     let color_mode = to_color_mode(command.get_color());
     // we want force colours in CI, to give e better UX experience
-    if matches!(command, BiomeCommand::Ci { .. }) {
-        console.set_color(ColorMode::Enabled);
+    if let BiomeCommand::Ci { cli_options, .. } = &command {
+        if cli_options.colors.is_none() {
+            console.set_color(ColorMode::Enabled);
+        } else {
+            console.set_color(color_mode);
+        }
     } else {
         console.set_color(color_mode);
     }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/3232

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I tested it locally, and now `--colors=off` doesn't show any colours

![Screenshot 2024-06-20 at 11 08 29](https://github.com/biomejs/biome/assets/602478/ec67745a-c63b-493a-ae4a-0ee6c806a55a)


<!-- What demonstrates that your implementation is correct? -->
