### PR TITLE
fix(useAdjacentOverloadSignatures): don't report #private and public members with same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,20 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - `noExtraNonNullAssertion` no longer reports a single non-null assertion enclosed in parentheses ([#3352](https://github.com/biomejs/biome/issues/3352)). Contributed by @Conaclos
 
+- `useAdjacentOverloadSignatures` no longer reports a `#private` class member and a public class member that share the same name ([#3309](https://github.com/biomejs/biome/issues/3309)).
+
+  The following code is no longer reported:
+
+  ```js
+  class C {
+    #f() {}
+    g() {}
+    f() {}
+  }
+  ```
+
+  Contributed by @Conaclos
+
 
 ### Parser
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misleading_instantiator.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misleading_instantiator.rs
@@ -3,8 +3,9 @@ use biome_analyze::{
 };
 use biome_console::{markup, MarkupBuf};
 use biome_js_syntax::{
-    AnyJsClassMember, AnyTsType, AnyTsTypeMember, JsClassDeclaration, JsSyntaxToken,
-    TsDeclareStatement, TsInterfaceDeclaration, TsReferenceType, TsTypeAliasDeclaration,
+    AnyJsClassMember, AnyTsType, AnyTsTypeMember, ClassMemberName, JsClassDeclaration,
+    JsSyntaxToken, TsDeclareStatement, TsInterfaceDeclaration, TsReferenceType,
+    TsTypeAliasDeclaration,
 };
 use biome_rowan::{declare_node_union, AstNode, TextRange};
 
@@ -189,27 +190,27 @@ fn check_class_methods(js_class_decl: &JsClassDeclaration) -> Option<RuleState> 
         .as_js_identifier_binding()?
         .name_token()
         .ok()?;
-
     for member in js_class_decl.members() {
-        match member {
-            AnyJsClassMember::TsMethodSignatureClassMember(method)
-                if method.name().ok()?.name()? == "new" =>
-            {
-                let return_type = method.return_type_annotation()?.ty().ok()?;
-                match return_type.as_any_ts_type()? {
-                    AnyTsType::TsReferenceType(ref_type) => {
-                        let return_type_ident = extract_return_type_ident(ref_type)?;
-                        if class_ident.text_trimmed() == return_type_ident.text_trimmed() {
+        if let AnyJsClassMember::TsMethodSignatureClassMember(method) = member {
+            if let Some(ClassMemberName::Public(name)) = method.name().ok()?.name() {
+                if name.text() == "new" {
+                    let return_type = method.return_type_annotation()?.ty().ok()?;
+                    match return_type.as_any_ts_type()? {
+                        AnyTsType::TsReferenceType(ref_type) => {
+                            let return_type_ident = extract_return_type_ident(ref_type)?;
+                            if class_ident.text_trimmed() == return_type_ident.text_trimmed() {
+                                return Some(RuleState::ClassMisleadingNew(method.range()));
+                            }
+                        }
+                        AnyTsType::TsThisType(this_type)
+                            if this_type.this_token().ok().is_some() =>
+                        {
                             return Some(RuleState::ClassMisleadingNew(method.range()));
                         }
+                        _ => continue,
                     }
-                    AnyTsType::TsThisType(this_type) if this_type.this_token().ok().is_some() => {
-                        return Some(RuleState::ClassMisleadingNew(method.range()));
-                    }
-                    _ => continue,
                 }
             }
-            _ => continue,
         }
     }
     None

--- a/crates/biome_js_analyze/src/lint/suspicious/no_then_property.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_then_property.rs
@@ -4,8 +4,8 @@ use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnosti
 use biome_console::{markup, MarkupBuf};
 use biome_js_syntax::{
     AnyJsArrayElement, AnyJsAssignment, AnyJsAssignmentPattern, AnyJsCallArgument,
-    AnyJsClassMemberName, AnyJsDeclarationClause, AnyJsExportClause, AnyJsExportNamedSpecifier,
-    AnyJsExpression, AnyJsObjectMemberName, AnyJsTemplateElement, JsMethodObjectMember,
+    AnyJsDeclarationClause, AnyJsExportClause, AnyJsExportNamedSpecifier, AnyJsExpression,
+    AnyJsObjectMemberName, AnyJsTemplateElement, ClassMemberName, JsMethodObjectMember,
 };
 use biome_js_syntax::{
     AnyJsClassMember, AnyJsObjectMember, JsAssignmentExpression, JsCallExpression,
@@ -222,43 +222,14 @@ fn process_js_method_object_member(node: &JsMethodObjectMember) -> Option<RuleSt
 }
 
 fn process_js_class_member(node: &AnyJsClassMember) -> Option<RuleState> {
-    if let Some(AnyJsClassMemberName::JsPrivateClassMemberName(_)) = node.name().ok()? {
-        return None;
-    }
-    match node {
-        AnyJsClassMember::JsGetterClassMember(node) => {
-            if node.name().ok()?.name()? == "then" {
-                return Some(RuleState {
-                    range: node.name().ok()?.range(),
-                    message: NoThenPropertyMessage::Class,
-                });
-            }
+    let any_class_member_name = node.name().ok()??;
+    if let Some(ClassMemberName::Public(name)) = any_class_member_name.name() {
+        if name == "then" {
+            return Some(RuleState {
+                range: any_class_member_name.range(),
+                message: NoThenPropertyMessage::Class,
+            });
         }
-        AnyJsClassMember::JsMethodClassMember(node) => {
-            if node.name().ok()?.name()? == "then" {
-                return Some(RuleState {
-                    range: node.name().ok()?.range(),
-                    message: NoThenPropertyMessage::Class,
-                });
-            }
-        }
-        AnyJsClassMember::JsPropertyClassMember(node) => {
-            if node.name().ok()?.name()? == "then" {
-                return Some(RuleState {
-                    range: node.name().ok()?.range(),
-                    message: NoThenPropertyMessage::Class,
-                });
-            }
-        }
-        AnyJsClassMember::JsSetterClassMember(node) => {
-            if node.name().ok()?.name()? == "then" {
-                return Some(RuleState {
-                    range: node.name().ok()?.range(),
-                    message: NoThenPropertyMessage::Class,
-                });
-            }
-        }
-        _ => return None,
     }
     None
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/useAdjacentOverloadSignatures/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAdjacentOverloadSignatures/valid.ts
@@ -62,3 +62,10 @@ function f (): {
   functionA(x: number): number,
 } {
 }
+
+// Issue https://github.com/biomejs/biome/issues/3309#issuecomment-2208870371
+class C {
+  #f(): void {}
+  g(): void {}
+  f(): void {}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useAdjacentOverloadSignatures/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAdjacentOverloadSignatures/valid.ts.snap
@@ -69,4 +69,10 @@ function f (): {
 } {
 }
 
+// Issue https://github.com/biomejs/biome/issues/3309#issuecomment-2208870371
+class C {
+  #f(): void {}
+  g(): void {}
+  f(): void {}
+}
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingInstantiator/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingInstantiator/valid.ts
@@ -49,3 +49,7 @@ interface foo {
 interface foo {
   new <T>(): 'x';
 }
+
+class C {
+  #new(): C;
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingInstantiator/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingInstantiator/valid.ts.snap
@@ -56,6 +56,8 @@ interface foo {
   new <T>(): 'x';
 }
 
+class C {
+  #new(): C;
+}
+
 ```
-
-


### PR DESCRIPTION
## Summary

Fix #3309
I introduced a new enum `ClassMemberName` that is returned by `AnyJsClassMemberName::name`.
This allows to carry the information if the name was #private or public.
I had to refactor the code of `useAdjacentOverloadSignatures` to accommodate with this change.

I also fixed `noMisleadingInstantiator` that previously reported `class C { #new(): C {} }`.

## Test Plan

I added tests.
