### PR TITLE
refactor(js_formatter): remove `NeedsParentheses::needs_parentheses_aith_parent`

### DIFF
--- a/crates/biome_js_formatter/src/js/assignments/array_assignment_pattern.rs
+++ b/crates/biome_js_formatter/src/js/assignments/array_assignment_pattern.rs
@@ -2,7 +2,7 @@ use crate::parentheses::NeedsParentheses;
 use crate::prelude::*;
 use biome_formatter::write;
 use biome_js_syntax::JsArrayAssignmentPattern;
-use biome_js_syntax::{JsArrayAssignmentPatternFields, JsSyntaxNode};
+use biome_js_syntax::JsArrayAssignmentPatternFields;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsArrayAssignmentPattern;
@@ -46,11 +46,6 @@ impl FormatNodeRule<JsArrayAssignmentPattern> for FormatJsArrayAssignmentPattern
 impl NeedsParentheses for JsArrayAssignmentPattern {
     #[inline]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-
-    #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/assignments/computed_member_assignment.rs
+++ b/crates/biome_js_formatter/src/js/assignments/computed_member_assignment.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
-use biome_js_syntax::{AnyJsComputedMember, JsComputedMemberAssignment, JsSyntaxNode};
+use biome_js_syntax::{AnyJsComputedMember, JsComputedMemberAssignment};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsComputedMemberAssignment;
@@ -23,11 +23,6 @@ impl FormatNodeRule<JsComputedMemberAssignment> for FormatJsComputedMemberAssign
 impl NeedsParentheses for JsComputedMemberAssignment {
     #[inline]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-
-    #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/assignments/object_assignment_pattern.rs
+++ b/crates/biome_js_formatter/src/js/assignments/object_assignment_pattern.rs
@@ -2,7 +2,7 @@ use crate::parentheses::NeedsParentheses;
 use crate::prelude::*;
 use crate::utils::JsObjectPatternLike;
 use biome_formatter::write;
-use biome_js_syntax::{JsObjectAssignmentPattern, JsSyntaxNode};
+use biome_js_syntax::JsObjectAssignmentPattern;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsObjectAssignmentPattern;
@@ -33,11 +33,6 @@ impl FormatNodeRule<JsObjectAssignmentPattern> for FormatJsObjectAssignmentPatte
 impl NeedsParentheses for JsObjectAssignmentPattern {
     #[inline]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-
-    #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/assignments/parenthesized_assignment.rs
+++ b/crates/biome_js_formatter/src/js/assignments/parenthesized_assignment.rs
@@ -2,7 +2,7 @@ use crate::parentheses::NeedsParentheses;
 use crate::prelude::*;
 use biome_formatter::write;
 use biome_js_syntax::JsParenthesizedAssignment;
-use biome_js_syntax::{JsParenthesizedAssignmentFields, JsSyntaxNode};
+use biome_js_syntax::JsParenthesizedAssignmentFields;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsParenthesizedAssignment;
@@ -37,11 +37,6 @@ impl FormatNodeRule<JsParenthesizedAssignment> for FormatJsParenthesizedAssignme
 impl NeedsParentheses for JsParenthesizedAssignment {
     #[inline]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-
-    #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/assignments/static_member_assignment.rs
+++ b/crates/biome_js_formatter/src/js/assignments/static_member_assignment.rs
@@ -1,7 +1,7 @@
 use crate::js::expressions::static_member_expression::AnyJsStaticMemberLike;
 use crate::parentheses::NeedsParentheses;
 use crate::prelude::*;
-use biome_js_syntax::{JsStaticMemberAssignment, JsSyntaxNode};
+use biome_js_syntax::JsStaticMemberAssignment;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsStaticMemberAssignment;
@@ -19,11 +19,6 @@ impl FormatNodeRule<JsStaticMemberAssignment> for FormatJsStaticMemberAssignment
 impl NeedsParentheses for JsStaticMemberAssignment {
     #[inline]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-
-    #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/bogus/bogus_assignment.rs
+++ b/crates/biome_js_formatter/src/js/bogus/bogus_assignment.rs
@@ -1,6 +1,6 @@
 use crate::parentheses::NeedsParentheses;
 use crate::FormatBogusNodeRule;
-use biome_js_syntax::{JsBogusAssignment, JsSyntaxNode};
+use biome_js_syntax::JsBogusAssignment;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsBogusAssignment;
@@ -10,11 +10,6 @@ impl FormatBogusNodeRule<JsBogusAssignment> for FormatJsBogusAssignment {}
 impl NeedsParentheses for JsBogusAssignment {
     #[inline]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-
-    #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/bogus/bogus_expression.rs
+++ b/crates/biome_js_formatter/src/js/bogus/bogus_expression.rs
@@ -1,6 +1,6 @@
 use crate::parentheses::NeedsParentheses;
 use crate::FormatBogusNodeRule;
-use biome_js_syntax::{JsBogusExpression, JsSyntaxNode};
+use biome_js_syntax::JsBogusExpression;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsBogusExpression;
@@ -11,10 +11,5 @@ impl NeedsParentheses for JsBogusExpression {
     #[inline]
     fn needs_parentheses(&self) -> bool {
         false
-    }
-
-    #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
-        self.needs_parentheses()
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/array_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/array_expression.rs
@@ -2,10 +2,10 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::{write, FormatRuleWithOptions};
+use biome_js_syntax::JsArrayExpression;
 use biome_js_syntax::{
     AnyJsArrayElement, AnyJsExpression, JsArrayElementList, JsArrayExpressionFields,
 };
-use biome_js_syntax::{JsArrayExpression, JsSyntaxNode};
 use biome_rowan::SyntaxResult;
 
 #[derive(Debug, Clone, Default)]
@@ -126,10 +126,6 @@ fn should_break(elements: &JsArrayElementList) -> SyntaxResult<bool> {
 impl NeedsParentheses for JsArrayExpression {
     #[inline(always)]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-    #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -9,7 +9,7 @@ use biome_formatter::write;
 use biome_js_syntax::{
     AnyJsAssignmentPattern, AnyJsForInitializer, JsArrowFunctionExpression, JsAssignmentExpression,
     JsComputedMemberName, JsExpressionStatement, JsForStatement, JsSequenceExpression,
-    JsSyntaxKind, JsSyntaxNode,
+    JsSyntaxKind,
 };
 use biome_rowan::{match_ast, AstNode};
 
@@ -27,7 +27,10 @@ impl FormatNodeRule<JsAssignmentExpression> for FormatJsAssignmentExpression {
 }
 
 impl NeedsParentheses for JsAssignmentExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         match_ast! {
             match &parent {
                 JsAssignmentExpression(_) => false,
@@ -35,7 +38,7 @@ impl NeedsParentheses for JsAssignmentExpression {
                 JsComputedMemberName(_) => false,
 
                 JsArrowFunctionExpression(_) => {
-                    is_arrow_function_body(self.syntax(), &parent)
+                    is_arrow_function_body(self.syntax(), parent)
                 },
 
                 JsForStatement(for_statement) => {

--- a/crates/biome_js_formatter/src/js/expressions/bigint_literal_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/bigint_literal_expression.rs
@@ -5,8 +5,8 @@ use std::borrow::Cow;
 use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
+use biome_js_syntax::JsBigintLiteralExpression;
 use biome_js_syntax::JsBigintLiteralExpressionFields;
-use biome_js_syntax::{JsBigintLiteralExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsBigintLiteralExpression;
@@ -43,11 +43,6 @@ impl FormatNodeRule<JsBigintLiteralExpression> for FormatJsBigintLiteralExpressi
 impl NeedsParentheses for JsBigintLiteralExpression {
     #[inline(always)]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-
-    #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/binary_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/binary_expression.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use crate::utils::{needs_binary_like_parentheses, AnyJsBinaryLikeExpression};
 
 use crate::parentheses::NeedsParentheses;
-use biome_js_syntax::{JsBinaryExpression, JsSyntaxNode};
+use biome_js_syntax::JsBinaryExpression;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsBinaryExpression;
@@ -22,8 +22,8 @@ impl FormatNodeRule<JsBinaryExpression> for FormatJsBinaryExpression {
 }
 
 impl NeedsParentheses for JsBinaryExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()), &parent)
+    fn needs_parentheses(&self) -> bool {
+        needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()))
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/boolean_literal_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/boolean_literal_expression.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
+use biome_js_syntax::JsBooleanLiteralExpression;
 use biome_js_syntax::JsBooleanLiteralExpressionFields;
-use biome_js_syntax::{JsBooleanLiteralExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsBooleanLiteralExpression;
@@ -27,10 +27,6 @@ impl FormatNodeRule<JsBooleanLiteralExpression> for FormatJsBooleanLiteralExpres
 impl NeedsParentheses for JsBooleanLiteralExpression {
     #[inline(always)]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-    #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/call_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/call_expression.rs
@@ -3,9 +3,7 @@ use biome_formatter::write;
 
 use crate::parentheses::{resolve_left_most_expression, NeedsParentheses};
 use crate::utils::member_chain::MemberChain;
-use biome_js_syntax::{
-    AnyJsExpression, JsCallExpression, JsCallExpressionFields, JsSyntaxKind, JsSyntaxNode,
-};
+use biome_js_syntax::{AnyJsExpression, JsCallExpression, JsCallExpressionFields, JsSyntaxKind};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsCallExpression;
@@ -61,17 +59,20 @@ impl FormatNodeRule<JsCallExpression> for FormatJsCallExpression {
 }
 
 impl NeedsParentheses for JsCallExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        matches!(parent.kind(), JsSyntaxKind::JS_NEW_EXPRESSION)
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
+        parent.kind() == JsSyntaxKind::JS_NEW_EXPRESSION
             || (parent.kind() == JsSyntaxKind::JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE
                 && self.callee().map_or(true, |callee| {
-                    let leftmost = resolve_left_most_expression(&callee);
-                    let leftmost = leftmost.syntax();
+                    let callee_range = callee.range();
+                    let leftmost = resolve_left_most_expression(callee);
                     // require parens for iife and
                     // when the leftmost expression is not a class expression or a function expression
-                    callee.syntax() != leftmost
+                    callee_range != leftmost.range()
                         && matches!(
-                            leftmost.kind(),
+                            leftmost.syntax().kind(),
                             JsSyntaxKind::JS_CLASS_EXPRESSION
                                 | JsSyntaxKind::JS_FUNCTION_EXPRESSION
                         )

--- a/crates/biome_js_formatter/src/js/expressions/class_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/class_expression.rs
@@ -5,7 +5,7 @@ use biome_formatter::{format_args, write};
 use crate::parentheses::{
     is_callee, is_first_in_statement, FirstInStatementMode, NeedsParentheses,
 };
-use biome_js_syntax::{JsClassExpression, JsSyntaxKind, JsSyntaxNode};
+use biome_js_syntax::{JsClassExpression, JsSyntaxKind};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsClassExpression;
@@ -44,7 +44,10 @@ impl FormatNodeRule<JsClassExpression> for FormatJsClassExpression {
 }
 
 impl NeedsParentheses for JsClassExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         (parent.kind() == JsSyntaxKind::JS_EXTENDS_CLAUSE && !self.decorators().is_empty())
             || is_callee(self.syntax(), &parent)
             || is_first_in_statement(

--- a/crates/biome_js_formatter/src/js/expressions/computed_member_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/computed_member_expression.rs
@@ -5,7 +5,7 @@ use crate::parentheses::NeedsParentheses;
 use biome_formatter::{format_args, write};
 use biome_js_syntax::{
     AnyJsComputedMember, AnyJsExpression, AnyJsLiteralExpression, JsComputedMemberExpression,
-    JsSyntaxKind, JsSyntaxNode,
+    JsSyntaxKind,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -74,12 +74,12 @@ impl Format<JsFormatContext> for FormatComputedMemberLookup<'_> {
 }
 
 impl NeedsParentheses for JsComputedMemberExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        if matches!(parent.kind(), JsSyntaxKind::JS_NEW_EXPRESSION) && self.is_optional_chain() {
-            return true;
-        }
-
-        member_chain_callee_needs_parens(self.clone().into(), &parent)
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
+        (parent.kind() == JsSyntaxKind::JS_NEW_EXPRESSION && self.is_optional_chain())
+            || member_chain_callee_needs_parens(self.clone().into(), &parent)
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/function_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/function_expression.rs
@@ -6,7 +6,7 @@ use crate::parentheses::{
 };
 
 use biome_formatter::FormatRuleWithOptions;
-use biome_js_syntax::{JsFunctionExpression, JsSyntaxNode};
+use biome_js_syntax::JsFunctionExpression;
 
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct FormatJsFunctionExpression {
@@ -34,7 +34,10 @@ impl FormatNodeRule<JsFunctionExpression> for FormatJsFunctionExpression {
 }
 
 impl NeedsParentheses for JsFunctionExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         is_callee(self.syntax(), &parent)
             || is_tag(self.syntax(), &parent)
             || is_first_in_statement(

--- a/crates/biome_js_formatter/src/js/expressions/identifier_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/identifier_expression.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
 use biome_js_syntax::assign_ext::AnyJsMemberAssignment;
-use biome_js_syntax::{AnyJsExpression, JsIdentifierExpression, JsSyntaxNode};
+use biome_js_syntax::{AnyJsExpression, JsIdentifierExpression};
 use biome_js_syntax::{JsIdentifierExpressionFields, JsSyntaxKind};
 use biome_rowan::SyntaxNodeOptionExt;
 
@@ -23,7 +23,10 @@ impl FormatNodeRule<JsIdentifierExpression> for FormatJsIdentifierExpression {
 }
 
 impl NeedsParentheses for JsIdentifierExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         let Ok(name) = self.name().and_then(|x| x.value_token()) else {
             return false;
         };

--- a/crates/biome_js_formatter/src/js/expressions/import_call_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/import_call_expression.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
 use biome_js_syntax::JsImportCallExpressionFields;
-use biome_js_syntax::{JsImportCallExpression, JsSyntaxKind, JsSyntaxNode};
+use biome_js_syntax::{JsImportCallExpression, JsSyntaxKind};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsImportCallExpression;
@@ -24,7 +24,9 @@ impl FormatNodeRule<JsImportCallExpression> for FormatJsImportCallExpression {
 }
 
 impl NeedsParentheses for JsImportCallExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        matches!(parent.kind(), JsSyntaxKind::JS_NEW_EXPRESSION)
+    fn needs_parentheses(&self) -> bool {
+        self.syntax()
+            .parent()
+            .is_some_and(|parent| parent.kind() == JsSyntaxKind::JS_NEW_EXPRESSION)
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/import_meta_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/import_meta_expression.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
+use biome_js_syntax::JsImportMetaExpression;
 use biome_js_syntax::JsImportMetaExpressionFields;
-use biome_js_syntax::{JsImportMetaExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsImportMetaExpression;
@@ -33,10 +33,6 @@ impl FormatNodeRule<JsImportMetaExpression> for FormatJsImportMetaExpression {
 
 impl NeedsParentheses for JsImportMetaExpression {
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/in_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/in_expression.rs
@@ -3,7 +3,7 @@ use crate::utils::{needs_binary_like_parentheses, AnyJsBinaryLikeExpression};
 
 use crate::parentheses::NeedsParentheses;
 
-use biome_js_syntax::{AnyJsStatement, JsInExpression, JsSyntaxNode};
+use biome_js_syntax::{AnyJsStatement, JsInExpression};
 use biome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
@@ -20,12 +20,11 @@ impl FormatNodeRule<JsInExpression> for FormatJsInExpression {
 }
 
 impl NeedsParentheses for JsInExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         if is_in_for_initializer(self) {
             return true;
         }
-
-        needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()), &parent)
+        needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()))
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/instanceof_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/instanceof_expression.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use crate::utils::{needs_binary_like_parentheses, AnyJsBinaryLikeExpression};
 
 use crate::parentheses::NeedsParentheses;
-use biome_js_syntax::{JsInstanceofExpression, JsSyntaxNode};
+use biome_js_syntax::JsInstanceofExpression;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsInstanceofExpression;
@@ -22,8 +22,8 @@ impl FormatNodeRule<JsInstanceofExpression> for FormatJsInstanceofExpression {
 }
 
 impl NeedsParentheses for JsInstanceofExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()), &parent)
+    fn needs_parentheses(&self) -> bool {
+        needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()))
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/logical_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/logical_expression.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use crate::utils::{needs_binary_like_parentheses, AnyJsBinaryLikeExpression};
 
 use crate::parentheses::NeedsParentheses;
-use biome_js_syntax::{JsLogicalExpression, JsSyntaxNode};
+use biome_js_syntax::JsLogicalExpression;
 use biome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
@@ -23,13 +23,11 @@ impl FormatNodeRule<JsLogicalExpression> for FormatJsLogicalExpression {
 }
 
 impl NeedsParentheses for JsLogicalExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        match JsLogicalExpression::try_cast(parent) {
-            Ok(parent) => parent.operator() != self.operator(),
-            Err(parent) => needs_binary_like_parentheses(
-                &AnyJsBinaryLikeExpression::from(self.clone()),
-                &parent,
-            ),
+    fn needs_parentheses(&self) -> bool {
+        if let Some(parent) = self.parent::<JsLogicalExpression>() {
+            parent.operator() != self.operator()
+        } else {
+            needs_binary_like_parentheses(&AnyJsBinaryLikeExpression::from(self.clone()))
         }
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/new_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/new_expression.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
+use biome_js_syntax::JsNewExpressionFields;
 use biome_js_syntax::{JsNewExpression, JsSyntaxKind};
-use biome_js_syntax::{JsNewExpressionFields, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsNewExpression;
@@ -43,7 +43,9 @@ impl FormatNodeRule<JsNewExpression> for FormatJsNewExpression {
 }
 
 impl NeedsParentheses for JsNewExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        matches!(parent.kind(), JsSyntaxKind::JS_EXTENDS_CLAUSE)
+    fn needs_parentheses(&self) -> bool {
+        self.syntax()
+            .parent()
+            .is_some_and(|node| node.kind() == JsSyntaxKind::JS_EXTENDS_CLAUSE)
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/new_target_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/new_target_expression.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
+use biome_js_syntax::JsNewTargetExpression;
 use biome_js_syntax::JsNewTargetExpressionFields;
-use biome_js_syntax::{JsNewTargetExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsNewTargetExpression;
@@ -33,10 +33,6 @@ impl FormatNodeRule<JsNewTargetExpression> for FormatJsNewTargetExpression {
 
 impl NeedsParentheses for JsNewTargetExpression {
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/null_literal_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/null_literal_expression.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
+use biome_js_syntax::JsNullLiteralExpression;
 use biome_js_syntax::JsNullLiteralExpressionFields;
-use biome_js_syntax::{JsNullLiteralExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsNullLiteralExpression;
@@ -23,10 +23,6 @@ impl FormatNodeRule<JsNullLiteralExpression> for FormatJsNullLiteralExpression {
 impl NeedsParentheses for JsNullLiteralExpression {
     #[inline(always)]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-    #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/number_literal_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/number_literal_expression.rs
@@ -3,7 +3,7 @@ use biome_formatter::token::number::format_number_token;
 
 use crate::parentheses::{is_member_object, NeedsParentheses};
 use biome_js_syntax::JsNumberLiteralExpression;
-use biome_js_syntax::{JsNumberLiteralExpressionFields, JsSyntaxNode};
+use biome_js_syntax::JsNumberLiteralExpressionFields;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsNumberLiteralExpression;
@@ -24,7 +24,10 @@ impl FormatNodeRule<JsNumberLiteralExpression> for FormatJsNumberLiteralExpressi
 }
 
 impl NeedsParentheses for JsNumberLiteralExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         is_member_object(self.syntax(), &parent)
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/object_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/object_expression.rs
@@ -2,7 +2,7 @@ use crate::parentheses::{is_first_in_statement, FirstInStatementMode, NeedsParen
 use crate::prelude::*;
 use crate::utils::JsObjectLike;
 use biome_formatter::write;
-use biome_js_syntax::{JsObjectExpression, JsSyntaxKind, JsSyntaxNode};
+use biome_js_syntax::{JsObjectExpression, JsSyntaxKind};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsObjectExpression;
@@ -27,7 +27,10 @@ impl FormatNodeRule<JsObjectExpression> for FormatJsObjectExpression {
 }
 
 impl NeedsParentheses for JsObjectExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         matches!(parent.kind(), JsSyntaxKind::JS_EXTENDS_CLAUSE)
             || is_first_in_statement(
                 self.clone().into(),

--- a/crates/biome_js_formatter/src/js/expressions/parenthesized_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/parenthesized_expression.rs
@@ -3,7 +3,7 @@ use biome_formatter::{format_args, write, CstFormatContext};
 
 use crate::parentheses::NeedsParentheses;
 use biome_js_syntax::{
-    AnyJsExpression, JsParenthesizedExpression, JsParenthesizedExpressionFields, JsSyntaxNode,
+    AnyJsExpression, JsParenthesizedExpression, JsParenthesizedExpressionFields,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -60,11 +60,6 @@ impl FormatNodeRule<JsParenthesizedExpression> for FormatJsParenthesizedExpressi
 impl NeedsParentheses for JsParenthesizedExpression {
     #[inline(always)]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-
-    #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/post_update_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/post_update_expression.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 use biome_formatter::write;
 
 use crate::parentheses::{unary_like_expression_needs_parentheses, NeedsParentheses};
+use biome_js_syntax::JsPostUpdateExpression;
 use biome_js_syntax::JsPostUpdateExpressionFields;
-use biome_js_syntax::{JsPostUpdateExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsPostUpdateExpression;
@@ -24,8 +24,8 @@ impl FormatNodeRule<JsPostUpdateExpression> for FormatJsPostUpdateExpression {
 }
 
 impl NeedsParentheses for JsPostUpdateExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        unary_like_expression_needs_parentheses(self.syntax(), &parent)
+    fn needs_parentheses(&self) -> bool {
+        unary_like_expression_needs_parentheses(self.syntax())
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/pre_update_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/pre_update_expression.rs
@@ -4,9 +4,8 @@ use crate::prelude::*;
 use biome_formatter::write;
 use biome_js_syntax::JsPreUpdateExpressionFields;
 use biome_js_syntax::{
-    JsPreUpdateExpression, JsPreUpdateOperator, JsSyntaxNode, JsUnaryExpression, JsUnaryOperator,
+    JsPreUpdateExpression, JsPreUpdateOperator, JsUnaryExpression, JsUnaryOperator,
 };
-use biome_rowan::match_ast;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsPreUpdateExpression;
@@ -27,22 +26,16 @@ impl FormatNodeRule<JsPreUpdateExpression> for FormatJsPreUpdateExpression {
 }
 
 impl NeedsParentheses for JsPreUpdateExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        match_ast! {
-            match &parent {
-                JsUnaryExpression(unary) => {
-                    let parent_operator = unary.operator();
-                    let operator = self.operator();
-
-                    (parent_operator == Ok(JsUnaryOperator::Plus)
-                        && operator == Ok(JsPreUpdateOperator::Increment))
-                        || (parent_operator == Ok(JsUnaryOperator::Minus)
-                            && operator == Ok(JsPreUpdateOperator::Decrement))
-                },
-                _ => {
-                    unary_like_expression_needs_parentheses(self.syntax(), &parent)
-                }
-            }
+    fn needs_parentheses(&self) -> bool {
+        if let Some(unary) = self.parent::<JsUnaryExpression>() {
+            let parent_operator = unary.operator();
+            let operator = self.operator();
+            (parent_operator == Ok(JsUnaryOperator::Plus)
+                && operator == Ok(JsPreUpdateOperator::Increment))
+                || (parent_operator == Ok(JsUnaryOperator::Minus)
+                    && operator == Ok(JsPreUpdateOperator::Decrement))
+        } else {
+            unary_like_expression_needs_parentheses(self.syntax())
         }
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/regex_literal_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/regex_literal_expression.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 use biome_formatter::write;
 
 use crate::parentheses::NeedsParentheses;
+use biome_js_syntax::JsRegexLiteralExpression;
 use biome_js_syntax::JsRegexLiteralExpressionFields;
-use biome_js_syntax::{JsRegexLiteralExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsRegexLiteralExpression;
@@ -50,10 +50,6 @@ impl FormatNodeRule<JsRegexLiteralExpression> for FormatJsRegexLiteralExpression
 impl NeedsParentheses for JsRegexLiteralExpression {
     #[inline(always)]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-    #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/sequence_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/sequence_expression.rs
@@ -3,9 +3,7 @@ use crate::prelude::*;
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::{format_args, write};
 use biome_js_syntax::JsSyntaxKind::JS_SEQUENCE_EXPRESSION;
-use biome_js_syntax::{
-    JsSequenceExpression, JsSequenceExpressionFields, JsSyntaxKind, JsSyntaxNode,
-};
+use biome_js_syntax::{JsSequenceExpression, JsSequenceExpressionFields, JsSyntaxKind};
 use biome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
@@ -75,7 +73,10 @@ impl FormatNodeRule<JsSequenceExpression> for FormatJsSequenceExpression {
 }
 
 impl NeedsParentheses for JsSequenceExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         !matches!(
             parent.kind(),
             JsSyntaxKind::JS_RETURN_STATEMENT |

--- a/crates/biome_js_formatter/src/js/expressions/string_literal_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/string_literal_expression.rs
@@ -3,9 +3,9 @@ use crate::prelude::*;
 use crate::utils::{FormatLiteralStringToken, StringLiteralParentKind};
 
 use crate::parentheses::NeedsParentheses;
+use biome_js_syntax::JsStringLiteralExpression;
 use biome_js_syntax::JsStringLiteralExpressionFields;
 use biome_js_syntax::{JsExpressionStatement, JsSyntaxKind};
-use biome_js_syntax::{JsStringLiteralExpression, JsSyntaxNode};
 use biome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
@@ -32,19 +32,20 @@ impl FormatNodeRule<JsStringLiteralExpression> for FormatJsStringLiteralExpressi
 }
 
 impl NeedsParentheses for JsStringLiteralExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        if let Some(expression_statement) = JsExpressionStatement::cast(parent) {
-            return expression_statement
+    fn needs_parentheses(&self) -> bool {
+        if let Some(expression_statement) = self.parent::<JsExpressionStatement>() {
+            expression_statement
                 .syntax()
                 .parent()
-                .map_or(false, |grand_parent| {
+                .is_some_and(|grand_parent| {
                     matches!(
                         grand_parent.kind(),
                         JsSyntaxKind::JS_STATEMENT_LIST | JsSyntaxKind::JS_MODULE_ITEM_LIST
                     )
-                });
+                })
+        } else {
+            false
         }
-        false
     }
 }
 

--- a/crates/biome_js_formatter/src/js/expressions/super_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/super_expression.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 use biome_formatter::write;
 
 use crate::parentheses::NeedsParentheses;
+use biome_js_syntax::JsSuperExpression;
 use biome_js_syntax::JsSuperExpressionFields;
-use biome_js_syntax::{JsSuperExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsSuperExpression;
@@ -23,10 +23,6 @@ impl FormatNodeRule<JsSuperExpression> for FormatJsSuperExpression {
 impl NeedsParentheses for JsSuperExpression {
     #[inline(always)]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-    #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/template_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/template_expression.rs
@@ -4,7 +4,7 @@ use biome_formatter::write;
 use crate::js::expressions::static_member_expression::member_chain_callee_needs_parens;
 use crate::js::lists::template_element_list::FormatJsTemplateElementListOptions;
 use crate::parentheses::NeedsParentheses;
-use biome_js_syntax::{AnyJsExpression, JsSyntaxNode, JsTemplateExpression, TsTemplateLiteralType};
+use biome_js_syntax::{AnyJsExpression, JsTemplateExpression, TsTemplateLiteralType};
 use biome_js_syntax::{JsSyntaxToken, TsTypeArguments};
 use biome_rowan::{declare_node_union, SyntaxResult};
 
@@ -91,8 +91,11 @@ impl AnyJsTemplate {
 
 /// `TemplateLiteral`'s are `PrimaryExpression's that never need parentheses.
 impl NeedsParentheses for JsTemplateExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         if self.tag().is_some() {
+            let Some(parent) = self.syntax().parent() else {
+                return false;
+            };
             member_chain_callee_needs_parens(self.clone().into(), &parent)
         } else {
             false

--- a/crates/biome_js_formatter/src/js/expressions/this_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/this_expression.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 use biome_formatter::write;
 
 use crate::parentheses::NeedsParentheses;
+use biome_js_syntax::JsThisExpression;
 use biome_js_syntax::JsThisExpressionFields;
-use biome_js_syntax::{JsSyntaxNode, JsThisExpression};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsThisExpression;
@@ -22,10 +22,6 @@ impl FormatNodeRule<JsThisExpression> for FormatJsThisExpression {
 impl NeedsParentheses for JsThisExpression {
     #[inline(always)]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-    #[inline(always)]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/unary_expression.rs
@@ -1,14 +1,8 @@
+use crate::parentheses::{unary_like_expression_needs_parentheses, NeedsParentheses};
 use crate::prelude::*;
 use biome_formatter::{format_args, write};
-
-use crate::parentheses::{unary_like_expression_needs_parentheses, NeedsParentheses};
-
-use biome_js_syntax::JsSyntaxNode;
-use biome_js_syntax::JsUnaryExpression;
-use biome_js_syntax::{
-    JsInExpression, JsInstanceofExpression, JsUnaryExpressionFields, JsUnaryOperator,
-};
-use biome_rowan::match_ast;
+use biome_js_syntax::{AnyJsExpression, JsUnaryExpression};
+use biome_js_syntax::{JsUnaryExpressionFields, JsUnaryOperator};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsUnaryExpression;
@@ -57,26 +51,22 @@ impl FormatNodeRule<JsUnaryExpression> for FormatJsUnaryExpression {
 }
 
 impl NeedsParentheses for JsUnaryExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        match_ast! {
-            match &parent {
-                JsUnaryExpression(parent_unary) => {
-                    let parent_operator = parent_unary.operator();
-                    let operator = self.operator();
+    fn needs_parentheses(&self) -> bool {
+        match self.parent::<AnyJsExpression>() {
+            Some(AnyJsExpression::JsUnaryExpression(parent_unary)) => {
+                let parent_operator = parent_unary.operator();
+                let operator = self.operator();
 
-                    matches!(operator, Ok(JsUnaryOperator::Plus | JsUnaryOperator::Minus))
-                        && parent_operator == operator
-                },
-                // A user typing `!foo instanceof Bar` probably intended `!(foo instanceof Bar)`,
-                // so format to `(!foo) instance Bar` to what is really happening
-                JsInstanceofExpression(_) => true,
-                // A user typing `!foo in bar` probably intended `!(foo instanceof Bar)`,
-                // so format to `(!foo) in bar` to what is really happening
-                JsInExpression(_) => true,
-                _ => {
-                    unary_like_expression_needs_parentheses(self.syntax(), &parent)
-                }
+                matches!(operator, Ok(JsUnaryOperator::Plus | JsUnaryOperator::Minus))
+                    && parent_operator == operator
             }
+            // A user typing `!foo instanceof Bar` probably intended `!(foo instanceof Bar)`,
+            // so format to `(!foo) instance Bar` to what is really happening
+            Some(AnyJsExpression::JsInstanceofExpression(_)) => true,
+            // A user typing `!foo in bar` probably intended `!(foo instanceof Bar)`,
+            // so format to `(!foo) in bar` to what is really happening
+            Some(AnyJsExpression::JsInExpression(_)) => true,
+            _ => unary_like_expression_needs_parentheses(self.syntax()),
         }
     }
 }

--- a/crates/biome_js_formatter/src/js/expressions/yield_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/yield_expression.rs
@@ -3,8 +3,8 @@ use biome_formatter::write;
 
 use crate::js::expressions::await_expression::await_or_yield_needs_parens;
 use crate::parentheses::NeedsParentheses;
+use biome_js_syntax::JsYieldExpression;
 use biome_js_syntax::{JsSyntaxKind, JsYieldExpressionFields};
-use biome_js_syntax::{JsSyntaxNode, JsYieldExpression};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsYieldExpression;
@@ -25,10 +25,14 @@ impl FormatNodeRule<JsYieldExpression> for FormatJsYieldExpression {
 }
 
 impl NeedsParentheses for JsYieldExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        matches!(parent.kind(), JsSyntaxKind::JS_AWAIT_EXPRESSION)
-            || await_or_yield_needs_parens(&parent, self.syntax())
-            || parent.kind() == JsSyntaxKind::TS_TYPE_ASSERTION_EXPRESSION
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
+        matches!(
+            parent.kind(),
+            JsSyntaxKind::JS_AWAIT_EXPRESSION | JsSyntaxKind::TS_TYPE_ASSERTION_EXPRESSION
+        ) || await_or_yield_needs_parens(&parent, self.syntax())
     }
 }
 

--- a/crates/biome_js_formatter/src/jsx/expressions/tag_expression.rs
+++ b/crates/biome_js_formatter/src/jsx/expressions/tag_expression.rs
@@ -4,7 +4,7 @@ use crate::utils::jsx::{get_wrap_state, WrapState};
 use biome_formatter::{format_args, write};
 use biome_js_syntax::{
     JsArrowFunctionExpression, JsBinaryExpression, JsBinaryOperator, JsCallArgumentList,
-    JsCallExpression, JsSyntaxKind, JsSyntaxNode, JsxExpressionChild, JsxTagExpression,
+    JsCallExpression, JsSyntaxKind, JsxExpressionChild, JsxTagExpression,
 };
 use biome_rowan::AstNode;
 
@@ -109,7 +109,10 @@ pub fn should_expand(expression: &JsxTagExpression) -> bool {
 }
 
 impl NeedsParentheses for JsxTagExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         match parent.kind() {
             JsSyntaxKind::JS_BINARY_EXPRESSION => {
                 let binary = JsBinaryExpression::unwrap_cast(parent.clone());

--- a/crates/biome_js_formatter/src/ts/assignments/as_assignment.rs
+++ b/crates/biome_js_formatter/src/ts/assignments/as_assignment.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::{format_args, write};
-use biome_js_syntax::{AnyJsAssignment, AnyTsType, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken};
+use biome_js_syntax::{AnyJsAssignment, AnyTsType, JsSyntaxKind, JsSyntaxToken};
 use biome_js_syntax::{TsAsAssignment, TsSatisfiesAssignment};
 use biome_rowan::{declare_node_union, SyntaxResult};
 
@@ -20,8 +20,8 @@ impl FormatNodeRule<TsAsAssignment> for FormatTsAsAssignment {
 }
 
 impl NeedsParentheses for TsAsAssignment {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        TsAsOrSatisfiesAssignment::from(self.clone()).needs_parentheses_with_parent(parent)
+    fn needs_parentheses(&self) -> bool {
+        TsAsOrSatisfiesAssignment::from(self.clone()).needs_parentheses()
     }
 }
 
@@ -46,16 +46,18 @@ impl Format<JsFormatContext> for TsAsOrSatisfiesAssignment {
 }
 
 impl NeedsParentheses for TsAsOrSatisfiesAssignment {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        matches!(
-            parent.kind(),
-            JsSyntaxKind::JS_ASSIGNMENT_EXPRESSION
-                | JsSyntaxKind::TS_NON_NULL_ASSERTION_ASSIGNMENT
-                | JsSyntaxKind::TS_TYPE_ASSERTION_ASSIGNMENT
-                | JsSyntaxKind::JS_PRE_UPDATE_EXPRESSION
-                | JsSyntaxKind::JS_POST_UPDATE_EXPRESSION
-                | JsSyntaxKind::JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY
-        )
+    fn needs_parentheses(&self) -> bool {
+        self.syntax().parent().is_some_and(|parent| {
+            matches!(
+                parent.kind(),
+                JsSyntaxKind::JS_ASSIGNMENT_EXPRESSION
+                    | JsSyntaxKind::TS_NON_NULL_ASSERTION_ASSIGNMENT
+                    | JsSyntaxKind::TS_TYPE_ASSERTION_ASSIGNMENT
+                    | JsSyntaxKind::JS_PRE_UPDATE_EXPRESSION
+                    | JsSyntaxKind::JS_POST_UPDATE_EXPRESSION
+                    | JsSyntaxKind::JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY
+            )
+        })
     }
 }
 

--- a/crates/biome_js_formatter/src/ts/assignments/non_null_assertion_assignment.rs
+++ b/crates/biome_js_formatter/src/ts/assignments/non_null_assertion_assignment.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
+use biome_js_syntax::TsNonNullAssertionAssignment;
 use biome_js_syntax::TsNonNullAssertionAssignmentFields;
-use biome_js_syntax::{JsSyntaxNode, TsNonNullAssertionAssignment};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsNonNullAssertionAssignment;
@@ -29,11 +29,6 @@ impl FormatNodeRule<TsNonNullAssertionAssignment> for FormatTsNonNullAssertionAs
 impl NeedsParentheses for TsNonNullAssertionAssignment {
     #[inline]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-
-    #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/assignments/satisfies_assignment.rs
+++ b/crates/biome_js_formatter/src/ts/assignments/satisfies_assignment.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use crate::ts::assignments::as_assignment::TsAsOrSatisfiesAssignment;
-use biome_js_syntax::JsSyntaxNode;
 use biome_js_syntax::TsSatisfiesAssignment;
 
 #[derive(Debug, Clone, Default)]
@@ -19,14 +18,13 @@ impl FormatNodeRule<TsSatisfiesAssignment> for FormatTsSatisfiesAssignment {
 }
 
 impl NeedsParentheses for TsSatisfiesAssignment {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        TsAsOrSatisfiesAssignment::from(self.clone()).needs_parentheses_with_parent(parent)
+    fn needs_parentheses(&self) -> bool {
+        TsAsOrSatisfiesAssignment::from(self.clone()).needs_parentheses()
     }
 }
 
 #[cfg(test)]
 mod tests {
-
     use crate::assert_needs_parentheses;
     use biome_js_syntax::TsSatisfiesAssignment;
 

--- a/crates/biome_js_formatter/src/ts/assignments/type_assertion_assignment.rs
+++ b/crates/biome_js_formatter/src/ts/assignments/type_assertion_assignment.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxKind, JsSyntaxNode, TsTypeAssertionAssignmentFields};
+use biome_js_syntax::{JsSyntaxKind, TsTypeAssertionAssignmentFields};
 
 use crate::parentheses::NeedsParentheses;
 use biome_js_syntax::TsTypeAssertionAssignment;
@@ -38,7 +38,10 @@ impl FormatNodeRule<TsTypeAssertionAssignment> for FormatTsTypeAssertionAssignme
 }
 
 impl NeedsParentheses for TsTypeAssertionAssignment {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         matches!(
             parent.kind(),
             JsSyntaxKind::JS_ASSIGNMENT_EXPRESSION

--- a/crates/biome_js_formatter/src/ts/bogus/bogus_type.rs
+++ b/crates/biome_js_formatter/src/ts/bogus/bogus_type.rs
@@ -1,6 +1,6 @@
 use crate::parentheses::NeedsParentheses;
 use crate::FormatBogusNodeRule;
-use biome_js_syntax::{JsSyntaxNode, TsBogusType};
+use biome_js_syntax::TsBogusType;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatTsBogusType;
@@ -9,10 +9,6 @@ impl FormatBogusNodeRule<TsBogusType> for FormatTsBogusType {}
 
 impl NeedsParentheses for TsBogusType {
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/expressions/instantiation_expression.rs
+++ b/crates/biome_js_formatter/src/ts/expressions/instantiation_expression.rs
@@ -1,7 +1,7 @@
 use crate::{parentheses::NeedsParentheses, prelude::*};
 use biome_formatter::write;
 use biome_js_syntax::{
-    AnyJsMemberExpression, JsSyntaxNode, TsInstantiationExpression, TsInstantiationExpressionFields,
+    AnyJsMemberExpression, TsInstantiationExpression, TsInstantiationExpressionFields,
 };
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsInstantiationExpression;
@@ -25,13 +25,13 @@ impl FormatNodeRule<TsInstantiationExpression> for FormatTsInstantiationExpressi
 }
 
 impl NeedsParentheses for TsInstantiationExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        let Some(member_expr) = AnyJsMemberExpression::cast(parent) else {
-            return false;
-        };
-        member_expr
-            .object()
-            .map(|object| object.syntax() == self.syntax())
-            .unwrap_or(false)
+    fn needs_parentheses(&self) -> bool {
+        self.parent::<AnyJsMemberExpression>()
+            .is_some_and(|member_expr| {
+                member_expr
+                    .object()
+                    .map(|object| object.syntax() == self.syntax())
+                    .unwrap_or(false)
+            })
     }
 }

--- a/crates/biome_js_formatter/src/ts/expressions/non_null_assertion_expression.rs
+++ b/crates/biome_js_formatter/src/ts/expressions/non_null_assertion_expression.rs
@@ -3,8 +3,8 @@ use crate::prelude::*;
 use crate::js::expressions::static_member_expression::member_chain_callee_needs_parens;
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
+use biome_js_syntax::TsNonNullAssertionExpression;
 use biome_js_syntax::{JsSyntaxKind, TsNonNullAssertionExpressionFields};
-use biome_js_syntax::{JsSyntaxNode, TsNonNullAssertionExpression};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsNonNullAssertionExpression;
@@ -29,7 +29,10 @@ impl FormatNodeRule<TsNonNullAssertionExpression> for FormatTsNonNullAssertionEx
 }
 
 impl NeedsParentheses for TsNonNullAssertionExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         matches!(parent.kind(), JsSyntaxKind::JS_EXTENDS_CLAUSE)
             || member_chain_callee_needs_parens(self.clone().into(), &parent)
     }

--- a/crates/biome_js_formatter/src/ts/expressions/satisfies_expression.rs
+++ b/crates/biome_js_formatter/src/ts/expressions/satisfies_expression.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use crate::ts::expressions::as_expression::TsAsOrSatisfiesExpression;
-use biome_js_syntax::{JsSyntaxNode, TsSatisfiesExpression};
+use biome_js_syntax::TsSatisfiesExpression;
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsSatisfiesExpression;
@@ -18,8 +18,8 @@ impl FormatNodeRule<TsSatisfiesExpression> for FormatTsSatisfiesExpression {
 }
 
 impl NeedsParentheses for TsSatisfiesExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        TsAsOrSatisfiesExpression::from(self.clone()).needs_parentheses_with_parent(parent)
+    fn needs_parentheses(&self) -> bool {
+        TsAsOrSatisfiesExpression::from(self.clone()).needs_parentheses()
     }
 }
 

--- a/crates/biome_js_formatter/src/ts/expressions/type_assertion_expression.rs
+++ b/crates/biome_js_formatter/src/ts/expressions/type_assertion_expression.rs
@@ -69,7 +69,10 @@ impl FormatNodeRule<TsTypeAssertionExpression> for FormatTsTypeAssertionExpressi
 }
 
 impl NeedsParentheses for TsTypeAssertionExpression {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         match parent.kind() {
             JsSyntaxKind::TS_AS_EXPRESSION => true,
             JsSyntaxKind::TS_SATISFIES_EXPRESSION => true,

--- a/crates/biome_js_formatter/src/ts/module/import_type.rs
+++ b/crates/biome_js_formatter/src/ts/module/import_type.rs
@@ -3,8 +3,8 @@ use crate::utils::{FormatLiteralStringToken, StringLiteralParentKind};
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
+use biome_js_syntax::TsImportType;
 use biome_js_syntax::TsImportTypeFields;
-use biome_js_syntax::{JsSyntaxNode, TsImportType};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsImportType;
@@ -47,7 +47,7 @@ impl FormatNodeRule<TsImportType> for FormatTsImportType {
 }
 
 impl NeedsParentheses for TsImportType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/any_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/any_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsAnyType, TsAnyTypeFields};
+use biome_js_syntax::{TsAnyType, TsAnyTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsAnyType;
@@ -21,7 +21,7 @@ impl FormatNodeRule<TsAnyType> for FormatTsAnyType {
 
 impl NeedsParentheses for TsAnyType {
     #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/array_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/array_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsArrayType, TsArrayTypeFields};
+use biome_js_syntax::{TsArrayType, TsArrayTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsArrayType;
@@ -31,7 +31,7 @@ impl FormatNodeRule<TsArrayType> for FormatTsArrayType {
 
 impl NeedsParentheses for TsArrayType {
     #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/asserts_return_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/asserts_return_type.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
+use biome_js_syntax::TsAssertsReturnType;
 use biome_js_syntax::TsAssertsReturnTypeFields;
-use biome_js_syntax::{JsSyntaxNode, TsAssertsReturnType};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsAssertsReturnType;
@@ -34,7 +34,7 @@ impl FormatNodeRule<TsAssertsReturnType> for FormatTsAssertsReturnType {
 
 impl NeedsParentheses for TsAssertsReturnType {
     #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/bigint_literal_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/bigint_literal_type.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::token::string::ToAsciiLowercaseCow;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsBigintLiteralType, TsBigintLiteralTypeFields};
+use biome_js_syntax::{TsBigintLiteralType, TsBigintLiteralTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsBigintLiteralType;
@@ -40,7 +40,7 @@ impl FormatNodeRule<TsBigintLiteralType> for FormatTsBigintLiteralType {
 }
 
 impl NeedsParentheses for TsBigintLiteralType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/bigint_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/bigint_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsBigintType, TsBigintTypeFields};
+use biome_js_syntax::{TsBigintType, TsBigintTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsBigintType;
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsBigintType> for FormatTsBigintType {
 }
 
 impl NeedsParentheses for TsBigintType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/boolean_literal_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/boolean_literal_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsBooleanLiteralType, TsBooleanLiteralTypeFields};
+use biome_js_syntax::{TsBooleanLiteralType, TsBooleanLiteralTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsBooleanLiteralType;
@@ -19,7 +19,7 @@ impl FormatNodeRule<TsBooleanLiteralType> for FormatTsBooleanLiteralType {
 }
 
 impl NeedsParentheses for TsBooleanLiteralType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/boolean_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/boolean_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsBooleanType, TsBooleanTypeFields};
+use biome_js_syntax::{TsBooleanType, TsBooleanTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsBooleanType;
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsBooleanType> for FormatTsBooleanType {
 }
 
 impl NeedsParentheses for TsBooleanType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/conditional_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/conditional_type.rs
@@ -5,7 +5,7 @@ use crate::parentheses::{
     is_check_type, is_in_many_type_union_or_intersection_list,
     operator_type_or_higher_needs_parens, NeedsParentheses,
 };
-use biome_js_syntax::{JsSyntaxKind, JsSyntaxNode, TsConditionalType};
+use biome_js_syntax::{JsSyntaxKind, TsConditionalType};
 use biome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
@@ -26,7 +26,10 @@ impl FormatNodeRule<TsConditionalType> for FormatTsConditionalType {
 }
 
 impl NeedsParentheses for TsConditionalType {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         match parent.kind() {
             JsSyntaxKind::TS_CONDITIONAL_TYPE => {
                 let conditional = TsConditionalType::unwrap_cast(parent.clone());

--- a/crates/biome_js_formatter/src/ts/types/constructor_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/constructor_type.rs
@@ -3,8 +3,8 @@ use crate::prelude::*;
 use crate::parentheses::NeedsParentheses;
 use crate::ts::types::function_type::function_like_type_needs_parentheses;
 use biome_formatter::write;
+use biome_js_syntax::TsConstructorType;
 use biome_js_syntax::TsConstructorTypeFields;
-use biome_js_syntax::{JsSyntaxNode, TsConstructorType};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsConstructorType;
@@ -45,8 +45,8 @@ impl FormatNodeRule<TsConstructorType> for FormatTsConstructorType {
 }
 
 impl NeedsParentheses for TsConstructorType {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        function_like_type_needs_parentheses(self.syntax(), &parent)
+    fn needs_parentheses(&self) -> bool {
+        function_like_type_needs_parentheses(self.syntax())
     }
 }
 

--- a/crates/biome_js_formatter/src/ts/types/function_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/function_type.rs
@@ -60,15 +60,15 @@ impl FormatNodeRule<TsFunctionType> for FormatTsFunctionType {
 }
 
 impl NeedsParentheses for TsFunctionType {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
-        function_like_type_needs_parentheses(self.syntax(), &parent)
+    fn needs_parentheses(&self) -> bool {
+        function_like_type_needs_parentheses(self.syntax())
     }
 }
 
-pub(super) fn function_like_type_needs_parentheses(
-    node: &JsSyntaxNode,
-    parent: &JsSyntaxNode,
-) -> bool {
+pub(super) fn function_like_type_needs_parentheses(node: &JsSyntaxNode) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
     match parent.kind() {
         JsSyntaxKind::TS_RETURN_TYPE_ANNOTATION => {
             let grand_parent = parent.parent();
@@ -78,10 +78,10 @@ pub(super) fn function_like_type_needs_parentheses(
             })
         }
         _ => {
-            is_check_type(node, parent)
-                || is_includes_inferred_return_types_with_extends_constraints(node, parent)
-                || operator_type_or_higher_needs_parens(node, parent)
-                || is_in_many_type_union_or_intersection_list(node, parent)
+            is_check_type(node, &parent)
+                || is_includes_inferred_return_types_with_extends_constraints(node, &parent)
+                || operator_type_or_higher_needs_parens(node, &parent)
+                || is_in_many_type_union_or_intersection_list(node, &parent)
         }
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/indexed_access_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/indexed_access_type.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
+use biome_js_syntax::TsIndexedAccessType;
 use biome_js_syntax::TsIndexedAccessTypeFields;
-use biome_js_syntax::{JsSyntaxNode, TsIndexedAccessType};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsIndexedAccessType;
@@ -33,7 +33,7 @@ impl FormatNodeRule<TsIndexedAccessType> for FormatTsIndexedAccessType {
 }
 
 impl NeedsParentheses for TsIndexedAccessType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/infer_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/infer_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::{operator_type_or_higher_needs_parens, NeedsParentheses};
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxKind, JsSyntaxNode, TsInferType, TsInferTypeFields};
+use biome_js_syntax::{JsSyntaxKind, TsInferType, TsInferTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsInferType;
@@ -30,7 +30,10 @@ impl FormatNodeRule<TsInferType> for FormatTsInferType {
 }
 
 impl NeedsParentheses for TsInferType {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         if parent.kind() == JsSyntaxKind::TS_REST_TUPLE_TYPE_ELEMENT {
             false
         } else if matches!(

--- a/crates/biome_js_formatter/src/ts/types/intersection_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/intersection_type.rs
@@ -6,7 +6,7 @@ use crate::utils::{
     TsIntersectionOrUnionTypeList,
 };
 use biome_formatter::{format_args, write};
-use biome_js_syntax::{JsSyntaxNode, TsIntersectionType, TsIntersectionTypeFields};
+use biome_js_syntax::{TsIntersectionType, TsIntersectionTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsIntersectionType;
@@ -32,10 +32,9 @@ impl FormatNodeRule<TsIntersectionType> for FormatTsIntersectionType {
 }
 
 impl NeedsParentheses for TsIntersectionType {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         union_or_intersection_type_needs_parentheses(
             self.syntax(),
-            &parent,
             &TsIntersectionOrUnionTypeList::TsIntersectionTypeElementList(self.types()),
         )
     }

--- a/crates/biome_js_formatter/src/ts/types/mapped_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/mapped_type.rs
@@ -4,7 +4,7 @@ use crate::parentheses::NeedsParentheses;
 use crate::utils::FormatOptionalSemicolon;
 use biome_formatter::trivia::FormatLeadingComments;
 use biome_formatter::{format_args, write};
-use biome_js_syntax::{JsSyntaxNode, TsMappedType, TsMappedTypeFields};
+use biome_js_syntax::{TsMappedType, TsMappedTypeFields};
 use biome_rowan::Direction;
 
 #[derive(Debug, Clone, Default)]
@@ -96,7 +96,7 @@ impl FormatNodeRule<TsMappedType> for FormatTsMappedType {
 }
 
 impl NeedsParentheses for TsMappedType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/never_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/never_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsNeverType, TsNeverTypeFields};
+use biome_js_syntax::{TsNeverType, TsNeverTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsNeverType;
@@ -19,7 +19,7 @@ impl FormatNodeRule<TsNeverType> for FormatTsNeverType {
 }
 
 impl NeedsParentheses for TsNeverType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/non_primitive_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/non_primitive_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsNonPrimitiveType, TsNonPrimitiveTypeFields};
+use biome_js_syntax::{TsNonPrimitiveType, TsNonPrimitiveTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsNonPrimitiveType;
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsNonPrimitiveType> for FormatTsNonPrimitiveType {
 }
 
 impl NeedsParentheses for TsNonPrimitiveType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/null_literal_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/null_literal_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsNullLiteralType, TsNullLiteralTypeFields};
+use biome_js_syntax::{TsNullLiteralType, TsNullLiteralTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsNullLiteralType;
@@ -19,7 +19,7 @@ impl FormatNodeRule<TsNullLiteralType> for FormatTsNullLiteralType {
 }
 
 impl NeedsParentheses for TsNullLiteralType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/number_literal_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/number_literal_type.rs
@@ -3,7 +3,7 @@ use biome_formatter::token::number::format_number_token;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsNumberLiteralType, TsNumberLiteralTypeFields};
+use biome_js_syntax::{TsNumberLiteralType, TsNumberLiteralTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsNumberLiteralType;
@@ -26,7 +26,7 @@ impl FormatNodeRule<TsNumberLiteralType> for FormatTsNumberLiteralType {
 }
 
 impl NeedsParentheses for TsNumberLiteralType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/number_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/number_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsNumberType, TsNumberTypeFields};
+use biome_js_syntax::{TsNumberType, TsNumberTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsNumberType;
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsNumberType> for FormatTsNumberType {
 }
 
 impl NeedsParentheses for TsNumberType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/object_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/object_type.rs
@@ -2,7 +2,7 @@ use crate::parentheses::NeedsParentheses;
 use crate::prelude::*;
 use crate::utils::JsObjectLike;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsObjectType};
+use biome_js_syntax::TsObjectType;
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsObjectType;
@@ -23,7 +23,7 @@ impl FormatNodeRule<TsObjectType> for FormatTsObjectType {
 }
 
 impl NeedsParentheses for TsObjectType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/parenthesized_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/parenthesized_type.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
+use biome_js_syntax::TsParenthesizedType;
 use biome_js_syntax::TsParenthesizedTypeFields;
-use biome_js_syntax::{JsSyntaxNode, TsParenthesizedType};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsParenthesizedType;
@@ -30,11 +30,6 @@ impl FormatNodeRule<TsParenthesizedType> for FormatTsParenthesizedType {
 impl NeedsParentheses for TsParenthesizedType {
     #[inline]
     fn needs_parentheses(&self) -> bool {
-        false
-    }
-
-    #[inline]
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/reference_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/reference_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsReferenceType, TsReferenceTypeFields};
+use biome_js_syntax::{TsReferenceType, TsReferenceTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsReferenceType;
@@ -23,7 +23,7 @@ impl FormatNodeRule<TsReferenceType> for FormatTsReferenceType {
 }
 
 impl NeedsParentheses for TsReferenceType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/string_literal_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/string_literal_type.rs
@@ -3,7 +3,7 @@ use crate::utils::{FormatLiteralStringToken, StringLiteralParentKind};
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsStringLiteralType, TsStringLiteralTypeFields};
+use biome_js_syntax::{TsStringLiteralType, TsStringLiteralTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsStringLiteralType;
@@ -27,7 +27,7 @@ impl FormatNodeRule<TsStringLiteralType> for FormatTsStringLiteralType {
 }
 
 impl NeedsParentheses for TsStringLiteralType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/string_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/string_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsStringType, TsStringTypeFields};
+use biome_js_syntax::{TsStringType, TsStringTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsStringType;
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsStringType> for FormatTsStringType {
 }
 
 impl NeedsParentheses for TsStringType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/symbol_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/symbol_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsSymbolType, TsSymbolTypeFields};
+use biome_js_syntax::{TsSymbolType, TsSymbolTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsSymbolType;
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsSymbolType> for FormatTsSymbolType {
 }
 
 impl NeedsParentheses for TsSymbolType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/template_literal_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/template_literal_type.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
+use biome_js_syntax::TsTemplateLiteralType;
 use biome_js_syntax::TsTemplateLiteralTypeFields;
-use biome_js_syntax::{JsSyntaxNode, TsTemplateLiteralType};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsTemplateLiteralType;
@@ -32,7 +32,7 @@ impl FormatNodeRule<TsTemplateLiteralType> for FormatTsTemplateLiteralType {
 }
 
 impl NeedsParentheses for TsTemplateLiteralType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/this_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/this_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsThisType, TsThisTypeFields};
+use biome_js_syntax::{TsThisType, TsThisTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsThisType;
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsThisType> for FormatTsThisType {
 }
 
 impl NeedsParentheses for TsThisType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/tuple_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/tuple_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsTupleType, TsTupleTypeFields};
+use biome_js_syntax::{TsTupleType, TsTupleTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsTupleType;
@@ -40,7 +40,7 @@ impl FormatNodeRule<TsTupleType> for FormatTsTupleType {
 }
 
 impl NeedsParentheses for TsTupleType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/type_operator_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/type_operator_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::{operator_type_or_higher_needs_parens, NeedsParentheses};
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsTypeOperatorType, TsTypeOperatorTypeFields};
+use biome_js_syntax::{TsTypeOperatorType, TsTypeOperatorTypeFields};
 use biome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
@@ -21,7 +21,10 @@ impl FormatNodeRule<TsTypeOperatorType> for FormatTsTypeOperatorType {
 }
 
 impl NeedsParentheses for TsTypeOperatorType {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         operator_type_or_higher_needs_parens(self.syntax(), &parent)
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/typeof_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/typeof_type.rs
@@ -2,9 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{
-    JsSyntaxKind, JsSyntaxNode, TsIndexedAccessType, TsTypeofType, TsTypeofTypeFields,
-};
+use biome_js_syntax::{JsSyntaxKind, TsIndexedAccessType, TsTypeofType, TsTypeofTypeFields};
 use biome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
@@ -35,7 +33,10 @@ impl FormatNodeRule<TsTypeofType> for FormatTsTypeofType {
 }
 
 impl NeedsParentheses for TsTypeofType {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
+        let Some(parent) = self.syntax().parent() else {
+            return false;
+        };
         match parent.kind() {
             JsSyntaxKind::TS_ARRAY_TYPE => true,
             // Typeof operators are parenthesized when used as an object type in an indexed access

--- a/crates/biome_js_formatter/src/ts/types/undefined_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/undefined_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsUndefinedType, TsUndefinedTypeFields};
+use biome_js_syntax::{TsUndefinedType, TsUndefinedTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsUndefinedType;
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsUndefinedType> for FormatTsUndefinedType {
 }
 
 impl NeedsParentheses for TsUndefinedType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/union_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/union_type.rs
@@ -5,8 +5,8 @@ use crate::utils::{
     TsIntersectionOrUnionTypeList,
 };
 use biome_formatter::{format_args, write, Buffer};
+use biome_js_syntax::TsUnionTypeFields;
 use biome_js_syntax::{JsSyntaxKind, JsSyntaxToken, TsTupleTypeElementList, TsUnionType};
-use biome_js_syntax::{JsSyntaxNode, TsUnionTypeFields};
 use biome_rowan::SyntaxNodeOptionExt;
 
 #[derive(Debug, Clone, Default)]
@@ -156,10 +156,9 @@ impl FormatNodeRule<TsUnionType> for FormatTsUnionType {
 }
 
 impl NeedsParentheses for TsUnionType {
-    fn needs_parentheses_with_parent(&self, parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         union_or_intersection_type_needs_parentheses(
             self.syntax(),
-            &parent,
             &TsIntersectionOrUnionTypeList::TsUnionTypeVariantList(self.types()),
         )
     }

--- a/crates/biome_js_formatter/src/ts/types/unknown_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/unknown_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsUnknownType, TsUnknownTypeFields};
+use biome_js_syntax::{TsUnknownType, TsUnknownTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsUnknownType;
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsUnknownType> for FormatTsUnknownType {
 }
 
 impl NeedsParentheses for TsUnknownType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/ts/types/void_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/void_type.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::parentheses::NeedsParentheses;
 use biome_formatter::write;
-use biome_js_syntax::{JsSyntaxNode, TsVoidType, TsVoidTypeFields};
+use biome_js_syntax::{TsVoidType, TsVoidTypeFields};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsVoidType;
@@ -20,7 +20,7 @@ impl FormatNodeRule<TsVoidType> for FormatTsVoidType {
 }
 
 impl NeedsParentheses for TsVoidType {
-    fn needs_parentheses_with_parent(&self, _parent: JsSyntaxNode) -> bool {
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_formatter/src/utils/typescript.rs
+++ b/crates/biome_js_formatter/src/utils/typescript.rs
@@ -106,18 +106,20 @@ pub(crate) fn should_hug_type(ty: &AnyTsType, f: &Formatter<JsFormatContext>) ->
 
 pub(crate) fn union_or_intersection_type_needs_parentheses(
     node: &JsSyntaxNode,
-    parent: &JsSyntaxNode,
     types: &TsIntersectionOrUnionTypeList,
 ) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
     debug_assert!(matches!(
         node.kind(),
         JsSyntaxKind::TS_INTERSECTION_TYPE | JsSyntaxKind::TS_UNION_TYPE
     ));
 
-    if is_in_many_type_union_or_intersection_list(node, parent) {
+    if is_in_many_type_union_or_intersection_list(node, &parent) {
         types.len() > 1
     } else {
-        operator_type_or_higher_needs_parens(node, parent)
+        operator_type_or_higher_needs_parens(node, &parent)
     }
 }
 


### PR DESCRIPTION
## Summary

This PR removes `NeedsParentheses::needs_parentheses_aith_parent`.
This function creates an indirection and creates as much code as it avoids.

It was sometimes confusing to understand which function between  `NeedsParentheses::needs_parentheses` and `NeedsParentheses::needs_parentheses_aith_parent` was called because some code call one, and other call the other.

Also, this leads to code duplication in `Any*` impl.

## Test Plan

CI must pass.
