### PR TITLE
feat: support OpenBSD

### DIFF
--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -64,7 +64,7 @@ tokio = { workspace = true, features = ["process"] }
 [target.'cfg(windows)'.dependencies]
 mimalloc = "0.1.43"
 
-[target.'cfg(all(target_family="unix", not(all(target_arch = "aarch64", target_env = "musl"))))'.dependencies]
+[target.'cfg(all(target_family="unix", not(all(target_arch = "aarch64", target_env = "musl")), not(target_os = "openbsd")))'.dependencies]
 tikv-jemallocator = "0.6.0"
 
 [dev-dependencies]

--- a/crates/biome_cli/src/main.rs
+++ b/crates/biome_cli/src/main.rs
@@ -25,8 +25,12 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-// Jemallocator does not work on aarch64 with musl, so we'll use the system allocator instead
-#[cfg(all(target_env = "musl", target_os = "linux", target_arch = "aarch64"))]
+// Jemallocator does not work on aarch64 with musl, or on OpenBSD, so we'll use
+// the system allocator instead
+#[cfg(any(
+    all(target_env = "musl", target_os = "linux", target_arch = "aarch64"),
+    target_os = "openbsd"
+))]
 #[global_allocator]
 static GLOBAL: std::alloc::System = std::alloc::System;
 

--- a/xtask/bench/Cargo.toml
+++ b/xtask/bench/Cargo.toml
@@ -35,7 +35,7 @@ url                       = "2.5.2"
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1.43"
 
-[target.'cfg(all(target_family="unix", not(all(target_arch = "aarch64", target_env = "musl"))))'.dependencies]
+[target.'cfg(all(target_family="unix", not(all(target_arch = "aarch64", target_env = "musl")), not(target_os = "openbsd")))'.dependencies]
 tikv-jemallocator = "0.6.0"
 
 [features]


### PR DESCRIPTION
Use `std::alloc::System` for OpenBSD as `jemalloc` is not supported.

NOTE: I'm only 80% sure this works, as I was unable to finish compiling this on my OpenBSD laptop: I got all the way to 603/617 and then ran out of memory (my laptop is pretty ancient... like from 2012.) I'd love it if someone who has a beefier OpenBSD box could give this a spin.

I'm also unsure if there are other parts of the repo that need to be updated to ensure OpenBSD artifacts get built and distributed accordingly. Happy to make changes to support that if folks could point me in the right direction.

closes #3672