### PR TITLE
feat(graphql_formatter): implement BracketSpacing option

### DIFF
--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -217,6 +217,7 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("Line ending", markup!({DebugDisplay(formatter_configuration.line_ending)}))}
                             {KeyValuePair("Line width", markup!({DebugDisplay(formatter_configuration.line_width.value())}))}
                             {KeyValuePair("Attribute position", markup!({DebugDisplay(formatter_configuration.attribute_position)}))}
+                            {KeyValuePair("Bracket spacing", markup!({DebugDisplay(formatter_configuration.bracket_spacing)}))}
                             {KeyValuePair("Ignore", markup!({DebugDisplay(formatter_configuration.ignore.iter().collect::<Vec<_>>())}))}
                             {KeyValuePair("Include", markup!({DebugDisplay(formatter_configuration.include.iter().collect::<Vec<_>>())}))}
                         ).fmt(fmt)?;
@@ -275,6 +276,7 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("Indent width", markup!({DebugDisplayOption(graphql_formatter_configuration.indent_width)}))}
                             {KeyValuePair("Line ending", markup!({DebugDisplayOption(graphql_formatter_configuration.line_ending)}))}
                             {KeyValuePair("Line width", markup!({DebugDisplayOption(graphql_formatter_configuration.line_width)}))}
+                            {KeyValuePair("Bracket spacing", markup!({DebugDisplay(graphql_formatter_configuration.bracket_spacing)}))}
                             {KeyValuePair("Quote style", markup!({DebugDisplay(graphql_formatter_configuration.quote_style)}))}
                         ).fmt(fmt)?;
                     }

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -217,7 +217,7 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("Line ending", markup!({DebugDisplay(formatter_configuration.line_ending)}))}
                             {KeyValuePair("Line width", markup!({DebugDisplay(formatter_configuration.line_width.value())}))}
                             {KeyValuePair("Attribute position", markup!({DebugDisplay(formatter_configuration.attribute_position)}))}
-                            {KeyValuePair("Bracket spacing", markup!({DebugDisplayOption(formatter_configuration.bracket_spacing)}))}
+                            {KeyValuePair("Bracket spacing", markup!({DebugDisplay(formatter_configuration.bracket_spacing)}))}
                             {KeyValuePair("Ignore", markup!({DebugDisplay(formatter_configuration.ignore.iter().collect::<Vec<_>>())}))}
                             {KeyValuePair("Include", markup!({DebugDisplay(formatter_configuration.include.iter().collect::<Vec<_>>())}))}
                         ).fmt(fmt)?;
@@ -232,14 +232,14 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("Trailing commas", markup!({DebugDisplay(javascript_formatter_configuration.trailing_commas)}))}
                             {KeyValuePair("Semicolons", markup!({DebugDisplay(javascript_formatter_configuration.semicolons)}))}
                             {KeyValuePair("Arrow parentheses", markup!({DebugDisplay(javascript_formatter_configuration.arrow_parentheses)}))}
-                            {KeyValuePair("Bracket spacing", markup!({DebugDisplay(javascript_formatter_configuration.bracket_spacing)}))}
+                            {KeyValuePair("Bracket spacing", markup!({DebugDisplayOption(javascript_formatter_configuration.bracket_spacing)}))}
                             {KeyValuePair("Bracket same line", markup!({DebugDisplay(javascript_formatter_configuration.bracket_same_line)}))}
                             {KeyValuePair("Quote style", markup!({DebugDisplay(javascript_formatter_configuration.quote_style)}))}
                             {KeyValuePair("Indent style", markup!({DebugDisplayOption(javascript_formatter_configuration.indent_style)}))}
                             {KeyValuePair("Indent width", markup!({DebugDisplayOption(javascript_formatter_configuration.indent_width)}))}
                             {KeyValuePair("Line ending", markup!({DebugDisplayOption(javascript_formatter_configuration.line_ending)}))}
                             {KeyValuePair("Line width", markup!({DebugDisplayOption(javascript_formatter_configuration.line_width.map(|lw| lw.value()))}))}
-                            {KeyValuePair("Attribute position", markup!({DebugDisplay(javascript_formatter_configuration.attribute_position)}))}
+                            {KeyValuePair("Attribute position", markup!({DebugDisplayOption(javascript_formatter_configuration.attribute_position)}))}
                         )
                         .fmt(fmt)?;
 

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -277,7 +277,7 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("Line ending", markup!({DebugDisplayOption(graphql_formatter_configuration.line_ending)}))}
                             {KeyValuePair("Line width", markup!({DebugDisplayOption(graphql_formatter_configuration.line_width)}))}
                             {KeyValuePair("Bracket spacing", markup!({DebugDisplayOption(graphql_formatter_configuration.bracket_spacing)}))}
-                            {KeyValuePair("Quote style", markup!({DebugDisplay(graphql_formatter_configuration.quote_style)}))}
+                            {KeyValuePair("Quote style", markup!({DebugDisplayOption(graphql_formatter_configuration.quote_style)}))}
                         ).fmt(fmt)?;
                     }
 

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -217,7 +217,7 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("Line ending", markup!({DebugDisplay(formatter_configuration.line_ending)}))}
                             {KeyValuePair("Line width", markup!({DebugDisplay(formatter_configuration.line_width.value())}))}
                             {KeyValuePair("Attribute position", markup!({DebugDisplay(formatter_configuration.attribute_position)}))}
-                            {KeyValuePair("Bracket spacing", markup!({DebugDisplay(formatter_configuration.bracket_spacing)}))}
+                            {KeyValuePair("Bracket spacing", markup!({DebugDisplayOption(formatter_configuration.bracket_spacing)}))}
                             {KeyValuePair("Ignore", markup!({DebugDisplay(formatter_configuration.ignore.iter().collect::<Vec<_>>())}))}
                             {KeyValuePair("Include", markup!({DebugDisplay(formatter_configuration.include.iter().collect::<Vec<_>>())}))}
                         ).fmt(fmt)?;

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -276,7 +276,7 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("Indent width", markup!({DebugDisplayOption(graphql_formatter_configuration.indent_width)}))}
                             {KeyValuePair("Line ending", markup!({DebugDisplayOption(graphql_formatter_configuration.line_ending)}))}
                             {KeyValuePair("Line width", markup!({DebugDisplayOption(graphql_formatter_configuration.line_width)}))}
-                            {KeyValuePair("Bracket spacing", markup!({DebugDisplay(graphql_formatter_configuration.bracket_spacing)}))}
+                            {KeyValuePair("Bracket spacing", markup!({DebugDisplayOption(graphql_formatter_configuration.bracket_spacing)}))}
                             {KeyValuePair("Quote style", markup!({DebugDisplay(graphql_formatter_configuration.quote_style)}))}
                         ).fmt(fmt)?;
                     }

--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -5,7 +5,8 @@ use biome_deserialize::{json::deserialize_from_json_str, StringSet};
 use biome_deserialize_macros::Deserializable;
 use biome_diagnostics::{DiagnosticExt, PrintDiagnostic};
 use biome_formatter::{
-    AttributePosition, IndentWidth, LineEnding, LineWidth, ParseFormatNumberError, QuoteStyle,
+    AttributePosition, BracketSpacing, IndentWidth, LineEnding, LineWidth, ParseFormatNumberError,
+    QuoteStyle,
 };
 use biome_fs::{FileSystem, OpenOptions};
 use biome_js_formatter::context::{ArrowParentheses, QuoteProperties, Semicolons, TrailingCommas};
@@ -210,6 +211,7 @@ impl TryFrom<PrettierConfiguration> for biome_configuration::PartialConfiguratio
             enabled: Some(true),
             // deprecated
             indent_size: None,
+            bracket_spacing: Some(BracketSpacing::default()),
         };
         result.formatter = Some(formatter);
 
@@ -246,7 +248,7 @@ impl TryFrom<PrettierConfiguration> for biome_configuration::PartialConfiguratio
             trailing_comma: None,
             quote_style: Some(quote_style),
             quote_properties: Some(value.quote_props.into()),
-            bracket_spacing: Some(value.bracket_spacing),
+            bracket_spacing: Some(value.bracket_spacing.into()),
             jsx_quote_style: Some(jsx_quote_style),
             attribute_position: Some(AttributePosition::default()),
         };
@@ -349,7 +351,6 @@ impl TryFrom<Override> for biome_configuration::OverridePattern {
                 .map(|trailing_comma| trailing_comma.into()),
             quote_style,
             quote_properties: options.quote_props.map(|quote_props| quote_props.into()),
-            bracket_spacing: options.bracket_spacing,
             jsx_quote_style,
             ..Default::default()
         };

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -3786,7 +3786,10 @@ fn applies_custom_bracket_spacing_for_graphql() {
     let mut console = BufferConsole::default();
 
     let file_path = Path::new("file.graphql");
-    fs.insert(file_path.into(), APPLY_BRACKET_SPACING_BEFORE_GRAPHQL.as_bytes());
+    fs.insert(
+        file_path.into(),
+        APPLY_BRACKET_SPACING_BEFORE_GRAPHQL.as_bytes(),
+    );
 
     let result = run_cli(
         DynRef::Borrowed(&mut fs),
@@ -3799,7 +3802,7 @@ fn applies_custom_bracket_spacing_for_graphql() {
                 ("--write"),
                 file_path.as_os_str().to_str().unwrap(),
             ]
-                .as_slice(),
+            .as_slice(),
         ),
     );
 

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -121,6 +121,17 @@ let foo = {a, b};
 const {a, b} = foo;
 "#;
 
+const APPLY_BRACKET_SPACING_BEFORE_GRAPHQL: &str = r#"{
+	field_value(
+		object_value: {key: "value"}
+	)
+}"#;
+
+const APPLY_BRACKET_SPACING_AFTER_GRAPHQL: &str = r#"{
+	field_value(object_value: {key: "value"})
+}
+"#;
+
 const APPLY_BRACKET_SAME_LINE_BEFORE: &str = r#"<Foo
 	className={style}
 	reallyLongAttributeName1={longComplexValue}
