### PR TITLE
feat: support eslint config .eslintrc on migrate

### DIFF
--- a/crates/biome_cli/tests/commands/migrate_eslint.rs
+++ b/crates/biome_cli/tests/commands/migrate_eslint.rs
@@ -60,6 +60,59 @@ fn migrate_eslintrcjson() {
 }
 
 #[test]
+fn migrate_eslintrc() {
+    let biomejson = r#"{ "linter": { "enabled": true } }"#;
+    let eslintrc = r#"{
+        "ignorePatterns": [
+            "**/*.test.js", // trailing comma amd comment
+        ],
+        "globals": {
+            "var1": "writable",
+            "var2": "readonly"
+        },
+        "rules": {
+            "dot-notation": 0,
+            "default-param-last": "off",
+            "eqeqeq": "warn",
+            "getter-return": [2,
+                // support unknown options
+                { "allowImplicit": true }
+            ],
+            "no-eval": 1,
+            "no-extra-label": ["error"]
+        },
+        "overrides": [{
+            "files": ["bin/*.js", "lib/*.js"],
+            "excludedFiles": "*.test.js",
+            "rules": {
+                "eqeqeq": ["off"]
+            }
+        }],
+        "unknownField": "ignored"
+    }"#;
+
+    let mut fs = MemoryFileSystem::default();
+    fs.insert(Path::new("biome.json").into(), biomejson.as_bytes());
+    fs.insert(Path::new(".eslintrc").into(), eslintrc.as_bytes());
+
+    let mut console = BufferConsole::default();
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(["migrate", "eslint"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "migrate_eslintrc",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn migrate_eslintrcjson_write() {
     let biomejson = r#"{ "linter": { "enabled": true } }"#;
     let eslintrc = r#"{

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrc.snap
@@ -1,0 +1,81 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 424
+expression: content
+---
+## `biome.json`
+
+```json
+{ "linter": { "enabled": true } }
+```
+
+## `.eslintrc`
+
+```eslintrc
+{
+        "ignorePatterns": [
+            "**/*.test.js", // trailing comma amd comment
+        ],
+        "globals": {
+            "var1": "writable",
+            "var2": "readonly"
+        },
+        "rules": {
+            "dot-notation": 0,
+            "default-param-last": "off",
+            "eqeqeq": "warn",
+            "getter-return": [2,
+                // support unknown options
+                { "allowImplicit": true }
+            ],
+            "no-eval": 1,
+            "no-extra-label": ["error"]
+        },
+        "overrides": [{
+            "files": ["bin/*.js", "lib/*.js"],
+            "excludedFiles": "*.test.js",
+            "rules": {
+                "eqeqeq": ["off"]
+            }
+        }],
+        "unknownField": "ignored"
+    }
+```
+
+# Emitted Messages
+
+```block
+biome.json migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Configuration file can be updated.
+  
+    1    │ - {·"linter":·{·"enabled":·true·}·}
+       1 │ + {
+       2 │ + → "linter":·{
+       3 │ + → → "enabled":·true,
+       4 │ + → → "rules":·{
+       5 │ + → → → "recommended":·false,
+       6 │ + → → → "complexity":·{·"noUselessLabel":·"error",·"useLiteralKeys":·"off"·},
+       7 │ + → → → "security":·{·"noGlobalEval":·"warn"·},
+       8 │ + → → → "style":·{·"useDefaultParameterLast":·"off"·},
+       9 │ + → → → "suspicious":·{·"noDoubleEquals":·"warn",·"useGetterReturn":·"error"·}
+      10 │ + → → },
+      11 │ + → → "ignore":·["**/*.test.js"]
+      12 │ + → },
+      13 │ + → "javascript":·{·"globals":·["var2",·"var1"]·},
+      14 │ + → "overrides":·[
+      15 │ + → → {
+      16 │ + → → → "ignore":·["*.test.js"],
+      17 │ + → → → "include":·["bin/*.js",·"lib/*.js"],
+      18 │ + → → → "linter":·{·"rules":·{·"suspicious":·{·"noDoubleEquals":·"off"·}·}·}
+      19 │ + → → }
+      20 │ + → ]
+      21 │ + }
+      22 │ + 
+  
+
+```
+
+```block
+Run the command with the option --write to apply the changes.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_no_eslint_config_packagejson.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_no_eslint_config_packagejson.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 424
 expression: content
 ---
 ## `biome.json`
@@ -22,7 +23,7 @@ expression: content
 ```block
 migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Migration has encountered an error: The default ESLint configuration file `.eslintrc.*` was not found in the working directory.
+  × Migration has encountered an error: The default ESLint configuration file `.eslintrc[.*]` was not found in the working directory.
   
 
 


### PR DESCRIPTION
I find it not work When I use `biome migrate eslint` with a .eslintrc file

## Summary
Support .eslintrc and tested locally

## Test Plan

Works for me
<img width="1143" alt="image" src="https://github.com/biomejs/biome/assets/12555402/ef73d2ac-bf2e-421f-a724-261448472a5b">
