### PR TITLE
feat(lsp): deprecate `biome.rename` in favor of `biome.experimental.rename`

### DIFF
--- a/crates/biome_lsp/src/extension_settings.rs
+++ b/crates/biome_lsp/src/extension_settings.rs
@@ -54,10 +54,10 @@ impl ExtensionSettings {
     }
 
     pub(crate) fn requires_configuration(&self) -> bool {
-        self.settings
-            .experimental
-            .as_ref()
-            .and_then(|experimental| experimental.enable_renaming)
-            .unwrap_or(self.settings.rename.unwrap_or_default())
+        if let Some(experimental) = &self.settings.experimental {
+            experimental.rename.unwrap_or_else(|| self.settings.rename.unwrap_or_default())
+        } else {
+            self.settings.rename.unwrap_or_default()
+        }
     }
 }

--- a/crates/biome_lsp/src/extension_settings.rs
+++ b/crates/biome_lsp/src/extension_settings.rs
@@ -53,7 +53,7 @@ impl ExtensionSettings {
         Ok(())
     }
 
-    pub(crate) fn requires_configuration(&self) -> bool {
+    pub(crate) fn renames_enabled(&self) -> bool {
         if let Some(experimental) = &self.settings.experimental {
             experimental
                 .rename
@@ -61,5 +61,9 @@ impl ExtensionSettings {
         } else {
             self.settings.rename.unwrap_or_default()
         }
+    }
+
+    pub(crate) fn requires_configuration(&self) -> bool {
+        self.settings.require_configuration.unwrap_or_default()
     }
 }

--- a/crates/biome_lsp/src/extension_settings.rs
+++ b/crates/biome_lsp/src/extension_settings.rs
@@ -54,13 +54,15 @@ impl ExtensionSettings {
     }
 
     pub(crate) fn renames_enabled(&self) -> bool {
-        if let Some(experimental) = &self.settings.experimental {
-            experimental
-                .rename
-                .unwrap_or_else(|| self.settings.rename.unwrap_or_default())
-        } else {
-            self.settings.rename.unwrap_or_default()
-        }
+        let new_setting = self
+            .settings
+            .experimental
+            .as_ref()
+            .is_some_and(|experimental| experimental.rename.unwrap_or(false));
+
+        let old_setting = self.settings.rename.unwrap_or(false);
+
+        new_setting | old_setting
     }
 
     pub(crate) fn requires_configuration(&self) -> bool {

--- a/crates/biome_lsp/src/extension_settings.rs
+++ b/crates/biome_lsp/src/extension_settings.rs
@@ -13,10 +13,21 @@ pub struct WorkspaceSettings {
     pub unstable: bool,
 
     /// Enable rename capability
+    /// Deprecated, use `experimental.rename` instead
     pub rename: Option<bool>,
 
     /// Only run Biome if a `biome.json` configuration file exists.
     pub require_configuration: Option<bool>,
+
+    /// Experimental settings
+    pub experimental: Option<ExperimentalSettings>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExperimentalSettings {
+    /// Enable experimental symbol renaming
+    pub rename: Option<bool>,
 }
 
 /// The `biome.*` extension settings
@@ -43,6 +54,10 @@ impl ExtensionSettings {
     }
 
     pub(crate) fn requires_configuration(&self) -> bool {
-        self.settings.require_configuration.unwrap_or_default()
+        self.settings
+            .experimental
+            .as_ref()
+            .and_then(|experimental| experimental.enable_renaming)
+            .unwrap_or(self.settings.rename.unwrap_or_default())
     }
 }

--- a/crates/biome_lsp/src/extension_settings.rs
+++ b/crates/biome_lsp/src/extension_settings.rs
@@ -53,7 +53,7 @@ impl ExtensionSettings {
         Ok(())
     }
 
-    pub(crate) fn renames_enabled(&self) -> bool {
+    pub(crate) fn rename_enabled(&self) -> bool {
         let new_setting = self
             .settings
             .experimental

--- a/crates/biome_lsp/src/extension_settings.rs
+++ b/crates/biome_lsp/src/extension_settings.rs
@@ -55,7 +55,9 @@ impl ExtensionSettings {
 
     pub(crate) fn requires_configuration(&self) -> bool {
         if let Some(experimental) = &self.settings.experimental {
-            experimental.rename.unwrap_or_else(|| self.settings.rename.unwrap_or_default())
+            experimental
+                .rename
+                .unwrap_or_else(|| self.settings.rename.unwrap_or_default())
         } else {
             self.settings.rename.unwrap_or_default()
         }

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -199,7 +199,7 @@ impl LSPServer {
 
         let rename = {
             let config = self.session.extension_settings.read().ok();
-            config.is_some_and(|x| x.renames_enabled())
+            config.is_some_and(|x| x.rename_enabled())
         };
 
         capabilities.add_capability(

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -199,9 +199,7 @@ impl LSPServer {
 
         let rename = {
             let config = self.session.extension_settings.read().ok();
-            config
-                .and_then(|x| Some(x.renames_enabled()))
-                .unwrap_or(false)
+            config.is_some_and(|x| x.renames_enabled())
         };
 
         capabilities.add_capability(

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -199,7 +199,9 @@ impl LSPServer {
 
         let rename = {
             let config = self.session.extension_settings.read().ok();
-            config.and_then(|x| Some(x.renames_enabled())).unwrap_or(false)
+            config
+                .and_then(|x| Some(x.renames_enabled()))
+                .unwrap_or(false)
         };
 
         capabilities.add_capability(

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -199,7 +199,7 @@ impl LSPServer {
 
         let rename = {
             let config = self.session.extension_settings.read().ok();
-            config.and_then(|x| x.settings.rename).unwrap_or(false)
+            config.and_then(|x| Some(x.renames_enabled())).unwrap_or(false)
         };
 
         capabilities.add_capability(


### PR DESCRIPTION
## Summary

This pull request deprecates the `biome.rename` LSP setting in favor of `biome.experimental.rename` to align with the new name of the setting that will be used in the upcoming version of the VS Code extension.

This is a non-breaking change, and the old setting name will continue to work for now, although the new name will be preferred.

## Test Plan

Tested manually that setting either `biome.rename` and `biome.experimental.rename` to `true` resulted in the `biome_rename` capability being registered.
