### PR TITLE
refactor(js_semantic): minor changes

### DIFF
--- a/crates/biome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/biome_js_semantic/src/semantic_model/closure.rs
@@ -83,7 +83,7 @@ pub struct Capture {
     data: Rc<SemanticModelData>,
     ty: CaptureType,
     node: JsSyntaxNode,
-    binding_id: BindingIndex,
+    binding_id: BindingId,
 }
 
 impl Capture {
@@ -101,7 +101,7 @@ impl Capture {
     pub fn binding(&self) -> Binding {
         Binding {
             data: self.data.clone(),
-            index: self.binding_id,
+            id: self.binding_id,
         }
     }
 
@@ -121,7 +121,7 @@ pub struct AllCapturesIter {
     data: Rc<SemanticModelData>,
     closure_range: TextRange,
     scopes: Vec<ScopeId>,
-    references: Vec<SemanticModelScopeReference>,
+    references: Vec<ReferenceId>,
 }
 
 impl Iterator for AllCapturesIter {
@@ -130,9 +130,9 @@ impl Iterator for AllCapturesIter {
     fn next(&mut self) -> Option<Self::Item> {
         'references: loop {
             while let Some(reference) = self.references.pop() {
-                let binding = &self.data.bindings[reference.binding_id as usize];
+                let binding = &self.data.bindings[reference.binding_id().index()];
                 if self.closure_range.intersect(binding.range).is_none() {
-                    let reference = &binding.references[reference.reference_id as usize];
+                    let reference = &binding.references[reference.index()];
                     return Some(Capture {
                         data: self.data.clone(),
                         node: self.data.binding_node_by_start[&reference.range.start()].clone(), // TODO change node to store the range
@@ -150,9 +150,9 @@ impl Iterator for AllCapturesIter {
                 }
                 self.references.clear();
                 self.references
-                    .extend(scope.read_references.iter().cloned());
+                    .extend(scope.read_references.iter().copied());
                 self.references
-                    .extend(scope.write_references.iter().cloned());
+                    .extend(scope.write_references.iter().copied());
                 self.scopes.extend(scope.children.iter());
                 continue 'references;
             }
@@ -268,7 +268,7 @@ impl Closure {
         let scopes = scope.children.clone();
 
         let mut references = scope.read_references.clone();
-        references.extend(scope.write_references.iter().cloned());
+        references.extend(scope.write_references.iter().copied());
 
         AllCapturesIter {
             data: self.data.clone(),

--- a/crates/biome_js_semantic/src/semantic_model/reference.rs
+++ b/crates/biome_js_semantic/src/semantic_model/reference.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 #[derive(Debug)]
 pub struct Reference {
     pub(crate) data: Rc<SemanticModelData>,
-    pub(crate) index: ReferenceIndex,
+    pub(crate) index: ReferenceId,
 }
 
 impl Reference {
@@ -15,7 +15,7 @@ impl Reference {
         let reference = self.data.next_reference(self.index)?;
         Some(Reference {
             data: self.data.clone(),
-            index: reference.index,
+            index: reference.id,
         })
     }
 
@@ -26,10 +26,10 @@ impl Reference {
             if reference.is_read() {
                 return Some(Reference {
                     data: self.data.clone(),
-                    index: reference.index,
+                    index: reference.id,
                 });
             } else {
-                index = reference.index;
+                index = reference.id;
             }
         }
 
@@ -43,10 +43,10 @@ impl Reference {
             if reference.is_write() {
                 return Some(Reference {
                     data: self.data.clone(),
-                    index: reference.index,
+                    index: reference.id,
                 });
             } else {
-                index = reference.index;
+                index = reference.id;
             }
         }
 
@@ -77,7 +77,7 @@ impl Reference {
     pub fn binding(&self) -> Option<Binding> {
         Some(Binding {
             data: self.data.clone(),
-            index: self.index.binding(),
+            id: self.index.binding_id(),
         })
     }
 
@@ -125,7 +125,7 @@ impl Reference {
 #[derive(Debug)]
 pub struct FunctionCall {
     pub(crate) data: Rc<SemanticModelData>,
-    pub(crate) index: ReferenceIndex,
+    pub(crate) index: ReferenceId,
 }
 
 impl FunctionCall {

--- a/crates/biome_js_semantic/src/semantic_model/scope.rs
+++ b/crates/biome_js_semantic/src/semantic_model/scope.rs
@@ -13,13 +13,13 @@ pub(crate) struct SemanticModelScopeData {
     // All children scope of this scope
     pub(crate) children: Vec<ScopeId>,
     // All bindings of this scope (points to SemanticModelData::bindings)
-    pub(crate) bindings: Vec<u32>,
+    pub(crate) bindings: Vec<BindingId>,
     // Map pointing to the [bindings] vec of each bindings by its name
-    pub(crate) bindings_by_name: FxHashMap<TokenText, u32>,
+    pub(crate) bindings_by_name: FxHashMap<TokenText, BindingId>,
     // All read references of a scope
-    pub(crate) read_references: Vec<SemanticModelScopeReference>,
+    pub(crate) read_references: Vec<ReferenceId>,
     // All write references of a scope
-    pub(crate) write_references: Vec<SemanticModelScopeReference>,
+    pub(crate) write_references: Vec<ReferenceId>,
     // Identify if this scope is from a closure or not
     pub(crate) is_closure: bool,
 }
@@ -88,11 +88,11 @@ impl Scope {
         let data = &self.data.scopes[self.id.index()];
 
         let name = name.as_ref();
-        let id = data.bindings_by_name.get(name)?;
+        let id = *data.bindings_by_name.get(name)?;
 
         Some(Binding {
             data: self.data.clone(),
-            index: (*id).into(),
+            id,
         })
     }
 
@@ -121,15 +121,6 @@ impl Scope {
     pub fn closure(&self) -> Option<Closure> {
         Closure::from_scope(self.data.clone(), self.id)
     }
-}
-
-/// Represents a reference inside a scope.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub(crate) struct SemanticModelScopeReference {
-    // Points to [SemanticModel]::bindings vec
-    pub(crate) binding_id: u32,
-    // Points do [SemanticModelBinding]::references vec
-    pub(crate) reference_id: u32,
 }
 
 /// Iterate all descendents scopes of the specified scope in breadth-first order.
@@ -174,7 +165,7 @@ impl Iterator for ScopeBindingsIter {
         // it was created by [Scope::bindings] method.
         debug_assert!((self.scope_id.index()) < self.data.scopes.len());
 
-        let id = self.data.scopes[self.scope_id.index()]
+        let id = *self.data.scopes[self.scope_id.index()]
             .bindings
             .get(self.binding_index as usize)?;
 
@@ -182,7 +173,7 @@ impl Iterator for ScopeBindingsIter {
 
         Some(Binding {
             data: self.data.clone(),
-            index: (*id).into(),
+            id,
         })
     }
 }


### PR DESCRIPTION
## Summary

This is a follow-up of #3408
This PR aims to improve the code readability.

I renamed `BindingIndex` and `ReferenceIndex` into `BindingId` and `ReferenceId` and added the same methods as `ScopeId`.
Note that I kept the internal representation `u32` because we don't need a niche optimization for them.
Also, I removed `SemanticModelScopeReference` that is  a duplicate of `ReferenceId`.

## Test Plan

CI must pass.
