### PR TITLE
fix(noControlCharactersInRegex): handle \u correctly in Unicode-aware regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,13 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [suspicious/noControlCharactersInRegex](https://www.biomejs.dev/linter/rules/no-control-characters-in-regex) now corretcly handle `\u` escapes in unicode-aware regexes.
+
+  Previously, the rule didn't consider regex with the `v` flags as unicode-aware regexes.
+  Moreover, `\uhhhh` was not handled in unicode-aware regexes.
+
+  Contributed by @Conaclos
+
 ### Parser
 
 #### Bug fixes

--- a/crates/biome_js_analyze/src/utils.rs
+++ b/crates/biome_js_analyze/src/utils.rs
@@ -8,38 +8,6 @@ pub mod rename;
 #[cfg(test)]
 pub mod tests;
 
-#[derive(Debug, PartialEq)]
-pub enum EscapeError {
-    EscapeAtEndOfString,
-    InvalidEscapedChar(char),
-}
-
-struct InterpretEscapedString<'a> {
-    s: std::str::Chars<'a>,
-}
-
-impl<'a> Iterator for InterpretEscapedString<'a> {
-    type Item = Result<char, EscapeError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.s.next().map(|c| match c {
-            '\\' => match self.s.next() {
-                None => Err(EscapeError::EscapeAtEndOfString),
-                Some('n') => Ok('\n'),
-                Some('\\') => Ok('\\'),
-                Some(c) => Err(EscapeError::InvalidEscapedChar(c)),
-            },
-            c => Ok(c),
-        })
-    }
-}
-
-/// unescape
-///
-pub(crate) fn unescape_string(s: &str) -> Result<String, EscapeError> {
-    (InterpretEscapedString { s: s.chars() }).collect()
-}
-
 /// Verifies that both nodes are equal by checking their descendants (nodes included) kinds
 /// and tokens (same kind and inner token text).
 pub(crate) fn is_node_equal(a_node: &JsSyntaxNode, b_node: &JsSyntaxNode) -> bool {

--- a/crates/biome_js_analyze/tests/specs/suspicious/noControlCharactersInRegex/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noControlCharactersInRegex/invalid.js
@@ -21,5 +21,7 @@ var regex = /FOO\\\x1fFOO\\x1f/;
 var regex = /(?<a>\\x1f)/;
 var regex = /(?<\u{1d49c}>.)\x1f/;
 var regex = /\u{1111}*\x1F/u;
+var regex = /\u{1111}*\x1F/v;
 var regex = /\u{1F}/u;
 var regex = /\u{1F}/gui;
+var regex = /\u000C\n/u;

--- a/crates/biome_js_analyze/tests/specs/suspicious/noControlCharactersInRegex/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noControlCharactersInRegex/invalid.js.snap
@@ -27,9 +27,10 @@ var regex = /FOO\\\x1fFOO\\x1f/;
 var regex = /(?<a>\\x1f)/;
 var regex = /(?<\u{1d49c}>.)\x1f/;
 var regex = /\u{1111}*\x1F/u;
+var regex = /\u{1111}*\x1F/v;
 var regex = /\u{1F}/u;
 var regex = /\u{1F}/gui;
-
+var regex = /\u000C\n/u;
 ```
 
 # Diagnostics
@@ -380,7 +381,7 @@ invalid.js:22:13 lint/suspicious/noControlCharactersInRegex ━━━━━━�
   > 22 │ var regex = /(?<\u{1d49c}>.)\x1f/;
        │             ^^^^^^^^^^^^^^^^^^^^^
     23 │ var regex = /\u{1111}*\x1F/u;
-    24 │ var regex = /\u{1F}/u;
+    24 │ var regex = /\u{1111}*\x1F/v;
   
   i Control characters are unusual and potentially incorrect inputs, so they are disallowed.
   
@@ -396,8 +397,8 @@ invalid.js:23:13 lint/suspicious/noControlCharactersInRegex ━━━━━━�
     22 │ var regex = /(?<\u{1d49c}>.)\x1f/;
   > 23 │ var regex = /\u{1111}*\x1F/u;
        │             ^^^^^^^^^^^^^^^^
-    24 │ var regex = /\u{1F}/u;
-    25 │ var regex = /\u{1F}/gui;
+    24 │ var regex = /\u{1111}*\x1F/v;
+    25 │ var regex = /\u{1F}/u;
   
   i Control characters are unusual and potentially incorrect inputs, so they are disallowed.
   
@@ -407,14 +408,14 @@ invalid.js:23:13 lint/suspicious/noControlCharactersInRegex ━━━━━━�
 ```
 invalid.js:24:13 lint/suspicious/noControlCharactersInRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Unexpected control character(s) in regular expression: \u{1F}
+  ! Unexpected control character(s) in regular expression: \x1F
   
     22 │ var regex = /(?<\u{1d49c}>.)\x1f/;
     23 │ var regex = /\u{1111}*\x1F/u;
-  > 24 │ var regex = /\u{1F}/u;
-       │             ^^^^^^^^^
-    25 │ var regex = /\u{1F}/gui;
-    26 │ 
+  > 24 │ var regex = /\u{1111}*\x1F/v;
+       │             ^^^^^^^^^^^^^^^^
+    25 │ var regex = /\u{1F}/u;
+    26 │ var regex = /\u{1F}/gui;
   
   i Control characters are unusual and potentially incorrect inputs, so they are disallowed.
   
@@ -427,14 +428,44 @@ invalid.js:25:13 lint/suspicious/noControlCharactersInRegex ━━━━━━�
   ! Unexpected control character(s) in regular expression: \u{1F}
   
     23 │ var regex = /\u{1111}*\x1F/u;
-    24 │ var regex = /\u{1F}/u;
-  > 25 │ var regex = /\u{1F}/gui;
-       │             ^^^^^^^^^^^
-    26 │ 
+    24 │ var regex = /\u{1111}*\x1F/v;
+  > 25 │ var regex = /\u{1F}/u;
+       │             ^^^^^^^^^
+    26 │ var regex = /\u{1F}/gui;
+    27 │ var regex = /\u000C\n/u;
   
   i Control characters are unusual and potentially incorrect inputs, so they are disallowed.
   
 
 ```
 
+```
+invalid.js:26:13 lint/suspicious/noControlCharactersInRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Unexpected control character(s) in regular expression: \u{1F}
+  
+    24 │ var regex = /\u{1111}*\x1F/v;
+    25 │ var regex = /\u{1F}/u;
+  > 26 │ var regex = /\u{1F}/gui;
+       │             ^^^^^^^^^^^
+    27 │ var regex = /\u000C\n/u;
+  
+  i Control characters are unusual and potentially incorrect inputs, so they are disallowed.
+  
+
+```
+
+```
+invalid.js:27:13 lint/suspicious/noControlCharactersInRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Unexpected control character(s) in regular expression: \u000C
+  
+    25 │ var regex = /\u{1F}/u;
+    26 │ var regex = /\u{1F}/gui;
+  > 27 │ var regex = /\u000C\n/u;
+       │             ^^^^^^^^^^^
+  
+  i Control characters are unusual and potentially incorrect inputs, so they are disallowed.
+  
+
+```


### PR DESCRIPTION
## Summary

This PR fixes `noControlCharactersInRegex` by supporting `\uhhhh` in Unicode-aware regexes and by recognizing regexes with the `v` flag as Unicode-aware.

I took the opportunity of improving the code.
There are more room for improvement in a follow-up PR.

## Test Plan

I added some tests.
