### PR TITLE
refactor(js_semantic): use range start to identify the declaration in read/write

### DIFF
--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -201,10 +201,10 @@ impl SemanticModelBuilder {
             }
             Read {
                 range,
-                declared_at: declaration_at, //TODO change to binding_id like we do with scope_id
+                declaration_at,
                 scope_id,
             } => {
-                let binding_id = self.bindings_by_start[&declaration_at.start()];
+                let binding_id = self.bindings_by_start[&declaration_at];
                 let binding = &mut self.bindings[binding_id as usize];
                 let reference_index = binding.references.len() as u32;
 
@@ -224,13 +224,13 @@ impl SemanticModelBuilder {
             }
             HoistedRead {
                 range,
-                declared_at: declaration_at,
+                declaration_at,
                 scope_id,
             } => {
-                let binding_id = self.bindings_by_start[&declaration_at.start()];
+                let binding_id = self.bindings_by_start[&declaration_at];
                 let binding = &mut self.bindings[binding_id as usize];
-
                 let reference_index = binding.references.len() as u32;
+
                 binding.references.push(SemanticModelReference {
                     index: (binding.id, reference_index).into(),
                     range,
@@ -247,10 +247,10 @@ impl SemanticModelBuilder {
             }
             Write {
                 range,
-                declared_at: declaration_at,
+                declaration_at,
                 scope_id,
             } => {
-                let binding_id = self.bindings_by_start[&declaration_at.start()];
+                let binding_id = self.bindings_by_start[&declaration_at];
                 let binding = &mut self.bindings[binding_id as usize];
 
                 let reference_index = binding.references.len() as u32;
@@ -270,10 +270,10 @@ impl SemanticModelBuilder {
             }
             HoistedWrite {
                 range,
-                declared_at: declaration_at,
+                declaration_at,
                 scope_id,
             } => {
-                let binding_id = self.bindings_by_start[&declaration_at.start()];
+                let binding_id = self.bindings_by_start[&declaration_at];
                 let binding = &mut self.bindings[binding_id as usize];
 
                 let reference_index = binding.references.len() as u32;
@@ -327,8 +327,8 @@ impl SemanticModelBuilder {
                         .push(SemanticModelUnresolvedReference { range }),
                 }
             }
-            Exported { range } => {
-                self.exported.insert(range.start());
+            Export { declaration_at, .. } => {
+                self.exported.insert(declaration_at);
             }
         }
     }

--- a/xtask/coverage/src/symbols/msts.rs
+++ b/xtask/coverage/src/symbols/msts.rs
@@ -93,23 +93,21 @@ impl TestCase for SymbolsMicrosoftTestCase {
                 // We do the same below because TS classifies some string literals as symbols and we also
                 // filter them below.
                 match x {
-                    SemanticEvent::DeclarationFound { .. }
-                    | SemanticEvent::Read { .. }
-                    | SemanticEvent::HoistedRead { .. }
-                    | SemanticEvent::Write { .. }
-                    | SemanticEvent::HoistedWrite { .. }
-                    | SemanticEvent::UnresolvedReference { .. } => {
-                        let name = &code[x.range()];
-                        !name.contains('\"') && !name.contains('\'')
+                    SemanticEvent::DeclarationFound { range, .. }
+                    | SemanticEvent::Read { range, .. }
+                    | SemanticEvent::HoistedRead { range, .. }
+                    | SemanticEvent::Write { range, .. }
+                    | SemanticEvent::HoistedWrite { range, .. }
+                    | SemanticEvent::UnresolvedReference { range, .. } => {
+                        let name = &code[*range];
+                        !name.contains('\"') && !name.contains('\'') &&
+                        // Ignore the current event if one was already processed for the same range.
+                        prev_starts.insert(range.start())
                     }
                     SemanticEvent::ScopeStarted { .. }
                     | SemanticEvent::ScopeEnded { .. }
-                    | SemanticEvent::Exported { .. } => false,
+                    | SemanticEvent::Export { .. } => false,
                 }
-            })
-            .filter(|x| {
-                // Ignore the current event if one was already processed for the same range.
-                prev_starts.insert(x.range().start())
             })
             .collect();
         actual.sort_by_key(|x| x.range().start());


### PR DESCRIPTION
## Summary

Previous PR switched from range to range start to identify a declaration.
This PR spread the change even further by using range start to identify the declaration in a read, write and export.

## Test Plan

CI must pass.
