### PR TITLE
fix(lint): don't request alt text for elements hidden from assistive technologies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Linter
 
+#### Bug fixes
+
+- Don't request alt text for elements hidden from assistive technologies ([#3316](https://github.com/biomejs/biome/issues/3316)). Contributed by @robintown
+
 ### Parser
 
 ## v1.8.3 (2024-06-27)

--- a/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
@@ -1,6 +1,6 @@
 use biome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::{fmt::Display, fmt::Formatter, markup};
-use biome_js_syntax::{jsx_ext::AnyJsxElement, TextRange};
+use biome_js_syntax::{jsx_ext::AnyJsxElement, static_value::StaticValue, TextRange};
 use biome_rowan::AstNode;
 
 declare_rule! {
@@ -84,11 +84,12 @@ impl Rule for UseAltText {
         let has_alt = has_valid_alt_text(element);
         let has_aria_label = has_valid_label(element, "aria-label");
         let has_aria_labelledby = has_valid_label(element, "aria-labelledby");
+        let aria_hidden = is_aria_hidden(element);
         match element.name_value_token()?.text_trimmed() {
             "object" => {
                 let has_title = has_valid_label(element, "title");
 
-                if !has_title && !has_aria_label && !has_aria_labelledby {
+                if !has_title && !has_aria_label && !has_aria_labelledby && !aria_hidden {
                     match element {
                         AnyJsxElement::JsxOpeningElement(opening_element) => {
                             if !opening_element.has_accessible_child() {
@@ -105,12 +106,12 @@ impl Rule for UseAltText {
                 }
             }
             "img" => {
-                if !has_alt && !has_aria_label && !has_aria_labelledby {
+                if !has_alt && !has_aria_label && !has_aria_labelledby && !aria_hidden {
                     return Some((ValidatedElement::Img, element.syntax().text_range()));
                 }
             }
             "area" => {
-                if !has_alt && !has_aria_label && !has_aria_labelledby {
+                if !has_alt && !has_aria_label && !has_aria_labelledby && !aria_hidden {
                     return Some((ValidatedElement::Area, element.syntax().text_range()));
                 }
             }
@@ -119,6 +120,7 @@ impl Rule for UseAltText {
                     && !has_alt
                     && !has_aria_label
                     && !has_aria_labelledby
+                    && !aria_hidden
                 {
                     return Some((ValidatedElement::Input, element.syntax().text_range()));
                 }
@@ -137,7 +139,7 @@ impl Rule for UseAltText {
         Some(
             RuleDiagnostic::new(rule_category!(), range, message).note(markup! {
                 "Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page."
-            }),
+            }).note(markup! { "If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the "<Emphasis>"aria-hidden"</Emphasis>" attribute."}),
         )
     }
 }
@@ -177,5 +179,18 @@ fn has_valid_label(element: &AnyJsxElement, name_to_lookup: &str) -> bool {
             attribute.as_static_value().map_or(true, |value| {
                 !value.is_null_or_undefined() && value.is_not_string_constant("")
             }) && !element.has_trailing_spread_prop(&attribute)
+        })
+}
+
+fn is_aria_hidden(element: &AnyJsxElement) -> bool {
+    element
+        .find_attribute_by_name("aria-hidden")
+        .map_or(false, |attribute| {
+            attribute
+                .as_static_value()
+                .map_or(true, |value| match value {
+                    StaticValue::Boolean(token) => token.text_trimmed() == "true",
+                    _ => false,
+                })
         })
 }

--- a/crates/biome_js_analyze/tests/specs/a11y/useAltText/area.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useAltText/area.jsx
@@ -10,6 +10,8 @@
   <area aria-label={undefined} />
   <area aria-labelledby="" />
   <area aria-labelledby={undefined} />
+  <area aria-hidden={false} />
+  <area aria-hidden={undefined} />
 </>;
 
 //valid
@@ -17,6 +19,8 @@
 <>
   <area aria-label="foo" />
   <area aria-labelledby="id1" />
+  <area aria-hidden />
+  <area aria-hidden={true} />
   <area alt="" />
   <area alt="This is descriptive!" />
   <area alt={altText} />

--- a/crates/biome_js_analyze/tests/specs/a11y/useAltText/area.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useAltText/area.jsx.snap
@@ -16,6 +16,8 @@ expression: area.jsx
   <area aria-label={undefined} />
   <area aria-labelledby="" />
   <area aria-labelledby={undefined} />
+  <area aria-hidden={false} />
+  <area aria-hidden={undefined} />
 </>;
 
 //valid
@@ -23,6 +25,8 @@ expression: area.jsx
 <>
   <area aria-label="foo" />
   <area aria-labelledby="id1" />
+  <area aria-hidden />
+  <area aria-hidden={true} />
   <area alt="" />
   <area alt="This is descriptive!" />
   <area alt={altText} />
@@ -45,6 +49,8 @@ area.jsx:4:2 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -61,6 +67,8 @@ area.jsx:5:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
     7 │   <area src="xyz" />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -79,6 +87,8 @@ area.jsx:6:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -95,6 +105,8 @@ area.jsx:7:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
     9 │   <area aria-label="" />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -113,6 +125,8 @@ area.jsx:8:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -129,6 +143,8 @@ area.jsx:9:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
     11 │   <area aria-labelledby="" />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -147,6 +163,8 @@ area.jsx:10:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -160,9 +178,11 @@ area.jsx:11:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━
   > 11 │   <area aria-labelledby="" />
        │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     12 │   <area aria-labelledby={undefined} />
-    13 │ </>;
+    13 │   <area aria-hidden={false} />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -176,12 +196,50 @@ area.jsx:12:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━
     11 │   <area aria-labelledby="" />
   > 12 │   <area aria-labelledby={undefined} />
        │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    13 │ </>;
-    14 │ 
+    13 │   <area aria-hidden={false} />
+    14 │   <area aria-hidden={undefined} />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
 
+```
+area.jsx:13:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Provide a text alternative through the alt, aria-label or aria-labelledby attribute
+  
+    11 │   <area aria-labelledby="" />
+    12 │   <area aria-labelledby={undefined} />
+  > 13 │   <area aria-hidden={false} />
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │   <area aria-hidden={undefined} />
+    15 │ </>;
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```
+
+```
+area.jsx:14:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Provide a text alternative through the alt, aria-label or aria-labelledby attribute
+  
+    12 │   <area aria-labelledby={undefined} />
+    13 │   <area aria-hidden={false} />
+  > 14 │   <area aria-hidden={undefined} />
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    15 │ </>;
+    16 │ 
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/a11y/useAltText/img.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useAltText/img.jsx
@@ -12,8 +12,10 @@
   <img role="none" />
   <img aria-label={undefined} />
   <img aria-labelledby={undefined} />
+  <img aria-hidden={undefined} />
   <img aria-label="" />
   <img aria-labelledby="" />
+  <img aria-hidden={false} />
 </>;
 
 // valid
@@ -50,4 +52,6 @@
   <img alt={plugin.name + " Logo"} />
   <img aria-label="foo" />
   <img aria-labelledby="id1" />
+  <img aria-hidden />
+  <img aria-hidden={true} />
 </>;

--- a/crates/biome_js_analyze/tests/specs/a11y/useAltText/img.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useAltText/img.jsx.snap
@@ -18,8 +18,10 @@ expression: img.jsx
   <img role="none" />
   <img aria-label={undefined} />
   <img aria-labelledby={undefined} />
+  <img aria-hidden={undefined} />
   <img aria-label="" />
   <img aria-labelledby="" />
+  <img aria-hidden={false} />
 </>;
 
 // valid
@@ -56,6 +58,8 @@ expression: img.jsx
   <img alt={plugin.name + " Logo"} />
   <img aria-label="foo" />
   <img aria-labelledby="id1" />
+  <img aria-hidden />
+  <img aria-hidden={true} />
 </>;
 
 ```
@@ -75,6 +79,8 @@ img.jsx:3:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -91,6 +97,8 @@ img.jsx:4:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
     6 │   <img src="xyz" />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -109,6 +117,8 @@ img.jsx:5:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -125,6 +135,8 @@ img.jsx:6:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
     8 │   <img {...this.props} />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -143,6 +155,8 @@ img.jsx:7:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -159,6 +173,8 @@ img.jsx:8:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
     10 │   <img alt role="presentation" />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -177,6 +193,8 @@ img.jsx:9:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -193,6 +211,8 @@ img.jsx:10:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
     12 │   <img role="none" />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -211,6 +231,8 @@ img.jsx:11:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -228,6 +250,8 @@ img.jsx:12:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -241,9 +265,11 @@ img.jsx:13:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
   > 13 │   <img aria-label={undefined} />
        │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     14 │   <img aria-labelledby={undefined} />
-    15 │   <img aria-label="" />
+    15 │   <img aria-hidden={undefined} />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -257,10 +283,12 @@ img.jsx:14:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
     13 │   <img aria-label={undefined} />
   > 14 │   <img aria-labelledby={undefined} />
        │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    15 │   <img aria-label="" />
-    16 │   <img aria-labelledby="" />
+    15 │   <img aria-hidden={undefined} />
+    16 │   <img aria-label="" />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -272,12 +300,14 @@ img.jsx:15:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
   
     13 │   <img aria-label={undefined} />
     14 │   <img aria-labelledby={undefined} />
-  > 15 │   <img aria-label="" />
-       │   ^^^^^^^^^^^^^^^^^^^^^
-    16 │   <img aria-labelledby="" />
-    17 │ </>;
+  > 15 │   <img aria-hidden={undefined} />
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    16 │   <img aria-label="" />
+    17 │   <img aria-labelledby="" />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -288,15 +318,53 @@ img.jsx:16:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━�
   ! Provide a text alternative through the alt, aria-label or aria-labelledby attribute
   
     14 │   <img aria-labelledby={undefined} />
-    15 │   <img aria-label="" />
-  > 16 │   <img aria-labelledby="" />
-       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    17 │ </>;
-    18 │ 
+    15 │   <img aria-hidden={undefined} />
+  > 16 │   <img aria-label="" />
+       │   ^^^^^^^^^^^^^^^^^^^^^
+    17 │   <img aria-labelledby="" />
+    18 │   <img aria-hidden={false} />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
 
+```
+img.jsx:17:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Provide a text alternative through the alt, aria-label or aria-labelledby attribute
+  
+    15 │   <img aria-hidden={undefined} />
+    16 │   <img aria-label="" />
+  > 17 │   <img aria-labelledby="" />
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    18 │   <img aria-hidden={false} />
+    19 │ </>;
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```
+
+```
+img.jsx:18:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Provide a text alternative through the alt, aria-label or aria-labelledby attribute
+  
+    16 │   <img aria-label="" />
+    17 │   <img aria-labelledby="" />
+  > 18 │   <img aria-hidden={false} />
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    19 │ </>;
+    20 │ 
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/a11y/useAltText/input.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useAltText/input.jsx
@@ -9,6 +9,8 @@
   <input type="image" aria-label={undefined} />
   <input type="image" aria-labelledby="" />
   <input type="image" aria-labelledby={undefined} />
+  <input type="image" aria-hidden={false} />
+  <input type="image" aria-hidden={undefined} />
 </>;
 
 // valid
@@ -18,6 +20,8 @@
   <input type="foo" />
   <input type="image" aria-label="foo" />
   <input type="image" aria-labelledby="id1" />
+  <input type="image" aria-hidden />
+  <input type="image" aria-hidden={true} />
   <input type="image" alt="" />
   <input type="image" alt="This is descriptive!" />
   <input type="image" alt={altText} />

--- a/crates/biome_js_analyze/tests/specs/a11y/useAltText/input.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useAltText/input.jsx.snap
@@ -15,6 +15,8 @@ expression: input.jsx
   <input type="image" aria-label={undefined} />
   <input type="image" aria-labelledby="" />
   <input type="image" aria-labelledby={undefined} />
+  <input type="image" aria-hidden={false} />
+  <input type="image" aria-hidden={undefined} />
 </>;
 
 // valid
@@ -24,6 +26,8 @@ expression: input.jsx
   <input type="foo" />
   <input type="image" aria-label="foo" />
   <input type="image" aria-labelledby="id1" />
+  <input type="image" aria-hidden />
+  <input type="image" aria-hidden={true} />
   <input type="image" alt="" />
   <input type="image" alt="This is descriptive!" />
   <input type="image" alt={altText} />
@@ -47,6 +51,8 @@ input.jsx:3:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -63,6 +69,8 @@ input.jsx:4:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━
     6 │   <input type="image">Foo</input>
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -81,6 +89,8 @@ input.jsx:5:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -97,6 +107,8 @@ input.jsx:6:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━
     8 │   <input type="image" aria-label="" />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -115,6 +127,8 @@ input.jsx:7:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -131,6 +145,8 @@ input.jsx:8:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━
     10 │   <input type="image" aria-labelledby="" />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -149,6 +165,8 @@ input.jsx:9:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -162,9 +180,11 @@ input.jsx:10:3 lint/a11y/useAltText ━━━━━━━━━━━━━━�
   > 10 │   <input type="image" aria-labelledby="" />
        │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     11 │   <input type="image" aria-labelledby={undefined} />
-    12 │ </>;
+    12 │   <input type="image" aria-hidden={false} />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -178,12 +198,50 @@ input.jsx:11:3 lint/a11y/useAltText ━━━━━━━━━━━━━━�
     10 │   <input type="image" aria-labelledby="" />
   > 11 │   <input type="image" aria-labelledby={undefined} />
        │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    12 │ </>;
-    13 │ 
+    12 │   <input type="image" aria-hidden={false} />
+    13 │   <input type="image" aria-hidden={undefined} />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
 
+```
+input.jsx:12:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Provide a text alternative through the alt, aria-label or aria-labelledby attribute
+  
+    10 │   <input type="image" aria-labelledby="" />
+    11 │   <input type="image" aria-labelledby={undefined} />
+  > 12 │   <input type="image" aria-hidden={false} />
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    13 │   <input type="image" aria-hidden={undefined} />
+    14 │ </>;
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```
+
+```
+input.jsx:13:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Provide a text alternative through the alt, aria-label or aria-labelledby attribute
+  
+    11 │   <input type="image" aria-labelledby={undefined} />
+    12 │   <input type="image" aria-hidden={false} />
+  > 13 │   <input type="image" aria-hidden={undefined} />
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ </>;
+    15 │ 
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/a11y/useAltText/object.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useAltText/object.jsx
@@ -6,8 +6,10 @@
   <object title={undefined} />
   <object aria-label="" />
   <object aria-labelledby="" />
+  <object aria-hidden={false} />
   <object aria-label={undefined} />
   <object aria-labelledby={undefined} />
+  <object aria-hidden={undefined} />
 </>;
 
 //valid
@@ -15,6 +17,8 @@
 <>
   <object aria-label="foo" />
   <object aria-labelledby="id1" />
+  <object aria-hidden />
+  <object aria-hidden={true} />
   <object>Foo</object>
   <object><p>This is descriptive!</p></object>
   <Object />

--- a/crates/biome_js_analyze/tests/specs/a11y/useAltText/object.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useAltText/object.jsx.snap
@@ -12,8 +12,10 @@ expression: object.jsx
   <object title={undefined} />
   <object aria-label="" />
   <object aria-labelledby="" />
+  <object aria-hidden={false} />
   <object aria-label={undefined} />
   <object aria-labelledby={undefined} />
+  <object aria-hidden={undefined} />
 </>;
 
 //valid
@@ -21,6 +23,8 @@ expression: object.jsx
 <>
   <object aria-label="foo" />
   <object aria-labelledby="id1" />
+  <object aria-hidden />
+  <object aria-hidden={true} />
   <object>Foo</object>
   <object><p>This is descriptive!</p></object>
   <Object />
@@ -43,6 +47,8 @@ object.jsx:4:3 lint/a11y/useAltText ━━━━━━━━━━━━━━�
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -59,6 +65,8 @@ object.jsx:5:3 lint/a11y/useAltText ━━━━━━━━━━━━━━�
     7 │   <object aria-label="" />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -77,6 +85,8 @@ object.jsx:6:3 lint/a11y/useAltText ━━━━━━━━━━━━━━�
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
   
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
 
 ```
 
@@ -90,9 +100,11 @@ object.jsx:7:3 lint/a11y/useAltText ━━━━━━━━━━━━━━�
   > 7 │   <object aria-label="" />
       │   ^^^^^^^^^^^^^^^^^^^^^^^^
     8 │   <object aria-labelledby="" />
-    9 │   <object aria-label={undefined} />
+    9 │   <object aria-hidden={false} />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -106,10 +118,12 @@ object.jsx:8:3 lint/a11y/useAltText ━━━━━━━━━━━━━━�
      7 │   <object aria-label="" />
    > 8 │   <object aria-labelledby="" />
        │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-     9 │   <object aria-label={undefined} />
-    10 │   <object aria-labelledby={undefined} />
+     9 │   <object aria-hidden={false} />
+    10 │   <object aria-label={undefined} />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -121,12 +135,14 @@ object.jsx:9:3 lint/a11y/useAltText ━━━━━━━━━━━━━━�
   
      7 │   <object aria-label="" />
      8 │   <object aria-labelledby="" />
-   > 9 │   <object aria-label={undefined} />
-       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    10 │   <object aria-labelledby={undefined} />
-    11 │ </>;
+   > 9 │   <object aria-hidden={false} />
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 │   <object aria-label={undefined} />
+    11 │   <object aria-labelledby={undefined} />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
@@ -137,15 +153,53 @@ object.jsx:10:3 lint/a11y/useAltText ━━━━━━━━━━━━━━�
   ! Provide a text alternative through the title, aria-label or aria-labelledby attribute
   
      8 │   <object aria-labelledby="" />
-     9 │   <object aria-label={undefined} />
-  > 10 │   <object aria-labelledby={undefined} />
-       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    11 │ </>;
-    12 │ 
+     9 │   <object aria-hidden={false} />
+  > 10 │   <object aria-label={undefined} />
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    11 │   <object aria-labelledby={undefined} />
+    12 │   <object aria-hidden={undefined} />
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
   
 
 ```
 
+```
+object.jsx:11:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Provide a text alternative through the title, aria-label or aria-labelledby attribute
+  
+     9 │   <object aria-hidden={false} />
+    10 │   <object aria-label={undefined} />
+  > 11 │   <object aria-labelledby={undefined} />
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │   <object aria-hidden={undefined} />
+    13 │ </>;
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```
+
+```
+object.jsx:12:3 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Provide a text alternative through the title, aria-label or aria-labelledby attribute
+  
+    10 │   <object aria-label={undefined} />
+    11 │   <object aria-labelledby={undefined} />
+  > 12 │   <object aria-hidden={undefined} />
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    13 │ </>;
+    14 │ 
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```


### PR DESCRIPTION
## Summary

Fixes https://github.com/biomejs/biome/issues/3316

## Test Plan

I've added test cases with `aria-hidden` to all useAltText tests.