### PR TITLE
fix(js_semantic): take strict mode into account to compute declaration scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,10 +285,24 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### Bug fixes
 
 - Don't request alt text for elements hidden from assistive technologies ([#3316](https://github.com/biomejs/biome/issues/3316)). Contributed by @robintown
+
 - Fix [[#3149](https://github.com/biomejs/biome/issues/3149)] crashes that occurred when applying the `noUselessFragments` unsafe fixes in certain scenarios. Contributed by @unvalley
+
 - `noExcessiveNestedTestSuites`: Fix another edge case where the rule would alert on heavily nested zod schemas. Contributed by @dyc3
 
 - `noExtraNonNullAssertion` no longer reports a single non-null assertion enclosed in parentheses ([#3352](https://github.com/biomejs/biome/issues/3352)). Contributed by @Conaclos
+
+- [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare/) no longer report redeclartions for lexically scoped function declarations [#3664](https://github.com/biomejs/biome/issues/3664).
+
+  In JavaScript strict mode, function declarations are lexically scoped:
+  they cannot be accessed outside the block where they are declared.
+
+  In non-strict mode, function declarations are hoisted to the top of the enclosing function or global scope.
+
+  Previously Biome always hoisted function declarations.
+  It now takes into account whether the code is in strict or non strict mode.
+
+  Contributed by @Conaclos
 
 - `useAdjacentOverloadSignatures` no longer reports a `#private` class member and a public class member that share the same name ([#3309](https://github.com/biomejs/biome/issues/3309)).
 

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/invalid-non-strict-mode.cjs
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/invalid-non-strict-mode.cjs
@@ -1,0 +1,23 @@
+switch (x) {
+	case 0: {
+		function foo() {}
+		break;
+	}
+	default: {
+		function foo() {}
+		break;
+	}
+}
+
+function f() {
+	switch (x) {
+		case 0: {
+			function foo() {}
+			break;
+		}
+		default: {
+			function foo() {}
+			break;
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/invalid-non-strict-mode.cjs.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/invalid-non-strict-mode.cjs.snap
@@ -1,0 +1,79 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid-non-strict-mode.cjs
+---
+# Input
+```cjs
+switch (x) {
+	case 0: {
+		function foo() {}
+		break;
+	}
+	default: {
+		function foo() {}
+		break;
+	}
+}
+
+function f() {
+	switch (x) {
+		case 0: {
+			function foo() {}
+			break;
+		}
+		default: {
+			function foo() {}
+			break;
+		}
+	}
+}
+```
+
+# Diagnostics
+```
+invalid-non-strict-mode.cjs:7:12 lint/suspicious/noRedeclare ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'foo'. Consider to delete it or rename it.
+  
+    5 │ 	}
+    6 │ 	default: {
+  > 7 │ 		function foo() {}
+      │ 		         ^^^
+    8 │ 		break;
+    9 │ 	}
+  
+  i 'foo' is defined here:
+  
+    1 │ switch (x) {
+    2 │ 	case 0: {
+  > 3 │ 		function foo() {}
+      │ 		         ^^^
+    4 │ 		break;
+    5 │ 	}
+  
+
+```
+
+```
+invalid-non-strict-mode.cjs:19:13 lint/suspicious/noRedeclare ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'foo'. Consider to delete it or rename it.
+  
+    17 │ 		}
+    18 │ 		default: {
+  > 19 │ 			function foo() {}
+       │ 			         ^^^
+    20 │ 			break;
+    21 │ 		}
+  
+  i 'foo' is defined here:
+  
+    13 │ 	switch (x) {
+    14 │ 		case 0: {
+  > 15 │ 			function foo() {}
+       │ 			         ^^^
+    16 │ 			break;
+    17 │ 		}
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-function-strict-mode.cjs
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-function-strict-mode.cjs
@@ -1,0 +1,28 @@
+function f() {
+	"use strict"
+	switch (x) {
+		case 0: {
+			function foo() {}
+			break;
+		}
+		default: {
+			function foo() {}
+			break;
+		}
+	}
+}
+
+class C {
+	method() {
+		switch (x) {
+			case 0: {
+				function foo() {}
+				break;
+			}
+			default: {
+				function foo() {}
+				break;
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-function-strict-mode.cjs.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-function-strict-mode.cjs.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-function-strict-mode.cjs
+---
+# Input
+```cjs
+function f() {
+	"use strict"
+	switch (x) {
+		case 0: {
+			function foo() {}
+			break;
+		}
+		default: {
+			function foo() {}
+			break;
+		}
+	}
+}
+
+class C {
+	method() {
+		switch (x) {
+			case 0: {
+				function foo() {}
+				break;
+			}
+			default: {
+				function foo() {}
+				break;
+			}
+		}
+	}
+}
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-strict-mode.cjs
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-strict-mode.cjs
@@ -1,0 +1,11 @@
+"use strict"
+switch (x) {
+	case 0: {
+		function foo() {}
+		break;
+	}
+	default: {
+		function foo() {}
+		break;
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-strict-mode.cjs.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-strict-mode.cjs.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-strict-mode.cjs
+---
+# Input
+```cjs
+"use strict"
+switch (x) {
+	case 0: {
+		function foo() {}
+		break;
+	}
+	default: {
+		function foo() {}
+		break;
+	}
+}
+```

--- a/crates/biome_js_semantic/src/tests/functions.rs
+++ b/crates/biome_js_semantic/src/tests/functions.rs
@@ -15,14 +15,6 @@ assert_semantics! {
           }
           b(1);
         ",
-    ok_function_inner_function3,
-        "function f() {
-            if (true) {
-              function g/*#G*/(){console.log(1)}
-            }
-            g/*READ G*/()
-          }
-        f()",
 }
 
 // modules


### PR DESCRIPTION
## Summary

Fix #3664

Function declarations are not hoisted in strict mode.
The semantic model now registers if a scope is in strict mode.

We could in a near future, expose this information directly in the semantic model.
This could simplify the implementation of some linter rules.

## Test Plan

I added some test
