### PR TITLE
refactor(js_semantic): separate binding and scope nodes

### DIFF
--- a/crates/biome_js_semantic/src/semantic_model/binding.rs
+++ b/crates/biome_js_semantic/src/semantic_model/binding.rs
@@ -68,7 +68,7 @@ impl Binding {
     /// Returns the syntax node associated with this binding.
     pub fn syntax(&self) -> &JsSyntaxNode {
         let binding = self.data.binding(self.index);
-        &self.data.binding_nodes[&binding.range.start()]
+        &self.data.binding_node_by_start[&binding.range.start()]
     }
 
     /// Returns the typed AST node associated with this binding.

--- a/crates/biome_js_semantic/src/semantic_model/binding.rs
+++ b/crates/biome_js_semantic/src/semantic_model/binding.rs
@@ -68,7 +68,7 @@ impl Binding {
     /// Returns the syntax node associated with this binding.
     pub fn syntax(&self) -> &JsSyntaxNode {
         let binding = self.data.binding(self.index);
-        &self.data.node_by_range[&binding.range]
+        &self.data.binding_nodes[&binding.range]
     }
 
     /// Returns the typed AST node associated with this binding.

--- a/crates/biome_js_semantic/src/semantic_model/binding.rs
+++ b/crates/biome_js_semantic/src/semantic_model/binding.rs
@@ -68,7 +68,7 @@ impl Binding {
     /// Returns the syntax node associated with this binding.
     pub fn syntax(&self) -> &JsSyntaxNode {
         let binding = self.data.binding(self.index);
-        &self.data.binding_nodes[&binding.range]
+        &self.data.binding_nodes[&binding.range.start()]
     }
 
     /// Returns the typed AST node associated with this binding.

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -11,7 +11,7 @@ use std::collections::hash_map::Entry;
 /// [std::sync::Arc] and stored inside the [SemanticModel].
 pub struct SemanticModelBuilder {
     root: AnyJsRoot,
-    binding_nodes: FxHashMap<TextRange, JsSyntaxNode>,
+    binding_nodes: FxHashMap<TextSize, JsSyntaxNode>,
     scope_nodes: FxHashMap<TextRange, JsSyntaxNode>,
     globals: Vec<SemanticModelGlobalBindingData>,
     globals_by_name: FxHashMap<String, Option<usize>>,
@@ -59,7 +59,7 @@ impl SemanticModelBuilder {
             | TS_LITERAL_ENUM_MEMBER_NAME
             | JS_IDENTIFIER_ASSIGNMENT => {
                 self.binding_nodes
-                    .insert(node.text_trimmed_range(), node.clone());
+                    .insert(node.text_trimmed_range().start(), node.clone());
             }
 
             // Accessible from scopes, closures
@@ -184,7 +184,7 @@ impl SemanticModelBuilder {
 
                 scope.bindings.push(binding_id);
                 // Handle bindings with a bogus name
-                if let Some(node) = self.binding_nodes.get(&range) {
+                if let Some(node) = self.binding_nodes.get(&range.start()) {
                     if let Some(node) = JsIdentifierBinding::cast_ref(node) {
                         if let Ok(name_token) = node.name_token() {
                             let name = name_token.token_text_trimmed();
@@ -308,7 +308,7 @@ impl SemanticModelBuilder {
                     SemanticModelReferenceType::Write { hoisted: false }
                 };
 
-                let node = &self.binding_nodes[&range];
+                let node = &self.binding_nodes[&range.start()];
                 let name = node.text_trimmed().to_string();
 
                 match self.globals_by_name.entry(name) {

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -14,15 +14,15 @@ pub struct SemanticModelBuilder {
     binding_nodes: FxHashMap<TextSize, JsSyntaxNode>,
     scope_nodes: FxHashMap<TextRange, JsSyntaxNode>,
     globals: Vec<SemanticModelGlobalBindingData>,
-    globals_by_name: FxHashMap<String, Option<usize>>,
+    globals_by_name: FxHashMap<String, Option<u32>>,
     scopes: Vec<SemanticModelScopeData>,
     scope_range_by_start: FxHashMap<TextSize, BTreeSet<Interval<u32, u32>>>,
     scope_hoisted_to_by_range: FxHashMap<TextSize, u32>,
     bindings: Vec<SemanticModelBindingData>,
     /// maps a binding range start to its index inside SemanticModelBuilder::bindings vec
-    bindings_by_start: FxHashMap<TextSize, usize>,
-    /// maps a reference range start to its bindings. usize points to SemanticModelBuilder::bindings vec
-    declared_at_by_start: FxHashMap<TextSize, usize>,
+    bindings_by_start: FxHashMap<TextSize, u32>,
+    /// maps a reference range start to its bindings. u32 points to SemanticModelBuilder::bindings vec
+    declared_at_by_start: FxHashMap<TextSize, u32>,
     exported: FxHashSet<TextSize>,
     unresolved_references: Vec<SemanticModelUnresolvedReference>,
 }
@@ -172,7 +172,7 @@ impl SemanticModelBuilder {
                 // event extractor
                 debug_assert!((binding_scope_id as usize) < self.scopes.len());
 
-                let binding_id = self.bindings.len();
+                let binding_id = self.bindings.len() as u32;
                 self.bindings.push(SemanticModelBindingData {
                     id: binding_id.into(),
                     range,
@@ -206,7 +206,7 @@ impl SemanticModelBuilder {
                 let binding_id = match self.bindings_by_start.entry(declaration_at.start()) {
                     Entry::Occupied(entry) => *entry.get(),
                     Entry::Vacant(entry) => {
-                        let id = self.bindings.len();
+                        let id = self.bindings.len() as u32;
                         self.bindings.push(SemanticModelBindingData {
                             id: id.into(),
                             range,
@@ -215,8 +215,8 @@ impl SemanticModelBuilder {
                         *entry.insert(id)
                     }
                 };
-                let binding = &mut self.bindings[binding_id];
-                let reference_index = binding.references.len();
+                let binding = &mut self.bindings[binding_id as usize];
+                let reference_index = binding.references.len() as u32;
 
                 binding.references.push(SemanticModelReference {
                     index: (binding.id, reference_index).into(),
@@ -238,9 +238,9 @@ impl SemanticModelBuilder {
                 scope_id,
             } => {
                 let binding_id = self.bindings_by_start[&declaration_at.start()];
-                let binding = &mut self.bindings[binding_id];
+                let binding = &mut self.bindings[binding_id as usize];
 
-                let reference_index = binding.references.len();
+                let reference_index = binding.references.len() as u32;
                 binding.references.push(SemanticModelReference {
                     index: (binding.id, reference_index).into(),
                     range,
@@ -261,9 +261,9 @@ impl SemanticModelBuilder {
                 scope_id,
             } => {
                 let binding_id = self.bindings_by_start[&declaration_at.start()];
-                let binding = &mut self.bindings[binding_id];
+                let binding = &mut self.bindings[binding_id as usize];
 
-                let reference_index = binding.references.len();
+                let reference_index = binding.references.len() as u32;
                 binding.references.push(SemanticModelReference {
                     index: (binding.id, reference_index).into(),
                     range,
@@ -284,9 +284,9 @@ impl SemanticModelBuilder {
                 scope_id,
             } => {
                 let binding_id = self.bindings_by_start[&declaration_at.start()];
-                let binding = &mut self.bindings[binding_id];
+                let binding = &mut self.bindings[binding_id as usize];
 
-                let reference_index = binding.references.len();
+                let reference_index = binding.references.len() as u32;
                 binding.references.push(SemanticModelReference {
                     index: (binding.id, reference_index).into(),
                     range,
@@ -316,12 +316,12 @@ impl SemanticModelBuilder {
                         let entry = entry.get_mut();
                         match entry {
                             Some(index) => {
-                                self.globals[*index]
+                                self.globals[(*index) as usize]
                                     .references
                                     .push(SemanticModelGlobalReferenceData { range, ty });
                             }
                             None => {
-                                let id = self.globals.len();
+                                let id = self.globals.len() as u32;
                                 self.globals.push(SemanticModelGlobalBindingData {
                                     references: vec![SemanticModelGlobalReferenceData {
                                         range,

--- a/crates/biome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/biome_js_semantic/src/semantic_model/closure.rs
@@ -135,7 +135,7 @@ impl Iterator for AllCapturesIter {
                     let reference = &binding.references[reference.reference_id as usize];
                     return Some(Capture {
                         data: self.data.clone(),
-                        node: self.data.binding_nodes[&reference.range.start()].clone(), // TODO change node to store the range
+                        node: self.data.binding_node_by_start[&reference.range.start()].clone(), // TODO change node to store the range
                         ty: CaptureType::ByReference,
                         binding_id: binding.id,
                     });
@@ -235,7 +235,7 @@ impl Closure {
     }
 
     pub(super) fn from_scope(data: Rc<SemanticModelData>, scope_id: u32) -> Option<Closure> {
-        let node = &data.scope_nodes[&data.scopes[scope_id as usize].range];
+        let node = &data.scope_node_by_range[&data.scopes[scope_id as usize].range];
         match node.kind() {
             JsSyntaxKind::JS_FUNCTION_DECLARATION
             | JsSyntaxKind::JS_FUNCTION_EXPRESSION

--- a/crates/biome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/biome_js_semantic/src/semantic_model/closure.rs
@@ -135,7 +135,7 @@ impl Iterator for AllCapturesIter {
                     let reference = &binding.references[reference.reference_id];
                     return Some(Capture {
                         data: self.data.clone(),
-                        node: self.data.binding_nodes[&reference.range].clone(), // TODO change node to store the range
+                        node: self.data.binding_nodes[&reference.range.start()].clone(), // TODO change node to store the range
                         ty: CaptureType::ByReference,
                         binding_id: binding.id,
                     });

--- a/crates/biome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/biome_js_semantic/src/semantic_model/closure.rs
@@ -135,7 +135,7 @@ impl Iterator for AllCapturesIter {
                     let reference = &binding.references[reference.reference_id];
                     return Some(Capture {
                         data: self.data.clone(),
-                        node: self.data.node_by_range[&reference.range].clone(), // TODO change node to store the range
+                        node: self.data.binding_nodes[&reference.range].clone(), // TODO change node to store the range
                         ty: CaptureType::ByReference,
                         binding_id: binding.id,
                     });
@@ -246,7 +246,7 @@ impl Closure {
         scope_id: u32,
         closure_range: &TextRange,
     ) -> Option<Closure> {
-        let node = &data.node_by_range[closure_range];
+        let node = &data.scope_nodes[closure_range];
         match node.kind() {
             JsSyntaxKind::JS_FUNCTION_DECLARATION
             | JsSyntaxKind::JS_FUNCTION_EXPRESSION

--- a/crates/biome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/biome_js_semantic/src/semantic_model/closure.rs
@@ -130,9 +130,9 @@ impl Iterator for AllCapturesIter {
     fn next(&mut self) -> Option<Self::Item> {
         'references: loop {
             while let Some(reference) = self.references.pop() {
-                let binding = &self.data.bindings[reference.binding_id];
+                let binding = &self.data.bindings[reference.binding_id as usize];
                 if self.closure_range.intersect(binding.range).is_none() {
-                    let reference = &binding.references[reference.reference_id];
+                    let reference = &binding.references[reference.reference_id as usize];
                     return Some(Capture {
                         data: self.data.clone(),
                         node: self.data.binding_nodes[&reference.range.start()].clone(), // TODO change node to store the range

--- a/crates/biome_js_semantic/src/semantic_model/globals.rs
+++ b/crates/biome_js_semantic/src/semantic_model/globals.rs
@@ -22,7 +22,7 @@ pub struct GlobalReference {
 impl GlobalReference {
     pub fn syntax(&self) -> &JsSyntaxNode {
         let reference = &self.data.globals[self.global_id].references[self.id];
-        &self.data.node_by_range[&reference.range]
+        &self.data.binding_nodes[&reference.range]
     }
 
     /// Returns if this reference is just reading its binding

--- a/crates/biome_js_semantic/src/semantic_model/globals.rs
+++ b/crates/biome_js_semantic/src/semantic_model/globals.rs
@@ -22,7 +22,7 @@ pub struct GlobalReference {
 impl GlobalReference {
     pub fn syntax(&self) -> &JsSyntaxNode {
         let reference = &self.data.globals[self.global_id].references[self.id];
-        &self.data.binding_nodes[&reference.range]
+        &self.data.binding_nodes[&reference.range.start()]
     }
 
     /// Returns if this reference is just reading its binding

--- a/crates/biome_js_semantic/src/semantic_model/globals.rs
+++ b/crates/biome_js_semantic/src/semantic_model/globals.rs
@@ -15,25 +15,25 @@ pub struct SemanticModelGlobalReferenceData {
 
 pub struct GlobalReference {
     pub(crate) data: Rc<SemanticModelData>,
-    pub(crate) global_id: usize,
-    pub(crate) id: usize,
+    pub(crate) global_id: u32,
+    pub(crate) id: u32,
 }
 
 impl GlobalReference {
     pub fn syntax(&self) -> &JsSyntaxNode {
-        let reference = &self.data.globals[self.global_id].references[self.id];
+        let reference = &self.data.globals[self.global_id as usize].references[self.id as usize];
         &self.data.binding_nodes[&reference.range.start()]
     }
 
     /// Returns if this reference is just reading its binding
     pub fn is_read(&self) -> bool {
-        let reference = &self.data.globals[self.global_id].references[self.id];
+        let reference = &self.data.globals[self.global_id as usize].references[self.id as usize];
         matches!(reference.ty, SemanticModelReferenceType::Read { .. })
     }
 
     /// Returns if this reference is writing its binding
     pub fn is_write(&self) -> bool {
-        let reference = &self.data.globals[self.global_id].references[self.id];
+        let reference = &self.data.globals[self.global_id as usize].references[self.id as usize];
         matches!(reference.ty, SemanticModelReferenceType::Write { .. })
     }
 }

--- a/crates/biome_js_semantic/src/semantic_model/globals.rs
+++ b/crates/biome_js_semantic/src/semantic_model/globals.rs
@@ -22,7 +22,7 @@ pub struct GlobalReference {
 impl GlobalReference {
     pub fn syntax(&self) -> &JsSyntaxNode {
         let reference = &self.data.globals[self.global_id as usize].references[self.id as usize];
-        &self.data.binding_nodes[&reference.range.start()]
+        &self.data.binding_node_by_start[&reference.range.start()]
     }
 
     /// Returns if this reference is just reading its binding

--- a/crates/biome_js_semantic/src/semantic_model/model.rs
+++ b/crates/biome_js_semantic/src/semantic_model/model.rs
@@ -38,8 +38,8 @@ pub(crate) struct SemanticModelData {
     // Maps the start of a node range to a scope id
     pub(crate) scope_hoisted_to_by_range: FxHashMap<TextSize, u32>,
     // Map to each by its range
-    pub(crate) binding_nodes: FxHashMap<TextSize, JsSyntaxNode>,
-    pub(crate) scope_nodes: FxHashMap<TextRange, JsSyntaxNode>,
+    pub(crate) binding_node_by_start: FxHashMap<TextSize, JsSyntaxNode>,
+    pub(crate) scope_node_by_range: FxHashMap<TextRange, JsSyntaxNode>,
     // Maps any range start in the code to its bindings (usize points to bindings vec)
     pub(crate) declared_at_by_start: FxHashMap<TextSize, u32>,
     // List of all the declarations

--- a/crates/biome_js_semantic/src/semantic_model/model.rs
+++ b/crates/biome_js_semantic/src/semantic_model/model.rs
@@ -38,7 +38,8 @@ pub(crate) struct SemanticModelData {
     // Maps the start of a node range to a scope id
     pub(crate) scope_hoisted_to_by_range: FxHashMap<TextSize, u32>,
     // Map to each by its range
-    pub(crate) node_by_range: FxHashMap<TextRange, JsSyntaxNode>,
+    pub(crate) binding_nodes: FxHashMap<TextRange, JsSyntaxNode>,
+    pub(crate) scope_nodes: FxHashMap<TextRange, JsSyntaxNode>,
     // Maps any range start in the code to its bindings (usize points to bindings vec)
     pub(crate) declared_at_by_start: FxHashMap<TextSize, usize>,
     // List of all the declarations

--- a/crates/biome_js_semantic/src/semantic_model/model.rs
+++ b/crates/biome_js_semantic/src/semantic_model/model.rs
@@ -38,7 +38,7 @@ pub(crate) struct SemanticModelData {
     // Maps the start of a node range to a scope id
     pub(crate) scope_hoisted_to_by_range: FxHashMap<TextSize, u32>,
     // Map to each by its range
-    pub(crate) binding_nodes: FxHashMap<TextRange, JsSyntaxNode>,
+    pub(crate) binding_nodes: FxHashMap<TextSize, JsSyntaxNode>,
     pub(crate) scope_nodes: FxHashMap<TextRange, JsSyntaxNode>,
     // Maps any range start in the code to its bindings (usize points to bindings vec)
     pub(crate) declared_at_by_start: FxHashMap<TextSize, usize>,

--- a/crates/biome_js_semantic/src/semantic_model/reference.rs
+++ b/crates/biome_js_semantic/src/semantic_model/reference.rs
@@ -70,7 +70,7 @@ impl Reference {
 
     /// Returns the node of this reference
     pub fn syntax(&self) -> &JsSyntaxNode {
-        &self.data.binding_nodes[&self.range().start()]
+        &self.data.binding_node_by_start[&self.range().start()]
     }
 
     /// Returns the binding of this reference
@@ -137,7 +137,7 @@ impl FunctionCall {
 
     /// Returns the node of this reference
     pub fn syntax(&self) -> &JsSyntaxNode {
-        &self.data.binding_nodes[&self.range().start()]
+        &self.data.binding_node_by_start[&self.range().start()]
     }
 
     /// Returns the typed AST node of this reference
@@ -188,7 +188,7 @@ pub struct UnresolvedReference {
 impl UnresolvedReference {
     pub fn syntax(&self) -> &JsSyntaxNode {
         let reference = &self.data.unresolved_references[self.id as usize];
-        &self.data.binding_nodes[&reference.range.start()]
+        &self.data.binding_node_by_start[&reference.range.start()]
     }
 
     pub fn tree(&self) -> AnyJsIdentifierUsage {

--- a/crates/biome_js_semantic/src/semantic_model/reference.rs
+++ b/crates/biome_js_semantic/src/semantic_model/reference.rs
@@ -70,7 +70,7 @@ impl Reference {
 
     /// Returns the node of this reference
     pub fn syntax(&self) -> &JsSyntaxNode {
-        &self.data.node_by_range[self.range()]
+        &self.data.binding_nodes[self.range()]
     }
 
     /// Returns the binding of this reference
@@ -137,7 +137,7 @@ impl FunctionCall {
 
     /// Returns the node of this reference
     pub fn syntax(&self) -> &JsSyntaxNode {
-        &self.data.node_by_range[self.range()]
+        &self.data.binding_nodes[self.range()]
     }
 
     /// Returns the typed AST node of this reference
@@ -188,7 +188,7 @@ pub struct UnresolvedReference {
 impl UnresolvedReference {
     pub fn syntax(&self) -> &JsSyntaxNode {
         let reference = &self.data.unresolved_references[self.id];
-        &self.data.node_by_range[&reference.range]
+        &self.data.binding_nodes[&reference.range]
     }
 
     pub fn tree(&self) -> AnyJsIdentifierUsage {

--- a/crates/biome_js_semantic/src/semantic_model/reference.rs
+++ b/crates/biome_js_semantic/src/semantic_model/reference.rs
@@ -70,7 +70,7 @@ impl Reference {
 
     /// Returns the node of this reference
     pub fn syntax(&self) -> &JsSyntaxNode {
-        &self.data.binding_nodes[self.range()]
+        &self.data.binding_nodes[&self.range().start()]
     }
 
     /// Returns the binding of this reference
@@ -137,7 +137,7 @@ impl FunctionCall {
 
     /// Returns the node of this reference
     pub fn syntax(&self) -> &JsSyntaxNode {
-        &self.data.binding_nodes[self.range()]
+        &self.data.binding_nodes[&self.range().start()]
     }
 
     /// Returns the typed AST node of this reference
@@ -188,7 +188,7 @@ pub struct UnresolvedReference {
 impl UnresolvedReference {
     pub fn syntax(&self) -> &JsSyntaxNode {
         let reference = &self.data.unresolved_references[self.id];
-        &self.data.binding_nodes[&reference.range]
+        &self.data.binding_nodes[&reference.range.start()]
     }
 
     pub fn tree(&self) -> AnyJsIdentifierUsage {

--- a/crates/biome_js_semantic/src/semantic_model/reference.rs
+++ b/crates/biome_js_semantic/src/semantic_model/reference.rs
@@ -182,12 +182,12 @@ pub struct SemanticModelUnresolvedReference {
 #[derive(Debug)]
 pub struct UnresolvedReference {
     pub(crate) data: Rc<SemanticModelData>,
-    pub(crate) id: usize,
+    pub(crate) id: u32,
 }
 
 impl UnresolvedReference {
     pub fn syntax(&self) -> &JsSyntaxNode {
-        let reference = &self.data.unresolved_references[self.id];
+        let reference = &self.data.unresolved_references[self.id as usize];
         &self.data.binding_nodes[&reference.range.start()]
     }
 
@@ -196,7 +196,7 @@ impl UnresolvedReference {
     }
 
     pub fn range(&self) -> &TextRange {
-        let reference = &self.data.unresolved_references[self.id];
+        let reference = &self.data.unresolved_references[self.id as usize];
         &reference.range
     }
 }

--- a/crates/biome_js_semantic/src/semantic_model/scope.rs
+++ b/crates/biome_js_semantic/src/semantic_model/scope.rs
@@ -112,7 +112,7 @@ impl Scope {
     }
 
     pub fn syntax(&self) -> &JsSyntaxNode {
-        &self.data.node_by_range[self.range()]
+        &self.data.scope_nodes[self.range()]
     }
 
     /// Return the [Closure] associated with this scope if

--- a/crates/biome_js_semantic/src/semantic_model/scope.rs
+++ b/crates/biome_js_semantic/src/semantic_model/scope.rs
@@ -112,7 +112,7 @@ impl Scope {
     }
 
     pub fn syntax(&self) -> &JsSyntaxNode {
-        &self.data.scope_nodes[self.range()]
+        &self.data.scope_node_by_range[self.range()]
     }
 
     /// Return the [Closure] associated with this scope if

--- a/crates/biome_js_semantic/src/semantic_model/scope.rs
+++ b/crates/biome_js_semantic/src/semantic_model/scope.rs
@@ -13,9 +13,9 @@ pub(crate) struct SemanticModelScopeData {
     // All children scope of this scope
     pub(crate) children: Vec<u32>,
     // All bindings of this scope (points to SemanticModelData::bindings)
-    pub(crate) bindings: Vec<usize>,
+    pub(crate) bindings: Vec<u32>,
     // Map pointing to the [bindings] vec of each bindings by its name
-    pub(crate) bindings_by_name: FxHashMap<TokenText, usize>,
+    pub(crate) bindings_by_name: FxHashMap<TokenText, u32>,
     // All read references of a scope
     pub(crate) read_references: Vec<SemanticModelScopeReference>,
     // All write references of a scope
@@ -127,9 +127,9 @@ impl Scope {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub(crate) struct SemanticModelScopeReference {
     // Points to [SemanticModel]::bindings vec
-    pub(crate) binding_id: usize,
+    pub(crate) binding_id: u32,
     // Points do [SemanticModelBinding]::references vec
-    pub(crate) reference_id: usize,
+    pub(crate) reference_id: u32,
 }
 
 /// Iterate all descendents scopes of the specified scope in breadth-first order.
@@ -163,7 +163,7 @@ impl FusedIterator for ScopeDescendentsIter {}
 pub struct ScopeBindingsIter {
     data: Rc<SemanticModelData>,
     scope_id: u32,
-    binding_index: usize,
+    binding_index: u32,
 }
 
 impl Iterator for ScopeBindingsIter {
@@ -176,7 +176,7 @@ impl Iterator for ScopeBindingsIter {
 
         let id = self.data.scopes[self.scope_id as usize]
             .bindings
-            .get(self.binding_index)?;
+            .get(self.binding_index as usize)?;
 
         self.binding_index += 1;
 

--- a/crates/biome_js_semantic/src/semantic_model/scope.rs
+++ b/crates/biome_js_semantic/src/semantic_model/scope.rs
@@ -119,7 +119,7 @@ impl Scope {
     /// it has one, otherwise returns None.
     /// See [HasClosureAstNode] for nodes that have closure.
     pub fn closure(&self) -> Option<Closure> {
-        Closure::from_scope(self.data.clone(), self.id, self.range())
+        Closure::from_scope(self.data.clone(), self.id)
     }
 }
 


### PR DESCRIPTION
## Summary

This PR introduces minor changes for the semantic model.
It separates binding and scope nodes to make easier refactoring around the way we identify a scope and a binding.
I also change all usize to u32.

## Test Plan

CI must pass
