### PR TITLE
feat(cli): lift limit of max diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,14 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### CLI
 
+#### Bug fixes
+
+- When a `--reporter` is provided, and it's different from the default one, the value provided by via `--max-diagnostics` is ignored and **the limit is lifted**. Contributed by @ematipico
+
 #### New features
 
-- Add `--graphql-linter-enabled` option, to control whether the linter should enabled or not for GraphQL files. Contributed by @ematipico
+- Add `--graphql-linter-enabled` option, to control whether the linter should be enabled or not for GraphQL files. Contributed by @ematipico
+- The option `--max-diagnostics` now accept a `none` value, which lifts the limit of diagnostics shown. Contributed by @ematipico
 
 ### Configuration
 
@@ -118,7 +123,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   }
 }
 ```
-- Fix [#3410](https://github.com/biomejs/biome/issues/3410) by correctly parsing break statements containing keywords. 
+- Fix [#3410](https://github.com/biomejs/biome/issues/3410) by correctly parsing break statements containing keywords.
   ```js
   out: while (true) {
     break out;

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -27,14 +27,14 @@ pub struct CliOptions {
     #[bpaf(long("config-path"), argument("PATH"), optional)]
     pub config_path: Option<String>,
 
-    /// Cap the amount of diagnostics displayed.
+    /// Cap the amount of diagnostics displayed. When `none` is provided, the limit is lifted.
     #[bpaf(
         long("max-diagnostics"),
-        argument("NUMBER"),
-        fallback(20),
+        argument("none|<NUMBER>"),
+        fallback(MaxDiagnostics::default()),
         display_fallback
     )]
-    pub max_diagnostics: u16,
+    pub max_diagnostics: MaxDiagnostics,
 
     /// Skip over files containing syntax errors instead of emitting an error diagnostic.
     #[bpaf(long("skip-errors"), switch)]
@@ -133,6 +133,12 @@ pub enum CliReporter {
     Summary,
 }
 
