### PR TITLE
refactor(noUndeclaredVariables): recognize Svelte 5 runes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,6 +361,13 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [noUndeclaredVariables](https://biomejs.dev/linter/rules/no-undeclared-variables/) recognized Svelte 5 runes in Svelte components and svelte files.
+
+  Svelte 5 introduced runes.
+  The rule now recognizes Svelte 5 runes in files ending with the `.svelte`, `.svelte.js` or `.svelte.ts` extensions.
+
+  Contributed by @Conaclos
+
 - [noBlankTarget](https://biomejs.dev/linter/rules/no-blank-target) now supports an array of allowed domains.
 
   The following configuration allows `example.com` and `example.org` as blank targets.

--- a/crates/biome_js_analyze/src/globals/javascript/language.rs
+++ b/crates/biome_js_analyze/src/globals/javascript/language.rs
@@ -1,7 +1,7 @@
 /// Sorted array of ES builtin
 ///
 /// Source: <https://github.com/sindresorhus/globals/blob/9e2e2598dabdb845ff76c0c3acf5c52c812a64de/globals.json#L2-L70>
-pub const ES_BUILTIN: &[&str; 67] = &[
+pub const ES_BUILTIN: &[&str] = &[
     "AggregateError",
     "Array",
     "ArrayBuffer",
@@ -74,7 +74,7 @@ pub const ES_BUILTIN: &[&str; 67] = &[
 /// Sorted array of ES5 builtin
 ///
 /// Source: <https://github.com/sindresorhus/globals/blob/9e2e2598dabdb845ff76c0c3acf5c52c812a64de/globals.json#L71-L110>
-pub const ES_5: &[&str; 38] = &[
+pub const ES_5: &[&str] = &[
     "Array",
     "Boolean",
     "Date",
@@ -118,7 +118,7 @@ pub const ES_5: &[&str; 38] = &[
 /// Sorted array of ES2015 builtin
 ///
 /// Source: <https://github.com/sindresorhus/globals/blob/9e2e2598dabdb845ff76c0c3acf5c52c812a64de/globals.json#L111-L170>
-pub const ES_2015: &[&str; 58] = &[
+pub const ES_2015: &[&str] = &[
     "Array",
     "ArrayBuffer",
     "Boolean",
@@ -182,7 +182,7 @@ pub const ES_2015: &[&str; 58] = &[
 /// Sorted array of ES2017 builtin
 ///
 /// Source: <https://github.com/sindresorhus/globals/blob/9e2e2598dabdb845ff76c0c3acf5c52c812a64de/globals.json#L171-L232>
-pub const ES_2017: &[&str; 60] = &[
+pub const ES_2017: &[&str] = &[
     "Array",
     "ArrayBuffer",
     "Atomics",
@@ -248,7 +248,7 @@ pub const ES_2017: &[&str; 60] = &[
 /// Sorted array of ES2020 builtin
 ///
 /// Source: <https://github.com/sindresorhus/globals/blob/9e2e2598dabdb845ff76c0c3acf5c52c812a64de/globals.json#L233-L298>
-pub const ES_2020: &[&str; 64] = &[
+pub const ES_2020: &[&str] = &[
     "Array",
     "ArrayBuffer",
     "Atomics",
@@ -318,7 +318,7 @@ pub const ES_2020: &[&str; 64] = &[
 /// Sorted array of ES2021 builtin
 ///
 /// Source: <https://github.com/sindresorhus/globals/blob/9e2e2598dabdb845ff76c0c3acf5c52c812a64de/globals.json#L299-L367>
-pub const ES_2021: &[&str; 67] = &[
+pub const ES_2021: &[&str] = &[
     "AggregateError",
     "Array",
     "ArrayBuffer",

--- a/crates/biome_js_analyze/src/globals/javascript/node.rs
+++ b/crates/biome_js_analyze/src/globals/javascript/node.rs
@@ -1,7 +1,7 @@
 /// Sorted array of Node builtin
 ///
 /// Source: <https://github.com/sindresorhus/globals/blob/9e2e2598dabdb845ff76c0c3acf5c52c812a64de/globals.json#L1801-L1869>
-pub const BUILTIN: &[&str; 67] = &[
+pub const BUILTIN: &[&str] = &[
     "AbortController",
     "AbortSignal",
     "Blob",
@@ -74,7 +74,7 @@ pub const BUILTIN: &[&str; 67] = &[
 /// Sorted array of Node
 ///
 /// Source: <https://github.com/sindresorhus/globals/blob/9e2e2598dabdb845ff76c0c3acf5c52c812a64de/globals.json#L1727-L1800>
-pub const NODE: &[&str; 72] = &[
+pub const NODE: &[&str] = &[
     "AbortController",
     "AbortSignal",
     "Blob",
@@ -152,7 +152,7 @@ pub const NODE: &[&str; 72] = &[
 /// Sorted array of CommonJs builtin
 ///
 /// Source: <https://github.com/sindresorhus/globals/blob/9e2e2598dabdb845ff76c0c3acf5c52c812a64de/globals.json#L1870-L1875>
-pub const COMMON_JS: &[&str; 4] = &["exports", "global", "module", "require"];
+pub const COMMON_JS: &[&str] = &["exports", "global", "module", "require"];
 
 /// Returns `true` if `name` is a node global
 ///

--- a/crates/biome_js_analyze/src/globals/javascript/web.rs
+++ b/crates/biome_js_analyze/src/globals/javascript/web.rs
@@ -1,7 +1,7 @@
 /// Sorted array of browser builtin
 ///
 /// Source: <https://github.com/sindresorhus/globals/blob/9e2e2598dabdb845ff76c0c3acf5c52c812a64de/globals.json#L368-L1442>
-pub const BROWSER: &[&str; 1073] = &[
+pub const BROWSER: &[&str] = &[
     "AbortController",
     "AbortSignal",
     "AbsoluteOrientationSensor",
@@ -1080,7 +1080,7 @@ pub const BROWSER: &[&str; 1073] = &[
 /// Sorted array of browser service worker builtin
 ///
 /// Source: <https://github.com/sindresorhus/globals/blob/9e2e2598dabdb845ff76c0c3acf5c52c812a64de/globals.json#L2212-L2334>
-pub const SERVICE_WORKER: &[&str; 121] = &[
+pub const SERVICE_WORKER: &[&str] = &[
     "Blob",
     "BroadcastChannel",
     "ByteLengthQueuingStrategy",
@@ -1207,7 +1207,7 @@ pub const SERVICE_WORKER: &[&str; 121] = &[
 /// Sorted array of browser web worker builtin
 ///
 /// Source: <https://github.com/sindresorhus/globals/blob/9e2e2598dabdb845ff76c0c3acf5c52c812a64de/globals.json#L1443-L1726>
-pub const WEB_WORKER: &[&str; 282] = &[
+pub const WEB_WORKER: &[&str] = &[
     "AbortController",
     "AbortSignal",
     "AudioData",

--- a/crates/biome_js_analyze/src/globals/module/node.rs
+++ b/crates/biome_js_analyze/src/globals/module/node.rs
@@ -1,7 +1,7 @@
 /// Sorted array of Node builtin modules
 ///
 /// Source: <https://github.com/inspect-js/is-core-module/blob/8317b311856a61935d7257ad5f31f9b0cfd13b5f/core.json#L1-L158>
-pub const BUILTIN_MODULES: &[&str; 156] = &[
+pub const BUILTIN_MODULES: &[&str] = &[
     "_debug_agent",
     "_debugger",
     "_http_agent",

--- a/crates/biome_js_analyze/src/globals/typescript/language.rs
+++ b/crates/biome_js_analyze/src/globals/typescript/language.rs
@@ -1,7 +1,7 @@
 /// Sorted array of TypeScript ES5 builtin
 ///
 /// Source: <https://github.com/typescript-eslint/typescript-eslint/blob/4d6d0d5950f587780dec998816d458ae4b27a513/packages/scope-manager/src/lib/es5.ts>
-pub const ES_5: &[&str; 119] = &[
+pub const ES_5: &[&str] = &[
     "Array",
     "ArrayBuffer",
     "ArrayBufferConstructor",
@@ -126,7 +126,7 @@ pub const ES_5: &[&str; 119] = &[
 /// Sorted array of TypeScript ES2015 builtin
 ///
 /// Source: <https://github.com/typescript-eslint/typescript-eslint/blob/4d6d0d5950f587780dec998816d458ae4b27a513/packages/scope-manager/src/lib/es2015.ts>
-pub const ES_2015: &[&str; 143] = &[
+pub const ES_2015: &[&str] = &[
     "Array",
     "ArrayBuffer",
     "ArrayBufferConstructor",
@@ -272,12 +272,12 @@ pub const ES_2015: &[&str; 143] = &[
     "WeakSetConstructor",
 ];
 
-pub const ES_6: &[&str; 143] = ES_2015;
+pub const ES_6: &[&str] = ES_2015;
 
 /// Sorted array of TypeScript ES2016 builtin
 ///
 /// Source: <https://github.com/typescript-eslint/typescript-eslint/blob/4d6d0d5950f587780dec998816d458ae4b27a513/packages/scope-manager/src/lib/es2016.ts>
-pub const ES_2016: &[&str; 143] = &[
+pub const ES_2016: &[&str] = &[
     "Array",
     "ArrayBuffer",
     "ArrayBufferConstructor",
@@ -423,12 +423,12 @@ pub const ES_2016: &[&str; 143] = &[
     "WeakSetConstructor",
 ];
 
-pub const ES_7: &[&str; 143] = ES_2016;
+pub const ES_7: &[&str] = ES_2016;
 
 /// Sorted array of TypeScript ES2017 builtin
 ///
 /// Source: <https://github.com/typescript-eslint/typescript-eslint/blob/4d6d0d5950f587780dec998816d458ae4b27a513/packages/scope-manager/src/lib/es2017.ts>
-pub const ES_2017: &[&str; 146] = &[
+pub const ES_2017: &[&str] = &[
     "Array",
     "ArrayBuffer",
     "ArrayBufferConstructor",
@@ -580,7 +580,7 @@ pub const ES_2017: &[&str; 146] = &[
 /// Sorted array of TypeScript ES2018 builtin
 ///
 /// Source: <https://github.com/typescript-eslint/typescript-eslint/blob/4d6d0d5950f587780dec998816d458ae4b27a513/packages/scope-manager/src/lib/es2018.ts>
-pub const ES_2018: &[&str; 152] = &[
+pub const ES_2018: &[&str] = &[
     "Array",
     "ArrayBuffer",
     "ArrayBufferConstructor",
@@ -738,7 +738,7 @@ pub const ES_2018: &[&str; 152] = &[
 /// Sorted array of TypeScript ES2019 builtin
 ///
 /// Source: <https://github.com/typescript-eslint/typescript-eslint/blob/4d6d0d5950f587780dec998816d458ae4b27a513/packages/scope-manager/src/lib/es2019.ts>
-pub const ES_2019: &[&str; 153] = &[
+pub const ES_2019: &[&str] = &[
     "Array",
     "ArrayBuffer",
     "ArrayBufferConstructor",
@@ -897,7 +897,7 @@ pub const ES_2019: &[&str; 153] = &[
 /// Sorted array of TypeScript ES2020 builtin
 ///
 /// Source: <https://github.com/typescript-eslint/typescript-eslint/blob/4d6d0d5950f587780dec998816d458ae4b27a513/packages/scope-manager/src/lib/es2020.ts>
-pub const ES_2020: &[&str; 163] = &[
+pub const ES_2020: &[&str] = &[
     "Array",
     "ArrayBuffer",
     "ArrayBufferConstructor",
@@ -1066,7 +1066,7 @@ pub const ES_2020: &[&str; 163] = &[
 /// Sorted array of TypeScript ES2021 builtin
 ///
 /// Source: <https://github.com/typescript-eslint/typescript-eslint/blob/4d6d0d5950f587780dec998816d458ae4b27a513/packages/scope-manager/src/lib/es2021.ts>
-pub const ES_2021: &[&str; 169] = &[
+pub const ES_2021: &[&str] = &[
     "AggregateError",
     "AggregateErrorConstructor",
     "Array",
@@ -1241,7 +1241,7 @@ pub const ES_2021: &[&str; 169] = &[
 /// Sorted array of TypeScript ES2022 builtin
 ///
 /// Source: <https://github.com/typescript-eslint/typescript-eslint/blob/4d6d0d5950f587780dec998816d458ae4b27a513/packages/scope-manager/src/lib/es2022.ts>
-pub const ES_2022: &[&str; 171] = &[
+pub const ES_2022: &[&str] = &[
     "AggregateError",
     "AggregateErrorConstructor",
     "Array",
@@ -1418,7 +1418,7 @@ pub const ES_2022: &[&str; 171] = &[
 /// Sorted array of TypeScript ES2023 builtin
 ///
 /// Source: <https://github.com/typescript-eslint/typescript-eslint/blob/4d6d0d5950f587780dec998816d458ae4b27a513/packages/scope-manager/src/lib/esnext.ts>
-pub const ES_2023: &[&str; 171] = &[
+pub const ES_2023: &[&str] = &[
     "AggregateError",
     "AggregateErrorConstructor",
     "Array",
@@ -1595,7 +1595,7 @@ pub const ES_2023: &[&str; 171] = &[
 /// Sorted array of TypeScript ESNext builtin
 ///
 /// Source: <https://github.com/typescript-eslint/typescript-eslint/blob/4d6d0d5950f587780dec998816d458ae4b27a513/packages/scope-manager/src/lib/es5.ts>
-pub const ES_NEXT: &[&str; 180] = &[
+pub const ES_NEXT: &[&str] = &[
     "AggregateError",
     "AggregateErrorConstructor",
     "Array",

--- a/crates/biome_js_analyze/src/globals/typescript/node.rs
+++ b/crates/biome_js_analyze/src/globals/typescript/node.rs
@@ -1,7 +1,7 @@
 /// Sorted array of TypeScript Node globals
 ///
 /// Source: <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8279710799f3c39d5cd129cac5705b809b66022a/types/node/globals.d.ts#L17-L411>
-pub const NODE: &[&str; 42] = &[
+pub const NODE: &[&str] = &[
     "AbortController",
     "AbortSignal",
     "Array",

--- a/crates/biome_js_analyze/src/globals/typescript/web.rs
+++ b/crates/biome_js_analyze/src/globals/typescript/web.rs
@@ -1,7 +1,7 @@
 /// Sorted array of TypeScript DOM builtin
 ///
 /// Source: <https://github.com/typescript-eslint/typescript-eslint/blob/4d6d0d5950f587780dec998816d458ae4b27a513/packages/scope-manager/src/lib/dom.ts>
-pub const DOM: &[&str; 1431] = &[
+pub const DOM: &[&str] = &[
     "ANGLE_instanced_arrays",
     "ARIAMixin",
     "AbortController",
@@ -1438,7 +1438,7 @@ pub const DOM: &[&str; 1431] = &[
 /// Sorted array of TypeScript Web Worker builtin
 ///
 /// Source: <https://github.com/typescript-eslint/typescript-eslint/blob/4d6d0d5950f587780dec998816d458ae4b27a513/packages/scope-manager/src/lib/webworker.ts>
-pub const WEB_WORKER: &[&str; 579] = &[
+pub const WEB_WORKER: &[&str] = &[
     "ANGLE_instanced_arrays",
     "AbortController",
     "AbortSignal",

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -117,6 +117,7 @@ pub(crate) fn analyze_and_snap(
     let parsed = parse(input_code, source_type, parser_options.clone());
     let root = parsed.tree();
 
+    //
     let options = create_analyzer_options(input_file, &mut diagnostics);
 
     let (_, errors) =

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalid.svelte.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalid.svelte.ts
@@ -1,0 +1,8 @@
+class Todo {
+    done = $unknown(false);
+    text = $unknown();
+
+    constructor(text) {
+        this.text = text;
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalid.svelte.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalid.svelte.ts.snap
@@ -1,0 +1,51 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.svelte.ts
+---
+# Input
+```ts
+class Todo {
+    done = $unknown(false);
+    text = $unknown();
+
+    constructor(text) {
+        this.text = text;
+    }
+}
+```
+
+# Diagnostics
+```
+invalid.svelte.ts:2:12 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The $unknown variable is undeclared.
+  
+    1 │ class Todo {
+  > 2 │     done = $unknown(false);
+      │            ^^^^^^^^
+    3 │     text = $unknown();
+    4 │ 
+  
+  i By default, Biome recognizes browser and Node.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
+
+```
+
+```
+invalid.svelte.ts:3:12 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The $unknown variable is undeclared.
+  
+    1 │ class Todo {
+    2 │     done = $unknown(false);
+  > 3 │     text = $unknown();
+      │            ^^^^^^^^
+    4 │ 
+    5 │     constructor(text) {
+  
+  i By default, Biome recognizes browser and Node.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid.js
@@ -1,0 +1,1 @@
+const x = global1;

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid.js.snap
@@ -1,0 +1,8 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```jsx
+const x = global1;
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid.options.json
@@ -1,0 +1,5 @@
+{
+    "javascript": {
+        "globals": ["global1"]
+    }
+}

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -93,6 +93,15 @@ pub fn create_analyzer_options(
                 ReactClassic => Some(JsxRuntime::ReactClassic),
                 Transparent => Some(JsxRuntime::Transparent),
             };
+            analyzer_configuration.globals = configuration
+                .javascript
+                .as_ref()
+                .and_then(|js| {
+                    js.globals
+                        .as_ref()
+                        .map(|globals| globals.iter().cloned().collect())
+                })
+                .unwrap_or_default();
 
             settings
                 .merge_with_configuration(configuration, None, None, &[])


### PR DESCRIPTION
## Summary

Add support for Svelte 5 runes.

I fixed an issue in our test infra where `globals` was always empty.
I added a test to check that it is now set correctly.

Unfortunately our test infra doesn't call `resolve_analyzer_options` and I don't see an easy way to do it because it is language dependent and our test infra is mostly language independent.
Thus, I was not able to write a test for Svelte runes. 

Also, I took the opportunity of removing the size from the constant slices of globals.