@@ -3763,6 +3774,42 @@ fn should_error_if_unchanged_files_only_with_changed_flag() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "should_error_if_unchanged_files_only_with_changed_flag",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn applies_custom_bracket_spacing_for_graphql() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("file.graphql");
+    fs.insert(file_path.into(), APPLY_BRACKET_SPACING_BEFORE_GRAPHQL.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                ("--bracket-spacing"),
+                ("false"),
+                ("--write"),
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+                .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, file_path, APPLY_BRACKET_SPACING_AFTER_GRAPHQL);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "applies_custom_bracket_spacing_graphql",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -31,6 +31,8 @@ The configuration that is contained inside the file `biome.json`
         --line-width=NUMBER   What's the max width of a line. Defaults to 80.
         --attribute-position=<multiline|auto>  The attribute position style in HTMLish languages. By
                               default auto.
+        --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
+                              Defaults to true.
         --jsx-quote-style=<double|single>  The type of quotes used in JSX. Defaults to double.
         --quote-properties=<preserve|as-needed>  When properties in objects are quoted. Defaults to asNeeded.
         --trailing-comma=<all|es5|none>  Print trailing commas wherever possible in multi-line comma-separated
@@ -41,8 +43,6 @@ The configuration that is contained inside the file `biome.json`
                               only in for statements where it is necessary because of ASI.
         --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow functions.
                               Defaults to "always".
-        --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
-                              Defaults to true.
         --bracket-same-line=<true|false>  Whether to hug the closing bracket of multiline HTML/JSX tags
                               to the end of the last line, rather than being alone on the following line.
                               Defaults to false.

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -33,6 +33,8 @@ The configuration that is contained inside the file `biome.json`
         --line-width=NUMBER   What's the max width of a line. Defaults to 80.
         --attribute-position=<multiline|auto>  The attribute position style in HTMLish languages. By
                               default auto.
+        --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
+                              Defaults to true.
         --jsx-quote-style=<double|single>  The type of quotes used in JSX. Defaults to double.
         --quote-properties=<preserve|as-needed>  When properties in objects are quoted. Defaults to asNeeded.
         --trailing-comma=<all|es5|none>  Print trailing commas wherever possible in multi-line comma-separated
@@ -43,8 +45,6 @@ The configuration that is contained inside the file `biome.json`
                               only in for statements where it is necessary because of ASI.
         --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow functions.
                               Defaults to "always".
-        --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
-                              Defaults to true.
         --bracket-same-line=<true|false>  Whether to hug the closing bracket of multiline HTML/JSX tags
                               to the end of the last line, rather than being alone on the following line.
                               Defaults to false.

--- a/crates/biome_cli/tests/snapshots/main_commands_format/applies_custom_bracket_spacing_graphql.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/applies_custom_bracket_spacing_graphql.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.graphql`
+
+```graphql
+{
+	field_value(object_value: {key: "value"})
+}
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -17,6 +17,8 @@ Generic options applied to all files
         --line-width=NUMBER   What's the max width of a line. Defaults to 80.
         --attribute-position=<multiline|auto>  The attribute position style in HTMLish languages. By
                               default auto.
+        --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
+                              Defaults to true.
 
 Formatting options specific to the JavaScript files
         --jsx-quote-style=<double|single>  The type of quotes used in JSX. Defaults to double.
@@ -29,8 +31,6 @@ Formatting options specific to the JavaScript files
                               only in for statements where it is necessary because of ASI.
         --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow functions.
                               Defaults to "always".
-        --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
-                              Defaults to true.
         --bracket-same-line=<true|false>  Whether to hug the closing bracket of multiline HTML/JSX tags
                               to the end of the last line, rather than being alone on the following line.
                               Defaults to false.
@@ -49,6 +49,8 @@ Formatting options specific to the JavaScript files
         --quote-style=<double|single>  The type of quotes used in JavaScript code. Defaults to double.
         --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx elements.
                               Defaults to auto.
+        --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
+                              Defaults to true.
 
 Set of properties to integrate Biome with a VCS software.
         --vcs-client-kind=<git>  The kind of client.

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate.snap
@@ -30,24 +30,25 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
        6 │ + → → "indentWidth":·2,
        7 │ + → → "lineEnding":·"lf",
        8 │ + → → "lineWidth":·80,
-       9 │ + → → "attributePosition":·"auto"
-      10 │ + → },
-      11 │ + → "linter":·{·"enabled":·true·},
-      12 │ + → "javascript":·{
-      13 │ + → → "formatter":·{
-      14 │ + → → → "jsxQuoteStyle":·"double",
-      15 │ + → → → "quoteProperties":·"asNeeded",
-      16 │ + → → → "trailingCommas":·"all",
-      17 │ + → → → "semicolons":·"always",
-      18 │ + → → → "arrowParentheses":·"always",
-      19 │ + → → → "bracketSpacing":·true,
+       9 │ + → → "attributePosition":·"auto",
+      10 │ + → → "bracketSpacing":·true
+      11 │ + → },
+      12 │ + → "linter":·{·"enabled":·true·},
+      13 │ + → "javascript":·{
+      14 │ + → → "formatter":·{
+      15 │ + → → → "jsxQuoteStyle":·"double",
+      16 │ + → → → "quoteProperties":·"asNeeded",
+      17 │ + → → → "trailingCommas":·"all",
+      18 │ + → → → "semicolons":·"always",
+      19 │ + → → → "arrowParentheses":·"always",
       20 │ + → → → "bracketSameLine":·false,
       21 │ + → → → "quoteStyle":·"single",
-      22 │ + → → → "attributePosition":·"auto"
-      23 │ + → → }
-      24 │ + → }
-      25 │ + }
-      26 │ + 
+      22 │ + → → → "attributePosition":·"auto",
+      23 │ + → → → "bracketSpacing":·true
+      24 │ + → → }
+      25 │ + → }
+      26 │ + }
+      27 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_end_of_line.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_end_of_line.snap
@@ -34,23 +34,24 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
        6 │ + → → "indentWidth":·2,
        7 │ + → → "lineEnding":·"lf",
        8 │ + → → "lineWidth":·80,
-       9 │ + → → "attributePosition":·"auto"
-      10 │ + → },
-      11 │ + → "javascript":·{
-      12 │ + → → "formatter":·{
-      13 │ + → → → "jsxQuoteStyle":·"double",
-      14 │ + → → → "quoteProperties":·"asNeeded",
-      15 │ + → → → "trailingCommas":·"all",
-      16 │ + → → → "semicolons":·"asNeeded",
-      17 │ + → → → "arrowParentheses":·"always",
-      18 │ + → → → "bracketSpacing":·true,
+       9 │ + → → "attributePosition":·"auto",
+      10 │ + → → "bracketSpacing":·true
+      11 │ + → },
+      12 │ + → "javascript":·{
+      13 │ + → → "formatter":·{
+      14 │ + → → → "jsxQuoteStyle":·"double",
+      15 │ + → → → "quoteProperties":·"asNeeded",
+      16 │ + → → → "trailingCommas":·"all",
+      17 │ + → → → "semicolons":·"asNeeded",
+      18 │ + → → → "arrowParentheses":·"always",
       19 │ + → → → "bracketSameLine":·false,
       20 │ + → → → "quoteStyle":·"single",
-      21 │ + → → → "attributePosition":·"auto"
-      22 │ + → → }
-      23 │ + → }
-      24 │ + }
-      25 │ + 
+      21 │ + → → → "attributePosition":·"auto",
+      22 │ + → → → "bracketSpacing":·true
+      23 │ + → → }
+      24 │ + → }
+      25 │ + }
+      26 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_fix.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_fix.snap
@@ -13,7 +13,8 @@ expression: content
     "indentWidth": 2,
     "lineEnding": "lf",
     "lineWidth": 80,
-    "attributePosition": "auto"
+    "attributePosition": "auto",
+    "bracketSpacing": true
   },
   "linter": { "enabled": true },
   "javascript": {
@@ -23,10 +24,10 @@ expression: content
       "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
-      "bracketSpacing": true,
       "bracketSameLine": false,
       "quoteStyle": "single",
-      "attributePosition": "auto"
+      "attributePosition": "auto",
+      "bracketSpacing": true
     }
   }
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_jsonc.snap
@@ -30,24 +30,25 @@ biome.jsonc migrate ━━━━━━━━━━━━━━━━━━━━
        6 │ + → → "indentWidth":·2,
        7 │ + → → "lineEnding":·"lf",
        8 │ + → → "lineWidth":·80,
-       9 │ + → → "attributePosition":·"auto"
-      10 │ + → },
-      11 │ + → "linter":·{·"enabled":·true·},
-      12 │ + → "javascript":·{
-      13 │ + → → "formatter":·{
-      14 │ + → → → "jsxQuoteStyle":·"double",
-      15 │ + → → → "quoteProperties":·"asNeeded",
-      16 │ + → → → "trailingCommas":·"all",
-      17 │ + → → → "semicolons":·"always",
-      18 │ + → → → "arrowParentheses":·"always",
-      19 │ + → → → "bracketSpacing":·true,
+       9 │ + → → "attributePosition":·"auto",
+      10 │ + → → "bracketSpacing":·true
+      11 │ + → },
+      12 │ + → "linter":·{·"enabled":·true·},
+      13 │ + → "javascript":·{
+      14 │ + → → "formatter":·{
+      15 │ + → → → "jsxQuoteStyle":·"double",
+      16 │ + → → → "quoteProperties":·"asNeeded",
+      17 │ + → → → "trailingCommas":·"all",
+      18 │ + → → → "semicolons":·"always",
+      19 │ + → → → "arrowParentheses":·"always",
       20 │ + → → → "bracketSameLine":·false,
       21 │ + → → → "quoteStyle":·"single",
-      22 │ + → → → "attributePosition":·"auto"
-      23 │ + → → }
-      24 │ + → }
-      25 │ + }
-      26 │ + 
+      22 │ + → → → "attributePosition":·"auto",
+      23 │ + → → → "bracketSpacing":·true
+      24 │ + → → }
+      25 │ + → }
+      26 │ + }
+      27 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_overrides.snap
@@ -41,39 +41,40 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
        6 │ + → → "indentWidth":·2,
        7 │ + → → "lineEnding":·"lf",
        8 │ + → → "lineWidth":·80,
