### PR TITLE
fix(lint/use_arrow_function): add a trailing comma to single type parameter when JSX is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - `useConsistentArrayType` and `useShorthandArrayType` now ignore `Array` in the `extends` and `implements` clauses. Fix [#3247](https://github.com/biomejs/biome/issues/3247). Contributed by @Conaclos
 - Fixes [#3066](https://github.com/biomejs/biome/issues/3066) by taking into account the dependencies declared in the `package.json`. Contributed by @ematipico
+- The code action of the `useArrowFunction` rule now preserves a trailing comma when there is only a single type parameter in the arrow function and JSX is enabled. Fixes [#3292](https://github.com/biomejs/biome/issues/3292). Contributed by @Sec-ant
 
 ## v1.8.2 (2024-06-20)
 

--- a/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
@@ -7,11 +7,11 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
-    AnyJsExpression, AnyJsFunctionBody, AnyJsStatement, JsConstructorClassMember, JsFunctionBody,
-    JsFunctionDeclaration, JsFunctionExportDefaultDeclaration, JsFunctionExpression,
-    JsGetterClassMember, JsGetterObjectMember, JsLanguage, JsMethodClassMember,
-    JsMethodObjectMember, JsModule, JsScript, JsSetterClassMember, JsSetterObjectMember,
-    JsStaticInitializationBlockClassMember, JsSyntaxKind, T,
+    AnyJsExpression, AnyJsFunctionBody, AnyJsStatement, JsConstructorClassMember, JsFileSource,
+    JsFunctionBody, JsFunctionDeclaration, JsFunctionExportDefaultDeclaration,
+    JsFunctionExpression, JsGetterClassMember, JsGetterObjectMember, JsLanguage,
+    JsMethodClassMember, JsMethodObjectMember, JsModule, JsScript, JsSetterClassMember,
+    JsSetterObjectMember, JsStaticInitializationBlockClassMember, JsSyntaxKind, T,
 };
 use biome_rowan::{
     declare_node_union, AstNode, AstNodeList, AstSeparatedList, BatchMutationExt, Language,
@@ -154,6 +154,23 @@ impl Rule for UseArrowFunction {
             arrow_function_builder = arrow_function_builder.with_async_token(async_token);
         }
         if let Some(type_parameters) = function_expression.type_parameters() {
+            let mut type_parameters_iter =
+                type_parameters.items().iter().filter_map(|item| item.ok());
+            let type_parameter = type_parameters_iter.next();
+            // Keep a trailing comma when there is a single type parameter in arrow functions and JSX is enabled
+            // Or the parser will treat it as a JSX tag and fail to parse it.
+            let type_parameters = if type_parameter.is_some()
+                && type_parameters_iter.next().is_none()
+                && ctx.source_type::<JsFileSource>().is_jsx()
+            {
+                make::ts_type_parameters(
+                    make::token(T![<]),
+                    make::ts_type_parameter_list(type_parameter, Some(make::token(T![,]))),
+                    make::token(T![>]),
+                )
+            } else {
+                type_parameters
+            };
             arrow_function_builder = arrow_function_builder.with_type_parameters(type_parameters);
         }
         if let Some(return_type_annotation) = function_expression.return_type_annotation() {

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.tsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.tsx
@@ -1,0 +1,7 @@
+const f1 = function<T> (x: T): T {
+	return x;
+}
+
+const f2 = async function<T> (x: T): Promise<T> {
+	return x;
+}

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.tsx.snap
@@ -1,0 +1,72 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.tsx
+---
+# Input
+```tsx
+const f1 = function<T> (x: T): T {
+	return x;
+}
+
+const f2 = async function<T> (x: T): Promise<T> {
+	return x;
+}
+
+```
+
+# Diagnostics
+```
+invalid.tsx:1:12 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+  > 1 │ const f1 = function<T> (x: T): T {
+      │            ^^^^^^^^^^^^^^^^^^^^^^^
+  > 2 │ 	return x;
+  > 3 │ }
+      │ ^
+    4 │ 
+    5 │ const f2 = async function<T> (x: T): Promise<T> {
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    1   │ - const·f1·=·function<T>·(x:·T):·T·{
+    2   │ - → return·x;
+    3   │ - }
+      1 │ + const·f1·=·<T,>(x:·T):·T·=>·x
+    4 2 │   
+    5 3 │   const f2 = async function<T> (x: T): Promise<T> {
+  
+
+```
+
+```
+invalid.tsx:5:12 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+    3 │ }
+    4 │ 
+  > 5 │ const f2 = async function<T> (x: T): Promise<T> {
+      │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 6 │ 	return x;
+  > 7 │ }
+      │ ^
+    8 │ 
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    3 3 │   }
+    4 4 │   
+    5   │ - const·f2·=·async·function<T>·(x:·T):·Promise<T>·{
+    6   │ - → return·x;
+    7   │ - }
+      5 │ + const·f2·=·async·<T,>(x:·T):·Promise<T>·=>·x
+    8 6 │   
+  
+
+```


### PR DESCRIPTION
## Summary

When JSX is enabled, the code fix should transform this:

```tsx
const f1 = function<T> (x: T): T {
	return x;
}
```

into this:

```tsx
const f1 = <T,>(x: T): T => x
```

instead of this:

```tsx
const f1 = <T>(x: T): T => x
```

Otherwise the parser will treat `<T>` as a JSX tag.

Closes #3292

## Test Plan

I added test cases.
