### PR TITLE
fix(js_formatter): keep parens around infer in unions/intersections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Formatter
 
+#### Bug fixes
+
+- Keep the parentheses around `infer` declarations in type unions and type intersections ([#3419](https://github.com/biomejs/biome/issues/3419)). Contributed by @Conaclos
+
 ### JavaScript APIs
 
 ### Linter

--- a/crates/biome_js_formatter/src/ts/types/infer_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/infer_type.rs
@@ -33,6 +33,12 @@ impl NeedsParentheses for TsInferType {
     fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
         if parent.kind() == JsSyntaxKind::TS_REST_TUPLE_TYPE_ELEMENT {
             false
+        } else if matches!(
+            parent.kind(),
+            JsSyntaxKind::TS_INTERSECTION_TYPE_ELEMENT_LIST
+                | JsSyntaxKind::TS_UNION_TYPE_VARIANT_LIST
+        ) {
+            true
         } else {
             operator_type_or_higher_needs_parens(self.syntax(), parent)
         }
@@ -62,6 +68,10 @@ mod tests {
         );
         assert_needs_parentheses!(
             "type A = T extends [(infer string)?] ? string : never",
+            TsInferType
+        );
+        assert_needs_parentheses!(
+            "type A = T extends [(infer string) | undefined] ? string : never",
             TsInferType
         );
 

--- a/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_intersection.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_intersection.ts
@@ -1,0 +1,1 @@
+type Type<T> = [T] extends [(infer S extends string) & {}] ? S : T;

--- a/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_intersection.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_intersection.ts.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: ts/type/injfer_in_intersection.ts
+---
+# Input
+
+```ts
+type Type<T> = [T] extends [(infer S extends string) & {}] ? S : T;
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+-----
+
+```ts
+type Type<T> = [T] extends [(infer S extends string) & {}] ? S : T;
+```

--- a/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_union.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_union.ts
@@ -1,0 +1,1 @@
+type Type<T> = [T] extends [(infer S extends string) | undefined] ? S : T;

--- a/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_union.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_union.ts.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: ts/type/injfer_in_union.ts
+---
+# Input
+
+```ts
+type Type<T> = [T] extends [(infer S extends string) | undefined] ? S : T;
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+-----
+
+```ts
+type Type<T> = [T] extends [(infer S extends string) | undefined] ? S : T;
+```


### PR DESCRIPTION
## Summary

Fix #3419
This also handle `infer` in intersections.

## Test Plan

I added two tests.