### PR TITLE
fix(core): don't create a new project when the configuration changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Editors
 
+#### Bug fixes
+
+- Fix [#3577](https://github.com/biomejs/biome/issues/3577), where the update of the configuration file was resulting in the creation of a new internal project. Contributed by @ematipico
+
 ### Formatter
 
 #### Enhancements

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -598,7 +598,7 @@ fn resolve_manifest(cli_session: &CliSession) -> Result<(), WorkspaceError> {
             content: result.content,
             version: 0,
         })?;
-        workspace.update_current_project(UpdateProjectParams { path: biome_path })?;
+        workspace.update_current_manifest(UpdateProjectParams { path: biome_path })?;
     }
 
     Ok(())

--- a/crates/biome_lsp/src/handlers/analysis.rs
+++ b/crates/biome_lsp/src/handlers/analysis.rs
@@ -1,5 +1,6 @@
 use crate::converters::from_proto;
 use crate::converters::line_index::LineIndex;
+use crate::diagnostics::LspError;
 use crate::session::Session;
 use crate::utils;
 use anyhow::{Context, Result};
@@ -37,7 +38,7 @@ fn fix_all_kind() -> CodeActionKind {
 pub(crate) fn code_actions(
     session: &Session,
     params: CodeActionParams,
-) -> Result<Option<CodeActionResponse>> {
+) -> Result<Option<CodeActionResponse>, LspError> {
     let url = params.text_document.uri.clone();
     let biome_path = session.file_path(&url)?;
 

--- a/crates/biome_lsp/src/handlers/rename.rs
+++ b/crates/biome_lsp/src/handlers/rename.rs
@@ -1,13 +1,17 @@
 use std::collections::HashMap;
 
 use crate::converters::from_proto;
+use crate::diagnostics::LspError;
 use crate::{session::Session, utils};
 use anyhow::{Context, Result};
 use tower_lsp::lsp_types::{RenameParams, WorkspaceEdit};
 use tracing::trace;
 
 #[tracing::instrument(level = "debug", skip(session), err)]
-pub(crate) fn rename(session: &Session, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+pub(crate) fn rename(
+    session: &Session,
+    params: RenameParams,
+) -> Result<Option<WorkspaceEdit>, LspError> {
     let url = params.text_document_position.text_document.uri;
     let biome_path = session.file_path(&url)?;
 

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -618,7 +618,7 @@ impl ServerFactory {
         workspace_method!(builder, unregister_project_folder);
         workspace_method!(builder, open_file);
         workspace_method!(builder, open_project);
-        workspace_method!(builder, update_current_project);
+        workspace_method!(builder, update_current_manifest);
         workspace_method!(builder, get_syntax_tree);
         workspace_method!(builder, get_control_flow_graph);
         workspace_method!(builder, get_formatter_ir);

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -1,4 +1,5 @@
 use crate::converters::{negotiated_encoding, PositionEncoding, WideEncoding};
+use crate::diagnostics::LspError;
 use crate::documents::Document;
 use crate::extension_settings::ExtensionSettings;
 use crate::extension_settings::CONFIGURATION_SECTION;
@@ -7,7 +8,7 @@ use anyhow::Result;
 use biome_analyze::RuleCategoriesBuilder;
 use biome_configuration::ConfigurationPathHint;
 use biome_console::markup;
-use biome_diagnostics::PrintDescription;
+use biome_diagnostics::{DiagnosticExt, Error, PrintDescription};
 use biome_fs::{BiomePath, FileSystem};
 use biome_service::configuration::{
     load_configuration, LoadedConfiguration, PartialConfigurationExt,
@@ -260,13 +261,13 @@ impl Session {
     /// Get a [`Document`] matching the provided [`lsp_types::Url`]
     ///
     /// If document does not exist, result is [WorkspaceError::NotFound]
-    pub(crate) fn document(&self, url: &lsp_types::Url) -> Result<Document, WorkspaceError> {
+    pub(crate) fn document(&self, url: &lsp_types::Url) -> Result<Document, Error> {
         self.documents
             .read()
             .unwrap()
             .get(url)
             .cloned()
-            .ok_or_else(WorkspaceError::not_found)
+            .ok_or_else(|| WorkspaceError::not_found().with_file_path(url.to_string()))
     }
 
     /// Set the [`Document`] for the provided [`lsp_types::Url`]
@@ -298,7 +299,7 @@ impl Session {
     /// them to the client. Called from [`handlers::text_document`] when a file's
     /// contents changes.
     #[tracing::instrument(level = "trace", skip_all, fields(url = display(&url), diagnostic_count), err)]
-    pub(crate) async fn update_diagnostics(&self, url: lsp_types::Url) -> Result<()> {
+    pub(crate) async fn update_diagnostics(&self, url: lsp_types::Url) -> Result<(), LspError> {
         let biome_path = self.file_path(&url)?;
         let doc = self.document(&url)?;
         if self.configuration_status().is_error() && !self.notified_broken_configuration() {
@@ -491,7 +492,8 @@ impl Session {
                         directory_path: configuration_path,
                         ..
                     } = loaded_configuration;
-                    info!("Loaded workspace setting");
+                    info!("Configuration loaded successfully from disk.");
+                    info!("Update workspace settings.");
                     let fs = &self.fs;
 
                     let result =
@@ -499,23 +501,29 @@ impl Session {
 
                     match result {
                         Ok((vcs_base_path, gitignore_matches)) => {
-                            if let ConfigurationPathHint::FromWorkspace(path) = &base_path {
-                                // We don't need the key
-                                let _ = self.workspace.register_project_folder(
-                                    RegisterProjectFolderParams {
-                                        path: Some(path.clone()),
-                                        // This is naive, but we don't know if the user has a file already open or not, so we register every project as the current one.
-                                        // The correct one is actually set when the LSP calls `textDocument/didOpen`
-                                        set_as_current_workspace: true,
-                                    },
-                                );
-                            } else {
-                                let _ = self.workspace.register_project_folder(
-                                    RegisterProjectFolderParams {
-                                        path: fs.working_directory(),
-                                        set_as_current_workspace: true,
-                                    },
-                                );
+                            let register_result =
+                                if let ConfigurationPathHint::FromWorkspace(path) = &base_path {
+                                    // We don't need the key
+                                    self.workspace
+                                        .register_project_folder(RegisterProjectFolderParams {
+                                            path: Some(path.clone()),
+                                            // This is naive, but we don't know if the user has a file already open or not, so we register every project as the current one.
+                                            // The correct one is actually set when the LSP calls `textDocument/didOpen`
+                                            set_as_current_workspace: true,
+                                        })
+                                        .err()
+                                } else {
+                                    self.workspace
+                                        .register_project_folder(RegisterProjectFolderParams {
+                                            path: fs.working_directory(),
+                                            set_as_current_workspace: true,
+                                        })
+                                        .err()
+                                };
+                            if let Some(error) = register_result {
+                                error!("Failed to register the project folder: {}", error);
+                                self.client.log_message(MessageType::ERROR, &error).await;
+                                return ConfigurationStatus::Error;
                             }
                             let result = self.workspace.update_settings(UpdateSettingsParams {
                                 workspace_directory: fs.working_directory(),

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -580,7 +580,7 @@ impl Session {
                         }
                         let result = self
                             .workspace
-                            .update_current_project(UpdateProjectParams { path: biome_path });
+                            .update_current_manifest(UpdateProjectParams { path: biome_path });
                         if let Err(err) = result {
                             error!("{}", err);
                         }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -62,6 +62,10 @@ pub struct WorkspaceSettings {
 }
 
 impl WorkspaceSettings {
+    pub fn get_current_project_key(&self) -> ProjectKey {
+        self.current_project
+    }
+
     /// Retrieves the settings of the current workspace folder
     pub fn get_current_settings(&self) -> Option<&Settings> {
         trace!("Current key {:?}", self.current_project);

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -863,7 +863,7 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
     ) -> Result<(), WorkspaceError>;
 
     /// Sets the current project path
-    fn update_current_project(&self, params: UpdateProjectParams) -> Result<(), WorkspaceError>;
+    fn update_current_manifest(&self, params: UpdateProjectParams) -> Result<(), WorkspaceError>;
 
     // Return a textual, debug representation of the syntax tree for a given document
     fn get_syntax_tree(

--- a/crates/biome_service/src/workspace/client.rs
+++ b/crates/biome_service/src/workspace/client.rs
@@ -136,8 +136,8 @@ where
         self.request("biome/unregister_project_folder", params)
     }
 
-    fn update_current_project(&self, params: UpdateProjectParams) -> Result<(), WorkspaceError> {
-        self.request("biome/update_current_project", params)
+    fn update_current_manifest(&self, params: UpdateProjectParams) -> Result<(), WorkspaceError> {
+        self.request("biome/update_current_manifest", params)
     }
 
     fn get_syntax_tree(

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -499,6 +499,7 @@ impl Workspace for WorkspaceServer {
         params: RegisterProjectFolderParams,
     ) -> Result<ProjectKey, WorkspaceError> {
         let current_project_path = self.get_current_project_path();
+        dbg!("CALLED THIS");
         debug!(
             "Compare the current project with the new one {:?} {:?} {:?}",
             current_project_path.as_deref(),
@@ -506,7 +507,12 @@ impl Workspace for WorkspaceServer {
             current_project_path.as_deref() != params.path.as_ref()
         );
 
-        if current_project_path.as_deref() != params.path.as_ref() {
+        let is_new_path = match (current_project_path.as_deref(), params.path.as_ref()) {
+            (Some(current_project_path), Some(params_path)) => current_project_path != params_path,
+            _ => true,
+        };
+
+        if is_new_path {
             let path = params.path.unwrap_or_default();
             let key = self.register_project(path.clone());
             if params.set_as_current_workspace {

--- a/crates/biome_service/src/workspace_types.rs
+++ b/crates/biome_service/src/workspace_types.rs
@@ -456,7 +456,7 @@ pub fn methods() -> [WorkspaceMethod; 20] {
         WorkspaceMethod::of::<SupportsFeatureParams, SupportsFeatureResult>("file_features"),
         workspace_method!(update_settings),
         workspace_method!(register_project_folder),
-        workspace_method!(update_current_project),
+        workspace_method!(update_current_manifest),
         workspace_method!(open_project),
         workspace_method!(open_file),
         workspace_method!(change_file),

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3038,7 +3038,7 @@ export interface Workspace {
 	registerProjectFolder(
 		params: RegisterProjectFolderParams,
 	): Promise<ProjectKey>;
-	updateCurrentProject(params: UpdateProjectParams): Promise<void>;
+	updateCurrentManifest(params: UpdateProjectParams): Promise<void>;
 	openProject(params: OpenProjectParams): Promise<void>;
 	openFile(params: OpenFileParams): Promise<void>;
 	changeFile(params: ChangeFileParams): Promise<void>;
@@ -3072,8 +3072,8 @@ export function createWorkspace(transport: Transport): Workspace {
 		registerProjectFolder(params) {
 			return transport.request("biome/register_project_folder", params);
 		},
-		updateCurrentProject(params) {
-			return transport.request("biome/update_current_project", params);
+		updateCurrentManifest(params) {
+			return transport.request("biome/update_current_manifest", params);
 		},
 		openProject(params) {
 			return transport.request("biome/open_project", params);


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/3577

The bug: a new project was always created when a configuration was updated.

The fix
- we check if the project we registering is new or not. If not, we return the current key
- we don't throw an error if the manifest isn't found


I took the opportunity to do some minor refactors:
- more trace logging
- print the error in there's a failure inside the LSP

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I tested it manually, as I was able to reproduce it locally. Now bug is gone and the Biome LSP doesn't crush anymore 

<!-- What demonstrates that your implementation is correct? -->
