### PR TITLE
feat(lsp): use home directory as working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   - `--log-path`: a directory where to store the daemon logs. The commands also accepts the environment variable `BIOME_LOG_PATH`.
   - `--log-prefix-name`: a prefix that's added to the file name of the logs. It defaults to `server.log`. The commands also accepts the environment variable `BIOME_LOG_PREFIX_NAME`.
 
-  @Contributed by @ematipico
-   
+  Contributed by @ematipico
+
 
 #### Enhancements
 
@@ -105,6 +105,21 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### Bug fixes
 
 - Fix [#3577](https://github.com/biomejs/biome/issues/3577), where the update of the configuration file was resulting in the creation of a new internal project. Contributed by @ematipico
+
+#### Enhancements
+
+- When an LSP is not able to provide a [`rootUri` or a `workspaceFolders`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize), the Biome LSP will use the **user home directory** as working directory.
+  The user home directory differs based on the OS:
+
+  | Platform | 	Value                 | 	Example         |
+  |----------|------------------------|------------------|
+  | Linux    | 	`$HOME`	              | `/home/alice`    |
+  | macOS    | 	`$HOME`               | `/home/alice`    |
+  | Windows  | 	`{FOLDERID_Profile}`	 | `C:\Users\Alice` |
+
+  If the LSP can't retrieve the user directory, it will fall back to the root directory.
+
+  Contributed by @ematipico
 
 ### Formatter
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,7 @@ dependencies = [
  "biome_rowan",
  "biome_service",
  "biome_text_edit",
+ "directories",
  "futures",
  "rustc-hash 1.1.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ bpaf               = { version = "0.9.12", features = ["derive"] }
 countme            = "3.0.1"
 crossbeam          = "0.8.4"
 dashmap            = "5.5.3"
+directories        = "5.0.1"
 enumflags2         = "0.7.10"
 getrandom          = "0.2.15"
 ignore             = "0.4.22"

--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -840,7 +840,9 @@ fn fs_error_dereferenced_symlink() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
+        DynRef::Owned(Box::new(
+            OsFileSystem::new().with_working_directory(root_path.clone()),
+        )),
         &mut console,
         Args::from([("check"), root_path.display().to_string().as_str()].as_slice()),
     );
@@ -884,7 +886,9 @@ fn fs_error_infinite_symlink_expansion_to_dirs() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
+        DynRef::Owned(Box::new(
+            OsFileSystem::new().with_working_directory(root_path.clone()),
+        )),
         &mut console,
         Args::from([("check"), (root_path.display().to_string().as_str())].as_slice()),
     );
@@ -930,7 +934,9 @@ fn fs_error_infinite_symlink_expansion_to_files() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
+        DynRef::Owned(Box::new(
+            OsFileSystem::new().with_working_directory(root_path.clone()),
+        )),
         &mut console,
         Args::from([("check"), (root_path.display().to_string().as_str())].as_slice()),
     );
@@ -1110,7 +1116,9 @@ fn fs_files_ignore_symlink() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
+        DynRef::Owned(Box::new(
+            OsFileSystem::new().with_working_directory(root_path.clone()),
+        )),
         &mut console,
         Args::from(
             [

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -866,7 +866,9 @@ fn fs_error_dereferenced_symlink() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
+        DynRef::Owned(Box::new(
+            OsFileSystem::new().with_working_directory(root_path.clone()),
+        )),
         &mut console,
         Args::from([("lint"), root_path.display().to_string().as_str()].as_slice()),
     );
@@ -910,7 +912,9 @@ fn fs_error_infinite_symlink_expansion_to_dirs() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
+        DynRef::Owned(Box::new(
+            OsFileSystem::new().with_working_directory(root_path.clone()),
+        )),
         &mut console,
         Args::from([("lint"), (root_path.display().to_string().as_str())].as_slice()),
     );
@@ -956,7 +960,9 @@ fn fs_error_infinite_symlink_expansion_to_files() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
+        DynRef::Owned(Box::new(
+            OsFileSystem::new().with_working_directory(root_path.clone()),
+        )),
         &mut console,
         Args::from([("lint"), (root_path.display().to_string().as_str())].as_slice()),
     );
@@ -1137,7 +1143,9 @@ fn fs_files_ignore_symlink() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
+        DynRef::Owned(Box::new(
+            OsFileSystem::new().with_working_directory(root_path.clone()),
+        )),
         &mut console,
         Args::from(
             [
@@ -1189,7 +1197,9 @@ fn include_files_in_subdir() {
         .unwrap();
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
+        DynRef::Owned(Box::new(
+            OsFileSystem::new().with_working_directory(root_path.clone()),
+        )),
         &mut console,
         Args::from([("lint"), root_path.display().to_string().as_str()].as_slice()),
     );
@@ -1247,7 +1257,9 @@ fn include_files_in_symlinked_subdir() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(subroot_path.clone()))),
+        DynRef::Owned(Box::new(
+            OsFileSystem::new().with_working_directory(subroot_path.clone()),
+        )),
         &mut console,
         Args::from([("lint"), subroot_path.display().to_string().as_str()].as_slice()),
     );
@@ -1307,7 +1319,9 @@ fn ignore_file_in_subdir_in_symlinked_dir() {
     }
 
     let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(subroot_path.clone()))),
+        DynRef::Owned(Box::new(
+            OsFileSystem::new().with_working_directory(subroot_path.clone()),
+        )),
         &mut console,
         Args::from([("lint"), subroot_path.display().to_string().as_str()].as_slice()),
     );

--- a/crates/biome_fs/Cargo.toml
+++ b/crates/biome_fs/Cargo.toml
@@ -15,7 +15,7 @@ version              = "0.5.7"
 [dependencies]
 biome_diagnostics = { workspace = true }
 crossbeam         = { workspace = true }
-directories       = "5.0.1"
+directories       = { workspace = true }
 indexmap          = { workspace = true }
 oxc_resolver      = { workspace = true }
 parking_lot       = { version = "0.12.3", features = ["arc_lock"] }

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -28,15 +28,20 @@ pub struct OsFileSystem {
 }
 
 impl OsFileSystem {
-    pub fn new(working_directory: PathBuf) -> Self {
+    pub fn new() -> Self {
         Self {
-            working_directory: Some(working_directory),
+            working_directory: None,
             configuration_resolver: AssertUnwindSafe(Resolver::new(ResolveOptions {
                 condition_names: vec!["node".to_string(), "import".to_string()],
                 extensions: vec![".json".to_string(), ".jsonc".to_string()],
                 ..ResolveOptions::default()
             })),
         }
+    }
+
+    pub fn with_working_directory(mut self, working_directory: impl Into<Option<PathBuf>>) -> Self {
+        self.working_directory = working_directory.into();
+        self
     }
 }
 

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -23,6 +23,7 @@ biome_fs            = { workspace = true }
 biome_rowan         = { workspace = true }
 biome_service       = { workspace = true }
 biome_text_edit     = { workspace = true }
+directories         = { workspace = true }
 futures             = "0.3.30"
 rustc-hash          = { workspace = true }
 serde               = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/discussions/2772

The original issue was triggered when **a single file** was opened by a single client. When this occurs, the client can't pass `rootUri` or `workspaceFolders`. When this happens, the working directory becomes `env::current_dir()`, which is the `/` in this particular case.

In this PR I refactored the code, and before falling back to `env::current_dir()`, we attempt to retrieve the home directory of the user, and use that one as working directory.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I manually tested the feature using a local project

<!-- What demonstrates that your implementation is correct? -->
