### PR TITLE
refactor(js_analyze): improve restricted regex error meesages

### DIFF
--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -583,7 +583,7 @@ declare_lint_rule! {
     ///                 "selector": {
     ///                     "kind": "interface"
     ///                 },
-    ///                 "match": "I(.*)|(.*)Error",
+    ///                 "match": "I(.*)|(.*?)Error",
     ///                 "formats": ["PascalCase"]
     ///             }
     ///             // default conventions


### PR DESCRIPTION
## Summary

Improve error messages for invalid restricted regexes.

## Test Plan

This is not currently testable because JSON serialization doesn't unescape `\\`.