### PR TITLE
fix(formatter): prevent line break when comment follows end of attributes, irrespective of bracketSameLine value

### DIFF
--- a/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
+++ b/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
@@ -87,7 +87,6 @@ impl Format<JsFormatContext> for AnyJsxOpeningElement {
                     let wants_bracket_same_line = attributes.is_empty() && !name_has_comments;
 
                     if self.is_self_closing() {
-                        println!("{}", self.syntax().to_string());
                         if force_bracket_same_line && !last_attribute_has_comments {
                             write!(f, [format_close])
                         } else {

--- a/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
+++ b/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
@@ -87,11 +87,7 @@ impl Format<JsFormatContext> for AnyJsxOpeningElement {
                     let wants_bracket_same_line = attributes.is_empty() && !name_has_comments;
 
                     if self.is_self_closing() {
-                        if force_bracket_same_line && !last_attribute_has_comments {
-                            write!(f, [format_close])
-                        } else {
-                            write!(f, [soft_line_break_or_space(), format_close])
-                        }
+                        write!(f, [soft_line_break_or_space(), format_close])
                     } else if force_bracket_same_line && last_attribute_has_comments {
                         write!(f, [soft_line_break(), format_close])
                     } else if force_bracket_same_line || wants_bracket_same_line {

--- a/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
+++ b/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
@@ -263,7 +263,7 @@ fn has_last_attribute_comments(element: &AnyJsxOpeningElement, comments: &JsComm
     let last_attribute_has_comments = element
         .syntax()
         .tokens()
-        .map(|token| token.text().contains(">") && token.has_leading_comments())
+        .map(|token| token.text().contains('>') && token.has_leading_comments())
         .any(|has_comment| has_comment);
 
     // println!("syntax: {}", element.syntax().to_string());

--- a/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
+++ b/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
@@ -87,6 +87,7 @@ impl Format<JsFormatContext> for AnyJsxOpeningElement {
                     let wants_bracket_same_line = attributes.is_empty() && !name_has_comments;
 
                     if self.is_self_closing() {
+                        println!("{}", self.syntax().to_string());
                         if force_bracket_same_line && !last_attribute_has_comments {
                             write!(f, [format_close])
                         } else {
@@ -266,12 +267,5 @@ fn has_last_attribute_comments(element: &AnyJsxOpeningElement, comments: &JsComm
         .map(|token| token.text().contains('>') && token.has_leading_comments())
         .any(|has_comment| has_comment);
 
-    // println!("syntax: {}", element.syntax().to_string());
-
-    // println!(
-    //     "has_comments_on_last_attribute: {}",
-    //     has_comments_on_last_attribute
-    // );
-    // println!("last_attribute_comments: {}", last_attribute_has_comments);
     has_comments_on_last_attribute || last_attribute_has_comments
 }

--- a/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
+++ b/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
@@ -23,7 +23,6 @@ declare_node_union! {
 impl Format<JsFormatContext> for AnyJsxOpeningElement {
     fn fmt(&self, f: &mut Formatter<JsFormatContext>) -> FormatResult<()> {
         let layout = self.compute_layout(f.context().comments())?;
-
         let l_angle_token = self.l_angle_token()?;
         let name = self.name()?;
         let type_arguments = self.type_arguments();
@@ -69,7 +68,10 @@ impl Format<JsFormatContext> for AnyJsxOpeningElement {
                     ]
                 )
             }
-            OpeningElementLayout::IndentAttributes { name_has_comments } => {
+            OpeningElementLayout::IndentAttributes {
+                name_has_comments,
+                last_attribute_has_comments,
+            } => {
                 let format_inner = format_with(|f| {
                     write!(
                         f,
@@ -85,7 +87,13 @@ impl Format<JsFormatContext> for AnyJsxOpeningElement {
                     let wants_bracket_same_line = attributes.is_empty() && !name_has_comments;
 
                     if self.is_self_closing() {
-                        write!(f, [soft_line_break_or_space(), format_close])
+                        if force_bracket_same_line && !last_attribute_has_comments {
+                            write!(f, [format_close])
+                        } else {
+                            write!(f, [soft_line_break_or_space(), format_close])
+                        }
+                    } else if force_bracket_same_line && last_attribute_has_comments {
+                        write!(f, [soft_line_break(), format_close])
                     } else if force_bracket_same_line || wants_bracket_same_line {
                         write!(f, [format_close])
                     } else {
@@ -96,7 +104,6 @@ impl Format<JsFormatContext> for AnyJsxOpeningElement {
                 let has_multiline_string_attribute = attributes
                     .iter()
                     .any(|attribute| is_multiline_string_literal_attribute(&attribute));
-
                 write![
                     f,
                     [group(&format_inner).should_expand(has_multiline_string_attribute)]
@@ -166,7 +173,10 @@ impl AnyJsxOpeningElement {
         {
             OpeningElementLayout::SingleStringAttribute
         } else {
-            OpeningElementLayout::IndentAttributes { name_has_comments }
+            OpeningElementLayout::IndentAttributes {
+                name_has_comments,
+                last_attribute_has_comments: has_last_attribute_comments(self, comments),
+            }
         };
 
         Ok(layout)
@@ -200,7 +210,10 @@ enum OpeningElementLayout {
     ///   moreAttributes={withSomeExpression}
     /// ></div>;
     /// ```
-    IndentAttributes { name_has_comments: bool },
+    IndentAttributes {
+        name_has_comments: bool,
+        last_attribute_has_comments: bool,
+    },
 }
 
 /// Returns `true` if this is an attribute with a [JsxString] initializer that does not contain any new line characters.
@@ -239,4 +252,26 @@ fn as_string_literal_attribute_value(attribute: &AnyJsxAttribute) -> Option<JsxS
         }
         JsxSpreadAttribute(_) => None,
     }
+}
+
+fn has_last_attribute_comments(element: &AnyJsxOpeningElement, comments: &JsComments) -> bool {
+    let has_comments_on_last_attribute = element
+        .attributes()
+        .last()
+        .map_or(false, |attribute| comments.has_comments(attribute.syntax()));
+
+    let last_attribute_has_comments = element
+        .syntax()
+        .tokens()
+        .map(|token| token.text().contains(">") && token.has_leading_comments())
+        .any(|has_comment| has_comment);
+
+    // println!("syntax: {}", element.syntax().to_string());
+
+    // println!(
+    //     "has_comments_on_last_attribute: {}",
+    //     has_comments_on_last_attribute
+    // );
+    // println!("last_attribute_comments: {}", last_attribute_has_comments);
+    has_comments_on_last_attribute || last_attribute_has_comments
 }

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx
@@ -1,17 +1,24 @@
 const a = <div></div>;
 
 <Foo
-    className={style}
-    reallyLongAttributeName1={longComplexValue}
-    reallyLongAttributeName2={anotherLongValue}
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
 />;
 
 <Foo
-    className={style}
-    reallyLongAttributeName1={longComplexValue}
-    reallyLongAttributeName2={anotherLongValue}
+		className={style}
+		reallyLongAttributeName1={longComplexValue}
+		reallyLongAttributeName2={anotherLongValue} // this is comment
+/>;
+
+<Foo
+		className={style}
+		reallyLongAttributeName1={longComplexValue}
+		reallyLongAttributeName2={anotherLongValue}
+		// this is comment
 >
-    Hi
+	Hi
 </Foo>;
 
 <div className="hi" />;

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx
@@ -9,14 +9,22 @@ const a = <div></div>;
 <Foo
 		className={style}
 		reallyLongAttributeName1={longComplexValue}
-		reallyLongAttributeName2={anotherLongValue} // this is comment
+		reallyLongAttributeName2={anotherLongValue} // comment
 />;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+>
+	Hi
+</Foo>;
 
 <Foo
 		className={style}
 		reallyLongAttributeName1={longComplexValue}
 		reallyLongAttributeName2={anotherLongValue}
-		// this is comment
+		// comment
 >
 	Hi
 </Foo>;

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
@@ -125,7 +125,8 @@ const a = <div></div>;
 <Foo
 	className={style}
 	reallyLongAttributeName1={longComplexValue}
-	reallyLongAttributeName2={anotherLongValue}/>;
+	reallyLongAttributeName2={anotherLongValue}
+/>;
 
 <Foo
 	className={style}

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
@@ -17,14 +17,22 @@ const a = <div></div>;
 <Foo
 		className={style}
 		reallyLongAttributeName1={longComplexValue}
-		reallyLongAttributeName2={anotherLongValue} // this is comment
+		reallyLongAttributeName2={anotherLongValue} // comment
 />;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+>
+	Hi
+</Foo>;
 
 <Foo
 		className={style}
 		reallyLongAttributeName1={longComplexValue}
 		reallyLongAttributeName2={anotherLongValue}
-		// this is comment
+		// comment
 >
 	Hi
 </Foo>;
@@ -69,14 +77,22 @@ const a = <div></div>;
 <Foo
 	className={style}
 	reallyLongAttributeName1={longComplexValue}
-	reallyLongAttributeName2={anotherLongValue} // this is comment
+	reallyLongAttributeName2={anotherLongValue} // comment
 />;
 
 <Foo
 	className={style}
 	reallyLongAttributeName1={longComplexValue}
 	reallyLongAttributeName2={anotherLongValue}
-	// this is comment
+>
+	Hi
+</Foo>;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+	// comment
 >
 	Hi
 </Foo>;
@@ -114,14 +130,21 @@ const a = <div></div>;
 <Foo
 	className={style}
 	reallyLongAttributeName1={longComplexValue}
-	reallyLongAttributeName2={anotherLongValue} // this is comment
+	reallyLongAttributeName2={anotherLongValue} // comment
 />;
 
 <Foo
 	className={style}
 	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}>
+	Hi
+</Foo>;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
 	reallyLongAttributeName2={anotherLongValue}
-	// this is comment
+	// comment
 >
 	Hi
 </Foo>;

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 212
 info: jsx/bracket_same_line/bracket_same_line.jsx
 ---
 # Input
@@ -8,21 +9,29 @@ info: jsx/bracket_same_line/bracket_same_line.jsx
 const a = <div></div>;
 
 <Foo
-    className={style}
-    reallyLongAttributeName1={longComplexValue}
-    reallyLongAttributeName2={anotherLongValue}
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
 />;
 
 <Foo
-    className={style}
-    reallyLongAttributeName1={longComplexValue}
-    reallyLongAttributeName2={anotherLongValue}
+		className={style}
+		reallyLongAttributeName1={longComplexValue}
+		reallyLongAttributeName2={anotherLongValue} // this is comment
+/>;
+
+<Foo
+		className={style}
+		reallyLongAttributeName1={longComplexValue}
+		reallyLongAttributeName2={anotherLongValue}
+		// this is comment
 >
-    Hi
+	Hi
 </Foo>;
 
 <div className="hi" />;
 <div className="hi"></div>;
+
 ```
 
 
@@ -60,7 +69,14 @@ const a = <div></div>;
 <Foo
 	className={style}
 	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue} // this is comment
+/>;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
 	reallyLongAttributeName2={anotherLongValue}
+	// this is comment
 >
 	Hi
 </Foo>;
@@ -93,13 +109,20 @@ const a = <div></div>;
 <Foo
 	className={style}
 	reallyLongAttributeName1={longComplexValue}
-	reallyLongAttributeName2={anotherLongValue}
+	reallyLongAttributeName2={anotherLongValue}/>;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue} // this is comment
 />;
 
 <Foo
 	className={style}
 	reallyLongAttributeName1={longComplexValue}
-	reallyLongAttributeName2={anotherLongValue}>
+	reallyLongAttributeName2={anotherLongValue}
+	// this is comment
+>
 	Hi
 </Foo>;
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

```ts
// before format
<div
  sx={{
    position: 'absolute'
  }}
  // comment
>
  test
</div>

<div
  sx={{
    position: 'absolute'
  }} // comment
>
  test
</div>
```
```ts
// after format
```ts
<div
  sx={{
    position: 'absolute'
  }} 
>
  // comment
  test
</div>
```
There was a bug where when the `bracket same line` option was true and there was a comment after an attribute, that comment would be formatted as the value of the element.
When the comment is //, putting the bracket on the same line would also comment out the closing `>`, so I thought that even if bracket same line is true, we shouldn't break the line when there's a comment after an attribute.
I created a function called `has_last_attribute_comments` in `crates/biome_js_formatter/src/jsx/tag/opening_element.rs` that returns a boolean indicating whether there's a comment after an attribute.
I added a last_attribute_comments argument to `OpeningElementLayout::IndentAttributes` and passed has_last_attribute_comments to it.
When both `force_bracket_same_line` and `last_attribute_has_comments` are true, we make it break the line.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
 added test cases for when attributes have comments in `crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.js`x.
I confirmed that all tests in the jsx_module in `crates/biome_js_formatter/tests/spec_tests.rs` pass.

close #3354