### PR TITLE
fix(useNamingConvention): don't suggest renaming in global declaration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,13 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [noUnusedVariables](https://biomejs.dev/linter/rules/no-unused-variables/) now checks TypeScript declaration files.
+
+  This allows to report a type that is unused because it isn't exported.
+  Global declarations files (declarations files without exports and imports) are still ignored.
+
+  Contributed by @Conaclos
+
 #### Bug fixes
 
 - Don't request alt text for elements hidden from assistive technologies ([#3316](https://github.com/biomejs/biome/issues/3316)). Contributed by @robintown
@@ -223,6 +230,14 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   ```ts
   type AAb = any
   ```
+
+  Contributed by @Conaclos
+
+- [useNamingConvention](https://biomejs.dev/linter/rules/use-naming-convention/) no longer provides fixes for global TypeScript declaration files.
+
+  Global TypeScript declaration files have no epxorts and no imports.
+  All the declared types are available in all files of the project.
+  Thus, it is not safe to propose renaming only in the declaration file.
 
   Contributed by @Conaclos
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_implicit_any_let.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_implicit_any_let.rs
@@ -49,11 +49,9 @@ impl Rule for NoImplicitAnyLet {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let source_type = ctx.source_type::<JsFileSource>().language();
-        let is_ts_source = source_type.is_typescript();
         let node = ctx.query();
-        let is_declaration = source_type.is_definition_file();
 
-        if node.is_const() || is_declaration || !is_ts_source {
+        if source_type.is_definition_file() || !source_type.is_typescript() || node.is_const() {
             return None;
         }
 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalid.d.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalid.d.ts
@@ -1,0 +1,3 @@
+export const C: number
+
+interface Unused {}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalid.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalid.d.ts.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.d.ts
+---
+# Input
+```ts
+export const C: number
+
+interface Unused {}
+
+```
+
+# Diagnostics
+```
+invalid.d.ts:3:11 lint/correctness/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This interface is unused.
+  
+    1 │ export const C: number
+    2 │ 
+  > 3 │ interface Unused {}
+      │           ^^^^^^
+    4 │ 
+  
+  i Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidGlobal.d.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidGlobal.d.ts
@@ -1,0 +1,1 @@
+interface camelCase {}

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidGlobal.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidGlobal.d.ts.snap
@@ -1,0 +1,20 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidGlobal.d.ts
+---
+# Input
+```ts
+interface camelCase {}
+```
+
+# Diagnostics
+```
+invalidGlobal.d.ts:1:11 lint/style/useNamingConvention ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This interface name should be in PascalCase.
+  
+  > 1 │ interface camelCase {}
+      │           ^^^^^^^^^
+  
+
+```

--- a/crates/biome_js_semantic/src/semantic_model/model.rs
+++ b/crates/biome_js_semantic/src/semantic_model/model.rs
@@ -147,6 +147,10 @@ impl SemanticModelData {
     pub fn is_exported(&self, range: TextRange) -> bool {
         self.exported.contains(&range.start())
     }
+
+    pub fn has_exports(&self) -> bool {
+        !self.exported.is_empty()
+    }
 }
 
 impl PartialEq for SemanticModelData {
@@ -362,6 +366,11 @@ impl SemanticModel {
         T: CanBeImportedExported,
     {
         node.is_exported(self)
+    }
+
+    /// Returns `true` if the file contains at least one export.
+    pub fn has_exports(&self) -> bool {
+        self.data.has_exports()
     }
 
     /// Returns if the node is imported or is a reference to a binding


### PR DESCRIPTION
## Summary

This PR makes two changes:

- `useNamingConvention` no longer suggests renaming in declaration files without exports
- `noUnusedVariables` now report unused types in declaration files with at least one export

## Test Plan

I added tests.