### PR TITLE
fix(cli): apply offsets for htmlish js file sources

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_astro_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_astro_files.snap
@@ -29,9 +29,11 @@ file.astro:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━�
 
   × This is an unexpected use of the debugger statement.
   
+    1 │ ---
   > 2 │ debugger;
       │ ^^^^^^^^^
-    3 │ 
+    3 │ ---
+    4 │ <div></div>
   
   i Unsafe fix: Remove debugger statement
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_js_files.snap
@@ -28,21 +28,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-file.vue:1:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.vue:2:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Use === instead of ==
   
-  > 1 │ a == b;
+    1 │ <script setup lang="js">
+  > 2 │ a == b;
       │   ^^
-    2 │ delete a.c;
-    3 │ 
+    3 │ delete a.c;
+    4 │ 
   
   i == is only allowed when comparing against null
   
-  > 1 │ a == b;
+  > 1 │ <script setup lang="js">
       │   ^^
-    2 │ delete a.c;
-    3 │ 
+    2 │ a == b;
+    3 │ delete a.c;
   
   i Using == may be unsafe if you are relying on type coercion
   
@@ -54,15 +55,16 @@ file.vue:1:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━�
 ```
 
 ```block
-file.vue:2:1 lint/performance/noDelete  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.vue:3:1 lint/performance/noDelete  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Avoid the delete operator which can impact performance.
   
-    1 │ a == b;
-  > 2 │ delete a.c;
+    1 │ <script setup lang="js">
+    2 │ a == b;
+  > 3 │ delete a.c;
       │ ^^^^^^^^^^
-    3 │ 
-    4 │ var foo = "";
+    4 │ 
+    5 │ var foo = "";
   
   i Unsafe fix: Use an undefined assignment instead.
   
@@ -76,15 +78,16 @@ file.vue:2:1 lint/performance/noDelete  FIXABLE  ━━━━━━━━━━�
 ```
 
 ```block
-file.vue:4:1 lint/style/noVar  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.vue:5:1 lint/style/noVar  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Use let or const instead of var.
   
-    2 │ delete a.c;
-    3 │ 
-  > 4 │ var foo = "";
+    3 │ delete a.c;
+    4 │ 
+  > 5 │ var foo = "";
       │ ^^^^^^^^^^^^
-    5 │ 
+    6 │ </script>
+    7 │ <template></template>
   
   i A variable declared with var is accessible in the whole module. Thus, the variable can be accessed before its initialization and outside the block where it is declared.
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_ts_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_ts_files.snap
@@ -28,21 +28,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-file.vue:1:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.vue:2:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Use === instead of ==
   
-  > 1 │ a == b;
+    1 │ <script setup lang="ts">
+  > 2 │ a == b;
       │   ^^
-    2 │ delete a.c;
-    3 │ 
+    3 │ delete a.c;
+    4 │ 
   
   i == is only allowed when comparing against null
   
-  > 1 │ a == b;
+  > 1 │ <script setup lang="ts">
       │   ^^
-    2 │ delete a.c;
-    3 │ 
+    2 │ a == b;
+    3 │ delete a.c;
   
   i Using == may be unsafe if you are relying on type coercion
   
@@ -54,15 +55,16 @@ file.vue:1:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━�
 ```
 
 ```block
-file.vue:2:1 lint/performance/noDelete  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.vue:3:1 lint/performance/noDelete  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Avoid the delete operator which can impact performance.
   
-    1 │ a == b;
-  > 2 │ delete a.c;
+    1 │ <script setup lang="ts">
+    2 │ a == b;
+  > 3 │ delete a.c;
       │ ^^^^^^^^^^
-    3 │ 
-    4 │ var foo: string = "";
+    4 │ 
+    5 │ var foo: string = "";
   
   i Unsafe fix: Use an undefined assignment instead.
   
@@ -76,15 +78,16 @@ file.vue:2:1 lint/performance/noDelete  FIXABLE  ━━━━━━━━━━�
 ```
 
 ```block
-file.vue:4:8 lint/style/noInferrableTypes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.vue:5:8 lint/style/noInferrableTypes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This type annotation is trivially inferred from its initialization.
   
-    2 │ delete a.c;
-    3 │ 
-  > 4 │ var foo: string = "";
+    3 │ delete a.c;
+    4 │ 
+  > 5 │ var foo: string = "";
       │        ^^^^^^^^
-    5 │ 
+    6 │ </script>
+    7 │ <template></template>
   
   i Safe fix: Remove the type annotation.
   
@@ -98,15 +101,16 @@ file.vue:4:8 lint/style/noInferrableTypes  FIXABLE  ━━━━━━━━━�
 ```
 
 ```block
-file.vue:4:1 lint/style/noVar  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.vue:5:1 lint/style/noVar  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Use let or const instead of var.
   
-    2 │ delete a.c;
-    3 │ 
-  > 4 │ var foo: string = "";
+    3 │ delete a.c;
+    4 │ 
+  > 5 │ var foo: string = "";
       │ ^^^^^^^^^^^^^^^^^^^^
-    5 │ 
+    6 │ </script>
+    7 │ <template></template>
   
   i A variable declared with var is accessible in the whole module. Thus, the variable can be accessed before its initialization and outside the block where it is declared.
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/vue_compiler_macros_as_globals.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/vue_compiler_macros_as_globals.snap
@@ -42,15 +42,15 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-file.vue:16:36 lint/suspicious/noExplicitAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.vue:17:36 lint/suspicious/noExplicitAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected any. Specify a different type.
   
-    15 │ const slots = defineSlots<{
-  > 16 │ 		default(props: { msg: string }): any
+    16 │ const slots = defineSlots<{
+  > 17 │ 		default(props: { msg: string }): any
        │ 		                                 ^^^
-    17 │ }>()
-    18 │ 
+    18 │ }>()
+    19 │ 
   
   i any disables many type checking rules. Its use should be avoided.
   

--- a/crates/biome_diagnostics/src/serde.rs
+++ b/crates/biome_diagnostics/src/serde.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use biome_console::{fmt, markup, MarkupBuf};
+use biome_rowan::TextSize;
 use biome_text_edit::TextEdit;
 use biome_text_size::TextRange;
 use serde::{
@@ -72,6 +73,14 @@ impl Diagnostic {
             tags,
             source,
         }
+    }
+
+    pub fn with_offset(mut self, offset: TextSize) -> Self {
+        self.location.span = self
+            .location
+            .span
+            .map(|span| TextRange::new(span.start() + offset, span.end() + offset));
+        self
     }
 }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
When we print diagnostics, previously the spans would be relative to the start of the js code, not to the start of the file. This was causing diagnostics to point to the wrong line for vue, svelte, and astro files.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #3366

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Tested manually on some of my own vue/svelte projects. Updated the snapshots.
