### PR TITLE
refactor: consistently use `cast`, `cast_ref` and `try_cast`

### DIFF
--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -20284,9 +20284,12 @@ impl AstNode for AnyCssQueryFeatureValue {
             CSS_NUMBER => AnyCssQueryFeatureValue::CssNumber(CssNumber { syntax }),
             CSS_RATIO => AnyCssQueryFeatureValue::CssRatio(CssRatio { syntax }),
             _ => {
-                if let Some(any_css_dimension) = AnyCssDimension::cast(syntax.clone()) {
-                    return Some(AnyCssQueryFeatureValue::AnyCssDimension(any_css_dimension));
-                }
+                let syntax = match AnyCssDimension::try_cast(syntax) {
+                    Ok(any_css_dimension) => {
+                        return Some(AnyCssQueryFeatureValue::AnyCssDimension(any_css_dimension));
+                    }
+                    Err(syntax) => syntax,
+                };
                 if let Some(any_css_function) = AnyCssFunction::cast(syntax) {
                     return Some(AnyCssQueryFeatureValue::AnyCssFunction(any_css_function));
                 }
@@ -21682,9 +21685,12 @@ impl AstNode for AnyCssValue {
             CSS_STRING => AnyCssValue::CssString(CssString { syntax }),
             CSS_UNICODE_RANGE => AnyCssValue::CssUnicodeRange(CssUnicodeRange { syntax }),
             _ => {
-                if let Some(any_css_dimension) = AnyCssDimension::cast(syntax.clone()) {
-                    return Some(AnyCssValue::AnyCssDimension(any_css_dimension));
-                }
+                let syntax = match AnyCssDimension::try_cast(syntax) {
+                    Ok(any_css_dimension) => {
+                        return Some(AnyCssValue::AnyCssDimension(any_css_dimension));
+                    }
+                    Err(syntax) => syntax,
+                };
                 if let Some(any_css_function) = AnyCssFunction::cast(syntax) {
                     return Some(AnyCssValue::AnyCssFunction(any_css_function));
                 }

--- a/crates/biome_graphql_syntax/src/generated/nodes.rs
+++ b/crates/biome_graphql_syntax/src/generated/nodes.rs
@@ -6044,13 +6044,14 @@ impl AstNode for AnyGraphqlDefinition {
                 AnyGraphqlDefinition::GraphqlSelectionSet(GraphqlSelectionSet { syntax })
             }
             _ => {
-                if let Some(any_graphql_type_definition) =
-                    AnyGraphqlTypeDefinition::cast(syntax.clone())
-                {
-                    return Some(AnyGraphqlDefinition::AnyGraphqlTypeDefinition(
-                        any_graphql_type_definition,
-                    ));
-                }
+                let syntax = match AnyGraphqlTypeDefinition::try_cast(syntax) {
+                    Ok(any_graphql_type_definition) => {
+                        return Some(AnyGraphqlDefinition::AnyGraphqlTypeDefinition(
+                            any_graphql_type_definition,
+                        ));
+                    }
+                    Err(syntax) => syntax,
+                };
                 if let Some(any_graphql_type_extension) = AnyGraphqlTypeExtension::cast(syntax) {
                     return Some(AnyGraphqlDefinition::AnyGraphqlTypeExtension(
                         any_graphql_type_extension,

--- a/crates/biome_grit_syntax/src/generated/nodes.rs
+++ b/crates/biome_grit_syntax/src/generated/nodes.rs
@@ -11328,11 +11328,14 @@ impl AstNode for AnyGritPredicateMatchSubject {
         }
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if let Some(any_grit_container) = AnyGritContainer::cast(syntax.clone()) {
-            return Some(AnyGritPredicateMatchSubject::AnyGritContainer(
-                any_grit_container,
-            ));
-        }
+        let syntax = match AnyGritContainer::try_cast(syntax) {
+            Ok(any_grit_container) => {
+                return Some(AnyGritPredicateMatchSubject::AnyGritContainer(
+                    any_grit_container,
+                ));
+            }
+            Err(syntax) => syntax,
+        };
         if let Some(any_grit_literal) = AnyGritLiteral::cast(syntax) {
             return Some(AnyGritPredicateMatchSubject::AnyGritLiteral(
                 any_grit_literal,

--- a/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_tabindex.rs
@@ -195,7 +195,7 @@ fn attribute_has_negative_tabindex(
         AnyJsxAttributeValue::JsxExpressionAttributeValue(value) => {
             let expression = value.expression().ok()?;
             let expression_value =
-                AnyNumberLikeExpression::cast_ref(expression.syntax())?.value()?;
+                AnyNumberLikeExpression::cast(expression.into_syntax())?.value()?;
             Some(is_negative_tabindex(&expression_value))
         }
         _ => None,

--- a/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
@@ -138,12 +138,11 @@ impl Rule for NoPositiveTabindex {
             }
             TabindexProp::JsPropertyObjectMember(js_object_member) => {
                 let expression = js_object_member.value().ok()?;
-                let expression_syntax_node = expression.syntax();
+                let range = expression.range();
                 let expression_value =
-                    AnyNumberLikeExpression::cast_ref(expression_syntax_node)?.value()?;
-
+                    AnyNumberLikeExpression::cast(expression.into_syntax())?.value()?;
                 if !is_tabindex_valid(&expression_value) {
-                    return Some(expression_syntax_node.text_trimmed_range());
+                    return Some(range);
                 }
             }
         }
@@ -214,7 +213,7 @@ fn attribute_has_valid_tabindex(jsx_any_attribute_value: &AnyJsxAttributeValue) 
         AnyJsxAttributeValue::JsxExpressionAttributeValue(value) => {
             let expression = value.expression().ok()?;
             let expression_value =
-                AnyNumberLikeExpression::cast_ref(expression.syntax())?.value()?;
+                AnyNumberLikeExpression::cast(expression.into_syntax())?.value()?;
 
             Some(is_tabindex_valid(&expression_value))
         }

--- a/crates/biome_js_analyze/src/lint/complexity/no_for_each.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_for_each.rs
@@ -81,7 +81,7 @@ impl Rule for NoForEach {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let member_expression =
-            AnyJsMemberExpression::cast_ref(node.callee().ok()?.omit_parentheses().syntax())?;
+            AnyJsMemberExpression::cast(node.callee().ok()?.omit_parentheses().into_syntax())?;
         if member_expression.member_name()?.text() != "forEach" {
             return None;
         }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -135,12 +135,11 @@ impl Rule for NoUselessFragments {
                                 if JsxExpressionAttributeValue::can_cast(parent.kind()) {
                                     in_jsx_attr_expr = true;
                                 }
-                                if let Some(parenthesized_expression) =
-                                    JsParenthesizedExpression::cast_ref(&parent)
-                                {
-                                    parenthesized_expression.syntax().parent()
-                                } else {
-                                    Some(parent)
+                                match JsParenthesizedExpression::try_cast(parent) {
+                                    Ok(parenthesized_expression) => {
+                                        parenthesized_expression.syntax().parent()
+                                    }
+                                    Err(parent) => Some(parent),
                                 }
                             })
                             .map_or(false, |parent| {

--- a/crates/biome_js_analyze/src/lint/complexity/use_flat_map.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_flat_map.rs
@@ -70,7 +70,7 @@ impl Rule for UseFlatMap {
             }
         }
         let flat_member_expression =
-            AnyJsMemberExpression::cast_ref(flat_call.callee().ok()?.syntax())?;
+            AnyJsMemberExpression::cast(flat_call.callee().ok()?.into_syntax())?;
         if flat_member_expression.member_name()?.text() == "flat" {
             let Ok(AnyJsExpression::JsCallExpression(map_call)) = flat_member_expression.object()
             else {
@@ -78,7 +78,7 @@ impl Rule for UseFlatMap {
             };
             let map_call_arguments = map_call.arguments().ok()?.args();
             let map_member_expression =
-                AnyJsMemberExpression::cast_ref(map_call.callee().ok()?.syntax())?;
+                AnyJsMemberExpression::cast(map_call.callee().ok()?.into_syntax())?;
             if map_member_expression.member_name()?.text() == "map" && map_call_arguments.len() == 1
             {
                 return Some(map_call);

--- a/crates/biome_js_analyze/src/lint/correctness/no_constant_condition.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_constant_condition.rs
@@ -106,7 +106,7 @@ impl Rule for NoConstantCondition {
         // If the statement contains a valid yield expression returned from a `while`, `for`, or `do...while` statement,
         // we don't need to examine the statement's `test`.
         if let Some(any_js_stmt) = conditional_stmt.body() {
-            if conditional_stmt.is_in_generator_function().unwrap_or(false)
+            if conditional_stmt.is_in_generator_function()
                 && has_valid_yield_expression(&any_js_stmt).unwrap_or(false)
             {
                 return None;
@@ -158,15 +158,15 @@ impl ConditionalStatement {
         }
     }
     // Checks if the self statement is in a generator function
-    fn is_in_generator_function(&self) -> Option<bool> {
-        self.syntax().ancestors().find_map(|node| {
-            if let Some(func_decl) = JsFunctionDeclaration::cast_ref(&node) {
-                return Some(func_decl.star_token().is_some());
-            };
-            if let Some(func_expr) = JsFunctionExpression::cast(node) {
-                return Some(func_expr.star_token().is_some());
-            };
-            None
+    fn is_in_generator_function(&self) -> bool {
+        self.syntax().ancestors().any(|node| {
+            match JsFunctionDeclaration::try_cast(node) {
+                Ok(func_decl) => func_decl.star_token(),
+                Err(node) => {
+                    JsFunctionExpression::cast(node).and_then(|func_expr| func_expr.star_token())
+                }
+            }
+            .is_some()
         })
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_constant_math_min_max_clamp.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_constant_math_min_max_clamp.rs
@@ -147,7 +147,7 @@ fn get_math_min_or_max_call(
     model: &SemanticModel,
 ) -> Option<MathMinOrMaxCall> {
     let callee = call_expression.callee().ok()?.omit_parentheses();
-    let member_expr = AnyJsMemberExpression::cast_ref(callee.syntax())?;
+    let member_expr = AnyJsMemberExpression::cast(callee.into_syntax())?;
 
     let member_name = member_expr.member_name()?;
     let member_name = member_name.text();

--- a/crates/biome_js_analyze/src/lint/correctness/no_flat_map_identity.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_flat_map_identity.rs
@@ -55,7 +55,7 @@ impl Rule for NoFlatMapIdentity {
         let flat_map_call = ctx.query();
 
         let flat_map_expression =
-            AnyJsMemberExpression::cast_ref(flat_map_call.callee().ok()?.syntax())?;
+            AnyJsMemberExpression::cast(flat_map_call.callee().ok()?.into_syntax())?;
 
         if flat_map_expression.object().is_err() {
             return None;

--- a/crates/biome_js_analyze/src/lint/correctness/no_string_case_mismatch.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_string_case_mismatch.rs
@@ -184,7 +184,7 @@ impl StringCase {
             return None;
         }
         let callee = call.callee().ok()?;
-        let member_expr = AnyJsMemberExpression::cast_ref(callee.syntax())?;
+        let member_expr = AnyJsMemberExpression::cast(callee.into_syntax())?;
         let member_name = member_expr.member_name()?;
         let member_name = member_name.text();
         if member_name == "toLowerCase" {

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
@@ -265,22 +265,22 @@ impl AnyMember {
                     AnyJsClassMember::JsGetterClassMember(member) => member
                         .modifiers()
                         .iter()
-                        .filter_map(|x| TsAccessibilityModifier::cast_ref(x.syntax()))
+                        .filter_map(|x| TsAccessibilityModifier::cast(x.into_syntax()))
                         .any(|accessibility| accessibility.is_private()),
                     AnyJsClassMember::JsMethodClassMember(member) => member
                         .modifiers()
                         .iter()
-                        .filter_map(|x| TsAccessibilityModifier::cast_ref(x.syntax()))
+                        .filter_map(|x| TsAccessibilityModifier::cast(x.into_syntax()))
                         .any(|accessibility| accessibility.is_private()),
                     AnyJsClassMember::JsPropertyClassMember(member) => member
                         .modifiers()
                         .iter()
-                        .filter_map(|x| TsAccessibilityModifier::cast_ref(x.syntax()))
+                        .filter_map(|x| TsAccessibilityModifier::cast(x.into_syntax()))
                         .any(|accessibility| accessibility.is_private()),
                     AnyJsClassMember::JsSetterClassMember(member) => member
                         .modifiers()
                         .iter()
-                        .filter_map(|x| TsAccessibilityModifier::cast_ref(x.syntax()))
+                        .filter_map(|x| TsAccessibilityModifier::cast(x.into_syntax()))
                         .any(|accessibility| accessibility.is_private()),
                     _ => false,
                 };
@@ -291,7 +291,7 @@ impl AnyMember {
                 param
                     .modifiers()
                     .iter()
-                    .filter_map(|x| TsAccessibilityModifier::cast_ref(x.syntax()))
+                    .filter_map(|x| TsAccessibilityModifier::cast(x.into_syntax()))
                     .any(|accessibility| accessibility.is_private()),
             ),
         }

--- a/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
@@ -115,17 +115,19 @@ fn enclosing_function_if_call_is_at_top_level(
     let mut prev_node = None;
 
     for node in call.syntax().ancestors() {
-        if let Some(enclosing_function) = AnyJsFunctionOrMethod::cast_ref(&node) {
-            return Some(enclosing_function);
-        }
-
-        if let Some(prev_node) = prev_node {
-            if is_conditional_expression(&node, &prev_node) {
-                return None;
+        match AnyJsFunctionOrMethod::try_cast(node) {
+            Ok(enclosing_function) => {
+                return Some(enclosing_function);
+            }
+            Err(node) => {
+                if let Some(prev_node) = prev_node {
+                    if is_conditional_expression(&node, &prev_node) {
+                        return None;
+                    }
+                }
+                prev_node = Some(node);
             }
         }
-
-        prev_node = Some(node);
     }
 
     None

--- a/crates/biome_js_analyze/src/lint/correctness/use_is_nan.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_is_nan.rs
@@ -296,7 +296,7 @@ fn has_nan(expr: AnyJsExpression, model: &SemanticModel) -> bool {
             }
             reference
         } else {
-            let member_expr = AnyJsMemberExpression::cast_ref(expr.syntax())?;
+            let member_expr = AnyJsMemberExpression::cast(expr.into_syntax())?;
             if member_expr.member_name()?.text() != "NaN" {
                 return None;
             }

--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -257,7 +257,7 @@ fn handle_potential_react_component(
     }
 
     if is_inside_jsx {
-        if let Some(node) = ReactComponentExpression::cast_ref(node.syntax()) {
+        if let Some(node) = ReactComponentExpression::cast(node.into_syntax()) {
             let range = handle_react_component(node, model)?;
             Some(range)
         } else {
@@ -265,7 +265,7 @@ fn handle_potential_react_component(
         }
     } else {
         let range =
-            handle_react_component(ReactComponentExpression::cast_ref(node.syntax())?, model)?;
+            handle_react_component(ReactComponentExpression::cast(node.into_syntax())?, model)?;
         Some(range)
     }
 }
@@ -291,7 +291,7 @@ fn handle_react_component(
 /// ```
 fn handle_jsx_tag(node: &JsxTagExpression, model: &SemanticModel) -> Option<Vec<TextRange>> {
     let tag = node.tag().ok()?;
-    let tag = AnyJsxChild::cast_ref(tag.syntax())?;
+    let tag = AnyJsxChild::cast(tag.into_syntax())?;
     handle_jsx_child(&tag, model)
 }
 

--- a/crates/biome_js_analyze/src/lint/nursery/no_console.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_console.rs
@@ -40,7 +40,7 @@ impl Rule for NoConsole {
         let call_expression = ctx.query();
         let model = ctx.model();
         let callee = call_expression.callee().ok()?;
-        let member_expression = AnyJsMemberExpression::cast_ref(callee.syntax())?;
+        let member_expression = AnyJsMemberExpression::cast(callee.into_syntax())?;
         let object = member_expression.object().ok()?;
         let (reference, name) = global_identifier(&object)?;
         if name.text() != "console" {

--- a/crates/biome_js_analyze/src/lint/nursery/use_date_now.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_date_now.rs
@@ -195,8 +195,7 @@ fn get_new_date_issue(expr: &JsNewExpression) -> Option<(AnyJsExpression, UseDat
         return None;
     }
 
-    let parent = &get_parent_without_parenthesis(expr.syntax())?;
-
+    let parent = get_parent_without_parenthesis(expr.syntax())?;
     match parent {
         AnyJsExpression::JsBinaryExpression(binary_expr) => {
             let operator = binary_expr.operator().ok()?;
@@ -224,7 +223,7 @@ fn get_new_date_issue(expr: &JsNewExpression) -> Option<(AnyJsExpression, UseDat
                     | JsAssignmentOperator::RemainderAssign
                     | JsAssignmentOperator::ExponentAssign
             ) {
-                let any_expr = AnyJsExpression::cast_ref(expr.right().ok()?.syntax())?;
+                let any_expr = AnyJsExpression::cast(expr.right().ok()?.into_syntax())?;
 
                 return Some((any_expr, UseDateNowIssueKind::ReplaceConstructor));
             }
@@ -235,13 +234,13 @@ fn get_new_date_issue(expr: &JsNewExpression) -> Option<(AnyJsExpression, UseDat
             let operator = unary_expr.operator().ok()?;
 
             let syntax = match operator {
-                JsUnaryOperator::Plus => unary_expr.syntax(),
-                JsUnaryOperator::Minus => expr.syntax(),
+                JsUnaryOperator::Plus => unary_expr.into_syntax(),
+                JsUnaryOperator::Minus => expr.syntax().clone(),
                 _ => return None,
             };
 
             Some((
-                AnyJsExpression::cast_ref(syntax)?,
+                AnyJsExpression::cast(syntax)?,
                 UseDateNowIssueKind::ReplaceConstructor,
             ))
         }
@@ -259,7 +258,7 @@ fn get_new_date_issue(expr: &JsNewExpression) -> Option<(AnyJsExpression, UseDat
 
             if call_name == "Number" || call_name == "BigInt" {
                 return Some((
-                    AnyJsExpression::cast_ref(call_expr.syntax())?,
+                    AnyJsExpression::cast(call_expr.into_syntax())?,
                     UseDateNowIssueKind::ReplaceNumberConstructor,
                 ));
             }

--- a/crates/biome_js_analyze/src/lint/performance/no_accumulating_spread.rs
+++ b/crates/biome_js_analyze/src/lint/performance/no_accumulating_spread.rs
@@ -127,7 +127,7 @@ fn is_known_accumulator(node: &JsSpread, model: &SemanticModel) -> Option<bool> 
     }
 
     let callee = call_expression.callee().ok()?;
-    let member_expression = AnyJsMemberExpression::cast_ref(callee.syntax())?;
+    let member_expression = AnyJsMemberExpression::cast(callee.into_syntax())?;
 
     // We only care about `.reduce` and `.reduceRight`.
     let member_name = member_expression.member_name()?;

--- a/crates/biome_js_analyze/src/lint/performance/no_barrel_file.rs
+++ b/crates/biome_js_analyze/src/lint/performance/no_barrel_file.rs
@@ -67,11 +67,11 @@ impl Rule for NoBarrelFile {
         }
         let items = ctx.query().items();
 
-        for i in items {
-            if let Some(export) = JsExport::cast(i.into()) {
+        for item in items {
+            if let Some(export) = JsExport::cast(item.into()) {
                 if let Ok(export_from_clause) = export.export_clause() {
                     if let Some(export_from_clause) =
-                        JsExportFromClause::cast(export_from_clause.clone().into())
+                        JsExportFromClause::cast_ref(export_from_clause.syntax())
                     {
                         if export_from_clause.type_token().is_none() {
                             return Some(export);
@@ -79,7 +79,7 @@ impl Rule for NoBarrelFile {
                     }
 
                     if let Some(export_from_clause) =
-                        JsExportNamedFromClause::cast(export_from_clause.into())
+                        JsExportNamedFromClause::cast(export_from_clause.into_syntax())
                     {
                         if export_from_clause.type_token().is_some() {
                             continue;

--- a/crates/biome_js_analyze/src/lint/style/use_exponentiation_operator.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_exponentiation_operator.rs
@@ -72,7 +72,7 @@ impl Rule for UseExponentiationOperator {
         let node = ctx.query();
         let model = ctx.model();
         let callee = node.callee().ok()?.omit_parentheses();
-        let member_expr = AnyJsMemberExpression::cast_ref(callee.syntax())?;
+        let member_expr = AnyJsMemberExpression::cast(callee.into_syntax())?;
         if member_expr.member_name()?.text() != "pow" {
             return None;
         }

--- a/crates/biome_js_analyze/src/lint/style/use_numeric_literals.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_numeric_literals.rs
@@ -168,7 +168,7 @@ fn get_callee(expr: &JsCallExpression, model: &SemanticModel) -> Option<&'static
         }
         return None;
     }
-    let callee = AnyJsMemberExpression::cast_ref(callee.syntax())?;
+    let callee = AnyJsMemberExpression::cast(callee.into_syntax())?;
     if callee.member_name()?.text() != "parseInt" {
         return None;
     }

--- a/crates/biome_js_analyze/src/lint/style/use_shorthand_assign.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_shorthand_assign.rs
@@ -90,7 +90,7 @@ impl Rule for UseShorthandAssign {
         let binary_expression = match right {
             AnyJsExpression::JsBinaryExpression(binary_expression) => binary_expression,
             AnyJsExpression::JsParenthesizedExpression(param) => {
-                JsBinaryExpression::cast_ref(param.expression().ok()?.syntax())?
+                JsBinaryExpression::cast(param.expression().ok()?.into_syntax())?
             }
             _ => return None,
         };

--- a/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
@@ -263,7 +263,7 @@ fn is_array_method_index(
     call_expression: &JsCallExpression,
 ) -> Option<bool> {
     let member_expression =
-        AnyJsMemberExpression::cast_ref(call_expression.callee().ok()?.syntax())?;
+        AnyJsMemberExpression::cast(call_expression.callee().ok()?.into_syntax())?;
     let name = member_expression.member_name()?;
     let name = name.text();
     if matches!(

--- a/crates/biome_js_analyze/src/lint/suspicious/no_console_log.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_console_log.rs
@@ -53,7 +53,7 @@ impl Rule for NoConsoleLog {
         let call_expression = ctx.query();
         let model = ctx.model();
         let callee = call_expression.callee().ok()?;
-        let member_expression = AnyJsMemberExpression::cast_ref(callee.syntax())?;
+        let member_expression = AnyJsMemberExpression::cast(callee.into_syntax())?;
         if member_expression.member_name()?.text() != "log" {
             return None;
         }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_control_characters_in_regex.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_control_characters_in_regex.rs
@@ -182,7 +182,7 @@ fn collect_control_characters_from_expression(
         let raw_pattern = args
             .next()
             .and_then(|arg| arg.ok())
-            .and_then(|arg| JsStringLiteralExpression::cast_ref(arg.syntax()))
+            .and_then(|arg| JsStringLiteralExpression::cast(arg.into_syntax()))
             .and_then(|js_string_literal| js_string_literal.inner_string_text().ok())?
             .to_string();
 
@@ -191,7 +191,7 @@ fn collect_control_characters_from_expression(
         let regexp_flags = args
             .next()
             .and_then(|arg| arg.ok())
-            .and_then(|arg| JsStringLiteralExpression::cast_ref(arg.syntax()))
+            .and_then(|arg| JsStringLiteralExpression::cast(arg.into_syntax()))
             .map(|js_string_literal| js_string_literal.text())
             .unwrap_or_default();
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_class_members.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_class_members.rs
@@ -189,20 +189,20 @@ impl Rule for NoDuplicateClassMembers {
         let node = ctx.query();
         node.into_iter()
             .filter_map(|member| {
-                let member_definition = AnyClassMemberDefinition::cast_ref(member.syntax())?;
-                let member_name_node = member_definition.name()?;
+                let member = AnyClassMemberDefinition::cast(member.into_syntax())?;
+                let member_name_node = member.name()?;
                 let member_state = MemberState {
                     name: get_member_name(&member_name_node)?.to_string(),
-                    is_static: is_static_member(member_definition.modifiers_list()),
+                    is_static: is_static_member(member.modifiers_list()),
                 };
 
-                let member_type = member_definition.member_type();
+                let member_type = member.member_type();
                 if let Some(stored_members) = defined_members.get_mut(&member_state) {
                     if stored_members.contains(&MemberType::Normal)
                         || stored_members.contains(&member_type)
                         || member_type == MemberType::Normal
                     {
-                        return Some(member_definition);
+                        return Some(member);
                     } else {
                         stored_members.insert(member_type);
                     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_import_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_import_assign.rs
@@ -95,7 +95,7 @@ impl Rule for NoImportAssign {
                 let model = ctx.model();
                 for reference in ident_binding.all_writes(model) {
                     invalid_assign_list.push((
-                        JsIdentifierAssignment::cast(reference.syntax().clone())?,
+                        JsIdentifierAssignment::cast_ref(reference.syntax())?,
                         ident_binding.clone(),
                     ));
                 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misleading_character_class.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misleading_character_class.rs
@@ -131,7 +131,7 @@ impl Rule for NoMisleadingCharacterClass {
                     let raw_regex_pattern = args
                         .next()
                         .and_then(|arg| arg.ok())
-                        .and_then(|arg| JsStringLiteralExpression::cast_ref(arg.syntax()))
+                        .and_then(|arg| JsStringLiteralExpression::cast(arg.into_syntax()))
                         .and_then(|js_string_literal| js_string_literal.inner_string_text().ok())?
                         .to_string();
 
@@ -139,7 +139,7 @@ impl Rule for NoMisleadingCharacterClass {
                     let regexp_flags = args
                         .next()
                         .and_then(|arg| arg.ok())
-                        .and_then(|arg| JsStringLiteralExpression::cast_ref(arg.syntax()))
+                        .and_then(|arg| JsStringLiteralExpression::cast(arg.into_syntax()))
                         .map(|js_string_literal| js_string_literal.text())
                         .unwrap_or_default();
 
@@ -157,7 +157,7 @@ impl Rule for NoMisleadingCharacterClass {
                     let raw_regex_pattern = args
                         .next()
                         .and_then(|arg| arg.ok())
-                        .and_then(|arg| JsStringLiteralExpression::cast_ref(arg.syntax()))
+                        .and_then(|arg| JsStringLiteralExpression::cast(arg.into_syntax()))
                         .and_then(|js_string_literal| js_string_literal.inner_string_text().ok())?
                         .to_string();
 
@@ -166,7 +166,7 @@ impl Rule for NoMisleadingCharacterClass {
                     let regexp_flags = args
                         .next()
                         .and_then(|arg| arg.ok())
-                        .and_then(|arg| JsStringLiteralExpression::cast_ref(arg.syntax()))
+                        .and_then(|arg| JsStringLiteralExpression::cast(arg.into_syntax()))
                         .map(|js_string_literal| js_string_literal.text())
                         .unwrap_or_default();
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misrefactored_shorthand_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misrefactored_shorthand_assign.rs
@@ -79,7 +79,7 @@ impl Rule for NoMisrefactoredShorthandAssign {
         let binary_expression = match right {
             AnyJsExpression::JsBinaryExpression(binary_expression) => binary_expression,
             AnyJsExpression::JsParenthesizedExpression(param) => {
-                JsBinaryExpression::cast_ref(param.expression().ok()?.syntax())?
+                JsBinaryExpression::cast(param.expression().ok()?.into_syntax())?
             }
             _ => return None,
         };

--- a/crates/biome_js_analyze/src/lint/suspicious/no_prototype_builtins.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_prototype_builtins.rs
@@ -64,7 +64,7 @@ impl Rule for NoPrototypeBuiltins {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let call_expr = ctx.query();
         let callee = call_expr.callee().ok()?.omit_parentheses();
-        if let Some(member_expr) = AnyJsMemberExpression::cast_ref(callee.syntax()) {
+        if let Some(member_expr) = AnyJsMemberExpression::cast(callee.into_syntax()) {
             let member_name = member_expr.member_name()?;
             let member_name_text = member_name.text();
             return is_prototype_builtins(member_name_text).then_some(RuleState {

--- a/crates/biome_js_analyze/src/lint/suspicious/use_getter_return.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_getter_return.rs
@@ -113,8 +113,8 @@ impl Rule for UseGetterReturn {
                         }
                     }
                     InstructionKind::Return => {
-                        if let Some(NodeOrToken::Node(ref node)) = instruction.node {
-                            if let Some(ref return_stmt) = JsReturnStatement::cast_ref(node) {
+                        if let Some(NodeOrToken::Node(node)) = &instruction.node {
+                            if let Some(return_stmt) = JsReturnStatement::cast_ref(node) {
                                 if return_stmt.argument().is_none() {
                                     invalid_returns.push(InvalidGetterReturn::EmptyReturn(
                                         return_stmt.range(),

--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -501,8 +501,7 @@ mod test {
                 .filter(|x| x.text_trimmed() == "useRef()")
                 .last()
                 .unwrap();
-            let call = JsCallExpression::cast_ref(&node).unwrap();
-            assert!(is_react_hook_call(&call));
+            assert!(is_react_hook_call(&JsCallExpression::unwrap_cast(node)));
         }
 
         {

--- a/crates/biome_js_analyze/src/syntax/correctness/no_super_without_extends.rs
+++ b/crates/biome_js_analyze/src/syntax/correctness/no_super_without_extends.rs
@@ -33,19 +33,23 @@ impl Rule for NoSuperWithoutExtends {
         let node = ctx.query();
 
         for syntax in node.syntax().ancestors() {
-            // ancestor is class declaration
-            if let Some(class_declaration) = JsClassDeclaration::cast_ref(&syntax) {
-                if class_declaration.extends_clause().is_none() {
-                    return Some(());
+            match JsClassDeclaration::try_cast(syntax) {
+                Ok(class_declaration) => {
+                    // ancestor is class declaration
+                    if class_declaration.extends_clause().is_none() {
+                        return Some(());
+                    }
+                    return None;
                 }
-                return None;
-            }
-            // ancestor is class expression
-            else if let Some(class_expression) = JsClassExpression::cast_ref(&syntax) {
-                if class_expression.extends_clause().is_none() {
-                    return Some(());
+                Err(syntax) => {
+                    // ancestor is class expression
+                    if let Some(class_expression) = JsClassExpression::cast(syntax) {
+                        if class_expression.extends_clause().is_none() {
+                            return Some(());
+                        }
+                        return None;
+                    }
                 }
-                return None;
             }
         }
 

--- a/crates/biome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -420,7 +420,7 @@ pub fn can_avoid_parentheses(arrow: &JsArrowFunctionExpression, f: &mut JsFormat
             && !parameters
                 .as_js_parameters()
                 .and_then(|p| p.items().first()?.ok())
-                .and_then(|p| JsFormalParameter::cast(p.syntax().clone()))
+                .and_then(|p| JsFormalParameter::cast(p.into_syntax()))
                 .is_some_and(|p| {
                     f.context().comments().has_comments(p.syntax())
                         || p.initializer().is_some()

--- a/crates/biome_js_formatter/src/parentheses.rs
+++ b/crates/biome_js_formatter/src/parentheses.rs
@@ -346,7 +346,7 @@ pub(crate) fn get_expression_left_side(
                     })
                 }
                 expression => {
-                    return AnyJsBinaryLikeExpression::cast(expression.syntax().clone()).and_then(
+                    return AnyJsBinaryLikeExpression::cast_ref(expression.syntax()).and_then(
                         |binary_like| match binary_like.left().ok() {
                             Some(AnyJsBinaryLikeLeftExpression::AnyJsExpression(expression)) => {
                                 Some(AnyJsExpressionLeftSide::from(expression))

--- a/crates/biome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/biome_js_formatter/src/utils/assignment_like.rs
@@ -933,7 +933,7 @@ impl AnyJsAssignmentLike {
                 let mut has_leading_comments = comments.has_leading_comments(union_type.syntax());
                 while is_nested_union_type(&union_type)? && !has_leading_comments {
                     if let Some(Ok(inner_union_type)) = union_type.types().last() {
-                        let inner_union_type = TsUnionType::cast_ref(inner_union_type.syntax());
+                        let inner_union_type = TsUnionType::cast(inner_union_type.into_syntax());
                         if let Some(inner_union_type) = inner_union_type {
                             has_leading_comments =
                                 comments.has_leading_comments(inner_union_type.syntax());

--- a/crates/biome_js_syntax/src/jsx_ext.rs
+++ b/crates/biome_js_syntax/src/jsx_ext.rs
@@ -282,9 +282,9 @@ impl JsxAttributeList {
 
     pub fn find_by_name(&self, name_to_lookup: &str) -> SyntaxResult<Option<JsxAttribute>> {
         let attribute = self.iter().find_map(|attribute| {
-            let attribute = JsxAttribute::cast_ref(attribute.syntax())?;
+            let attribute = JsxAttribute::cast(attribute.into_syntax())?;
             let name = attribute.name().ok()?;
-            let name = JsxName::cast_ref(name.syntax())?;
+            let name = JsxName::cast(name.into_syntax())?;
             if name.value_token().ok()?.text_trimmed() == name_to_lookup {
                 Some(attribute)
             } else {
@@ -454,7 +454,7 @@ impl AnyJsxChild {
             }
             AnyJsxChild::JsxElement(element) => {
                 let opening_element = element.opening_element().ok()?;
-                let jsx_element = AnyJsxElement::cast(opening_element.syntax().clone())?;
+                let jsx_element = AnyJsxElement::cast(opening_element.into_syntax())?;
 
                 // We don't check if a component (e.g. <Text aria-hidden />) is using the `aria-hidden` property,
                 // since we don't have enough information about how the property is used.
@@ -462,7 +462,7 @@ impl AnyJsxChild {
                     || !jsx_element.has_truthy_attribute("aria-hidden")
             }
             AnyJsxChild::JsxSelfClosingElement(element) => {
-                let jsx_element = AnyJsxElement::cast(element.syntax().clone())?;
+                let jsx_element = AnyJsxElement::unwrap_cast(element.syntax().clone());
                 jsx_element.is_custom_component()
                     || !jsx_element.has_truthy_attribute("aria-hidden")
             }

--- a/crates/biome_rowan/src/ast/mod.rs
+++ b/crates/biome_rowan/src/ast/mod.rs
@@ -169,7 +169,7 @@ pub trait AstNode: Clone {
     /// builder.finish_node();
     ///
     /// let root_syntax = builder.finish();
-    /// let root = RawLanguageRoot::cast(root_syntax.clone()).expect("Root to be a raw language root");
+    /// let root = RawLanguageRoot::cast_ref(&root_syntax).expect("Root to be a raw language root");
     ///
     /// // Returns `OK` because syntax is a `RawLanguageRoot`
     /// assert_eq!(RawLanguageRoot::try_cast(root.syntax().clone()), Ok(root.clone()));
@@ -178,7 +178,7 @@ pub trait AstNode: Clone {
     /// ```
     fn try_cast(syntax: SyntaxNode<Self::Language>) -> Result<Self, SyntaxNode<Self::Language>> {
         if Self::can_cast(syntax.kind()) {
-            Ok(Self::cast(syntax).expect("Expected casted node because 'can_cast' returned true."))
+            Ok(Self::unwrap_cast(syntax))
         } else {
             Err(syntax)
         }
@@ -202,7 +202,7 @@ pub trait AstNode: Clone {
     /// builder.finish_node();
     ///
     /// let root_syntax = builder.finish();
-    /// let root = RawLanguageRoot::cast(root_syntax.clone()).expect("Root to be a raw language root");
+    /// let root = RawLanguageRoot::cast_ref(&root_syntax).expect("Root to be a raw language root");
     ///
     /// // Returns `OK` because syntax is a `RawLanguageRoot`
     /// assert_eq!(RawLanguageRoot::try_cast_node(root.clone()), Ok(root.clone()));
@@ -212,8 +212,7 @@ pub trait AstNode: Clone {
     /// ```
     fn try_cast_node<T: AstNode<Language = Self::Language>>(node: T) -> Result<Self, T> {
         if Self::can_cast(node.syntax().kind()) {
-            Ok(Self::cast(node.into_syntax())
-                .expect("Expected casted node because 'can_cast' returned true."))
+            Ok(Self::unwrap_cast(node.into_syntax()))
         } else {
             Err(node)
         }

--- a/xtask/codegen/src/generate_nodes.rs
+++ b/xtask/codegen/src/generate_nodes.rs
@@ -416,12 +416,15 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
                     let variant_name = format_ident!("{}", en);
                     let variable_name = format_ident!("{}", Case::Snake.convert(en.as_str()));
                     (
-                        // cast() code
+                        // try_cast() code
                         if i != variant_of_variants.len() - 1 {
                             quote! {
-                            if let Some(#variable_name) = #variant_name::cast(syntax.clone()) {
+                            let syntax = match #variant_name::try_cast(syntax) {
+                                Ok(#variable_name) => {
                                     return Some(#name::#variant_name(#variable_name));
-                            }}
+                                }
+                                Err(syntax) => syntax,
+                            };}
                         } else {
                             // if this is the last variant, do not clone syntax
                             quote! {


### PR DESCRIPTION
## Summary

This PR tries to avoid node cloning by consistently using `cast`, `cast_ref` and `try_cast`.

## Test Plan

CI must pass.