+impl CliReporter {
+    pub(crate) const fn is_default(&self) -> bool {
+        matches!(self, Self::Default)
+    }
+}
+
 impl FromStr for CliReporter {
     type Err = String;
 
@@ -159,6 +165,74 @@ impl Display for CliReporter {
             CliReporter::Summary => f.write_str("summary"),
             CliReporter::GitHub => f.write_str("github"),
             CliReporter::Junit => f.write_str("junit"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Bpaf)]
+pub enum MaxDiagnostics {
+    None,
+    Limit(u32),
+}
+
+impl MaxDiagnostics {
+    pub fn ok(&self) -> Option<u32> {
+        match self {
+            MaxDiagnostics::None => None,
+            MaxDiagnostics::Limit(value) => Some(*value),
+        }
+    }
+}
+
+impl Default for MaxDiagnostics {
+    fn default() -> Self {
+        Self::Limit(20)
+    }
+}
+
+impl Display for MaxDiagnostics {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MaxDiagnostics::None => {
+                write!(f, "none")
+            }
+            MaxDiagnostics::Limit(value) => {
+                write!(f, "{value}")
+            }
+        }
+    }
+}
+
+impl FromStr for MaxDiagnostics {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "none" => Ok(MaxDiagnostics::None),
+            _ => {
+                if let Ok(value) = s.parse::<u32>() {
+                    Ok(MaxDiagnostics::Limit(value))
+                } else {
+                    Err(format!("Invalid value provided. Provide 'none' to lift the limit, or a number between 0 and {}.", u32::MAX))
+                }
+            }
+        }
+    }
+}
+
+impl From<MaxDiagnostics> for u64 {
+    fn from(value: MaxDiagnostics) -> Self {
+        match value {
+            MaxDiagnostics::None => u64::MAX,
+            MaxDiagnostics::Limit(value) => value as u64,
+        }
+    }
+}
+
+impl From<MaxDiagnostics> for u32 {
+    fn from(value: MaxDiagnostics) -> Self {
+        match value {
+            MaxDiagnostics::None => u32::MAX,
+            MaxDiagnostics::Limit(value) => value,
         }
     }
 }

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -37,7 +37,7 @@ pub struct Execution {
     traversal_mode: TraversalMode,
 
     /// The maximum number of diagnostics that can be printed in console
-    max_diagnostics: u16,
+    max_diagnostics: u32,
 }
 
 impl Execution {
@@ -281,7 +281,7 @@ impl Execution {
         &self.traversal_mode
     }
 
-    pub(crate) fn get_max_diagnostics(&self) -> u16 {
+    pub(crate) fn get_max_diagnostics(&self) -> u32 {
         self.max_diagnostics
     }
 
@@ -395,7 +395,12 @@ pub fn execute_mode(
     cli_options: &CliOptions,
     paths: Vec<OsString>,
 ) -> Result<(), CliDiagnostic> {
-    execution.max_diagnostics = cli_options.max_diagnostics;
+    // If a custom reporter was provided, let's lift the limit so users can see all of them
+    execution.max_diagnostics = if cli_options.reporter.is_default() {
+        cli_options.max_diagnostics.into()
+    } else {
+        u32::MAX
+    };
 
     // don't do any traversal if there's some content coming from stdin
     if let Some(stdin) = execution.as_stdin_file() {

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -26,6 +26,7 @@ use biome_service::workspace::{
 use std::ffi::OsString;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
+use tracing::info;
 
 /// Useful information during the traversal of files and virtual content
 #[derive(Debug, Clone)]
@@ -399,6 +400,7 @@ pub fn execute_mode(
     execution.max_diagnostics = if cli_options.reporter.is_default() {
         cli_options.max_diagnostics.into()
     } else {
+        info!("Removing the limit of --max-diagnostics, because of a reporter different from the default one: {}", cli_options.reporter);
         u32::MAX
     };
 

--- a/crates/biome_cli/src/execute/process_file/format.rs
+++ b/crates/biome_cli/src/execute/process_file/format.rs
@@ -28,7 +28,7 @@ pub(crate) fn format_with_guard<'ctx>(
                 .guard()
                 .pull_diagnostics(
                     RuleCategoriesBuilder::default().with_syntax().build(),
-                    max_diagnostics.into(),
+                    max_diagnostics,
                     Vec::new(),
                     Vec::new(),
                 )

--- a/crates/biome_cli/src/execute/process_file/lint.rs
+++ b/crates/biome_cli/src/execute/process_file/lint.rs
@@ -70,7 +70,7 @@ pub(crate) fn lint_with_guard<'ctx>(
                         .with_syntax()
                         .with_lint()
                         .build(),
-                    max_diagnostics.into(),
+                    max_diagnostics,
                     only,
                     skip,
                 )

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -22,7 +22,7 @@ use std::{
     panic::catch_unwind,
     path::{Path, PathBuf},
     sync::{
-        atomic::{AtomicU16, AtomicUsize, Ordering},
+        atomic::{AtomicUsize, Ordering},
         Once,
     },
     thread,
@@ -74,7 +74,7 @@ pub(crate) fn traverse(
     let workspace = &*session.app.workspace;
 
     let max_diagnostics = execution.get_max_diagnostics();
-    let remaining_diagnostics = AtomicU16::new(max_diagnostics);
+    let remaining_diagnostics = AtomicU32::new(max_diagnostics);
 
     let printer = DiagnosticsPrinter::new(execution)
         .with_verbose(cli_options.verbose)
@@ -212,8 +212,8 @@ impl<'ctx> DiagnosticsPrinter<'ctx> {
         self
     }
 
-    fn with_max_diagnostics(mut self, value: u16) -> Self {
-        self.max_diagnostics = value as u32;
+    fn with_max_diagnostics(mut self, value: u32) -> Self {
+        self.max_diagnostics = value;
         self
     }
 
@@ -482,7 +482,7 @@ pub(crate) struct TraversalOptions<'ctx, 'app> {
     pub(crate) messages: Sender<Message>,
     /// The approximate number of diagnostics the console will print before
     /// folding the rest into the "skipped diagnostics" counter
-    pub(crate) remaining_diagnostics: &'ctx AtomicU16,
+    pub(crate) remaining_diagnostics: &'ctx AtomicU32,
 }
 
 impl<'ctx, 'app> TraversalOptions<'ctx, 'app> {

--- a/crates/biome_cli/tests/cases/diagnostics.rs
+++ b/crates/biome_cli/tests/cases/diagnostics.rs
@@ -5,6 +5,7 @@ use biome_fs::MemoryFileSystem;
 use biome_service::DynRef;
 use bpaf::Args;
 use std::path::{Path, PathBuf};
+use std::u8;
 
 const TEST_CONTENTS: &str = "debugger;";
 
@@ -193,4 +194,55 @@ import { FC, memo, useCallback } from "react";
         console,
         result,
     ));
+}
+
+#[test]
+fn max_diagnostics_are_lifted() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    for i in 0..u8::MAX {
+        let file_path = PathBuf::from(format!("src/file_{i}.js"));
+        fs.insert(file_path, UNFORMATTED.as_bytes());
+    }
+
+    let file_path = PathBuf::from("file.js".to_string());
+    fs.insert(
+        file_path.clone(),
+        "debugger;".repeat(u8::MAX as usize * 2).as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("ci"),
+                ("--max-diagnostics"),
+                ("none"),
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    for i in 0..u8::MAX {
+        let file_path = PathBuf::from(format!("src/file_{i}.js"));
+        fs.remove(&file_path);
+    }
+
+    let messages = &console.out_buffer;
+
+    let errors = format!("{}", u8::MAX as usize * 2 + 1);
+
+    assert!(messages
+        .iter()
+        .filter(|m| m.level == LogLevel::Log)
+        .any(|m| {
+            let content = format!("{:?}", m.content);
+
+            content.contains(&errors)
+        }));
 }

--- a/crates/biome_cli/tests/cases/diagnostics.rs
+++ b/crates/biome_cli/tests/cases/diagnostics.rs
@@ -5,7 +5,6 @@ use biome_fs::MemoryFileSystem;
 use biome_service::DynRef;
 use bpaf::Args;
 use std::path::{Path, PathBuf};
-use std::u8;
 
 const TEST_CONTENTS: &str = "debugger;";
 

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -113,7 +113,8 @@ Global options applied to all commands
         --config-path=PATH    Set the file path to the configuration file, or the directory path to find
                               `biome.json` or `biome.jsonc`. If used, it disables the default configuration
                               file resolution.
-        --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
+        --max-diagnostics=<none|<NUMBER>>  Cap the amount of diagnostics displayed. When `none` is provided,
+                              the limit is lifted.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
         --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -115,7 +115,8 @@ Global options applied to all commands
         --config-path=PATH    Set the file path to the configuration file, or the directory path to find
                               `biome.json` or `biome.jsonc`. If used, it disables the default configuration
                               file resolution.
-        --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
+        --max-diagnostics=<none|<NUMBER>>  Cap the amount of diagnostics displayed. When `none` is provided,
+                              the limit is lifted.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
         --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -81,7 +81,8 @@ Global options applied to all commands
         --config-path=PATH    Set the file path to the configuration file, or the directory path to find
                               `biome.json` or `biome.jsonc`. If used, it disables the default configuration
                               file resolution.
-        --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
+        --max-diagnostics=<none|<NUMBER>>  Cap the amount of diagnostics displayed. When `none` is provided,
+                              the limit is lifted.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
         --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -44,7 +44,8 @@ Global options applied to all commands
         --config-path=PATH    Set the file path to the configuration file, or the directory path to find
                               `biome.json` or `biome.jsonc`. If used, it disables the default configuration
                               file resolution.
-        --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
+        --max-diagnostics=<none|<NUMBER>>  Cap the amount of diagnostics displayed. When `none` is provided,
+                              the limit is lifted.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
         --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
@@ -18,7 +18,8 @@ Global options applied to all commands
         --config-path=PATH    Set the file path to the configuration file, or the directory path to find
                               `biome.json` or `biome.jsonc`. If used, it disables the default configuration
                               file resolution.
-        --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
+        --max-diagnostics=<none|<NUMBER>>  Cap the amount of diagnostics displayed. When `none` is provided,
+                              the limit is lifted.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
         --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -18,7 +18,8 @@ Global options applied to all commands
         --config-path=PATH    Set the file path to the configuration file, or the directory path to find
                               `biome.json` or `biome.jsonc`. If used, it disables the default configuration
                               file resolution.
-        --max-diagnostics=NUMBER  Cap the amount of diagnostics displayed.
+        --max-diagnostics=<none|<NUMBER>>  Cap the amount of diagnostics displayed. When `none` is provided,
+                              the limit is lifted.
                               [default: 20]
         --skip-errors         Skip over files containing syntax errors instead of emitting an error diagnostic.
         --no-errors-on-unmatched  Silence errors that would be emitted in case no files were processed


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/3450

Following https://github.com/biomejs/biome/discussions/3060, I added a new `none` value that can be passed to `--max-diagnostics`, which sets the limit to `u32::MAX`. I believe this limit is unreachable in most of the projects.

Also, when a reporter that isn't the default is passed, we ignore `--max-diagnostics` and set the its default to the max value. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test

<!-- What demonstrates that your implementation is correct? -->
