### PR TITLE
refactor: remove try_cast_node

### DIFF
--- a/crates/biome_js_analyze/src/lint/suspicious/no_exports_in_test.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_exports_in_test.rs
@@ -56,7 +56,7 @@ impl MaybeExport {
             MaybeExport::JsExport(_) => true,
             MaybeExport::JsAssignmentExpression(assignment_expr) => {
                 let left = assignment_expr.left().ok();
-                left.and_then(|left| AnyJsMemberAssignment::try_cast_node(left).ok())
+                left.and_then(|left| AnyJsMemberAssignment::cast(left.into_syntax()))
                     .is_some_and(|member_expr| {
                         let object = member_expr.object().ok();
                         object.is_some_and(|object| match object {

--- a/crates/biome_json_analyze/src/utils.rs
+++ b/crates/biome_json_analyze/src/utils.rs
@@ -1,7 +1,7 @@
 use biome_json_syntax::{JsonMember, JsonMemberList, JsonMemberName, JsonObjectValue};
 use biome_rowan::AstNode;
 
-/// Mathes a JSON member name node against a path
+/// Matches a JSON member name node against a path
 pub fn matches_path(optional_node: Option<&JsonMemberName>, path: &[&str]) -> bool {
     if path.is_empty() {
         return true;
@@ -42,7 +42,7 @@ pub fn matches_path(optional_node: Option<&JsonMemberName>, path: &[&str]) -> bo
                 None
             }
         })
-        .and_then(|p| JsonMember::try_cast(p).ok()?.name().ok());
+        .and_then(|p| JsonMember::cast(p)?.name().ok());
 
     matches_path(optional_parent_node.as_ref(), &path[..path.len() - 1])
 }

--- a/crates/biome_rowan/src/ast/mod.rs
+++ b/crates/biome_rowan/src/ast/mod.rs
@@ -184,40 +184,6 @@ pub trait AstNode: Clone {
         }
     }
 
-    /// Tries to cast the AST `node` into this node.
-    ///
-    /// # Returns
-    /// * [Ok] if the passed node can be cast into this [AstNode]
-    /// * [Err] if the node is of another kind
-    /// ```
-    /// # use biome_rowan::AstNode;
-    /// # use biome_rowan::raw_language::{LiteralExpression, RawLanguageKind, RawLanguageRoot, RawSyntaxTreeBuilder};
-    ///
-    /// let mut builder = RawSyntaxTreeBuilder::new();
-    ///
-    /// builder.start_node(RawLanguageKind::ROOT);
-    /// builder.start_node(RawLanguageKind::LITERAL_EXPRESSION);
-    /// builder.token(RawLanguageKind::STRING_TOKEN, "'abcd'");
-    /// builder.finish_node();
-    /// builder.finish_node();
-    ///
-    /// let root_syntax = builder.finish();
-    /// let root = RawLanguageRoot::cast_ref(&root_syntax).expect("Root to be a raw language root");
-    ///
-    /// // Returns `OK` because syntax is a `RawLanguageRoot`
-    /// assert_eq!(RawLanguageRoot::try_cast_node(root.clone()), Ok(root.clone()));
-    ///
-    /// // Returns `Err` with the node passed to `try_cast_node` because `root` isn't a `LiteralExpression`
-    /// assert_eq!(LiteralExpression::try_cast_node(root.clone()), Err(root.clone()));
-    /// ```
-    fn try_cast_node<T: AstNode<Language = Self::Language>>(node: T) -> Result<Self, T> {
-        if Self::can_cast(node.syntax().kind()) {
-            Ok(Self::unwrap_cast(node.into_syntax()))
-        } else {
-            Err(node)
-        }
-    }
-
     /// Returns the underlying syntax node.
     fn syntax(&self) -> &SyntaxNode<Self::Language>;
 


### PR DESCRIPTION
## Summary

Follow-up of #3520
The PR removes `try_cast_node` (only used once) and replace some `try_cast` with `cast` when it makes sense.

## Test Plan

CI must pass.
