### PR TITLE
fix(cli): disable colors when using the github reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Fix [#3104](https://github.com/biomejs/biome/issues/3104) by suppressing node warnings when using `biome migrate`. Contributed by @SuperchupuDev
 
+- Force colors to be off when using the GitHub reporter to properly create annotations in GitHub actions ([#3148](https://github.com/biomejs/biome/issues/3148)). Contributed by @Sec-ant
+
 ### Parser
 
 #### New features

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -51,7 +51,7 @@ pub struct CliOptions {
     /// Allows to change how diagnostics and summary are reported.
     #[bpaf(
         long("reporter"),
-        argument("json|json-pretty|summary"),
+        argument("json|json-pretty|github|junit|summary"),
         fallback(CliReporter::default())
     )]
     pub reporter: CliReporter,

--- a/crates/biome_cli/src/main.rs
+++ b/crates/biome_cli/src/main.rs
@@ -8,7 +8,7 @@ use biome_cli::{
     biome_command, open_transport, setup_panic_handler, to_color_mode, BiomeCommand, CliDiagnostic,
     CliSession,
 };
-use biome_console::{markup, ColorMode, ConsoleExt, EnvConsole};
+use biome_console::{markup, ConsoleExt, EnvConsole};
 use biome_diagnostics::{set_bottom_frame, Diagnostic, PrintDiagnostic};
 use biome_service::workspace;
 use std::process::{ExitCode, Termination};
@@ -37,17 +37,7 @@ fn main() -> ExitCode {
     let mut console = EnvConsole::default();
     let command = biome_command().fallback_to_usage().run();
 
-    let color_mode = to_color_mode(command.get_color());
-    // we want force colours in CI, to give e better UX experience
-    if let BiomeCommand::Ci { cli_options, .. } = &command {
-        if cli_options.colors.is_none() {
-            console.set_color(ColorMode::Enabled);
-        } else {
-            console.set_color(color_mode);
-        }
-    } else {
-        console.set_color(color_mode);
-    }
+    console.set_color(to_color_mode(command.get_color()));
 
     let is_verbose = command.is_verbose();
     let result = run_workspace(&mut console, command);

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -107,7 +107,8 @@ Global options applied to all commands
         --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed
                               during the execution of the command.
         --error-on-warnings   Tell Biome to exit with an error code if some diagnostics emit warnings.
-        --reporter=<json|json-pretty|summary>  Allows to change how diagnostics and summary are reported.
+        --reporter=<json|json-pretty|github|junit|summary>  Allows to change how diagnostics and summary
+                              are reported.
         --log-level=<none|debug|info|warn|error>  The level of logging. In order, from the most verbose
                               to the least verbose: debug, info, warn, error.
                               The value `none` won't show any logging.

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -109,7 +109,8 @@ Global options applied to all commands
         --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed
                               during the execution of the command.
         --error-on-warnings   Tell Biome to exit with an error code if some diagnostics emit warnings.
-        --reporter=<json|json-pretty|summary>  Allows to change how diagnostics and summary are reported.
+        --reporter=<json|json-pretty|github|junit|summary>  Allows to change how diagnostics and summary
+                              are reported.
         --log-level=<none|debug|info|warn|error>  The level of logging. In order, from the most verbose
                               to the least verbose: debug, info, warn, error.
                               The value `none` won't show any logging.

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -83,7 +83,8 @@ Global options applied to all commands
         --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed
                               during the execution of the command.
         --error-on-warnings   Tell Biome to exit with an error code if some diagnostics emit warnings.
-        --reporter=<json|json-pretty|summary>  Allows to change how diagnostics and summary are reported.
+        --reporter=<json|json-pretty|github|junit|summary>  Allows to change how diagnostics and summary
+                              are reported.
         --log-level=<none|debug|info|warn|error>  The level of logging. In order, from the most verbose
                               to the least verbose: debug, info, warn, error.
                               The value `none` won't show any logging.

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -50,7 +50,8 @@ Global options applied to all commands
         --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed
                               during the execution of the command.
         --error-on-warnings   Tell Biome to exit with an error code if some diagnostics emit warnings.
-        --reporter=<json|json-pretty|summary>  Allows to change how diagnostics and summary are reported.
+        --reporter=<json|json-pretty|github|junit|summary>  Allows to change how diagnostics and summary
+                              are reported.
         --log-level=<none|debug|info|warn|error>  The level of logging. In order, from the most verbose
                               to the least verbose: debug, info, warn, error.
                               The value `none` won't show any logging.

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
@@ -24,7 +24,8 @@ Global options applied to all commands
         --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed
                               during the execution of the command.
         --error-on-warnings   Tell Biome to exit with an error code if some diagnostics emit warnings.
-        --reporter=<json|json-pretty|summary>  Allows to change how diagnostics and summary are reported.
+        --reporter=<json|json-pretty|github|junit|summary>  Allows to change how diagnostics and summary
+                              are reported.
         --log-level=<none|debug|info|warn|error>  The level of logging. In order, from the most verbose
                               to the least verbose: debug, info, warn, error.
                               The value `none` won't show any logging.

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -24,7 +24,8 @@ Global options applied to all commands
         --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed
                               during the execution of the command.
         --error-on-warnings   Tell Biome to exit with an error code if some diagnostics emit warnings.
-        --reporter=<json|json-pretty|summary>  Allows to change how diagnostics and summary are reported.
+        --reporter=<json|json-pretty|github|junit|summary>  Allows to change how diagnostics and summary
+                              are reported.
         --log-level=<none|debug|info|warn|error>  The level of logging. In order, from the most verbose
                               to the least verbose: debug, info, warn, error.
                               The value `none` won't show any logging.

--- a/packages/tailwindcss-config-analyzer/src/generate-tailwind-preset.ts
+++ b/packages/tailwindcss-config-analyzer/src/generate-tailwind-preset.ts
@@ -60,7 +60,7 @@ function generateVariants(variants: SortConfig["variants"]) {
 	for (const { name } of variants) {
 		output += `${INDENT}"${name}",\n`
 	}
-	output += `];\n`;
+	output += "];\n";
 	return output;
 }
 


### PR DESCRIPTION
## Summary

Fixes #3148

## Test Plan

I ran the command locally: `cargo run --bin biome lint ./test.js --reporter=github`
