### PR TITLE
feat(core): include turbo into well known jsonc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### Enhancements
 
 - Implement [css suppression action](https://github.com/biomejs/biome/issues/3278). Contributed by @togami2864
-- Feature [#3306](https://github.com/biomejs/biome/pull/3306) support comments in `turbo.json`. Contributed by @Netail
+- Add support of comments in `turbo.json`. Contributed by @Netail
 
 ### CLI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 ## Unreleased
 
 - Implement [css suppression action](https://github.com/biomejs/biome/issues/3278). Contributed by @togami2864
+- Feature [#3306](https://github.com/biomejs/biome/pull/3306) support comments in `turbo.json`. Contributed by @Netail
 
-## v1.8.3 (2022-06-27)
+## v1.8.3 (2024-06-27)
 
 ### CLI
 

--- a/crates/biome_json_syntax/src/file_source.rs
+++ b/crates/biome_json_syntax/src/file_source.rs
@@ -66,7 +66,7 @@ impl JsonFileSource {
         // https://github.com/palantir/tslint/blob/285fc1db18d1fd24680d6a2282c6445abf1566ee/src/configuration.ts#L268
         "tslint.json",
         // Just strip comments
-        // https://github.com/vercel/turbo/blob/54ea3f06989860e98c4245ba085106e1f725f602/crates/turbopack-core/src/asset.rs#L71
+        // https://github.com/vercel/turbo/blob/0f327961157a5ab07bbb353ac6ecb9a9df7e29b3/crates/turborepo-lib/src/turbo_json/mod.rs#L963
         "turbo.json",
     ];
 

--- a/crates/biome_json_syntax/src/file_source.rs
+++ b/crates/biome_json_syntax/src/file_source.rs
@@ -65,6 +65,9 @@ impl JsonFileSource {
         // Just strip comments
         // https://github.com/palantir/tslint/blob/285fc1db18d1fd24680d6a2282c6445abf1566ee/src/configuration.ts#L268
         "tslint.json",
+        // Just strip comments
+        // https://github.com/vercel/turbo/blob/54ea3f06989860e98c4245ba085106e1f725f602/crates/turbopack-core/src/asset.rs#L71
+        "turbo.json",
     ];
 
     // Well-known JSON-like files that support comments and trailing commas

--- a/xtask/codegen/src/language_kind.rs
+++ b/xtask/codegen/src/language_kind.rs
@@ -62,7 +62,7 @@ impl FromStr for LanguageKind {
             "html" => Ok(LanguageKind::Html),
             "yaml" => Ok(LanguageKind::Yaml),
             _ => Err(format!(
-                "Language {kind} not supported, please use: `js`, `css`, `json`, `grit`, `graphql`, `html`, `yaml` or yml"
+                "Language {kind} not supported, please use: `js`, `css`, `json`, `grit`, `graphql`, `html` or `yaml`"
             )),
         }
     }


### PR DESCRIPTION
## Summary

Add turbo.json to well known jsonc files.

Also remove yaml alias from error as aliases of other languages aren't included either
