### PR TITLE
chore(grit): implement node-like compilers + fixes

### DIFF
--- a/crates/biome_grit_patterns/src/grit_context.rs
+++ b/crates/biome_grit_patterns/src/grit_context.rs
@@ -8,11 +8,13 @@ use crate::grit_target_node::GritTargetNode;
 use crate::grit_tree::GritTargetTree;
 use anyhow::Result;
 use grit_pattern_matcher::context::{ExecContext, QueryContext};
-use grit_pattern_matcher::file_owners::FileOwners;
+use grit_pattern_matcher::file_owners::{FileOwner, FileOwners};
 use grit_pattern_matcher::pattern::{
     CallBuiltIn, GritFunctionDefinition, Pattern, PatternDefinition, PredicateDefinition, State,
 };
-use grit_util::AnalysisLogs;
+use grit_util::{AnalysisLogs, FileOrigin};
+use path_absolutize::Absolutize;
+use std::path::PathBuf;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct GritQueryContext;
@@ -21,7 +23,7 @@ impl QueryContext for GritQueryContext {
     type Node<'a> = GritTargetNode<'a>;
     type NodePattern = GritNodePattern;
     type LeafNodePattern = GritLeafNodePattern;
-    type ExecContext<'a> = GritExecContext;
+    type ExecContext<'a> = GritExecContext<'a>;
     type Binding<'a> = GritBinding<'a>;
     type CodeSnippet = GritCodeSnippet;
     type ResolvedPattern<'a> = GritResolvedPattern<'a>;
@@ -30,32 +32,47 @@ impl QueryContext for GritQueryContext {
     type Tree<'a> = GritTargetTree;
 }
 
-#[derive(Debug)]
-pub struct GritExecContext {
+pub struct GritExecContext<'a> {
     lang: GritTargetLanguage,
+    loadable_files: &'a [GritTargetFile],
+    files: &'a FileOwners<GritTargetTree>,
+    functions: Vec<GritFunctionDefinition<GritQueryContext>>,
+    patterns: Vec<PatternDefinition<GritQueryContext>>,
+    predicates: Vec<PredicateDefinition<GritQueryContext>>,
 }
 
-impl GritExecContext {
-    pub fn new(lang: GritTargetLanguage) -> Self {
-        Self { lang }
+impl<'a> GritExecContext<'a> {
+    pub fn new(
+        lang: GritTargetLanguage,
+        loadable_files: &'a [GritTargetFile],
+        files: &'a FileOwners<GritTargetTree>,
+    ) -> Self {
+        Self {
+            lang,
+            loadable_files,
+            files,
+            functions: Vec::new(),
+            patterns: Vec::new(),
+            predicates: Vec::new(),
+        }
     }
 }
 
-impl<'a> ExecContext<'a, GritQueryContext> for GritExecContext {
+impl<'a> ExecContext<'a, GritQueryContext> for GritExecContext<'a> {
     fn pattern_definitions(&self) -> &[PatternDefinition<GritQueryContext>] {
-        todo!()
+        &self.patterns
     }
 
     fn predicate_definitions(&self) -> &[PredicateDefinition<GritQueryContext>] {
-        todo!()
+        &self.predicates
     }
 
     fn function_definitions(&self) -> &[GritFunctionDefinition<GritQueryContext>] {
-        todo!()
+        &self.functions
     }
 
     fn ignore_limit_pattern(&self) -> bool {
-        todo!()
+        false
     }
 
     fn call_built_in(
@@ -65,11 +82,11 @@ impl<'a> ExecContext<'a, GritQueryContext> for GritExecContext {
         _state: &mut State<'a, GritQueryContext>,
         _logs: &mut AnalysisLogs,
     ) -> Result<GritResolvedPattern<'a>> {
-        todo!()
+        unimplemented!("built-in functions are still TODO")
     }
 
     fn files(&self) -> &FileOwners<GritTargetTree> {
-        todo!()
+        self.files
     }
 
     fn language(&self) -> &GritTargetLanguage {
@@ -92,10 +109,68 @@ impl<'a> ExecContext<'a, GritQueryContext> for GritExecContext {
 
     fn load_file(
         &self,
-        _file: &<GritQueryContext as QueryContext>::File<'a>,
-        _state: &mut State<'a, GritQueryContext>,
-        _logs: &mut AnalysisLogs,
+        file: &GritFile<'a>,
+        state: &mut State<'a, GritQueryContext>,
+        logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        todo!()
+        match file {
+            GritFile::Resolved(_) => {
+                // Assume the file is already loaded
+            }
+            GritFile::Ptr(ptr) => {
+                if state.files.is_loaded(ptr) {
+                    return Ok(true);
+                }
+
+                let index = ptr.file;
+                let file = &self.loadable_files[index as usize];
+
+                // TODO: Verify the workspace's maximum file size.
+
+                let file = file_owner_from_matches(&file.path, &file.content, &self.lang, logs)?;
+                if let Some(file) = file {
+                    self.files.push(file);
+                    state.files.load_file(ptr, self.files.last().unwrap());
+                }
+            }
+        }
+        Ok(true)
     }
+}
+
+fn file_owner_from_matches(
+    name: impl Into<PathBuf>,
+    source: &str,
+    language: &GritTargetLanguage,
+    logs: &mut AnalysisLogs,
+) -> Result<Option<FileOwner<GritTargetTree>>> {
+    let name = name.into();
+
+    let Some(tree) = language
+        .get_parser()
+        .parse_file(source, Some(&name), logs, FileOrigin::Fresh)
+    else {
+        return Ok(None);
+    };
+
+    let absolute_path = name.absolutize()?.to_path_buf();
+    Ok(Some(FileOwner {
+        name,
+        absolute_path,
+        tree,
+        matches: Default::default(),
+        new: false,
+    }))
+}
+
+/// Simple wrapper for target files so that we can avoid doing file I/O inside
+/// the Grit engine.
+///
+/// This should suffice as long as we only do single-file queries, but when we
+/// want to support multifile queries, we probably need to implement a solution
+/// that can use the Biome workspace.
+#[derive(Clone, Debug)]
+pub struct GritTargetFile {
+    pub path: PathBuf,
+    pub content: String,
 }

--- a/crates/biome_grit_patterns/src/grit_node_patterns.rs
+++ b/crates/biome_grit_patterns/src/grit_node_patterns.rs
@@ -20,11 +20,14 @@ impl AstNodePattern<GritQueryContext> for GritNodePattern {
     const INCLUDES_TRIVIA: bool = true;
 
     fn children(&self) -> Vec<PatternOrPredicate<GritQueryContext>> {
-        todo!()
+        self.args
+            .iter()
+            .map(|arg| PatternOrPredicate::Pattern(&arg.pattern))
+            .collect()
     }
 
-    fn matches_kind_of(&self, _node: &GritTargetNode) -> bool {
-        todo!()
+    fn matches_kind_of(&self, node: &GritTargetNode) -> bool {
+        self.kind == node.kind()
     }
 }
 
@@ -108,8 +111,8 @@ impl PatternName for GritNodePattern {
 
 #[derive(Clone, Debug)]
 pub struct GritNodePatternArg {
-    slot_index: u32,
-    pattern: Pattern<GritQueryContext>,
+    pub slot_index: u32,
+    pub pattern: Pattern<GritQueryContext>,
 }
 
 impl GritNodePatternArg {
@@ -145,12 +148,20 @@ impl AstLeafNodePattern<GritQueryContext> for GritLeafNodePattern {
 impl Matcher<GritQueryContext> for GritLeafNodePattern {
     fn execute<'a>(
         &'a self,
-        _binding: &GritResolvedPattern,
+        binding: &GritResolvedPattern,
         _state: &mut State<'a, GritQueryContext>,
         _context: &'a GritExecContext,
         _logs: &mut AnalysisLogs,
     ) -> Result<bool> {
-        todo!()
+        let Some(node) = binding.get_last_binding().and_then(Binding::singleton) else {
+            return Ok(false);
+        };
+        // TODO: Implement leaf node normalization.
+        if self.kind != node.kind() {
+            Ok(false)
+        } else {
+            Ok(node.text() == self.text)
+        }
     }
 }
 

--- a/crates/biome_grit_patterns/src/grit_query.rs
+++ b/crates/biome_grit_patterns/src/grit_query.rs
@@ -1,5 +1,5 @@
 use crate::diagnostics::CompilerDiagnostic;
-use crate::grit_context::{GritExecContext, GritQueryContext};
+use crate::grit_context::{GritExecContext, GritQueryContext, GritTargetFile};
 use crate::grit_resolved_pattern::GritResolvedPattern;
 use crate::grit_target_language::GritTargetLanguage;
 use crate::grit_tree::GritTargetTree;
@@ -9,12 +9,29 @@ use crate::pattern_compiler::{
 };
 use crate::variables::{VarRegistry, VariableLocations};
 use crate::CompileError;
+use anyhow::bail;
 use anyhow::Result;
 use biome_grit_syntax::{GritRoot, GritRootExt};
-use grit_pattern_matcher::effects::Effect;
-use grit_pattern_matcher::pattern::{FileRegistry, Matcher, Pattern, State};
+use grit_pattern_matcher::binding::Binding;
+use grit_pattern_matcher::constants::{
+    ABSOLUTE_PATH_INDEX, FILENAME_INDEX, NEW_FILES_INDEX, PROGRAM_INDEX,
+};
+use grit_pattern_matcher::file_owners::{FileOwner, FileOwners};
+use grit_pattern_matcher::pattern::{
+    FilePtr, FileRegistry, Matcher, Pattern, ResolvedPattern, State, VariableSourceLocations,
+};
+use grit_util::{Ast, ByteRange, InputRanges, Range, VariableMatch};
 use im::Vector;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+// These need to remain ordered by index.
+const GLOBAL_VARS: [(&str, usize); 4] = [
+    ("$new_files", NEW_FILES_INDEX),
+    ("$program", PROGRAM_INDEX),
+    ("$filename", FILENAME_INDEX),
+    ("$absolute_filename", ABSOLUTE_PATH_INDEX),
+];
 
 /// Represents a top-level Grit query.
 ///
@@ -25,38 +42,68 @@ pub struct GritQuery {
     /// Diagnostics discovered during compilation of the query.
     pub diagnostics: Vec<CompilerDiagnostic>,
 
-    /// Context for executing the query.
-    context: GritExecContext,
+    /// Target language for the query.
+    language: GritTargetLanguage,
 
     /// All variables discovered during query compilation.
-    variables: VariableLocations,
+    variable_locations: VariableLocations,
 }
 
 impl GritQuery {
-    pub fn execute<'a>(
-        &'a self,
-        tree: &'a GritTargetTree,
-    ) -> Result<Vector<Effect<'a, GritQueryContext>>> {
-        let var_registry = VarRegistry::from_locations(&self.variables);
+    pub fn execute(&self, file: GritTargetFile) -> Result<Vec<GritQueryResult>> {
+        let file_owners = FileOwners::new();
+        let files = vec![file];
+        let file_ptr = FilePtr::new(0, 0);
+        let context = GritExecContext::new(self.language.clone(), &files, &file_owners);
 
-        let binding = GritResolvedPattern::from_tree(tree);
-        let mut state = State::new(
-            var_registry.into(),
-            FileRegistry::new_from_paths(Vec::new()),
-        );
+        let var_registry = VarRegistry::from_locations(&self.variable_locations);
+
+        let file_registry =
+            FileRegistry::new_from_paths(files.iter().map(|file| &file.path).collect());
+        let binding = FilePattern::Single(file_ptr);
+
+        let mut state = State::new(var_registry.into(), file_registry);
         let mut logs = Vec::new().into();
 
-        self.pattern
-            .execute(&binding, &mut state, &self.context, &mut logs)?;
+        let mut results: Vec<GritQueryResult> = Vec::new();
+        if self
+            .pattern
+            .execute(&binding.into(), &mut state, &context, &mut logs)?
+        {
+            for file in state.files.files() {
+                if let Some(result) = GritQueryResult::from_file(file)? {
+                    results.push(result)
+                }
+            }
+            results.extend(results_from_bindings_history(
+                &files[0].path,
+                &state,
+                &self.language,
+            ));
+        }
 
-        Ok(state.effects)
+        Ok(results)
     }
 
-    pub fn from_node(root: GritRoot, lang: GritTargetLanguage) -> Result<Self, CompileError> {
-        let context = CompilationContext::new_anonymous(lang);
+    pub fn from_node(
+        root: GritRoot,
+        source_path: &Path,
+        lang: GritTargetLanguage,
+    ) -> Result<Self, CompileError> {
+        let context = CompilationContext::new(source_path, lang);
 
-        let mut vars_array = Vec::new();
-        let mut global_vars = BTreeMap::new();
+        let mut vars_array = vec![GLOBAL_VARS
+            .iter()
+            .map(|global_var| VariableSourceLocations {
+                name: global_var.0.to_string(),
+                file: source_path.to_string_lossy().into_owned(),
+                locations: BTreeSet::new(),
+            })
+            .collect::<Vec<VariableSourceLocations>>()];
+        let mut global_vars: BTreeMap<String, usize> = GLOBAL_VARS
+            .iter()
+            .map(|(global_var, index)| ((*global_var).to_string(), *index))
+            .collect();
         let mut diagnostics = Vec::new();
 
         // We're not in a local scope yet, so this map is kinda useless.
@@ -76,14 +123,221 @@ impl GritQuery {
             &mut node_context,
         )?;
 
-        let context = GritExecContext::new(context.lang);
-        let locations = VariableLocations::new(vars_array);
+        let language = context.lang;
+        let variable_locations = VariableLocations::new(vars_array);
 
         Ok(Self {
             pattern,
-            context,
+            language,
             diagnostics,
-            variables: locations,
+            variable_locations,
         })
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GritQueryResult {
+    Match(Match),
+    Rewrite(Rewrite),
+    CreateFile(CreateFile),
+}
+
+impl GritQueryResult {
+    pub fn from_file(file: &Vector<&FileOwner<GritTargetTree>>) -> anyhow::Result<Option<Self>> {
+        if file.is_empty() {
+            bail!("cannot have file with no versions")
+        }
+
+        let result = if file.len() == 1 {
+            let file = file.last().unwrap();
+            if file.new {
+                Some(GritQueryResult::CreateFile(CreateFile::new(
+                    &file.name,
+                    &file.tree.source(),
+                )))
+            } else if let Some(ranges) = &file.matches.borrow().input_matches {
+                if ranges.suppressed {
+                    None
+                } else {
+                    Some(GritQueryResult::Match(Match::from_file_ranges(
+                        ranges, &file.name,
+                    )))
+                }
+            } else {
+                None
+            }
+        } else {
+            Some(GritQueryResult::Rewrite(Rewrite::from_file(
+                file.front().unwrap(),
+                file.back().unwrap(),
+            )?))
+        };
+
+        Ok(result)
+    }
+}
+enum FilePattern {
+    Single(FilePtr),
+    Many(Vec<FilePtr>),
+}
+
+impl From<FilePtr> for FilePattern {
+    fn from(file: FilePtr) -> Self {
+        Self::Single(file)
+    }
+}
+
+impl From<Vec<FilePtr>> for FilePattern {
+    fn from(files: Vec<FilePtr>) -> Self {
+        Self::Many(files)
+    }
+}
+
+impl From<FilePattern> for GritResolvedPattern<'_> {
+    fn from(val: FilePattern) -> Self {
+        match val {
+            FilePattern::Single(file) => Self::from_file_pointer(file),
+            FilePattern::Many(files) => Self::from_files(Self::from_list_parts(
+                files.into_iter().map(Self::from_file_pointer),
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Match {
+    pub messages: Vec<Message>,
+    pub variables: Vec<VariableMatch>,
+    pub source_file: PathBuf,
+    pub ranges: Vec<Range>,
+}
+
+impl Match {
+    fn from_file_ranges(match_ranges: &InputRanges, path: &Path) -> Self {
+        Self {
+            source_file: path.to_owned(),
+            ranges: match_ranges.ranges.clone(),
+            variables: match_ranges.variables.clone(),
+            messages: vec![],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Rewrite {
+    pub original: Match,
+    pub rewritten: OutputFile,
+}
+
+impl From<Rewrite> for GritQueryResult {
+    fn from(value: Rewrite) -> Self {
+        GritQueryResult::Rewrite(value)
+    }
+}
+
+impl Rewrite {
+    fn new(original: Match, rewritten: OutputFile) -> Self {
+        Self {
+            original,
+            rewritten,
+        }
+    }
+
+    fn from_file(
+        initial: &FileOwner<GritTargetTree>,
+        rewritten_file: &FileOwner<GritTargetTree>,
+    ) -> anyhow::Result<Self> {
+        let original = if let Some(ranges) = &initial.matches.borrow().input_matches {
+            Match::from_file_ranges(ranges, &initial.name)
+        } else {
+            bail!("cannot have rewrite without matches")
+        };
+        let rewritten = OutputFile::from_file(rewritten_file);
+        Ok(Rewrite::new(original, rewritten))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreateFile {
+    pub rewritten: OutputFile,
+    range: Option<Vec<Range>>,
+}
+
+impl From<CreateFile> for GritQueryResult {
+    fn from(value: CreateFile) -> Self {
+        GritQueryResult::CreateFile(value)
+    }
+}
+
+impl CreateFile {
+    fn new(path: &Path, body: &str) -> Self {
+        CreateFile {
+            rewritten: OutputFile::new(path, body, None),
+            range: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct OutputFile {
+    pub messages: Vec<Message>,
+    pub variables: Vec<VariableMatch>,
+    pub source_file: PathBuf,
+    pub content: String,
+    pub byte_ranges: Option<Vec<ByteRange>>,
+}
+
+impl OutputFile {
+    fn new(name: &Path, body: &str, byte_range: Option<&[ByteRange]>) -> Self {
+        Self {
+            source_file: name.to_owned(),
+            content: body.to_owned(),
+            variables: Vec::new(),
+            messages: Vec::new(),
+            byte_ranges: byte_range.map(|range| range.to_vec()),
+        }
+    }
+
+    fn from_file(file: &FileOwner<GritTargetTree>) -> Self {
+        Self::new(
+            &file.name,
+            &file.tree.source(),
+            file.matches.borrow().byte_ranges.as_deref(),
+        )
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Message {
+    pub message: String,
+    pub range: Vec<Range>,
+    pub variable_runtime_id: String,
+}
+
+fn results_from_bindings_history(
+    path: &Path,
+    state: &State<GritQueryContext>,
+    language: &GritTargetLanguage,
+) -> Vec<GritQueryResult> {
+    println!("{state:#?}");
+    let mut results = Vec::new();
+    for scope in state.bindings.iter() {
+        for content in scope.last().unwrap().iter() {
+            for value in content.value_history.iter() {
+                if let Some(bindings) = value.get_bindings() {
+                    for binding in bindings {
+                        if let Some(range) = binding.position(language) {
+                            results.push(GritQueryResult::Match(Match {
+                                messages: Vec::new(),
+                                source_file: path.to_path_buf(),
+                                ranges: vec![range],
+                                variables: Vec::new(),
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    results
 }

--- a/crates/biome_grit_patterns/src/grit_resolved_pattern.rs
+++ b/crates/biome_grit_patterns/src/grit_resolved_pattern.rs
@@ -11,8 +11,8 @@ use grit_pattern_matcher::constant::Constant;
 use grit_pattern_matcher::context::{ExecContext, QueryContext};
 use grit_pattern_matcher::effects::Effect;
 use grit_pattern_matcher::pattern::{
-    Accessor, DynamicPattern, DynamicSnippet, DynamicSnippetPart, FilePtr, FileRegistry, GritCall,
-    ListIndex, Pattern, PatternName, PatternOrResolved, ResolvedFile, ResolvedPattern,
+    Accessor, DynamicPattern, DynamicSnippet, DynamicSnippetPart, File, FilePtr, FileRegistry,
+    GritCall, ListIndex, Pattern, PatternName, PatternOrResolved, ResolvedFile, ResolvedPattern,
     ResolvedSnippet, State,
 };
 use grit_util::{AnalysisLogs, Ast, CodeRange, Range};
@@ -531,7 +531,12 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
                 .into()),
             GritResolvedPattern::List(_) => todo!(),
             GritResolvedPattern::Map(_) => todo!(),
-            GritResolvedPattern::File(_) => todo!(),
+            GritResolvedPattern::File(file) => Ok(format!(
+                "{}:\n{}",
+                file.name(state).text(state, language)?,
+                file.body(state).text(state, language)?
+            )
+            .into()),
             GritResolvedPattern::Files(_) => todo!(),
             GritResolvedPattern::Constant(_) => todo!(),
         }

--- a/crates/biome_grit_patterns/src/grit_target_language.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language.rs
@@ -35,9 +35,27 @@ macro_rules! generate_target_language {
                 }
             }
 
-            fn get_parser(&self) -> Box<dyn Parser<Tree = GritTargetTree>> {
+            pub fn get_parser(&self) -> Box<dyn Parser<Tree = GritTargetTree>> {
                 match self {
                     $(Self::$language(_) => Box::new($parser)),+
+                }
+            }
+
+            pub fn kind_by_name(&self, name: &str) -> Option<GritTargetSyntaxKind> {
+                match self {
+                    $(Self::$language(lang) => lang.kind_by_name(name).map(Into::into)),+
+                }
+            }
+
+            pub fn name_for_kind(&self, name: GritTargetSyntaxKind) -> &'static str {
+                match self {
+                    $(Self::$language(lang) => lang.name_for_kind(name)),+
+                }
+            }
+
+            pub fn named_slots_for_kind(&self, kind: GritTargetSyntaxKind) -> &'static [(&'static str, u32)] {
+                match self {
+                    $(Self::$language(lang) => lang.named_slots_for_kind(kind)),+
                 }
             }
 
@@ -159,6 +177,31 @@ trait GritTargetLanguageImpl {
     type Kind: SyntaxKind;
 
     fn language_name(&self) -> &'static str;
+
+    /// Returns the syntax kind for a node by name.
+    ///
+    /// This is the inverse of [Self::name_for_kind()].
+    ///
+    /// For compatibility with existing Grit snippets (as well as the online
+    /// Grit playground), node names should be aligned with TreeSitter's
+    /// `ts_language_symbol_for_name()`.
+    fn kind_by_name(&self, node_name: &str) -> Option<Self::Kind>;
+
+    /// Returns the node name for a given syntax kind.
+    ///
+    /// This is the inverse of [Self::kind_by_name()].
+    ///
+    /// For compatibility with existing Grit snippets (as well as the online
+    /// Grit playground), node names should be aligned with TreeSitter's
+    /// `ts_language_symbol_name()`.
+    fn name_for_kind(&self, kind: GritTargetSyntaxKind) -> &'static str;
+
+    /// Returns the slots with their names for the given node kind.
+    ///
+    /// For compatibility with existing Grit snippets (as well as the online
+    /// Grit playground), node names should be aligned with TreeSitter's
+    /// `ts_language_field_name_for_id()`.
+    fn named_slots_for_kind(&self, kind: GritTargetSyntaxKind) -> &'static [(&'static str, u32)];
 
     /// Strings that provide context for parsing snippets.
     ///

--- a/crates/biome_grit_patterns/src/grit_target_language/js_target_language.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language/js_target_language.rs
@@ -16,6 +16,70 @@ impl GritTargetLanguageImpl for JsTargetLanguage {
         "JavaScript"
     }
 
+    /// Returns the syntax kind for a node by name.
+    ///
+    /// For compatibility with existing Grit snippets (as well as the online
+    /// Grit playground), node names should be aligned with TreeSitter's
+    /// `ts_language_symbol_for_name()`.
+    fn kind_by_name(&self, node_name: &str) -> Option<JsSyntaxKind> {
+        use JsSyntaxKind::*;
+        let kind = match node_name {
+            "assignment_expression" => JS_ASSIGNMENT_EXPRESSION,
+            "call_expression" => JS_CALL_EXPRESSION,
+            "new_expression" => JS_NEW_EXPRESSION,
+            // TODO: Many more of these. We should probably find a way to
+            // generate these impls from TS `grammar.js` files, combined with
+            // our `js.ungram`.
+            _ => return None,
+        };
+
+        Some(kind)
+    }
+
+    /// Returns the node name for a given syntax kind.
+    ///
+    /// For compatibility with existing Grit snippets (as well as the online
+    /// Grit playground), node names should be aligned with TreeSitter's
+    /// `ts_language_symbol_name()`.
+    fn name_for_kind(&self, kind: GritTargetSyntaxKind) -> &'static str {
+        let Some(kind) = kind.as_js_kind() else {
+            return "(unexpected language)";
+        };
+
+        use JsSyntaxKind::*;
+        match kind {
+            JS_ASSIGNMENT_EXPRESSION => "assignment_expression",
+            JS_CALL_EXPRESSION => "call_expression",
+            JS_NEW_EXPRESSION => "new_expression",
+            // TODO: Many more of these. We should probably find a way to
+            // generate these impls from TS `grammar.js` files, combined with
+            // our `js.ungram`.
+            _ => "(unknown node)",
+        }
+    }
+
+    /// Returns the slots with their names for the given node kind.
+    ///
+    /// For compatibility with existing Grit snippets (as well as the online
+    /// Grit playground), node names should be aligned with TreeSitter's
+    /// `ts_language_field_name_for_id()`.
+    fn named_slots_for_kind(&self, kind: GritTargetSyntaxKind) -> &'static [(&'static str, u32)] {
+        let Some(kind) = kind.as_js_kind() else {
+            return &[];
+        };
+
+        use JsSyntaxKind::*;
+        match kind {
+            JS_ASSIGNMENT_EXPRESSION => &[],
+            JS_CALL_EXPRESSION => &[("function", 0), ("type_arguments", 2), ("arguments", 3)],
+            JS_NEW_EXPRESSION => &[],
+            // TODO: Many more of these. We should probably find a way to
+            // generate these impls from TS `grammar.js` files, combined with
+            // our `js.ungram`.
+            _ => &[],
+        }
+    }
+
     fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
         &[
             ("", ""),

--- a/crates/biome_grit_patterns/src/grit_target_node.rs
+++ b/crates/biome_grit_patterns/src/grit_target_node.rs
@@ -1,4 +1,5 @@
-use crate::{util::TextRangeGritExt, GritTargetTree};
+use crate::grit_tree::GritTargetTree;
+use crate::util::TextRangeGritExt;
 use biome_js_syntax::{JsSyntaxKind, JsSyntaxNode, JsSyntaxToken};
 use biome_rowan::{NodeOrToken, SyntaxKind, SyntaxSlot, TextRange};
 use grit_util::{AstCursor, AstNode as GritAstNode, ByteRange, CodeRange};
@@ -243,13 +244,18 @@ impl<'a> GritTargetNode<'a> {
     }
 
     #[inline]
+    pub fn source(&self) -> &'a str {
+        self.tree.text()
+    }
+
+    #[inline]
     pub fn start_byte(&self) -> u32 {
         self.text_trimmed_range().start().into()
     }
 
     pub fn text(&self) -> &'a str {
         let trimmed_range = self.text_trimmed_range();
-        &self.tree.text()[trimmed_range.start().into()..trimmed_range.end().into()]
+        &self.source()[trimmed_range.start().into()..trimmed_range.end().into()]
     }
 }
 

--- a/crates/biome_grit_patterns/src/lib.rs
+++ b/crates/biome_grit_patterns/src/lib.rs
@@ -20,17 +20,19 @@ mod util;
 mod variables;
 
 pub use errors::*;
+pub use grit_context::GritTargetFile;
 pub use grit_query::GritQuery;
 pub use grit_target_language::{GritTargetLanguage, JsTargetLanguage};
-pub use grit_tree::GritTargetTree;
 
 use biome_grit_parser::parse_grit;
+use std::path::Path;
 
 /// Compiles a Grit pattern from the given source string.
 pub fn compile_pattern(
     source: &str,
+    path: &Path,
     language: GritTargetLanguage,
 ) -> Result<GritQuery, CompileError> {
     let parsed = parse_grit(source);
-    GritQuery::from_node(parsed.tree(), language)
+    GritQuery::from_node(parsed.tree(), path, language)
 }

--- a/crates/biome_grit_patterns/src/pattern_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler.rs
@@ -31,6 +31,7 @@ mod assignment_compiler;
 mod auto_wrap;
 mod before_compiler;
 mod bubble_compiler;
+mod call_compiler;
 mod container_compiler;
 mod contains_compiler;
 mod divide_compiler;
@@ -49,8 +50,10 @@ mod match_compiler;
 mod maybe_compiler;
 mod modulo_compiler;
 mod multiply_compiler;
+mod node_like_compiler;
 mod not_compiler;
 mod or_compiler;
+mod predicate_call_compiler;
 mod predicate_compiler;
 mod predicate_return_compiler;
 mod rewrite_compiler;
@@ -83,6 +86,7 @@ use crate::{grit_context::GritQueryContext, CompileError};
 use biome_grit_syntax::{AnyGritMaybeCurlyPattern, AnyGritPattern, GritSyntaxKind};
 use biome_rowan::AstNode as _;
 use grit_pattern_matcher::pattern::{DynamicPattern, DynamicSnippet, DynamicSnippetPart, Pattern};
+use node_like_compiler::NodeLikeCompiler;
 
 pub(crate) struct PatternCompiler;
 
@@ -156,7 +160,9 @@ impl PatternCompiler {
             AnyGritPattern::GritMulOperation(node) => Ok(Pattern::Multiply(Box::new(
                 MultiplyCompiler::from_node(node, context)?,
             ))),
-            AnyGritPattern::GritNodeLike(_) => todo!(),
+            AnyGritPattern::GritNodeLike(node) => {
+                NodeLikeCompiler::from_node_with_rhs(node, context, is_rhs)
+            }
             AnyGritPattern::GritPatternAccumulate(node) => Ok(Pattern::Accumulate(Box::new(
                 AccumulateCompiler::from_node(node, context)?,
             ))),

--- a/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
@@ -1,0 +1,186 @@
+use super::{compilation_context::NodeCompilationContext, PatternCompiler};
+use crate::{grit_context::GritQueryContext, CompileError, NodeLikeArgumentError};
+use biome_grit_syntax::{
+    AnyGritMaybeNamedArg, AnyGritPattern, GritNamedArgList, GritNodeLike, GritSyntaxKind,
+};
+use biome_rowan::{AstNode, TextRange};
+use grit_pattern_matcher::pattern::{Call, CallFunction, FilePattern, Pattern};
+use grit_util::Language;
+use std::collections::BTreeMap;
+
+const VALID_FILE_ARGS: &[&str] = &["$name", "$body"];
+
+/// Takes a parsed Grit CST node for node-like syntax (`foo()`) and creates a
+/// node pattern.
+pub(super) fn call_pattern_from_node_with_name(
+    node: &GritNodeLike,
+    name: String,
+    context: &mut NodeCompilationContext,
+) -> Result<Pattern<GritQueryContext>, CompileError> {
+    let named_args = named_args_from_node(node, &name, context)?;
+    let mut args = named_args_to_map(named_args, context)?;
+    let named_args_count = node.named_args().into_iter().count();
+    if args.len() != named_args_count {
+        return Err(NodeLikeArgumentError::DuplicateArguments { name }.into());
+    }
+
+    let lang = &context.compilation.lang;
+    if name == "file" {
+        for arg in &args {
+            if !VALID_FILE_ARGS.contains(&arg.0.as_str()) {
+                return Err(NodeLikeArgumentError::UnknownVariable {
+                    name,
+                    arg_name: arg.0.clone(),
+                    valid_vars: VALID_FILE_ARGS
+                        .iter()
+                        .map(|arg| (*arg).to_string())
+                        .collect(),
+                }
+                .into());
+            }
+        }
+
+        let name = args
+            .remove_entry("$name")
+            .map_or(Pattern::Underscore, |p| p.1);
+        let body = args.remove_entry("$body").map_or(Pattern::Top, |p| p.1);
+        Ok(Pattern::File(Box::new(FilePattern::new(name, body))))
+    } else if let Some(info) = context.compilation.function_definition_info.get(&name) {
+        let args = match_args_to_params(&name, args, &collect_params(&info.parameters), lang)?;
+        Ok(Pattern::CallFunction(Box::new(CallFunction::new(
+            info.index, args,
+        ))))
+    } else if let Some(info) = context.compilation.pattern_definition_info.get(&name) {
+        let args = match_args_to_params(&name, args, &collect_params(&info.parameters), lang)?;
+        Ok(Pattern::Call(Box::new(Call::new(info.index, args))))
+    } else {
+        Err(CompileError::UnknownFunctionOrPattern(name))
+    }
+}
+
+pub(super) fn collect_params(parameters: &[(String, TextRange)]) -> Vec<String> {
+    parameters.iter().map(|p| p.0.clone()).collect()
+}
+
+pub(super) fn match_args_to_params(
+    name: &str,
+    mut args: BTreeMap<String, Pattern<GritQueryContext>>,
+    params: &[String],
+    language: &impl Language,
+) -> Result<Vec<Option<Pattern<GritQueryContext>>>, CompileError> {
+    for arg_name in args.keys() {
+        if !params.contains(arg_name) {
+            Err(NodeLikeArgumentError::UnknownVariable {
+                name: name.to_string(),
+                arg_name: arg_name.clone(),
+                valid_vars: params
+                    .iter()
+                    .map(|p| p.strip_prefix(language.metavariable_prefix()).unwrap_or(p))
+                    .map(str::to_string)
+                    .collect(),
+            })?
+        }
+    }
+
+    Ok(params.iter().map(|param| args.remove(param)).collect())
+}
+
+pub(super) fn named_args_from_node(
+    node: &GritNodeLike,
+    name: &str,
+    context: &mut NodeCompilationContext,
+) -> Result<Vec<(String, AnyGritPattern)>, CompileError> {
+    let expected_params = if let Some(info) = context.compilation.function_definition_info.get(name)
+    {
+        Some(collect_params(&info.parameters))
+    } else {
+        context
+            .compilation
+            .pattern_definition_info
+            .get(name)
+            .map(|info| collect_params(&info.parameters))
+    };
+
+    node_to_args_pairs(
+        name,
+        node.named_args(),
+        &context.compilation.lang,
+        &expected_params,
+    )
+}
+
+pub(super) fn named_args_to_map(
+    named_args: Vec<(String, AnyGritPattern)>,
+    context: &mut NodeCompilationContext,
+) -> Result<BTreeMap<String, Pattern<GritQueryContext>>, CompileError> {
+    let args = named_args
+        .into_iter()
+        .map(|(name, pattern)| {
+            let key = context.compilation.lang.metavariable_prefix().to_owned() + &name;
+            let pattern = PatternCompiler::from_node_with_rhs(&pattern, context, true)?;
+            Ok((key, pattern))
+        })
+        .collect::<Result<_, CompileError>>()?;
+    Ok(args)
+}
+
+pub(super) fn node_to_args_pairs(
+    fn_name: &str,
+    named_args: GritNamedArgList,
+    lang: &impl Language,
+    expected_params: &Option<Vec<String>>,
+) -> Result<Vec<(String, AnyGritPattern)>, CompileError> {
+    named_args
+        .into_iter()
+        .enumerate()
+        .map(|(i, node)| match node {
+            Ok(AnyGritMaybeNamedArg::AnyGritPattern(pattern)) => {
+                let var = match pattern {
+                    AnyGritPattern::GritVariable(var) => var,
+                    _ => Err(NodeLikeArgumentError::ExpectedVariable {
+                        name: fn_name.to_string(),
+                    })?,
+                };
+
+                let name = var.text();
+                let name = name
+                    .strip_prefix(lang.metavariable_prefix())
+                    .filter(|stripped| {
+                        expected_params.as_ref().map_or(true, |expected| {
+                            expected.iter().any(|exp| exp == &name || exp == stripped)
+                        })
+                    })
+                    .or_else(|| {
+                        expected_params.as_ref().and_then(|params| {
+                            params
+                                .get(i)
+                                .map(|p| p.strip_prefix(lang.metavariable_prefix()).unwrap_or(p))
+                        })
+                    })
+                    .ok_or_else(|| {
+                        if let Some(exp) = expected_params {
+                            NodeLikeArgumentError::TooManyArguments {
+                                name: fn_name.to_string(),
+                                max_args: exp.len(),
+                            }
+                        } else {
+                            NodeLikeArgumentError::MissingArgumentName {
+                                name: fn_name.to_string(),
+                                variable: name.clone(),
+                            }
+                        }
+                    })?;
+                Ok((name.to_owned(), AnyGritPattern::GritVariable(var)))
+            }
+            Ok(AnyGritMaybeNamedArg::GritNamedArg(named_arg)) => {
+                let name = named_arg.name()?;
+                let pattern = named_arg.pattern()?;
+                Ok((name.text(), pattern))
+            }
+            Ok(AnyGritMaybeNamedArg::GritBogusNamedArg(_)) => Err(CompileError::UnexpectedKind(
+                GritSyntaxKind::GRIT_BOGUS_NAMED_ARG.into(),
+            )),
+            Err(err) => Err(err.into()),
+        })
+        .collect()
+}

--- a/crates/biome_grit_patterns/src/pattern_compiler/node_like_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/node_like_compiler.rs
@@ -1,0 +1,96 @@
+use super::compilation_context::NodeCompilationContext;
+use super::{call_compiler::*, PatternCompiler};
+use crate::grit_node_patterns::{GritNodePattern, GritNodePatternArg};
+use crate::grit_target_node::GritTargetSyntaxKind;
+use crate::NodeLikeArgumentError;
+use crate::{grit_context::GritQueryContext, CompileError};
+use biome_grit_syntax::GritNodeLike;
+use biome_rowan::AstNode;
+use grit_pattern_matcher::pattern::Pattern;
+use std::cmp::Ordering;
+
+pub(crate) struct NodeLikeCompiler;
+
+impl NodeLikeCompiler {
+    pub(crate) fn from_node_with_rhs(
+        node: &GritNodeLike,
+        context: &mut NodeCompilationContext,
+        is_rhs: bool,
+    ) -> Result<Pattern<GritQueryContext>, CompileError> {
+        let name = node.name()?;
+        let name = name.text();
+
+        let lang = &context.compilation.lang;
+        if let Some(kind) = lang.kind_by_name(&name) {
+            node_pattern_from_node_with_name_and_kind(node, name, kind, context, is_rhs)
+        } else {
+            call_pattern_from_node_with_name(node, name, context)
+        }
+    }
+}
+
+/// Takes a parsed Grit CST node for node-like syntax (`foo()`) and creates a
+/// node pattern.
+fn node_pattern_from_node_with_name_and_kind(
+    node: &GritNodeLike,
+    name: String,
+    kind: GritTargetSyntaxKind,
+    context: &mut NodeCompilationContext,
+    is_rhs: bool,
+) -> Result<Pattern<GritQueryContext>, CompileError> {
+    let mut named_args = named_args_from_node(node, &name, context)?;
+
+    // Handle `comment(content = ...)`
+    if context.compilation.lang.is_comment_kind(kind) {
+        let args = match named_args.len().cmp(&1) {
+            Ordering::Equal => {
+                let (arg_name, node) = named_args.remove(0);
+                if arg_name != "content" {
+                    Err(NodeLikeArgumentError::UnknownArgument {
+                        name,
+                        argument: arg_name,
+                        valid_args: vec!["content".to_string()],
+                    })?;
+                }
+
+                let pattern = PatternCompiler::from_node(&node, context)?;
+                vec![GritNodePatternArg::new(0, pattern)]
+            }
+            Ordering::Less => Vec::new(),
+            Ordering::Greater => Err(NodeLikeArgumentError::TooManyArguments {
+                name: "comment".to_string(),
+                max_args: 1,
+            })?,
+        };
+
+        return Ok(Pattern::AstNode(Box::new(GritNodePattern { kind, args })));
+    }
+
+    let mut args: Vec<GritNodePatternArg> = Vec::with_capacity(named_args.len());
+    for (arg_name, node) in named_args {
+        let node_slots = &context.compilation.lang.named_slots_for_kind(kind);
+
+        let Some((_, slot_index)) = node_slots
+            .iter()
+            .find(|(slot_name, _)| *slot_name == arg_name)
+        else {
+            return Err(NodeLikeArgumentError::UnknownArgument {
+                name,
+                argument: arg_name,
+                valid_args: node_slots
+                    .iter()
+                    .map(|(_, slot_name)| slot_name.to_string())
+                    .collect(),
+            })?;
+        };
+
+        if args.iter().any(|arg| arg.slot_index == *slot_index) {
+            Err(NodeLikeArgumentError::DuplicateArguments { name: arg_name })?;
+        }
+
+        let pattern = PatternCompiler::from_node_with_rhs(&node, context, is_rhs)?;
+        args.push(GritNodePatternArg::new(*slot_index, pattern));
+    }
+
+    Ok(Pattern::AstNode(Box::new(GritNodePattern { kind, args })))
+}

--- a/crates/biome_grit_patterns/src/pattern_compiler/predicate_call_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/predicate_call_compiler.rs
@@ -1,0 +1,42 @@
+use super::call_compiler::*;
+use super::compilation_context::NodeCompilationContext;
+use crate::NodeLikeArgumentError;
+use crate::{grit_context::GritQueryContext, CompileError};
+use biome_grit_syntax::GritPredicateCall;
+use biome_rowan::AstNode;
+use grit_pattern_matcher::pattern::PrCall;
+
+pub(crate) struct PrCallCompiler;
+
+impl PrCallCompiler {
+    pub(crate) fn from_node(
+        node: &GritPredicateCall,
+        context: &mut NodeCompilationContext,
+    ) -> Result<PrCall<GritQueryContext>, CompileError> {
+        let name = node.name()?;
+        let name = name.text();
+
+        let info = if let Some(info) = context.compilation.predicate_definition_info.get(&name) {
+            info
+        } else if let Some(info) = context.compilation.function_definition_info.get(&name) {
+            info
+        } else {
+            return Err(CompileError::UnknownFunctionOrPredicate(name));
+        };
+        let params = collect_params(&info.parameters);
+        let expected_params = Some(params.clone());
+        let named_args = node_to_args_pairs(
+            &name,
+            node.named_args(),
+            &context.compilation.lang,
+            &expected_params,
+        )?;
+        let args = named_args_to_map(named_args, context)?;
+        if args.len() != node.named_args().into_iter().count() {
+            Err(NodeLikeArgumentError::DuplicateArguments { name: name.clone() })?
+        }
+
+        let args = match_args_to_params(&name, args, &params, &context.compilation.lang)?;
+        Ok(PrCall::new(info.index, args))
+    }
+}

--- a/crates/biome_grit_patterns/src/pattern_compiler/predicate_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/predicate_compiler.rs
@@ -4,7 +4,8 @@ use super::{
     compilation_context::NodeCompilationContext, equal_compiler::PrEqualCompiler,
     if_compiler::PrIfCompiler, match_compiler::PrMatchCompiler, maybe_compiler::PrMaybeCompiler,
     not_compiler::PrNotCompiler, or_compiler::PrOrCompiler,
-    predicate_return_compiler::PrReturnCompiler, rewrite_compiler::PrRewriteCompiler,
+    predicate_call_compiler::PrCallCompiler, predicate_return_compiler::PrReturnCompiler,
+    rewrite_compiler::PrRewriteCompiler,
 };
 use crate::{grit_context::GritQueryContext, CompileError};
 use biome_grit_syntax::{AnyGritPredicate, GritSyntaxKind};
@@ -38,7 +39,9 @@ impl PredicateCompiler {
             AnyGritPredicate::GritPredicateAssignment(node) => Ok(Predicate::Assignment(Box::new(
                 PrAssignmentCompiler::from_node(node, context)?,
             ))),
-            AnyGritPredicate::GritPredicateCall(_) => todo!(),
+            AnyGritPredicate::GritPredicateCall(node) => Ok(Predicate::Call(Box::new(
+                PrCallCompiler::from_node(node, context)?,
+            ))),
             AnyGritPredicate::GritPredicateEqual(node) => Ok(Predicate::Equal(Box::new(
                 PrEqualCompiler::from_node(node, context)?,
             ))),

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -775,6 +775,7 @@ impl Workspace for WorkspaceServer {
     ) -> Result<ParsePatternResult, WorkspaceError> {
         let pattern = biome_grit_patterns::compile_pattern(
             &params.pattern,
+            Path::new("filename"), // TODO: Pass the real filename.
             biome_grit_patterns::JsTargetLanguage.into(),
         )?;
         let pattern_id = PatternId::from("1234"); // TODO: Generate a real ID.


### PR DESCRIPTION
## Summary

I feel I will have a pretty major announcement coming up soon, since this PR brings the bindings in a state where an actual Grit query can execute and match against an arbitrary JS snippet. The pattern execution appears to return a correct `true` or `false` result indicating whether the query matched or not. Also, if I change the pattern in the quick test to use the rewrite operator (`=>`) I can see the Grit engine produce an `Effect`, which is a data structure describing the rewrite that should take place, so this is really exciting.

What does _not_ work yet, is extracting the ranges where matches are found when I don't use a rewrite operator. I suppose I could also try modifying the query to include an empty rewrite and extract the range from the `Effect`, but  maybe @morgante knows an easier trick to do what I want. In any case, I'll keep that for a follow-up PR.

Of course there are plenty of other things that still need polishing/implementation before this could be considered ready for real adoption, but now that we are reaching the point where the engine is finally doing actual useful stuff, it may also become easier for other contributors to help out since many of the improvements that still need to be made should be doable independently. I'll write up a bit more about the things to do when I send out the announcement.

## Test Plan

Updated the quick test, but I'll start adding more systematic tests soon.
