### PR TITLE
ci: use `cargo t` instead of `nextest`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,7 @@
-
 # This workflow run when something is pushed on main and it does:
-  # - normal checks like in the normal PRs
-  # - expand the test suite to be run on multiple OS
-  # - runs the coverage and prints in the command line
+# - normal checks like in the normal PRs
+# - expand the test suite to be run on multiple OS
+# - runs the coverage and prints in the command line
 name: CI on main
 on:
   workflow_dispatch:
@@ -92,12 +91,9 @@ jobs:
       - name: Install toolchain
         uses: moonrepo/setup-rust@e013866c4215f77c925f42f60257dec7dd18836e # v1.2.1
         with:
-          bins: cargo-nextest
           cache-base: main
       - name: Run tests on ${{ matrix.os }}
-        run: cargo nextest run --workspace --verbose
-      - name: Clean cache
-        run: cargo cache --autoclean
+        run: cargo test --workspace
 
   coverage:
     name: Test262 Coverage
@@ -105,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [ windows-latest, ubuntu-latest ]
     steps:
       # ref: https://github.com/orgs/community/discussions/26952
       - name: Support longpaths

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -92,12 +92,9 @@ jobs:
       - name: Install toolchain
         uses: moonrepo/setup-rust@e013866c4215f77c925f42f60257dec7dd18836e # v1.2.1
         with:
-          bins: cargo-nextest
           cache-base: main
       - name: Run tests
-        run: cargo nextest run --workspace --verbose
-      - name: Run doctests
-        run: cargo test --doc
+        run: cargo test --workspace
 
   test-node-api:
     name: Test node.js API

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,6 @@ just install-tools
 This command will install:
 - `cargo-binstall`, to install binary extensions for `cargo`.
 - `cargo-insta`, a `cargo` extension to manage snapshot testing inside the repository.
-- `cargo-nextest`, a `cargo` extension to for optionally running tests faster.
 - `taplo-cli`, a small tool for formatting TOML files.
 - `wasm-pack` and `wasm-tools` for managing the WASM build of Biome.
 

--- a/justfile
+++ b/justfile
@@ -11,12 +11,12 @@ alias qt := test-quick
 # Installs the tools needed to develop
 install-tools:
 	cargo install cargo-binstall
-	cargo binstall cargo-insta cargo-nextest taplo-cli wasm-pack wasm-tools knope
+	cargo binstall cargo-insta taplo-cli wasm-pack wasm-tools knope
 
 # Upgrades the tools needed to develop
 upgrade-tools:
 	cargo install cargo-binstall --force
-	cargo binstall cargo-insta cargo-nextest taplo-cli wasm-pack wasm-tools knope --force
+	cargo binstall cargo-insta taplo-cli wasm-pack wasm-tools knope --force
 
 # Generate all files across crates and tools. You rarely want to use it locally.
 gen-all:
@@ -109,11 +109,11 @@ _touch file:
 
 # Run tests of all crates
 test:
-	cargo nextest run --no-fail-fast
+	cargo test run --no-fail-fast
 
 # Run tests for the crate passed as argument e.g. just test-create biome_cli
 test-crate name:
-	cargo nextest run -E 'package({{name}})' --no-fail-fast
+	cargo test run -p {{name}} --no-fail-fast
 
 # Run doc tests
 test-doc:


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md

-->

## Summary

`cargo test` seems to be faster than `nextest`, and it's one less tool to install

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

CI should pass

<!-- What demonstrates that your implementation is correct? -->
