### PR TITLE
refactor(js_semantic): use trimmed range to identify scopes and bindings

### DIFF
--- a/crates/biome_js_analyze/tests/specs/correctness/noInvalidUseBeforeDeclaration/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noInvalidUseBeforeDeclaration/invalid.js.snap
@@ -72,15 +72,12 @@ invalid.js:4:11 lint/correctness/noInvalidUseBeforeDeclaration ━━━━━�
 ```
 
 ```
-invalid.js:4:13 lint/correctness/noInvalidUseBeforeDeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:6:1 lint/correctness/noInvalidUseBeforeDeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This variable is used before its declaration.
   
-    2 │ const a = 0;
-    3 │ 
-  > 4 │ const b = b;
-      │             
-  > 5 │ 
+    4 │ const b = b;
+    5 │ 
   > 6 │ c;
       │ ^
     7 │ let c;
@@ -122,15 +119,12 @@ invalid.js:9:9 lint/correctness/noInvalidUseBeforeDeclaration ━━━━━━
 ```
 
 ```
-invalid.js:9:11 lint/correctness/noInvalidUseBeforeDeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:11:1 lint/correctness/noInvalidUseBeforeDeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This variable is used before its declaration.
   
-     7 │ let c;
-     8 │ 
-   > 9 │ let d = d;
-       │           
-  > 10 │ 
+     9 │ let d = d;
+    10 │ 
   > 11 │ e;
        │ ^
     12 │ var e;
@@ -192,5 +186,3 @@ invalid.js:18:16 lint/correctness/noInvalidUseBeforeDeclaration ━━━━━�
   
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/correctness/noInvalidUseBeforeDeclaration/invalidBindingPattern.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noInvalidUseBeforeDeclaration/invalidBindingPattern.js.snap
@@ -96,7 +96,7 @@ invalidBindingPattern.js:4:18 lint/correctness/noInvalidUseBeforeDeclaration ━
     2 │ function f([b = a, a = 0]) {}
     3 │ function f({ x: [b = a, { a = 0 }] }) {}
   > 4 │ function f({ a = a }) {}