-       9 │ + → → "attributePosition":·"auto"
-      10 │ + → },
-      11 │ + → "javascript":·{
-      12 │ + → → "formatter":·{
-      13 │ + → → → "jsxQuoteStyle":·"double",
-      14 │ + → → → "quoteProperties":·"asNeeded",
-      15 │ + → → → "trailingCommas":·"all",
-      16 │ + → → → "semicolons":·"asNeeded",
-      17 │ + → → → "arrowParentheses":·"always",
-      18 │ + → → → "bracketSpacing":·true,
+       9 │ + → → "attributePosition":·"auto",
+      10 │ + → → "bracketSpacing":·true
+      11 │ + → },
+      12 │ + → "javascript":·{
+      13 │ + → → "formatter":·{
+      14 │ + → → → "jsxQuoteStyle":·"double",
+      15 │ + → → → "quoteProperties":·"asNeeded",
+      16 │ + → → → "trailingCommas":·"all",
+      17 │ + → → → "semicolons":·"asNeeded",
+      18 │ + → → → "arrowParentheses":·"always",
       19 │ + → → → "bracketSameLine":·false,
       20 │ + → → → "quoteStyle":·"single",
-      21 │ + → → → "attributePosition":·"auto"
-      22 │ + → → }
-      23 │ + → },
-      24 │ + → "overrides":·[
-      25 │ + → → {·"include":·["**/*.test.js"],·"formatter":·{·"indentStyle":·"space"·}·},
-      26 │ + → → {
-      27 │ + → → → "include":·["**/*.spec.js"],
-      28 │ + → → → "javascript":·{
-      29 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
-      30 │ + → → → }
-      31 │ + → → },
-      32 │ + → → {
-      33 │ + → → → "include":·["**/*.ts"],
-      34 │ + → → → "javascript":·{
-      35 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
-      36 │ + → → → },
-      37 │ + → → → "formatter":·{·"indentStyle":·"space"·}
-      38 │ + → → }
-      39 │ + → ]
-      40 │ + }
-      41 │ + 
+      21 │ + → → → "attributePosition":·"auto",
+      22 │ + → → → "bracketSpacing":·true
+      23 │ + → → }
+      24 │ + → },
+      25 │ + → "overrides":·[
+      26 │ + → → {·"include":·["**/*.test.js"],·"formatter":·{·"indentStyle":·"space"·}·},
+      27 │ + → → {
+      28 │ + → → → "include":·["**/*.spec.js"],
+      29 │ + → → → "javascript":·{
+      30 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
+      31 │ + → → → }
+      32 │ + → → },
+      33 │ + → → {
+      34 │ + → → → "include":·["**/*.ts"],
+      35 │ + → → → "javascript":·{
+      36 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
+      37 │ + → → → },
+      38 │ + → → → "formatter":·{·"indentStyle":·"space"·}
+      39 │ + → → }
+      40 │ + → ]
+      41 │ + }
+      42 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_with_ignore.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_with_ignore.snap
@@ -44,24 +44,25 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
        7 │ + → → "lineEnding":·"lf",
        8 │ + → → "lineWidth":·80,
        9 │ + → → "attributePosition":·"auto",
-      10 │ + → → "ignore":·["dist/**",·"node_modules/**",·"generated/*.spec.js"]
-      11 │ + → },
-      12 │ + → "linter":·{·"enabled":·true·},
-      13 │ + → "javascript":·{
-      14 │ + → → "formatter":·{
-      15 │ + → → → "jsxQuoteStyle":·"double",
-      16 │ + → → → "quoteProperties":·"asNeeded",
-      17 │ + → → → "trailingCommas":·"all",
-      18 │ + → → → "semicolons":·"always",
-      19 │ + → → → "arrowParentheses":·"always",
-      20 │ + → → → "bracketSpacing":·true,
+      10 │ + → → "bracketSpacing":·true,
+      11 │ + → → "ignore":·["dist/**",·"node_modules/**",·"generated/*.spec.js"]
+      12 │ + → },
+      13 │ + → "linter":·{·"enabled":·true·},
+      14 │ + → "javascript":·{
+      15 │ + → → "formatter":·{
+      16 │ + → → → "jsxQuoteStyle":·"double",
+      17 │ + → → → "quoteProperties":·"asNeeded",
+      18 │ + → → → "trailingCommas":·"all",
+      19 │ + → → → "semicolons":·"always",
+      20 │ + → → → "arrowParentheses":·"always",
       21 │ + → → → "bracketSameLine":·false,
       22 │ + → → → "quoteStyle":·"single",
-      23 │ + → → → "attributePosition":·"auto"
-      24 │ + → → }
-      25 │ + → }
-      26 │ + }
-      27 │ + 
+      23 │ + → → → "attributePosition":·"auto",
+      24 │ + → → → "bracketSpacing":·true
+      25 │ + → → }
+      26 │ + → }
+      27 │ + }
+      28 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write.snap
@@ -13,7 +13,8 @@ expression: content
     "indentWidth": 2,
     "lineEnding": "lf",
     "lineWidth": 80,
-    "attributePosition": "auto"
+    "attributePosition": "auto",
+    "bracketSpacing": true
   },
   "linter": { "enabled": true },
   "javascript": {
@@ -23,10 +24,10 @@ expression: content
       "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
-      "bracketSpacing": true,
       "bracketSameLine": false,
       "quoteStyle": "single",
-      "attributePosition": "auto"
+      "attributePosition": "auto",
+      "bracketSpacing": true
     }
   }
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_biome_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_biome_jsonc.snap
@@ -13,7 +13,8 @@ expression: content
     "indentWidth": 2,
     "lineEnding": "lf",
     "lineWidth": 80,
-    "attributePosition": "auto"
+    "attributePosition": "auto",
+    "bracketSpacing": true
   },
   "linter": { "enabled": true },
   "javascript": {
@@ -23,10 +24,10 @@ expression: content
       "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
-      "bracketSpacing": true,
       "bracketSameLine": false,
       "quoteStyle": "single",
-      "attributePosition": "auto"
+      "attributePosition": "auto",
+      "bracketSpacing": true
     }
   }
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_packagejson.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_packagejson.snap
@@ -13,7 +13,8 @@ expression: content
     "indentWidth": 2,
     "lineEnding": "lf",
     "lineWidth": 80,
-    "attributePosition": "auto"
+    "attributePosition": "auto",
+    "bracketSpacing": true
   },
   "linter": { "enabled": true },
   "javascript": {
@@ -23,10 +24,10 @@ expression: content
       "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
-      "bracketSpacing": true,
       "bracketSameLine": false,
       "quoteStyle": "single",
-      "attributePosition": "auto"
+      "attributePosition": "auto",
+      "bracketSpacing": true
     }
   }
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_with_ignore_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_with_ignore_file.snap
@@ -14,6 +14,7 @@ expression: content
     "lineEnding": "lf",
     "lineWidth": 80,
     "attributePosition": "auto",
+    "bracketSpacing": true,
     "ignore": ["dist/**", "node_modules/**", "generated/*.spec.js"]
   },
   "linter": { "enabled": true },
@@ -24,10 +25,10 @@ expression: content
       "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
-      "bracketSpacing": true,
       "bracketSameLine": false,
       "quoteStyle": "single",
-      "attributePosition": "auto"
+      "attributePosition": "auto",
+      "bracketSpacing": true
     }
   }
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettierjson_migrate_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettierjson_migrate_write.snap
@@ -13,7 +13,8 @@ expression: content
     "indentWidth": 2,
     "lineEnding": "lf",
     "lineWidth": 80,
-    "attributePosition": "auto"
+    "attributePosition": "auto",
+    "bracketSpacing": true
   },
   "linter": { "enabled": true },
   "javascript": {
@@ -23,10 +24,10 @@ expression: content
       "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
-      "bracketSpacing": true,
       "bracketSameLine": false,
       "quoteStyle": "single",
-      "attributePosition": "auto"
+      "attributePosition": "auto",
+      "bracketSpacing": true
     }
   }
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
@@ -93,14 +93,14 @@ JavaScript Formatter:
   Trailing commas:              All
   Semicolons:                   Always
   Arrow parentheses:            Always
-  Bracket spacing:              None
+  Bracket spacing:              unset
   Bracket same line:            false
   Quote style:                  Double
   Indent style:                 Tab
   Indent width:                 2
   Line ending:                  Lf
   Line width:                   100
-  Attribute position:           None
+  Attribute position:           unset
 
 JSON Formatter:
   Enabled:                      true
@@ -124,8 +124,8 @@ GraphQL Formatter:
   Indent width:                 unset
   Line ending:                  unset
   Line width:                   unset
-  Bracket spacing:              None
-  Quote style:                  None
+  Bracket spacing:              unset
+  Quote style:                  unset
 
 Server:
   Version:                      0.0.0

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
@@ -82,6 +82,7 @@ Formatter:
   Line ending:                  Lf
   Line width:                   120
   Attribute position:           Multiline
+  Bracket spacing:              BracketSpacing(true)
   Ignore:                       ["configuration-schema.json"]
   Include:                      ["**/*.html", "**/*.css", "**/*.js", "**/*.ts", "**/*.tsx", "**/*.jsx", "**/*.json", "**/*.md"]
 
