### PR TITLE
chore: fix rules check snippet to emit an error code

### DIFF
--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -921,12 +921,12 @@ pub enum Never {}
 
 /// Type alias of [ops::ControlFlow] with the `B` generic type defaulting to [Never]
 ///
-/// By default the analysis loop never breaks, so it behaves mostly like
+/// By default, the analysis loop never breaks, so it behaves mostly like
 /// `let b = loop {};` and has a "break type" of `!` (the `!` type isn't stable
-/// yet so I'm using an empty enum instead but they're identical for this
+/// yet, so I'm using an empty enum instead, but they're identical for this
 /// purpose)
 ///
-/// In practice it's not really a `loop` but a `for` because it's iterating on
+/// In practice, it's not really a `loop` but a `for` because it's iterating on
 /// all nodes in the syntax tree, so when it reaches the end of the iterator
 /// the loop will exit but without producing a value of type `B`: for this
 /// reason the `analyze` function returns an `Option<B>` that's set to

--- a/crates/biome_js_analyze/src/lint/nursery/no_irregular_whitespace.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_irregular_whitespace.rs
@@ -13,18 +13,18 @@ const IRREGULAR_WHITESPACES: &[char; 22] = &[
 declare_lint_rule! {
     /// Disallows the use of irregular whitespace characters.
     ///
-    /// Invalid or irregular whitespace causes issues with ECMAScript 5 parsers and also makes code harder to debug.
+    /// Invalid or irregular whitespace causes issues with various parsers and also makes code harder to debug.
     ///
     /// ## Examples
     ///
     /// ### Invalid
     ///
     /// ```js,expect_diagnostic
-    /// constcount=1;
+    /// constcount;
     /// ```
     ///
     /// ```js,expect_diagnostic
-    /// const foo = 'thing';
+    /// const foo;
     /// ```
     ///
     /// ### Valid
@@ -67,6 +67,9 @@ impl Rule for NoIrregularWhitespace {
                     "Irregular whitespaces found."
                 },
             )
+            .note(markup!{
+                "Irregular whitespaces can cause issues to other parsers, and make the code harder to debug."
+            })
             .note(markup! {
                 "Replace the irregular whitespaces with normal whitespaces or tabs."
             }),

--- a/crates/biome_js_analyze/tests/specs/nursery/noIrregularWhitespace/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noIrregularWhitespace/invalid.js.snap
@@ -38,6 +38,8 @@ invalid.js:1:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     2 │ /* \u{c}    */ const↡foo↡=↡'thing';
     3 │ /* \u{feff} */ const�foo�=�'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -53,6 +55,8 @@ invalid.js:1:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     2 │ /* \u{c}    */ const↡foo↡=↡'thing';
     3 │ /* \u{feff} */ const�foo�=�'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -67,6 +71,8 @@ invalid.js:1:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
       │                           ^
     2 │ /* \u{c}    */ const↡foo↡=↡'thing';
     3 │ /* \u{feff} */ const�foo�=�'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -84,6 +90,8 @@ invalid.js:2:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     3 │ /* \u{feff} */ const�foo�=�'thing';
     4 │ /* \u{a0}   */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -100,6 +108,8 @@ invalid.js:2:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     3 │ /* \u{feff} */ const�foo�=�'thing';
     4 │ /* \u{a0}   */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -115,6 +125,8 @@ invalid.js:2:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
       │                           ^
     3 │ /* \u{feff} */ const�foo�=�'thing';
     4 │ /* \u{a0}   */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -133,6 +145,8 @@ invalid.js:3:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     4 │ /* \u{a0}   */ const␠foo␠=␠'thing';
     5 │ /* \u{1680} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -149,6 +163,8 @@ invalid.js:3:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
       │                         ^
     4 │ /* \u{a0}   */ const␠foo␠=␠'thing';
     5 │ /* \u{1680} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -167,6 +183,8 @@ invalid.js:3:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     4 │ /* \u{a0}   */ const␠foo␠=␠'thing';
     5 │ /* \u{1680} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -183,6 +201,8 @@ invalid.js:4:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
       │                     ^
     5 │ /* \u{1680} */ const␠foo␠=␠'thing';
     6 │ /* \u{2000} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -201,6 +221,8 @@ invalid.js:4:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     5 │ /* \u{1680} */ const␠foo␠=␠'thing';
     6 │ /* \u{2000} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -217,6 +239,8 @@ invalid.js:4:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
       │                           ^
     5 │ /* \u{1680} */ const␠foo␠=␠'thing';
     6 │ /* \u{2000} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -235,6 +259,8 @@ invalid.js:5:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     6 │ /* \u{2000} */ const␠foo␠=␠'thing';
     7 │ /* \u{2001} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -251,6 +277,8 @@ invalid.js:5:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
       │                         ^
     6 │ /* \u{2000} */ const␠foo␠=␠'thing';
     7 │ /* \u{2001} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -269,6 +297,8 @@ invalid.js:5:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     6 │ /* \u{2000} */ const␠foo␠=␠'thing';
     7 │ /* \u{2001} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -285,6 +315,8 @@ invalid.js:6:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
       │                     ^
     7 │ /* \u{2001} */ const␠foo␠=␠'thing';
     8 │ /* \u{2002} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -303,6 +335,8 @@ invalid.js:6:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     7 │ /* \u{2001} */ const␠foo␠=␠'thing';
     8 │ /* \u{2002} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -319,6 +353,8 @@ invalid.js:6:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
       │                           ^
     7 │ /* \u{2001} */ const␠foo␠=␠'thing';
     8 │ /* \u{2002} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -337,6 +373,8 @@ invalid.js:7:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     8 │ /* \u{2002} */ const␠foo␠=␠'thing';
     9 │ /* \u{2003} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -353,6 +391,8 @@ invalid.js:7:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
       │                         ^
     8 │ /* \u{2002} */ const␠foo␠=␠'thing';
     9 │ /* \u{2003} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -371,6 +411,8 @@ invalid.js:7:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     8 │ /* \u{2002} */ const␠foo␠=␠'thing';
     9 │ /* \u{2003} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -387,6 +429,8 @@ invalid.js:8:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                     ^
      9 │ /* \u{2003} */ const␠foo␠=␠'thing';
     10 │ /* \u{2004} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -405,6 +449,8 @@ invalid.js:8:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
      9 │ /* \u{2003} */ const␠foo␠=␠'thing';
     10 │ /* \u{2004} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -421,6 +467,8 @@ invalid.js:8:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                           ^
      9 │ /* \u{2003} */ const␠foo␠=␠'thing';
     10 │ /* \u{2004} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -439,6 +487,8 @@ invalid.js:9:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     10 │ /* \u{2004} */ const␠foo␠=␠'thing';
     11 │ /* \u{2005} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -455,6 +505,8 @@ invalid.js:9:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                         ^
     10 │ /* \u{2004} */ const␠foo␠=␠'thing';
     11 │ /* \u{2005} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -473,6 +525,8 @@ invalid.js:9:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     10 │ /* \u{2004} */ const␠foo␠=␠'thing';
     11 │ /* \u{2005} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -489,6 +543,8 @@ invalid.js:10:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                     ^
     11 │ /* \u{2005} */ const␠foo␠=␠'thing';
     12 │ /* \u{2006} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -507,6 +563,8 @@ invalid.js:10:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     11 │ /* \u{2005} */ const␠foo␠=␠'thing';
     12 │ /* \u{2006} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -523,6 +581,8 @@ invalid.js:10:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                           ^
     11 │ /* \u{2005} */ const␠foo␠=␠'thing';
     12 │ /* \u{2006} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -541,6 +601,8 @@ invalid.js:11:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     12 │ /* \u{2006} */ const␠foo␠=␠'thing';
     13 │ /* \u{2007} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -557,6 +619,8 @@ invalid.js:11:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                         ^
     12 │ /* \u{2006} */ const␠foo␠=␠'thing';
     13 │ /* \u{2007} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -575,6 +639,8 @@ invalid.js:11:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     12 │ /* \u{2006} */ const␠foo␠=␠'thing';
     13 │ /* \u{2007} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -591,6 +657,8 @@ invalid.js:12:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                     ^
     13 │ /* \u{2007} */ const␠foo␠=␠'thing';
     14 │ /* \u{2008} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -609,6 +677,8 @@ invalid.js:12:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     13 │ /* \u{2007} */ const␠foo␠=␠'thing';
     14 │ /* \u{2008} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -625,6 +695,8 @@ invalid.js:12:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                           ^
     13 │ /* \u{2007} */ const␠foo␠=␠'thing';
     14 │ /* \u{2008} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -643,6 +715,8 @@ invalid.js:13:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     14 │ /* \u{2008} */ const␠foo␠=␠'thing';
     15 │ /* \u{2009} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -659,6 +733,8 @@ invalid.js:13:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                         ^
     14 │ /* \u{2008} */ const␠foo␠=␠'thing';
     15 │ /* \u{2009} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -677,6 +753,8 @@ invalid.js:13:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     14 │ /* \u{2008} */ const␠foo␠=␠'thing';
     15 │ /* \u{2009} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -693,6 +771,8 @@ invalid.js:14:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                     ^
     15 │ /* \u{2009} */ const␠foo␠=␠'thing';
     16 │ /* \u{200a} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -711,6 +791,8 @@ invalid.js:14:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     15 │ /* \u{2009} */ const␠foo␠=␠'thing';
     16 │ /* \u{200a} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -727,6 +809,8 @@ invalid.js:14:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                           ^
     15 │ /* \u{2009} */ const␠foo␠=␠'thing';
     16 │ /* \u{200a} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -745,6 +829,8 @@ invalid.js:15:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     16 │ /* \u{200a} */ const␠foo␠=␠'thing';
     17 │ /* \u{200b} */ const�foo�=�'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -761,6 +847,8 @@ invalid.js:15:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                         ^
     16 │ /* \u{200a} */ const␠foo␠=␠'thing';
     17 │ /* \u{200b} */ const�foo�=�'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -779,6 +867,8 @@ invalid.js:15:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     16 │ /* \u{200a} */ const␠foo␠=␠'thing';
     17 │ /* \u{200b} */ const�foo�=�'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -795,6 +885,8 @@ invalid.js:16:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                     ^
     17 │ /* \u{200b} */ const�foo�=�'thing';
     18 │ /* \u{202f} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -813,6 +905,8 @@ invalid.js:16:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     17 │ /* \u{200b} */ const�foo�=�'thing';
     18 │ /* \u{202f} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -829,6 +923,8 @@ invalid.js:16:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                           ^
     17 │ /* \u{200b} */ const�foo�=�'thing';
     18 │ /* \u{202f} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -847,6 +943,8 @@ invalid.js:17:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     18 │ /* \u{202f} */ const␠foo␠=␠'thing';
     19 │ /* \u{205f} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -863,6 +961,8 @@ invalid.js:17:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                         ^
     18 │ /* \u{202f} */ const␠foo␠=␠'thing';
     19 │ /* \u{205f} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -881,6 +981,8 @@ invalid.js:17:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     18 │ /* \u{202f} */ const␠foo␠=␠'thing';
     19 │ /* \u{205f} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -897,6 +999,8 @@ invalid.js:18:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                     ^
     19 │ /* \u{205f} */ const␠foo␠=␠'thing';
     20 │ /* \u{3000} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -915,6 +1019,8 @@ invalid.js:18:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     19 │ /* \u{205f} */ const␠foo␠=␠'thing';
     20 │ /* \u{3000} */ const␠foo␠=␠'thing';
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -931,6 +1037,8 @@ invalid.js:18:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                           ^
     19 │ /* \u{205f} */ const␠foo␠=␠'thing';
     20 │ /* \u{3000} */ const␠foo␠=␠'thing';
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -949,6 +1057,8 @@ invalid.js:19:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     20 │ /* \u{3000} */ const␠foo␠=␠'thing';
     21 │ 
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -965,6 +1075,8 @@ invalid.js:19:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                         ^
     20 │ /* \u{3000} */ const␠foo␠=␠'thing';
     21 │ 
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -983,6 +1095,8 @@ invalid.js:19:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
     20 │ /* \u{3000} */ const␠foo␠=␠'thing';
     21 │ 
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -998,6 +1112,8 @@ invalid.js:20:21 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
   > 20 │ /* \u{3000} */ const␠foo␠=␠'thing';
        │                     ^
     21 │ 
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
@@ -1015,6 +1131,8 @@ invalid.js:20:25 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
        │                         ^
     21 │ 
   
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
+  
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   
 
@@ -1030,6 +1148,8 @@ invalid.js:20:27 lint/nursery/noIrregularWhitespace ━━━━━━━━━�
   > 20 │ /* \u{3000} */ const␠foo␠=␠'thing';
        │                           ^
     21 │ 
+  
+  i Irregular whitespaces can cause issues to other parsers, and make the code harder to debug.
   
   i Replace the irregular whitespaces with normal whitespaces or tabs.
   

--- a/xtask/rules_check/Cargo.toml
+++ b/xtask/rules_check/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-edition = "2021"
-name    = "rules_check"
-publish = false
-version = "0.0.0"
 description = "Internal script to make sure that the metadata or the rules are correct"
+edition     = "2021"
+name        = "rules_check"
+publish     = false
+version     = "0.0.0"
 
 [dependencies]
 anyhow             = { workspace = true }

--- a/xtask/rules_check/Cargo.toml
+++ b/xtask/rules_check/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2021"
 name    = "rules_check"
 publish = false
 version = "0.0.0"
+description = "Internal script to make sure that the metadata or the rules are correct"
 
 [dependencies]
 anyhow             = { workspace = true }

--- a/xtask/rules_check/src/lib.rs
+++ b/xtask/rules_check/src/lib.rs
@@ -4,8 +4,8 @@
 use anyhow::{bail, ensure};
 use biome_analyze::options::JsxRuntime;
 use biome_analyze::{
-    AnalysisFilter, AnalyzerConfiguration, AnalyzerOptions, GroupCategory, Queryable,
-    RegistryVisitor, Rule, RuleCategory, RuleFilter, RuleGroup, RuleMetadata, ControlFlow
+    AnalysisFilter, AnalyzerConfiguration, AnalyzerOptions, ControlFlow, GroupCategory, Queryable,
+    RegistryVisitor, Rule, RuleCategory, RuleFilter, RuleGroup, RuleMetadata,
 };
 use biome_console::{markup, Console};
 use biome_css_parser::CssParserOptions;
@@ -177,7 +177,7 @@ fn assert_lint(
                         },
                     );
                 }
-                has_error =true;
+                has_error = true;
                 bail!("Analysis of '{group}/{rule}' on the following code block returned multiple diagnostics.\n\n{code}");
             }
         } else {
@@ -191,7 +191,7 @@ fn assert_lint(
                     },
                 );
             }
-            has_error =true;
+            has_error = true;
             bail!("Analysis of '{group}/{rule}' on the following code block returned an unexpected diagnostic.\n\n{code}");
         }
         diagnostic_count += 1;
@@ -390,7 +390,7 @@ fn assert_lint(
             "Analysis of '{group}/{rule}' on the following code block returned no diagnostics.\n\n{code}",
         );
     }
-    
+
     if has_error {
         bail!("A code snippet must emit one single diagnostic, but it seems multiple diagnostics were emitted. Make sure that all the snippets inside the code block 'expect_diagnostic' emit only one diagnostic.")
     }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes the `rules_check` script to correctly return an error when a snippet emits multiple diagnostics. I updated the `no_irregular_whitespace` docs because it was silently failing.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

CI should pass

<!-- What demonstrates that your implementation is correct? -->
