### PR TITLE
refactor(js_formatter): reduce copy by taking ownership in `needs_parentheses_with_parent`

### DIFF
--- a/crates/biome_js_formatter/src/js/assignments/array_assignment_pattern.rs
+++ b/crates/biome_js_formatter/src/js/assignments/array_assignment_pattern.rs
@@ -50,7 +50,7 @@ impl NeedsParentheses for JsArrayAssignmentPattern {
     }
 
     #[inline]
-    fn needs_parentheses_with_parent(&self, _: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/assignments/computed_member_assignment.rs
+++ b/crates/biome_js_formatter/src/js/assignments/computed_member_assignment.rs
@@ -27,7 +27,7 @@ impl NeedsParentheses for JsComputedMemberAssignment {
     }
 
     #[inline]
-    fn needs_parentheses_with_parent(&self, _: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/assignments/identifier_assignment.rs
+++ b/crates/biome_js_formatter/src/js/assignments/identifier_assignment.rs
@@ -22,13 +22,14 @@ impl FormatNodeRule<JsIdentifierAssignment> for FormatJsIdentifierAssignment {
 
 impl NeedsParentheses for JsIdentifierAssignment {
     #[inline]
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         let Ok(name) = self.name_token() else {
             return false;
         };
         match name.text_trimmed() {
-            "async" => JsForOfStatement::cast_ref(parent)
-                .is_some_and(|for_of| for_of.await_token().is_none()),
+            "async" => {
+                JsForOfStatement::cast(parent).is_some_and(|for_of| for_of.await_token().is_none())
+            }
             "let" => parent.kind() == JsSyntaxKind::JS_FOR_OF_STATEMENT,
             _ => false,
         }

--- a/crates/biome_js_formatter/src/js/assignments/object_assignment_pattern.rs
+++ b/crates/biome_js_formatter/src/js/assignments/object_assignment_pattern.rs
@@ -37,7 +37,7 @@ impl NeedsParentheses for JsObjectAssignmentPattern {
     }
 
     #[inline]
-    fn needs_parentheses_with_parent(&self, _: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/assignments/parenthesized_assignment.rs
+++ b/crates/biome_js_formatter/src/js/assignments/parenthesized_assignment.rs
@@ -41,7 +41,7 @@ impl NeedsParentheses for JsParenthesizedAssignment {
     }
 
     #[inline]
-    fn needs_parentheses_with_parent(&self, _: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/assignments/static_member_assignment.rs
+++ b/crates/biome_js_formatter/src/js/assignments/static_member_assignment.rs
@@ -23,7 +23,7 @@ impl NeedsParentheses for JsStaticMemberAssignment {
     }
 
     #[inline]
-    fn needs_parentheses_with_parent(&self, _: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/bogus/bogus_assignment.rs
+++ b/crates/biome_js_formatter/src/js/bogus/bogus_assignment.rs
@@ -14,7 +14,7 @@ impl NeedsParentheses for JsBogusAssignment {
     }
 
     #[inline]
-    fn needs_parentheses_with_parent(&self, _: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/bogus/bogus_expression.rs
+++ b/crates/biome_js_formatter/src/js/bogus/bogus_expression.rs
@@ -14,7 +14,7 @@ impl NeedsParentheses for JsBogusExpression {
     }
 
     #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         self.needs_parentheses()
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/array_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/array_expression.rs
@@ -129,7 +129,7 @@ impl NeedsParentheses for JsArrayExpression {
         false
     }
     #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -821,7 +821,7 @@ impl ArrowFunctionLayout {
 }
 
 impl NeedsParentheses for JsArrowFunctionExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match parent.kind() {
             JsSyntaxKind::TS_AS_EXPRESSION
             | JsSyntaxKind::TS_SATISFIES_EXPRESSION
@@ -830,9 +830,9 @@ impl NeedsParentheses for JsArrowFunctionExpression {
             | JsSyntaxKind::TS_TYPE_ASSERTION_EXPRESSION => true,
 
             _ => {
-                is_conditional_test(self.syntax(), parent)
-                    || update_or_lower_expression_needs_parentheses(self.syntax(), parent)
-                    || is_binary_like_left_or_right(self.syntax(), parent)
+                is_conditional_test(self.syntax(), &parent)
+                    || update_or_lower_expression_needs_parentheses(self.syntax(), &parent)
+                    || is_binary_like_left_or_right(self.syntax(), &parent)
             }
         }
     }

--- a/crates/biome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -27,15 +27,15 @@ impl FormatNodeRule<JsAssignmentExpression> for FormatJsAssignmentExpression {
 }
 
 impl NeedsParentheses for JsAssignmentExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match_ast! {
-            match parent {
+            match &parent {
                 JsAssignmentExpression(_) => false,
                 // `[a = b]`
                 JsComputedMemberName(_) => false,
 
                 JsArrowFunctionExpression(_) => {
-                    is_arrow_function_body(self.syntax(), parent)
+                    is_arrow_function_body(self.syntax(), &parent)
                 },
 
                 JsForStatement(for_statement) => {

--- a/crates/biome_js_formatter/src/js/expressions/await_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/await_expression.rs
@@ -61,8 +61,8 @@ impl FormatNodeRule<JsAwaitExpression> for FormatJsAwaitExpression {
 }
 
 impl NeedsParentheses for JsAwaitExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
-        await_or_yield_needs_parens(parent, self.syntax())
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+        await_or_yield_needs_parens(&parent, self.syntax())
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/bigint_literal_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/bigint_literal_expression.rs
@@ -47,7 +47,7 @@ impl NeedsParentheses for JsBigintLiteralExpression {
     }
 
     #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/binary_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/binary_expression.rs
@@ -22,8 +22,8 @@ impl FormatNodeRule<JsBinaryExpression> for FormatJsBinaryExpression {
 }
 
 impl NeedsParentheses for JsBinaryExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
-        needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()), parent)
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+        needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()), &parent)
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/boolean_literal_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/boolean_literal_expression.rs
@@ -30,7 +30,7 @@ impl NeedsParentheses for JsBooleanLiteralExpression {
         false
     }
     #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/call_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/call_expression.rs
@@ -61,7 +61,7 @@ impl FormatNodeRule<JsCallExpression> for FormatJsCallExpression {
 }
 
 impl NeedsParentheses for JsCallExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         matches!(parent.kind(), JsSyntaxKind::JS_NEW_EXPRESSION)
             || (parent.kind() == JsSyntaxKind::JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE
                 && self.callee().map_or(true, |callee| {

--- a/crates/biome_js_formatter/src/js/expressions/class_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/class_expression.rs
@@ -44,9 +44,9 @@ impl FormatNodeRule<JsClassExpression> for FormatJsClassExpression {
 }
 
 impl NeedsParentheses for JsClassExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         (parent.kind() == JsSyntaxKind::JS_EXTENDS_CLAUSE && !self.decorators().is_empty())
-            || is_callee(self.syntax(), parent)
+            || is_callee(self.syntax(), &parent)
             || is_first_in_statement(
                 self.clone().into(),
                 FirstInStatementMode::ExpressionOrExportDefault,

--- a/crates/biome_js_formatter/src/js/expressions/computed_member_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/computed_member_expression.rs
@@ -74,12 +74,12 @@ impl Format<JsFormatContext> for FormatComputedMemberLookup<'_> {
 }
 
 impl NeedsParentheses for JsComputedMemberExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         if matches!(parent.kind(), JsSyntaxKind::JS_NEW_EXPRESSION) && self.is_optional_chain() {
             return true;
         }
 
-        member_chain_callee_needs_parens(self.clone().into(), parent)
+        member_chain_callee_needs_parens(self.clone().into(), &parent)
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/conditional_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/conditional_expression.rs
@@ -40,7 +40,7 @@ impl FormatNodeRule<JsConditionalExpression> for FormatJsConditionalExpression {
 }
 
 impl NeedsParentheses for JsConditionalExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match parent.kind() {
             JsSyntaxKind::JS_UNARY_EXPRESSION
             | JsSyntaxKind::JS_AWAIT_EXPRESSION
@@ -49,10 +49,10 @@ impl NeedsParentheses for JsConditionalExpression {
             | JsSyntaxKind::TS_SATISFIES_EXPRESSION => true,
 
             _ => {
-                is_conditional_test(self.syntax(), parent)
-                    || update_or_lower_expression_needs_parentheses(self.syntax(), parent)
-                    || is_binary_like_left_or_right(self.syntax(), parent)
-                    || is_spread(self.syntax(), parent)
+                is_conditional_test(self.syntax(), &parent)
+                    || update_or_lower_expression_needs_parentheses(self.syntax(), &parent)
+                    || is_binary_like_left_or_right(self.syntax(), &parent)
+                    || is_spread(self.syntax(), &parent)
             }
         }
     }

--- a/crates/biome_js_formatter/src/js/expressions/function_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/function_expression.rs
@@ -34,9 +34,9 @@ impl FormatNodeRule<JsFunctionExpression> for FormatJsFunctionExpression {
 }
 
 impl NeedsParentheses for JsFunctionExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
-        is_callee(self.syntax(), parent)
-            || is_tag(self.syntax(), parent)
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+        is_callee(self.syntax(), &parent)
+            || is_tag(self.syntax(), &parent)
             || is_first_in_statement(
                 self.clone().into(),
                 FirstInStatementMode::ExpressionOrExportDefault,

--- a/crates/biome_js_formatter/src/js/expressions/identifier_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/identifier_expression.rs
@@ -23,7 +23,7 @@ impl FormatNodeRule<JsIdentifierExpression> for FormatJsIdentifierExpression {
 }
 
 impl NeedsParentheses for JsIdentifierExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         let Ok(name) = self.name().and_then(|x| x.value_token()) else {
             return false;
         };

--- a/crates/biome_js_formatter/src/js/expressions/import_call_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/import_call_expression.rs
@@ -24,7 +24,7 @@ impl FormatNodeRule<JsImportCallExpression> for FormatJsImportCallExpression {
 }
 
 impl NeedsParentheses for JsImportCallExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         matches!(parent.kind(), JsSyntaxKind::JS_NEW_EXPRESSION)
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/import_meta_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/import_meta_expression.rs
@@ -36,7 +36,7 @@ impl NeedsParentheses for JsImportMetaExpression {
         false
     }
 
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/in_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/in_expression.rs
@@ -20,12 +20,12 @@ impl FormatNodeRule<JsInExpression> for FormatJsInExpression {
 }
 
 impl NeedsParentheses for JsInExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         if is_in_for_initializer(self) {
             return true;
         }
 
-        needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()), parent)
+        needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()), &parent)
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/instanceof_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/instanceof_expression.rs
@@ -22,8 +22,8 @@ impl FormatNodeRule<JsInstanceofExpression> for FormatJsInstanceofExpression {
 }
 
 impl NeedsParentheses for JsInstanceofExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
-        needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()), parent)
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+        needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()), &parent)
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/logical_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/logical_expression.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use crate::utils::{needs_binary_like_parentheses, AnyJsBinaryLikeExpression};
 
 use crate::parentheses::NeedsParentheses;
-use biome_js_syntax::{JsLogicalExpression, JsLogicalOperator, JsSyntaxKind, JsSyntaxNode};
+use biome_js_syntax::{JsLogicalExpression, JsSyntaxNode};
 use biome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
@@ -23,14 +23,13 @@ impl FormatNodeRule<JsLogicalExpression> for FormatJsLogicalExpression {
 }
 
 impl NeedsParentheses for JsLogicalExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
-        if let Some(parent) = JsLogicalExpression::cast_ref(parent) {
-            parent.operator() != self.operator()
-        } else if parent.kind() == JsSyntaxKind::JS_LOGICAL_EXPRESSION {
-            self.operator()
-                .is_ok_and(|operator| operator == JsLogicalOperator::NullishCoalescing)
-        } else {
-            needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()), parent)
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+        match JsLogicalExpression::try_cast(parent) {
+            Ok(parent) => parent.operator() != self.operator(),
+            Err(parent) => needs_binary_like_parentheses(
+                &AnyJsBinaryLikeExpression::from(self.clone()),
+                &parent,
+            ),
         }
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/new_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/new_expression.rs
@@ -43,7 +43,7 @@ impl FormatNodeRule<JsNewExpression> for FormatJsNewExpression {
 }
 
 impl NeedsParentheses for JsNewExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         matches!(parent.kind(), JsSyntaxKind::JS_EXTENDS_CLAUSE)
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/new_target_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/new_target_expression.rs
@@ -36,7 +36,7 @@ impl NeedsParentheses for JsNewTargetExpression {
         false
     }
 
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/null_literal_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/null_literal_expression.rs
@@ -26,7 +26,7 @@ impl NeedsParentheses for JsNullLiteralExpression {
         false
     }
     #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/number_literal_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/number_literal_expression.rs
@@ -24,8 +24,8 @@ impl FormatNodeRule<JsNumberLiteralExpression> for FormatJsNumberLiteralExpressi
 }
 
 impl NeedsParentheses for JsNumberLiteralExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
-        is_member_object(self.syntax(), parent)
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+        is_member_object(self.syntax(), &parent)
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/object_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/object_expression.rs
@@ -27,7 +27,7 @@ impl FormatNodeRule<JsObjectExpression> for FormatJsObjectExpression {
 }
 
 impl NeedsParentheses for JsObjectExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         matches!(parent.kind(), JsSyntaxKind::JS_EXTENDS_CLAUSE)
             || is_first_in_statement(
                 self.clone().into(),

--- a/crates/biome_js_formatter/src/js/expressions/parenthesized_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/parenthesized_expression.rs
@@ -64,7 +64,7 @@ impl NeedsParentheses for JsParenthesizedExpression {
     }
 
     #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/post_update_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/post_update_expression.rs
@@ -24,8 +24,8 @@ impl FormatNodeRule<JsPostUpdateExpression> for FormatJsPostUpdateExpression {
 }
 
 impl NeedsParentheses for JsPostUpdateExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
-        unary_like_expression_needs_parentheses(self.syntax(), parent)
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+        unary_like_expression_needs_parentheses(self.syntax(), &parent)
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/pre_update_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/pre_update_expression.rs
@@ -27,9 +27,9 @@ impl FormatNodeRule<JsPreUpdateExpression> for FormatJsPreUpdateExpression {
 }
 
 impl NeedsParentheses for JsPreUpdateExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match_ast! {
-            match parent {
+            match &parent {
                 JsUnaryExpression(unary) => {
                     let parent_operator = unary.operator();
                     let operator = self.operator();
@@ -40,7 +40,7 @@ impl NeedsParentheses for JsPreUpdateExpression {
                             && operator == Ok(JsPreUpdateOperator::Decrement))
                 },
                 _ => {
-                    unary_like_expression_needs_parentheses(self.syntax(), parent)
+                    unary_like_expression_needs_parentheses(self.syntax(), &parent)
                 }
             }
         }

--- a/crates/biome_js_formatter/src/js/expressions/regex_literal_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/regex_literal_expression.rs
@@ -53,7 +53,7 @@ impl NeedsParentheses for JsRegexLiteralExpression {
         false
     }
     #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/sequence_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/sequence_expression.rs
@@ -75,7 +75,7 @@ impl FormatNodeRule<JsSequenceExpression> for FormatJsSequenceExpression {
 }
 
 impl NeedsParentheses for JsSequenceExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         !matches!(
             parent.kind(),
             JsSyntaxKind::JS_RETURN_STATEMENT |

--- a/crates/biome_js_formatter/src/js/expressions/static_member_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/static_member_expression.rs
@@ -171,12 +171,12 @@ impl AnyJsStaticMemberLike {
 }
 
 impl NeedsParentheses for JsStaticMemberExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         if matches!(parent.kind(), JsSyntaxKind::JS_NEW_EXPRESSION) && self.is_optional_chain() {
             return true;
         }
 
-        member_chain_callee_needs_parens(self.clone().into(), parent)
+        member_chain_callee_needs_parens(self.clone().into(), &parent)
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/string_literal_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/string_literal_expression.rs
@@ -32,8 +32,8 @@ impl FormatNodeRule<JsStringLiteralExpression> for FormatJsStringLiteralExpressi
 }
 
 impl NeedsParentheses for JsStringLiteralExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
-        if let Some(expression_statement) = JsExpressionStatement::cast_ref(parent) {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+        if let Some(expression_statement) = JsExpressionStatement::cast(parent) {
             return expression_statement
                 .syntax()
                 .parent()

--- a/crates/biome_js_formatter/src/js/expressions/super_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/super_expression.rs
@@ -26,7 +26,7 @@ impl NeedsParentheses for JsSuperExpression {
         false
     }
     #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/template_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/template_expression.rs
@@ -91,9 +91,9 @@ impl AnyJsTemplate {
 
 /// `TemplateLiteral`'s are `PrimaryExpression's that never need parentheses.
 impl NeedsParentheses for JsTemplateExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         if self.tag().is_some() {
-            member_chain_callee_needs_parens(self.clone().into(), parent)
+            member_chain_callee_needs_parens(self.clone().into(), &parent)
         } else {
             false
         }

--- a/crates/biome_js_formatter/src/js/expressions/this_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/this_expression.rs
@@ -25,7 +25,7 @@ impl NeedsParentheses for JsThisExpression {
         false
     }
     #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/unary_expression.rs
@@ -57,9 +57,9 @@ impl FormatNodeRule<JsUnaryExpression> for FormatJsUnaryExpression {
 }
 
 impl NeedsParentheses for JsUnaryExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match_ast! {
-            match parent {
+            match &parent {
                 JsUnaryExpression(parent_unary) => {
                     let parent_operator = parent_unary.operator();
                     let operator = self.operator();
@@ -74,7 +74,7 @@ impl NeedsParentheses for JsUnaryExpression {
                 // so format to `(!foo) in bar` to what is really happening
                 JsInExpression(_) => true,
                 _ => {
-                    unary_like_expression_needs_parentheses(self.syntax(), parent)
+                    unary_like_expression_needs_parentheses(self.syntax(), &parent)
                 }
             }
         }

--- a/crates/biome_js_formatter/src/js/expressions/yield_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/yield_expression.rs
@@ -25,9 +25,9 @@ impl FormatNodeRule<JsYieldExpression> for FormatJsYieldExpression {
 }
 
 impl NeedsParentheses for JsYieldExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         matches!(parent.kind(), JsSyntaxKind::JS_AWAIT_EXPRESSION)
-            || await_or_yield_needs_parens(parent, self.syntax())
+            || await_or_yield_needs_parens(&parent, self.syntax())
             || parent.kind() == JsSyntaxKind::TS_TYPE_ASSERTION_EXPRESSION
     }
 }

--- a/crates/biome_js_formatter/src/jsx/expressions/tag_expression.rs
+++ b/crates/biome_js_formatter/src/jsx/expressions/tag_expression.rs
@@ -109,7 +109,7 @@ pub fn should_expand(expression: &JsxTagExpression) -> bool {
 }
 
 impl NeedsParentheses for JsxTagExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match parent.kind() {
             JsSyntaxKind::JS_BINARY_EXPRESSION => {
                 let binary = JsBinaryExpression::unwrap_cast(parent.clone());
@@ -129,7 +129,7 @@ impl NeedsParentheses for JsxTagExpression {
             | JsSyntaxKind::JS_SPREAD
             | JsSyntaxKind::JSX_SPREAD_ATTRIBUTE
             | JsSyntaxKind::JSX_SPREAD_CHILD => true,
-            _ => is_callee(self.syntax(), parent) || is_tag(self.syntax(), parent),
+            _ => is_callee(self.syntax(), &parent) || is_tag(self.syntax(), &parent),
         }
     }
 }

--- a/crates/biome_js_formatter/src/parentheses.rs
+++ b/crates/biome_js_formatter/src/parentheses.rs
@@ -56,13 +56,13 @@ pub trait NeedsParentheses: AstNode<Language = JsLanguage> {
     fn needs_parentheses(&self) -> bool {
         self.syntax()
             .parent()
-            .map_or(false, |parent| self.needs_parentheses_with_parent(&parent))
+            .map_or(false, |parent| self.needs_parentheses_with_parent(parent))
     }
 
     /// Returns `true` if this node requires parentheses to form valid syntax or improve readability.
     ///
     /// Returns `false` if the parentheses can be omitted safely without changing semantics.
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool;
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool;
 }
 
 impl NeedsParentheses for AnyJsLiteralExpression {
@@ -87,7 +87,7 @@ impl NeedsParentheses for AnyJsLiteralExpression {
     }
 
     #[inline]
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match self {
             AnyJsLiteralExpression::JsBigintLiteralExpression(big_int) => {
                 big_int.needs_parentheses_with_parent(parent)
@@ -166,7 +166,7 @@ impl NeedsParentheses for AnyJsExpression {
         }
     }
 
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match self {
             AnyJsExpression::JsImportMetaExpression(meta) => {
                 meta.needs_parentheses_with_parent(parent)
@@ -278,7 +278,7 @@ declare_node_union! {
 }
 
 impl NeedsParentheses for AnyJsExpressionLeftSide {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match self {
             AnyJsExpressionLeftSide::AnyJsExpression(expression) => {
                 expression.needs_parentheses_with_parent(parent)
@@ -894,7 +894,7 @@ impl NeedsParentheses for AnyJsAssignment {
         }
     }
 
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match self {
             AnyJsAssignment::JsComputedMemberAssignment(assignment) => {
                 assignment.needs_parentheses_with_parent(parent)
@@ -940,7 +940,7 @@ impl NeedsParentheses for AnyJsAssignmentPattern {
         }
     }
 
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match self {
             AnyJsAssignmentPattern::AnyJsAssignment(assignment) => {
                 assignment.needs_parentheses_with_parent(parent)
@@ -996,7 +996,7 @@ impl NeedsParentheses for AnyTsType {
         }
     }
 
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match self {
             AnyTsType::TsAnyType(ty) => ty.needs_parentheses_with_parent(parent),
             AnyTsType::TsArrayType(ty) => ty.needs_parentheses_with_parent(parent),

--- a/crates/biome_js_formatter/src/ts/assignments/as_assignment.rs
+++ b/crates/biome_js_formatter/src/ts/assignments/as_assignment.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsAsAssignment> for FormatTsAsAssignment {
 }
 
 impl NeedsParentheses for TsAsAssignment {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         TsAsOrSatisfiesAssignment::from(self.clone()).needs_parentheses_with_parent(parent)
     }
 }
@@ -46,7 +46,7 @@ impl Format<JsFormatContext> for TsAsOrSatisfiesAssignment {
 }
 
 impl NeedsParentheses for TsAsOrSatisfiesAssignment {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         matches!(
             parent.kind(),
             JsSyntaxKind::JS_ASSIGNMENT_EXPRESSION

--- a/crates/biome_js_formatter/src/ts/assignments/non_null_assertion_assignment.rs
+++ b/crates/biome_js_formatter/src/ts/assignments/non_null_assertion_assignment.rs
@@ -33,7 +33,7 @@ impl NeedsParentheses for TsNonNullAssertionAssignment {
     }
 
     #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/assignments/satisfies_assignment.rs
+++ b/crates/biome_js_formatter/src/ts/assignments/satisfies_assignment.rs
@@ -19,7 +19,7 @@ impl FormatNodeRule<TsSatisfiesAssignment> for FormatTsSatisfiesAssignment {
 }
 
 impl NeedsParentheses for TsSatisfiesAssignment {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         TsAsOrSatisfiesAssignment::from(self.clone()).needs_parentheses_with_parent(parent)
     }
 }

--- a/crates/biome_js_formatter/src/ts/assignments/type_assertion_assignment.rs
+++ b/crates/biome_js_formatter/src/ts/assignments/type_assertion_assignment.rs
@@ -38,7 +38,7 @@ impl FormatNodeRule<TsTypeAssertionAssignment> for FormatTsTypeAssertionAssignme
 }
 
 impl NeedsParentheses for TsTypeAssertionAssignment {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         matches!(
             parent.kind(),
             JsSyntaxKind::JS_ASSIGNMENT_EXPRESSION

--- a/crates/biome_js_formatter/src/ts/bogus/bogus_type.rs
+++ b/crates/biome_js_formatter/src/ts/bogus/bogus_type.rs
@@ -12,7 +12,7 @@ impl NeedsParentheses for TsBogusType {
         false
     }
 
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/expressions/as_expression.rs
+++ b/crates/biome_js_formatter/src/ts/expressions/as_expression.rs
@@ -23,7 +23,7 @@ impl FormatNodeRule<TsAsExpression> for FormatTsAsExpression {
 }
 
 impl NeedsParentheses for TsAsExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         TsAsOrSatisfiesExpression::from(self.clone()).needs_parentheses_with_parent(parent)
     }
 }
@@ -87,7 +87,7 @@ impl Format<JsFormatContext> for TsAsOrSatisfiesExpression {
 }
 
 impl NeedsParentheses for TsAsOrSatisfiesExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match parent.kind() {
             JsSyntaxKind::JS_CONDITIONAL_EXPRESSION => true,
 
@@ -106,8 +106,8 @@ impl NeedsParentheses for TsAsOrSatisfiesExpression {
             }
 
             _ => {
-                type_cast_like_needs_parens(self.syntax(), parent)
-                    || is_binary_like_left_or_right(self.syntax(), parent)
+                type_cast_like_needs_parens(self.syntax(), &parent)
+                    || is_binary_like_left_or_right(self.syntax(), &parent)
             }
         }
     }

--- a/crates/biome_js_formatter/src/ts/expressions/instantiation_expression.rs
+++ b/crates/biome_js_formatter/src/ts/expressions/instantiation_expression.rs
@@ -1,7 +1,7 @@
 use crate::{parentheses::NeedsParentheses, prelude::*};
 use biome_formatter::write;
 use biome_js_syntax::{
-    AnyJsMemberExpression, TsInstantiationExpression, TsInstantiationExpressionFields,
+    AnyJsMemberExpression, JsSyntaxNode, TsInstantiationExpression, TsInstantiationExpressionFields,
 };
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsInstantiationExpression;
@@ -25,8 +25,8 @@ impl FormatNodeRule<TsInstantiationExpression> for FormatTsInstantiationExpressi
 }
 
 impl NeedsParentheses for TsInstantiationExpression {
-    fn needs_parentheses_with_parent(&self, parent: &biome_js_syntax::JsSyntaxNode) -> bool {
-        let Some(member_expr) = AnyJsMemberExpression::cast_ref(parent) else {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+        let Some(member_expr) = AnyJsMemberExpression::cast(parent) else {
             return false;
         };
         member_expr

--- a/crates/biome_js_formatter/src/ts/expressions/non_null_assertion_expression.rs
+++ b/crates/biome_js_formatter/src/ts/expressions/non_null_assertion_expression.rs
@@ -29,8 +29,8 @@ impl FormatNodeRule<TsNonNullAssertionExpression> for FormatTsNonNullAssertionEx
 }
 
 impl NeedsParentheses for TsNonNullAssertionExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         matches!(parent.kind(), JsSyntaxKind::JS_EXTENDS_CLAUSE)
-            || member_chain_callee_needs_parens(self.clone().into(), parent)
+            || member_chain_callee_needs_parens(self.clone().into(), &parent)
     }
 }

--- a/crates/biome_js_formatter/src/ts/expressions/satisfies_expression.rs
+++ b/crates/biome_js_formatter/src/ts/expressions/satisfies_expression.rs
@@ -18,7 +18,7 @@ impl FormatNodeRule<TsSatisfiesExpression> for FormatTsSatisfiesExpression {
 }
 
 impl NeedsParentheses for TsSatisfiesExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         TsAsOrSatisfiesExpression::from(self.clone()).needs_parentheses_with_parent(parent)
     }
 }

--- a/crates/biome_js_formatter/src/ts/expressions/type_assertion_expression.rs
+++ b/crates/biome_js_formatter/src/ts/expressions/type_assertion_expression.rs
@@ -69,11 +69,11 @@ impl FormatNodeRule<TsTypeAssertionExpression> for FormatTsTypeAssertionExpressi
 }
 
 impl NeedsParentheses for TsTypeAssertionExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match parent.kind() {
             JsSyntaxKind::TS_AS_EXPRESSION => true,
             JsSyntaxKind::TS_SATISFIES_EXPRESSION => true,
-            _ => type_cast_like_needs_parens(self.syntax(), parent),
+            _ => type_cast_like_needs_parens(self.syntax(), &parent),
         }
     }
 }

--- a/crates/biome_js_formatter/src/ts/module/import_type.rs
+++ b/crates/biome_js_formatter/src/ts/module/import_type.rs
@@ -47,7 +47,7 @@ impl FormatNodeRule<TsImportType> for FormatTsImportType {
 }
 
 impl NeedsParentheses for TsImportType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/any_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/any_type.rs
@@ -21,7 +21,7 @@ impl FormatNodeRule<TsAnyType> for FormatTsAnyType {
 
 impl NeedsParentheses for TsAnyType {
     #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/array_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/array_type.rs
@@ -31,7 +31,7 @@ impl FormatNodeRule<TsArrayType> for FormatTsArrayType {
 
 impl NeedsParentheses for TsArrayType {
     #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/asserts_return_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/asserts_return_type.rs
@@ -34,7 +34,7 @@ impl FormatNodeRule<TsAssertsReturnType> for FormatTsAssertsReturnType {
 
 impl NeedsParentheses for TsAssertsReturnType {
     #[inline]
-    fn needs_parentheses_with_parent(&self, _: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/bigint_literal_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/bigint_literal_type.rs
@@ -40,7 +40,7 @@ impl FormatNodeRule<TsBigintLiteralType> for FormatTsBigintLiteralType {
 }
 
 impl NeedsParentheses for TsBigintLiteralType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/bigint_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/bigint_type.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsBigintType> for FormatTsBigintType {
 }
 
 impl NeedsParentheses for TsBigintType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/boolean_literal_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/boolean_literal_type.rs
@@ -19,7 +19,7 @@ impl FormatNodeRule<TsBooleanLiteralType> for FormatTsBooleanLiteralType {
 }
 
 impl NeedsParentheses for TsBooleanLiteralType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/boolean_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/boolean_type.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsBooleanType> for FormatTsBooleanType {
 }
 
 impl NeedsParentheses for TsBooleanType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/conditional_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/conditional_type.rs
@@ -26,7 +26,7 @@ impl FormatNodeRule<TsConditionalType> for FormatTsConditionalType {
 }
 
 impl NeedsParentheses for TsConditionalType {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match parent.kind() {
             JsSyntaxKind::TS_CONDITIONAL_TYPE => {
                 let conditional = TsConditionalType::unwrap_cast(parent.clone());
@@ -37,12 +37,12 @@ impl NeedsParentheses for TsConditionalType {
                     .as_ref()
                     == Ok(self.syntax());
 
-                is_check_type(self.syntax(), parent) || is_extends_type
+                is_check_type(self.syntax(), &parent) || is_extends_type
             }
 
             _ => {
-                is_in_many_type_union_or_intersection_list(self.syntax(), parent)
-                    || operator_type_or_higher_needs_parens(self.syntax(), parent)
+                is_in_many_type_union_or_intersection_list(self.syntax(), &parent)
+                    || operator_type_or_higher_needs_parens(self.syntax(), &parent)
             }
         }
     }

--- a/crates/biome_js_formatter/src/ts/types/constructor_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/constructor_type.rs
@@ -45,8 +45,8 @@ impl FormatNodeRule<TsConstructorType> for FormatTsConstructorType {
 }
 
 impl NeedsParentheses for TsConstructorType {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
-        function_like_type_needs_parentheses(self.syntax(), parent)
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+        function_like_type_needs_parentheses(self.syntax(), &parent)
     }
 }
 

--- a/crates/biome_js_formatter/src/ts/types/function_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/function_type.rs
@@ -60,8 +60,8 @@ impl FormatNodeRule<TsFunctionType> for FormatTsFunctionType {
 }
 
 impl NeedsParentheses for TsFunctionType {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
-        function_like_type_needs_parentheses(self.syntax(), parent)
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+        function_like_type_needs_parentheses(self.syntax(), &parent)
     }
 }
 

--- a/crates/biome_js_formatter/src/ts/types/indexed_access_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/indexed_access_type.rs
@@ -33,7 +33,7 @@ impl FormatNodeRule<TsIndexedAccessType> for FormatTsIndexedAccessType {
 }
 
 impl NeedsParentheses for TsIndexedAccessType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/infer_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/infer_type.rs
@@ -30,7 +30,7 @@ impl FormatNodeRule<TsInferType> for FormatTsInferType {
 }
 
 impl NeedsParentheses for TsInferType {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         if parent.kind() == JsSyntaxKind::TS_REST_TUPLE_TYPE_ELEMENT {
             false
         } else if matches!(
@@ -40,7 +40,7 @@ impl NeedsParentheses for TsInferType {
         ) {
             true
         } else {
-            operator_type_or_higher_needs_parens(self.syntax(), parent)
+            operator_type_or_higher_needs_parens(self.syntax(), &parent)
         }
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/intersection_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/intersection_type.rs
@@ -32,10 +32,10 @@ impl FormatNodeRule<TsIntersectionType> for FormatTsIntersectionType {
 }
 
 impl NeedsParentheses for TsIntersectionType {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         union_or_intersection_type_needs_parentheses(
             self.syntax(),
-            parent,
+            &parent,
             &TsIntersectionOrUnionTypeList::TsIntersectionTypeElementList(self.types()),
         )
     }

--- a/crates/biome_js_formatter/src/ts/types/mapped_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/mapped_type.rs
@@ -96,7 +96,7 @@ impl FormatNodeRule<TsMappedType> for FormatTsMappedType {
 }
 
 impl NeedsParentheses for TsMappedType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/never_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/never_type.rs
@@ -19,7 +19,7 @@ impl FormatNodeRule<TsNeverType> for FormatTsNeverType {
 }
 
 impl NeedsParentheses for TsNeverType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/non_primitive_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/non_primitive_type.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsNonPrimitiveType> for FormatTsNonPrimitiveType {
 }
 
 impl NeedsParentheses for TsNonPrimitiveType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/null_literal_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/null_literal_type.rs
@@ -19,7 +19,7 @@ impl FormatNodeRule<TsNullLiteralType> for FormatTsNullLiteralType {
 }
 
 impl NeedsParentheses for TsNullLiteralType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/number_literal_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/number_literal_type.rs
@@ -26,7 +26,7 @@ impl FormatNodeRule<TsNumberLiteralType> for FormatTsNumberLiteralType {
 }
 
 impl NeedsParentheses for TsNumberLiteralType {
-    fn needs_parentheses_with_parent(&self, _: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/number_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/number_type.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsNumberType> for FormatTsNumberType {
 }
 
 impl NeedsParentheses for TsNumberType {
-    fn needs_parentheses_with_parent(&self, _: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/object_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/object_type.rs
@@ -23,7 +23,7 @@ impl FormatNodeRule<TsObjectType> for FormatTsObjectType {
 }
 
 impl NeedsParentheses for TsObjectType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/parenthesized_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/parenthesized_type.rs
@@ -34,7 +34,7 @@ impl NeedsParentheses for TsParenthesizedType {
     }
 
     #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/reference_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/reference_type.rs
@@ -23,7 +23,7 @@ impl FormatNodeRule<TsReferenceType> for FormatTsReferenceType {
 }
 
 impl NeedsParentheses for TsReferenceType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/string_literal_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/string_literal_type.rs
@@ -27,7 +27,7 @@ impl FormatNodeRule<TsStringLiteralType> for FormatTsStringLiteralType {
 }
 
 impl NeedsParentheses for TsStringLiteralType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/string_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/string_type.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsStringType> for FormatTsStringType {
 }
 
 impl NeedsParentheses for TsStringType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/symbol_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/symbol_type.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsSymbolType> for FormatTsSymbolType {
 }
 
 impl NeedsParentheses for TsSymbolType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/template_literal_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/template_literal_type.rs
@@ -32,7 +32,7 @@ impl FormatNodeRule<TsTemplateLiteralType> for FormatTsTemplateLiteralType {
 }
 
 impl NeedsParentheses for TsTemplateLiteralType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/this_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/this_type.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsThisType> for FormatTsThisType {
 }
 
 impl NeedsParentheses for TsThisType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/tuple_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/tuple_type.rs
@@ -40,7 +40,7 @@ impl FormatNodeRule<TsTupleType> for FormatTsTupleType {
 }
 
 impl NeedsParentheses for TsTupleType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/type_operator_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/type_operator_type.rs
@@ -21,8 +21,8 @@ impl FormatNodeRule<TsTypeOperatorType> for FormatTsTypeOperatorType {
 }
 
 impl NeedsParentheses for TsTypeOperatorType {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
-        operator_type_or_higher_needs_parens(self.syntax(), parent)
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+        operator_type_or_higher_needs_parens(self.syntax(), &parent)
     }
 }
 

--- a/crates/biome_js_formatter/src/ts/types/typeof_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/typeof_type.rs
@@ -35,7 +35,7 @@ impl FormatNodeRule<TsTypeofType> for FormatTsTypeofType {
 }
 
 impl NeedsParentheses for TsTypeofType {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match parent.kind() {
             JsSyntaxKind::TS_ARRAY_TYPE => true,
             // Typeof operators are parenthesized when used as an object type in an indexed access

--- a/crates/biome_js_formatter/src/ts/types/undefined_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/undefined_type.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsUndefinedType> for FormatTsUndefinedType {
 }
 
 impl NeedsParentheses for TsUndefinedType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/union_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/union_type.rs
@@ -156,10 +156,10 @@ impl FormatNodeRule<TsUnionType> for FormatTsUnionType {
 }
 
 impl NeedsParentheses for TsUnionType {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         union_or_intersection_type_needs_parentheses(
             self.syntax(),
-            parent,
+            &parent,
             &TsIntersectionOrUnionTypeList::TsUnionTypeVariantList(self.types()),
         )
     }

--- a/crates/biome_js_formatter/src/ts/types/unknown_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/unknown_type.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsUnknownType> for FormatTsUnknownType {
 }
 
 impl NeedsParentheses for TsUnknownType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/void_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/void_type.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsVoidType> for FormatTsVoidType {
 }
 
 impl NeedsParentheses for TsVoidType {
-    fn needs_parentheses_with_parent(&self, _parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/biome_js_formatter/src/utils/binary_like_expression.rs
@@ -552,7 +552,7 @@ impl From<AnyJsBinaryLikeExpression> for AnyJsExpression {
 }
 
 impl NeedsParentheses for AnyJsBinaryLikeExpression {
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match self {
             AnyJsBinaryLikeExpression::JsLogicalExpression(expression) => {
                 expression.needs_parentheses_with_parent(parent)
@@ -666,7 +666,7 @@ impl NeedsParentheses for AnyJsBinaryLikeLeftExpression {
         }
     }
 
-    fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
+    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
         match self {
             AnyJsBinaryLikeLeftExpression::AnyJsExpression(expression) => {
                 expression.needs_parentheses_with_parent(parent)


### PR DESCRIPTION
## Summary

This is a minor refactoring that reduces node cloning by taking ownership of `parent` in `needs_parentheses_with_parent`

## Test Plan

CI must pass