### PR TITLE
test(parse/json): add test for bug where overrides erroneously override special parsing options

### DIFF
--- a/crates/biome_cli/tests/cases/overrides_formatter.rs
+++ b/crates/biome_cli/tests/cases/overrides_formatter.rs
@@ -671,3 +671,64 @@ fn takes_last_formatter_enabled_into_account() {
         result,
     ));
 }
+
+#[test]
+#[ignore = "Enable when we fix the behavior of how overrides are applied for json files"]
+fn does_not_override_well_known_special_files_when_config_override_is_present() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let file_path = Path::new("biome.json");
+    fs.insert(
+        file_path.into(),
+        r#"{
+            "overrides": [
+                {
+                    "include": [
+                        "**/*.json"
+                    ],
+                    "formatter": { "enabled": false }
+                }
+            ]
+        }"#
+        .as_bytes(),
+    );
+
+    let tsconfig = Path::new("tsconfig.json");
+    fs.insert(
+        tsconfig.into(),
+        r#"{
+    // This is a comment
+    "compilerOptions": {},
+}"#,
+    );
+
+    let other_json = Path::new("other.json");
+    fs.insert(
+        other_json.into(),
+        r#"{
+    "asta": ["lorem", "ipsum", "first", "second"]
+}"#,
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                "check",
+                other_json.as_os_str().to_str().unwrap(),
+                tsconfig.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "does_not_override_well_known_special_files_when_config_override_is_present",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/does_not_override_well_known_special_files_when_config_override_is_present.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/does_not_override_well_known_special_files_when_config_override_is_present.snap
@@ -1,0 +1,39 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "overrides": [
+    {
+      "include": ["**/*.json"],
+      "formatter": { "enabled": false }
+    }
+  ]
+}
+```
+
+## `other.json`
+
+```json
+{
+    "asta": ["lorem", "ipsum", "first", "second"]
+}
+```
+
+## `tsconfig.json`
+
+```json
+{
+    // This is a comment
+    "compilerOptions": {},
+}
+```
+
+# Emitted Messages
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This one is kinda weird, and this doesn't really feel like the correct fix. I'm unfamiliar with this area of the codebase.

If an override is applied to a json file that is considered "well known" to be parsed with trailing commas and/or comments, then those settings will not be applied because the override is present (not necessarily using the override's value, if the settings are cached).
For example, if we add the following override to this repo's `biome.json`, running `biome check` will fail, even though it should be effectively a no-op.
```json
"overrides": [
    {
      "include": ["**/*.json"],
      "formatter": {
        "indentStyle": "space"
      }
    }
  ]
```
Note that json files that have different default parsing settings, that also match the override must be checked. The following command does _not_ reproduce the issue:
```bash
cargo run --bin biome -- check packages/@biomejs/backend-jsonrpc/tsconfig.json
```

~~This PR aims to fix this behavior, allowing the settings from `JsonFileSource` take more precedence if the settings are `true`.~~ This PR now just adds a disabled unit test for the correct behavior.

I'd like to know more about the purpose of caching the settings. ~~Removing this cache read branch from the following code also fixes the issue:~~ (After testing it again, this change actually doesn't fix it)
https://github.com/biomejs/biome/blob/cc65fe857929896b88a40cfee759a1f80d3ab876/crates/biome_service/src/settings.rs#L1095-L1100

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
blocks: #3246
tangentally related to: #1724
additional context: https://github.com/biomejs/biome/pull/3246#issuecomment-2183434313

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
The following command now runs without emitting diagnostics, with the override applied to `biome.json`.
```
pnpm check
```
Planning to add a specific unit test.
