### PR TITLE
refactor(formatter): improve string normalization

### DIFF
--- a/crates/biome_css_formatter/src/utils/string_utils.rs
+++ b/crates/biome_css_formatter/src/utils/string_utils.rs
@@ -116,9 +116,6 @@ struct StringInformation {
     /// This is the quote that the is calculated and eventually used inside the string.
     /// It could be different from the one inside the formatter options
     preferred_quote: QuoteStyle,
-    /// It flags if the raw content has quotes (single or double). The raw content is the
-    /// content of a string literal without the quotes
-    raw_content_has_quotes: bool,
 }
 
 impl FormatLiteralStringToken<'_> {
@@ -153,35 +150,32 @@ impl FormatLiteralStringToken<'_> {
         // preferred quote style without having to check the content.
         if !matches!(self.token().kind(), CSS_STRING_LITERAL) {
             return StringInformation {
-                raw_content_has_quotes: false,
                 preferred_quote: chosen_quote,
             };
         }
 
         let literal = self.token().text_trimmed();
-        let alternate = chosen_quote.other();
+        let alternate_quote = chosen_quote.other();
+        let chosen_quote_byte = chosen_quote.as_byte();
+        let alternate_quote_byte = alternate_quote.as_byte();
 
-        let char_count = literal.chars().count();
-
-        let (preferred_quotes_count, alternate_quotes_count) = literal.chars().enumerate().fold(
-            (0, 0),
-            |(preferred_quotes_counter, alternate_quotes_counter), (index, current_character)| {
-                if index == 0 || index == char_count - 1 {
-                    (preferred_quotes_counter, alternate_quotes_counter)
-                } else if current_character == chosen_quote.as_char() {
-                    (preferred_quotes_counter + 1, alternate_quotes_counter)
-                } else if current_character == alternate.as_char() {
-                    (preferred_quotes_counter, alternate_quotes_counter + 1)
+        let quoteless = &literal[1..literal.len() - 1];
+        let (chosen_quote_count, alternate_quote_count) = quoteless.bytes().fold(
+            (0u32, 0u32),
+            |(chosen_quote_count, alternate_quote_count), current_character| {
+                if current_character == chosen_quote_byte {
+                    (chosen_quote_count + 1, alternate_quote_count)
+                } else if current_character == alternate_quote_byte {
+                    (chosen_quote_count, alternate_quote_count + 1)
                 } else {
-                    (preferred_quotes_counter, alternate_quotes_counter)
+                    (chosen_quote_count, alternate_quote_count)
                 }
             },
         );
 
         StringInformation {
-            raw_content_has_quotes: preferred_quotes_count > 0 || alternate_quotes_count > 0,
-            preferred_quote: if preferred_quotes_count > alternate_quotes_count {
-                alternate
+            preferred_quote: if chosen_quote_count > alternate_quote_count {
+                alternate_quote
             } else {
                 chosen_quote
             },
@@ -214,74 +208,32 @@ impl<'token> LiteralStringNormaliser<'token> {
             .token
             .compute_string_information(self.chosen_quote_style);
 
-        match self.token.token.kind() {
-            CSS_STRING_LITERAL => self.normalise_string_literal(string_information),
-            _ => self.normalise_non_string_token(string_information),
-        }
+        // Normalize string token and non-string token.
+        //
+        // Add the chosen quotes to any non-string tokensto normalize them into strings.
+        //
+        // CSS has various places where "string-like" tokens can be used without quotes, but the
+        // semantics aren't affected by whether they are present or not. This function lets those
+        // tokens become string literals by safely adding quotes around them.
+        self.normalise_tokens(string_information)
     }
 
     fn get_token(&self) -> &'token CssSyntaxToken {
         self.token.token()
     }
 
-    fn normalise_string_literal(&self, string_information: StringInformation) -> Cow<'token, str> {
+    fn normalise_tokens(&self, string_information: StringInformation) -> Cow<'token, str> {
         let preferred_quote = string_information.preferred_quote;
         let polished_raw_content = self.normalize_string(&string_information);
 
         match polished_raw_content {
-            Cow::Borrowed(raw_content) => {
-                let final_content = self.swap_quotes(raw_content, &string_information);
-                match final_content {
-                    Cow::Borrowed(final_content) => Cow::Borrowed(final_content),
-                    Cow::Owned(final_content) => Cow::Owned(final_content),
-                }
-            }
-            Cow::Owned(s) => {
+            Cow::Borrowed(raw_content) => self.swap_quotes(raw_content, &string_information),
+            Cow::Owned(mut s) => {
                 // content is owned, meaning we allocated a new string,
                 // so we force replacing quotes, regardless
-                let final_content = std::format!(
-                    "{}{}{}",
-                    preferred_quote.as_char(),
-                    s.as_str(),
-                    preferred_quote.as_char()
-                );
-
-                Cow::Owned(final_content)
-            }
-        }
-    }
-
-    /// Add the chosen quotes to any other kind of token to normalize it into a string.
-    ///
-    /// CSS has various places where "string-like" tokens can be used without quotes, but the
-    /// semantics aren't affected by whether they are present or not. This function lets those
-    /// tokens become string literals by safely adding quotes around them.
-    fn normalise_non_string_token(
-        &self,
-        string_information: StringInformation,
-    ) -> Cow<'token, str> {
-        let preferred_quote = string_information.preferred_quote;
-        let polished_raw_content = self.normalize_string(&string_information);
-
-        match polished_raw_content {
-            Cow::Borrowed(raw_content) => {
-                let final_content = self.swap_quotes(raw_content, &string_information);
-                match final_content {
-                    Cow::Borrowed(final_content) => Cow::Borrowed(final_content),
-                    Cow::Owned(final_content) => Cow::Owned(final_content),
-                }
-            }
-            Cow::Owned(s) => {
-                // content is owned, meaning we allocated a new string,
-                // so we force replacing quotes, regardless
-                let final_content = std::format!(
-                    "{}{}{}",
-                    preferred_quote.as_char(),
-                    s.as_str(),
-                    preferred_quote.as_char()
-                );
-
-                Cow::Owned(final_content)
+                s.insert(0, preferred_quote.as_char());
+                s.push(preferred_quote.as_char());
+                Cow::Owned(s)
             }
         }
     }
@@ -308,22 +260,18 @@ impl<'token> LiteralStringNormaliser<'token> {
         content_to_use: &'token str,
         string_information: &StringInformation,
     ) -> Cow<'token, str> {
-        let original_content = self.get_token().text_trimmed();
-        let preferred_quote = string_information.preferred_quote;
+        let preferred_quote = string_information.preferred_quote.as_char();
+        let original = self.get_token().text_trimmed();
 
-        let raw_content_has_quotes = string_information.raw_content_has_quotes;
-
-        if raw_content_has_quotes {
-            Cow::Borrowed(original_content)
-        } else if !original_content.starts_with(preferred_quote.as_char()) {
+        if original.starts_with(preferred_quote) {
+            Cow::Borrowed(original)
+        } else {
             Cow::Owned(std::format!(
                 "{}{}{}",
-                preferred_quote.as_char(),
+                preferred_quote,
                 content_to_use,
-                preferred_quote.as_char()
+                preferred_quote,
             ))
-        } else {
-            Cow::Borrowed(original_content)
         }
     }
 }

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -496,22 +496,7 @@ impl QuoteStyle {
         }
     }
 
-    pub fn as_string(&self) -> &str {
-        match self {
-            QuoteStyle::Double => "\"",
-            QuoteStyle::Single => "'",
-        }
-    }
-
-    /// Returns the quote, prepended with a backslash (escaped)
-    pub fn as_escaped(&self) -> &str {
-        match self {
-            QuoteStyle::Double => "\\\"",
-            QuoteStyle::Single => "\\'",
-        }
-    }
-
-    pub fn as_bytes(&self) -> u8 {
+    pub fn as_byte(&self) -> u8 {
         self.as_char() as u8
     }
 

--- a/crates/biome_formatter/src/token/string.rs
+++ b/crates/biome_formatter/src/token/string.rs
@@ -35,18 +35,6 @@ impl ToAsciiLowercaseCow for String {
     }
 }
 
-/// This signal is used to tell to the next character what it should do
-#[derive(Eq, PartialEq)]
-pub enum CharSignal {
-    /// There hasn't been any signal
-    None,
-    /// The function decided to keep the previous character
-    Keep,
-    /// The function has decided to print the character. Saves the character that was
-    /// already written
-    AlreadyPrinted(char),
-}
-
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum Quote {
     Double,
@@ -61,22 +49,7 @@ impl Quote {
         }
     }
 
-    pub fn as_string(&self) -> &str {
-        match self {
-            Quote::Double => "\"",
-            Quote::Single => "'",
-        }
-    }
-
-    /// Returns the quote, prepended with a backslash (escaped)
-    pub fn as_escaped(&self) -> &str {
-        match self {
-            Quote::Double => "\\\"",
-            Quote::Single => "\\'",
-        }
-    }
-
-    pub fn as_bytes(&self) -> u8 {
+    pub fn as_byte(&self) -> u8 {
         self.as_char() as u8
     }
 
@@ -91,182 +64,112 @@ impl Quote {
 
 /// This function is responsible of:
 ///
-/// - reducing the number of escapes
-/// - normalising the new lines
+/// - escape `preferred_quote`
+/// - unescape alternate quotes of `preferred_quote`
+/// - remove unneed escapes (if `is_escape_preserved` is `true`)
+/// - normalise the new lines by replacing `\r\n` with `\n`.
 ///
-/// # Escaping
+/// The function allocates a new string only if at least one change is performed.
 ///
-/// The way it works is the following: we split the content by analyzing all the
-/// characters that could keep the escape.
+/// In the followinf example `"` is escaped, `\'` and `\l` are unescaped, and the newline is normalized.
 ///
-/// Each time we retrieve one of this character, we push inside a new string all the content
-/// found **before** the current character.
-///
-/// After that the function checks if the current character should be also be printed or not.
-/// These characters (like quotes) can have an escape that might be removed. If that happens,
-/// we use [CharSignal] to tell to the next iteration what it should do with that character.
-///
-/// For example, let's take this example:
-/// ```js
-/// ("hello! \'")
 /// ```
-///
-/// Here, we want to remove the backslash (\) from the content. So when we encounter `\`,
-/// the algorithm checks if after `\` there's a `'`, and if so, then we push inside the final string
-/// only `'` and we ignore the backlash. Then we signal the next iteration with [CharSignal::AlreadyPrinted],
-/// so when we process the next `'`, we decide to ignore it and reset the signal.
-///
-/// Another example is the following:
-///
-/// ```js
-/// (" \\' ")
+/// use biome_formatter::token::string::{normalize_string, Quote};
+/// assert_eq!(
+///     normalize_string(" \"He\\llo\\tworld\" \\' \\' \r\n ", Quote::Double, false),
+///     " \\\"Hello\\tworld\\\" ' ' \n ",
+/// );
 /// ```
-///
-/// Here, we need to keep all the backslash. We check the first one and we look ahead. We find another
-/// `\`, so we keep it the first and we signal the next iteration with [CharSignal::Keep].
-/// Then the next iteration comes along. We have the second `\`, we look ahead we find a `'`. Although,
-/// as opposed to the previous example, we have a signal that says that we should keep the current
-/// character. Then we do so. The third iteration comes along and we find `'`. We still have the
-/// [CharSignal::Keep]. We do so and then we set the signal to [CharSignal::None]
-///
-/// # Newlines
-///
-/// By default the formatter uses `\n` as a newline. The function replaces
-/// `\r\n` with `\n`,
 pub fn normalize_string(
     raw_content: &str,
     preferred_quote: Quote,
     is_escape_preserved: bool,
 ) -> Cow<str> {
-    let alternate_quote = preferred_quote.other();
-
-    // A string should be manipulated only if its raw content contains backslash, quotes or line terminators
-    if !raw_content.contains([
-        '\\',
-        '\r',
-        preferred_quote.as_char(),
-        alternate_quote.as_char(),
-    ]) {
-        return Cow::Borrowed(raw_content);
-    }
-
+    let alternate_quote = preferred_quote.other().as_byte();
+    let preferred_quote = preferred_quote.as_byte();
     let mut reduced_string = String::new();
-    let mut signal = CharSignal::None;
-
-    let mut chars = raw_content.char_indices().peekable();
-
-    while let Some((_, current_char)) = chars.next() {
-        let next_character = chars.peek();
-
-        if let CharSignal::AlreadyPrinted(char) = signal {
-            if char == current_char {
-                continue;
-            }
-        }
-
-        match current_char {
-            '\\' => {
-                let bytes = raw_content.as_bytes();
-
-                if let Some((next_index, next_character)) = next_character {
+    let mut copy_start = 0;
+    let mut bytes = raw_content.bytes().enumerate();
+    while let Some((byte_index, byte)) = bytes.next() {
+        match byte {
+            // If the next character is escaped
+            b'\\' => {
+                if let Some((escaped_index, escaped)) = bytes.next() {
                     // If we encounter an alternate quote that is escaped, we have to
                     // remove the escape from it.
                     // This is done because of how the enclosed strings can change.
                     // Check `computed_preferred_quote` for more details.
-                    if *next_character as u8 == alternate_quote.as_bytes()
-                        // This check is a safety net for cases where the backslash is at the end
-                        // of the raw content:
-                        // ("\\")
-                        // The second backslash is at the end.
-                        && *next_index < bytes.len()
-                    {
-                        match signal {
-                            CharSignal::Keep => {
-                                reduced_string.push(current_char);
+                    let should_unescape = match escaped {
+                        // The next character is another backslash, or
+                        // a character that should be kept in the next iteration
+                        b'^'
+                        | b'\n'
+                        | b'0'..=b'7'
+                        | b'\\'
+                        | b'b'
+                        | b'f'
+                        | b'n'
+                        | b'r'
+                        | b't'
+                        | b'u'
+                        | b'v'
+                        | b'x' => false,
+                        b'\r' => {
+                            // If we encounter the sequence "\r\n", then skip '\r'
+                            if let Some((next_byte_index, b'\n')) = bytes.next() {
+                                reduced_string.push_str(&raw_content[copy_start..escaped_index]);
+                                copy_start = next_byte_index;
                             }
-                            _ => {
-                                reduced_string.push(alternate_quote.as_char());
-                                signal = CharSignal::AlreadyPrinted(alternate_quote.as_char());
-                            }
+                            false
                         }
-                    } else if signal == CharSignal::Keep {
-                        reduced_string.push(current_char);
-                        signal = CharSignal::None;
-                    }
-                    // The next character is another backslash, or
-                    // a character that should be kept in the next iteration
-                    else if "^\n\r\"'01234567\\bfnrtuvx\u{2028}\u{2029}".contains(*next_character)
-                    {
-                        signal = CharSignal::Keep;
-                        // fallback, keep the backslash
-                        reduced_string.push(current_char);
-                    } else {
-                        // these, usually characters that can have their
-                        // escape removed: "\a" => "a"
-                        // So we ignore the current slash and we continue
-                        // to the next iteration
-                        if is_escape_preserved {
-                            reduced_string.push(current_char);
+                        0xE2 => {
+                            // Prserve escaping of Unicode characters U+2028 and U+2029
+                            !(matches!(bytes.next(), Some((_, 0x80)))
+                                && matches!(bytes.next(), Some((_, 0xA8 | 0xA9))))
                         }
-                        continue;
+                        _ => {
+                            // these, usually characters that can have their
+                            // escape removed: "\a" => "a"
+                            // So we ignore the current slash and we continue
+                            // to the next iteration
+                            //
+                            // We always unescape alternate quots regardless of `is_escape_preserved`.
+                            escaped == alternate_quote
+                                || (escaped != preferred_quote && !is_escape_preserved)
+                        }
+                    };
+                    if should_unescape {
+                        reduced_string.push_str(&raw_content[copy_start..byte_index]);
+                        copy_start = escaped_index;
                     }
-                } else {
-                    // fallback, keep the backslash
-                    reduced_string.push(current_char);
                 }
             }
-            '\n' | '\t' => {
-                if let CharSignal::AlreadyPrinted(the_char) = signal {
-                    if matches!(the_char, '\n' | '\t') {
-                        signal = CharSignal::None
-                    }
-                } else {
-                    reduced_string.push(current_char);
+            // If we encounter the sequence "\r\n", then skip '\r'
+            b'\r' => {
+                if let Some((next_byte_index, b'\n')) = bytes.next() {
+                    reduced_string.push_str(&raw_content[copy_start..byte_index]);
+                    copy_start = next_byte_index;
                 }
-            }
-            // If the current character is \r and the
-            // next is \n, skip over the entire sequence
-            '\r' if next_character.map_or(false, |(_, c)| *c == '\n') => {
-                reduced_string.push('\n');
-                signal = CharSignal::AlreadyPrinted('\n');
             }
             _ => {
                 // If we encounter a preferred quote and it's not escaped, we have to replace it with
                 // an escaped version.
                 // This is done because of how the enclosed strings can change.
                 // Check `computed_preferred_quote` for more details.
-                if current_char == preferred_quote.as_char() {
-                    let last_char = &reduced_string.chars().last();
-                    if let Some('\\') = last_char {
-                        reduced_string.push(preferred_quote.as_char());
-                    } else {
-                        reduced_string.push_str(preferred_quote.as_escaped());
-                    }
-                } else if current_char == alternate_quote.as_char() {
-                    match signal {
-                        CharSignal::None | CharSignal::Keep => {
-                            reduced_string.push(alternate_quote.as_char());
-                        }
-                        CharSignal::AlreadyPrinted(_) => (),
-                    }
-                } else {
-                    reduced_string.push(current_char);
+                if byte == preferred_quote {
+                    reduced_string.push_str(&raw_content[copy_start..byte_index]);
+                    reduced_string.push('\\');
+                    copy_start = byte_index;
                 }
-                signal = CharSignal::None;
             }
         }
     }
-
-    // Don't allocate a new string of this is empty
-    if reduced_string.is_empty() {
+    if copy_start == 0 && reduced_string.is_empty() {
         Cow::Borrowed(raw_content)
     } else {
-        // don't allocate a new string if the new string is still equals to the input string
-        if reduced_string == raw_content {
-            Cow::Borrowed(raw_content)
-        } else {
-            Cow::Owned(reduced_string)
-        }
+        // Copy the remaining characters
+        reduced_string.push_str(&raw_content[copy_start..]);
+        Cow::Owned(reduced_string)
     }
 }
 
@@ -276,13 +179,47 @@ mod tests {
 
     #[test]
     fn normalize_newline() {
+        assert_eq!(normalize_string("a\nb", Quote::Double, true), "a\nb");
+        assert_eq!(normalize_string("a\r\nb", Quote::Double, false), "a\nb");
+        assert_eq!(normalize_string("a\\\r\nb", Quote::Double, false), "a\\\nb");
+    }
+
+    #[test]
+    fn normalize_escapes() {
+        assert_eq!(normalize_string("\\", Quote::Double, false), "\\");
+        assert_eq!(normalize_string("\\t", Quote::Double, false), "\\t");
         assert_eq!(
-            normalize_string("a\nb", Quote::Double, true),
-            Cow::Borrowed("a\nb")
+            normalize_string("\\\u{2028}", Quote::Double, false),
+            "\\\u{2028}"
         );
         assert_eq!(
-            normalize_string("a\r\nb", Quote::Double, false),
-            Cow::Borrowed("a\nb")
+            normalize_string("\\\u{2029}", Quote::Double, false),
+            "\\\u{2029}"
         );
+
+        assert_eq!(normalize_string("a\\a", Quote::Double, false), "aa");
+        assert_eq!(normalize_string("👍\\👍", Quote::Single, false), "👍👍");
+        assert_eq!(
+            normalize_string("\\\u{2027}", Quote::Double, false),
+            "\u{2027}"
+        );
+        assert_eq!(
+            normalize_string("\\\u{2030}", Quote::Double, false),
+            "\u{2030}"
+        );
+
+        assert_eq!(normalize_string("a\\a", Quote::Double, true), "a\\a");
+        assert_eq!(normalize_string("👍\\👍", Quote::Single, true), "👍\\👍");
+    }
+
+    #[test]
+    fn normalize_quotes() {
+        assert_eq!(normalize_string("\"", Quote::Double, false), "\\\"");
+        assert_eq!(normalize_string("\'", Quote::Double, false), "'");
+        assert_eq!(normalize_string("\\'", Quote::Double, false), "'");
+
+        assert_eq!(normalize_string("\"", Quote::Single, false), "\"");
+        assert_eq!(normalize_string("\\'", Quote::Single, false), "\\'");
+        assert_eq!(normalize_string("\\\"", Quote::Single, false), "\"");
     }
 }


### PR DESCRIPTION
## Summary

While I was working on #3558, I noted a room for improving string utilities.

This PR improves the implementation of the string utilities:

- Reduce an unnecessary lookup (counting the number of characters) when we check the number of quotes inside a string
- Avoid a string allocation when string contents are normalized
- Avoid a string allocation when quotes are normalized

The PR has also the aim of improving performance of string normalization by avoiding `peekable()` and iterating over bytes instead of chars.

The PR also normalizes strings before evaluating if quotes are needed for import attribute keys.
This is a follow-up of #3558.

There is more room for improvements for example to avoid code duplication.
The change are already large in this PR, I prefer to defer them in a follow-up PR.

## Test Plan

I improved the test coverage of the `normalise_string` function.
