### PR TITLE
chore(js_formatter): ignore files with only bogus nodes for generating prettier compat reports

### DIFF
--- a/crates/biome_formatter_test/src/diff_report.rs
+++ b/crates/biome_formatter_test/src/diff_report.rs
@@ -109,6 +109,10 @@ impl DiffReport {
             "js/v8_intrinsic",
             // Babel plugins (mostly experimental syntaxes)
             "js/babel-plugins/",
+            // Bogus nodes
+            "js/optional-chaining-assignment/valid-parenthesized.js",
+            "typescript/conformance/classes/constructorDeclarations/constructorParameters/readonlyReadonly.ts",
+            "typescript/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement21.ts",
             // Experimental syntax: `do {}`
             "js/async-do-expressions/",
             "js/do/",

--- a/crates/biome_js_formatter/report.md
+++ b/crates/biome_js_formatter/report.md
@@ -1,6 +1,6 @@
 ## Overall Metrics
 
-**Average compatibility**: 96.88
+**Average compatibility**: 97.04
 
 <details>
     <summary>Definition</summary>
@@ -8,7 +8,7 @@
     $$average = \frac\{\sum_{file}^\{files}compatibility_\{file}}\{files}$$
 </details>
 
-**Compatible lines**: 98.07
+**Compatible lines**: 98.09
 
 <details>
     <summary>Definition</summary>
@@ -4168,16 +4168,6 @@
 **Prettier Similarity**: 100.00%
 
 
-### js/optional-chaining-assignment/valid-parenthesized.js
-```diff
--a?.b = c;
-+(a?.b) = c;
-
-```
-
-**Prettier Similarity**: 0.00%
-
-
 ### js/optional-chaining/chaining.js
 
 **Prettier Similarity**: 100.00%
@@ -7261,20 +7251,6 @@
 **Prettier Similarity**: 92.31%
 
 
-### typescript/conformance/classes/constructorDeclarations/constructorParameters/readonlyReadonly.ts
-```diff
- class C {
--  readonly x: number;
--  constructor(readonly y: number) {}
-+  readonly readonly x: number;
-+  constructor(readonly readonly y: number) {}
- }
-
-```
-
-**Prettier Similarity**: 50.00%
-
-
 ### typescript/conformance/classes/mixinAccessModifiers.ts
 
 **Prettier Similarity**: 100.00%
@@ -7368,18 +7344,6 @@
 ### typescript/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement2.ts
 
 **Prettier Similarity**: 100.00%
-
-
-### typescript/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement21.ts
-```diff
- //@target: ES5
--for (var of of) {
--}
-+for (var of of) { }
-
-```
-
-**Prettier Similarity**: 33.33%
 
 
 ### typescript/conformance/parser/ecmascript5/Statements/parserForInStatement2.ts

--- a/crates/biome_js_formatter/report_incompatible.md
+++ b/crates/biome_js_formatter/report_incompatible.md
@@ -1,6 +1,6 @@
 ## Overall Metrics
 
-**Average compatibility**: 96.88
+**Average compatibility**: 97.04
 
 <details>
     <summary>Definition</summary>
@@ -8,7 +8,7 @@
     $$average = \frac\{\sum_{file}^\{files}compatibility_\{file}}\{files}$$
 </details>
 
-**Compatible lines**: 98.07
+**Compatible lines**: 98.09
 
 <details>
     <summary>Definition</summary>
@@ -1533,16 +1533,6 @@
 **Prettier Similarity**: 66.67%
 
 
-### js/optional-chaining-assignment/valid-parenthesized.js
-```diff
--a?.b = c;
-+(a?.b) = c;
-
-```
-
-**Prettier Similarity**: 0.00%
-
-
 ### js/preserve-line/member-chain.js
 ```diff
  fooBar
@@ -2994,32 +2984,6 @@
 ```
 
 **Prettier Similarity**: 92.31%
-
-
-### typescript/conformance/classes/constructorDeclarations/constructorParameters/readonlyReadonly.ts
-```diff
- class C {
--  readonly x: number;
--  constructor(readonly y: number) {}
-+  readonly readonly x: number;
-+  constructor(readonly readonly y: number) {}
- }
-
-```
-
-**Prettier Similarity**: 50.00%
-
-
-### typescript/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement21.ts
-```diff
- //@target: ES5
--for (var of of) {
--}
-+for (var of of) { }
-
-```
-
-**Prettier Similarity**: 33.33%
 
 
 ### typescript/custom/abstract/abstractProperties.ts


### PR DESCRIPTION
## Summary

Ignore Prettier incompatibility from files that contain only bogus nodes.
I updated the reports.

## Test Plan

CI must pass