### PR TITLE
fix(lint/useHookAtTopLevel): don't flag jest function calls that look like hooks

### DIFF
--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -152,6 +152,21 @@ pub(crate) fn is_react_hook_call(call: &JsCallExpression) -> bool {
         return false;
     };
 
+    // HACK: jest has some functions that start with `use` and are not hooks
+    if let Some(expr) = call
+        .callee()
+        .ok()
+        .and_then(|callee| callee.as_js_static_member_expression().cloned())
+        .and_then(|member| member.object().ok())
+        .and_then(|object| object.as_js_identifier_expression().cloned())
+        .and_then(|ident| ident.name().ok())
+        .and_then(|name| name.value_token().ok())
+    {
+        if expr.text_trimmed() == "jest" {
+            return false;
+        }
+    }
+
     is_react_hook(name.text_trimmed())
 }
 

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js
@@ -125,3 +125,8 @@ test('c', () => {
 
     expect(result.current).toBeDefined();
 });
+
+describe("foo", () => {
+  beforeEach(() => jest.useFakeTimers('legacy'));
+  afterEach(() => jest.useRealTimers());
+})

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js.snap
@@ -132,6 +132,9 @@ test('c', () => {
     expect(result.current).toBeDefined();
 });
 
+describe("foo", () => {
+  beforeEach(() => jest.useFakeTimers('legacy'));
+  afterEach(() => jest.useRealTimers());
+})
+
 ```
-
-


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Jest has some functions that our heuristics flag as a react hook. This PR makes it so biome doesn't flag `jest.useFakeTimers` and `jest.useRealTimers` as react hooks.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #3337

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Honestly, I don't exactly have a clean reproduction for the linked issue.
