### PR TITLE
fix(configuration): merge inherited overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,13 +86,19 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### Bug fixes
 
 - `biome lint --write` now takes `--only` and `--skip` into account ([#3470](https://github.com/biomejs/biome/issues/3470)). Contributed by @Conaclos
+
 - Fix [#3368](https://github.com/biomejs/biome/issues/3368), now the reporter `github` tracks the diagnostics that belong to formatting and organize imports. Contributed by @ematipico
+
 - Fix [#3545](https://github.com/biomejs/biome/issues/3545), display a warning, 'Avoid using unnecessary Fragment,' when a Fragment contains only one child element that is placed on a new line. Contributed by @satojin219
+
+- Migrating from Prettier or ESLint no longer overwrite the `overrides` field from the configuration ([#3544](https://github.com/biomejs/biome/issues/3544)). Contributed by @Conaclos
 
 ### Configuration
 
-- Add support for loading configuration from `.editorconfig` files ([#1724](https://github.com/biomejs/biome/issues/1724)). Contributed by @dyc3
+- Add support for loading configuration from `.editorconfig` files ([#1724](https://github.com/biomejs/biome/issues/1724)).
+
   Configuration supplied in `.editorconfig` will be overridden by the configuration in `biome.json`. Support is disabled by default and can be enabled by adding the following to your formatter configuration in `biome.json`:
+
   ```json
   {
     "formatter": {
@@ -100,6 +106,58 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
     }
   }
   ```
+
+  Contributed by @dyc3
+
+- `overrides` from an extended configuration is now merged with the `overrides` of the extension.
+
+  Given the following shared configuration `biome.shared.json`:
+
+  ```json5
+  {
+    "overrides": [
+      {
+        "include": ["**/*.json"],
+        // ...
+      }
+    ]
+  }
+  ```
+
+  and the following configuration:
+
+  ```json5
+  {
+    "extends": ["./biome.shared.json"],
+    "overrides": [
+      {
+        "include": ["**/*.ts"],
+        // ...
+      }
+    ]
+  }
+  ```
+
+  Previously, the `overrides` from `biome.shared.json` was overwritten.
+  It is now merged and results in the following configuration:
+
+  ```json5
+  {
+    "extends": ["./biome.shared.json"],
+    "overrides": [
+      {
+        "include": ["**/*.json"],
+        // ...
+      },
+      {
+        "include": ["**/*.ts"],
+        // ...
+      }
+    ]
+  }
+  ```
+
+  Contributed by @Conaclos
 
 ### Editors
 

--- a/crates/biome_cli/tests/commands/migrate_eslint.rs
+++ b/crates/biome_cli/tests/commands/migrate_eslint.rs
@@ -665,3 +665,41 @@ fn migrate_eslintrcjson_extended_rules() {
         result,
     ));
 }
+
+#[test]
+fn migrate_merge_with_overrides() {
+    let biomejson = r#"{
+        "overrides": [{
+            "include": ["*.js"],
+            "linter": { "enabled": false }
+        }]
+    }"#;
+    let eslintrc = r#"{
+        "overrides": [{
+            "files": ["bin/*.js", "lib/*.js"],
+            "excludedFiles": "*.test.js",
+            "rules": {
+                "eqeqeq": ["off"]
+            }
+        }]
+    }"#;
+
+    let mut fs = MemoryFileSystem::default();
+    fs.insert(Path::new("biome.json").into(), biomejson.as_bytes());
+    fs.insert(Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
+
+    let mut console = BufferConsole::default();
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(["migrate", "eslint"].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "migrate_merge_with_overrides",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_merge_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_merge_overrides.snap
@@ -1,0 +1,70 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "extends": ["shared.json"],
+  "overrides": [
+    {
+      "include": ["**/*.js"],
+      "linter": { "rules": { "correctness": { "noUnusedVariables": "error" } } }
+    }
+  ]
+}
+```
+
+## `shared.json`
+
+```json
+{
+            "overrides": [{
+                "include": ["**/*.js"],
+                "linter": { "rules": { "suspicious": { "noDebugger": "off" } } }
+            }]
+        }
+```
+
+## `test.js`
+
+```js
+debugger; const a = 0;
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+test.js:1:17 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This variable is unused.
+  
+  > 1 │ debugger; const a = 0;
+      │                 ^
+  
+  i Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend a with an underscore.
+  
+  - debugger;·const·a·=·0;
+  + debugger;·const·_a·=·0;
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_merge_with_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_merge_with_overrides.snap
@@ -1,0 +1,62 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "overrides": [
+    {
+      "include": ["*.js"],
+      "linter": { "enabled": false }
+    }
+  ]
+}
+```
+
+## `.eslintrc.json`
+
+```json
+{
+        "overrides": [{
+            "files": ["bin/*.js", "lib/*.js"],
+            "excludedFiles": "*.test.js",
+            "rules": {
+                "eqeqeq": ["off"]
+            }
+        }]
+    }
+```
+
+# Emitted Messages
+
+```block
+biome.json migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Configuration file can be updated.
+  
+    1  1 │   {
+    2    │ - ········"overrides":·[{
+    3    │ - ············"include":·["*.js"],
+    4    │ - ············"linter":·{·"enabled":·false·}
+    5    │ - ········}]
+    6    │ - ····}
+       2 │ + → "linter":·{·"rules":·{·"recommended":·false·}·},
+       3 │ + → "overrides":·[
+       4 │ + → → {·"include":·["*.js"],·"linter":·{·"enabled":·false·}·},
+       5 │ + → → {
+       6 │ + → → → "ignore":·["*.test.js"],
+       7 │ + → → → "include":·["bin/*.js",·"lib/*.js"],
+       8 │ + → → → "linter":·{·"rules":·{·"suspicious":·{·"noDoubleEquals":·"off"·}·}·}
+       9 │ + → → }
+      10 │ + → ]
+      11 │ + }
+      12 │ + 
+  
+
+```
+
+```block
+Run the command with the option --write to apply the changes.
+```

--- a/crates/biome_deserialize/src/merge.rs
+++ b/crates/biome_deserialize/src/merge.rs
@@ -1,4 +1,4 @@
-use std::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8};
+use std::hash::{BuildHasher, Hash};
 
 /// Trait that allows deep merging of types, including injection of defaults.
 pub trait Merge {
@@ -8,6 +8,12 @@ pub trait Merge {
     /// in `self`. Complex types may get recursively merged instead of
     /// overwritten.
     fn merge_with(&mut self, other: Self);
+}
+
+impl<T: Merge> Merge for Box<T> {
+    fn merge_with(&mut self, other: Self) {
+        self.as_mut().merge_with(*other);
+    }
 }
 
 impl<T: Merge> Merge for Option<T> {
@@ -21,29 +27,91 @@ impl<T: Merge> Merge for Option<T> {
     }
 }
 
+impl<T> Merge for Vec<T> {
+    fn merge_with(&mut self, other: Self) {
+        self.extend(other);
+    }
+}
+
+impl<T: Eq + Hash, S: BuildHasher + Default> Merge for std::collections::HashSet<T, S> {
+    fn merge_with(&mut self, other: Self) {
+        self.extend(other);
+    }
+}
+
+impl<K: Hash + Eq, V: Merge, S: Default + BuildHasher> Merge
+    for std::collections::HashMap<K, V, S>
+{
+    fn merge_with(&mut self, other: Self) {
+        for (k, v) in other {
+            if let Some(self_value) = self.get_mut(&k) {
+                self_value.merge_with(v);
+            } else {
+                self.insert(k, v);
+            }
+        }
+    }
+}
+
+impl<K: Ord, V: Merge> Merge for std::collections::BTreeMap<K, V> {
+    fn merge_with(&mut self, other: Self) {
+        for (k, v) in other {
+            if let Some(self_value) = self.get_mut(&k) {
+                self_value.merge_with(v);
+            } else {
+                self.insert(k, v);
+            }
+        }
+    }
+}
+
+impl<T: Hash + Eq> Merge for indexmap::IndexSet<T> {
+    fn merge_with(&mut self, other: Self) {
+        self.extend(other);
+    }
+}
+
+impl<K: Hash + Eq, V: Merge, S: Default + BuildHasher> Merge for indexmap::IndexMap<K, V, S> {
+    fn merge_with(&mut self, other: Self) {
+        for (k, v) in other {
+            if let Some(self_value) = self.get_mut(&k) {
+                self_value.merge_with(v);
+            } else {
+                self.insert(k, v);
+            }
+        }
+    }
+}
+
 /// This macro is used to implement [Merge] for all (primitive) types where
 /// merging can simply be implemented through overwriting the value.
 macro_rules! overwrite_on_merge {
-    ( $ty:ident ) => {
+    ( $ty:path ) => {
         impl Merge for $ty {
             fn merge_with(&mut self, other: Self) {
-                *self = other
+                *self = other;
             }
         }
     };
 }
 
 overwrite_on_merge!(bool);
-overwrite_on_merge!(u8);
-overwrite_on_merge!(u16);
-overwrite_on_merge!(u32);
-overwrite_on_merge!(u64);
-overwrite_on_merge!(i8);
+overwrite_on_merge!(f32);
+overwrite_on_merge!(f64);
 overwrite_on_merge!(i16);
 overwrite_on_merge!(i32);
 overwrite_on_merge!(i64);
-overwrite_on_merge!(NonZeroU8);
-overwrite_on_merge!(NonZeroU16);
-overwrite_on_merge!(NonZeroU32);
-overwrite_on_merge!(NonZeroU64);
+overwrite_on_merge!(i8);
+overwrite_on_merge!(isize);
+overwrite_on_merge!(u16);
+overwrite_on_merge!(u32);
+overwrite_on_merge!(u64);
+overwrite_on_merge!(u8);
+overwrite_on_merge!(usize);
+
+overwrite_on_merge!(std::num::NonZeroU16);
+overwrite_on_merge!(std::num::NonZeroU32);
+overwrite_on_merge!(std::num::NonZeroU64);
+overwrite_on_merge!(std::num::NonZeroU8);
+overwrite_on_merge!(std::num::NonZeroUsize);
 overwrite_on_merge!(String);

--- a/crates/biome_deserialize_macros/src/merge_derive.rs
+++ b/crates/biome_deserialize_macros/src/merge_derive.rs
@@ -57,7 +57,7 @@ fn generate_merge_newtype(ident: Ident) -> TokenStream {
     quote! {
         impl biome_deserialize::Merge for #ident {
             fn merge_with(&mut self, other: Self) {
-                self.0 = other.0;
+                biome_deserialize::Merge::merge_with(&mut self.0, other.0);
             }
         }
     }


### PR DESCRIPTION
## Summary

Fix #3544

We no longer overwrite the `overrides` field. This fixes #3544 and allows inheriting the `overrides` of an extended configuration.

I took the opportunity of adding more implementations of the `Merge` trait. Basically I implemented `Merge` for the same types as `Deserializable` implement.

## Test Plan

I added a migration test.
