### PR TITLE
feat(editorconfig): reenable editorconfig support, add cli flag to disable it

### DIFF
--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -10,8 +10,10 @@ use biome_configuration::{
     organize_imports::PartialOrganizeImports, PartialConfiguration, PartialFormatterConfiguration,
     PartialLinterConfiguration,
 };
+use biome_console::{markup, ConsoleExt};
 use biome_deserialize::Merge;
-use biome_service::configuration::PartialConfigurationExt;
+use biome_diagnostics::PrintDiagnostic;
+use biome_service::configuration::{load_editorconfig, PartialConfigurationExt};
 use biome_service::workspace::RegisterProjectFolderParams;
 use biome_service::{
     configuration::{load_configuration, LoadedConfiguration},
@@ -81,34 +83,46 @@ pub(crate) fn check(
         session.app.console,
         cli_options.verbose,
     )?;
-    // let fs = &session.app.fs;
-    // let (editorconfig, editorconfig_diagnostics) = {
-    //     let search_path = loaded_configuration
-    //         .directory_path
-    //         .clone()
-    //         .unwrap_or_else(|| fs.working_directory().unwrap_or_default());
-    //     load_editorconfig(fs, search_path)?
-    // };
-    // for diagnostic in editorconfig_diagnostics {
-    //     session.app.console.error(markup! {
-    //         {PrintDiagnostic::simple(&diagnostic)}
-    //     })
-    // }
 
     resolve_manifest(&session)?;
 
+    let editorconfig_search_path = loaded_configuration.directory_path.clone();
     let LoadedConfiguration {
-        configuration: mut fs_configuration,
+        configuration: biome_configuration,
         directory_path: configuration_path,
         ..
     } = loaded_configuration;
-    // let mut fs_configuration = if let Some(mut fs_configuration) = editorconfig {
-    //     // this makes biome configuration take precedence over editorconfig configuration
-    //     fs_configuration.merge_with(biome_configuration);
-    //     fs_configuration
-    // } else {
-    //     biome_configuration
-    // };
+
+    let should_use_editorconfig = configuration
+        .as_ref()
+        .and_then(|f| f.formatter.as_ref())
+        .and_then(|f| f.use_editorconfig)
+        .unwrap_or(
+            biome_configuration
+                .formatter
+                .as_ref()
+                .and_then(|f| f.use_editorconfig)
+                .unwrap_or_default(),
+        );
+    let mut fs_configuration = if should_use_editorconfig {
+        let (editorconfig, editorconfig_diagnostics) = {
+            let search_path = editorconfig_search_path.unwrap_or_else(|| {
+                let fs = &session.app.fs;
+                fs.working_directory().unwrap_or_default()
+            });
+            load_editorconfig(&session.app.fs, search_path)?
+        };
+        for diagnostic in editorconfig_diagnostics {
+            session.app.console.error(markup! {
+                {PrintDiagnostic::simple(&diagnostic)}
+            })
+        }
+        editorconfig.unwrap_or_default()
+    } else {
+        Default::default()
+    };
+    // this makes biome configuration take precedence over editorconfig configuration
+    fs_configuration.merge_with(biome_configuration);
 
     let formatter = fs_configuration
         .formatter

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -16,7 +16,7 @@ use biome_console::{markup, ConsoleExt};
 use biome_deserialize::Merge;
 use biome_diagnostics::PrintDiagnostic;
 use biome_service::configuration::{
-    load_configuration, LoadedConfiguration, PartialConfigurationExt,
+    load_configuration, load_editorconfig, LoadedConfiguration, PartialConfigurationExt,
 };
 use biome_service::workspace::{RegisterProjectFolderParams, UpdateSettingsParams};
 use std::ffi::OsString;
@@ -78,33 +78,46 @@ pub(crate) fn format(
         session.app.console,
         cli_options.verbose,
     )?;
-    // let fs = &session.app.fs;
-    // let (editorconfig, editorconfig_diagnostics) = {
-    //     let search_path = loaded_configuration
-    //         .directory_path
-    //         .clone()
-    //         .unwrap_or_else(|| fs.working_directory().unwrap_or_default());
-    //     load_editorconfig(fs, search_path)?
-    // };
-    // for diagnostic in editorconfig_diagnostics {
-    //     session.app.console.error(markup! {
-    //         {PrintDiagnostic::simple(&diagnostic)}
-    //     })
-    // }
 
     resolve_manifest(&session)?;
+
+    let editorconfig_search_path = loaded_configuration.directory_path.clone();
     let LoadedConfiguration {
-        mut configuration,
+        configuration: biome_configuration,
         directory_path: configuration_path,
         ..
     } = loaded_configuration;
-    // let mut configuration = if let Some(mut configuration) = editorconfig {
-    //     // this makes biome configuration take precedence over editorconfig configuration
-    //     configuration.merge_with(biome_configuration);
-    //     configuration
-    // } else {
-    //     biome_configuration
-    // };
+
+    let should_use_editorconfig = formatter_configuration
+        .as_ref()
+        .and_then(|f| f.use_editorconfig)
+        .unwrap_or(
+            biome_configuration
+                .formatter
+                .as_ref()
+                .and_then(|f| f.use_editorconfig)
+                .unwrap_or_default(),
+        );
+    let mut fs_configuration = if should_use_editorconfig {
+        let (editorconfig, editorconfig_diagnostics) = {
+            let search_path = editorconfig_search_path.unwrap_or_else(|| {
+                let fs = &session.app.fs;
+                fs.working_directory().unwrap_or_default()
+            });
+            load_editorconfig(&session.app.fs, search_path)?
+        };
+        for diagnostic in editorconfig_diagnostics {
+            session.app.console.error(markup! {
+                {PrintDiagnostic::simple(&diagnostic)}
+            })
+        }
+        editorconfig.unwrap_or_default()
+    } else {
+        Default::default()
+    };
+    // this makes biome configuration take precedence over editorconfig configuration
+    fs_configuration.merge_with(biome_configuration);
+    let mut configuration = fs_configuration;
 
     // TODO: remove in biome 2.0
     let console = &mut *session.app.console;

--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -209,6 +209,9 @@ impl TryFrom<PrettierConfiguration> for biome_configuration::PartialConfiguratio
             ignore: None,
             include: None,
             enabled: Some(true),
+            // editorconfig support is intentionally set to true, because prettier always reads the editorconfig file
+            // see: https://github.com/prettier/prettier/issues/15255
+            use_editorconfig: Some(true),
             // deprecated
             indent_size: None,
             bracket_spacing: Some(BracketSpacing::default()),

--- a/crates/biome_cli/tests/cases/editorconfig.rs
+++ b/crates/biome_cli/tests/cases/editorconfig.rs
@@ -7,7 +7,6 @@ use bpaf::Args;
 use std::path::Path;
 
 #[test]
-#[ignore = "enable once we have the configuration to turn it on"]
 fn should_use_editorconfig() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
@@ -18,6 +17,62 @@ fn should_use_editorconfig() {
         r#"
 [*]
 max_line_length = 300
+"#,
+    );
+
+    let test_file = Path::new("test.js");
+    let contents = r#"console.log("really long string that should cause a break if the line width remains at the default 80 characters");
+"#;
+    fs.insert(test_file.into(), contents);
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                ("--write"),
+                ("--use-editorconfig=true"),
+                test_file.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, test_file, contents);
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_use_editorconfig",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_use_editorconfig_enabled_from_biome_conf() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let editorconfig = Path::new(".editorconfig");
+    fs.insert(
+        editorconfig.into(),
+        r#"
+[*]
+max_line_length = 300
+"#,
+    );
+
+    let biomeconfig = Path::new("biome.json");
+    fs.insert(
+        biomeconfig.into(),
+        r#"{
+    "formatter": {
+        "useEditorconfig": true
+    }
+}
 "#,
     );
 
