### PR TITLE
fix(lint/sources): update sources renamed rules

### DIFF
--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -562,7 +562,7 @@ pub(crate) fn migrate_eslint_any_rule(
             let rule = group.no_redundant_alt.get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
-        "jsx-a11y/interactive-support-focus" => {
+        "jsx-a11y/interactive-supports-focus" => {
             if !options.include_nursery {
                 return false;
             }
@@ -1052,7 +1052,7 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
-        "no-sparse-array" => {
+        "no-sparse-arrays" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group.no_sparse_array.get_or_insert(Default::default());
             rule.set_level(rule_severity.into());

--- a/crates/biome_css_analyze/src/lint/nursery/no_empty_block.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_empty_block.rs
@@ -47,7 +47,7 @@ declare_lint_rule! {
         name: "noEmptyBlock",
         language: "css",
         recommended: true,
-        sources: &[RuleSource::Stylelint("no-empty-block")],
+        sources: &[RuleSource::Stylelint("block-no-empty")],
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/nursery/use_focusable_interactive.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_focusable_interactive.rs
@@ -41,7 +41,7 @@ declare_lint_rule! {
         version: "1.8.0",
         name: "useFocusableInteractive",
         language: "jsx",
-        sources: &[RuleSource::EslintJsxA11y("interactive-support-focus")],
+        sources: &[RuleSource::EslintJsxA11y("interactive-supports-focus")],
         recommended: true,
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/use_throw_only_error.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_throw_only_error.rs
@@ -53,7 +53,7 @@ declare_lint_rule! {
         version: "1.8.0",
         name: "useThrowOnlyError",
         language: "js",
-        sources: &[RuleSource::Eslint("no-throw-literal"), RuleSource::EslintTypeScript("no-throw-literal"), RuleSource::EslintTypeScript("only-throw-error")],
+        sources: &[RuleSource::Eslint("no-throw-literal"), RuleSource::EslintTypeScript("only-throw-error")],
         source_kind: RuleSourceKind::Inspired,
         recommended: false,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_sparse_array.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_sparse_array.rs
@@ -23,7 +23,7 @@ declare_lint_rule! {
         version: "1.0.0",
         name: "noSparseArray",
         language: "js",
-        sources: &[RuleSource::Eslint("no-sparse-array")],
+        sources: &[RuleSource::Eslint("no-sparse-arrays")],
         recommended: true,
         fix_kind: FixKind::Unsafe,
     }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
I've noticed, when looking for dead links in website repo, that some source rules have changed names, resulting in 404 links in the website.

`jsx-a11y/interactive-support-focus` -> `jsx-a11y/interactive-supports-focus` (typo ?)

`no-sparse-array` -> `no-sparse-arrays` (typo ?)

`no-empty-block` -> `block-no-empty` (typo ?)

`interactive-support-focus` -> `interactive-supports-focus` (typo ?)

`typescript/no-throw-literal` -> Its now an option inside `typescript/only-throw-error`

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Should pass
