### PR TITLE
feat(lint): add rule `useStrictMode`

### DIFF
--- a/crates/biome_configuration/src/linter/rules.rs
+++ b/crates/biome_configuration/src/linter/rules.rs
@@ -2963,6 +2963,9 @@ pub struct Nursery {
     #[doc = "Enforce the sorting of CSS utility classes."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_sorted_classes: Option<RuleFixConfiguration<UseSortedClasses>>,
+    #[doc = "Enforce the use of the directive \"use strict\" in script files."]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_strict_mode: Option<RuleFixConfiguration<UseStrictMode>>,
     #[doc = "Require new when throwing an error."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_throw_new_error: Option<RuleFixConfiguration<UseThrowNewError>>,
@@ -3041,6 +3044,7 @@ impl Nursery {
         "useNumberToFixedDigitsArgument",
         "useSemanticElements",
         "useSortedClasses",
+        "useStrictMode",
         "useThrowNewError",
         "useThrowOnlyError",
         "useTopLevelRegex",
@@ -3070,6 +3074,7 @@ impl Nursery {
         "useFocusableInteractive",
         "useGenericFontNames",
         "useSemanticElements",
+        "useStrictMode",
     ];
     const RECOMMENDED_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
@@ -3095,6 +3100,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]),
     ];
     const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
@@ -3149,6 +3155,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended_true(&self) -> bool {
@@ -3405,24 +3412,29 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
             }
         }
-        if let Some(rule) = self.use_throw_new_error.as_ref() {
+        if let Some(rule) = self.use_strict_mode.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
             }
         }
-        if let Some(rule) = self.use_throw_only_error.as_ref() {
+        if let Some(rule) = self.use_throw_new_error.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
             }
         }
-        if let Some(rule) = self.use_top_level_regex.as_ref() {
+        if let Some(rule) = self.use_throw_only_error.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
             }
         }
-        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+        if let Some(rule) = self.use_top_level_regex.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]));
+            }
+        }
+        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]));
             }
         }
         index_set
@@ -3669,24 +3681,29 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
             }
         }
-        if let Some(rule) = self.use_throw_new_error.as_ref() {
+        if let Some(rule) = self.use_strict_mode.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
             }
         }
-        if let Some(rule) = self.use_throw_only_error.as_ref() {
+        if let Some(rule) = self.use_throw_new_error.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
             }
         }
-        if let Some(rule) = self.use_top_level_regex.as_ref() {
+        if let Some(rule) = self.use_throw_only_error.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
             }
         }
-        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+        if let Some(rule) = self.use_top_level_regex.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]));
+            }
+        }
+        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]));
             }
         }
         index_set
