### PR TITLE
fix(js_formatter): remove useless parens around infer type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,7 +183,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
-- Keep the parentheses around `infer` declarations in type unions and type intersections ([#3419](https://github.com/biomejs/biome/issues/3419)). Contributed by @Conaclos
+- Keep the parentheses around `infer ... extends` declarations in type unions and type intersections ([#3419](https://github.com/biomejs/biome/issues/3419)). Contributed by @Conaclos
 
 - Keep parentheses around a `yield` expression inside a type assertion.
 

--- a/crates/biome_js_formatter/src/ts/types/infer_type.rs
+++ b/crates/biome_js_formatter/src/ts/types/infer_type.rs
@@ -38,16 +38,16 @@ mod tests {
     #[test]
     fn needs_parentheses() {
         assert_needs_parentheses!(
-            "type A = T extends (infer string)[] ? string : never",
+            "type A<T> = T extends (infer string)[] ? string : never",
             TsInferType
         );
         assert_needs_parentheses!(
-            "type A = T extends unique (infer string) ? string : never",
+            "type A<T> = T extends unique (infer string) ? string : never",
             TsInferType
         );
 
         assert_not_needs_parentheses!(
-            "type A = T extends [number, ...infer string] ? string : never",
+            "type A<T> = T extends [number, ...infer string] ? string : never",
             TsInferType
         );
         assert_needs_parentheses!(
@@ -55,16 +55,20 @@ mod tests {
             TsInferType
         );
         assert_needs_parentheses!(
-            "type A = T extends [(infer string) | undefined] ? string : never",
+            "type A<T> = [T] extends [(infer S extends string) | undefined] ? S : T",
             TsInferType
         );
 
         assert_needs_parentheses!(
-            "type A = T extends (infer string)[a] ? string : never",
+            "type A<T> = T extends (infer string)[a] ? string : never",
             TsInferType
         );
         assert_not_needs_parentheses!(
-            "type A = T extends a[(infer string)] ? string : never",
+            "type A<T> = T extends a[(infer string)] ? string : never",
+            TsInferType
+        );
+        assert_not_needs_parentheses!(
+            "type A = T extends () => infer R | B ? R : never",
             TsInferType
         );
     }

--- a/crates/biome_js_syntax/src/parentheses/tstype.rs
+++ b/crates/biome_js_syntax/src/parentheses/tstype.rs
@@ -56,7 +56,7 @@ impl NeedsParentheses for TsInferType {
         match parent.kind() {
             JsSyntaxKind::TS_REST_TUPLE_TYPE_ELEMENT => false,
             JsSyntaxKind::TS_INTERSECTION_TYPE_ELEMENT_LIST
-            | JsSyntaxKind::TS_UNION_TYPE_VARIANT_LIST => true,
+            | JsSyntaxKind::TS_UNION_TYPE_VARIANT_LIST => self.constraint().is_some(),
             _ => operator_type_or_higher_needs_parens(self.syntax(), parent),
         }
     }


### PR DESCRIPTION
## Summary

Fix a regression introduced in #3451 and detected by the [Ecosystem CI](https://github.com/biomejs/ecosystem-ci/actions/runs/10491208466/job/29060285601)

## Test Plan

I added a test.