### PR TITLE
fix(biome-css-parser): incorrect option name in hint when using `:global` in CSS module

### DIFF
--- a/crates/biome_css_parser/src/syntax/at_rule/value.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/value.rs
@@ -308,7 +308,7 @@ fn expected_at_rule_declaration_clause(p: &CssParser, range: TextRange) -> Parse
 ///
 /// This function returns an error diagnostic indicating that the @value at-rule
 /// is not a standard CSS feature. It also provides a hint on how to enable
-/// parsing of @value at-rules by setting the `css_modules` option to `true`
+/// parsing of @value at-rules by setting the `css.parser.cssModules` option to `true`
 /// in the configuration file.
 pub(crate) fn value_at_rule_not_allowed(p: &CssParser, range: TextRange) -> ParseDiagnostic {
     p.err_builder(
@@ -316,6 +316,6 @@ pub(crate) fn value_at_rule_not_allowed(p: &CssParser, range: TextRange) -> Pars
         range,
     )
         .with_hint(
-            "You can enable @value at-rule parsing by setting the `css_modules` option to `true` in your configuration file.",
+            "You can enable @value at-rule parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.",
         )
 }

--- a/crates/biome_css_parser/src/syntax/css_modules.rs
+++ b/crates/biome_css_parser/src/syntax/css_modules.rs
@@ -10,7 +10,7 @@ pub(crate) const CSS_MODULES_SCOPE_SET: TokenSet<CssSyntaxKind> = token_set![T![
 ///
 /// This function returns an error diagnostic indicating that the `:local` or `:global` pseudo-classes
 /// are not standard CSS features. It also provides a hint on how to enable
-/// parsing of these pseudo-classes by setting the `css_modules` option to `true`
+/// parsing of these pseudo-classes by setting the `css.parser.cssModules` option to `true`
 /// in the configuration file.
 pub(crate) fn local_or_global_not_allowed(p: &CssParser, range: TextRange) -> ParseDiagnostic {
     p.err_builder(
@@ -18,7 +18,7 @@ pub(crate) fn local_or_global_not_allowed(p: &CssParser, range: TextRange) -> Pa
         range,
     )
         .with_hint(
-            "You can enable `:local` and `:global` pseudo-class parsing by setting the `css_modules` option to `true` in your configuration file.",
+            "You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.",
         )
 }
 
@@ -30,14 +30,14 @@ pub(crate) fn expected_any_css_module_scope(p: &CssParser, range: TextRange) -> 
 ///
 /// This function returns an error diagnostic indicating that the `composes` declaration
 /// is not a standard CSS feature. It also provides a hint on how to enable parsing of the
-/// `composes` declaration by setting the `css_modules` option to `true` in the configuration file.
+/// `composes` declaration by setting the `css.parser.cssModules` option to `true` in the configuration file.
 pub(crate) fn composes_not_allowed(p: &CssParser, range: TextRange) -> ParseDiagnostic {
     p.err_builder(
         "`composes` declaration is not a standard CSS feature.",
         range,
     )
         .with_hint(
-            "You can enable `composes` declaration parsing by setting the `css_modules` option to `true` in your configuration file.",
+            "You can enable `composes` declaration parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.",
         )
 }
 

--- a/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_selector.rs
+++ b/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_selector.rs
@@ -24,7 +24,7 @@ pub(crate) fn is_at_pseudo_class_function_selector(p: &mut CssParser) -> bool {
 /// Parses a pseudo-class function selector for CSS Modules.
 ///
 /// This function parses a pseudo-class function selector, specifically `:local` or `:global`, in CSS Modules.
-/// If the `css_modules` option is not enabled, it generates a diagnostic error and skips the selector.
+/// If the `css.parser.cssModules` option is not enabled, it generates a diagnostic error and skips the selector.
 /// ```css
 /// :local(.className) {
 ///     color: red;

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_keyframes/disabled_css_module/at_rule_keyframe_disabled_css_modules.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_keyframes/disabled_css_module/at_rule_keyframe_disabled_css_modules.css.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_css_parser/tests/spec_test.rs
+assertion_line: 169
 expression: snapshot
 ---
 ## Input
@@ -358,7 +359,7 @@ at_rule_keyframe_disabled_css_modules.css:3:13 parse ━━━━━━━━━
     4 │ @keyframes :local("test") {}
     5 │ @keyframes :local test {}
   
-  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 at_rule_keyframe_disabled_css_modules.css:4:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -371,7 +372,7 @@ at_rule_keyframe_disabled_css_modules.css:4:13 parse ━━━━━━━━━
     5 │ @keyframes :local test {}
     6 │ @keyframes :local "test" {}
   
-  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 at_rule_keyframe_disabled_css_modules.css:5:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -384,7 +385,7 @@ at_rule_keyframe_disabled_css_modules.css:5:13 parse ━━━━━━━━━
     6 │ @keyframes :local "test" {}
     7 │ @keyframes :global(test) {}
   
-  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 at_rule_keyframe_disabled_css_modules.css:6:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -397,7 +398,7 @@ at_rule_keyframe_disabled_css_modules.css:6:13 parse ━━━━━━━━━
     7 │ @keyframes :global(test) {}
     8 │ @keyframes :global("test") {}
   
-  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 at_rule_keyframe_disabled_css_modules.css:7:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -410,7 +411,7 @@ at_rule_keyframe_disabled_css_modules.css:7:13 parse ━━━━━━━━━
     8 │ @keyframes :global("test") {}
     9 │ @keyframes :global test {}
   
-  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 at_rule_keyframe_disabled_css_modules.css:8:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -423,7 +424,7 @@ at_rule_keyframe_disabled_css_modules.css:8:13 parse ━━━━━━━━━
      9 │ @keyframes :global test {}
     10 │ @keyframes :global "test" {}
   
-  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 at_rule_keyframe_disabled_css_modules.css:9:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -436,7 +437,7 @@ at_rule_keyframe_disabled_css_modules.css:9:13 parse ━━━━━━━━━
     10 │ @keyframes :global "test" {}
     11 │ 
   
-  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 at_rule_keyframe_disabled_css_modules.css:10:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -448,6 +449,6 @@ at_rule_keyframe_disabled_css_modules.css:10:13 parse ━━━━━━━━�
        │             ^^^^^^
     11 │ 
   
-  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/value/at_rule_value_disabled.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/value/at_rule_value_disabled.css.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_css_parser/tests/spec_test.rs
+assertion_line: 169
 expression: snapshot
 ---
 ## Input
@@ -104,7 +105,7 @@ at_rule_value_disabled.css:1:2 parse ━━━━━━━━━━━━━━�
     2 │ @value common-gradient: transparent 75%, var(--ring-line-color) 75%, currentColor 79%;
     3 │ 
   
-  i You can enable @value at-rule parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable @value at-rule parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 at_rule_value_disabled.css:2:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -115,6 +116,6 @@ at_rule_value_disabled.css:2:2 parse ━━━━━━━━━━━━━━�
       │  ^^^^^
     3 │ 
   
-  i You can enable @value at-rule parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable @value at-rule parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/error/property/composes/disabled/composes_error_disabled.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/property/composes/disabled/composes_error_disabled.css.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_css_parser/tests/spec_test.rs
+assertion_line: 169
 expression: snapshot
 ---
 ## Input
@@ -266,7 +267,7 @@ composes_error_disabled.css:2:2 parse ━━━━━━━━━━━━━━
     3 │ }
     4 │ 
   
-  i You can enable `composes` declaration parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `composes` declaration parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 composes_error_disabled.css:6:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -278,7 +279,7 @@ composes_error_disabled.css:6:2 parse ━━━━━━━━━━━━━━
     7 │ }
     8 │ 
   
-  i You can enable `composes` declaration parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `composes` declaration parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 composes_error_disabled.css:10:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -290,6 +291,6 @@ composes_error_disabled.css:10:2 parse ━━━━━━━━━━━━━�
     11 │ }
     12 │ 
   
-  i You can enable `composes` declaration parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `composes` declaration parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector/disabled/pseudo_class_function_selector_disabled.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector/disabled/pseudo_class_function_selector_disabled.css.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_css_parser/tests/spec_test.rs
+assertion_line: 169
 expression: snapshot
 ---
 ## Input
@@ -193,7 +194,7 @@ pseudo_class_function_selector_disabled.css:1:2 parse ━━━━━━━━�
     2 │ :local(.class div + #id) {}
     3 │ :global(.class div) .div {}
   
-  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 pseudo_class_function_selector_disabled.css:2:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -205,7 +206,7 @@ pseudo_class_function_selector_disabled.css:2:2 parse ━━━━━━━━�
     3 │ :global(.class div) .div {}
     4 │ 
   
-  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 pseudo_class_function_selector_disabled.css:3:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -217,6 +218,6 @@ pseudo_class_function_selector_disabled.css:3:2 parse ━━━━━━━━�
       │  ^^^^^^
     4 │ 
   
-  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css_modules` option to `true` in your configuration file.
+  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixed #3402 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Checklist

* [x]  Test snapshot updated.
<!-- What demonstrates that your implementation is correct? -->