@@ -92,14 +93,14 @@ JavaScript Formatter:
   Trailing commas:              All
   Semicolons:                   Always
   Arrow parentheses:            Always
-  Bracket spacing:              false
+  Bracket spacing:              None
   Bracket same line:            false
   Quote style:                  Double
   Indent style:                 Tab
   Indent width:                 2
   Line ending:                  Lf
   Line width:                   100
-  Attribute position:           Auto
+  Attribute position:           None
 
 JSON Formatter:
   Enabled:                      true
@@ -123,7 +124,8 @@ GraphQL Formatter:
   Indent width:                 unset
   Line ending:                  unset
   Line width:                   unset
-  Quote style:                  Double
+  Bracket spacing:              None
+  Quote style:                  None
 
 Server:
   Version:                      0.0.0

--- a/crates/biome_configuration/src/formatter.rs
+++ b/crates/biome_configuration/src/formatter.rs
@@ -1,6 +1,8 @@
 use biome_deserialize::StringSet;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
-use biome_formatter::{AttributePosition, IndentStyle, IndentWidth, LineEnding, LineWidth};
+use biome_formatter::{
+    AttributePosition, BracketSpacing, IndentStyle, IndentWidth, LineEnding, LineWidth,
+};
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -45,6 +47,10 @@ pub struct FormatterConfiguration {
     #[partial(bpaf(long("attribute-position"), argument("multiline|auto"), optional))]
     pub attribute_position: AttributePosition,
 
+    /// Whether to insert spaces around brackets in object literals. Defaults to true.
+    #[partial(bpaf(long("bracket-spacing"), argument("true|false"), optional))]
+    pub bracket_spacing: BracketSpacing,
+
     /// A list of Unix shell style patterns. The formatter will ignore files/folders that will
     /// match these patterns.
     #[partial(bpaf(hide))]
@@ -71,6 +77,7 @@ impl PartialFormatterConfiguration {
             line_ending: self.line_ending.unwrap_or_default(),
             line_width: self.line_width.unwrap_or_default(),
             attribute_position: self.attribute_position.unwrap_or_default(),
+            bracket_spacing: self.bracket_spacing.unwrap_or_default(),
             ignore: self.ignore.clone().unwrap_or_default(),
             include: self.include.clone().unwrap_or_default(),
         }
@@ -88,6 +95,7 @@ impl Default for FormatterConfiguration {
             line_ending: LineEnding::default(),
             line_width: LineWidth::default(),
             attribute_position: AttributePosition::default(),
+            bracket_spacing: Default::default(),
             ignore: Default::default(),
             include: Default::default(),
         }

--- a/crates/biome_configuration/src/graphql.rs
+++ b/crates/biome_configuration/src/graphql.rs
@@ -1,6 +1,6 @@
 use crate::PlainIndentStyle;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
-use biome_formatter::{IndentWidth, LineEnding, LineWidth, QuoteStyle};
+use biome_formatter::{BracketSpacing, IndentWidth, LineEnding, LineWidth, QuoteStyle};
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 
@@ -55,7 +55,12 @@ pub struct GraphqlFormatter {
         argument("double|single"),
         optional
     ))]
-    pub quote_style: QuoteStyle,
+    pub quote_style: Option<QuoteStyle>,
+
+    // it's also a top-level configurable property.
+    /// Whether to insert spaces around brackets in object literals. Defaults to true.
+    #[partial(bpaf(long("bracket-spacing"), argument("true|false"), optional))]
+    pub bracket_spacing: Option<BracketSpacing>,
 }
 
 impl PartialGraphqlFormatter {
@@ -66,7 +71,8 @@ impl PartialGraphqlFormatter {
             indent_width: self.indent_width,
             line_ending: self.line_ending,
             line_width: self.line_width,
-            quote_style: self.quote_style.unwrap_or_default(),
+            quote_style: self.quote_style,
+            bracket_spacing: self.bracket_spacing,
         }
     }
 }
@@ -80,5 +86,5 @@ fn default_graphql() {
     assert_eq!(graphql_configuration.indent_width, None);
     assert_eq!(graphql_configuration.line_ending, None);
     assert_eq!(graphql_configuration.line_width, None);
-    assert_eq!(graphql_configuration.quote_style, QuoteStyle::Double);
+    assert_eq!(graphql_configuration.quote_style, None);
 }

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -1,6 +1,8 @@
 use crate::PlainIndentStyle;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
-use biome_formatter::{AttributePosition, IndentWidth, LineEnding, LineWidth, QuoteStyle};
+use biome_formatter::{
+    AttributePosition, BracketSpacing, IndentWidth, LineEnding, LineWidth, QuoteStyle,
+};
 use biome_js_formatter::context::{
     trailing_commas::TrailingCommas, ArrowParentheses, QuoteProperties, Semicolons,
 };
@@ -38,10 +40,6 @@ pub struct JavascriptFormatter {
     /// Whether to add non-necessary parentheses to arrow functions. Defaults to "always".
     #[partial(bpaf(long("arrow-parentheses"), argument("always|as-needed"), optional))]
     pub arrow_parentheses: ArrowParentheses,
-
-    /// Whether to insert spaces around brackets in object literals. Defaults to true.
-    #[partial(bpaf(long("bracket-spacing"), argument("true|false"), optional))]
-    pub bracket_spacing: bool,
 
     /// Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.
     #[partial(bpaf(long("bracket-same-line"), argument("true|false"), optional))]
@@ -98,7 +96,12 @@ pub struct JavascriptFormatter {
         argument("multiline|auto"),
         optional
     ))]
-    pub attribute_position: AttributePosition,
+    pub attribute_position: Option<AttributePosition>,
+
+    // it's also a top-level configurable property.
+    /// Whether to insert spaces around brackets in object literals. Defaults to true.
+    #[partial(bpaf(long("bracket-spacing"), argument("true|false"), optional))]
+    pub bracket_spacing: Option<BracketSpacing>,
 }
 
 impl PartialJavascriptFormatter {
@@ -111,7 +114,7 @@ impl PartialJavascriptFormatter {
             trailing_commas: self.trailing_commas.unwrap_or_default(),
             semicolons: self.semicolons.unwrap_or_default(),
             arrow_parentheses: self.arrow_parentheses.unwrap_or_default(),
-            bracket_spacing: self.bracket_spacing.unwrap_or_default(),
+            bracket_spacing: self.bracket_spacing,
             bracket_same_line: self.bracket_same_line.unwrap_or_default(),
             indent_style: self.indent_style,
             indent_size: self.indent_size,
@@ -119,7 +122,7 @@ impl PartialJavascriptFormatter {
             line_ending: self.line_ending,
             line_width: self.line_width,
             quote_style: self.quote_style.unwrap_or_default(),
-            attribute_position: self.attribute_position.unwrap_or_default(),
+            attribute_position: self.attribute_position,
         }
     }
 }
