### PR TITLE
feat: adds an option to `HTML` printer for MDX

### DIFF
--- a/crates/biome_wasm/src/utils.rs
+++ b/crates/biome_wasm/src/utils.rs
@@ -62,7 +62,7 @@ impl DiagnosticPrinter {
             .with_file_path(&self.file_name)
             .with_file_source_code(&self.file_source);
 
-        let mut html = HTML(&mut self.buffer);
+        let mut html = HTML::new(&mut self.buffer);
         Formatter::new(&mut html)
             .write_markup(markup!({ printer(&err) }))
             .map_err(into_error)?;


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

 I am rewriting the docs generation of the lint rules, and MDX breaks if there are curly braces that aren't escaped. 

In MDX, curly braces are the beginning of an expression. With this option, we tell the HTML printer to escape curly braces.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added new tests. I will merge it and use it for the website

<!-- What demonstrates that your implementation is correct? -->
