### PR TITLE
chore: update biome_js_analyze/lint/complexity/use_optional_chain to use js tag instead of ts

### DIFF
--- a/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
@@ -18,7 +18,7 @@ use crate::JsRuleAction;
 declare_lint_rule! {
     /// Enforce using concise optional chain instead of chained logical expressions.
     ///
-    /// TypeScript 3.7 added support for the optional chain operator.
+    /// TypeScript 3.7 introduced support for the optional chain operator, which was later standardized and included in the ECMAScript specification.
     /// This operator allows you to safely access properties and methods on objects when they are potentially `null` or `undefined`.
     /// The optional chain operator only chains when the property value is `null` or `undefined`.
     /// It is much safer than relying upon logical operator chaining; which chains on any truthy value.
@@ -75,7 +75,7 @@ declare_lint_rule! {
     pub UseOptionalChain {
         version: "1.0.0",
         name: "useOptionalChain",
-        language: "ts",
+        language: "js",
         sources: &[RuleSource::EslintTypeScript("prefer-optional-chain")],
         recommended: true,
         fix_kind: FixKind::Unsafe,


### PR DESCRIPTION
## Summary

While searching for JS-specific lint rules, I initially overlooked this rule due to the ts lang tag.