### PR TITLE
fix(grit): correct calculation of line and column numbers

### DIFF
--- a/crates/biome_grit_patterns/src/grit_binding.rs
+++ b/crates/biome_grit_patterns/src/grit_binding.rs
@@ -69,7 +69,7 @@ impl<'a> Binding<'a, GritQueryContext> for GritBinding<'a> {
         match self {
             Self::Node(node) => {
                 let source = SourceFile::new(SourceCode {
-                    text: node.text(),
+                    text: node.source(),
                     line_starts: None,
                 });
                 source.to_grit_range(node.text_trimmed_range())

--- a/crates/biome_grit_patterns/tests/specs/ts/identifier.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/identifier.snap
@@ -7,36 +7,36 @@ SnapshotResult {
     matched_ranges: [
         Range {
             start: Position {
-                line: 1,
-                column: 4,
+                line: 3,
+                column: 8,
             },
             end: Position {
-                line: 1,
-                column: 4,
+                line: 3,
+                column: 11,
             },
             start_byte: 25,
             end_byte: 28,
         },
         Range {
             start: Position {
-                line: 1,
-                column: 4,
+                line: 6,
+                column: 3,
             },
             end: Position {
-                line: 1,
-                column: 4,
+                line: 6,
+                column: 6,
             },
             start_byte: 52,
             end_byte: 55,
         },
         Range {
             start: Position {
-                line: 1,
-                column: 4,
+                line: 11,
+                column: 2,
             },
             end: Position {
-                line: 1,
-                column: 4,
+                line: 11,
+                column: 5,
             },
             start_byte: 99,
             end_byte: 102,


### PR DESCRIPTION
## Summary

Fixed an issue that caused line and column numbers in ranges to be incorrect.

## Test Plan

Updated snapshots.
