### PR TITLE
chore: unhide `search` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Add `--graphql-linter-enabled` option, to control whether the linter should be enabled or not for GraphQL files. Contributed by @ematipico
 
-- New EXPERIMENTAL `search` command. The search command allows you to search a Biome project using [GritQL] syntax: https://docs.grit.io/language/overview
+- New EXPERIMENTAL `search` command. The search command allows you to search a Biome project using [GritQL syntax](https://biomejs.dev/reference/gritql).
 
-  GritQL is a powerful language that lets you do _structural_ searches on your codebase. This means that trivia such as whitespace or even the type of strings quotes used will be ignored in your search query. It also has [many features](https://docs.grit.io/language/syntax) for querying the structure of your code, making it much more elegant for searching code than regular expressions.
+  GritQL is a powerful language that lets you do _structural_ searches on your codebase. This means that trivia such as whitespace or even the type of strings quotes used will be ignored in your search query. It also has many features for querying the structure of your code, making it much more elegant for searching code than regular expressions.
 
   While we believe this command may already be useful to users in some situations (especially when integrated in the IDE extensions!), we also had an ulterior motive for adding this command: We intend to utilize GritQL for our plugin efforts, and by allowing our users to try it out in a first iteration, we hope to gain insight in the type of queries you want to do, as well as the bugs we need to focus on.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### New features
 
 - Add `--graphql-linter-enabled` option, to control whether the linter should be enabled or not for GraphQL files. Contributed by @ematipico
+
+- New EXPERIMENTAL `search` command. The search command allows you to search a Biome project using [GritQL] syntax: https://docs.grit.io/language/overview
+
+  GritQL is a powerful language that lets you do _structural_ searches on your codebase. This means that trivia such as whitespace or even the type of strings quotes used will be ignored in your search query. It also has [many features](https://docs.grit.io/language/syntax) for querying the structure of your code, making it much more elegant for searching code than regular expressions.
+
+  While we believe this command may already be useful to users in some situations (especially when integrated in the IDE extensions!), we also had an ulterior motive for adding this command: We intend to utilize GritQL for our plugin efforts, and by allowing our users to try it out in a first iteration, we hope to gain insight in the type of queries you want to do, as well as the bugs we need to focus on.
+
+  For now, the `search` command is explicitly marked as EXPERIMENTAL, since many bugs remain. Keep this in mind when you try it out, and please [let us know](https://github.com/biomejs/biome/issues) your issues!
+
+  Note: GritQL escapes code snippets using backticks, but most shells interpret backticks as command invocations. To avoid this, it's best to put _single quotes_ around your Grit queries.
+
+  ```shell
+  biome search '`console.log($message)`' # find all `console.log` invocations
+  ```
+
+  Contributed by @arendjr and @BackupMiles
+
 - The option `--max-diagnostics` now accept a `none` value, which lifts the limit of diagnostics shown. Contributed by @ematipico
   - Add a new reporter `--reporter=gitlab`, that emits diagnostics for using the [GitLab Code Quality report](https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool).
 

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -47,12 +47,12 @@ pub(crate) mod version;
 #[bpaf(options, version(VERSION))]
 /// Biome official CLI. Use it to check the health of your project or run it to check single files.
 pub enum BiomeCommand {
-    /// Shows the Biome version information and quit
+    /// Shows the Biome version information and quit.
     #[bpaf(command)]
     Version(#[bpaf(external(cli_options), hide_usage)] CliOptions),
 
     #[bpaf(command)]
-    /// Prints information for debugging
+    /// Prints information for debugging.
     Rage(
         #[bpaf(external(cli_options), hide_usage)] CliOptions,
         /// Prints the Biome daemon server logs
@@ -65,7 +65,7 @@ pub enum BiomeCommand {
         #[bpaf(long("linter"), switch)]
         bool,
     ),
-    /// Start the Biome daemon server process
+    /// Starts the Biome daemon server process.
     #[bpaf(command)]
     Start {
         /// Allows to change the prefix applied to the file name of the logs.
@@ -94,7 +94,7 @@ pub enum BiomeCommand {
         config_path: Option<PathBuf>,
     },
 
-    /// Stop the Biome daemon server process
+    /// Stops the Biome daemon server process.
     #[bpaf(command)]
     Stop,
 
@@ -368,7 +368,7 @@ pub enum BiomeCommand {
         #[bpaf(long("jsonc"), switch)]
         bool,
     ),
-    /// Acts as a server for the Language Server Protocol over stdin/stdout
+    /// Acts as a server for the Language Server Protocol over stdin/stdout.
     #[bpaf(command("lsp-proxy"))]
     LspProxy {
         /// Allows to change the prefix applied to the file name of the logs.
@@ -398,7 +398,7 @@ pub enum BiomeCommand {
         #[bpaf(long("stdio"), hide, hide_usage, switch)]
         stdio: bool,
     },
-    /// It updates the configuration when there are breaking changes
+    /// Updates the configuration when there are breaking changes.
     #[bpaf(command)]
     Migrate {
         #[bpaf(external, hide_usage)]
@@ -416,8 +416,18 @@ pub enum BiomeCommand {
         sub_command: Option<MigrateSubCommand>,
     },
 
-    /// Searches for Grit patterns across a project.
-    #[bpaf(command, hide)] // !! Command is hidden until ready for release.
+    /// [EXPERIMENTAL] Searches for Grit patterns across a project.
+    ///
+    /// Note: GritQL escapes code snippets using backticks, but most shells
+    /// interpret backticks as command invocations. To avoid this, it's best to
+    /// put single quotes around your Grit queries.
+    ///
+    /// ## Example
+    ///
+    /// ```shell
+    /// biome search '`console.log($message)`' # find all `console.log` invocations
+    /// ```
+    #[bpaf(command)]
     Search {
         #[bpaf(external, hide_usage)]
         cli_options: CliOptions,
@@ -450,7 +460,7 @@ pub enum BiomeCommand {
         paths: Vec<OsString>,
     },
 
-    /// A command to retrieve the documentation of various aspects of the CLI.
+    /// Shows documentation of various aspects of the CLI.
     ///
     /// ## Examples
     ///
@@ -469,7 +479,7 @@ pub enum BiomeCommand {
     },
 
     #[bpaf(command)]
-    /// Clean the logs emitted by the daemon
+    /// Cleans the logs emitted by the daemon.
     Clean,
 
     #[bpaf(command("__run_server"), hide)]

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -186,7 +186,7 @@ pub enum TraversalMode {
     Search {
         /// The GritQL pattern to search for.
         ///
-        /// Note that the search command (currently) does not support rewrites.
+        /// Note that the search command does not support rewrites.
         pattern: PatternId,
 
         /// An optional tuple.

--- a/crates/biome_cli/tests/snapshots/main_commands_explain/explain_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_explain/explain_help.snap
@@ -5,7 +5,7 @@ expression: content
 # Emitted Messages
 
 ```block
-A command to retrieve the documentation of various aspects of the CLI.
+Shows documentation of various aspects of the CLI.
 ## Examples
 ```shell biome explain noDebugger ```
 ```shell biome explain daemon-logs ```
@@ -19,5 +19,3 @@ Available options:
     -h, --help  Prints help information
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
@@ -5,7 +5,7 @@ expression: content
 # Emitted Messages
 
 ```block
-Acts as a server for the Language Server Protocol over stdin/stdout
+Acts as a server for the Language Server Protocol over stdin/stdout.
 
 Usage: lsp-proxy [--config-path=PATH]
 

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
@@ -5,7 +5,7 @@ expression: content
 # Emitted Messages
 
 ```block
-It updates the configuration when there are breaking changes
+Updates the configuration when there are breaking changes.
 
 Usage: migrate [--write] [COMMAND ...]
 

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -5,7 +5,7 @@ expression: content
 # Emitted Messages
 
 ```block
-Prints information for debugging
+Prints information for debugging.
 
 Usage: rage [--daemon-logs] [--formatter] [--linter]
 

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -383,7 +383,7 @@ impl Diagnostic for QueryDiagnostic {
     fn verbose_advices(&self, visitor: &mut dyn Visit) -> std::io::Result<()> {
         visitor.record_log(
             LogCategory::Info,
-            &markup! { "Please consult "<Hyperlink href="https://docs.grit.io/language/syntax">"the official grit syntax page"</Hyperlink>"." }
+            &markup! { "Please consult "<Hyperlink href="https://biomejs.dev/reference/gritql">"our GritQL reference"</Hyperlink>"." }
         )
     }
 }


### PR DESCRIPTION
## Summary

Marked as EXPERIMENTAL, and added a CHANGELOG entry.

Also made the subcommand descriptions a little bit more consistent.

The GritQL reference is created in this website PR: https://github.com/biomejs/website/pull/991

## Test Plan

Tested the `--help` output manually.
