### PR TITLE
fix(noUselessEscapeInRegex): handle \9 backreference

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_regex.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_regex.rs
@@ -84,7 +84,7 @@ impl Rule for NoUselessEscapeInRegex {
                         // quantrifiers
                         | b'*' | b'+' | b'?' | b'{' | b'}'
                         // Backreferences
-                        | b'1'..b'9'
+                        | b'1'..=b'9'
                         // Groups
                         | b'(' | b')'
                         // Alternation

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInRegex/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInRegex/invalid.js
@@ -47,3 +47,6 @@
 
 // Unlike ESLint, we report `\k` when it is not in a unicode-aware regex
 /(?<a>)\k<a>/;
+
+// A test with unicode characters that take more than one byte
+/😀\😀/

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInRegex/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInRegex/invalid.js.snap
@@ -53,6 +53,9 @@ expression: invalid.js
 
 // Unlike ESLint, we report `\k` when it is not in a unicode-aware regex
 /(?<a>)\k<a>/;
+
+// A test with unicode characters that take more than one byte
+/😀\😀/
 ```
 
 # Diagnostics
@@ -991,6 +994,8 @@ invalid.js:49:8 lint/nursery/noUselessEscapeInRegex  FIXABLE  ━━━━━━
     48 │ // Unlike ESLint, we report `\k` when it is not in a unicode-aware regex
   > 49 │ /(?<a>)\k<a>/;
        │        ^^
+    50 │ 
+    51 │ // A test with unicode characters that take more than one byte
   
   i The escape sequence is only useful if the regular expression is unicode-aware. To be unicode-aware, the `u` or `v` flag should be used.
   
@@ -998,5 +1003,21 @@ invalid.js:49:8 lint/nursery/noUselessEscapeInRegex  FIXABLE  ━━━━━━
   
     49 │ /(?<a>)\k<a>/;
        │        -      
+
+```
+
+```
+invalid.js:52:3 lint/nursery/noUselessEscapeInRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The character doesn't need to be escaped.
+  
+    51 │ // A test with unicode characters that take more than one byte
+  > 52 │ /😀\😀/
+       │    ^^^
+  
+  i Safe fix: Unescape the character.
+  
+    52 │ /😀\😀/
+       │    -   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInRegex/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInRegex/valid.js
@@ -16,10 +16,11 @@
 
 // https://github.com/eslint/eslint/issues/7472
 /\0/; // null character
-/\\1/; // \x01 character (octal literal)
-/(a)\\1/; // backreference
-/(a)\\12/; // backreference
-/[\\0]/; // null character in character class
+/\1/; // \x01 character (octal literal)
+/(a)\1/; // backreference
+/(a)\12/; // backreference
+/(a)\9/; // backreference
+/[\0]/; // null character in character class
 
 // https://github.com/eslint/eslint/issues/7789
 /]/;
@@ -31,7 +32,7 @@
 // ES2018
 /\]/u;
 // /(?<a>)\k<a>/; // Unlike ESLint, we report `\k` when it is not in a unicode-aware regex
-/(\\?<a>)/;
+/(\?<a>)/;
 /\p{ASCII}/u;
 /\P{ASCII}/u;
 /[\p{ASCII}]/u;
@@ -67,7 +68,7 @@
 /[\>>]/v;
 /[\??]/v;
 /[\@@]/v;
-/[\\``]/v;
+/[\``]/v;
 /[\~~]/v;
 /[^\^^]/v;
 /[_\^^]/v;
@@ -87,7 +88,7 @@
 /[>\>]/v;
 /[?\?]/v;
 /[@\@]/v;
-/[`\\`]/v;
+/[`\`]/v;
 /[~\~]/v;
 /[^^\^]/v;
 /[_^\^]/v;

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInRegex/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInRegex/valid.js.snap
@@ -22,10 +22,11 @@ expression: valid.js
 
 // https://github.com/eslint/eslint/issues/7472
 /\0/; // null character
-/\\1/; // \x01 character (octal literal)
-/(a)\\1/; // backreference
-/(a)\\12/; // backreference
-/[\\0]/; // null character in character class
+/\1/; // \x01 character (octal literal)
+/(a)\1/; // backreference
+/(a)\12/; // backreference
+/(a)\9/; // backreference
+/[\0]/; // null character in character class
 
 // https://github.com/eslint/eslint/issues/7789
 /]/;
@@ -37,7 +38,7 @@ expression: valid.js
 // ES2018
 /\]/u;
 // /(?<a>)\k<a>/; // Unlike ESLint, we report `\k` when it is not in a unicode-aware regex
-/(\\?<a>)/;
+/(\?<a>)/;
 /\p{ASCII}/u;
 /\P{ASCII}/u;
 /[\p{ASCII}]/u;
@@ -73,7 +74,7 @@ expression: valid.js
 /[\>>]/v;
 /[\??]/v;
 /[\@@]/v;
-/[\\``]/v;
+/[\``]/v;
 /[\~~]/v;
 /[^\^^]/v;
 /[_\^^]/v;
@@ -93,7 +94,7 @@ expression: valid.js
 /[>\>]/v;
 /[?\?]/v;
 /[@\@]/v;
-/[`\\`]/v;
+/[`\`]/v;
 /[~\~]/v;
 /[^^\^]/v;
 /[_^\^]/v;


### PR DESCRIPTION
## Summary

Fix the failing build on the website. See https://github.com/biomejs/website/actions/runs/10282489937/job/28454302319

Actually this caught a bug, because the range should be inclusive.

## Test Plan

I added a test to avoid a regression. I also added a test for Unicode characters.
