### PR TITLE
refactor(core): register syntax rules via visitor

### DIFF
--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -1,7 +1,7 @@
 use super::{
     search, AnalyzerCapabilities, CodeActionsParams, DebugCapabilities, ExtensionHandler,
     FormatterCapabilities, LintParams, LintResults, ParseResult, ParserCapabilities,
-    SearchCapabilities,
+    SearchCapabilities, SyntaxVisitor,
 };
 use crate::configuration::to_analyzer_rules;
 use crate::diagnostics::extension_error;
@@ -446,13 +446,10 @@ pub(crate) fn lint(params: LintParams) -> LintResults {
                 if organize_imports_enabled && !params.categories.is_syntax() {
                     rule_filter_list.push(RuleFilter::Rule("correctness", "organizeImports"));
                 }
-                rule_filter_list.push(RuleFilter::Rule(
-                    "correctness",
-                    "noDuplicatePrivateClassMembers",
-                ));
-                rule_filter_list.push(RuleFilter::Rule("correctness", "noInitializerWithDefinite"));
-                rule_filter_list.push(RuleFilter::Rule("correctness", "noSuperWithoutExtends"));
-                rule_filter_list.push(RuleFilter::Rule("nursery", "noSuperWithoutExtends"));
+                let mut syntax_visitor = SyntaxVisitor::default();
+                visit_registry(&mut syntax_visitor);
+                rule_filter_list.extend(syntax_visitor.enabled_rules);
+
                 rule_filter_list
             };
             let disabled_rules = params

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -3,6 +3,7 @@ use std::ffi::OsStr;
 
 use super::{
     CodeActionsParams, DocumentFileSource, ExtensionHandler, ParseResult, SearchCapabilities,
+    SyntaxVisitor,
 };
 use crate::configuration::to_analyzer_rules;
 use crate::file_handlers::DebugCapabilities;
@@ -345,7 +346,7 @@ fn lint(params: LintParams) -> LintResults {
             }
 
             let has_only_filter = !params.only.is_empty();
-            let enabled_rules = if has_only_filter {
+            let mut enabled_rules = if has_only_filter {
                 params
                     .only
                     .into_iter()
@@ -359,6 +360,9 @@ fn lint(params: LintParams) -> LintResults {
                     .into_iter()
                     .collect::<Vec<_>>()
             };
+            let mut syntax_visitor = SyntaxVisitor::default();
+            biome_js_analyze::visit_registry(&mut syntax_visitor);
+            enabled_rules.extend(syntax_visitor.enabled_rules);
             let disabled_rules = params
                 .skip
                 .into_iter()


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

A simple refactor to add Syntax rules to the `lint` function of each language automatically. Syntax rules are configuration free, so they can be added without a particular business logic.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current tests should pass

<!-- What demonstrates that your implementation is correct? -->

