### PR TITLE
fix(lint/useConsistentCurlyBraces): specify correct language type

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_consistent_curly_braces.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_consistent_curly_braces.rs
@@ -35,7 +35,7 @@ declare_lint_rule! {
     ///
     /// ### Valid
     ///
-    /// ```js
+    /// ```jsx
     /// <>
     ///     <Foo>Hello world</Foo>
     ///     <Foo foo="bar" />


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This is a small fix.
As part of reviewing the `jsx` code, I discovered the following. I believe it should be specified as `jsx`.

```
    /// ### Valid
    ///
    /// ```js // should be jsx?
    /// <>
    ///     <Foo>Hello world</Foo>
    ///     <Foo foo="bar" />
    ///     <Foo foo={5} />
    ///     <Foo foo={<Bar />} />
    /// </>
    /// ```
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
