### PR TITLE
refactor(noNodejsModules): ignore package.json dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,6 +293,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [noNodejsModules](https://biomejs.dev/linter/rules/no-nodejs-modules/) now ignores imports of a package which has the same name as a Node.js module. Contributed by @Conaclos
 
 #### Bug fixes
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_nodejs_modules.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_nodejs_modules.rs
@@ -1,7 +1,6 @@
 use crate::globals::is_node_builtin_module;
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
-};
+use crate::services::manifest::Manifest;
+use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{inner_string_text, AnyJsImportClause, AnyJsImportLike};
 use biome_rowan::AstNode;
@@ -11,6 +10,11 @@ declare_lint_rule! {
     /// Forbid the use of Node.js builtin modules.
     ///
     /// This can be useful for client-side web projects that don't have access to those modules.
+    ///
+    /// The rule also isn't triggered if there are dependencies declared in the `package.json` that match
+    /// the name of a built-in Node.js module.
+    ///
+    /// Type-only imports are ignored.
     ///
     /// ## Examples
     ///
@@ -29,6 +33,10 @@ declare_lint_rule! {
     /// ```js
     /// import fs from "fs-custom";
     /// ```
+    ///
+    /// ```ts
+    /// import type path from "node:path";
+    /// ```
     pub NoNodejsModules {
         version: "1.5.0",
         name: "noNodejsModules",
@@ -39,7 +47,7 @@ declare_lint_rule! {
 }
 
 impl Rule for NoNodejsModules {
-    type Query = Ast<AnyJsImportLike>;
+    type Query = Manifest<AnyJsImportLike>;
     type State = TextRange;
     type Signals = Option<Self::State>;
     type Options = ();
@@ -58,8 +66,17 @@ impl Rule for NoNodejsModules {
             }
         }
         let module_name = node.module_name_token()?;
-        is_node_builtin_module(&inner_string_text(&module_name))
-            .then_some(module_name.text_trimmed_range())
+        let module_name_text = inner_string_text(&module_name);
+        let module_name_text = module_name_text.text();
+        // Ignore dependencies
+        if ctx.is_dependency(module_name_text)
+            || ctx.is_dev_dependency(module_name_text)
+            || ctx.is_peer_dependency(module_name_text)
+            || ctx.is_optional_dependency(module_name_text)
+        {
+            return None;
+        }
+        is_node_builtin_module(module_name_text).then_some(module_name.text_trimmed_range())
     }
 
     fn diagnostic(_: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/tests/specs/correctness/noNodejsModules/valid-with-dep.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noNodejsModules/valid-with-dep.js
@@ -1,0 +1,1 @@
+import assert from "assert";

--- a/crates/biome_js_analyze/tests/specs/correctness/noNodejsModules/valid-with-dep.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noNodejsModules/valid-with-dep.js.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-with-dep.js
+---
+# Input
+```jsx
+import assert from "assert";
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noNodejsModules/valid-with-dep.package.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/noNodejsModules/valid-with-dep.package.json
@@ -1,0 +1,5 @@
+{
+	"dependencies": {
+		"assert": "1.0.0"
+	}
+}


### PR DESCRIPTION
## Summary

Similarly to `useNodejsImportProtocol`, `noNodejsModules` now ignore `package.json` dependencies that have the same name as Node.js modules.

## Test Plan

I added a test