@@ -3915,6 +3932,10 @@ impl Nursery {
                 .map(|conf| (conf.level(), conf.get_options())),
             "useSortedClasses" => self
                 .use_sorted_classes
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useStrictMode" => self
+                .use_strict_mode
                 .as_ref()
                 .map(|conf| (conf.level(), conf.get_options())),
             "useThrowNewError" => self

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -165,6 +165,7 @@ define_categories! {
     "lint/nursery/useNumberToFixedDigitsArgument": "https://biomejs.dev/linter/rules/use-number-to-fixed-digits-argument",
     "lint/nursery/useSemanticElements": "https://biomejs.dev/linter/rules/use-semantic-elements",
     "lint/nursery/useSortedClasses": "https://biomejs.dev/linter/rules/use-sorted-classes",
+    "lint/nursery/useStrictMode": "https://biomejs.dev/linter/rules/use-strict-mode",
     "lint/nursery/useThrowNewError": "https://biomejs.dev/linter/rules/use-throw-new-error",
     "lint/nursery/useThrowOnlyError": "https://biomejs.dev/linter/rules/use-throw-only-error",
     "lint/nursery/useTopLevelRegex": "https://biomejs.dev/linter/rules/use-top-level-regex",

--- a/crates/biome_js_analyze/src/lint/nursery.rs
+++ b/crates/biome_js_analyze/src/lint/nursery.rs
@@ -30,6 +30,7 @@ pub mod use_import_restrictions;
 pub mod use_number_to_fixed_digits_argument;
 pub mod use_semantic_elements;
 pub mod use_sorted_classes;
+pub mod use_strict_mode;
 pub mod use_throw_new_error;
 pub mod use_throw_only_error;
 pub mod use_top_level_regex;
@@ -67,6 +68,7 @@ declare_lint_group! {
             self :: use_number_to_fixed_digits_argument :: UseNumberToFixedDigitsArgument ,
             self :: use_semantic_elements :: UseSemanticElements ,
             self :: use_sorted_classes :: UseSortedClasses ,
+            self :: use_strict_mode :: UseStrictMode ,
             self :: use_throw_new_error :: UseThrowNewError ,
             self :: use_throw_only_error :: UseThrowOnlyError ,
             self :: use_top_level_regex :: UseTopLevelRegex ,

--- a/crates/biome_js_analyze/src/lint/nursery/use_strict_mode.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_strict_mode.rs
@@ -1,0 +1,94 @@
+use crate::JsRuleAction;
+use biome_analyze::{
+    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+};
+use biome_console::markup;
+use biome_js_factory::make::{
+    js_directive, js_directive_list, jsx_string_literal, jsx_string_literal_single_quotes,
+};
+use biome_js_syntax::{JsFileSource, JsScript};
+use biome_rowan::{AstNode, AstNodeList, BatchMutationExt};
+
+declare_lint_rule! {
+    /// Enforce the use of the directive `"use strict"` in script files.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```cjs,expect_diagnostic
+    /// var a = 1;
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```cjs
+    /// "use strict"
+    ///
+    /// var a = 1;
+    /// ```
+    ///
+    pub UseStrictMode {
+        version: "1.8.0",
+        name: "useStrictMode",
+        language: "js",
+        recommended: true,
+        fix_kind: FixKind::Safe,
+    }
+}
+
+impl Rule for UseStrictMode {
+    type Query = Ast<JsScript>;
+    type State = ();
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+        let file_source = ctx.source_type::<JsFileSource>();
+
+        if node.directives().is_empty() && file_source.is_script() {
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
+        let node = ctx.query();
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                node.range(),
+                markup! {
+                    "Unexpected absence of the directive "<Emphasis>"\"use strict\"."</Emphasis>
+                },
+            )
+            .note(markup! {
+                "Strict mode allows to opt-in some optimisations of the runtime engines, and it eliminates some JavaScript silent errors by changing them to throw errors."
+            })
+            .note(markup!{
+                "Check the "<Hyperlink href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode">"for more information regarding strict mode."</Hyperlink>
+            }),
+        )
+    }
+
+    fn action(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<JsRuleAction> {
+        let node = ctx.query().clone();
+        let mut mutation = ctx.root().begin();
+        let value = if ctx.as_preferred_quote().is_double() {
+            jsx_string_literal("use strict")
+        } else {
+            jsx_string_literal_single_quotes("use strict")
+        };
+        let directives = js_directive_list(vec![js_directive(value).build()]);
+        let new_node = node.clone().with_directives(directives);
+        mutation.replace_node(node, new_node);
+        Some(JsRuleAction::new(
+            ActionCategory::QuickFix,
+            ctx.metadata().applicability(),
+            markup!("Insert a top level"<Emphasis>"\"use strict\" "</Emphasis>".").to_owned(),
+            mutation,
+        ))
+    }
+}

--- a/crates/biome_js_analyze/src/lint/nursery/use_strict_mode.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_strict_mode.rs
@@ -30,7 +30,7 @@ declare_lint_rule! {
     /// ### Valid
     ///
     /// ```cjs
-    /// "use strict"
+    /// "use strict";
     ///
     /// var a = 1;
     /// ```

--- a/crates/biome_js_analyze/src/lint/nursery/use_strict_mode.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_strict_mode.rs
@@ -12,6 +12,13 @@ use biome_rowan::{AstNode, AstNodeList, BatchMutationExt};
 declare_lint_rule! {
     /// Enforce the use of the directive `"use strict"` in script files.
     ///
+    /// The JavaScript [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) prohibits some obsolete JavaScript syntaxes and makes some slight semantic chnmages to allow more optimizations by JavaScript engines.
+    ///  EcmaScript modules are always in strict mode, while JavaScript scripts are by default in non-strict mode, also known as _sloppy mode_.
+    /// A developer can add the `"use strict"` directive at the start of a script file to enable the strict mode in that file.
+    ///
+    /// Biome considers a CommonJS (`.cjs`) file as a script file.
+    /// By default, Biome recognizes a JavaScript file (`.js`) as a module file, except if `"type": "commonjs"` is specified in `package.json`.
+    ///
     /// ## Examples
     ///
     /// ### Invalid

--- a/crates/biome_js_analyze/src/options.rs
+++ b/crates/biome_js_analyze/src/options.rs
@@ -350,6 +350,8 @@ pub type UseSingleCaseStatement = < lint :: style :: use_single_case_statement :
 pub type UseSingleVarDeclarator = < lint :: style :: use_single_var_declarator :: UseSingleVarDeclarator as biome_analyze :: Rule > :: Options ;
 pub type UseSortedClasses =
     <lint::nursery::use_sorted_classes::UseSortedClasses as biome_analyze::Rule>::Options;
+pub type UseStrictMode =
+    <lint::nursery::use_strict_mode::UseStrictMode as biome_analyze::Rule>::Options;
 pub type UseTemplate = <lint::style::use_template::UseTemplate as biome_analyze::Rule>::Options;
 pub type UseThrowNewError =
     <lint::nursery::use_throw_new_error::UseThrowNewError as biome_analyze::Rule>::Options;

--- a/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/invalid.js
@@ -1,0 +1,5 @@
+
+
+function f() {
+	return "lorem ipsum"
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/invalid.js.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.js
+---
+# Input
+```jsx
+
+
+function f() {
+	return "lorem ipsum"
+}
+
+```
+
+# Diagnostics
+```
+invalid.js:3:1 lint/nursery/useStrictMode  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Unexpected absence of the directive "use strict".
+  
+  > 3 │ function f() {
+      │ ^^^^^^^^^^^^^^
+  > 4 │ 	return "lorem ipsum"
+  > 5 │ }
+      │ ^
+    6 │ 
+  
+  i Strict mode allows to opt-in some optimisations of the runtime engines, and it eliminates some JavaScript silent errors by changing them to throw errors.
+  
+  i Check the for more information regarding strict mode.
+  
+  i Safe fix: Insert a top level"use strict" .
+  
+    1 1 │   
+    2 2 │   
+      3 │ + "use·strict"
+      4 │ + 
+    3 5 │   function f() {
+    4 6 │   	return "lorem ipsum"
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/invalid.package.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/invalid.package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/valid.js
@@ -1,0 +1,2 @@
+/* should not generate diagnostics */
+// var a = 1;

--- a/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/valid.js.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+// var a = 1;
+```

--- a/crates/biome_js_syntax/src/file_source.rs
+++ b/crates/biome_js_syntax/src/file_source.rs
@@ -213,6 +213,10 @@ impl JsFileSource {
         self
     }
 
+    pub fn set_module_kind(&mut self, kind: ModuleKind) {
+        self.module_kind = kind;
+    }
+
     pub const fn with_version(mut self, version: LanguageVersion) -> Self {
         self.version = version;
         self
@@ -246,6 +250,10 @@ impl JsFileSource {
 
     pub const fn is_module(&self) -> bool {
         self.module_kind.is_module()
+    }
+
+    pub const fn is_script(&self) -> bool {
+        self.module_kind.is_script()
     }
 
     pub const fn is_typescript(&self) -> bool {

--- a/crates/biome_project/src/lib.rs
+++ b/crates/biome_project/src/lib.rs
@@ -8,7 +8,7 @@ use biome_diagnostics::serde::Diagnostic;
 use biome_parser::diagnostic::ParseDiagnostic;
 use biome_rowan::Language;
 pub use license::generated::*;
-pub use node_js_project::{Dependencies, NodeJsProject, PackageJson};
+pub use node_js_project::{Dependencies, NodeJsProject, PackageJson, PackageType};
 use std::any::TypeId;
 use std::fmt::Debug;
 use std::path::Path;

--- a/crates/biome_project/src/node_js_project/mod.rs
+++ b/crates/biome_project/src/node_js_project/mod.rs
@@ -1,6 +1,6 @@
 mod package_json;
 
-pub use crate::node_js_project::package_json::{Dependencies, PackageJson};
+pub use crate::node_js_project::package_json::{Dependencies, PackageJson, PackageType};
 use crate::{Manifest, Project, ProjectAnalyzeDiagnostic, ProjectAnalyzeResult, LICENSE_LIST};
 use biome_json_syntax::JsonRoot;
 use biome_rowan::Language;

--- a/crates/biome_project/src/node_js_project/package_json.rs
+++ b/crates/biome_project/src/node_js_project/package_json.rs
@@ -18,6 +18,7 @@ pub struct PackageJson {
     pub peer_dependencies: Dependencies,
     pub optional_dependencies: Dependencies,
     pub license: Option<(String, TextRange)>,
+    pub r#type: Option<PackageType>,
 }
 
 impl Manifest for PackageJson {
@@ -132,6 +133,9 @@ impl DeserializationVisitor for PackageJsonVisitor {
                         result.optional_dependencies = deps;
                     }
                 }
+                "type" => {
+                    result.r#type = Deserializable::deserialize(&value, &key_text, diagnostics);
+                }
                 _ => {
                     // each package can add their own field, so we should ignore any extraneous key
                     // and only deserialize the ones that Biome deems important
@@ -154,4 +158,11 @@ impl Deserializable for Version {
             Err(_) => Some(Version::Literal(value.text().to_string())),
         }
     }
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq, biome_deserialize_macros::Deserializable)]
+pub enum PackageType {
+    #[default]
+    Module,
+    Commonjs,
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1246,6 +1246,10 @@ export interface Nursery {
 	 */
 	useSortedClasses?: RuleFixConfiguration_for_UtilityClassSortingOptions;
 	/**
+	 * Enforce the use of the directive "use strict" in script files.
+	 */
+	useStrictMode?: RuleConfiguration_for_Null;
+	/**
 	 * Require new when throwing an error.
 	 */
 	useThrowNewError?: RuleFixConfiguration_for_Null;
@@ -2543,6 +2547,7 @@ export type Category =
 	| "lint/nursery/useNumberToFixedDigitsArgument"
 	| "lint/nursery/useSemanticElements"
 	| "lint/nursery/useSortedClasses"
+	| "lint/nursery/useStrictMode"
 	| "lint/nursery/useThrowNewError"
 	| "lint/nursery/useThrowOnlyError"
 	| "lint/nursery/useTopLevelRegex"

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1248,7 +1248,7 @@ export interface Nursery {
 	/**
 	 * Enforce the use of the directive "use strict" in script files.
 	 */
-	useStrictMode?: RuleConfiguration_for_Null;
+	useStrictMode?: RuleFixConfiguration_for_Null;
 	/**
 	 * Require new when throwing an error.
 	 */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2098,6 +2098,13 @@
 						{ "type": "null" }
 					]
 				},
+				"useStrictMode": {
+					"description": "Enforce the use of the directive \"use strict\" in script files.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"useThrowNewError": {
 					"description": "Require new when throwing an error.",
 					"anyOf": [

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2101,7 +2101,7 @@
 				"useStrictMode": {
 					"description": "Enforce the use of the directive \"use strict\" in script files.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }
 					]
 				},


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Adds a new rule called `useStrictMode` that enforces the use of `"use strict"` inside script files (CJS). 

This PR updates the logic of the workspace to "guess" the module kind by reading the `type` field inside the manifest.

If the manifest has `"commonjs"`, all `.js` files are marked as scripts.

I know that `commonjs` is the default value, but nowadays, nobody uses it, they use some sort of bundler and transpiler to handle the transformation of the code. I'd be happy to change the default value to commonjs if you think it's the correct approach.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added tests

<!-- What demonstrates that your implementation is correct? -->
