### PR TITLE
chore(css_semantic): allow an empty at-property declation

### DIFF
--- a/crates/biome_css_semantic/src/events.rs
+++ b/crates/biome_css_semantic/src/events.rs
@@ -40,7 +40,7 @@ pub enum SemanticEvent {
 pub struct SemanticEventExtractor {
     stash: VecDeque<SemanticEvent>,
     current_rule_stack: Vec<TextRange>,
-    in_root_selector: bool,
+    is_in_root_selector: bool,
 }
 
 impl SemanticEventExtractor {
@@ -85,7 +85,7 @@ impl SemanticEventExtractor {
                                 range: property_name.text_range(),
                             },
                             value: CssValue {
-                                value: value.text_trimmed().to_string(),
+                                text: value.text_trimmed().to_string(),
                                 range: value.text_range(),
                             },
                             range: node.text_range(),
@@ -113,7 +113,7 @@ impl SemanticEventExtractor {
             AnyCssSelector::CssCompoundSelector(selector) => {
                 if selector.text() == ":root" {
                     self.stash.push_back(SemanticEvent::RootSelectorStart);
-                    self.in_root_selector = true;
+                    self.is_in_root_selector = true;
                 }
                 self.add_selector_event(selector.text().to_string(), selector.range())
             }
@@ -150,7 +150,7 @@ impl SemanticEventExtractor {
                                     range: property_name.text_range(),
                                 },
                                 value: CssValue {
-                                    value: p.value().text().to_string(),
+                                    text: p.value().text().to_string(),
                                     range: p.value().range(),
                                 },
                                 range: node.text_range(),
@@ -177,9 +177,9 @@ impl SemanticEventExtractor {
         ) {
             self.current_rule_stack.pop();
             self.stash.push_back(SemanticEvent::RuleEnd);
-            if self.in_root_selector {
+            if self.is_in_root_selector {
                 self.stash.push_back(SemanticEvent::RootSelectorEnd);
-                self.in_root_selector = false;
+                self.is_in_root_selector = false;
             }
         }
     }

--- a/crates/biome_css_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_css_semantic/src/semantic_model/builder.rs
@@ -11,7 +11,7 @@ pub struct SemanticModelBuilder {
     root: CssRoot,
     node_by_range: FxHashMap<TextRange, CssSyntaxNode>,
     rules: Vec<Rule>,
-    global_css_variables: FxHashMap<String, CssGlobalCustomVariable>,
+    global_custom_variables: FxHashMap<String, CssGlobalCustomVariable>,
     current_rule_stack: Vec<Rule>,
     is_in_root_selector: bool,
 }
@@ -23,7 +23,7 @@ impl SemanticModelBuilder {
             node_by_range: FxHashMap::default(),
             rules: Vec::new(),
             current_rule_stack: Vec::new(),
-            global_css_variables: FxHashMap::default(),
+            global_custom_variables: FxHashMap::default(),
             is_in_root_selector: false,
         }
     }
@@ -33,7 +33,7 @@ impl SemanticModelBuilder {
             root: self.root,
             node_by_range: self.node_by_range,
             rules: self.rules,
-            global_css_variables: self.global_css_variables,
+            global_custom_variables: self.global_custom_variables,
         };
         SemanticModel::new(data)
     }
@@ -92,7 +92,7 @@ impl SemanticModelBuilder {
 
                 if let Some(current_rule) = self.current_rule_stack.last_mut() {
                     if is_global_var {
-                        self.global_css_variables.insert(
+                        self.global_custom_variables.insert(
                             property.name.clone(),
                             CssGlobalCustomVariable::Root(CssDeclaration {
                                 property: property.clone(),
@@ -121,7 +121,7 @@ impl SemanticModelBuilder {
                 inherits,
                 range,
             } => {
-                self.global_css_variables.insert(
+                self.global_custom_variables.insert(
                     property.name.to_string(),
                     CssGlobalCustomVariable::AtProperty {
                         property,

--- a/crates/biome_css_semantic/src/semantic_model/mod.rs
+++ b/crates/biome_css_semantic/src/semantic_model/mod.rs
@@ -122,7 +122,7 @@ mod tests {
     }
 
     #[test]
-    fn test_global_css_variables() {
+    fn test_global_custom_variables() {
         let parse = parse_css(
             r#"@property --item-size {
   syntax: "<percentage>";
@@ -140,7 +140,7 @@ mod tests {
 
         let root = parse.tree();
         let model = super::semantic_model(&root);
-        let global_custom_variables = model.global_css_variables();
+        let global_custom_variables = model.global_custom_variables();
 
         assert_eq!(global_custom_variables.len(), 3);
 
@@ -159,7 +159,7 @@ mod tests {
 
         let root = parse.tree();
         let model = super::semantic_model(&root);
-        let global_custom_variables = model.global_css_variables();
+        let global_custom_variables = model.global_custom_variables();
 
         assert_eq!(global_custom_variables.len(), 1);
 
@@ -168,8 +168,9 @@ mod tests {
         assert!(item_size);
     }
 
+    #[ignore]
     #[test]
-    fn debug() {
+    fn quick_test() {
         let parse = parse_css(
             r#"@property --item-size {
   syntax: "<percentage>";
@@ -182,6 +183,6 @@ mod tests {
         let root = parse.tree();
         let model = super::semantic_model(&root);
         dbg!(&model.rules());
-        dbg!(&model.global_css_variables());
+        dbg!(&model.global_custom_variables());
     }
 }

--- a/crates/biome_css_semantic/src/semantic_model/mod.rs
+++ b/crates/biome_css_semantic/src/semantic_model/mod.rs
@@ -154,6 +154,21 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_at_property() {
+        let parse = parse_css(r#"@property --item-size {}"#, CssParserOptions::default());
+
+        let root = parse.tree();
+        let model = super::semantic_model(&root);
+        let global_custom_variables = model.global_css_variables();
+
+        assert_eq!(global_custom_variables.len(), 1);
+
+        let item_size = global_custom_variables.contains_key("--item-size");
+
+        assert!(item_size);
+    }
+
+    #[test]
     fn debug() {
         let parse = parse_css(
             r#"@property --item-size {

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -34,7 +34,7 @@ impl SemanticModel {
         &self.data.rules
     }
 
-    pub fn global_css_variables(&self) -> &FxHashMap<String, CssDeclaration> {
+    pub fn global_css_variables(&self) -> &FxHashMap<String, CssGlobalCustomVariable> {
         &self.data.global_css_variables
     }
 }
@@ -51,7 +51,7 @@ pub(crate) struct SemanticModelData {
     /// List of all the css rules
     pub(crate) rules: Vec<Rule>,
     /// Map of CSS variables declared in the `:root` selector or using the @property rule.
-    pub(crate) global_css_variables: FxHashMap<String, CssDeclaration>,
+    pub(crate) global_css_variables: FxHashMap<String, CssGlobalCustomVariable>,
 }
 
 /// Represents a CSS rule set, including its selectors, declarations, and nested rules.
@@ -131,4 +131,29 @@ pub struct CssProperty {
 pub struct CssValue {
     pub text: String,
     pub range: TextRange,
+}
+
+/// Represents a CSS global custom variable declaration.
+/// This can be declared in the `:root` selector or using the `@property` rule.
+/// ```css
+/// :root {
+///   --custom-color: red;
+/// }
+///
+/// @property --item-size {
+///   syntax: "<percentage>";
+///   inherits: true;
+///   initial-value: 40%;
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub enum CssGlobalCustomVariable {
+    Root(CssDeclaration),
+    AtProperty {
+        property: CssProperty,
+        syntax: Option<String>,
+        inherits: Option<bool>,
+        initial_value: Option<CssValue>,
+        range: TextRange,
+    },
 }

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -34,7 +34,7 @@ impl SemanticModel {
         &self.data.rules
     }
 
-    pub fn global_css_variables(&self) -> &FxHashMap<String, CssCustomProperty> {
+    pub fn global_css_variables(&self) -> &FxHashMap<String, CssDeclaration> {
         &self.data.global_css_variables
     }
 }
@@ -51,7 +51,7 @@ pub(crate) struct SemanticModelData {
     /// List of all the css rules
     pub(crate) rules: Vec<Rule>,
     /// Map of CSS variables declared in the `:root` selector or using the @property rule.
-    pub(crate) global_css_variables: FxHashMap<String, CssCustomProperty>,
+    pub(crate) global_css_variables: FxHashMap<String, CssDeclaration>,
 }
 
 /// Represents a CSS rule set, including its selectors, declarations, and nested rules.
@@ -83,6 +83,12 @@ pub struct Rule {
 }
 
 /// Represents a CSS selector.
+/// /// ```css
+/// span {
+/// ^^^^
+///   color: red;
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct Selector {
     /// The name of the selector.
@@ -124,18 +130,5 @@ pub struct CssProperty {
 #[derive(Debug, Clone, Default)]
 pub struct CssValue {
     pub text: String,
-    pub range: TextRange,
-}
-
-/// Represents a CSS custom property declaration.
-/// ```css
-/// :root {
-///  --main-bg-color: brown;
-/// ^^^^^^^^^^^^^^^^^^^^^^^^
-/// }
-#[derive(Debug, Clone)]
-pub struct CssCustomProperty {
-    pub name: CssProperty,
-    pub value: CssValue,
     pub range: TextRange,
 }

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -34,7 +34,7 @@ impl SemanticModel {
         &self.data.rules
     }
 
-    pub fn global_css_variables(&self) -> &FxHashMap<String, CssVariable> {
+    pub fn global_css_variables(&self) -> &FxHashMap<String, CssCustomProperty> {
         &self.data.global_css_variables
     }
 }
@@ -51,7 +51,7 @@ pub(crate) struct SemanticModelData {
     /// List of all the css rules
     pub(crate) rules: Vec<Rule>,
     /// Map of CSS variables declared in the `:root` selector or using the @property rule.
-    pub(crate) global_css_variables: FxHashMap<String, CssVariable>,
+    pub(crate) global_css_variables: FxHashMap<String, CssCustomProperty>,
 }
 
 /// Represents a CSS rule set, including its selectors, declarations, and nested rules.
@@ -75,38 +75,10 @@ pub struct Rule {
     /// The selectors associated with this rule.
     pub selectors: Vec<Selector>,
     /// The declarations within this rule.
-    pub declarations: Vec<Declaration>,
+    pub declarations: Vec<CssDeclaration>,
     /// Any nested rules within this rule.
     pub children: Vec<Rule>,
     /// The text range of this rule in the source document.
-    pub range: TextRange,
-}
-
-/// Represents a CSS declaration (property-value pair).
-#[derive(Debug, Clone)]
-pub struct Declaration {
-    /// The property name.
-    pub property: CssProperty,
-    /// The property value.
-    pub value: CssValue,
-}
-
-#[derive(Debug, Clone)]
-pub struct CssProperty {
-    pub name: String,
-    pub range: TextRange,
-}
-
-#[derive(Debug, Clone)]
-pub struct CssValue {
-    pub value: String,
-    pub range: TextRange,
-}
-
-#[derive(Debug, Clone)]
-pub struct CssVariable {
-    pub name: CssProperty,
-    pub value: CssValue,
     pub range: TextRange,
 }
 
@@ -128,3 +100,42 @@ pub struct Selector {
 /// More details https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct Specificity(pub u32, pub u32, pub u32);
+
+/// Represents a CSS declaration (property-value pair).
+/// ```css
+/// a {
+///   color: red;
+///   ^^^^^^^^^^^
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct CssDeclaration {
+    pub property: CssProperty,
+    pub value: CssValue,
+    pub range: TextRange,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CssProperty {
+    pub name: String,
+    pub range: TextRange,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CssValue {
+    pub text: String,
+    pub range: TextRange,
+}
+
+/// Represents a CSS custom property declaration.
+/// ```css
+/// :root {
+///  --main-bg-color: brown;
+/// ^^^^^^^^^^^^^^^^^^^^^^^^
+/// }
+#[derive(Debug, Clone)]
+pub struct CssCustomProperty {
+    pub name: CssProperty,
+    pub value: CssValue,
+    pub range: TextRange,
+}

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -34,8 +34,8 @@ impl SemanticModel {
         &self.data.rules
     }
 
-    pub fn global_css_variables(&self) -> &FxHashMap<String, CssGlobalCustomVariable> {
-        &self.data.global_css_variables
+    pub fn global_custom_variables(&self) -> &FxHashMap<String, CssGlobalCustomVariable> {
+        &self.data.global_custom_variables
     }
 }
 
@@ -51,7 +51,7 @@ pub(crate) struct SemanticModelData {
     /// List of all the css rules
     pub(crate) rules: Vec<Rule>,
     /// Map of CSS variables declared in the `:root` selector or using the @property rule.
-    pub(crate) global_css_variables: FxHashMap<String, CssGlobalCustomVariable>,
+    pub(crate) global_custom_variables: FxHashMap<String, CssGlobalCustomVariable>,
 }
 
 /// Represents a CSS rule set, including its selectors, declarations, and nested rules.


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
- cleanup codebase
- Improve the definition of global css custom variables and allow an empty at-property declation
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
CI should pass
<!-- What demonstrates that your implementation is correct? -->
