### PR TITLE
fix(js_analyze): handle shorthand property renaming

### DIFF
--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidLocalVariable.js
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidLocalVariable.js
@@ -11,5 +11,7 @@ export default function () {
 export function f() {
     const a_var = 0;
     console.log(a_var);
-    return a_var;
+    return {
+        a_var // comment
+    };
 }

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidLocalVariable.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidLocalVariable.js.snap
@@ -17,7 +17,9 @@ export default function () {
 export function f() {
     const a_var = 0;
     console.log(a_var);
-    return a_var;
+    return {
+        a_var // comment
+    };
 }
 
 ```
@@ -126,7 +128,7 @@ invalidLocalVariable.js:12:11 lint/style/useNamingConvention  FIXABLE  ━━━
   > 12 │     const a_var = 0;
        │           ^^^^^
     13 │     console.log(a_var);
-    14 │     return a_var;
+    14 │     return {
   
   i Safe fix: Rename this symbol in camelCase.
   
@@ -134,12 +136,13 @@ invalidLocalVariable.js:12:11 lint/style/useNamingConvention  FIXABLE  ━━━
     11 11 │   export function f() {
     12    │ - ····const·a_var·=·0;
     13    │ - ····console.log(a_var);
-    14    │ - ····return·a_var;
        12 │ + ····const·aVar·=·0;
        13 │ + ····console.log(aVar);
-       14 │ + ····return·aVar;
-    15 15 │   }
-    16 16 │   
+    14 14 │       return {
+    15    │ - ········a_var·//·comment
+       15 │ + ········a_var:·aVar·//·comment
+    16 16 │       };
+    17 17 │   }
   
 
 ```


### PR DESCRIPTION
## Summary

Fix #3050

I also took the opportunity of removing some legacy code and improving the code:

- Trivias are already transferred by `replace_token`: we don't need to do that manually.
- We now have `AnyJsIdentifierUsage` to retrieve the name token.
- I added more comments to make the code more comprehensible

## Test Plan

I added a test in the `useNamingConvention` rule.
