### PR TITLE
chore(js_parser): remove decorators from rest arguments in the JS parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Parser
 
+- Remove decorators from rest arguments in the JS parser. Contributed by @denbezrukov
+
 ## v1.8.3 (2024-06-27)
 
 ### CLI

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
@@ -158,10 +158,9 @@ impl Rule for NoUselessConstructor {
                         // Ignore constructors with decorated parameters
                         return None;
                     }
-                },
-                AnyJsConstructorParameter::JsRestParameter(_) => {},
+                }
+                AnyJsConstructorParameter::JsRestParameter(_) => {}
             };
-
         }
         let class = constructor.syntax().ancestors().find_map(AnyJsClass::cast);
         if let Some(class) = &class {

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
@@ -143,7 +143,7 @@ impl Rule for NoUselessConstructor {
             return None;
         }
         for parameter in constructor.parameters().ok()?.parameters() {
-            let decorators = match parameter.ok()? {
+            match parameter.ok()? {
                 AnyJsConstructorParameter::AnyJsFormalParameter(
                     AnyJsFormalParameter::JsBogusParameter(_),
                 )
@@ -153,13 +153,15 @@ impl Rule for NoUselessConstructor {
                 }
                 AnyJsConstructorParameter::AnyJsFormalParameter(
                     AnyJsFormalParameter::JsFormalParameter(parameter),
-                ) => parameter.decorators(),
-                AnyJsConstructorParameter::JsRestParameter(parameter) => parameter.decorators(),
+                ) => {
+                    if !parameter.decorators().is_empty() {
+                        // Ignore constructors with decorated parameters
+                        return None;
+                    }
+                },
+                AnyJsConstructorParameter::JsRestParameter(_) => {},
             };
-            if !decorators.is_empty() {
-                // Ignore constructors with decorated parameters
-                return None;
-            }
+
         }
         let class = constructor.syntax().ancestors().find_map(AnyJsClass::cast);
         if let Some(class) = &class {

--- a/crates/biome_js_factory/src/generated/node_factory.rs
+++ b/crates/biome_js_factory/src/generated/node_factory.rs
@@ -3005,19 +3005,16 @@ pub fn js_regex_literal_expression(value_token: SyntaxToken) -> JsRegexLiteralEx
     ))
 }
 pub fn js_rest_parameter(
-    decorators: JsDecoratorList,
     dotdotdot_token: SyntaxToken,
     binding: AnyJsBindingPattern,
 ) -> JsRestParameterBuilder {
     JsRestParameterBuilder {
-        decorators,
         dotdotdot_token,
         binding,
         type_annotation: None,
     }
 }
 pub struct JsRestParameterBuilder {
-    decorators: JsDecoratorList,
     dotdotdot_token: SyntaxToken,
     binding: AnyJsBindingPattern,
     type_annotation: Option<TsTypeAnnotation>,
@@ -3031,7 +3028,6 @@ impl JsRestParameterBuilder {
         JsRestParameter::unwrap_cast(SyntaxNode::new_detached(
             JsSyntaxKind::JS_REST_PARAMETER,
             [
-                Some(SyntaxElement::Node(self.decorators.into_syntax())),
                 Some(SyntaxElement::Token(self.dotdotdot_token)),
                 Some(SyntaxElement::Node(self.binding.into_syntax())),
                 self.type_annotation

--- a/crates/biome_js_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_js_factory/src/generated/syntax_factory.rs
@@ -4408,15 +4408,8 @@ impl SyntaxFactory for JsSyntaxFactory {
             }
             JS_REST_PARAMETER => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<4usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<3usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
-                if let Some(element) = &current_element {
-                    if JsDecoratorList::can_cast(element.kind()) {
-                        slots.mark_present();
-                        current_element = elements.next();
-                    }
-                }
-                slots.next_slot();
                 if let Some(element) = &current_element {
                     if element.kind() == T ! [...] {
                         slots.mark_present();

--- a/crates/biome_js_formatter/src/js/bindings/rest_parameter.rs
+++ b/crates/biome_js_formatter/src/js/bindings/rest_parameter.rs
@@ -10,7 +10,6 @@ pub(crate) struct FormatJsRestParameter;
 impl FormatNodeRule<JsRestParameter> for FormatJsRestParameter {
     fn fmt_fields(&self, node: &JsRestParameter, f: &mut JsFormatter) -> FormatResult<()> {
         let JsRestParameterFields {
-            decorators,
             dotdotdot_token,
             binding,
             type_annotation,
@@ -19,7 +18,6 @@ impl FormatNodeRule<JsRestParameter> for FormatJsRestParameter {
         write![
             f,
             [
-                decorators.format(),
                 dotdotdot_token.format(),
                 binding.format(),
                 type_annotation.format(),

--- a/crates/biome_js_formatter/tests/quick_test.rs
+++ b/crates/biome_js_formatter/tests/quick_test.rs
@@ -14,15 +14,7 @@ mod language {
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
     let src = r#"
-type InstanceID = string;
-type MaybeCardWithAttachment = string;
-function outerFunctionToForceIndent() {
-    const cardWithAttachment: (id: InstanceID) => MaybeCardWithAttachment = (
-        id
-    ) => {
-        return `${id}test`;
-    };
-}
+(...action) => {};
 
     "#;
     let source_type = JsFileSource::tsx();

--- a/crates/biome_js_parser/src/syntax/function.rs
+++ b/crates/biome_js_parser/src/syntax/function.rs
@@ -912,7 +912,7 @@ pub(crate) fn parse_any_parameter(
     type_context: TypeContext,
 ) -> ParsedSyntax {
     let parameter = match p.cur() {
-        T![...] => parse_rest_parameter(p, decorator_list, expression_context, type_context),
+        T![...] => parse_rest_parameter(p, expression_context, type_context),
         T![this] => {
             // test_err ts ts_decorator_this_parameter_option { "parse_class_parameter_decorators": true }
             // class A {
@@ -963,17 +963,14 @@ pub(crate) fn parse_any_parameter(
 
 pub(crate) fn parse_rest_parameter(
     p: &mut JsParser,
-    decorator_list: ParsedSyntax,
     expression_context: ExpressionContext,
     type_context: TypeContext,
 ) -> ParsedSyntax {
     if !p.at(T![...]) {
         return Absent;
     }
+    let m = p.start();
 
-    let m = decorator_list
-        .or_else(|| empty_decorator_list(p))
-        .precede(p);
     p.bump(T![...]);
     parse_binding_pattern(p, expression_context).or_add_diagnostic(p, expected_binding);
 

--- a/crates/biome_js_parser/test_data/inline/err/arrow_rest_in_expr_in_initializer.rast
+++ b/crates/biome_js_parser/test_data/inline/err/arrow_rest_in_expr_in_initializer.rast
@@ -14,7 +14,6 @@ JsModule {
                     items: JsParameterList [
                         JsBogusParameter {
                             items: [
-                                JsDecoratorList [],
                                 DOT3@6..9 "..." [] [],
                                 JsIdentifierBinding {
                                     name_token: IDENT@9..11 "a" [] [Whitespace(" ")],
@@ -77,11 +76,10 @@ JsModule {
           0: L_PAREN@5..6 "(" [] []
           1: JS_PARAMETER_LIST@6..22
             0: JS_BOGUS_PARAMETER@6..22
-              0: JS_DECORATOR_LIST@6..6
-              1: DOT3@6..9 "..." [] []
-              2: JS_IDENTIFIER_BINDING@9..11
+              0: DOT3@6..9 "..." [] []
+              1: JS_IDENTIFIER_BINDING@9..11
                 0: IDENT@9..11 "a" [] [Whitespace(" ")]
-              3: JS_INITIALIZER_CLAUSE@11..22
+              2: JS_INITIALIZER_CLAUSE@11..22
                 0: EQ@11..13 "=" [] [Whitespace(" ")]
                 1: JS_IN_EXPRESSION@13..22
                   0: JS_STRING_LITERAL_EXPRESSION@13..17

--- a/crates/biome_js_parser/test_data/inline/err/invalid_arg_list.rast
+++ b/crates/biome_js_parser/test_data/inline/err/invalid_arg_list.rast
@@ -15,7 +15,6 @@ JsModule {
                 l_paren_token: L_PAREN@12..13 "(" [] [],
                 items: JsParameterList [
                     JsRestParameter {
-                        decorators: JsDecoratorList [],
                         dotdotdot_token: DOT3@13..16 "..." [] [],
                         binding: JsIdentifierBinding {
                             name_token: IDENT@16..20 "args" [] [],
@@ -211,11 +210,10 @@ JsModule {
         0: L_PAREN@12..13 "(" [] []
         1: JS_PARAMETER_LIST@13..20
           0: JS_REST_PARAMETER@13..20
-            0: JS_DECORATOR_LIST@13..13
-            1: DOT3@13..16 "..." [] []
-            2: JS_IDENTIFIER_BINDING@16..20
+            0: DOT3@13..16 "..." [] []
+            1: JS_IDENTIFIER_BINDING@16..20
               0: IDENT@16..20 "args" [] []
-            3: (empty)
+            2: (empty)
         2: R_PAREN@20..22 ")" [] [Whitespace(" ")]
       6: (empty)
       7: JS_FUNCTION_BODY@22..24

--- a/crates/biome_js_parser/test_data/inline/err/ts_formal_parameter_error.rast
+++ b/crates/biome_js_parser/test_data/inline/err/ts_formal_parameter_error.rast
@@ -57,7 +57,6 @@ JsModule {
                 items: JsParameterList [
                     JsBogusParameter {
                         items: [
-                            JsDecoratorList [],
                             DOT3@46..49 "..." [] [],
                             JsIdentifierBinding {
                                 name_token: IDENT@49..53 "rest" [] [],
@@ -104,7 +103,6 @@ JsModule {
                 items: JsParameterList [
                     JsBogusParameter {
                         items: [
-                            JsDecoratorList [],
                             DOT3@88..91 "..." [] [],
                             JsIdentifierBinding {
                                 name_token: IDENT@91..95 "rest" [] [],
@@ -187,18 +185,17 @@ JsModule {
         0: L_PAREN@45..46 "(" [] []
         1: JS_PARAMETER_LIST@46..72
           0: JS_BOGUS_PARAMETER@46..72
-            0: JS_DECORATOR_LIST@46..46
-            1: DOT3@46..49 "..." [] []
-            2: JS_IDENTIFIER_BINDING@49..53
+            0: DOT3@46..49 "..." [] []
+            1: JS_IDENTIFIER_BINDING@49..53
               0: IDENT@49..53 "rest" [] []
-            3: TS_TYPE_ANNOTATION@53..64
+            2: TS_TYPE_ANNOTATION@53..64
               0: COLON@53..55 ":" [] [Whitespace(" ")]
               1: TS_ARRAY_TYPE@55..64
                 0: TS_STRING_TYPE@55..61
                   0: STRING_KW@55..61 "string" [] []
                 1: L_BRACK@61..62 "[" [] []
                 2: R_BRACK@62..64 "]" [] [Whitespace(" ")]
-            4: JS_INITIALIZER_CLAUSE@64..72
+            3: JS_INITIALIZER_CLAUSE@64..72
               0: EQ@64..66 "=" [] [Whitespace(" ")]
               1: JS_STRING_LITERAL_EXPRESSION@66..72
                 0: JS_STRING_LITERAL@66..72 "\"init\"" [] []
@@ -220,9 +217,8 @@ JsModule {
         0: L_PAREN@87..88 "(" [] []
         1: JS_PARAMETER_LIST@88..106
           0: JS_BOGUS_PARAMETER@88..95
-            0: JS_DECORATOR_LIST@88..88
-            1: DOT3@88..91 "..." [] []
-            2: JS_IDENTIFIER_BINDING@91..95
+            0: DOT3@88..91 "..." [] []
+            1: JS_IDENTIFIER_BINDING@91..95
               0: IDENT@91..95 "rest" [] []
           1: COMMA@95..97 "," [] [Whitespace(" ")]
           2: JS_FORMAL_PARAMETER@97..106

--- a/crates/biome_js_parser/test_data/inline/ok/arguments_in_definition_file.d.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/arguments_in_definition_file.d.rast
@@ -14,7 +14,6 @@ JsModule {
                 l_paren_token: L_PAREN@10..11 "(" [] [],
                 items: JsParameterList [
                     JsRestParameter {
-                        decorators: JsDecoratorList [],
                         dotdotdot_token: DOT3@11..14 "..." [] [],
                         binding: JsIdentifierBinding {
                             name_token: IDENT@14..23 "arguments" [] [],
@@ -60,11 +59,10 @@ JsModule {
         0: L_PAREN@10..11 "(" [] []
         1: JS_PARAMETER_LIST@11..30
           0: JS_REST_PARAMETER@11..30
-            0: JS_DECORATOR_LIST@11..11
-            1: DOT3@11..14 "..." [] []
-            2: JS_IDENTIFIER_BINDING@14..23
+            0: DOT3@11..14 "..." [] []
+            1: JS_IDENTIFIER_BINDING@14..23
               0: IDENT@14..23 "arguments" [] []
-            3: TS_TYPE_ANNOTATION@23..30
+            2: TS_TYPE_ANNOTATION@23..30
               0: COLON@23..25 ":" [] [Whitespace(" ")]
               1: TS_ARRAY_TYPE@25..30
                 0: TS_ANY_TYPE@25..28

--- a/crates/biome_js_parser/test_data/inline/ok/async_arrow_expr.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/async_arrow_expr.rast
@@ -109,7 +109,6 @@ JsModule {
                         },
                         COMMA@65..67 "," [] [Whitespace(" ")],
                         JsRestParameter {
-                            decorators: JsDecoratorList [],
                             dotdotdot_token: DOT3@67..70 "..." [] [],
                             binding: JsIdentifierBinding {
                                 name_token: IDENT@70..73 "baz" [] [],
@@ -219,11 +218,10 @@ JsModule {
               4: (empty)
             3: COMMA@65..67 "," [] [Whitespace(" ")]
             4: JS_REST_PARAMETER@67..73
-              0: JS_DECORATOR_LIST@67..67
-              1: DOT3@67..70 "..." [] []
-              2: JS_IDENTIFIER_BINDING@70..73
+              0: DOT3@67..70 "..." [] []
+              1: JS_IDENTIFIER_BINDING@70..73
                 0: IDENT@70..73 "baz" [] []
-              3: (empty)
+              2: (empty)
           2: R_PAREN@73..75 ")" [] [Whitespace(" ")]
         3: (empty)
         4: FAT_ARROW@75..78 "=>" [] [Whitespace(" ")]

--- a/crates/biome_js_parser/test_data/inline/ok/call_arguments.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/call_arguments.rast
@@ -15,7 +15,6 @@ JsModule {
                 l_paren_token: L_PAREN@12..13 "(" [] [],
                 items: JsParameterList [
                     JsRestParameter {
-                        decorators: JsDecoratorList [],
                         dotdotdot_token: DOT3@13..16 "..." [] [],
                         binding: JsIdentifierBinding {
                             name_token: IDENT@16..20 "args" [] [],
@@ -235,11 +234,10 @@ JsModule {
         0: L_PAREN@12..13 "(" [] []
         1: JS_PARAMETER_LIST@13..20
           0: JS_REST_PARAMETER@13..20
-            0: JS_DECORATOR_LIST@13..13
-            1: DOT3@13..16 "..." [] []
-            2: JS_IDENTIFIER_BINDING@16..20
+            0: DOT3@13..16 "..." [] []
+            1: JS_IDENTIFIER_BINDING@16..20
               0: IDENT@16..20 "args" [] []
-            3: (empty)
+            2: (empty)
         2: R_PAREN@20..22 ")" [] [Whitespace(" ")]
       6: (empty)
       7: JS_FUNCTION_BODY@22..24

--- a/crates/biome_js_parser/test_data/inline/ok/object_expr_method.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/object_expr_method.rast
@@ -142,7 +142,6 @@ JsModule {
                                             l_paren_token: L_PAREN@71..72 "(" [] [],
                                             items: JsParameterList [
                                                 JsRestParameter {
-                                                    decorators: JsDecoratorList [],
                                                     dotdotdot_token: DOT3@72..75 "..." [] [],
                                                     binding: JsIdentifierBinding {
                                                         name_token: IDENT@75..79 "rest" [] [],
@@ -290,11 +289,10 @@ JsModule {
                       0: L_PAREN@71..72 "(" [] []
                       1: JS_PARAMETER_LIST@72..79
                         0: JS_REST_PARAMETER@72..79
-                          0: JS_DECORATOR_LIST@72..72
-                          1: DOT3@72..75 "..." [] []
-                          2: JS_IDENTIFIER_BINDING@75..79
+                          0: DOT3@72..75 "..." [] []
+                          1: JS_IDENTIFIER_BINDING@75..79
                             0: IDENT@75..79 "rest" [] []
-                          3: (empty)
+                          2: (empty)
                       2: R_PAREN@79..81 ")" [] [Whitespace(" ")]
                     5: (empty)
                     6: JS_FUNCTION_BODY@81..83

--- a/crates/biome_js_parser/test_data/inline/ok/paren_or_arrow_expr.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/paren_or_arrow_expr.rast
@@ -152,7 +152,6 @@ JsModule {
                         },
                         COMMA@69..71 "," [] [Whitespace(" ")],
                         JsRestParameter {
-                            decorators: JsDecoratorList [],
                             dotdotdot_token: DOT3@71..74 "..." [] [],
                             binding: JsIdentifierBinding {
                                 name_token: IDENT@74..77 "bar" [] [],
@@ -293,11 +292,10 @@ JsModule {
               4: (empty)
             1: COMMA@69..71 "," [] [Whitespace(" ")]
             2: JS_REST_PARAMETER@71..77
-              0: JS_DECORATOR_LIST@71..71
-              1: DOT3@71..74 "..." [] []
-              2: JS_IDENTIFIER_BINDING@74..77
+              0: DOT3@71..74 "..." [] []
+              1: JS_IDENTIFIER_BINDING@74..77
                 0: IDENT@74..77 "bar" [] []
-              3: (empty)
+              2: (empty)
           2: R_PAREN@77..79 ")" [] [Whitespace(" ")]
         3: (empty)
         4: FAT_ARROW@79..82 "=>" [] [Whitespace(" ")]

--- a/crates/biome_js_parser/test_data/inline/ok/ts_conditional_type.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/ts_conditional_type.rast
@@ -511,7 +511,6 @@ JsModule {
                             l_paren_token: L_PAREN@500..501 "(" [] [],
                             items: JsParameterList [
                                 JsRestParameter {
-                                    decorators: JsDecoratorList [],
                                     dotdotdot_token: DOT3@501..504 "..." [] [],
                                     binding: JsIdentifierBinding {
                                         name_token: IDENT@504..505 "a" [] [],
@@ -669,7 +668,6 @@ JsModule {
                                         l_paren_token: L_PAREN@639..640 "(" [] [],
                                         items: JsParameterList [
                                             JsRestParameter {
-                                                decorators: JsDecoratorList [],
                                                 dotdotdot_token: DOT3@640..643 "..." [] [],
                                                 binding: JsIdentifierBinding {
                                                     name_token: IDENT@643..647 "args" [] [],
@@ -726,7 +724,6 @@ JsModule {
                     l_paren_token: L_PAREN@686..687 "(" [] [],
                     items: JsParameterList [
                         JsRestParameter {
-                            decorators: JsDecoratorList [],
                             dotdotdot_token: DOT3@687..690 "..." [] [],
                             binding: JsIdentifierBinding {
                                 name_token: IDENT@690..694 "args" [] [],
@@ -887,7 +884,6 @@ JsModule {
                                         l_paren_token: L_PAREN@829..830 "(" [] [],
                                         items: JsParameterList [
                                             JsRestParameter {
-                                                decorators: JsDecoratorList [],
                                                 dotdotdot_token: DOT3@830..833 "..." [] [],
                                                 binding: JsIdentifierBinding {
                                                     name_token: IDENT@833..837 "args" [] [],
@@ -1777,11 +1773,10 @@ JsModule {
               0: L_PAREN@500..501 "(" [] []
               1: JS_PARAMETER_LIST@501..512
                 0: JS_REST_PARAMETER@501..512
-                  0: JS_DECORATOR_LIST@501..501
-                  1: DOT3@501..504 "..." [] []
-                  2: JS_IDENTIFIER_BINDING@504..505
+                  0: DOT3@501..504 "..." [] []
+                  1: JS_IDENTIFIER_BINDING@504..505
                     0: IDENT@504..505 "a" [] []
-                  3: TS_TYPE_ANNOTATION@505..512
+                  2: TS_TYPE_ANNOTATION@505..512
                     0: COLON@505..507 ":" [] [Whitespace(" ")]
                     1: TS_ARRAY_TYPE@507..512
                       0: TS_ANY_TYPE@507..510
@@ -1890,11 +1885,10 @@ JsModule {
                     0: L_PAREN@639..640 "(" [] []
                     1: JS_PARAMETER_LIST@640..652
                       0: JS_REST_PARAMETER@640..652
-                        0: JS_DECORATOR_LIST@640..640
-                        1: DOT3@640..643 "..." [] []
-                        2: JS_IDENTIFIER_BINDING@643..647
+                        0: DOT3@640..643 "..." [] []
+                        1: JS_IDENTIFIER_BINDING@643..647
                           0: IDENT@643..647 "args" [] []
-                        3: TS_TYPE_ANNOTATION@647..652
+                        2: TS_TYPE_ANNOTATION@647..652
                           0: COLON@647..649 ":" [] [Whitespace(" ")]
                           1: TS_ANY_TYPE@649..652
                             0: ANY_KW@649..652 "any" [] []
@@ -1927,11 +1921,10 @@ JsModule {
           0: L_PAREN@686..687 "(" [] []
           1: JS_PARAMETER_LIST@687..749
             0: JS_REST_PARAMETER@687..749
-              0: JS_DECORATOR_LIST@687..687
-              1: DOT3@687..690 "..." [] []
-              2: JS_IDENTIFIER_BINDING@690..694
+              0: DOT3@687..690 "..." [] []
+              1: JS_IDENTIFIER_BINDING@690..694
                 0: IDENT@690..694 "args" [] []
-              3: TS_TYPE_ANNOTATION@694..749
+              2: TS_TYPE_ANNOTATION@694..749
                 0: COLON@694..696 ":" [] [Whitespace(" ")]
                 1: TS_REFERENCE_TYPE@696..749
                   0: TS_QUALIFIED_NAME@696..706
@@ -2038,11 +2031,10 @@ JsModule {
                     0: L_PAREN@829..830 "(" [] []
                     1: JS_PARAMETER_LIST@830..910
                       0: JS_REST_PARAMETER@830..910
-                        0: JS_DECORATOR_LIST@830..830
-                        1: DOT3@830..833 "..." [] []
-                        2: JS_IDENTIFIER_BINDING@833..837
+                        0: DOT3@830..833 "..." [] []
+                        1: JS_IDENTIFIER_BINDING@833..837
                           0: IDENT@833..837 "args" [] []
-                        3: TS_TYPE_ANNOTATION@837..910
+                        2: TS_TYPE_ANNOTATION@837..910
                           0: COLON@837..839 ":" [] [Whitespace(" ")]
                           1: TS_CONDITIONAL_TYPE@839..910
                             0: TS_REFERENCE_TYPE@839..864

--- a/crates/biome_js_parser/test_data/inline/ok/ts_conditional_type_call_signature_lhs.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/ts_conditional_type_call_signature_lhs.rast
@@ -37,7 +37,6 @@ JsModule {
                         l_paren_token: L_PAREN@22..23 "(" [] [],
                         items: JsParameterList [
                             JsRestParameter {
-                                decorators: JsDecoratorList [],
                                 dotdotdot_token: DOT3@23..26 "..." [] [],
                                 binding: JsIdentifierBinding {
                                     name_token: IDENT@26..30 "args" [] [],
@@ -68,7 +67,6 @@ JsModule {
                         l_paren_token: L_PAREN@48..49 "(" [] [],
                         items: JsParameterList [
                             JsRestParameter {
-                                decorators: JsDecoratorList [],
                                 dotdotdot_token: DOT3@49..52 "..." [] [],
                                 binding: JsIdentifierBinding {
                                     name_token: IDENT@52..56 "args" [] [],
@@ -148,11 +146,10 @@ JsModule {
             0: L_PAREN@22..23 "(" [] []
             1: JS_PARAMETER_LIST@23..37
               0: JS_REST_PARAMETER@23..37
-                0: JS_DECORATOR_LIST@23..23
-                1: DOT3@23..26 "..." [] []
-                2: JS_IDENTIFIER_BINDING@26..30
+                0: DOT3@23..26 "..." [] []
+                1: JS_IDENTIFIER_BINDING@26..30
                   0: IDENT@26..30 "args" [] []
-                3: TS_TYPE_ANNOTATION@30..37
+                2: TS_TYPE_ANNOTATION@30..37
                   0: COLON@30..32 ":" [] [Whitespace(" ")]
                   1: TS_ARRAY_TYPE@32..37
                     0: TS_ANY_TYPE@32..35
@@ -170,11 +167,10 @@ JsModule {
             0: L_PAREN@48..49 "(" [] []
             1: JS_PARAMETER_LIST@49..71
               0: JS_REST_PARAMETER@49..71
-                0: JS_DECORATOR_LIST@49..49
-                1: DOT3@49..52 "..." [] []
-                2: JS_IDENTIFIER_BINDING@52..56
+                0: DOT3@49..52 "..." [] []
+                1: JS_IDENTIFIER_BINDING@52..56
                   0: IDENT@52..56 "args" [] []
-                3: TS_TYPE_ANNOTATION@56..71
+                2: TS_TYPE_ANNOTATION@56..71
                   0: COLON@56..58 ":" [] [Whitespace(" ")]
                   1: TS_REFERENCE_TYPE@58..71
                     0: JS_REFERENCE_IDENTIFIER@58..68

--- a/crates/biome_js_parser/test_data/inline/ok/ts_infer_type_allowed.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/ts_infer_type_allowed.rast
@@ -37,7 +37,6 @@ JsModule {
                         l_paren_token: L_PAREN@25..26 "(" [] [],
                         items: JsParameterList [
                             JsRestParameter {
-                                decorators: JsDecoratorList [],
                                 dotdotdot_token: DOT3@26..29 "..." [] [],
                                 binding: JsIdentifierBinding {
                                     name_token: IDENT@29..33 "args" [] [],
@@ -1383,7 +1382,6 @@ JsModule {
                             l_paren_token: L_PAREN@1344..1345 "(" [] [],
                             items: JsParameterList [
                                 JsRestParameter {
-                                    decorators: JsDecoratorList [],
                                     dotdotdot_token: DOT3@1345..1348 "..." [] [],
                                     binding: JsIdentifierBinding {
                                         name_token: IDENT@1348..1352 "args" [] [],
@@ -2287,7 +2285,6 @@ JsModule {
                         l_paren_token: L_PAREN@2150..2151 "(" [] [],
                         items: JsParameterList [
                             JsRestParameter {
-                                decorators: JsDecoratorList [],
                                 dotdotdot_token: DOT3@2151..2154 "..." [] [],
                                 binding: JsIdentifierBinding {
                                     name_token: IDENT@2154..2158 "args" [] [],
@@ -2484,7 +2481,6 @@ JsModule {
                         l_paren_token: L_PAREN@2337..2338 "(" [] [],
                         items: JsParameterList [
                             JsRestParameter {
-                                decorators: JsDecoratorList [],
                                 dotdotdot_token: DOT3@2338..2341 "..." [] [],
                                 binding: JsIdentifierBinding {
                                     name_token: IDENT@2341..2345 "args" [] [],
@@ -2693,7 +2689,6 @@ JsModule {
                         l_paren_token: L_PAREN@2530..2531 "(" [] [],
                         items: JsParameterList [
                             JsRestParameter {
-                                decorators: JsDecoratorList [],
                                 dotdotdot_token: DOT3@2531..2534 "..." [] [],
                                 binding: JsIdentifierBinding {
                                     name_token: IDENT@2534..2538 "args" [] [],
@@ -2970,7 +2965,6 @@ JsModule {
                                 },
                                 COMMA@2762..2764 "," [] [Whitespace(" ")],
                                 JsRestParameter {
-                                    decorators: JsDecoratorList [],
                                     dotdotdot_token: DOT3@2764..2767 "..." [] [],
                                     binding: JsIdentifierBinding {
                                         name_token: IDENT@2767..2771 "args" [] [],
@@ -3004,7 +2998,6 @@ JsModule {
                             l_paren_token: L_PAREN@2793..2794 "(" [] [],
                             items: JsParameterList [
                                 JsRestParameter {
-                                    decorators: JsDecoratorList [],
                                     dotdotdot_token: DOT3@2794..2797 "..." [] [],
                                     binding: JsIdentifierBinding {
                                         name_token: IDENT@2797..2801 "args" [] [],
@@ -3083,11 +3076,10 @@ JsModule {
             0: L_PAREN@25..26 "(" [] []
             1: JS_PARAMETER_LIST@26..42
               0: JS_REST_PARAMETER@26..42
-                0: JS_DECORATOR_LIST@26..26
-                1: DOT3@26..29 "..." [] []
-                2: JS_IDENTIFIER_BINDING@29..33
+                0: DOT3@26..29 "..." [] []
+                1: JS_IDENTIFIER_BINDING@29..33
                   0: IDENT@29..33 "args" [] []
-                3: TS_TYPE_ANNOTATION@33..42
+                2: TS_TYPE_ANNOTATION@33..42
                   0: COLON@33..35 ":" [] [Whitespace(" ")]
                   1: TS_INFER_TYPE@35..42
                     0: INFER_KW@35..41 "infer" [] [Whitespace(" ")]
@@ -4039,11 +4031,10 @@ JsModule {
               0: L_PAREN@1344..1345 "(" [] []
               1: JS_PARAMETER_LIST@1345..1359
                 0: JS_REST_PARAMETER@1345..1359
-                  0: JS_DECORATOR_LIST@1345..1345
-                  1: DOT3@1345..1348 "..." [] []
-                  2: JS_IDENTIFIER_BINDING@1348..1352
+                  0: DOT3@1345..1348 "..." [] []
+                  1: JS_IDENTIFIER_BINDING@1348..1352
                     0: IDENT@1348..1352 "args" [] []
-                  3: TS_TYPE_ANNOTATION@1352..1359
+                  2: TS_TYPE_ANNOTATION@1352..1359
                     0: COLON@1352..1354 ":" [] [Whitespace(" ")]
                     1: TS_ARRAY_TYPE@1354..1359
                       0: TS_ANY_TYPE@1354..1357
@@ -4676,11 +4667,10 @@ JsModule {
             0: L_PAREN@2150..2151 "(" [] []
             1: JS_PARAMETER_LIST@2151..2169
               0: JS_REST_PARAMETER@2151..2169
-                0: JS_DECORATOR_LIST@2151..2151
-                1: DOT3@2151..2154 "..." [] []
-                2: JS_IDENTIFIER_BINDING@2154..2158
+                0: DOT3@2151..2154 "..." [] []
+                1: JS_IDENTIFIER_BINDING@2154..2158
                   0: IDENT@2154..2158 "args" [] []
-                3: TS_TYPE_ANNOTATION@2158..2169
+                2: TS_TYPE_ANNOTATION@2158..2169
                   0: COLON@2158..2160 ":" [] [Whitespace(" ")]
                   1: TS_PARENTHESIZED_TYPE@2160..2169
                     0: L_PAREN@2160..2161 "(" [] []
@@ -4816,11 +4806,10 @@ JsModule {
             0: L_PAREN@2337..2338 "(" [] []
             1: JS_PARAMETER_LIST@2338..2358
               0: JS_REST_PARAMETER@2338..2358
-                0: JS_DECORATOR_LIST@2338..2338
-                1: DOT3@2338..2341 "..." [] []
-                2: JS_IDENTIFIER_BINDING@2341..2345
+                0: DOT3@2338..2341 "..." [] []
+                1: JS_IDENTIFIER_BINDING@2341..2345
                   0: IDENT@2341..2345 "args" [] []
-                3: TS_TYPE_ANNOTATION@2345..2358
+                2: TS_TYPE_ANNOTATION@2345..2358
                   0: COLON@2345..2347 ":" [] [Whitespace(" ")]
                   1: TS_PARENTHESIZED_TYPE@2347..2358
                     0: L_PAREN@2347..2348 "(" [] []
@@ -4965,11 +4954,10 @@ JsModule {
             0: L_PAREN@2530..2531 "(" [] []
             1: JS_PARAMETER_LIST@2531..2555
               0: JS_REST_PARAMETER@2531..2555
-                0: JS_DECORATOR_LIST@2531..2531
-                1: DOT3@2531..2534 "..." [] []
-                2: JS_IDENTIFIER_BINDING@2534..2538
+                0: DOT3@2531..2534 "..." [] []
+                1: JS_IDENTIFIER_BINDING@2534..2538
                   0: IDENT@2534..2538 "args" [] []
-                3: TS_TYPE_ANNOTATION@2538..2555
+                2: TS_TYPE_ANNOTATION@2538..2555
                   0: COLON@2538..2540 ":" [] [Whitespace(" ")]
                   1: TS_PARENTHESIZED_TYPE@2540..2555
                     0: L_PAREN@2540..2541 "(" [] []
@@ -5164,11 +5152,10 @@ JsModule {
                   4: (empty)
                 1: COMMA@2762..2764 "," [] [Whitespace(" ")]
                 2: JS_REST_PARAMETER@2764..2774
-                  0: JS_DECORATOR_LIST@2764..2764
-                  1: DOT3@2764..2767 "..." [] []
-                  2: JS_IDENTIFIER_BINDING@2767..2771
+                  0: DOT3@2764..2767 "..." [] []
+                  1: JS_IDENTIFIER_BINDING@2767..2771
                     0: IDENT@2767..2771 "args" [] []
-                  3: TS_TYPE_ANNOTATION@2771..2774
+                  2: TS_TYPE_ANNOTATION@2771..2774
                     0: COLON@2771..2773 ":" [] [Whitespace(" ")]
                     1: TS_REFERENCE_TYPE@2773..2774
                       0: JS_REFERENCE_IDENTIFIER@2773..2774
@@ -5188,11 +5175,10 @@ JsModule {
               0: L_PAREN@2793..2794 "(" [] []
               1: JS_PARAMETER_LIST@2794..2810
                 0: JS_REST_PARAMETER@2794..2810
-                  0: JS_DECORATOR_LIST@2794..2794
-                  1: DOT3@2794..2797 "..." [] []
-                  2: JS_IDENTIFIER_BINDING@2797..2801
+                  0: DOT3@2794..2797 "..." [] []
+                  1: JS_IDENTIFIER_BINDING@2797..2801
                     0: IDENT@2797..2801 "args" [] []
-                  3: TS_TYPE_ANNOTATION@2801..2810
+                  2: TS_TYPE_ANNOTATION@2801..2810
                     0: COLON@2801..2803 ":" [] [Whitespace(" ")]
                     1: TS_INFER_TYPE@2803..2810
                       0: INFER_KW@2803..2809 "infer" [] [Whitespace(" ")]

--- a/crates/biome_js_parser/test_data/inline/ok/ts_property_parameter.rast
+++ b/crates/biome_js_parser/test_data/inline/ok/ts_property_parameter.rast
@@ -279,7 +279,6 @@ JsModule {
                             },
                             COMMA@228..230 "," [] [Whitespace(" ")],
                             JsRestParameter {
-                                decorators: JsDecoratorList [],
                                 dotdotdot_token: DOT3@230..233 "..." [] [],
                                 binding: JsIdentifierBinding {
                                     name_token: IDENT@233..237 "rest" [] [],
@@ -512,11 +511,10 @@ JsModule {
                     0: JS_STRING_LITERAL@219..228 "\"default\"" [] []
               5: COMMA@228..230 "," [] [Whitespace(" ")]
               6: JS_REST_PARAMETER@230..237
-                0: JS_DECORATOR_LIST@230..230
-                1: DOT3@230..233 "..." [] []
-                2: JS_IDENTIFIER_BINDING@233..237
+                0: DOT3@230..233 "..." [] []
+                1: JS_IDENTIFIER_BINDING@233..237
                   0: IDENT@233..237 "rest" [] []
-                3: (empty)
+                2: (empty)
             2: R_PAREN@237..239 ")" [] [Whitespace(" ")]
           3: JS_FUNCTION_BODY@239..242
             0: L_CURLY@239..240 "{" [] []

--- a/crates/biome_js_syntax/src/generated/nodes.rs
+++ b/crates/biome_js_syntax/src/generated/nodes.rs
@@ -5831,23 +5831,19 @@ impl JsRestParameter {
     }
     pub fn as_fields(&self) -> JsRestParameterFields {
         JsRestParameterFields {
-            decorators: self.decorators(),
             dotdotdot_token: self.dotdotdot_token(),
             binding: self.binding(),
             type_annotation: self.type_annotation(),
         }
     }
-    pub fn decorators(&self) -> JsDecoratorList {
-        support::list(&self.syntax, 0usize)
-    }
     pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 1usize)
+        support::required_token(&self.syntax, 0usize)
     }
     pub fn binding(&self) -> SyntaxResult<AnyJsBindingPattern> {
-        support::required_node(&self.syntax, 2usize)
+        support::required_node(&self.syntax, 1usize)
     }
     pub fn type_annotation(&self) -> Option<TsTypeAnnotation> {
-        support::node(&self.syntax, 3usize)
+        support::node(&self.syntax, 2usize)
     }
 }
 #[cfg(feature = "serde")]
@@ -5861,7 +5857,6 @@ impl Serialize for JsRestParameter {
 }
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct JsRestParameterFields {
-    pub decorators: JsDecoratorList,
     pub dotdotdot_token: SyntaxResult<SyntaxToken>,
     pub binding: SyntaxResult<AnyJsBindingPattern>,
     pub type_annotation: Option<TsTypeAnnotation>,
@@ -21957,7 +21952,6 @@ impl AstNode for JsRestParameter {
 impl std::fmt::Debug for JsRestParameter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsRestParameter")
-            .field("decorators", &self.decorators())
             .field(
                 "dotdotdot_token",
                 &support::DebugSyntaxResult(self.dotdotdot_token()),

--- a/crates/biome_js_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_js_syntax/src/generated/nodes_mut.rs
@@ -2733,27 +2733,21 @@ impl JsRegexLiteralExpression {
     }
 }
 impl JsRestParameter {
-    pub fn with_decorators(self, element: JsDecoratorList) -> Self {
-        Self::unwrap_cast(
-            self.syntax
-                .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
-        )
-    }
     pub fn with_dotdotdot_token(self, element: SyntaxToken) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(1usize..=1usize, once(Some(element.into()))),
+                .splice_slots(0usize..=0usize, once(Some(element.into()))),
         )
     }
     pub fn with_binding(self, element: AnyJsBindingPattern) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(2usize..=2usize, once(Some(element.into_syntax().into()))),
+                .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
         )
     }
     pub fn with_type_annotation(self, element: Option<TsTypeAnnotation>) -> Self {
         Self::unwrap_cast(self.syntax.splice_slots(
-            3usize..=3usize,
+            2usize..=2usize,
             once(element.map(|element| element.into_syntax().into())),
         ))
     }

--- a/crates/biome_js_syntax/src/parameter_ext.rs
+++ b/crates/biome_js_syntax/src/parameter_ext.rs
@@ -489,7 +489,7 @@ impl AnyJsConstructorParameter {
     pub fn decorators(&self) -> Option<JsDecoratorList> {
         match self {
             AnyJsConstructorParameter::AnyJsFormalParameter(parameter) => parameter.decorators(),
-            AnyJsConstructorParameter::JsRestParameter(parameter) => Some(parameter.decorators()),
+            AnyJsConstructorParameter::JsRestParameter(_) => None,
             AnyJsConstructorParameter::TsPropertyParameter(parameter) => {
                 Some(parameter.decorators())
             }
@@ -521,7 +521,7 @@ impl AnyJsParameter {
     pub fn decorators(&self) -> Option<JsDecoratorList> {
         match self {
             AnyJsParameter::AnyJsFormalParameter(parameter) => parameter.decorators(),
-            AnyJsParameter::JsRestParameter(parameter) => Some(parameter.decorators()),
+            AnyJsParameter::JsRestParameter(_) => None,
             AnyJsParameter::TsThisParameter(_) => None,
         }
     }

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -1610,7 +1610,6 @@ JsFormalParameter =
 // (...a) => {}
 //  ^^^^
 JsRestParameter =
-	decorators: JsDecoratorList
 	'...'
 	binding: AnyJsBindingPattern
 	type_annotation: TsTypeAnnotation?


### PR DESCRIPTION
## Summary

It seems I was wrong to add decorators to a rest parameter because it makes no sense.

```
class A {
   method(@dec ...a) {}
}
```

## Test Plan

`cargo test`