### PR TITLE
refactor(json): allow comments in `.json` files under `.vscode` and `.zed` dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,17 +436,44 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Parser
 
+#### Enhancements
+
+- The JSON parser now allows comments in files with the `.json` extension under the `.vscode` and `.zed` directories.
+
+  Biome recognizes are well known JSON files that allows comments and/or trailing commas.
+  Previously, Biome did not recognize JSON files under the `.vscode` and the `.zed` directories as JSON files that allow comments.
+  You had to configure Biome to recognize them:
+
+  ```json
+  {
+    "overrides": [
+      {
+        "include": ["**/.vscode/*.json", "**/.zed/*.json"],
+        "json": { "parser": { "allowComments": true } }
+      }
+    ]
+  }
+  ```
+
+  This override is no longer needed!
+  Note that JSON files under the `.vscode` and the `.zed` directories don't accept trailing commas.
+
+  Contributed by @Conaclos
+
 #### Bug fixes
 
 - Fix [#3287](https://github.com/biomejs/biome/issues/3287) nested selectors with pseudo-classes. Contributed by @denbezrukov
+
 - Fix [#3349](https://github.com/biomejs/biome/issues/3349) allow CSS multiple ampersand support. Contributed by @denbezrukov
-```css
-.class {
-  && {
-    color: red;
+
+  ```css
+  .class {
+    && {
+      color: red;
+    }
   }
-}
-```
+  ```
+
 - Fix [#3410](https://github.com/biomejs/biome/issues/3410) by correctly parsing break statements containing keywords.
   ```js
   out: while (true) {

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/allow_trailing_commas_on_well_known_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/allow_trailing_commas_on_well_known_files.snap
@@ -1,0 +1,111 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 4
+  },
+  "overrides": [
+    {
+      "include": ["**/*.json"],
+      "json": { "parser": { "allowTrailingCommas": true } }
+    }
+  ]
+}
+```
+
+## `.vscode/settings.json`
+
+```json
+{
+    // This is a comment
+    "editor.rulers": [80, 100],
+}
+```
+
+## `other.json`
+
+```json
+{
+    "asta": ["lorem", "ipsum", "first", "second"],
+}
+```
+
+## `tsconfig.json`
+
+```json
+{
+    // This is a comment
+    "compilerOptions": {},
+}
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+other.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1 1 │   {
+    2   │ - ····"asta":·["lorem",·"ipsum",·"first",·"second"],
+    3   │ - }
+      2 │ + ····"asta":·["lorem",·"ipsum",·"first",·"second"]
+      3 │ + }
+      4 │ + 
+  
+
+```
+
+```block
+tsconfig.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1 1 │   {
+    2 2 │       // This is a comment
+    3   │ - ····"compilerOptions":·{},
+    4   │ - }
+      3 │ + ····"compilerOptions":·{}
+      4 │ + }
+      5 │ + 
+  
+
+```
+
+```block
+.vscode/settings.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1 1 │   {
+    2 2 │       // This is a comment
+    3   │ - ····"editor.rulers":·[80,·100],
+    4   │ - }
+      3 │ + ····"editor.rulers":·[80,·100]
+      4 │ + }
+      5 │ + 
+  
+
+```
+
+```block
+Checked 3 files in <TIME>. No fixes applied.
+Found 3 errors.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/disallow_comments_on_well_known_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/disallow_comments_on_well_known_files.snap
@@ -1,0 +1,225 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 4
+  },
+  "overrides": [
+    {
+      "include": ["**/*.json"],
+      "json": { "parser": { "allowComments": false } }
+    }
+  ]
+}
+```
+
+## `tsconfig.json`
+
+```json
+{
+    // This is a comment
+    "compilerOptions": {}
+}
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+tsconfig.json:2:5 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a property but instead found '// This is a comment'.
+  
+    1 │ {
+  > 2 │     // This is a comment
+      │     ^^^^^^^^^^^^^^^^^^^^
+    3 │     "compilerOptions": {}
+    4 │ }
+  
+  i Expected a property here.
+  
+    1 │ {
+  > 2 │     // This is a comment
+      │     ^^^^^^^^^^^^^^^^^^^^
+    3 │     "compilerOptions": {}
+    4 │ }
+  
+
+```
+
+```block
+tsconfig.json:3:5 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × End of file expected
+  
+    1 │ {
+    2 │     // This is a comment
+  > 3 │     "compilerOptions": {}
+      │     ^^^^^^^^^^^^^^^^^
+    4 │ }
+  
+  i Use an array for a sequence of values: `[1, 2]`
+  
+
+```
+
+```block
+tsconfig.json:3:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × End of file expected
+  
+    1 │ {
+    2 │     // This is a comment
+  > 3 │     "compilerOptions": {}
+      │                      ^
+    4 │ }
+  
+  i Use an array for a sequence of values: `[1, 2]`
+  
+
+```
+
+```block
+tsconfig.json:3:24 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × End of file expected
+  
+    1 │ {
+    2 │     // This is a comment
+  > 3 │     "compilerOptions": {}
+      │                        ^^
+    4 │ }
+  
+  i Use an array for a sequence of values: `[1, 2]`
+  
+
+```
+
+```block
+tsconfig.json:4:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × End of file expected
+  
+    2 │     // This is a comment
+    3 │     "compilerOptions": {}
+  > 4 │ }
+      │ ^
+  
+  i Use an array for a sequence of values: `[1, 2]`
+  
+
+```
+
+```block
+tsconfig.json:2:5 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a property but instead found '// This is a comment'.
+  
+    1 │ {
+  > 2 │     // This is a comment
+      │     ^^^^^^^^^^^^^^^^^^^^
+    3 │     "compilerOptions": {}
+    4 │ }
+  
+  i Expected a property here.
+  
+    1 │ {
+  > 2 │     // This is a comment
+      │     ^^^^^^^^^^^^^^^^^^^^
+    3 │     "compilerOptions": {}
+    4 │ }
+  
+
+```
+
+```block
+tsconfig.json:3:5 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × End of file expected
+  
+    1 │ {
+    2 │     // This is a comment
+  > 3 │     "compilerOptions": {}
+      │     ^^^^^^^^^^^^^^^^^
+    4 │ }
+  
+  i Use an array for a sequence of values: `[1, 2]`
+  
+
+```
+
+```block
+tsconfig.json:3:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × End of file expected
+  
+    1 │ {
+    2 │     // This is a comment
+  > 3 │     "compilerOptions": {}
+      │                      ^
+    4 │ }
+  
+  i Use an array for a sequence of values: `[1, 2]`
+  
+
+```
+
+```block
+tsconfig.json:3:24 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × End of file expected
+  
+    1 │ {
+    2 │     // This is a comment
+  > 3 │     "compilerOptions": {}
+      │                        ^^
+    4 │ }
+  
+  i Use an array for a sequence of values: `[1, 2]`
+  
+
+```
+
+```block
+tsconfig.json:4:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × End of file expected
+  
+    2 │     // This is a comment
+    3 │     "compilerOptions": {}
+  > 4 │ }
+      │ ^
+  
+  i Use an array for a sequence of values: `[1, 2]`
+  
+
+```
+
+```block
+tsconfig.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option.
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 11 errors.
+```

--- a/crates/biome_service/tests/workspace.rs
+++ b/crates/biome_service/tests/workspace.rs
@@ -145,6 +145,19 @@ mod test {
         .unwrap();
         assert!(well_known_json_with_comments_file.format_file().is_ok());
 
+        // well-known json-with-comments file allows comments
+        let well_known_json_with_comments_file = FileGuard::open(
+            workspace.as_ref(),
+            OpenFileParams {
+                path: BiomePath::new("project/.vscode/settings.json"),
+                content: r#"{"a": 42}//comment"#.into(),
+                version: 0,
+                document_file_source: None,
+            },
+        )
+        .unwrap();
+        assert!(well_known_json_with_comments_file.format_file().is_ok());
+
         // well-known json-with-comments file doesn't allow trailing commas
         let well_known_json_with_comments_file_with_trailing_commas = FileGuard::open(
             workspace.as_ref(),


### PR DESCRIPTION

## Summary

We now define `.json` files directly under the `.vscode` and the `.zed` directories as JSON files that allow comments.

## Test Plan

I added a test.