@@ -134,7 +137,7 @@ impl Default for JavascriptFormatter {
             trailing_commas: Default::default(),
             semicolons: Default::default(),
             arrow_parentheses: Default::default(),
-            bracket_spacing: true,
+            bracket_spacing: Default::default(),
             bracket_same_line: Default::default(),
             indent_style: Default::default(),
             indent_size: Default::default(),

--- a/crates/biome_configuration/src/overrides.rs
+++ b/crates/biome_configuration/src/overrides.rs
@@ -1,13 +1,13 @@
 use super::javascript::PartialJavascriptConfiguration;
 use super::json::PartialJsonConfiguration;
-use super::PartialCssConfiguration;
+use super::{PartialCssConfiguration, PartialGraphqlConfiguration};
 use crate::{
-    partial_css_configuration, partial_javascript_configuration, partial_json_configuration,
-    PlainIndentStyle, Rules,
+    partial_css_configuration, partial_graphql_configuration, partial_javascript_configuration,
+    partial_json_configuration, PlainIndentStyle, Rules,
 };
 use biome_deserialize::StringSet;
 use biome_deserialize_macros::{Deserializable, Merge};
-use biome_formatter::{AttributePosition, IndentWidth, LineEnding, LineWidth};
+use biome_formatter::{AttributePosition, BracketSpacing, IndentWidth, LineEnding, LineWidth};
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -59,6 +59,11 @@ pub struct OverridePattern {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[bpaf(external(partial_css_configuration), optional, hide)]
     pub css: Option<PartialCssConfiguration>,
+
+    /// Specific configuration for the Graphql language
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[bpaf(external(partial_graphql_configuration), optional, hide)]
+    pub graphql: Option<PartialGraphqlConfiguration>,
 
     /// Specific configuration for the Json language
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -131,6 +136,11 @@ pub struct OverrideFormatterConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[bpaf(long("attribute-position"), argument("multiline|auto"), optional)]
     pub attribute_position: Option<AttributePosition>,
+
+    /// Whether to insert spaces around brackets in object literals. Defaults to true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[bpaf(long("bracket-spacing"), argument("true|false"), optional)]
+    pub bracket_spacing: Option<BracketSpacing>,
 }
 
 #[derive(

--- a/crates/biome_css_formatter/src/context.rs
+++ b/crates/biome_css_formatter/src/context.rs
@@ -1,5 +1,5 @@
 use crate::CssCommentStyle;
-use biome_formatter::{prelude::*, AttributePosition, IndentWidth, QuoteStyle};
+use biome_formatter::{prelude::*, AttributePosition, BracketSpacing, IndentWidth, QuoteStyle};
 use biome_formatter::{
     CstFormatContext, FormatContext, FormatOptions, IndentStyle, LineEnding, LineWidth,
     TransformSourceMap,
@@ -62,7 +62,6 @@ pub struct CssFormatOptions {
     line_ending: LineEnding,
     line_width: LineWidth,
     quote_style: QuoteStyle,
-    attribute_position: AttributePosition,
     _file_source: CssFileSource,
 }
 
@@ -75,7 +74,6 @@ impl CssFormatOptions {
             line_ending: LineEnding::default(),
             line_width: LineWidth::default(),
             quote_style: QuoteStyle::default(),
-            attribute_position: AttributePosition::default(),
         }
     }
 
@@ -138,20 +136,24 @@ impl FormatOptions for CssFormatOptions {
         self.indent_width
     }
 
-    fn line_ending(&self) -> LineEnding {
-        self.line_ending
-    }
-
     fn line_width(&self) -> LineWidth {
         self.line_width
     }
 
-    fn as_print_options(&self) -> PrinterOptions {
-        PrinterOptions::from(self)
+    fn line_ending(&self) -> LineEnding {
+        self.line_ending
     }
 
     fn attribute_position(&self) -> AttributePosition {
-        self.attribute_position
+        AttributePosition::default()
+    }
+
+    fn bracket_spacing(&self) -> BracketSpacing {
+        BracketSpacing::default()
+    }
+
+    fn as_print_options(&self) -> PrinterOptions {
+        PrinterOptions::from(self)
     }
 }
 

--- a/crates/biome_formatter/src/format_element/document.rs
+++ b/crates/biome_formatter/src/format_element/document.rs
@@ -2,7 +2,7 @@ use super::tag::Tag;
 use crate::format_element::tag::DedentMode;
 use crate::prelude::tag::GroupMode;
 use crate::prelude::*;
-use crate::{format, write, AttributePosition};
+use crate::{format, write, AttributePosition, BracketSpacing};
 use crate::{
     BufferExtensions, Format, FormatContext, FormatElement, FormatOptions, FormatResult, Formatter,
     IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions, TransformSourceMap,
@@ -203,6 +203,10 @@ impl FormatOptions for IrFormatOptions {
         AttributePosition::default()
     }
 
+    fn bracket_spacing(&self) -> BracketSpacing {
+        BracketSpacing::default()
+    }
+
     fn as_print_options(&self) -> PrinterOptions {
         PrinterOptions {
             indent_width: self.indent_width(),
@@ -210,6 +214,7 @@ impl FormatOptions for IrFormatOptions {
             line_ending: LineEnding::Lf,
             indent_style: IndentStyle::Space,
             attribute_position: self.attribute_position(),
+            bracket_spacing: self.bracket_spacing(),
         }
     }
 }

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -567,6 +567,54 @@ impl From<QuoteStyle> for Quote {
     }
 }
 
+#[derive(Clone, Copy, Debug, Deserializable, Eq, Hash, Merge, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    serde(rename_all = "camelCase")
+)]
+pub struct BracketSpacing(bool);
+
+impl BracketSpacing {
+    /// Return the boolean value for this [BracketSpacing]
+    pub fn value(&self) -> bool {
+        self.0
+    }
+}
+
+impl Default for BracketSpacing {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
+impl From<bool> for BracketSpacing {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for BracketSpacing {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::write!(f, "{}", self.value())
+    }
+}
+
+impl FromStr for BracketSpacing {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let value = bool::from_str(s);
+
+        match value {
+            Ok(value) => Ok(Self(value)),
+            Err(_) => Err(
+                "Value not supported for BracketSpacing. Supported values are 'true' and 'false'.",
+            ),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Deserializable, Eq, Hash, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",
@@ -632,6 +680,9 @@ pub trait FormatOptions {
     /// The attribute position.
     fn attribute_position(&self) -> AttributePosition;
 
+    /// Whether to insert spaces around brackets in object literals. Defaults to true.
+    fn bracket_spacing(&self) -> BracketSpacing;
+
     /// Derives the print options from the these format options
     fn as_print_options(&self) -> PrinterOptions;
 }
@@ -681,6 +732,7 @@ pub struct SimpleFormatOptions {
     pub line_width: LineWidth,
     pub line_ending: LineEnding,
     pub attribute_position: AttributePosition,
+    pub bracket_spacing: BracketSpacing,
 }
 
 impl FormatOptions for SimpleFormatOptions {
@@ -704,6 +756,10 @@ impl FormatOptions for SimpleFormatOptions {
         self.attribute_position
     }
 
+    fn bracket_spacing(&self) -> BracketSpacing {
+        self.bracket_spacing
+    }
+
     fn as_print_options(&self) -> PrinterOptions {
         PrinterOptions::default()
             .with_indent_style(self.indent_style)
@@ -711,6 +767,7 @@ impl FormatOptions for SimpleFormatOptions {
             .with_print_width(self.line_width.into())
             .with_line_ending(self.line_ending)
             .with_attribute_position(self.attribute_position)
+            .with_bracket_spacing(self.bracket_spacing)
     }
 }
 

--- a/crates/biome_formatter/src/printer/printer_options/mod.rs
+++ b/crates/biome_formatter/src/printer/printer_options/mod.rs
@@ -1,4 +1,7 @@
-use crate::{AttributePosition, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth};
+use crate::{
+    AttributePosition, BracketSpacing, FormatOptions, IndentStyle, IndentWidth, LineEnding,
+    LineWidth,
+};
 
 /// Options that affect how the [crate::Printer] prints the format tokens
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -18,6 +21,9 @@ pub struct PrinterOptions {
 
     /// The attribute position style
     pub attribute_position: AttributePosition,
+
+    /// Whether to insert spaces around brackets in object literals. Defaults to true.
+    pub bracket_spacing: BracketSpacing,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -57,6 +63,7 @@ where
             .with_indent_width(options.indent_width())
             .with_print_width(options.line_width().into())
             .with_line_ending(options.line_ending())
+            .with_bracket_spacing(options.bracket_spacing())
     }
 }
 
@@ -89,6 +96,13 @@ impl PrinterOptions {
 
         self
     }
+
+    pub fn with_bracket_spacing(mut self, bracket_spacing: BracketSpacing) -> Self {
+        self.bracket_spacing = bracket_spacing;
+
+        self
+    }
+
     pub(crate) fn indent_style(&self) -> IndentStyle {
         self.indent_style
     }
@@ -107,6 +121,11 @@ impl PrinterOptions {
     pub(crate) fn attribute_position(&self) -> AttributePosition {
         self.attribute_position
     }
+
+    #[allow(dead_code)]
+    pub(crate) fn bracket_spacing(&self) -> BracketSpacing {
+        self.bracket_spacing
+    }
 }
 
 impl Default for PrinterOptions {
@@ -117,6 +136,7 @@ impl Default for PrinterOptions {
             indent_style: Default::default(),
             line_ending: LineEnding::Lf,
             attribute_position: AttributePosition::default(),
+            bracket_spacing: BracketSpacing::default(),
         }
     }
 }

--- a/crates/biome_graphql_formatter/src/context.rs
+++ b/crates/biome_graphql_formatter/src/context.rs
@@ -1,5 +1,5 @@
 use crate::GraphqlCommentStyle;
-use biome_formatter::{prelude::*, AttributePosition, IndentWidth, QuoteStyle};
+use biome_formatter::{prelude::*, AttributePosition, BracketSpacing, IndentWidth, QuoteStyle};
 use biome_formatter::{
     CstFormatContext, FormatContext, FormatOptions, IndentStyle, LineEnding, LineWidth,
     TransformSourceMap,
@@ -63,6 +63,7 @@ pub struct GraphqlFormatOptions {
     line_width: LineWidth,
     quote_style: QuoteStyle,
     attribute_position: AttributePosition,
+    bracket_spacing: BracketSpacing,
     _file_source: GraphqlFileSource,
 }
 
@@ -76,6 +77,7 @@ impl GraphqlFormatOptions {
             line_width: LineWidth::default(),
             quote_style: QuoteStyle::default(),
             attribute_position: AttributePosition::default(),
+            bracket_spacing: BracketSpacing::default(),
         }
     }
 
@@ -96,6 +98,11 @@ impl GraphqlFormatOptions {
 
     pub fn with_line_width(mut self, line_width: LineWidth) -> Self {
         self.line_width = line_width;
+        self
+    }
+
+    pub fn with_bracket_spacing(mut self, bracket_spacing: BracketSpacing) -> Self {
+        self.bracket_spacing = bracket_spacing;
         self
     }
 
@@ -124,6 +131,10 @@ impl GraphqlFormatOptions {
         self.quote_style = quote_style;
     }
 
+    pub fn set_bracket_spacing(&mut self, bracket_spacing: BracketSpacing) {
+        self.bracket_spacing = bracket_spacing;
+    }
+
     pub fn quote_style(&self) -> QuoteStyle {
         self.quote_style
     }
@@ -138,20 +149,24 @@ impl FormatOptions for GraphqlFormatOptions {
         self.indent_width
     }
 
-    fn line_ending(&self) -> LineEnding {
-        self.line_ending
-    }
-
     fn line_width(&self) -> LineWidth {
         self.line_width
     }
 
-    fn as_print_options(&self) -> PrinterOptions {
-        PrinterOptions::from(self)
+    fn line_ending(&self) -> LineEnding {
+        self.line_ending
     }
 
     fn attribute_position(&self) -> AttributePosition {
         self.attribute_position
+    }
+
+    fn bracket_spacing(&self) -> BracketSpacing {
+        self.bracket_spacing
+    }
+
+    fn as_print_options(&self) -> PrinterOptions {
+        PrinterOptions::from(self)
     }
 }
 
@@ -161,6 +176,7 @@ impl fmt::Display for GraphqlFormatOptions {
         writeln!(f, "Indent width: {}", self.indent_width.value())?;
         writeln!(f, "Line ending: {}", self.line_ending)?;
         writeln!(f, "Line width: {}", self.line_width.value())?;
+        writeln!(f, "Bracket spacing: {}", self.bracket_spacing.value())?;
         writeln!(f, "Quote style: {}", self.quote_style)
     }
 }

--- a/crates/biome_graphql_formatter/src/graphql/value/object_value.rs
+++ b/crates/biome_graphql_formatter/src/graphql/value/object_value.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{format_args, write};
+use biome_formatter::{format_args, write, FormatOptions};
 use biome_graphql_syntax::{GraphqlObjectValue, GraphqlObjectValueFields};
 
 #[derive(Debug, Clone, Default)]
@@ -16,7 +16,10 @@ impl FormatNodeRule<GraphqlObjectValue> for FormatGraphqlObjectValue {
             f,
             [group(&format_args![
                 l_curly_token.format(),
-                soft_block_indent_with_maybe_space(&members.format(), true), // TODO implement options.bracket_spacing
+                soft_block_indent_with_maybe_space(
+                    &members.format(),
+                    f.options().bracket_spacing().value()
+                ),
                 r_curly_token.format()
             ])]
         )

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/directive_definition.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/directive_definition.graphql.snap
@@ -55,6 +55,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/enum.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/enum.graphql.snap
@@ -55,6 +55,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/enum_extension.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/enum_extension.graphql.snap
@@ -46,6 +46,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/fragment.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/fragment.graphql.snap
@@ -51,6 +51,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/input_object.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/input_object.graphql.snap
@@ -77,6 +77,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/input_object_extension.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/input_object_extension.graphql.snap
@@ -49,6 +49,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/interface.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/interface.graphql.snap
@@ -111,6 +111,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/interface_extension.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/interface_extension.graphql.snap
@@ -65,6 +65,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/object.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/object.graphql.snap
@@ -117,6 +117,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/object_extension.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/object_extension.graphql.snap
@@ -57,6 +57,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/scalar.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/scalar.graphql.snap
@@ -30,6 +30,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/scalar_extension.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/scalar_extension.graphql.snap
@@ -27,6 +27,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/schema.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/schema.graphql.snap
@@ -52,6 +52,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/schema_extension.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/schema_extension.graphql.snap
@@ -47,6 +47,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/union.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/union.graphql.snap
@@ -40,6 +40,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/definitions/union_extension.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/definitions/union_extension.graphql.snap
@@ -23,6 +23,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/directive.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/directive.graphql.snap
@@ -78,6 +78,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/object/spacing/global/object_spacing.graphql
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/object/spacing/global/object_spacing.graphql
@@ -1,0 +1,5 @@
+{
+	field_value(
+		object_value: {key: "value"}
+	)
+}

--- a/crates/biome_graphql_formatter/tests/specs/graphql/object/spacing/global/object_spacing.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/object/spacing/global/object_spacing.graphql.snap
@@ -1,0 +1,53 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: graphql/object/spacing/global/object_spacing.graphql
+---
+# Input
+
+```graphql
+{
+	field_value(
+		object_value: {key: "value"}
+	)
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Bracket spacing: true
+Quote style: Double Quotes
+-----
+
+```graphql
+{
+	field_value(object_value: { key: "value" })
+}
+```
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Bracket spacing: true
+Quote style: Double Quotes
+-----
+
+```graphql
+{
+	field_value(object_value: { key: "value" })
+}
+```

--- a/crates/biome_graphql_formatter/tests/specs/graphql/object/spacing/global/options.json
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/object/spacing/global/options.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "formatter": {
+    "bracketSpacing": false
+  },
+  "graphql": {
+    "formatter": {
+      "bracketSpacing": true
+    }
+  }
+}

--- a/crates/biome_graphql_formatter/tests/specs/graphql/object/spacing/object_spacing.graphql
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/object/spacing/object_spacing.graphql
@@ -1,0 +1,5 @@
+{
+	field_value(
+		object_value: {key: "value"}
+	)
+}

--- a/crates/biome_graphql_formatter/tests/specs/graphql/object/spacing/object_spacing.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/object/spacing/object_spacing.graphql.snap
@@ -1,0 +1,53 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: graphql/object/spacing/object_spacing.graphql
+---
+# Input
+
+```graphql
+{
+	field_value(
+		object_value: {key: "value"}
+	)
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Bracket spacing: true
+Quote style: Double Quotes
+-----
+
+```graphql
+{
+	field_value(object_value: { key: "value" })
+}
+```
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Bracket spacing: false
+Quote style: Double Quotes
+-----
+
+```graphql
+{
+	field_value(object_value: {key: "value"})
+}
+```

--- a/crates/biome_graphql_formatter/tests/specs/graphql/object/spacing/options.json
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/object/spacing/options.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "formatter": {
+    "bracketSpacing": false
+  }
+}

--- a/crates/biome_graphql_formatter/tests/specs/graphql/operation.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/operation.graphql.snap
@@ -179,6 +179,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/selection_set.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/selection_set.graphql.snap
@@ -269,6 +269,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/simple.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/simple.graphql.snap
@@ -79,6 +79,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/type.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/type.graphql.snap
@@ -32,6 +32,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_graphql_formatter/tests/specs/graphql/value.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/value.graphql.snap
@@ -34,6 +34,7 @@ Indent style: Tab
 Indent width: 2
 Line ending: LF
 Line width: 80
+Bracket spacing: true
 Quote style: Double Quotes
 -----
 

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -4,8 +4,8 @@ use crate::comments::{FormatJsLeadingComment, JsCommentStyle, JsComments};
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::printer::PrinterOptions;
 use biome_formatter::{
-    AttributePosition, CstFormatContext, FormatContext, FormatElement, FormatOptions, IndentStyle,
-    IndentWidth, LineEnding, LineWidth, QuoteStyle, TransformSourceMap,
+    AttributePosition, BracketSpacing, CstFormatContext, FormatContext, FormatElement,
+    FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteStyle, TransformSourceMap,
 };
 use biome_js_syntax::{AnyJsFunctionBody, JsFileSource, JsLanguage};
 use std::fmt;
@@ -376,6 +376,10 @@ impl FormatOptions for JsFormatOptions {
         self.attribute_position
     }
 
+    fn bracket_spacing(&self) -> BracketSpacing {
+        self.bracket_spacing
+    }
+
     fn as_print_options(&self) -> PrinterOptions {
         PrinterOptions::from(self)
     }
@@ -517,33 +521,6 @@ impl fmt::Display for ArrowParentheses {
             ArrowParentheses::AsNeeded => write!(f, "As needed"),
             ArrowParentheses::Always => write!(f, "Always"),
         }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, Merge, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
-    serde(rename_all = "camelCase")
-)]
-pub struct BracketSpacing(bool);
-
-impl BracketSpacing {
-    /// Return the boolean value for this [BracketSpacing]
-    pub fn value(&self) -> bool {
-        self.0
-    }
-}
-
-impl Default for BracketSpacing {
-    fn default() -> Self {
-        Self(true)
-    }
-}
-
-impl From<bool> for BracketSpacing {
-    fn from(value: bool) -> Self {
-        Self(value)
     }
 }
 

