### PR TITLE
feat(cli): better environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
     Contributed by @NiclasvanEyk
 
+- Add new options to the `lsp-proxy` and `start` commands:
+  - `--log-path`: a directory where to store the daemon logs. The commands also accepts the environment variable `BIOME_LOG_PATH`.
+  - `--log-prefix-name`: a prefix that's added to the file name of the logs. It defaults to `server.log`. The commands also accepts the environment variable `BIOME_LOG_PREFIX_NAME`.
+
+  @Contributed by @ematipico
+   
+
 #### Enhancements
 
 - When a `--reporter` is provided, and it's different from the default one, the value provided by via `--max-diagnostics` is ignored and **the limit is lifted**. Contributed by @ematipico

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
  "biome_deserialize",
  "biome_deserialize_macros",
  "biome_diagnostics",
+ "biome_flags",
  "biome_formatter",
  "biome_fs",
  "biome_js_analyze",
@@ -414,6 +415,9 @@ dependencies = [
 [[package]]
 name = "biome_flags"
 version = "0.0.0"
+dependencies = [
+ "biome_console",
+]
 
 [[package]]
 name = "biome_formatter"

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -25,6 +25,7 @@ biome_console            = { workspace = true }
 biome_deserialize        = { workspace = true }
 biome_deserialize_macros = { workspace = true }
 biome_diagnostics        = { workspace = true }
+biome_flags              = { workspace = true }
 biome_formatter          = { workspace = true }
 biome_fs                 = { workspace = true }
 biome_js_analyze         = { workspace = true }

--- a/crates/biome_cli/src/commands/clean.rs
+++ b/crates/biome_cli/src/commands/clean.rs
@@ -9,8 +9,7 @@ pub fn clean(_cli_session: CliSession) -> Result<(), CliDiagnostic> {
     let logs_dir = biome_env()
         .biome_log_dir
         .value()
-        .map(PathBuf::from)
-        .unwrap_or(default_biome_log_dir());
+        .map_or(default_biome_log_dir(), PathBuf::from);
     remove_dir_all(logs_dir.clone()).and_then(|_| create_dir(logs_dir))?;
     Ok(())
 }

--- a/crates/biome_cli/src/commands/clean.rs
+++ b/crates/biome_cli/src/commands/clean.rs
@@ -1,10 +1,16 @@
-use crate::commands::daemon::biome_log_dir;
+use crate::commands::daemon::default_biome_log_dir;
 use crate::{CliDiagnostic, CliSession};
+use biome_flags::biome_env;
 use std::fs::{create_dir, remove_dir_all};
+use std::path::PathBuf;
 
 /// Runs the clean command
 pub fn clean(_cli_session: CliSession) -> Result<(), CliDiagnostic> {
-    let logs_dir = biome_log_dir();
+    let logs_dir = biome_env()
+        .biome_log_dir
+        .value()
+        .map(PathBuf::from)
+        .unwrap_or(default_biome_log_dir());
     remove_dir_all(logs_dir.clone()).and_then(|_| create_dir(logs_dir))?;
     Ok(())
 }

--- a/crates/biome_cli/src/commands/clean.rs
+++ b/crates/biome_cli/src/commands/clean.rs
@@ -1,4 +1,4 @@
-use crate::commands::daemon::default_biome_log_dir;
+use crate::commands::daemon::default_biome_log_path;
 use crate::{CliDiagnostic, CliSession};
 use biome_flags::biome_env;
 use std::fs::{create_dir, remove_dir_all};
@@ -6,10 +6,10 @@ use std::path::PathBuf;
 
 /// Runs the clean command
 pub fn clean(_cli_session: CliSession) -> Result<(), CliDiagnostic> {
-    let logs_dir = biome_env()
-        .biome_log_dir
+    let logs_path = biome_env()
+        .biome_log_path
         .value()
-        .map_or(default_biome_log_dir(), PathBuf::from);
-    remove_dir_all(logs_dir.clone()).and_then(|_| create_dir(logs_dir))?;
+        .map_or(default_biome_log_path(), PathBuf::from);
+    remove_dir_all(logs_path.clone()).and_then(|_| create_dir(logs_path))?;
     Ok(())
 }

--- a/crates/biome_cli/src/commands/daemon.rs
+++ b/crates/biome_cli/src/commands/daemon.rs
@@ -21,9 +21,16 @@ use tracing_tree::HierarchicalLayer;
 pub(crate) fn start(
     session: CliSession,
     config_path: Option<PathBuf>,
+    log_path: Option<PathBuf>,
+    log_file_name_prefix: Option<String>,
 ) -> Result<(), CliDiagnostic> {
     let rt = Runtime::new()?;
-    let did_spawn = rt.block_on(ensure_daemon(false, config_path))?;
+    let did_spawn = rt.block_on(ensure_daemon(
+        false,
+        config_path,
+        log_path,
+        log_file_name_prefix,
+    ))?;
 
     if did_spawn {
         session.app.console.log(markup! {
@@ -65,8 +72,10 @@ pub(crate) fn stop(session: CliSession) -> Result<(), CliDiagnostic> {
 pub(crate) fn run_server(
     stop_on_disconnect: bool,
     config_path: Option<PathBuf>,
+    log_path: Option<PathBuf>,
+    log_file_name_prefix: Option<String>,
 ) -> Result<(), CliDiagnostic> {
-    setup_tracing_subscriber();
+    setup_tracing_subscriber(log_path, log_file_name_prefix);
 
     let rt = Runtime::new()?;
     let factory = ServerFactory::new(stop_on_disconnect);
@@ -95,9 +104,18 @@ pub(crate) fn print_socket() -> Result<(), CliDiagnostic> {
     Ok(())
 }
 
-pub(crate) fn lsp_proxy(config_path: Option<PathBuf>) -> Result<(), CliDiagnostic> {
+pub(crate) fn lsp_proxy(
+    config_path: Option<PathBuf>,
+    log_path: Option<PathBuf>,
+    log_file_name_prefix: Option<String>,
+) -> Result<(), CliDiagnostic> {
     let rt = Runtime::new()?;
-    rt.block_on(start_lsp_proxy(&rt, config_path))?;
+    rt.block_on(start_lsp_proxy(
+        &rt,
+        config_path,
+        log_path,
+        log_file_name_prefix,
+    ))?;
 
     Ok(())
 }
@@ -105,8 +123,13 @@ pub(crate) fn lsp_proxy(config_path: Option<PathBuf>) -> Result<(), CliDiagnosti
 /// Start a proxy process.
 /// Receives a process via `stdin` and then copy the content to the LSP socket.
 /// Copy to the process on `stdout` when the LSP responds to a message
-async fn start_lsp_proxy(rt: &Runtime, config_path: Option<PathBuf>) -> Result<(), CliDiagnostic> {
-    ensure_daemon(true, config_path).await?;
+async fn start_lsp_proxy(
+    rt: &Runtime,
+    config_path: Option<PathBuf>,
+    log_path: Option<PathBuf>,
+    log_file_name_prefix: Option<String>,
+) -> Result<(), CliDiagnostic> {
+    ensure_daemon(true, config_path, log_path, log_file_name_prefix).await?;
 
     match open_socket().await? {
         Some((mut owned_read_half, mut owned_write_half)) => {
@@ -148,21 +171,20 @@ async fn start_lsp_proxy(rt: &Runtime, config_path: Option<PathBuf>) -> Result<(
     }
 }
 
-const fn log_file_name_prefix() -> &'static str {
-    "server.log"
-}
+pub(crate) fn read_most_recent_log_file(
+    log_path: Option<PathBuf>,
+    log_file_name_prefix: String,
+) -> io::Result<Option<String>> {
+    let biome_log_path = log_path.unwrap_or(default_biome_log_dir());
 
-pub(crate) fn read_most_recent_log_file() -> io::Result<Option<String>> {
-    let logs_dir = biome_log_dir();
-
-    let most_recent = fs::read_dir(logs_dir)?
+    let most_recent = fs::read_dir(biome_log_path)?
         .flatten()
         .filter(|file| file.file_type().map_or(false, |ty| ty.is_file()))
         .filter_map(|file| {
             match file
                 .file_name()
                 .to_str()?
-                .split_once(log_file_name_prefix())
+                .split_once(log_file_name_prefix.as_str())
             {
                 Some((_, date_part)) if date_part.split('-').count() == 4 => Some(file.path()),
                 _ => None,
@@ -176,14 +198,19 @@ pub(crate) fn read_most_recent_log_file() -> io::Result<Option<String>> {
     }
 }
 
-/// Setup the [tracing]-based logging system for the server
+/// Set up the [tracing]-based logging system for the server
 /// The events received by the subscriber are filtered at the `info` level,
 /// then printed using the [HierarchicalLayer] layer, and the resulting text
 /// is written to log files rotated on a hourly basis (in
 /// `biome-logs/server.log.yyyy-MM-dd-HH` files inside the system temporary
 /// directory)
-fn setup_tracing_subscriber() {
-    let file_appender = tracing_appender::rolling::hourly(biome_log_dir(), log_file_name_prefix());
+fn setup_tracing_subscriber(log_path: Option<PathBuf>, log_file_name_prefix: Option<String>) {
+    let biome_log_path = log_path.unwrap_or(biome_fs::ensure_cache_dir().join("biome-logs"));
+    let file_appender = tracing_appender::rolling::hourly(
+        biome_log_path,
+        // The `Option` is required because we have a command called __print-socket that spans a daemon only to retrieve its port
+        log_file_name_prefix.unwrap_or(String::from("server.log")),
+    );
 
     registry()
         .with(
@@ -199,10 +226,14 @@ fn setup_tracing_subscriber() {
         .init();
 }
 
-pub fn biome_log_dir() -> PathBuf {
-    match env::var_os("BIOME_LOG_DIR") {
+pub fn default_biome_log_dir() -> PathBuf {
+    match env::var_os("BIOME_LOG_PATH") {
         Some(directory) => PathBuf::from(directory),
-        None => biome_fs::ensure_cache_dir().join("biome-logs"),
+        // TODO: Remove in Biome v2, and use the None part as fallback.
+        None => match env::var_os("BIOME_LOG_DIR") {
+            Some(directory) => PathBuf::from(directory),
+            None => biome_fs::ensure_cache_dir().join("biome-logs"),
+        },
     }
 }
 

--- a/crates/biome_cli/src/commands/daemon.rs
+++ b/crates/biome_cli/src/commands/daemon.rs
@@ -175,7 +175,7 @@ pub(crate) fn read_most_recent_log_file(
     log_path: Option<PathBuf>,
     log_file_name_prefix: String,
 ) -> io::Result<Option<String>> {
-    let biome_log_path = log_path.unwrap_or(default_biome_log_dir());
+    let biome_log_path = log_path.unwrap_or(default_biome_log_path());
 
     let most_recent = fs::read_dir(biome_log_path)?
         .flatten()
@@ -226,7 +226,7 @@ fn setup_tracing_subscriber(log_path: Option<PathBuf>, log_file_name_prefix: Opt
         .init();
 }
 
-pub fn default_biome_log_dir() -> PathBuf {
+pub fn default_biome_log_path() -> PathBuf {
     match env::var_os("BIOME_LOG_PATH") {
         Some(directory) => PathBuf::from(directory),
         // TODO: Remove in Biome v2, and use the None part as fallback.

--- a/crates/biome_cli/src/commands/explain.rs
+++ b/crates/biome_cli/src/commands/explain.rs
@@ -3,7 +3,7 @@ use biome_console::{markup, ConsoleExt};
 use biome_flags::biome_env;
 use biome_service::documentation::Doc;
 
-use crate::commands::daemon::default_biome_log_dir;
+use crate::commands::daemon::default_biome_log_path;
 use crate::{CliDiagnostic, CliSession};
 
 fn print_rule(session: CliSession, metadata: &RuleMetadata) {
@@ -47,9 +47,9 @@ pub(crate) fn explain(session: CliSession, doc: Doc) -> Result<(), CliDiagnostic
         }
         Doc::DaemonLogs => {
             let cache_dir = biome_env()
-                .biome_log_dir
+                .biome_log_path
                 .value()
-                .unwrap_or(default_biome_log_dir().display().to_string());
+                .unwrap_or(default_biome_log_path().display().to_string());
             session.app.console.error(markup! {
                 <Info>"The daemon logs are available in the directory: \n"</Info>
             });

--- a/crates/biome_cli/src/commands/explain.rs
+++ b/crates/biome_cli/src/commands/explain.rs
@@ -1,8 +1,9 @@
 use biome_analyze::{FixKind, RuleMetadata};
 use biome_console::{markup, ConsoleExt};
+use biome_flags::biome_env;
 use biome_service::documentation::Doc;
 
-use crate::commands::daemon::biome_log_dir;
+use crate::commands::daemon::default_biome_log_dir;
 use crate::{CliDiagnostic, CliSession};
 
 fn print_rule(session: CliSession, metadata: &RuleMetadata) {
@@ -45,7 +46,10 @@ pub(crate) fn explain(session: CliSession, doc: Doc) -> Result<(), CliDiagnostic
             Ok(())
         }
         Doc::DaemonLogs => {
-            let cache_dir = biome_log_dir().display().to_string();
+            let cache_dir = biome_env()
+                .biome_log_dir
+                .value()
+                .unwrap_or(default_biome_log_dir().display().to_string());
             session.app.console.error(markup! {
                 <Info>"The daemon logs are available in the directory: \n"</Info>
             });

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -67,12 +67,32 @@ pub enum BiomeCommand {
     ),
     /// Start the Biome daemon server process
     #[bpaf(command)]
-    Start(
+    Start {
+        /// Allows to change the prefix applied to the file name of the logs.
+        #[bpaf(
+            env("BIOME_LOG_PREFIX_NAME"),
+            long("log-prefix-name"),
+            argument("STRING"),
+            hide_usage,
+            fallback(String::from("server.log")),
+            display_fallback
+        )]
+        log_prefix_name: String,
+
+        /// Allows to change the folder where logs are stored.
+        #[bpaf(
+            env("BIOME_LOG_PATH"),
+            long("log-path"),
+            argument("PATH"),
+            hide_usage,
+            fallback(biome_fs::ensure_cache_dir().join("biome-logs")),
+        )]
+        log_path: PathBuf,
         /// Allows to set a custom file path to the configuration file,
         /// or a custom directory path to find `biome.json` or `biome.jsonc`
         #[bpaf(env("BIOME_CONFIG_PATH"), long("config-path"), argument("PATH"))]
-        Option<PathBuf>,
-    ),
+        config_path: Option<PathBuf>,
+    },
 
     /// Stop the Biome daemon server process
     #[bpaf(command)]
@@ -350,15 +370,34 @@ pub enum BiomeCommand {
     ),
     /// Acts as a server for the Language Server Protocol over stdin/stdout
     #[bpaf(command("lsp-proxy"))]
-    LspProxy(
+    LspProxy {
+        /// Allows to change the prefix applied to the file name of the logs.
+        #[bpaf(
+            env("BIOME_LOG_PREFIX_NAME"),
+            long("log-prefix-name"),
+            argument("STRING"),
+            hide_usage,
+            fallback(String::from("server.log")),
+            display_fallback
+        )]
+        log_prefix_name: String,
+        /// Allows to change the folder where logs are stored.
+        #[bpaf(
+            env("BIOME_LOG_PATH"),
+            long("log-path"),
+            argument("PATH"),
+            hide_usage,
+            fallback(biome_fs::ensure_cache_dir().join("biome-logs")),
+        )]
+        log_path: PathBuf,
         /// Allows to set a custom file path to the configuration file,
         /// or a custom directory path to find `biome.json` or `biome.jsonc`
         #[bpaf(env("BIOME_CONFIG_PATH"), long("config-path"), argument("PATH"))]
-        Option<PathBuf>,
+        config_path: Option<PathBuf>,
         /// Bogus argument to make the command work with vscode-languageclient
         #[bpaf(long("stdio"), hide, hide_usage, switch)]
-        bool,
-    ),
+        stdio: bool,
+    },
     /// It updates the configuration when there are breaking changes
     #[bpaf(command)]
     Migrate {
@@ -435,6 +474,26 @@ pub enum BiomeCommand {
 
     #[bpaf(command("__run_server"), hide)]
     RunServer {
+        /// Allows to change the prefix applied to the file name of the logs.
+        #[bpaf(
+            env("BIOME_LOG_PREFIX_NAME"),
+            long("log-prefix-name"),
+            argument("STRING"),
+            hide_usage,
+            fallback(String::from("server.log")),
+            display_fallback
+        )]
+        log_prefix_name: String,
+        /// Allows to change the folder where logs are stored.
+        #[bpaf(
+            env("BIOME_LOG_PATH"),
+            long("log-path"),
+            argument("PATH"),
+            hide_usage,
+            fallback(biome_fs::ensure_cache_dir().join("biome-logs")),
+        )]
+        log_path: PathBuf,
+
         #[bpaf(long("stop-on-disconnect"), hide_usage)]
         stop_on_disconnect: bool,
         /// Allows to set a custom file path to the configuration file,
@@ -480,8 +539,8 @@ impl BiomeCommand {
             | BiomeCommand::Format { cli_options, .. }
             | BiomeCommand::Migrate { cli_options, .. }
             | BiomeCommand::Search { cli_options, .. } => Some(cli_options),
-            BiomeCommand::LspProxy(_, _)
-            | BiomeCommand::Start(_)
+            BiomeCommand::LspProxy { .. }
+            | BiomeCommand::Start { .. }
             | BiomeCommand::Stop
             | BiomeCommand::Init(_)
             | BiomeCommand::Explain { .. }

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -58,10 +58,10 @@ pub enum BiomeCommand {
         /// Prints the Biome daemon server logs
         #[bpaf(long("daemon-logs"), switch)]
         bool,
-        /// Prints the Biome configuration that the applied formatter configuration
+        /// Prints the formatter options applied
         #[bpaf(long("formatter"), switch)]
         bool,
-        /// Prints the Biome configuration that the applied linter configuration
+        /// Prints the linter options applied
         #[bpaf(long("linter"), switch)]
         bool,
     ),

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -362,10 +362,7 @@ struct BiomeServerLog;
 impl Display for BiomeServerLog {
     fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
         if let Ok(Some(log)) = read_most_recent_log_file(
-            biome_env()
-                .biome_log_dir
-                .value()
-                .map(|value| PathBuf::from(value)),
+            biome_env().biome_log_dir.value().map(PathBuf::from),
             biome_env()
                 .biome_log_prefix
                 .value()

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -1,12 +1,17 @@
 use biome_configuration::{ConfigurationPathHint, Rules};
 use biome_console::fmt::{Display, Formatter};
-use biome_console::{fmt, markup, ConsoleExt, HorizontalLine, Markup, Padding, SOFT_LINE};
+use biome_console::{
+    fmt, markup, ConsoleExt, DebugDisplay, DebugDisplayOption, HorizontalLine, KeyValuePair,
+    Padding, SOFT_LINE,
+};
 use biome_diagnostics::termcolor::{ColorChoice, WriteColor};
 use biome_diagnostics::{termcolor, PrintDescription};
+use biome_flags::biome_env;
 use biome_fs::FileSystem;
 use biome_service::configuration::{load_configuration, LoadedConfiguration};
 use biome_service::workspace::{client, RageEntry, RageParams};
 use biome_service::{DynRef, Workspace};
+use std::path::PathBuf;
 use std::{env, io, ops::Deref};
 use tokio::runtime::Runtime;
 
@@ -25,6 +30,8 @@ pub(crate) fn rage(
         .buffer()
         .supports_color();
 
+    let biome_env = biome_env();
+
     session.app.console.log(markup!("CLI:\n"
     {KeyValuePair("Version", markup!({VERSION}))}
     {KeyValuePair("Color support", markup!({DebugDisplay(terminal_supports_colors)}))}
@@ -32,9 +39,8 @@ pub(crate) fn rage(
     {Section("Platform")}
     {KeyValuePair("CPU Architecture", markup!({std::env::consts::ARCH}))}
     {KeyValuePair("OS", markup!({std::env::consts::OS}))}
-
     {Section("Environment")}
-    {EnvVarOs("BIOME_LOG_DIR")}
+    {biome_env}
     {EnvVarOs("NO_COLOR")}
     {EnvVarOs("TERM")}
     {EnvVarOs("JS_RUNTIME_VERSION")}
@@ -331,33 +337,6 @@ impl Display for RageConfigurationLintRules<'_> {
     }
 }
 
-struct DebugDisplay<T>(T);
-
-impl<T> Display for DebugDisplay<T>
-where
-    T: std::fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> io::Result<()> {
-        write!(f, "{:?}", self.0)
-    }
-}
-
-struct DebugDisplayOption<T>(Option<T>);
-
-impl<T> Display for DebugDisplayOption<T>
-where
-    T: std::fmt::Debug,
-{
-    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
-        if let Some(value) = &self.0 {
-            markup!({ DebugDisplay(value) }).fmt(fmt)?;
-        } else {
-            markup!(<Dim>"unset"</Dim>).fmt(fmt)?;
-        }
-        Ok(())
-    }
-}
-
 struct EnvVarOs(&'static str);
 
 impl fmt::Display for EnvVarOs {
@@ -378,30 +357,20 @@ impl Display for Section<'_> {
     }
 }
 
-struct KeyValuePair<'a>(&'a str, Markup<'a>);
-
-impl Display for KeyValuePair<'_> {
-    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
-        let KeyValuePair(key, value) = self;
-        write!(fmt, "  {key}:")?;
-
-        let padding_width = 30usize.saturating_sub(key.len() + 1);
-
-        for _ in 0..padding_width {
-            fmt.write_str(" ")?;
-        }
-
-        value.fmt(fmt)?;
-
-        fmt.write_str("\n")
-    }
-}
-
 struct BiomeServerLog;
 
 impl Display for BiomeServerLog {
     fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
-        if let Ok(Some(log)) = read_most_recent_log_file() {
+        if let Ok(Some(log)) = read_most_recent_log_file(
+            biome_env()
+                .biome_log_dir
+                .value()
+                .map(|value| PathBuf::from(value)),
+            biome_env()
+                .biome_log_prefix
+                .value()
+                .unwrap_or("server.log".to_string()),
+        ) {
             markup!("\n"<Emphasis><Underline>"Biome Server Log:"</Underline></Emphasis>"
 
 "<Warn>"\u{26a0} Please review the content of the log file before sharing it publicly as it may contain sensitive information:

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -362,7 +362,7 @@ struct BiomeServerLog;
 impl Display for BiomeServerLog {
     fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
         if let Ok(Some(log)) = read_most_recent_log_file(
-            biome_env().biome_log_dir.value().map(PathBuf::from),
+            biome_env().biome_log_path.value().map(PathBuf::from),
             biome_env()
                 .biome_log_prefix
                 .value()

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -234,10 +234,10 @@ impl<'app> CliSession<'app> {
             BiomeCommand::Init(emit_jsonc) => commands::init::init(self, emit_jsonc),
             BiomeCommand::LspProxy {
                 config_path,
-                log_path: log_dir,
+                log_path,
                 log_prefix_name,
                 ..
-            } => commands::daemon::lsp_proxy(config_path, Some(log_dir), Some(log_prefix_name)),
+            } => commands::daemon::lsp_proxy(config_path, Some(log_path), Some(log_prefix_name)),
             BiomeCommand::Migrate {
                 cli_options,
                 write,

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -6,7 +6,7 @@
 //! to parse commands and arguments, redirect the execution of the commands and
 //! execute the traversal of directory and files, based on the command that were passed.
 
-use biome_console::{ColorMode, Console};
+use biome_console::{markup, ColorMode, Console, ConsoleExt};
 use biome_fs::OsFileSystem;
 use biome_service::{App, DynRef, Workspace, WorkspaceRef};
 use commands::search::SearchCommandPayload;
@@ -35,9 +35,6 @@ pub use execute::{execute_mode, Execution, TraversalMode, VcsTargeted};
 pub use panic::setup_panic_handler;
 pub use reporter::{DiagnosticsPayload, Reporter, ReporterVisitor, TraversalSummary};
 pub use service::{open_transport, SocketTransport};
-
-#[cfg(debug_assertions)]
-pub use crate::commands::daemon::biome_log_dir;
 
 pub(crate) const VERSION: &str = match option_env!("BIOME_VERSION") {
     Some(version) => version,
@@ -70,6 +67,12 @@ impl<'app> CliSession<'app> {
         if has_metrics {
             crate::metrics::init_metrics();
         }
+        // TODO: remove in Biome v2
+        if env::var_os("BIOME_LOG_DIR").is_some() {
+            self.app.console.log(markup! {
+                <Warn>"The use of BIOME_LOG_DIR is deprecated. Use BIOME_LOG_PATH instead."</Warn>
+            });
+        }
 
         let result = match command {
             BiomeCommand::Version(_) => commands::version::full_version(self),
@@ -77,7 +80,11 @@ impl<'app> CliSession<'app> {
                 commands::rage::rage(self, daemon_logs, formatter, linter)
             }
             BiomeCommand::Clean => commands::clean::clean(self),
-            BiomeCommand::Start(config_path) => commands::daemon::start(self, config_path),
+            BiomeCommand::Start {
+                config_path,
+                log_path,
+                log_prefix_name,
+            } => commands::daemon::start(self, config_path, Some(log_path), Some(log_prefix_name)),
             BiomeCommand::Stop => commands::daemon::stop(self),
             BiomeCommand::Check {
                 apply,
@@ -225,7 +232,12 @@ impl<'app> CliSession<'app> {
             ),
             BiomeCommand::Explain { doc } => commands::explain::explain(self, doc),
             BiomeCommand::Init(emit_jsonc) => commands::init::init(self, emit_jsonc),
-            BiomeCommand::LspProxy(config_path, _) => commands::daemon::lsp_proxy(config_path),
+            BiomeCommand::LspProxy {
+                config_path,
+                log_path: log_dir,
+                log_prefix_name,
+                ..
+            } => commands::daemon::lsp_proxy(config_path, Some(log_dir), Some(log_prefix_name)),
             BiomeCommand::Migrate {
                 cli_options,
                 write,
@@ -253,7 +265,14 @@ impl<'app> CliSession<'app> {
             BiomeCommand::RunServer {
                 stop_on_disconnect,
                 config_path,
-            } => commands::daemon::run_server(stop_on_disconnect, config_path),
+                log_path,
+                log_prefix_name,
+            } => commands::daemon::run_server(
+                stop_on_disconnect,
+                config_path,
+                Some(log_path),
+                Some(log_prefix_name),
+            ),
             BiomeCommand::PrintSocket => commands::daemon::print_socket(),
         };
 

--- a/crates/biome_cli/tests/commands/rage.rs
+++ b/crates/biome_cli/tests/commands/rage.rs
@@ -350,7 +350,7 @@ fn assert_rage_snapshot(payload: SnapshotPayload<'_>) {
             .map(|line| match line.trim_start().split_once(':') {
                 Some((
                     "CPU Architecture" | "OS" | "NO_COLOR" | "TERM" | "BIOME_LOG_DIR"
-                    | "Color support",
+                    | "BIOME_LOG_PATH" | "Color support",
                     value,
                 )) => line.replace(value.trim_start(), "**PLACEHOLDER**"),
                 _ => line.to_string(),
@@ -389,7 +389,7 @@ impl TestLogDir {
         let guard = RAGE_GUARD.lock().unwrap();
         let path = env::temp_dir().join(name);
 
-        env::set_var("BIOME_LOG_DIR", &path);
+        env::set_var("BIOME_LOG_PATH", &path);
 
         Self {
             path,
@@ -401,6 +401,6 @@ impl TestLogDir {
 impl Drop for TestLogDir {
     fn drop(&mut self) {
         fs::remove_dir_all(&self.path).ok();
-        env::remove_var("BIOME_LOG_DIR");
+        env::remove_var("BIOME_LOG_PATH");
     }
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
@@ -10,6 +10,11 @@ Acts as a server for the Language Server Protocol over stdin/stdout
 Usage: lsp-proxy [--config-path=PATH]
 
 Available options:
+        --log-prefix-name=STRING  Allows to change the prefix applied to the file name of the logs.
+                            [env:BIOME_LOG_PREFIX_NAME: N/A]
+                            [default: server.log]
+        --log-path=PATH     Allows to change the folder where logs are stored.
+                            [env:BIOME_LOG_PATH: N/A]
         --config-path=PATH  Allows to set a custom file path to the configuration file, or a custom
                             directory path to find `biome.json` or `biome.jsonc`
                             [env:BIOME_CONFIG_PATH: N/A]

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -44,9 +44,8 @@ Global options applied to all commands
 
 Available options:
         --daemon-logs         Prints the Biome daemon server logs
-        --formatter           Prints the Biome configuration that the applied formatter
-                              configuration
-        --linter              Prints the Biome configuration that the applied linter configuration
+        --formatter           Prints the formatter options applied
+        --linter              Prints the linter options applied
     -h, --help                Prints help information
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_ok.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_ok.snap
@@ -15,6 +15,8 @@ Platform:
 
 Environment:
   BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PREFIX_NAME:        unset
+  BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**
   TERM:                         **PLACEHOLDER**
   JS_RUNTIME_VERSION:           unset
@@ -33,5 +35,3 @@ Server:
 Workspace:
   Open Documents:               0
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_ok.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_ok.snap
@@ -14,7 +14,7 @@ Platform:
   OS:                           **PLACEHOLDER**
 
 Environment:
-  BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PATH:               **PLACEHOLDER**
   BIOME_LOG_PREFIX_NAME:        unset
   BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_configuration.snap
@@ -24,7 +24,7 @@ Platform:
   OS:                           **PLACEHOLDER**
 
 Environment:
-  BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PATH:               **PLACEHOLDER**
   BIOME_LOG_PREFIX_NAME:        unset
   BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_configuration.snap
@@ -25,6 +25,8 @@ Platform:
 
 Environment:
   BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PREFIX_NAME:        unset
+  BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**
   TERM:                         **PLACEHOLDER**
   JS_RUNTIME_VERSION:           unset
@@ -47,5 +49,3 @@ Server:
 Workspace:
   Open Documents:               0
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
@@ -61,7 +61,7 @@ Platform:
   OS:                           **PLACEHOLDER**
 
 Environment:
-  BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PATH:               **PLACEHOLDER**
   BIOME_LOG_PREFIX_NAME:        unset
   BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
@@ -62,6 +62,8 @@ Platform:
 
 Environment:
   BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PREFIX_NAME:        unset
+  BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**
   TERM:                         **PLACEHOLDER**
   JS_RUNTIME_VERSION:           unset

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_jsonc_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_jsonc_configuration.snap
@@ -25,7 +25,7 @@ Platform:
   OS:                           **PLACEHOLDER**
 
 Environment:
-  BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PATH:               **PLACEHOLDER**
   BIOME_LOG_PREFIX_NAME:        unset
   BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_jsonc_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_jsonc_configuration.snap
@@ -26,6 +26,8 @@ Platform:
 
 Environment:
   BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PREFIX_NAME:        unset
+  BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**
   TERM:                         **PLACEHOLDER**
   JS_RUNTIME_VERSION:           unset

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_configuration.snap
@@ -42,7 +42,7 @@ Platform:
   OS:                           **PLACEHOLDER**
 
 Environment:
-  BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PATH:               **PLACEHOLDER**
   BIOME_LOG_PREFIX_NAME:        unset
   BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_configuration.snap
@@ -43,6 +43,8 @@ Platform:
 
 Environment:
   BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PREFIX_NAME:        unset
+  BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**
   TERM:                         **PLACEHOLDER**
   JS_RUNTIME_VERSION:           unset

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_malformed_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_malformed_configuration.snap
@@ -24,7 +24,7 @@ Platform:
   OS:                           **PLACEHOLDER**
 
 Environment:
-  BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PATH:               **PLACEHOLDER**
   BIOME_LOG_PREFIX_NAME:        unset
   BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_malformed_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_malformed_configuration.snap
@@ -25,6 +25,8 @@ Platform:
 
 Environment:
   BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PREFIX_NAME:        unset
+  BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**
   TERM:                         **PLACEHOLDER**
   JS_RUNTIME_VERSION:           unset
@@ -48,5 +50,3 @@ Server:
 Workspace:
   Open Documents:               0
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
@@ -15,6 +15,8 @@ Platform:
 
 Environment:
   BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PREFIX_NAME:        unset
+  BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**
   TERM:                         **PLACEHOLDER**
   JS_RUNTIME_VERSION:           unset
@@ -73,5 +75,3 @@ INFO biome_cli::commands::daemon Received shutdown signal
 ├─┘
 ├─7897ms INFO biome_lsp::server Starting Biome Language Server...
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
@@ -14,7 +14,7 @@ Platform:
   OS:                           **PLACEHOLDER**
 
 Environment:
-  BIOME_LOG_DIR:                **PLACEHOLDER**
+  BIOME_LOG_PATH:               **PLACEHOLDER**
   BIOME_LOG_PREFIX_NAME:        unset
   BIOME_CONFIG_PATH:            unset
   NO_COLOR:                     **PLACEHOLDER**

--- a/crates/biome_console/src/lib.rs
+++ b/crates/biome_console/src/lib.rs
@@ -6,11 +6,12 @@ use write::Termcolor;
 
 pub mod fmt;
 mod markup;
+mod utils;
 mod write;
 
 pub use self::markup::{Markup, MarkupBuf, MarkupElement, MarkupNode};
-use crate::fmt::{Display, Formatter};
 pub use biome_markup::markup;
+pub use utils::*;
 
 /// Determines the "output stream" a message should get printed to
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -227,64 +228,5 @@ impl Console for BufferConsole {
             // particular use case for multiple prompts
             Some(self.in_buffer[0].clone())
         }
-    }
-}
-
-/// A horizontal line with the given print width
-pub struct HorizontalLine {
-    width: usize,
-}
-
-impl HorizontalLine {
-    pub fn new(width: usize) -> Self {
-        Self { width }
-    }
-}
-
-impl Display for HorizontalLine {
-    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
-        fmt.write_str(&"\u{2501}".repeat(self.width))
-    }
-}
-
-// It prints `\n`
-pub struct Softline;
-
-pub const SOFT_LINE: Softline = Softline;
-
-impl Display for Softline {
-    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
-        fmt.write_str("\n")
-    }
-}
-
-// It prints `\n\n`
-pub struct Hardline;
-
-pub const HARD_LINE: Hardline = Hardline;
-
-impl Display for Hardline {
-    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
-        fmt.write_str("\n\n")
-    }
-}
-
-/// It prints N whitespaces, where N is the `width` provided by [Padding::new]
-pub struct Padding {
-    width: usize,
-}
-
-impl Padding {
-    pub fn new(width: usize) -> Self {
-        Self { width }
-    }
-}
-
-impl Display for Padding {
-    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
-        for _ in 0..self.width {
-            fmt.write_str(" ")?;
-        }
-        Ok(())
     }
 }

--- a/crates/biome_console/src/utils.rs
+++ b/crates/biome_console/src/utils.rs
@@ -1,0 +1,114 @@
+use crate::fmt::{Display, Formatter};
+use crate::{markup, Markup};
+use std::io;
+
+/// It displays a type that implements [std::fmt::Display]
+
+pub struct DebugDisplay<T>(pub T);
+
+impl<T> Display for DebugDisplay<T>
+where
+    T: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> io::Result<()> {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+/// It displays a `Option<T>`, where `T` implements [std::fmt::Display]
+pub struct DebugDisplayOption<T>(pub Option<T>);
+
+impl<T> Display for DebugDisplayOption<T>
+where
+    T: std::fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
+        use crate as biome_console;
+
+        if let Some(value) = &self.0 {
+            markup!({ DebugDisplay(value) }).fmt(fmt)?;
+        } else {
+            markup!(<Dim>"unset"</Dim>).fmt(fmt)?;
+        }
+        Ok(())
+    }
+}
+
+/// A horizontal line with the given print width
+pub struct HorizontalLine {
+    width: usize,
+}
+
+impl HorizontalLine {
+    pub fn new(width: usize) -> Self {
+        Self { width }
+    }
+}
+
+impl Display for HorizontalLine {
+    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
+        fmt.write_str(&"\u{2501}".repeat(self.width))
+    }
+}
+
+// It prints `\n`
+pub struct Softline;
+
+pub const SOFT_LINE: Softline = Softline;
+
+impl Display for Softline {
+    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
+        fmt.write_str("\n")
+    }
+}
+
+// It prints `\n\n`
+pub struct Hardline;
+
+pub const HARD_LINE: Hardline = Hardline;
+
+impl Display for Hardline {
+    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
+        fmt.write_str("\n\n")
+    }
+}
+
+/// It prints N whitespaces, where N is the `width` provided by [Padding::new]
+pub struct Padding {
+    width: usize,
+}
+
+impl Padding {
+    pub fn new(width: usize) -> Self {
+        Self { width }
+    }
+}
+
+impl Display for Padding {
+    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
+        for _ in 0..self.width {
+            fmt.write_str(" ")?;
+        }
+        Ok(())
+    }
+}
+
+/// It writes a pair of key-value, with the given padding
+pub struct KeyValuePair<'a>(pub &'a str, pub Markup<'a>);
+
+impl Display for KeyValuePair<'_> {
+    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
+        let KeyValuePair(key, value) = self;
+        write!(fmt, "  {key}:")?;
+
+        let padding_width = 30usize.saturating_sub(key.len() + 1);
+
+        for _ in 0..padding_width {
+            fmt.write_str(" ")?;
+        }
+
+        value.fmt(fmt)?;
+
+        fmt.write_str("\n")
+    }
+}

--- a/crates/biome_flags/Cargo.toml
+++ b/crates/biome_flags/Cargo.toml
@@ -15,6 +15,7 @@ version              = "0.0.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+biome_console = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/biome_flags/src/lib.rs
+++ b/crates/biome_flags/src/lib.rs
@@ -42,7 +42,10 @@ impl BiomeEnv {
 }
 
 pub struct BiomeEnvVariable {
+    /// The name of the environment variable
     name: &'static str,
+    /// The description of the variable.
+    // This field will be used in the website to automate its generation
     description: &'static str,
 }
 

--- a/crates/biome_flags/src/lib.rs
+++ b/crates/biome_flags/src/lib.rs
@@ -56,7 +56,7 @@ impl BiomeEnvVariable {
 
     /// It attempts to read the value of the variable
     pub fn value(&self) -> Option<String> {
-        env::var(&self.name).ok()
+        env::var(self.name).ok()
     }
 
     /// It returns the description of the variable
@@ -71,7 +71,7 @@ impl BiomeEnvVariable {
 }
 
 pub fn biome_env() -> &'static BiomeEnv {
-    BIOME_ENV.get_or_init(|| BiomeEnv::new())
+    BIOME_ENV.get_or_init(BiomeEnv::new)
 }
 
 impl Display for BiomeEnv {

--- a/crates/biome_flags/src/lib.rs
+++ b/crates/biome_flags/src/lib.rs
@@ -15,7 +15,7 @@ pub fn is_unstable() -> bool {
 pub static BIOME_VERSION: LazyLock<Option<&str>> = LazyLock::new(|| option_env!("BIOME_VERSION"));
 
 pub struct BiomeEnv {
-    pub biome_log_dir: BiomeEnvVariable,
+    pub biome_log_path: BiomeEnvVariable,
     pub biome_log_prefix: BiomeEnvVariable,
     pub biome_config_path: BiomeEnvVariable,
 }
@@ -25,8 +25,8 @@ pub static BIOME_ENV: OnceLock<BiomeEnv> = OnceLock::new();
 impl BiomeEnv {
     fn new() -> Self {
         Self {
-            biome_log_dir: BiomeEnvVariable::new(
-                "BIOME_LOG_DIR",
+            biome_log_path: BiomeEnvVariable::new(
+                "BIOME_LOG_PATH",
                 "The directory where the Daemon logs will be saved.",
             ),
             biome_log_prefix: BiomeEnvVariable::new(
@@ -76,12 +76,12 @@ pub fn biome_env() -> &'static BiomeEnv {
 
 impl Display for BiomeEnv {
     fn fmt(&self, fmt: &mut Formatter) -> std::io::Result<()> {
-        match self.biome_log_dir.value() {
+        match self.biome_log_path.value() {
             None => {
-                KeyValuePair(self.biome_log_dir.name, markup! { <Dim>"unset"</Dim> }).fmt(fmt)?;
+                KeyValuePair(self.biome_log_path.name, markup! { <Dim>"unset"</Dim> }).fmt(fmt)?;
             }
             Some(value) => {
-                KeyValuePair(self.biome_log_dir.name, markup! {{DebugDisplay(value)}}).fmt(fmt)?;
+                KeyValuePair(self.biome_log_path.name, markup! {{DebugDisplay(value)}}).fmt(fmt)?;
             }
         };
         match self.biome_log_prefix.value() {

--- a/crates/biome_flags/src/lib.rs
+++ b/crates/biome_flags/src/lib.rs
@@ -1,7 +1,10 @@
 //! A simple implementation of feature flags.
 
+use biome_console::fmt::{Display, Formatter};
+use biome_console::{markup, DebugDisplay, KeyValuePair};
+use std::env;
 use std::ops::Deref;
-use std::sync::LazyLock;
+use std::sync::{LazyLock, OnceLock};
 
 /// Returns `true` if this is an unstable build of Biome
 pub fn is_unstable() -> bool {
@@ -10,3 +13,96 @@ pub fn is_unstable() -> bool {
 
 /// The internal version of Biome. This is usually supplied during the CI build
 pub static BIOME_VERSION: LazyLock<Option<&str>> = LazyLock::new(|| option_env!("BIOME_VERSION"));
+
+pub struct BiomeEnv {
+    pub biome_log_dir: BiomeEnvVariable,
+    pub biome_log_prefix: BiomeEnvVariable,
+    pub biome_config_path: BiomeEnvVariable,
+}
+
+pub static BIOME_ENV: OnceLock<BiomeEnv> = OnceLock::new();
+
+impl BiomeEnv {
+    fn new() -> Self {
+        Self {
+            biome_log_dir: BiomeEnvVariable::new(
+                "BIOME_LOG_DIR",
+                "The directory where the Daemon logs will be saved.",
+            ),
+            biome_log_prefix: BiomeEnvVariable::new(
+                "BIOME_LOG_PREFIX_NAME",
+                "A prefix that's added to the name of the log. Default: `server.log.`",
+            ),
+            biome_config_path: BiomeEnvVariable::new(
+                "BIOME_CONFIG_PATH",
+                "A path to the configuration file",
+            ),
+        }
+    }
+}
+
+pub struct BiomeEnvVariable {
+    name: &'static str,
+    description: &'static str,
+}
+
+impl BiomeEnvVariable {
+    fn new(name: &'static str, description: &'static str) -> Self {
+        Self { name, description }
+    }
+
+    /// It attempts to read the value of the variable
+    pub fn value(&self) -> Option<String> {
+        env::var(&self.name).ok()
+    }
+
+    /// It returns the description of the variable
+    pub fn description(&self) -> &'static str {
+        self.description
+    }
+
+    /// It returns the name of the variable.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+pub fn biome_env() -> &'static BiomeEnv {
+    BIOME_ENV.get_or_init(|| BiomeEnv::new())
+}
+
+impl Display for BiomeEnv {
+    fn fmt(&self, fmt: &mut Formatter) -> std::io::Result<()> {
+        match self.biome_log_dir.value() {
+            None => {
+                KeyValuePair(self.biome_log_dir.name, markup! { <Dim>"unset"</Dim> }).fmt(fmt)?;
+            }
+            Some(value) => {
+                KeyValuePair(self.biome_log_dir.name, markup! {{DebugDisplay(value)}}).fmt(fmt)?;
+            }
+        };
+        match self.biome_log_prefix.value() {
+            None => {
+                KeyValuePair(self.biome_log_prefix.name, markup! { <Dim>"unset"</Dim> })
+                    .fmt(fmt)?;
+            }
+            Some(value) => {
+                KeyValuePair(self.biome_log_prefix.name, markup! {{DebugDisplay(value)}})
+                    .fmt(fmt)?;
+            }
+        };
+
+        match self.biome_config_path.value() {
+            None => {
+                KeyValuePair(self.biome_config_path.name, markup! { <Dim>"unset"</Dim> })
+                    .fmt(fmt)?;
+            }
+            Some(value) => {
+                KeyValuePair(self.biome_config_path.name, markup! {{DebugDisplay(value)}})
+                    .fmt(fmt)?;
+            }
+        };
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Until now, we've had some environment variables, but they were not very well documented, and some were not used at all. 

This PR exposes a new function called `biome_env` inside the `biome_flags` crate, and it exposes three environment variables:
- `BIOME_CONFIG_PATH`: already documented and used.
- `BIOME_LOG_PATH`: where to store the logs. It defaults to a directory that depends on the OS.
- `BIOME_LOG_PREFIX_NAME`: the prefix of the logs, it defaults to `server.log`

New options are added to the `lsp-proxy` an `starts` commands:
- `--log-path`
- `--log-prefix-name`

`BIOME_LOG_DIR` is deprecated because it isn't in line with the naming convention we've been using. We use "path" instead of "dir". 

These variables are added to `lsp-proxy` and `start` CLI commands, too.

These new variables are now correctly displayed in the rage output. The type `BiomeEnvVeriable` contains a `description` field. I plan to use this field for the website.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Updated the snapshots 

<!-- What demonstrates that your implementation is correct? -->