-      │                  ^^
+      │                  ^
     5 │ {
     6 │ 	const { b = a, a = 0 } = {};
   
@@ -183,5 +183,3 @@ invalidBindingPattern.js:13:11 lint/correctness/noInvalidUseBeforeDeclaration �
   
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid.js.snap
@@ -21,7 +21,7 @@ invalid.js:1:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━�
   ! A global variable should not be reassigned.
   
   > 1 │ window = {};
-      │ ^^^^^^^
+      │ ^^^^^^
     2 │ Object = null;
     3 │ undefined = 1;
   
@@ -31,14 +31,13 @@ invalid.js:1:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━�
 ```
 
 ```
-invalid.js:1:13 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:2:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! A global variable should not be reassigned.
   
-  > 1 │ window = {};
-      │             
+    1 │ window = {};
   > 2 │ Object = null;
-      │ ^^^^^^^
+      │ ^^^^^^
     3 │ undefined = 1;
     4 │ length = 1;
   
@@ -48,15 +47,14 @@ invalid.js:1:13 lint/suspicious/noGlobalAssign ━━━━━━━━━━━
 ```
 
 ```
-invalid.js:2:15 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:3:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! A global variable should not be reassigned.
   
     1 │ window = {};
-  > 2 │ Object = null;
-      │               
+    2 │ Object = null;
   > 3 │ undefined = 1;
-      │ ^^^^^^^^^^
+      │ ^^^^^^^^^
     4 │ length = 1;
     5 │ top = 1;
   
@@ -66,16 +64,14 @@ invalid.js:2:15 lint/suspicious/noGlobalAssign ━━━━━━━━━━━
 ```
 
 ```
-invalid.js:3:15 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:4:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! A global variable should not be reassigned.
   
-    1 │ window = {};
     2 │ Object = null;
-  > 3 │ undefined = 1;
-      │               
+    3 │ undefined = 1;
   > 4 │ length = 1;
-      │ ^^^^^^^
+      │ ^^^^^^
     5 │ top = 1;
     6 │ String++;
   
@@ -85,16 +81,14 @@ invalid.js:3:15 lint/suspicious/noGlobalAssign ━━━━━━━━━━━
 ```
 
 ```
-invalid.js:4:12 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:5:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! A global variable should not be reassigned.
   
-    2 │ Object = null;
     3 │ undefined = 1;
-  > 4 │ length = 1;
-      │            
+    4 │ length = 1;
   > 5 │ top = 1;
-      │ ^^^^
+      │ ^^^
     6 │ String++;
     7 │ ({Object = 0, String = 0} = {});
   
@@ -104,14 +98,12 @@ invalid.js:4:12 lint/suspicious/noGlobalAssign ━━━━━━━━━━━
 ```
 
 ```
-invalid.js:5:9 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:6:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! A global variable should not be reassigned.
   
-    3 │ undefined = 1;
     4 │ length = 1;
-  > 5 │ top = 1;
-      │         
+    5 │ top = 1;
   > 6 │ String++;
       │ ^^^^^^
     7 │ ({Object = 0, String = 0} = {});
@@ -130,7 +122,7 @@ invalid.js:7:3 lint/suspicious/noGlobalAssign ━━━━━━━━━━━�
     5 │ top = 1;
     6 │ String++;
   > 7 │ ({Object = 0, String = 0} = {});
-      │   ^^^^^^^
+      │   ^^^^^^
     8 │ require = 0;
   
   i Assigning to a global variable can override essential functionality.
@@ -146,7 +138,7 @@ invalid.js:7:15 lint/suspicious/noGlobalAssign ━━━━━━━━━━━
     5 │ top = 1;
     6 │ String++;
   > 7 │ ({Object = 0, String = 0} = {});
-      │               ^^^^^^^
+      │               ^^^^^^
     8 │ require = 0;
   
   i Assigning to a global variable can override essential functionality.
@@ -155,20 +147,16 @@ invalid.js:7:15 lint/suspicious/noGlobalAssign ━━━━━━━━━━━
 ```
 
 ```
-invalid.js:7:33 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:8:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! A global variable should not be reassigned.
   
-    5 │ top = 1;
     6 │ String++;
-  > 7 │ ({Object = 0, String = 0} = {});
-      │                                 
+    7 │ ({Object = 0, String = 0} = {});
   > 8 │ require = 0;
-      │ ^^^^^^^^
+      │ ^^^^^^^
   
   i Assigning to a global variable can override essential functionality.
   
 
 ```
-
-

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -56,7 +56,8 @@ impl SemanticModelBuilder {
             | TS_TYPE_PARAMETER_NAME
             | TS_LITERAL_ENUM_MEMBER_NAME
             | JS_IDENTIFIER_ASSIGNMENT => {
-                self.node_by_range.insert(node.text_range(), node.clone());
+                self.node_by_range
+                    .insert(node.text_trimmed_range(), node.clone());
             }
 
             // Accessible from scopes, closures
@@ -98,13 +99,15 @@ impl SemanticModelBuilder {
             | JS_CATCH_CLAUSE
             | TS_FUNCTION_TYPE
             | TS_MAPPED_TYPE => {
-                self.node_by_range.insert(node.text_range(), node.clone());
+                self.node_by_range
+                    .insert(node.text_trimmed_range(), node.clone());
             }
             _ => {
                 if let Some(conditional_type) = TsConditionalType::cast_ref(node) {
                     if let Ok(conditional_true_type) = conditional_type.true_type() {
                         let syntax = conditional_true_type.into_syntax();
-                        self.node_by_range.insert(syntax.text_range(), syntax);
+                        self.node_by_range
+                            .insert(syntax.text_trimmed_range(), syntax);
                     }
                 }
             }

--- a/crates/biome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/biome_js_semantic/src/semantic_model/closure.rs
@@ -18,7 +18,7 @@ macro_rules! SyntaxTextRangeHasClosureAstNode {
             impl HasClosureAstNode for $node {
                 #[inline(always)]
                 fn node_text_range(&self) -> TextRange {
-                    self.syntax().text_range()
+                    self.syntax().text_trimmed_range()
                 }
             }
         )*
@@ -50,7 +50,7 @@ macro_rules! SyntaxTextRangeHasClosureAstNode {
             fn node_text_range(&self) -> TextRange {
                 match self {
                     $(
-                        AnyHasClosureNode::$node(node) => node.syntax().text_range(),
+                        AnyHasClosureNode::$node(node) => node.syntax().text_trimmed_range(),
                     )*
                 }
             }
@@ -109,7 +109,7 @@ impl Capture {
     /// This is equivalent, but faster, to:
     ///
     /// ```rs, ignore
-    /// self.declaration().text_range()
+    /// self.declaration().text_trimmed_range()
     /// ```
     pub fn declaration_range(&self) -> &TextRange {
         let binding = self.data.binding(self.binding_id);

--- a/crates/biome_js_semantic/src/semantic_model/import.rs
+++ b/crates/biome_js_semantic/src/semantic_model/import.rs
@@ -22,7 +22,7 @@ impl CanBeImportedExported for JsIdentifierBinding {
     type Result = bool;
 
     fn is_exported(&self, model: &SemanticModel) -> Self::Result {
-        let range = self.syntax().text_range();
+        let range = self.syntax().text_trimmed_range();
         model.data.is_exported(range)
     }
 
@@ -35,7 +35,7 @@ impl CanBeImportedExported for TsIdentifierBinding {
     type Result = bool;
 
     fn is_exported(&self, model: &SemanticModel) -> Self::Result {
-        let range = self.syntax().text_range();
+        let range = self.syntax().text_trimmed_range();
         model.data.is_exported(range)
     }
 
@@ -48,7 +48,7 @@ impl CanBeImportedExported for AnyJsIdentifierBinding {
     type Result = bool;
 
     fn is_exported(&self, model: &SemanticModel) -> Self::Result {
-        let range = self.syntax().text_range();
+        let range = self.syntax().text_trimmed_range();
         model.data.is_exported(range)
     }
 
@@ -61,7 +61,7 @@ impl<T: HasDeclarationAstNode> CanBeImportedExported for T {
     type Result = Option<bool>;
 
     fn is_exported(&self, model: &SemanticModel) -> Self::Result {
-        let range = self.binding(model)?.syntax().text_range();
+        let range = self.binding(model)?.syntax().text_trimmed_range();
         Some(model.data.is_exported(range))
     }
 

--- a/crates/biome_js_semantic/src/semantic_model/model.rs
+++ b/crates/biome_js_semantic/src/semantic_model/model.rs
@@ -158,7 +158,7 @@ impl SemanticModel {
     /// let block_scope = arguments_reference.scope(&model);
     /// ```
     pub fn scope(&self, node: &JsSyntaxNode) -> Scope {
-        let range = node.text_range();
+        let range = node.text_trimmed_range();
         let id = self.data.scope(&range);
         Scope {
             data: self.data.clone(),
@@ -169,7 +169,7 @@ impl SemanticModel {
     /// Returns the [Scope] which the specified syntax node was hoisted to, if any.
     /// Can also be called from [AstNode]::scope_hoisted_to extension method.
     pub fn scope_hoisted_to(&self, node: &JsSyntaxNode) -> Option<Scope> {
-        let range = node.text_range();
+        let range = node.text_trimmed_range();
         let id = self.data.scope_hoisted_to(&range)?;
         Some(Scope {
             data: self.data.clone(),
@@ -209,7 +209,7 @@ impl SemanticModel {
     /// ```
     pub fn binding(&self, reference: &impl HasDeclarationAstNode) -> Option<Binding> {
         let reference = reference.node();
-        let range = reference.syntax().text_range();
+        let range = reference.syntax().text_trimmed_range();
         let id = *self.data.declared_at_by_start.get(&range.start())?;
         Some(Binding {
             data: self.data.clone(),
@@ -330,7 +330,7 @@ impl SemanticModel {
     }
 
     pub fn as_binding(&self, binding: &impl IsBindingAstNode) -> Binding {
-        let range = binding.syntax().text_range();
+        let range = binding.syntax().text_trimmed_range();
         let id = &self.data.bindings_by_start[&range.start()];
         Binding {
             data: self.data.clone(),

--- a/crates/biome_js_semantic/src/tests/assertions.rs
+++ b/crates/biome_js_semantic/src/tests/assertions.rs
@@ -265,7 +265,7 @@ impl SemanticAssertion {
                 .to_string();
 
             Some(SemanticAssertion::Declaration(DeclarationAssertion {
-                range: token.parent().unwrap().text_range(),
+                range: token.parent().unwrap().text_trimmed_range(),
                 declaration_name: name,
             }))
         } else if assertion_text.starts_with("/*READ ") {
@@ -277,7 +277,7 @@ impl SemanticAssertion {
                 .to_string();
 
             Some(SemanticAssertion::Read(ReadAssertion {
-                range: token.parent().unwrap().text_range(),
+                range: token.parent().unwrap().text_trimmed_range(),
                 declaration_assertion_name: symbol_name,
             }))
         } else if assertion_text.starts_with("/*WRITE ") {
@@ -289,7 +289,7 @@ impl SemanticAssertion {
                 .to_string();
 
             Some(SemanticAssertion::Write(WriteAssertion {
-                range: token.parent().unwrap().text_range(),
+                range: token.parent().unwrap().text_trimmed_range(),
                 declaration_assertion_name: symbol_name,
             }))
         } else if assertion_text.contains("/*START") {
@@ -300,7 +300,7 @@ impl SemanticAssertion {
                 .trim()
                 .to_string();
             Some(SemanticAssertion::ScopeStart(ScopeStartAssertion {
-                range: token.parent().unwrap().text_range(),
+                range: token.parent().unwrap().text_trimmed_range(),
                 scope_name,
             }))
         } else if assertion_text.contains("/*END") {
@@ -311,7 +311,7 @@ impl SemanticAssertion {
                 .trim()
                 .to_string();
             Some(SemanticAssertion::ScopeEnd(ScopeEndAssertion {
-                range: token.parent().unwrap().text_range(),
+                range: token.parent().unwrap().text_trimmed_range(),
                 scope_name,
             }))
         } else if assertion_text.starts_with("/*@") {
@@ -322,21 +322,21 @@ impl SemanticAssertion {
                 .trim()
                 .to_string();
             Some(SemanticAssertion::AtScope(AtScopeAssertion {
-                range: token.parent().unwrap().text_range(),
+                range: token.parent().unwrap().text_trimmed_range(),
                 scope_name,
             }))
         } else if assertion_text.contains("/*NOEVENT") {
             Some(SemanticAssertion::NoEvent(NoEventAssertion {
-                range: token.parent().unwrap().text_range(),
+                range: token.parent().unwrap().text_trimmed_range(),
             }))
         } else if assertion_text.contains("/*UNIQUE") {
             Some(SemanticAssertion::Unique(UniqueAssertion {
-                range: token.parent().unwrap().text_range(),
+                range: token.parent().unwrap().text_trimmed_range(),
             }))
         } else if assertion_text.contains("/*?") {
             Some(SemanticAssertion::UnresolvedReference(
                 UnresolvedReferenceAssertion {
-                    range: token.parent().unwrap().text_range(),
+                    range: token.parent().unwrap().text_trimmed_range(),
                 },
             ))
         } else {
@@ -906,9 +906,9 @@ fn error_assertion_name_clash(
     // If there is already an assertion with the same name. Suggest a rename
 
     let mut diagnostic =
-        TestSemanticDiagnostic::new("Assertion label conflict.", token.text_range());
+        TestSemanticDiagnostic::new("Assertion label conflict.", token.text_trimmed_range());
     diagnostic.push_advice(
-        token.text_range(),
+        token.text_trimmed_range(),
         "There is already a assertion with the same name. Consider renaming this one.",
     );
     diagnostic.push_advice(old_range, "Previous assertion");


### PR DESCRIPTION
## Summary

We used node ranges to identify scopes and bindings.
Int he past, this created some confusion because devs expected scopes and bindings to be identified by their trimmed ranges.
This PR makes the switch to trimmed ranges.

As a side effect, the diagnostics of some rules and coverage are improved :)

## Test Plan

CI must pass.
