### PR TITLE
fix(lint/noStaticOnlyClass): prevent error on static classes that extend other classes

### DIFF
--- a/crates/biome_js_analyze/src/lint/complexity/no_static_only_class.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_static_only_class.rs
@@ -149,6 +149,10 @@ impl Rule for NoStaticOnlyClass {
             return None;
         }
 
+        if class_declaration.extends_clause().is_some() {
+            return None;
+        }
+
         let all_members_static = class_declaration
             .members()
             .iter()

--- a/crates/biome_js_analyze/tests/specs/complexity/noStaticOnlyClass/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/noStaticOnlyClass/valid.ts
@@ -66,3 +66,32 @@ class StaticConstants1 {
 }
 
 class Empty {}
+
+class Environment {
+	type: string;
+
+	constructor(type: string) {
+		this.type = type;
+	}
+
+	getType(): string {
+		return this.type;
+	}
+}
+
+class Application extends Environment {
+	private static environment: Environment;
+
+	static initialize(type: string): void {
+		if (!Application.environment) {
+			Application.environment = new Environment(type);
+		}
+	}
+
+	static getEnvironment(): string {
+		if (!Application.environment) {
+			throw new Error("Application not initialized.");
+		}
+		return Application.environment.getType();
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/complexity/noStaticOnlyClass/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/noStaticOnlyClass/valid.ts
@@ -83,15 +83,15 @@ class Application extends Environment {
 	private static environment: Environment;
 
 	static initialize(type: string): void {
-		if (!Application.environment) {
-			Application.environment = new Environment(type);
+		if (!this.environment) {
+			this.environment = new Environment(type);
 		}
 	}
 
 	static getEnvironment(): string {
-		if (!Application.environment) {
+		if (!this.environment) {
 			throw new Error("Application not initialized.");
 		}
-		return Application.environment.getType();
+		return this.environment.getType();
 	}
 }

--- a/crates/biome_js_analyze/tests/specs/complexity/noStaticOnlyClass/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noStaticOnlyClass/valid.ts.snap
@@ -73,6 +73,33 @@ class StaticConstants1 {
 
 class Empty {}
 
+class Environment {
+	type: string;
+
+	constructor(type: string) {
+		this.type = type;
+	}
+
+	getType(): string {
+		return this.type;
+	}
+}
+
+class Application extends Environment {
+	private static environment: Environment;
+
+	static initialize(type: string): void {
+		if (!Application.environment) {
+			Application.environment = new Environment(type);
+		}
+	}
+
+	static getEnvironment(): string {
+		if (!Application.environment) {
+			throw new Error("Application not initialized.");
+		}
+		return Application.environment.getType();
+	}
+}
+
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/complexity/noStaticOnlyClass/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noStaticOnlyClass/valid.ts.snap
@@ -89,16 +89,16 @@ class Application extends Environment {
 	private static environment: Environment;
 
 	static initialize(type: string): void {
-		if (!Application.environment) {
-			Application.environment = new Environment(type);
+		if (!this.environment) {
+			this.environment = new Environment(type);
 		}
 	}
 
 	static getEnvironment(): string {
-		if (!Application.environment) {
+		if (!this.environment) {
 			throw new Error("Application not initialized.");
 		}
-		return Application.environment.getType();
+		return this.environment.getType();
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #3612

Updated `NoStaticOnlyClass` rule to exclude classes that have `extends` clause and added test case.

I'm wondering if i should do the same for `implements` clause?

## Test Plan

Ran `cargo test no_static_only_class` and then `cargo insta review` to accept the new snapshot changes.