--- a/crates/biome_json_formatter/src/context.rs
+++ b/crates/biome_json_formatter/src/context.rs
@@ -2,7 +2,7 @@ use crate::comments::{FormatJsonLeadingComment, JsonComments};
 use crate::JsonCommentStyle;
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::separated::TrailingSeparator;
-use biome_formatter::{prelude::*, AttributePosition, IndentWidth};
+use biome_formatter::{prelude::*, AttributePosition, BracketSpacing, IndentWidth};
 use biome_formatter::{
     CstFormatContext, FormatContext, FormatOptions, IndentStyle, LineEnding, LineWidth,
     TransformSourceMap,
@@ -173,20 +173,24 @@ impl FormatOptions for JsonFormatOptions {
         self.indent_width
     }
 
-    fn line_ending(&self) -> LineEnding {
-        self.line_ending
-    }
-
     fn line_width(&self) -> LineWidth {
         self.line_width
     }
 
-    fn as_print_options(&self) -> PrinterOptions {
-        PrinterOptions::from(self)
+    fn line_ending(&self) -> LineEnding {
+        self.line_ending
     }
 
     fn attribute_position(&self) -> AttributePosition {
         self.attribute_position
+    }
+
+    fn bracket_spacing(&self) -> BracketSpacing {
+        BracketSpacing::default()
+    }
+
+    fn as_print_options(&self) -> PrinterOptions {
+        PrinterOptions::from(self)
     }
 }
 

--- a/crates/biome_service/src/file_handlers/graphql.rs
+++ b/crates/biome_service/src/file_handlers/graphql.rs
@@ -20,7 +20,8 @@ use biome_analyze::{
 };
 use biome_diagnostics::{category, Applicability, Diagnostic, DiagnosticExt, Severity};
 use biome_formatter::{
-    FormatError, IndentStyle, IndentWidth, LineEnding, LineWidth, Printed, QuoteStyle,
+    BracketSpacing, FormatError, IndentStyle, IndentWidth, LineEnding, LineWidth, Printed,
+    QuoteStyle,
 };
 use biome_fs::BiomePath;
 use biome_graphql_analyze::analyze;
@@ -41,6 +42,7 @@ pub struct GraphqlFormatterSettings {
     pub indent_width: Option<IndentWidth>,
     pub indent_style: Option<IndentStyle>,
     pub quote_style: Option<QuoteStyle>,
+    pub bracket_spacing: Option<BracketSpacing>,
     pub enabled: Option<bool>,
 }
 
@@ -53,6 +55,7 @@ impl Default for GraphqlFormatterSettings {
             line_ending: Default::default(),
             line_width: Default::default(),
             quote_style: Default::default(),
+            bracket_spacing: Default::default(),
         }
     }
 }
