### PR TITLE
chore: ensure consistent naming for GitLab-related structs and types

### DIFF
--- a/crates/biome_cli/src/reporter/gitlab.rs
+++ b/crates/biome_cli/src/reporter/gitlab.rs
@@ -30,9 +30,9 @@ pub(crate) struct GitLabReporterVisitor<'a> {
 }
 
 #[derive(Default)]
-struct GitlabHasher(HashSet<u64>);
+struct GitLabHasher(HashSet<u64>);
 
-impl GitlabHasher {
+impl GitLabHasher {
     /// Enforces uniqueness of generated fingerprints in the context of a
     /// single report.
     fn rehash_until_unique(&mut self, fingerprint: u64) -> u64 {
@@ -68,19 +68,19 @@ impl<'a> ReporterVisitor for GitLabReporterVisitor<'a> {
         payload: DiagnosticsPayload,
     ) -> std::io::Result<()> {
         let hasher = RwLock::default();
-        let diagnostics = GitlabDiagnostics(payload, &hasher, self.repository_root.as_deref());
+        let diagnostics = GitLabDiagnostics(payload, &hasher, self.repository_root.as_deref());
         self.console.log(markup!({ diagnostics }));
         Ok(())
     }
 }
 
-struct GitlabDiagnostics<'a>(
+struct GitLabDiagnostics<'a>(
     DiagnosticsPayload,
-    &'a RwLock<GitlabHasher>,
+    &'a RwLock<GitLabHasher>,
     Option<&'a Path>,
 );
 
-impl<'a> GitlabDiagnostics<'a> {
+impl<'a> GitLabDiagnostics<'a> {
     fn attempt_to_relativize(&self, subject: &str) -> Option<PathBuf> {
         let Ok(resolved) = Path::new(subject).absolutize() else {
             return None;
@@ -116,7 +116,7 @@ impl<'a> GitlabDiagnostics<'a> {
     }
 }
 
-impl<'a> Display for GitlabDiagnostics<'a> {
+impl<'a> Display for GitLabDiagnostics<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> std::io::Result<()> {
         let mut hasher = self.1.write().unwrap();
         let gitlab_diagnostics: Vec<_> = self


### PR DESCRIPTION
## Summary
This pull request addresses the inconsistency in naming conventions related to GitLab within the codebase. The primary motivation for this change is to improve code readability and maintainability by ensuring that all references to GitLab are consistently capitalized and follow a standardized naming pattern.

This change solves the existing problem where different parts of the code used varying capitalizations for GitLab, which could lead to confusion and reduced clarity for developers working on the project.

There are no specific issues linked to this change, but it aligns with our ongoing effort to improve code quality.

## Test Plan
This change involves only renaming, so no functional tests are required. However, the implementation's correctness can be verified by checking that all instances of GitLab in the codebase are consistently capitalized.

Code Review: Ensure that the changes in the code accurately reflect the intended naming conventions without altering any logic.
Build and Run: Compile and run the application to confirm that no compilation errors are introduced due to the renaming.
No additional testing is necessary, as these changes are purely cosmetic.