@@ -44,7 +99,7 @@ max_line_length = 300
     assert_file_contents(&fs, test_file, contents);
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
-        "should_use_editorconfig",
+        "should_use_editorconfig_enabled_from_biome_conf",
         fs,
         console,
         result,
@@ -91,6 +146,7 @@ indent_style = tab
             [
                 ("format"),
                 ("--write"),
+                ("--use-editorconfig=true"),
                 test_file.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),

--- a/crates/biome_cli/tests/cases/overrides_formatter.rs
+++ b/crates/biome_cli/tests/cases/overrides_formatter.rs
@@ -673,7 +673,6 @@ fn takes_last_formatter_enabled_into_account() {
 }
 
 #[test]
-#[ignore = "Enable when we fix the behavior of how overrides are applied for json files"]
 fn does_not_override_well_known_special_files_when_config_override_is_present() {
     let mut console = BufferConsole::default();
     let mut fs = MemoryFileSystem::default();

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_use_editorconfig.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_use_editorconfig.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `.editorconfig`
+
+```editorconfig
+
+[*]
+max_line_length = 300
+
+```
+
+## `test.js`
+
+```js
+console.log("really long string that should cause a break if the line width remains at the default 80 characters");
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_use_editorconfig_enabled_from_biome_conf.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_use_editorconfig_enabled_from_biome_conf.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "useEditorconfig": true
+  }
+}
+```
+
+## `.editorconfig`
+
+```editorconfig
+
+[*]
+max_line_length = 300
+
+```
+
+## `test.js`
+
+```js
+console.log("really long string that should cause a break if the line width remains at the default 80 characters");
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -24,6 +24,8 @@ The configuration that is contained inside the file `biome.json`
                               this limit will be ignored for performance reasons. Defaults to 1 MiB
         --files-ignore-unknown=<true|false>  Tells Biome to not emit diagnostics when handling files
                               that doesn't know
+        --use-editorconfig=<true|false>  Use any `.editorconfig` files to configure the formatter. Configuration
+                              in `biome.json` will override `.editorconfig` configuration. Default: false.
         --indent-style=<tab|space>  The indent style.
         --indent-size=NUMBER  The size of the indentation, 2 by default (deprecated, use `indent-width`)
         --indent-width=NUMBER  The size of the indentation, 2 by default

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -26,6 +26,8 @@ The configuration that is contained inside the file `biome.json`
                               this limit will be ignored for performance reasons. Defaults to 1 MiB
         --files-ignore-unknown=<true|false>  Tells Biome to not emit diagnostics when handling files
                               that doesn't know
+        --use-editorconfig=<true|false>  Use any `.editorconfig` files to configure the formatter. Configuration
+                              in `biome.json` will override `.editorconfig` configuration. Default: false.
         --indent-style=<tab|space>  The indent style.
         --indent-size=NUMBER  The size of the indentation, 2 by default (deprecated, use `indent-width`)
         --indent-width=NUMBER  The size of the indentation, 2 by default

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -10,6 +10,8 @@ Run the formatter on a set of files.
 Usage: format [--write] [--staged] [--changed] [--since=REF] [PATH]...
 
 Generic options applied to all files
+        --use-editorconfig=<true|false>  Use any `.editorconfig` files to configure the formatter. Configuration
+                              in `biome.json` will override `.editorconfig` configuration. Default: false.
         --indent-style=<tab|space>  The indent style.
         --indent-size=NUMBER  The size of the indentation, 2 by default (deprecated, use `indent-width`)
         --indent-width=NUMBER  The size of the indentation, 2 by default

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate.snap
@@ -25,30 +25,31 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
        1 │ + {
        2 │ + → "formatter":·{
        3 │ + → → "enabled":·true,
-       4 │ + → → "formatWithErrors":·false,
-       5 │ + → → "indentStyle":·"space",
-       6 │ + → → "indentWidth":·2,
-       7 │ + → → "lineEnding":·"lf",
-       8 │ + → → "lineWidth":·80,
-       9 │ + → → "attributePosition":·"auto",
-      10 │ + → → "bracketSpacing":·true
-      11 │ + → },
-      12 │ + → "linter":·{·"enabled":·true·},
-      13 │ + → "javascript":·{
-      14 │ + → → "formatter":·{
-      15 │ + → → → "jsxQuoteStyle":·"double",
-      16 │ + → → → "quoteProperties":·"asNeeded",
-      17 │ + → → → "trailingCommas":·"all",
-      18 │ + → → → "semicolons":·"always",
-      19 │ + → → → "arrowParentheses":·"always",
-      20 │ + → → → "bracketSameLine":·false,
-      21 │ + → → → "quoteStyle":·"single",
-      22 │ + → → → "attributePosition":·"auto",
-      23 │ + → → → "bracketSpacing":·true
-      24 │ + → → }
-      25 │ + → }
-      26 │ + }
-      27 │ + 
+       4 │ + → → "useEditorconfig":·true,
+       5 │ + → → "formatWithErrors":·false,
+       6 │ + → → "indentStyle":·"space",
+       7 │ + → → "indentWidth":·2,
+       8 │ + → → "lineEnding":·"lf",
+       9 │ + → → "lineWidth":·80,
+      10 │ + → → "attributePosition":·"auto",
+      11 │ + → → "bracketSpacing":·true
+      12 │ + → },
+      13 │ + → "linter":·{·"enabled":·true·},
+      14 │ + → "javascript":·{
+      15 │ + → → "formatter":·{
+      16 │ + → → → "jsxQuoteStyle":·"double",
+      17 │ + → → → "quoteProperties":·"asNeeded",
+      18 │ + → → → "trailingCommas":·"all",
+      19 │ + → → → "semicolons":·"always",
+      20 │ + → → → "arrowParentheses":·"always",
+      21 │ + → → → "bracketSameLine":·false,
+      22 │ + → → → "quoteStyle":·"single",
+      23 │ + → → → "attributePosition":·"auto",
+      24 │ + → → → "bracketSpacing":·true
+      25 │ + → → }
+      26 │ + → }
+      27 │ + }
+      28 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_end_of_line.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_end_of_line.snap
@@ -29,29 +29,30 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
        1 │ + {
        2 │ + → "formatter":·{
        3 │ + → → "enabled":·true,
-       4 │ + → → "formatWithErrors":·false,
-       5 │ + → → "indentStyle":·"space",
-       6 │ + → → "indentWidth":·2,
-       7 │ + → → "lineEnding":·"lf",
-       8 │ + → → "lineWidth":·80,
-       9 │ + → → "attributePosition":·"auto",
-      10 │ + → → "bracketSpacing":·true
-      11 │ + → },
-      12 │ + → "javascript":·{
-      13 │ + → → "formatter":·{
-      14 │ + → → → "jsxQuoteStyle":·"double",
-      15 │ + → → → "quoteProperties":·"asNeeded",
-      16 │ + → → → "trailingCommas":·"all",
-      17 │ + → → → "semicolons":·"asNeeded",
-      18 │ + → → → "arrowParentheses":·"always",
-      19 │ + → → → "bracketSameLine":·false,
-      20 │ + → → → "quoteStyle":·"single",
-      21 │ + → → → "attributePosition":·"auto",
-      22 │ + → → → "bracketSpacing":·true
-      23 │ + → → }
-      24 │ + → }
-      25 │ + }
-      26 │ + 
+       4 │ + → → "useEditorconfig":·true,
+       5 │ + → → "formatWithErrors":·false,
+       6 │ + → → "indentStyle":·"space",
+       7 │ + → → "indentWidth":·2,
+       8 │ + → → "lineEnding":·"lf",
+       9 │ + → → "lineWidth":·80,
+      10 │ + → → "attributePosition":·"auto",
+      11 │ + → → "bracketSpacing":·true
+      12 │ + → },
+      13 │ + → "javascript":·{
+      14 │ + → → "formatter":·{
+      15 │ + → → → "jsxQuoteStyle":·"double",
+      16 │ + → → → "quoteProperties":·"asNeeded",
+      17 │ + → → → "trailingCommas":·"all",
+      18 │ + → → → "semicolons":·"asNeeded",
+      19 │ + → → → "arrowParentheses":·"always",
+      20 │ + → → → "bracketSameLine":·false,
+      21 │ + → → → "quoteStyle":·"single",
+      22 │ + → → → "attributePosition":·"auto",
+      23 │ + → → → "bracketSpacing":·true
+      24 │ + → → }
+      25 │ + → }
+      26 │ + }
+      27 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_fix.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_fix.snap
@@ -8,6 +8,7 @@ expression: content
 {
   "formatter": {
     "enabled": true,
+    "useEditorconfig": true,
     "formatWithErrors": false,
     "indentStyle": "space",
     "indentWidth": 2,

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_jsonc.snap
@@ -25,30 +25,31 @@ biome.jsonc migrate ━━━━━━━━━━━━━━━━━━━━
        1 │ + {
        2 │ + → "formatter":·{
        3 │ + → → "enabled":·true,
-       4 │ + → → "formatWithErrors":·false,
-       5 │ + → → "indentStyle":·"space",
-       6 │ + → → "indentWidth":·2,
-       7 │ + → → "lineEnding":·"lf",
-       8 │ + → → "lineWidth":·80,
-       9 │ + → → "attributePosition":·"auto",
-      10 │ + → → "bracketSpacing":·true
-      11 │ + → },
-      12 │ + → "linter":·{·"enabled":·true·},
-      13 │ + → "javascript":·{
-      14 │ + → → "formatter":·{
-      15 │ + → → → "jsxQuoteStyle":·"double",
-      16 │ + → → → "quoteProperties":·"asNeeded",
-      17 │ + → → → "trailingCommas":·"all",
-      18 │ + → → → "semicolons":·"always",
-      19 │ + → → → "arrowParentheses":·"always",
-      20 │ + → → → "bracketSameLine":·false,
-      21 │ + → → → "quoteStyle":·"single",
-      22 │ + → → → "attributePosition":·"auto",
-      23 │ + → → → "bracketSpacing":·true
-      24 │ + → → }
-      25 │ + → }
-      26 │ + }
-      27 │ + 
+       4 │ + → → "useEditorconfig":·true,
+       5 │ + → → "formatWithErrors":·false,
+       6 │ + → → "indentStyle":·"space",
+       7 │ + → → "indentWidth":·2,
+       8 │ + → → "lineEnding":·"lf",
+       9 │ + → → "lineWidth":·80,
+      10 │ + → → "attributePosition":·"auto",
+      11 │ + → → "bracketSpacing":·true
+      12 │ + → },
+      13 │ + → "linter":·{·"enabled":·true·},
+      14 │ + → "javascript":·{
+      15 │ + → → "formatter":·{
+      16 │ + → → → "jsxQuoteStyle":·"double",
+      17 │ + → → → "quoteProperties":·"asNeeded",
+      18 │ + → → → "trailingCommas":·"all",
+      19 │ + → → → "semicolons":·"always",
+      20 │ + → → → "arrowParentheses":·"always",
+      21 │ + → → → "bracketSameLine":·false,
+      22 │ + → → → "quoteStyle":·"single",
+      23 │ + → → → "attributePosition":·"auto",
+      24 │ + → → → "bracketSpacing":·true
+      25 │ + → → }
+      26 │ + → }
+      27 │ + }
+      28 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_overrides.snap
@@ -36,45 +36,46 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
        1 │ + {
        2 │ + → "formatter":·{
        3 │ + → → "enabled":·true,
-       4 │ + → → "formatWithErrors":·false,
-       5 │ + → → "indentStyle":·"space",
-       6 │ + → → "indentWidth":·2,
-       7 │ + → → "lineEnding":·"lf",
-       8 │ + → → "lineWidth":·80,
-       9 │ + → → "attributePosition":·"auto",
-      10 │ + → → "bracketSpacing":·true
-      11 │ + → },
-      12 │ + → "javascript":·{
-      13 │ + → → "formatter":·{
-      14 │ + → → → "jsxQuoteStyle":·"double",
-      15 │ + → → → "quoteProperties":·"asNeeded",
-      16 │ + → → → "trailingCommas":·"all",
-      17 │ + → → → "semicolons":·"asNeeded",
-      18 │ + → → → "arrowParentheses":·"always",
-      19 │ + → → → "bracketSameLine":·false,
-      20 │ + → → → "quoteStyle":·"single",
-      21 │ + → → → "attributePosition":·"auto",
-      22 │ + → → → "bracketSpacing":·true
-      23 │ + → → }
-      24 │ + → },
-      25 │ + → "overrides":·[
-      26 │ + → → {·"include":·["**/*.test.js"],·"formatter":·{·"indentStyle":·"space"·}·},
-      27 │ + → → {
-      28 │ + → → → "include":·["**/*.spec.js"],
-      29 │ + → → → "javascript":·{
-      30 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
-      31 │ + → → → }
-      32 │ + → → },
-      33 │ + → → {
-      34 │ + → → → "include":·["**/*.ts"],
-      35 │ + → → → "javascript":·{
-      36 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
-      37 │ + → → → },
-      38 │ + → → → "formatter":·{·"indentStyle":·"space"·}
-      39 │ + → → }
-      40 │ + → ]
-      41 │ + }
-      42 │ + 
+       4 │ + → → "useEditorconfig":·true,
+       5 │ + → → "formatWithErrors":·false,
+       6 │ + → → "indentStyle":·"space",
+       7 │ + → → "indentWidth":·2,
+       8 │ + → → "lineEnding":·"lf",
+       9 │ + → → "lineWidth":·80,
+      10 │ + → → "attributePosition":·"auto",
+      11 │ + → → "bracketSpacing":·true
+      12 │ + → },
+      13 │ + → "javascript":·{
+      14 │ + → → "formatter":·{
+      15 │ + → → → "jsxQuoteStyle":·"double",
+      16 │ + → → → "quoteProperties":·"asNeeded",
+      17 │ + → → → "trailingCommas":·"all",
+      18 │ + → → → "semicolons":·"asNeeded",
+      19 │ + → → → "arrowParentheses":·"always",
+      20 │ + → → → "bracketSameLine":·false,
+      21 │ + → → → "quoteStyle":·"single",
+      22 │ + → → → "attributePosition":·"auto",
+      23 │ + → → → "bracketSpacing":·true
+      24 │ + → → }
+      25 │ + → },
+      26 │ + → "overrides":·[
+      27 │ + → → {·"include":·["**/*.test.js"],·"formatter":·{·"indentStyle":·"space"·}·},
+      28 │ + → → {
+      29 │ + → → → "include":·["**/*.spec.js"],
+      30 │ + → → → "javascript":·{
+      31 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
+      32 │ + → → → }
+      33 │ + → → },
+      34 │ + → → {
+      35 │ + → → → "include":·["**/*.ts"],
+      36 │ + → → → "javascript":·{
+      37 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
+      38 │ + → → → },
+      39 │ + → → → "formatter":·{·"indentStyle":·"space"·}
+      40 │ + → → }
+      41 │ + → ]
+      42 │ + }
+      43 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_with_ignore.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_with_ignore.snap
@@ -38,31 +38,32 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
        1 │ + {
        2 │ + → "formatter":·{
        3 │ + → → "enabled":·true,
-       4 │ + → → "formatWithErrors":·false,
-       5 │ + → → "indentStyle":·"space",
-       6 │ + → → "indentWidth":·2,
-       7 │ + → → "lineEnding":·"lf",
-       8 │ + → → "lineWidth":·80,
-       9 │ + → → "attributePosition":·"auto",
-      10 │ + → → "bracketSpacing":·true,
-      11 │ + → → "ignore":·["dist/**",·"node_modules/**",·"generated/*.spec.js"]
-      12 │ + → },
-      13 │ + → "linter":·{·"enabled":·true·},
-      14 │ + → "javascript":·{
-      15 │ + → → "formatter":·{
-      16 │ + → → → "jsxQuoteStyle":·"double",
-      17 │ + → → → "quoteProperties":·"asNeeded",
-      18 │ + → → → "trailingCommas":·"all",
-      19 │ + → → → "semicolons":·"always",
-      20 │ + → → → "arrowParentheses":·"always",
-      21 │ + → → → "bracketSameLine":·false,
-      22 │ + → → → "quoteStyle":·"single",
-      23 │ + → → → "attributePosition":·"auto",
-      24 │ + → → → "bracketSpacing":·true
-      25 │ + → → }
-      26 │ + → }
-      27 │ + }
-      28 │ + 
+       4 │ + → → "useEditorconfig":·true,
+       5 │ + → → "formatWithErrors":·false,
+       6 │ + → → "indentStyle":·"space",
+       7 │ + → → "indentWidth":·2,
+       8 │ + → → "lineEnding":·"lf",
+       9 │ + → → "lineWidth":·80,
+      10 │ + → → "attributePosition":·"auto",
+      11 │ + → → "bracketSpacing":·true,
+      12 │ + → → "ignore":·["dist/**",·"node_modules/**",·"generated/*.spec.js"]
+      13 │ + → },
+      14 │ + → "linter":·{·"enabled":·true·},
+      15 │ + → "javascript":·{
+      16 │ + → → "formatter":·{
+      17 │ + → → → "jsxQuoteStyle":·"double",
+      18 │ + → → → "quoteProperties":·"asNeeded",
+      19 │ + → → → "trailingCommas":·"all",
+      20 │ + → → → "semicolons":·"always",
+      21 │ + → → → "arrowParentheses":·"always",
+      22 │ + → → → "bracketSameLine":·false,
+      23 │ + → → → "quoteStyle":·"single",
+      24 │ + → → → "attributePosition":·"auto",
+      25 │ + → → → "bracketSpacing":·true
+      26 │ + → → }
+      27 │ + → }
+      28 │ + }
+      29 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write.snap
@@ -8,6 +8,7 @@ expression: content
 {
   "formatter": {
     "enabled": true,
+    "useEditorconfig": true,
     "formatWithErrors": false,
     "indentStyle": "space",
     "indentWidth": 2,

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_biome_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_biome_jsonc.snap
@@ -8,6 +8,7 @@ expression: content
 {
   "formatter": {
     "enabled": true,
+    "useEditorconfig": true,
     "formatWithErrors": false,
     "indentStyle": "space",
     "indentWidth": 2,

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_packagejson.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_packagejson.snap
@@ -8,6 +8,7 @@ expression: content
 {
   "formatter": {
     "enabled": true,
+    "useEditorconfig": true,
     "formatWithErrors": false,
     "indentStyle": "space",
     "indentWidth": 2,

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_with_ignore_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_with_ignore_file.snap
@@ -8,6 +8,7 @@ expression: content
 {
   "formatter": {
     "enabled": true,
+    "useEditorconfig": true,
     "formatWithErrors": false,
     "indentStyle": "space",
     "indentWidth": 2,

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettierjson_migrate_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettierjson_migrate_write.snap
@@ -8,6 +8,7 @@ expression: content
 {
   "formatter": {
     "enabled": true,
+    "useEditorconfig": true,
     "formatWithErrors": false,
     "indentStyle": "space",
     "indentWidth": 2,

--- a/crates/biome_configuration/src/diagnostics.rs
+++ b/crates/biome_configuration/src/diagnostics.rs
@@ -79,10 +79,26 @@ impl BiomeDiagnostic {
     ) -> Self {
         Self::InvalidIgnorePattern(InvalidIgnorePattern {
             message: format!(
-                "Couldn't parse the {}, reason: {}",
+                "Couldn't parse the pattern \"{}\". Reason: {}",
                 pattern.into(),
                 reason.into()
             ),
+            file_path: None,
+        })
+    }
+
+    pub fn new_invalid_ignore_pattern_with_path(
+        pattern: impl Into<String>,
+        reason: impl Into<String>,
+        file_path: Option<impl Into<String>>,
+    ) -> Self {
+        Self::InvalidIgnorePattern(InvalidIgnorePattern {
+            message: format!(
+                "Couldn't parse the pattern \"{}\". Reason: {}",
+                pattern.into(),
+                reason.into()
+            ),
+            file_path: file_path.map(|f| f.into()),
         })
     }
 
@@ -161,6 +177,9 @@ pub struct InvalidIgnorePattern {
     #[message]
     #[description]
     pub message: String,
+
+    #[location(resource)]
+    pub file_path: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]

--- a/crates/biome_configuration/src/editorconfig.rs
+++ b/crates/biome_configuration/src/editorconfig.rs
@@ -54,12 +54,13 @@ impl EditorConfig {
             .into_iter()
             .map(|(k, v)| {
                 let patterns = match expand_unknown_glob_patterns(&k) {
-                    Ok(patterns) => patterns,
+                    Ok(patterns) => patterns.into_iter().map(hack_convert_double_star).collect(),
                     Err(err) => {
                         errors.push(err);
                         vec![k]
                     }
                 };
+
                 OverridePattern {
                     include: Some(patterns.into_iter().collect()),
                     formatter: Some(v.to_biome_override()),
@@ -306,6 +307,24 @@ fn expand_unknown_glob_patterns(pattern: &str) -> Result<Vec<String>, EditorConf
     Ok(expanded_patterns)
 }
 
+/// The EditorConfig spec allows for patterns like `**.yml`, which is not supported by biome. This function corrects such patterns so that they can be parsed by biome's glob parser.
+fn hack_convert_double_star(pattern: impl Into<String>) -> String {
+    pattern
+        .into()
+        .split('/')
+        .map(|component| {
+            if component == "**" {
+                component.to_string()
+            } else if component.contains("**") {
+                component.replace("**", "**/*")
+            } else {
+                component.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -433,5 +452,16 @@ insert_final_newline = false
             expanded,
             vec!["**/bar.1.js", "**/bar.2.js", "**/bar.3.js", "**/bar.4.js",]
         );
+    }
+
+    #[test]
+    fn should_correct_double_star() {
+        let pattern = "**.yml";
+        let corrected = hack_convert_double_star(pattern);
+        assert_eq!(corrected, "**/*.yml",);
+
+        let pattern = "**/*.yml";
+        let corrected = hack_convert_double_star(pattern);
+        assert_eq!(corrected, "**/*.yml",);
     }
 }

--- a/crates/biome_configuration/src/formatter.rs
+++ b/crates/biome_configuration/src/formatter.rs
@@ -17,6 +17,10 @@ pub struct FormatterConfiguration {
     #[partial(bpaf(hide))]
     pub enabled: bool,
 
+    #[partial(bpaf(long("use-editorconfig"), argument("true|false"), optional))]
+    /// Use any `.editorconfig` files to configure the formatter. Configuration in `biome.json` will override `.editorconfig` configuration. Default: false.
+    pub use_editorconfig: bool,
+
     /// Stores whether formatting should be allowed to proceed if a given file
     /// has syntax errors
     #[partial(bpaf(hide))]
@@ -80,6 +84,7 @@ impl PartialFormatterConfiguration {
             bracket_spacing: self.bracket_spacing.unwrap_or_default(),
             ignore: self.ignore.clone().unwrap_or_default(),
             include: self.include.clone().unwrap_or_default(),
+            use_editorconfig: self.use_editorconfig.unwrap_or_default(),
         }
     }
 }
@@ -98,6 +103,8 @@ impl Default for FormatterConfiguration {
             bracket_spacing: Default::default(),
             ignore: Default::default(),
             include: Default::default(),
+            // TODO: Biome 2.0: change to true
+            use_editorconfig: Default::default(),
         }
     }
 }

--- a/crates/biome_service/tests/invalid/formatter_extraneous_field.json.snap
+++ b/crates/biome_service/tests/invalid/formatter_extraneous_field.json.snap
@@ -16,6 +16,7 @@ formatter_extraneous_field.json:3:3 deserialize ━━━━━━━━━━�
   i Known keys:
   
   - enabled
+  - useEditorconfig
   - formatWithErrors
   - indentStyle
   - indentWidth

--- a/crates/biome_service/tests/invalid/formatter_quote_style.json.snap
+++ b/crates/biome_service/tests/invalid/formatter_quote_style.json.snap
@@ -16,6 +16,7 @@ formatter_quote_style.json:3:9 deserialize ━━━━━━━━━━━━�
   i Known keys:
   
   - enabled
+  - useEditorconfig
   - formatWithErrors
   - indentStyle
   - indentWidth

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -160,6 +160,10 @@ export interface PartialFormatterConfiguration {
 	 * What's the max width of a line. Defaults to 80.
 	 */
 	lineWidth?: LineWidth;
+	/**
+	 * Use any `.editorconfig` files to configure the formatter. Configuration in `biome.json` will override `.editorconfig` configuration. Default: false.
+	 */
+	useEditorconfig?: boolean;
 }
 /**
  * Options applied to GraphQL files

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1150,6 +1150,10 @@
 				"lineWidth": {
 					"description": "What's the max width of a line. Defaults to 80.",
 					"anyOf": [{ "$ref": "#/definitions/LineWidth" }, { "type": "null" }]
+				},
+				"useEditorconfig": {
+					"description": "Use any `.editorconfig` files to configure the formatter. Configuration in `biome.json` will override `.editorconfig` configuration. Default: false.",
+					"type": ["boolean", "null"]
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR reenables editorconfig support, and additionally adds a cli flag, `--use-editorconfig`, to control whether or not it's enabled.
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
related to: #1724
- [x] blocked by: #3260 

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
I've reenabled the unit tests that I wrote for this.
