### PR TITLE
fix(graphql_analyzer): use the correct macro to declare rule

### DIFF
--- a/xtask/codegen/src/generate_new_analyzer_rule.rs
+++ b/xtask/codegen/src/generate_new_analyzer_rule.rs
@@ -318,14 +318,14 @@ use biome_rowan::AstNode;
     /// ### Invalid
     ///
     /// ```graphql,expect_diagnostic
-    /// p {{}}
+    /// quer {{}}
     /// ```
     ///
     /// ### Valid
     ///
     /// ```graphql
-    /// p {{
-    ///   color: red;
+    /// query {{
+    ///   field
     /// }}
     /// ```
     ///

--- a/xtask/codegen/src/generate_new_analyzer_rule.rs
+++ b/xtask/codegen/src/generate_new_analyzer_rule.rs
@@ -298,12 +298,12 @@ impl Rule for {rule_name_upper_camel} {{
         }
         LanguageKind::Graphql => {
             format!(
-                r#"use biome_analyze::{{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic}};
+                r#"use biome_analyze::{{context::RuleContext, {macro_name}, Ast, Rule, RuleDiagnostic}};
 use biome_console::markup;
 use biome_graphql_syntax::GraphqlRoot;
 use biome_rowan::AstNode;
 
-declare_rule! {{
+{macro_name}! {{
     /// Succinct description of the rule.
     ///
     /// Put context and details about the rule.


### PR DESCRIPTION
## Summary

Currently GraphQL new lint rule template is using the old `declare_rule` macro. Additionally, the example included in the template is somewhat misleading (also causes `just new-graphql-lintrule` to fail).
This PR updates the template to use the new macros and provides a better example.

## Test Plan

Generate a new lint rule with `just new-graphql-lintrule abc` and confirm that the generated lint rule compiles fine.
