### PR TITLE
fix(migrate): suppress node warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ## Unreleased
 
+### CLI
+
+#### Bug fixes
+
+- Fix [#3104](https://github.com/biomejs/biome/issues/3104) by suppressing node warnings when using `biome migrate`. Contributed by @SuperchupuDev
+
 ### Parser
 
 #### New features
@@ -33,6 +39,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Fix [#3201](https://github.com/biomejs/biome/issues/3201) by correctly injecting the source code of the file when printing the diagnostics. Contributed by @ematipico
 - Fix [#3179](https://github.com/biomejs/biome/issues/3179) where comma separators are not correctly removed after running `biome migrate` and thus choke the parser. Contributed by @Sec-ant
 - Fix [#3232](https://github.com/biomejs/biome/issues/3232) by correctly using the colors set by the user. Contributed by @ematipico
+
 #### Enhancement
 
 - Reword the reporter message `No fixes needed` to `No fixes applied`.

--- a/crates/biome_cli/src/execute/migrate/node.rs
+++ b/crates/biome_cli/src/execute/migrate/node.rs
@@ -6,6 +6,7 @@ use crate::{diagnostics::MigrationDiagnostic, CliDiagnostic};
 /// returns the JSONified content of its default export.
 pub(crate) fn load_config(specifier: &str) -> Result<Resolution, CliDiagnostic> {
     let content_output = Command::new("node")
+        .env("NODE_NO_WARNINGS", "1")
         .arg("--eval")
         .arg(format!(
             "{UNCYCLE_FUNCTION} import('{specifier}').then((c) => console.log(JSON.stringify(uncycle(c.default))))"
@@ -19,6 +20,7 @@ pub(crate) fn load_config(specifier: &str) -> Result<Resolution, CliDiagnostic> 
         },
         Ok(output) => {
             let path_output = Command::new("node")
+                .env("NODE_NO_WARNINGS", "1")
                 .arg("--print")
                 .arg(format!(
                     "require.resolve('{specifier}')"
@@ -28,6 +30,7 @@ pub(crate) fn load_config(specifier: &str) -> Result<Resolution, CliDiagnostic> 
             if !output.stderr.is_empty() {
                 // Try with `require` before giving up.
                 let output2 = Command::new("node")
+                    .env("NODE_NO_WARNINGS", "1")
                     .arg("--eval")
                     .arg(format!(
                         "{UNCYCLE_FUNCTION} console.log(JSON.stringify(uncycle(require('{specifier}'))))"


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
Fixes #3104 by setting the `NODE_NO_WARNINGS` env variable

## Test Plan
- [x] Test the repro steps given in #3104 (basically making the config file throw a warning)
![image](https://github.com/biomejs/biome/assets/53496941/98370ced-0b2f-47ff-9440-74e83769c412)


