### PR TITLE
refactor(useExportType): don't report `export {}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,16 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [useExportType](https://biomejs.dev/linter/rules/use-export-type/) no longer report empty `export` ([#3535](https://github.com/biomejs/biome/issues/3535)).
+
+  An empty `export {}` allows you to force TypeScript to consider a file with no imports and exports as an EcmaScript module.
+  While `export type {}` is valid, it is more common to use `export {}`.
+  Users may find it confusing that the linter asks them to convert it to `export type {}`.
+  Also, a bundler should be able to remove `export {}` as well as `export type {}`.
+  So it is not so useful to report `export {}`.
+
+  Contributed by @Conaclos
+
 #### Bug fixes
 
 - Don't request alt text for elements hidden from assistive technologies ([#3316](https://github.com/biomejs/biome/issues/3316)). Contributed by @robintown

--- a/crates/biome_js_analyze/src/lint/style/use_export_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_export_type.rs
@@ -86,7 +86,12 @@ impl Rule for UseExportType {
         }
         let mut exports_only_types = true;
         let mut specifiers_requiring_type_marker = Vec::new();
-        for specifier in export_named_clause.specifiers() {
+        let specifiers = export_named_clause.specifiers();
+        if specifiers.is_empty() {
+            // Don't report `export {}`
+            return None;
+        }
+        for specifier in specifiers {
             let Ok((ref_name, specifier)) =
                 specifier.and_then(|specifier| Ok((specifier.local_name()?, specifier)))
             else {

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts
@@ -28,8 +28,6 @@ export { Interface, TypeAlias, Enum, func as f, Class };
 
 export /*0*/ { /*1*/ type /*2*/ func /*3*/, /*4*/ type Class as C /*5*/ } /*6*/;
 
-export {}
-
 import { type T7, type T8 } from "./mod.ts";
 export {
   /*1*/
@@ -37,3 +35,6 @@ export {
   /*2*/
   type T8,
 };
+
+import type * as Ns from ""
+export { Ns }

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts.snap
@@ -34,8 +34,6 @@ export { Interface, TypeAlias, Enum, func as f, Class };
 
 export /*0*/ { /*1*/ type /*2*/ func /*3*/, /*4*/ type Class as C /*5*/ } /*6*/;
 
-export {}
-
 import { type T7, type T8 } from "./mod.ts";
 export {
   /*1*/
@@ -43,6 +41,10 @@ export {
   /*2*/
   type T8,
 };
+
+import type * as Ns from ""
+export { Ns }
+
 ```
 
 # Diagnostics
@@ -187,7 +189,7 @@ invalid.ts:29:14 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
   > 29 │ export /*0*/ { /*1*/ type /*2*/ func /*3*/, /*4*/ type Class as C /*5*/ } /*6*/;
        │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     30 │ 
-    31 │ export {}
+    31 │ import { type T7, type T8 } from "./mod.ts";
   
   i Using export type allows transpilers to safely drop exports of types without looking for their definition.
   
@@ -198,62 +200,63 @@ invalid.ts:29:14 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
     29    │ - export·/*0*/·{·/*1*/·type·/*2*/·func·/*3*/,·/*4*/·type·Class·as·C·/*5*/·}·/*6*/;
        29 │ + export·/*0*/·type·{·/*1*/·/*2*/·func·/*3*/,·/*4*/·Class·as·C·/*5*/·}·/*6*/;
     30 30 │   
-    31 31 │   export {}
+    31 31 │   import { type T7, type T8 } from "./mod.ts";
   
 
 ```
 
 ```
-invalid.ts:31:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:32:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! All exports are only types and should thus use export type.
   
-    29 │ export /*0*/ { /*1*/ type /*2*/ func /*3*/, /*4*/ type Class as C /*5*/ } /*6*/;
-    30 │ 
-  > 31 │ export {}
-       │        ^^
-    32 │ 
-    33 │ import { type T7, type T8 } from "./mod.ts";
-  
-  i Using export type allows transpilers to safely drop exports of types without looking for their definition.
-  
-  i Safe fix: Use a grouped export type.
-  
-    31 │ export·type·{}
-       │        +++++  
-
-```
-
-```
-invalid.ts:34:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! All exports are only types and should thus use export type.
-  
-    33 │ import { type T7, type T8 } from "./mod.ts";
-  > 34 │ export {
+    31 │ import { type T7, type T8 } from "./mod.ts";
+  > 32 │ export {
        │        ^
-  > 35 │   /*1*/
-  > 36 │   type T7,
-  > 37 │   /*2*/
-  > 38 │   type T8,
-  > 39 │ };
+  > 33 │   /*1*/
+  > 34 │   type T7,
+  > 35 │   /*2*/
+  > 36 │   type T8,
+  > 37 │ };
        │ ^^
+    38 │ 
+    39 │ import type * as Ns from ""
   
   i Using export type allows transpilers to safely drop exports of types without looking for their definition.
   
   i Safe fix: Use a grouped export type.
   
-    32 32 │   
-    33 33 │   import { type T7, type T8 } from "./mod.ts";
-    34    │ - export·{
-       34 │ + export·type·{
-    35 35 │     /*1*/
-    36    │ - ··type·T7,
-       36 │ + ··T7,
-    37 37 │     /*2*/
-    38    │ - ··type·T8,
-       38 │ + ··T8,
-    39 39 │   };
+    30 30 │   
+    31 31 │   import { type T7, type T8 } from "./mod.ts";
+    32    │ - export·{
+       32 │ + export·type·{
+    33 33 │     /*1*/
+    34    │ - ··type·T7,
+       34 │ + ··T7,
+    35 35 │     /*2*/
+    36    │ - ··type·T8,
+       36 │ + ··T8,
+    37 37 │   };
+    38 38 │   
   
+
+```
+
+```
+invalid.ts:40:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! All exports are only types and should thus use export type.
+  
+    39 │ import type * as Ns from ""
+  > 40 │ export { Ns }
+       │        ^^^^^^
+    41 │ 
+  
+  i Using export type allows transpilers to safely drop exports of types without looking for their definition.
+  
+  i Safe fix: Use a grouped export type.
+  
+    40 │ export·type·{·Ns·}
+       │        +++++      
 
 ```

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/valid.ts
@@ -40,5 +40,4 @@ declare enum AmbientEnum {}
 declare class AmbientFunction {}
 export { AmbientClass, AmbientEnum, AmbientFunction }
 
-import type * as Ns from ""
-export { Ns }
+export {}

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/valid.ts.snap
@@ -46,25 +46,6 @@ declare enum AmbientEnum {}
 declare class AmbientFunction {}
 export { AmbientClass, AmbientEnum, AmbientFunction }
 
-import type * as Ns from ""
-export { Ns }
-```
-
-# Diagnostics
-```
-valid.ts:44:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! All exports are only types and should thus use export type.
-  
-    43 │ import type * as Ns from ""
-  > 44 │ export { Ns }
-       │        ^^^^^^
-  
-  i Using export type allows transpilers to safely drop exports of types without looking for their definition.
-  
-  i Safe fix: Use a grouped export type.
-  
-    44 │ export·type·{·Ns·}
-       │        +++++      
+export {}
 
 ```


### PR DESCRIPTION
## Summary

Close #3535

An empty `export {}` allows you to force TypeScript to consider a file with no imports and exports as an EcmaScript module.
While `export type {}` is valid, it is more common to use `export {}`.
Users may find it confusing that the linter asks them to convert it to `export type {}`.
Also, a bundler should be able to remove `export {}` as well as `export type {}`.
So it is not so useful to report `export {}`.

## Test Plan

I updated the tests.
