### PR TITLE
refactor: remove PlainIdentStyle

### DIFF
--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -195,9 +195,9 @@ impl TryFrom<PrettierConfiguration> for biome_configuration::PartialConfiguratio
         let line_width = LineWidth::try_from(value.print_width)?;
         let indent_width = IndentWidth::try_from(value.tab_width)?;
         let indent_style = if value.use_tabs {
-            biome_configuration::PlainIndentStyle::Tab
+            biome_formatter::IndentStyle::Tab
         } else {
-            biome_configuration::PlainIndentStyle::Space
+            biome_formatter::IndentStyle::Space
         };
         let formatter = biome_configuration::PartialFormatterConfiguration {
             indent_width: Some(indent_width),
@@ -297,9 +297,9 @@ impl TryFrom<Override> for biome_configuration::OverridePattern {
             };
             let indent_style = options.use_tabs.map(|use_tabs| {
                 if use_tabs {
-                    biome_configuration::PlainIndentStyle::Tab
+                    biome_formatter::IndentStyle::Tab
                 } else {
-                    biome_configuration::PlainIndentStyle::Space
+                    biome_formatter::IndentStyle::Space
                 }
             });
             let formatter = biome_configuration::OverrideFormatterConfiguration {

--- a/crates/biome_configuration/src/css.rs
+++ b/crates/biome_configuration/src/css.rs
@@ -1,6 +1,5 @@
-use crate::PlainIndentStyle;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
-use biome_formatter::{IndentWidth, LineEnding, LineWidth, QuoteStyle};
+use biome_formatter::{IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteStyle};
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 
@@ -54,7 +53,7 @@ pub struct CssFormatter {
 
     /// The indent style applied to CSS (and its super languages) files.
     #[partial(bpaf(long("css-formatter-indent-style"), argument("tab|space"), optional))]
-    pub indent_style: Option<PlainIndentStyle>,
+    pub indent_style: Option<IndentStyle>,
 
     /// The size of the indentation applied to CSS (and its super languages) files. Default to 2.
     #[partial(bpaf(long("css-formatter-indent-width"), argument("NUMBER"), optional))]

--- a/crates/biome_configuration/src/editorconfig.rs
+++ b/crates/biome_configuration/src/editorconfig.rs
@@ -12,13 +12,13 @@
 use std::{collections::HashMap, str::FromStr};
 
 use biome_diagnostics::{adapters::IniError, Error};
-use biome_formatter::{IndentWidth, LineEnding, LineWidth};
+use biome_formatter::{IndentStyle, IndentWidth, LineEnding, LineWidth};
 use serde::{Deserialize, Deserializer};
 
 use crate::{
     diagnostics::{EditorConfigDiagnostic, ParseFailedDiagnostic},
     OverrideFormatterConfiguration, OverridePattern, Overrides, PartialConfiguration,
-    PartialFormatterConfiguration, PlainIndentStyle,
+    PartialFormatterConfiguration,
 };
 
 pub fn parse_str(s: &str) -> Result<EditorConfig, EditorConfigDiagnostic> {
@@ -83,7 +83,7 @@ impl EditorConfig {
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(default)]
 pub struct EditorConfigOptions {
-    indent_style: Option<PlainIndentStyle>,
+    indent_style: Option<IndentStyle>,
     #[serde(deserialize_with = "deserialize_optional_indent_width_from_string")]
     indent_size: Option<IndentWidth>,
     end_of_line: Option<LineEnding>,
@@ -389,7 +389,7 @@ max_line_length = 80
         let (conf, _) = conf.to_biome();
         let conf = conf.expect("Failed to convert editorconfig to biome");
         let formatter = conf.formatter.expect("Formatter not set");
-        assert_eq!(formatter.indent_style, Some(PlainIndentStyle::Space));
+        assert_eq!(formatter.indent_style, Some(IndentStyle::Space));
         assert_eq!(formatter.indent_width.unwrap().value(), 4);
         assert_eq!(formatter.line_ending, Some(LineEnding::Crlf));
         assert_eq!(formatter.line_width.map(|v| v.value()), Some(80));

--- a/crates/biome_configuration/src/formatter.rs
+++ b/crates/biome_configuration/src/formatter.rs
@@ -28,7 +28,7 @@ pub struct FormatterConfiguration {
 
     /// The indent style.
     #[partial(bpaf(long("indent-style"), argument("tab|space"), optional))]
-    pub indent_style: PlainIndentStyle,
+    pub indent_style: IndentStyle,
 
     /// The size of the indentation, 2 by default (deprecated, use `indent-width`)
     #[partial(bpaf(long("indent-size"), argument("NUMBER"), optional))]
@@ -96,7 +96,7 @@ impl Default for FormatterConfiguration {
             format_with_errors: false,
             indent_size: IndentWidth::default(),
             indent_width: IndentWidth::default(),
-            indent_style: PlainIndentStyle::default(),
+            indent_style: IndentStyle::default(),
             line_ending: LineEnding::default(),
             line_width: LineWidth::default(),
             attribute_position: AttributePosition::default(),
@@ -115,39 +115,5 @@ impl FromStr for FormatterConfiguration {
 
     fn from_str(_s: &str) -> Result<Self, Self::Err> {
         Ok(Self::default())
-    }
-}
-
-impl From<PlainIndentStyle> for IndentStyle {
-    fn from(value: PlainIndentStyle) -> Self {
-        match value {
-            PlainIndentStyle::Tab => IndentStyle::Tab,
-            PlainIndentStyle::Space => IndentStyle::Space,
-        }
-    }
-}
-
-#[derive(
-    Clone, Copy, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize,
-)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
-pub enum PlainIndentStyle {
-    /// Tab
-    #[default]
-    Tab,
-    /// Space
-    Space,
-}
-
-impl FromStr for PlainIndentStyle {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "tab" => Ok(PlainIndentStyle::Tab),
-            "space" => Ok(PlainIndentStyle::Space),
-            _ => Err("Unsupported value for this option"),
-        }
     }
 }

--- a/crates/biome_configuration/src/graphql.rs
+++ b/crates/biome_configuration/src/graphql.rs
@@ -1,6 +1,7 @@
-use crate::PlainIndentStyle;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
-use biome_formatter::{BracketSpacing, IndentWidth, LineEnding, LineWidth, QuoteStyle};
+use biome_formatter::{
+    BracketSpacing, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteStyle,
+};
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 
@@ -35,7 +36,7 @@ pub struct GraphqlFormatter {
         argument("tab|space"),
         optional
     ))]
-    pub indent_style: Option<PlainIndentStyle>,
+    pub indent_style: Option<IndentStyle>,
 
     /// The size of the indentation applied to GraphQL files. Default to 2.
     #[partial(bpaf(long("graphql-formatter-indent-width"), argument("NUMBER"), optional))]

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -1,7 +1,6 @@
-use crate::PlainIndentStyle;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use biome_formatter::{
-    AttributePosition, BracketSpacing, IndentWidth, LineEnding, LineWidth, QuoteStyle,
+    AttributePosition, BracketSpacing, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteStyle,
 };
 use biome_js_formatter::context::{
     trailing_commas::TrailingCommas, ArrowParentheses, QuoteProperties, Semicolons,
@@ -55,7 +54,7 @@ pub struct JavascriptFormatter {
         argument("tab|space"),
         optional
     ))]
-    pub indent_style: Option<PlainIndentStyle>,
+    pub indent_style: Option<IndentStyle>,
 
     // TODO: Remove in 2.0.0
     /// The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.

--- a/crates/biome_configuration/src/json.rs
+++ b/crates/biome_configuration/src/json.rs
@@ -1,6 +1,5 @@
-use crate::PlainIndentStyle;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
-use biome_formatter::{IndentWidth, LineEnding, LineWidth};
+use biome_formatter::{IndentStyle, IndentWidth, LineEnding, LineWidth};
 use biome_json_formatter::context::TrailingCommas;
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
@@ -54,7 +53,7 @@ pub struct JsonFormatter {
 
     /// The indent style applied to JSON (and its super languages) files.
     #[partial(bpaf(long("json-formatter-indent-style"), argument("tab|space"), optional))]
-    pub indent_style: Option<PlainIndentStyle>,
+    pub indent_style: Option<IndentStyle>,
 
     /// The size of the indentation applied to JSON (and its super languages) files. Default to 2.
     #[partial(bpaf(long("json-formatter-indent-width"), argument("NUMBER"), optional))]

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -33,7 +33,7 @@ pub use analyzer::{
 };
 use biome_deserialize::{Deserialized, StringSet};
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
-use biome_formatter::QuoteStyle;
+use biome_formatter::{IndentStyle, QuoteStyle};
 use bpaf::Bpaf;
 pub use css::{
     partial_css_configuration, CssConfiguration, CssFormatter, PartialCssConfiguration,
@@ -41,7 +41,6 @@ pub use css::{
 };
 pub use formatter::{
     partial_formatter_configuration, FormatterConfiguration, PartialFormatterConfiguration,
-    PlainIndentStyle,
 };
 pub use graphql::{
     partial_graphql_configuration, GraphqlConfiguration, GraphqlFormatter, GraphqlLinter,
@@ -156,7 +155,7 @@ impl PartialConfiguration {
             }),
             formatter: Some(PartialFormatterConfiguration {
                 enabled: Some(true),
-                indent_style: Some(PlainIndentStyle::Tab),
+                indent_style: Some(IndentStyle::Tab),
                 ..Default::default()
             }),
             organize_imports: Some(PartialOrganizeImports {

--- a/crates/biome_configuration/src/overrides.rs
+++ b/crates/biome_configuration/src/overrides.rs
@@ -3,11 +3,13 @@ use super::json::PartialJsonConfiguration;
 use super::{PartialCssConfiguration, PartialGraphqlConfiguration};
 use crate::{
     partial_css_configuration, partial_graphql_configuration, partial_javascript_configuration,
-    partial_json_configuration, PlainIndentStyle,
+    partial_json_configuration,
 };
 use biome_deserialize::StringSet;
 use biome_deserialize_macros::{Deserializable, Merge};
-use biome_formatter::{AttributePosition, BracketSpacing, IndentWidth, LineEnding, LineWidth};
+use biome_formatter::{
+    AttributePosition, BracketSpacing, IndentStyle, IndentWidth, LineEnding, LineWidth,
+};
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -109,7 +111,7 @@ pub struct OverrideFormatterConfiguration {
     /// The indent style.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[bpaf(long("indent-style"), argument("tab|space"), optional)]
-    pub indent_style: Option<PlainIndentStyle>,
+    pub indent_style: Option<IndentStyle>,
 
     /// The size of the indentation, 2 by default (deprecated, use `indent-width`)
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -79,12 +79,12 @@ use std::num::ParseIntError;
 use std::str::FromStr;
 use token::string::Quote;
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
+#[derive(Debug, Default, Clone, Copy, Deserializable, Eq, Hash, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    serde(rename_all = "camelCase")
 )]
-#[derive(Default)]
 pub enum IndentStyle {
     /// Tab
     #[default]
@@ -112,10 +112,10 @@ impl FromStr for IndentStyle {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "tab" | "Tabs" => Ok(Self::Tab),
-            "space" | "Spaces" => Ok(Self::Space),
+            "tab" => Ok(Self::Tab),
+            "space" => Ok(Self::Space),
             // TODO: replace this error with a diagnostic
-            _ => Err("Value not supported for IndentStyle"),
+            _ => Err("Unsupported value for this option"),
         }
     }
 }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -11,7 +11,6 @@ use biome_configuration::{
     OverrideFormatterConfiguration, OverrideLinterConfiguration,
     OverrideOrganizeImportsConfiguration, Overrides, PartialConfiguration, PartialCssConfiguration,
     PartialGraphqlConfiguration, PartialJavascriptConfiguration, PartialJsonConfiguration,
-    PlainIndentStyle,
 };
 use biome_css_formatter::context::CssFormatOptions;
 use biome_css_parser::CssParserOptions;
@@ -1444,9 +1443,7 @@ pub fn to_override_settings(
                 format_with_errors: formatter
                     .format_with_errors
                     .unwrap_or(current_settings.formatter.format_with_errors),
-                indent_style: formatter
-                    .indent_style
-                    .map(|indent_style| indent_style.into()),
+                indent_style: formatter.indent_style,
                 indent_width: formatter.indent_width,
                 line_ending: formatter.line_ending,
                 line_width: formatter.line_width,
@@ -1612,10 +1609,7 @@ pub fn to_format_settings(
     working_directory: Option<PathBuf>,
     conf: FormatterConfiguration,
 ) -> Result<FormatSettings, WorkspaceError> {
-    let indent_style = match conf.indent_style {
-        PlainIndentStyle::Tab => IndentStyle::Tab,
-        PlainIndentStyle::Space => IndentStyle::Space,
-    };
+    let indent_style = conf.indent_style;
     let indent_width = conf.indent_width;
 
     Ok(FormatSettings {
@@ -1637,8 +1631,8 @@ impl TryFrom<OverrideFormatterConfiguration> for FormatSettings {
 
     fn try_from(conf: OverrideFormatterConfiguration) -> Result<Self, Self::Error> {
         let indent_style = match conf.indent_style {
-            Some(PlainIndentStyle::Tab) => IndentStyle::Tab,
-            Some(PlainIndentStyle::Space) => IndentStyle::Space,
+            Some(IndentStyle::Tab) => IndentStyle::Tab,
+            Some(IndentStyle::Space) => IndentStyle::Space,
             None => IndentStyle::default(),
         };
         let indent_width = conf

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -179,7 +179,7 @@ export interface PartialFormatterConfiguration {
 	/**
 	 * The indent style.
 	 */
-	indentStyle?: PlainIndentStyle;
+	indentStyle?: IndentStyle;
 	/**
 	 * The size of the indentation, 2 by default
 	 */
@@ -343,7 +343,7 @@ export interface PartialCssFormatter {
 	/**
 	 * The indent style applied to CSS (and its super languages) files.
 	 */
-	indentStyle?: PlainIndentStyle;
+	indentStyle?: IndentStyle;
 	/**
 	 * The size of the indentation applied to CSS (and its super languages) files. Default to 2.
 	 */
@@ -386,7 +386,7 @@ export interface PartialCssParser {
 export type AttributePosition = "auto" | "multiline";
 export type BracketSpacing = boolean;
 export type IndentWidth = number;
-export type PlainIndentStyle = "tab" | "space";
+export type IndentStyle = "tab" | "space";
 export type LineEnding = "lf" | "crlf" | "cr";
 /**
 	* Validated value for the `line_width` formatter options
@@ -409,7 +409,7 @@ export interface PartialGraphqlFormatter {
 	/**
 	 * The indent style applied to GraphQL files.
 	 */
-	indentStyle?: PlainIndentStyle;
+	indentStyle?: IndentStyle;
 	/**
 	 * The size of the indentation applied to GraphQL files. Default to 2.
 	 */
@@ -476,7 +476,7 @@ export interface PartialJavascriptFormatter {
 	/**
 	 * The indent style applied to JavaScript (and its super languages) files.
 	 */
-	indentStyle?: PlainIndentStyle;
+	indentStyle?: IndentStyle;
 	/**
 	 * The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.
 	 */
@@ -560,7 +560,7 @@ export interface PartialJsonFormatter {
 	/**
 	 * The indent style applied to JSON (and its super languages) files.
 	 */
-	indentStyle?: PlainIndentStyle;
+	indentStyle?: IndentStyle;
 	/**
 	 * The size of the indentation applied to JSON (and its super languages) files. Default to 2.
 	 */
@@ -1860,7 +1860,7 @@ export interface OverrideFormatterConfiguration {
 	/**
 	 * The indent style.
 	 */
-	indentStyle?: PlainIndentStyle;
+	indentStyle?: IndentStyle;
 	/**
 	 * The size of the indentation, 2 by default
 	 */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -978,10 +978,7 @@
 				},
 				"indentStyle": {
 					"description": "The indent style applied to CSS (and its super languages) files.",
-					"anyOf": [
-						{ "$ref": "#/definitions/PlainIndentStyle" },
-						{ "type": "null" }
-					]
+					"anyOf": [{ "$ref": "#/definitions/IndentStyle" }, { "type": "null" }]
 				},
 				"indentWidth": {
 					"description": "The size of the indentation applied to CSS (and its super languages) files. Default to 2.",
@@ -1187,10 +1184,7 @@
 				},
 				"indentStyle": {
 					"description": "The indent style.",
-					"anyOf": [
-						{ "$ref": "#/definitions/PlainIndentStyle" },
-						{ "type": "null" }
-					]
+					"anyOf": [{ "$ref": "#/definitions/IndentStyle" }, { "type": "null" }]
 				},
 				"indentWidth": {
 					"description": "The size of the indentation, 2 by default",
@@ -1248,10 +1242,7 @@
 				},
 				"indentStyle": {
 					"description": "The indent style applied to GraphQL files.",
-					"anyOf": [
-						{ "$ref": "#/definitions/PlainIndentStyle" },
-						{ "type": "null" }
-					]
+					"anyOf": [{ "$ref": "#/definitions/IndentStyle" }, { "type": "null" }]
 				},
 				"indentWidth": {
 					"description": "The size of the indentation applied to GraphQL files. Default to 2.",
@@ -1325,6 +1316,12 @@
 				}
 			},
 			"additionalProperties": false
+		},
+		"IndentStyle": {
+			"oneOf": [
+				{ "description": "Tab", "type": "string", "enum": ["tab"] },
+				{ "description": "Space", "type": "string", "enum": ["space"] }
+			]
 		},
 		"IndentWidth": { "type": "integer", "format": "uint8", "minimum": 0.0 },
 		"JavascriptAssists": {
@@ -1426,10 +1423,7 @@
 				},
 				"indentStyle": {
 					"description": "The indent style applied to JavaScript (and its super languages) files.",
-					"anyOf": [
-						{ "$ref": "#/definitions/PlainIndentStyle" },
-						{ "type": "null" }
-					]
+					"anyOf": [{ "$ref": "#/definitions/IndentStyle" }, { "type": "null" }]
 				},
 				"indentWidth": {
 					"description": "The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.",
@@ -1555,10 +1549,7 @@
 				},
 				"indentStyle": {
 					"description": "The indent style applied to JSON (and its super languages) files.",
-					"anyOf": [
-						{ "$ref": "#/definitions/PlainIndentStyle" },
-						{ "type": "null" }
-					]
+					"anyOf": [{ "$ref": "#/definitions/IndentStyle" }, { "type": "null" }]
 				},
 				"indentWidth": {
 					"description": "The size of the indentation applied to JSON (and its super languages) files. Default to 2.",
@@ -2317,10 +2308,7 @@
 				},
 				"indentStyle": {
 					"description": "The indent style.",
-					"anyOf": [
-						{ "$ref": "#/definitions/PlainIndentStyle" },
-						{ "type": "null" }
-					]
+					"anyOf": [{ "$ref": "#/definitions/IndentStyle" }, { "type": "null" }]
 				},
 				"indentWidth": {
 					"description": "The size of the indentation, 2 by default",
@@ -2470,12 +2458,6 @@
 				}
 			},
 			"additionalProperties": false
-		},
-		"PlainIndentStyle": {
-			"oneOf": [
-				{ "description": "Tab", "type": "string", "enum": ["tab"] },
-				{ "description": "Space", "type": "string", "enum": ["space"] }
-			]
 		},
 		"QuoteProperties": { "type": "string", "enum": ["asNeeded", "preserve"] },
 		"QuoteStyle": { "type": "string", "enum": ["double", "single"] },


### PR DESCRIPTION
## Summary

This is a minor change that removes `biome_configuration::PlainIndentStyle` and use `biome_formatter::IndentStyle` instead. I am not sure why we had this duplication in the first place. This is certainly for legacy reasons.

Note that removing `Tabs` and `Spaces` from the `FromStr` impl for `biome_formatter::IndentStyle` doesn't break anything because the implementation was not used.
 
## Test Plan

CI must pass.
