### PR TITLE
feat(linter): integrate css semantic model into the analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Implement [css suppression action](https://github.com/biomejs/biome/issues/3278). Contributed by @togami2864
 - Add support of comments in `turbo.json`. Contributed by @Netail
-- Implement [semantic model for css](https://github.com/biomejs/biome/pull/3546). Contributed by @togami2864
-- Integrate css semantic model into the analyzer. Contributed by @togami2864
+- Implement [semantic model for CSS](https://github.com/biomejs/biome/pull/3546). Contributed by @togami2864
+- Integrate CSS semantic model into the analyzer. Contributed by @togami2864
 
 ### CLI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Implement [css suppression action](https://github.com/biomejs/biome/issues/3278). Contributed by @togami2864
 - Add support of comments in `turbo.json`. Contributed by @Netail
+- Implement [semantic model for css](https://github.com/biomejs/biome/pull/3546). Contributed by @togami2864
+- Integrate css semantic model into the analyzer. Contributed by @togami2864
 
 ### CLI
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ dependencies = [
  "biome_analyze",
  "biome_console",
  "biome_css_parser",
+ "biome_css_semantic",
  "biome_css_syntax",
  "biome_deserialize",
  "biome_deserialize_macros",

--- a/crates/biome_css_analyze/Cargo.toml
+++ b/crates/biome_css_analyze/Cargo.toml
@@ -16,6 +16,7 @@ version              = "0.5.7"
 biome_analyze            = { workspace = true }
 biome_console            = { workspace = true }
 biome_css_syntax         = { workspace = true }
+biome_css_semantic       = { workspace = true }
 biome_deserialize        = { workspace = true }
 biome_deserialize_macros = { workspace = true }
 biome_diagnostics        = { workspace = true }

--- a/crates/biome_css_analyze/Cargo.toml
+++ b/crates/biome_css_analyze/Cargo.toml
@@ -15,8 +15,8 @@ version              = "0.5.7"
 [dependencies]
 biome_analyze            = { workspace = true }
 biome_console            = { workspace = true }
-biome_css_syntax         = { workspace = true }
 biome_css_semantic       = { workspace = true }
+biome_css_syntax         = { workspace = true }
 biome_deserialize        = { workspace = true }
 biome_deserialize_macros = { workspace = true }
 biome_diagnostics        = { workspace = true }

--- a/crates/biome_css_analyze/src/lib.rs
+++ b/crates/biome_css_analyze/src/lib.rs
@@ -2,6 +2,7 @@ mod keywords;
 mod lint;
 pub mod options;
 mod registry;
+mod services;
 mod suppression_action;
 mod utils;
 
@@ -169,7 +170,7 @@ mod tests {
         :popover-open {}
         .test::-webkit-scrollbar-button:horizontal:decrement {}
         @page :first { }
-       
+
         /* invalid */
         a:unknown { }
         a:pseudo-class { }

--- a/crates/biome_css_analyze/src/services/mod.rs
+++ b/crates/biome_css_analyze/src/services/mod.rs
@@ -1,0 +1,1 @@
+pub mod semantic;

--- a/crates/biome_css_analyze/src/services/semantic.rs
+++ b/crates/biome_css_analyze/src/services/semantic.rs
@@ -10,7 +10,7 @@ use biome_rowan::{AstNode, TextRange, WalkEvent};
 /// The [SemanticServices] types can be used as a queryable to get an instance
 /// of the whole [SemanticModel] without matching on a specific AST node
 ///
-/// ```rust
+/// ```ignore
 /// impl Rule for SampleCssLintRule {
 ///    type Query = SemanticServices;
 ///    type State = ();
@@ -147,9 +147,9 @@ impl QueryMatch for SemanticModelEvent {
     }
 }
 
-/// Query type usable by lint rules **that uses the semantic model** to match on specific [AstNode] types
+/// The [Semantic] type usable by lint rules **that uses the semantic model** to match on specific [AstNode] types
 ///
-/// ```rust
+/// ```ignore
 /// impl Rule for SampleCssLintRule {
 ///    type Query = Semantic<CssGenericProperty>;
 ///    type State = ();

--- a/crates/biome_css_analyze/src/services/semantic.rs
+++ b/crates/biome_css_analyze/src/services/semantic.rs
@@ -1,0 +1,129 @@
+use biome_analyze::{
+    FromServices, MissingServicesDiagnostic, Phase, Phases, QueryMatch, Queryable, RuleKey,
+    ServiceBag, Visitor, VisitorContext, VisitorFinishContext,
+};
+use biome_css_semantic::builder::SemanticModelBuilder;
+use biome_css_semantic::{model::SemanticModel, SemanticEventExtractor};
+use biome_css_syntax::{CssLanguage, CssRoot, CssSyntaxNode};
+use biome_rowan::{TextRange, WalkEvent};
+
+pub struct SemanticServices {
+    model: SemanticModel,
+}
+
+impl SemanticServices {
+    pub fn model(&self) -> &SemanticModel {
+        &self.model
+    }
+}
+
+impl FromServices for SemanticServices {
+    fn from_services(
+        rule_key: &RuleKey,
+        services: &ServiceBag,
+    ) -> Result<Self, MissingServicesDiagnostic> {
+        let model: &SemanticModel = services.get_service().ok_or_else(|| {
+            MissingServicesDiagnostic::new(rule_key.rule_name(), &["SemanticModel"])
+        })?;
+        Ok(Self {
+            model: model.clone(),
+        })
+    }
+}
+
+impl Phase for SemanticServices {
+    fn phase() -> Phases {
+        Phases::Semantic
+    }
+}
+
+impl Queryable for SemanticServices {
+    type Input = SemanticModelEvent;
+    type Output = SemanticModel;
+
+    type Language = CssLanguage;
+    type Services = Self;
+
+    fn build_visitor(
+        analyzer: &mut impl biome_analyze::AddVisitor<Self::Language>,
+        root: &<Self::Language as biome_rowan::Language>::Root,
+    ) {
+        analyzer.add_visitor(Phases::Syntax, || SemanticModelBuilderVisitor::new(root));
+        analyzer.add_visitor(Phases::Semantic, || SemanticModelVisitor);
+    }
+
+    fn unwrap_match(services: &ServiceBag, _: &SemanticModelEvent) -> Self::Output {
+        services
+            .get_service::<SemanticModel>()
+            .expect("SemanticModel service is not registered")
+            .clone()
+    }
+}
+
+pub struct SemanticModelBuilderVisitor {
+    extractor: SemanticEventExtractor,
+    builder: SemanticModelBuilder,
+}
+
+impl SemanticModelBuilderVisitor {
+    pub(crate) fn new(root: &CssRoot) -> Self {
+        Self {
+            extractor: SemanticEventExtractor::default(),
+            builder: SemanticModelBuilder::new(root.clone()),
+        }
+    }
+}
+
+impl Visitor for SemanticModelBuilderVisitor {
+    type Language = CssLanguage;
+
+    fn visit(&mut self, event: &WalkEvent<CssSyntaxNode>, _ctx: VisitorContext<CssLanguage>) {
+        match event {
+            WalkEvent::Enter(node) => {
+                self.builder.push_node(node);
+                self.extractor.enter(node);
+            }
+            WalkEvent::Leave(node) => {
+                self.extractor.leave(node);
+            }
+        }
+
+        while let Some(e) = self.extractor.pop() {
+            self.builder.push_event(e);
+        }
+    }
+
+    fn finish(self: Box<Self>, ctx: VisitorFinishContext<CssLanguage>) {
+        let model = self.builder.build();
+        ctx.services.insert_service(model);
+    }
+}
+
+pub struct SemanticModelEvent(TextRange);
+
+impl QueryMatch for SemanticModelEvent {
+    fn text_range(&self) -> TextRange {
+        self.0
+    }
+}
+
+pub struct SemanticModelVisitor;
+
+impl Visitor for SemanticModelVisitor {
+    type Language = CssLanguage;
+
+    fn visit(&mut self, event: &WalkEvent<CssSyntaxNode>, mut ctx: VisitorContext<CssLanguage>) {
+        let root = match event {
+            WalkEvent::Enter(node) => {
+                if node.parent().is_some() {
+                    return;
+                }
+                node.clone()
+            }
+            WalkEvent::Leave(_) => return,
+        };
+
+        let text_range = root.text_range();
+        ctx.match_query(SemanticModelEvent(text_range));
+    }
+}

--- a/crates/biome_css_analyze/src/services/semantic.rs
+++ b/crates/biome_css_analyze/src/services/semantic.rs
@@ -7,6 +7,25 @@ use biome_css_semantic::{model::SemanticModel, SemanticEventExtractor};
 use biome_css_syntax::{CssLanguage, CssRoot, CssSyntaxNode};
 use biome_rowan::{AstNode, TextRange, WalkEvent};
 
+/// The [SemanticServices] types can be used as a queryable to get an instance
+/// of the whole [SemanticModel] without matching on a specific AST node
+///
+/// ```rust
+/// impl Rule for SampleCssLintRule {
+///    type Query = SemanticServices;
+///    type State = ();
+///    type Signals = Option<Self::State>;
+///    type Options = ();
+
+///    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+///     let node = ctx.query();
+///     for n in node.rules() {
+///       // Do something with the rules
+///     }
+///     //.....//
+///    }
+/// }
+/// ```
 pub struct SemanticServices {
     model: SemanticModel,
 }
@@ -99,14 +118,6 @@ impl Visitor for SemanticModelBuilderVisitor {
     }
 }
 
-pub struct SemanticModelEvent(TextRange);
-
-impl QueryMatch for SemanticModelEvent {
-    fn text_range(&self) -> TextRange {
-        self.0
-    }
-}
-
 pub struct SemanticModelVisitor;
 
 impl Visitor for SemanticModelVisitor {
@@ -128,7 +139,34 @@ impl Visitor for SemanticModelVisitor {
     }
 }
 
+pub struct SemanticModelEvent(TextRange);
+
+impl QueryMatch for SemanticModelEvent {
+    fn text_range(&self) -> TextRange {
+        self.0
+    }
+}
+
 /// Query type usable by lint rules **that uses the semantic model** to match on specific [AstNode] types
+///
+/// ```rust
+/// impl Rule for SampleCssLintRule {
+///    type Query = Semantic<CssGenericProperty>;
+///    type State = ();
+///    type Signals = Option<Self::State>;
+///    type Options = ();
+
+///    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+///     let node = ctx.query();
+///     // The model holds all information about the semantic.
+///     let model = ctx.model();
+///     for n in model.rules() {
+///       // Do something with the rules
+///     }
+///     //.....//
+///    }
+/// }
+/// ```
 #[derive(Clone)]
 pub struct Semantic<N>(pub N);
 

--- a/crates/biome_css_semantic/src/semantic_model/mod.rs
+++ b/crates/biome_css_semantic/src/semantic_model/mod.rs
@@ -1,5 +1,5 @@
-mod builder;
-pub(crate) mod model;
+pub mod builder;
+pub mod model;
 
 use biome_css_syntax::CssRoot;
 use biome_rowan::AstNode;


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
Add `Semantic<N>` and `SemanticServices` to enable the lint rules to use a semantic model for CSS.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
Created the test lint rule and ran the test using `Semantic<>` and `SemanticServices`.
<!-- What demonstrates that your implementation is correct? -->