@@ -94,6 +97,11 @@ impl ServiceLanguage for GraphqlLanguage {
             .or(global.and_then(|g| g.line_ending))
             .unwrap_or_default();
 
+        let bracket_spacing = language
+            .and_then(|l| l.bracket_spacing)
+            .or(global.and_then(|g| g.bracket_spacing))
+            .unwrap_or_default();
+
         let options = GraphqlFormatOptions::new(
             document_file_source
                 .to_graphql_file_source()
@@ -103,6 +111,7 @@ impl ServiceLanguage for GraphqlLanguage {
         .with_indent_width(indent_width)
         .with_line_width(line_width)
         .with_line_ending(line_ending)
+        .with_bracket_spacing(bracket_spacing)
         .with_quote_style(language.and_then(|l| l.quote_style).unwrap_or_default());
         if let Some(overrides) = overrides {
             overrides.to_override_graphql_format_options(path, options)

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -27,15 +27,15 @@ use biome_analyze::{
 use biome_configuration::javascript::JsxRuntime;
 use biome_diagnostics::{category, Applicability, Diagnostic, DiagnosticExt, Severity};
 use biome_formatter::{
-    AttributePosition, FormatError, IndentStyle, IndentWidth, LineEnding, LineWidth, Printed,
-    QuoteStyle,
+    AttributePosition, BracketSpacing, FormatError, IndentStyle, IndentWidth, LineEnding,
+    LineWidth, Printed, QuoteStyle,
 };
 use biome_fs::BiomePath;
 use biome_js_analyze::utils::rename::{RenameError, RenameSymbolExtensions};
 use biome_js_analyze::{analyze, analyze_with_inspect_matcher, visit_registry, ControlFlowGraph};
 use biome_js_formatter::context::trailing_commas::TrailingCommas;
 use biome_js_formatter::context::{
-    ArrowParentheses, BracketSameLine, BracketSpacing, JsFormatOptions, QuoteProperties, Semicolons,
+    ArrowParentheses, BracketSameLine, JsFormatOptions, QuoteProperties, Semicolons,
 };
 use biome_js_formatter::format_node;
 use biome_js_parser::JsParserOptions;
@@ -161,7 +161,12 @@ impl ServiceLanguage for JsLanguage {
                 .and_then(|l| l.arrow_parentheses)
                 .unwrap_or_default(),
         )
-        .with_bracket_spacing(language.and_then(|l| l.bracket_spacing).unwrap_or_default())
+        .with_bracket_spacing(
+            language
+                .and_then(|l| l.bracket_spacing)
+                .or(global.and_then(|g| g.bracket_spacing))
+                .unwrap_or_default(),
+        )
         .with_bracket_same_line(
             language
                 .and_then(|l| l.bracket_same_line)

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -8,15 +8,17 @@ use biome_configuration::{
     push_to_analyzer_rules, BiomeDiagnostic, FilesConfiguration, FormatterConfiguration,
     JavascriptConfiguration, LinterConfiguration, OverrideFormatterConfiguration,
     OverrideLinterConfiguration, OverrideOrganizeImportsConfiguration, Overrides,
-    PartialConfiguration, PartialCssConfiguration, PartialJavascriptConfiguration,
-    PartialJsonConfiguration, PlainIndentStyle, Rules,
+    PartialConfiguration, PartialCssConfiguration, PartialGraphqlConfiguration,
+    PartialJavascriptConfiguration, PartialJsonConfiguration, PlainIndentStyle, Rules,
 };
 use biome_css_formatter::context::CssFormatOptions;
 use biome_css_parser::CssParserOptions;
 use biome_css_syntax::CssLanguage;
 use biome_deserialize::{Merge, StringSet};
 use biome_diagnostics::Category;
-use biome_formatter::{AttributePosition, IndentStyle, IndentWidth, LineEnding, LineWidth};
+use biome_formatter::{
+    AttributePosition, BracketSpacing, IndentStyle, IndentWidth, LineEnding, LineWidth,
+};
 use biome_fs::BiomePath;
 use biome_graphql_formatter::context::GraphqlFormatOptions;
 use biome_graphql_syntax::GraphqlLanguage;
@@ -219,6 +221,10 @@ impl Settings {
         if let Some(css) = configuration.css {
             self.languages.css = css.into();
         }
+        // graphql settings
+        if let Some(graphql) = configuration.graphql {
+            self.languages.graphql = graphql.into();
+        }
 
         // NOTE: keep this last. Computing the overrides require reading the settings computed by the parent settings.
         if let Some(overrides) = configuration.overrides {
@@ -332,6 +338,7 @@ pub struct FormatSettings {
     pub line_ending: Option<LineEnding>,
     pub line_width: Option<LineWidth>,
     pub attribute_position: Option<AttributePosition>,
+    pub bracket_spacing: Option<BracketSpacing>,
     /// List of ignore paths/files
     pub ignored_files: Matcher,
     /// List of included paths/files
@@ -348,6 +355,7 @@ impl Default for FormatSettings {
             line_ending: Some(LineEnding::default()),
             line_width: Some(LineWidth::default()),
             attribute_position: Some(AttributePosition::default()),
+            bracket_spacing: Some(BracketSpacing::default()),
             ignored_files: Matcher::empty(),
             included_files: Matcher::empty(),
         }
@@ -366,6 +374,8 @@ pub struct OverrideFormatSettings {
     pub indent_width: Option<IndentWidth>,
     pub line_ending: Option<LineEnding>,
     pub line_width: Option<LineWidth>,
+    pub bracket_spacing: Option<BracketSpacing>,
+    pub attribute_position: Option<AttributePosition>,
 }
 
 /// Linter settings for the entire workspace
@@ -455,10 +465,11 @@ impl From<JavascriptConfiguration> for LanguageSettings<JsLanguage> {
         language_setting.formatter.trailing_commas = Some(formatter.trailing_commas);
         language_setting.formatter.semicolons = Some(formatter.semicolons);
         language_setting.formatter.arrow_parentheses = Some(formatter.arrow_parentheses);
-        language_setting.formatter.bracket_spacing = Some(formatter.bracket_spacing.into());
         language_setting.formatter.bracket_same_line = Some(formatter.bracket_same_line.into());
         language_setting.formatter.enabled = Some(formatter.enabled);
         language_setting.formatter.line_width = formatter.line_width;
+        language_setting.formatter.bracket_spacing = formatter.bracket_spacing;
+        language_setting.formatter.attribute_position = formatter.attribute_position;
         language_setting.formatter.indent_width = formatter.indent_width.map(Into::into);
         language_setting.formatter.indent_style = formatter.indent_style.map(Into::into);
         language_setting.parser.parse_class_parameter_decorators =
@@ -515,6 +526,25 @@ impl From<PartialCssConfiguration> for LanguageSettings<CssLanguage> {
         if let Some(linter) = css.linter {
             // TODO: change RHS to `linter.enabled` when css linting is enabled by default
             language_setting.linter.enabled = Some(linter.enabled.unwrap_or_default());
+        }
+
+        language_setting
+    }
+}
+
+impl From<PartialGraphqlConfiguration> for LanguageSettings<GraphqlLanguage> {
+    fn from(graphql: PartialGraphqlConfiguration) -> Self {
+        let mut language_setting: LanguageSettings<GraphqlLanguage> = LanguageSettings::default();
+
+        if let Some(formatter) = graphql.formatter {
+            // TODO: change RHS to `formatter.enabled` when graphql formatting is enabled by default
+            language_setting.formatter.enabled = Some(formatter.enabled.unwrap_or_default());
+            language_setting.formatter.indent_width = formatter.indent_width;
+            language_setting.formatter.indent_style = formatter.indent_style.map(Into::into);
+            language_setting.formatter.line_width = formatter.line_width;
+            language_setting.formatter.line_ending = formatter.line_ending;
+            language_setting.formatter.quote_style = formatter.quote_style;
+            language_setting.formatter.bracket_spacing = formatter.bracket_spacing;
         }
 
         language_setting
@@ -1020,13 +1050,16 @@ impl OverrideSettingPattern {
         if let Some(arrow_parentheses) = js_formatter.arrow_parentheses {
             options.set_arrow_parentheses(arrow_parentheses);
         }
-        if let Some(bracket_spacing) = js_formatter.bracket_spacing {
+        if let Some(bracket_spacing) = js_formatter.bracket_spacing.or(formatter.bracket_spacing) {
             options.set_bracket_spacing(bracket_spacing);
         }
         if let Some(bracket_same_line) = js_formatter.bracket_same_line {
             options.set_bracket_same_line(bracket_same_line);
         }
-        if let Some(attribute_position) = js_formatter.attribute_position {
+        if let Some(attribute_position) = js_formatter
+            .attribute_position
+            .or(formatter.attribute_position)
+        {
             options.set_attribute_position(attribute_position);
         }
 
@@ -1124,6 +1157,12 @@ impl OverrideSettingPattern {
         }
         if let Some(line_width) = graphql_formatter.line_width.or(formatter.line_width) {
             options.set_line_width(line_width);
+        }
+        if let Some(bracket_spacing) = graphql_formatter
+            .bracket_spacing
+            .or(formatter.bracket_spacing)
+        {
+            options.set_bracket_spacing(bracket_spacing);
         }
         if let Some(quote_style) = graphql_formatter.quote_style {
             options.set_quote_style(quote_style);
@@ -1296,6 +1335,8 @@ pub fn to_override_settings(
                 indent_width: formatter.indent_width,
                 line_ending: formatter.line_ending,
                 line_width: formatter.line_width,
+                bracket_spacing: formatter.bracket_spacing,
+                attribute_position: formatter.attribute_position,
             })
             .unwrap_or_default();
         let linter = pattern
@@ -1315,11 +1356,14 @@ pub fn to_override_settings(
         let javascript = pattern.javascript.take().unwrap_or_default();
         let json = pattern.json.take().unwrap_or_default();
         let css = pattern.css.take().unwrap_or_default();
+        let graphql = pattern.graphql.take().unwrap_or_default();
         languages.javascript =
             to_javascript_language_settings(javascript, &current_settings.languages.javascript);
 
         languages.json = to_json_language_settings(json, &current_settings.languages.json);
         languages.css = to_css_language_settings(css, &current_settings.languages.css);
+        languages.graphql =
+            to_graphql_language_settings(graphql, &current_settings.languages.graphql);
 
         let pattern_setting = OverrideSettingPattern {
             include: to_matcher(working_directory.clone(), pattern.include.as_ref())?,
@@ -1350,7 +1394,8 @@ fn to_javascript_language_settings(
         formatter.trailing_commas.or(formatter.trailing_comma);
     language_setting.formatter.semicolons = formatter.semicolons;
     language_setting.formatter.arrow_parentheses = formatter.arrow_parentheses;
-    language_setting.formatter.bracket_spacing = formatter.bracket_spacing.map(Into::into);
+    dbg!(formatter.bracket_spacing);
+    language_setting.formatter.bracket_spacing = formatter.bracket_spacing;
     language_setting.formatter.bracket_same_line = formatter.bracket_same_line.map(Into::into);
     language_setting.formatter.enabled = formatter.enabled;
     language_setting.formatter.line_width = formatter.line_width;
@@ -1431,6 +1476,24 @@ fn to_css_language_settings(
     language_setting
 }
 
+fn to_graphql_language_settings(
+    mut conf: PartialGraphqlConfiguration,
+    _parent_settings: &LanguageSettings<GraphqlLanguage>,
+) -> LanguageSettings<GraphqlLanguage> {
+    let mut language_setting: LanguageSettings<GraphqlLanguage> = LanguageSettings::default();
+    let formatter = conf.formatter.take().unwrap_or_default();
+
+    language_setting.formatter.enabled = formatter.enabled;
+    language_setting.formatter.line_width = formatter.line_width;
+    language_setting.formatter.line_ending = formatter.line_ending;
+    language_setting.formatter.indent_width = formatter.indent_width.map(Into::into);
+    language_setting.formatter.indent_style = formatter.indent_style.map(Into::into);
+    language_setting.formatter.quote_style = formatter.quote_style;
+    language_setting.formatter.bracket_spacing = formatter.bracket_spacing;
+
+    language_setting
+}
+
 pub fn to_format_settings(
     working_directory: Option<PathBuf>,
     conf: FormatterConfiguration,
@@ -1449,6 +1512,7 @@ pub fn to_format_settings(
         line_width: Some(conf.line_width),
         format_with_errors: conf.format_with_errors,
         attribute_position: Some(conf.attribute_position),
+        bracket_spacing: Some(conf.bracket_spacing),
         ignored_files: to_matcher(working_directory.clone(), Some(&conf.ignore))?,
         included_files: to_matcher(working_directory, Some(&conf.include))?,
     })
@@ -1476,6 +1540,7 @@ impl TryFrom<OverrideFormatterConfiguration> for FormatSettings {
             line_ending: conf.line_ending,
             line_width: conf.line_width,
             attribute_position: Some(AttributePosition::default()),
+            bracket_spacing: Some(BracketSpacing::default()),
             format_with_errors: conf.format_with_errors.unwrap_or_default(),
             ignored_files: Matcher::empty(),
             included_files: Matcher::empty(),

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1394,7 +1394,6 @@ fn to_javascript_language_settings(
         formatter.trailing_commas.or(formatter.trailing_comma);
     language_setting.formatter.semicolons = formatter.semicolons;
     language_setting.formatter.arrow_parentheses = formatter.arrow_parentheses;
-    dbg!(formatter.bracket_spacing);
     language_setting.formatter.bracket_spacing = formatter.bracket_spacing;
     language_setting.formatter.bracket_same_line = formatter.bracket_same_line.map(Into::into);
     language_setting.formatter.enabled = formatter.enabled;

--- a/crates/biome_service/tests/invalid/formatter_extraneous_field.json.snap
+++ b/crates/biome_service/tests/invalid/formatter_extraneous_field.json.snap
@@ -22,8 +22,6 @@ formatter_extraneous_field.json:3:3 deserialize ━━━━━━━━━━�
   - lineEnding
   - lineWidth
   - attributePosition
+  - bracketSpacing
   - ignore
   - include
-  
-
-

--- a/crates/biome_service/tests/invalid/formatter_quote_style.json.snap
+++ b/crates/biome_service/tests/invalid/formatter_quote_style.json.snap
@@ -22,8 +22,6 @@ formatter_quote_style.json:3:9 deserialize ━━━━━━━━━━━━�
   - lineEnding
   - lineWidth
   - attributePosition
+  - bracketSpacing
   - ignore
   - include
-  
-
-

--- a/crates/biome_service/tests/invalid/overrides/incorrect_key.json.snap
+++ b/crates/biome_service/tests/invalid/overrides/incorrect_key.json.snap
@@ -20,9 +20,7 @@ incorrect_key.json:4:4 deserialize ━━━━━━━━━━━━━━━
   - javascript
   - json
   - css
+  - graphql
   - formatter
   - linter
   - organizeImports
-  
-
-

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -123,6 +123,10 @@ export interface PartialFormatterConfiguration {
 	 * The attribute position style in HTMLish languages. By default auto.
 	 */
 	attributePosition?: AttributePosition;
+	/**
+	 * Whether to insert spaces around brackets in object literals. Defaults to true.
+	 */
+	bracketSpacing?: BracketSpacing;
 	enabled?: boolean;
 	/**
 	 * Stores whether formatting should be allowed to proceed if a given file has syntax errors
@@ -323,6 +327,7 @@ export interface PartialCssParser {
 	cssModules?: boolean;
 }
 export type AttributePosition = "auto" | "multiline";
+export type BracketSpacing = boolean;
 export type IndentWidth = number;
 export type PlainIndentStyle = "tab" | "space";
 export type LineEnding = "lf" | "crlf" | "cr";
@@ -336,6 +341,10 @@ export type LineWidth = number;
  * Options that changes how the GraphQL formatter behaves
  */
 export interface PartialGraphqlFormatter {
+	/**
+	 * Whether to insert spaces around brackets in object literals. Defaults to true.
+	 */
+	bracketSpacing?: BracketSpacing;
 	/**
 	 * Control the formatter for GraphQL files.
 	 */
@@ -380,7 +389,7 @@ export interface PartialJavascriptFormatter {
 	/**
 	 * Whether to insert spaces around brackets in object literals. Defaults to true.
 	 */
-	bracketSpacing?: boolean;
+	bracketSpacing?: BracketSpacing;
 	/**
 	 * Control the formatter for JavaScript (and its super languages) files.
 	 */
@@ -534,6 +543,10 @@ export interface OverridePattern {
 	 * Specific configuration for the Json language
 	 */
 	formatter?: OverrideFormatterConfiguration;
+	/**
+	 * Specific configuration for the Graphql language
+	 */
+	graphql?: PartialGraphqlConfiguration;
 	/**
 	 * A list of Unix shell style patterns. The formatter will ignore files/folders that will match these patterns.
 	 */
@@ -1698,6 +1711,10 @@ export interface OverrideFormatterConfiguration {
 	 * The attribute position style.
 	 */
 	attributePosition?: AttributePosition;
+	/**
+	 * Whether to insert spaces around brackets in object literals. Defaults to true.
+	 */
+	bracketSpacing?: BracketSpacing;
 	enabled?: boolean;
 	/**
 	 * Stores whether formatting should be allowed to proceed if a given file has syntax errors

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -306,6 +306,7 @@
 		},
 		"ArrowParentheses": { "type": "string", "enum": ["always", "asNeeded"] },
 		"AttributePosition": { "type": "string", "enum": ["auto", "multiline"] },
+		"BracketSpacing": { "type": "boolean" },
 		"Complexity": {
 			"description": "A list of rules that belong to this group",
 			"type": "object",
@@ -1107,6 +1108,13 @@
 						{ "type": "null" }
 					]
 				},
+				"bracketSpacing": {
+					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
+					"anyOf": [
+						{ "$ref": "#/definitions/BracketSpacing" },
+						{ "type": "null" }
+					]
+				},
 				"enabled": { "type": ["boolean", "null"] },
 				"formatWithErrors": {
 					"description": "Stores whether formatting should be allowed to proceed if a given file has syntax errors",
@@ -1164,6 +1172,13 @@
 			"description": "Options that changes how the GraphQL formatter behaves",
 			"type": "object",
 			"properties": {
+				"bracketSpacing": {
+					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
+					"anyOf": [
+						{ "$ref": "#/definitions/BracketSpacing" },
+						{ "type": "null" }
+					]
+				},
 				"enabled": {
 					"description": "Control the formatter for GraphQL files.",
 					"type": ["boolean", "null"]
@@ -1304,7 +1319,10 @@
 				},
 				"bracketSpacing": {
 					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
-					"type": ["boolean", "null"]
+					"anyOf": [
+						{ "$ref": "#/definitions/BracketSpacing" },
+						{ "type": "null" }
+					]
 				},
 				"enabled": {
 					"description": "Control the formatter for JavaScript (and its super languages) files.",
@@ -2104,6 +2122,13 @@
 						{ "type": "null" }
 					]
 				},
+				"bracketSpacing": {
+					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
+					"anyOf": [
+						{ "$ref": "#/definitions/BracketSpacing" },
+						{ "type": "null" }
+					]
+				},
 				"enabled": { "type": ["boolean", "null"] },
 				"formatWithErrors": {
 					"description": "Stores whether formatting should be allowed to proceed if a given file has syntax errors",
@@ -2173,6 +2198,13 @@
 					"description": "Specific configuration for the Json language",
 					"anyOf": [
 						{ "$ref": "#/definitions/OverrideFormatterConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"graphql": {
+					"description": "Specific configuration for the Graphql language",
+					"anyOf": [
+						{ "$ref": "#/definitions/GraphqlConfiguration" },
 						{ "type": "null" }
 					]
 				},


### PR DESCRIPTION

## Summary

We have the BracketSpacing option for JavaScript files. We can reuse this option for GraphQL files. The main idea of the PR is to move BracketSpacing to the global formatter option so that we can use it for both languages.

Since I'm not very familiar with this part of the code, I'd like to ask for help in reviewing.

## Test Plan

`cargo test`
