### PR TITLE
feat(css_semantic): implement rule hierarchy tracking and enhance rule lookup

### DIFF
--- a/crates/biome_css_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_css_semantic/src/semantic_model/builder.rs
@@ -67,8 +67,12 @@ impl SemanticModelBuilder {
             SemanticEvent::RuleEnd => {
                 if let Some(completed_rule) = self.current_rule_stack.pop() {
                     if let Some(parent_rule) = self.current_rule_stack.last_mut() {
+                        self.range_to_rule
+                            .insert(completed_rule.range, completed_rule.clone());
                         parent_rule.children.push(completed_rule);
                     } else {
+                        self.range_to_rule
+                            .insert(completed_rule.range, completed_rule.clone());
                         self.rules.push(completed_rule);
                     }
                 }

--- a/crates/biome_css_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_css_semantic/src/semantic_model/builder.rs
@@ -13,6 +13,7 @@ pub struct SemanticModelBuilder {
     rules: Vec<Rule>,
     global_custom_variables: FxHashMap<String, CssGlobalCustomVariable>,
     current_rule_stack: Vec<Rule>,
+    range_to_rule: FxHashMap<TextRange, Rule>,
     is_in_root_selector: bool,
 }
 
@@ -24,6 +25,7 @@ impl SemanticModelBuilder {
             rules: Vec::new(),
             current_rule_stack: Vec::new(),
             global_custom_variables: FxHashMap::default(),
+            range_to_rule: FxHashMap::default(),
             is_in_root_selector: false,
         }
     }
@@ -34,6 +36,7 @@ impl SemanticModelBuilder {
             node_by_range: self.node_by_range,
             rules: self.rules,
             global_custom_variables: self.global_custom_variables,
+            range_to_rule: self.range_to_rule,
         };
         SemanticModel::new(data)
     }

--- a/crates/biome_css_semantic/src/semantic_model/mod.rs
+++ b/crates/biome_css_semantic/src/semantic_model/mod.rs
@@ -52,6 +52,8 @@ mod tests {
 
         assert_eq!(rule.selectors.len(), 1);
         assert_eq!(rule.declarations.len(), 2);
+        assert_eq!(rule.child_ids.len(), 0);
+        assert_eq!(rule.parent_id, None);
     }
     #[test]
     fn test_nested_selector() {
@@ -71,7 +73,15 @@ mod tests {
         let rule = model.rules().first().unwrap();
         assert_eq!(rule.selectors.len(), 1);
         assert_eq!(rule.declarations.len(), 1);
-        assert_eq!(rule.children.len(), 1);
+        assert_eq!(rule.child_ids.len(), 1);
+
+        let child_id = rule.child_ids.first().unwrap();
+        let child = model.get_rule_by_id(*child_id).unwrap();
+
+        assert_eq!(child.selectors.len(), 1);
+        assert_eq!(child.declarations.len(), 1);
+        assert_eq!(child.child_ids.len(), 0);
+        assert_eq!(child.parent_id, Some(rule.id));
     }
 
     #[test]
@@ -91,11 +101,14 @@ mod tests {
 
         assert_eq!(rule.selectors.len(), 1);
         assert_eq!(rule.declarations.len(), 0);
-        assert_eq!(rule.children.len(), 1);
+        assert_eq!(rule.child_ids.len(), 1);
 
-        let child = rule.children.first().unwrap();
+        let child_id = rule.child_ids.first().unwrap();
+        let child = model.get_rule_by_id(*child_id).unwrap();
         assert_eq!(child.selectors.len(), 1);
         assert_eq!(child.declarations.len(), 1);
+        assert_eq!(child.child_ids.len(), 0);
+        assert_eq!(child.parent_id, Some(rule.id));
     }
 
     #[test]
@@ -115,11 +128,14 @@ mod tests {
 
         assert_eq!(rule.selectors.len(), 1);
         assert_eq!(rule.declarations.len(), 0);
-        assert_eq!(rule.children.len(), 1);
+        assert_eq!(rule.child_ids.len(), 1);
 
-        let child = rule.children.first().unwrap();
+        let child_id = rule.child_ids.first().unwrap();
+        let child = model.get_rule_by_id(*child_id).unwrap();
         assert_eq!(child.selectors.len(), 0);
         assert_eq!(child.declarations.len(), 1);
+        assert_eq!(child.child_ids.len(), 0);
+        assert_eq!(child.parent_id, Some(rule.id));
     }
 
     #[test]
@@ -220,7 +236,7 @@ mod tests {
         // range of the declaration 'blue' in '.child'
         let range = TextRange::new(60.into(), 64.into());
         let rule = model.get_rule_by_range(range).unwrap();
-        dbg!(&rule);
+
         assert_eq!(rule.selectors.len(), 1);
         assert_eq!(rule.declarations.len(), 1);
 
@@ -228,6 +244,17 @@ mod tests {
 
         assert_eq!(rule.declarations[0].property.name, "color");
         assert_eq!(rule.declarations[0].value.text, "var(--foo)");
+
+        let parent = model.get_rule_by_id(rule.parent_id.unwrap()).unwrap();
+        assert_eq!(parent.selectors.len(), 1);
+        assert_eq!(parent.declarations.len(), 2);
+
+        assert_eq!(parent.selectors[0].name, "p");
+        assert_eq!(parent.declarations[0].property.name, "--foo");
+        assert_eq!(parent.declarations[0].value.text, "red");
+
+        assert_eq!(parent.declarations[1].property.name, "font-size");
+        assert_eq!(parent.declarations[1].value.text, "12px");
     }
 
     #[ignore]

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -180,16 +180,16 @@ pub enum CssGlobalCustomVariable {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct RuleId(u32);
+pub struct RuleId(u32);
 
 impl RuleId {
-    pub(crate) fn new(index: usize) -> Self {
+    pub fn new(index: usize) -> Self {
         // SAFETY: We didn't handle files execedding `u32::MAX` bytes.
         // Thus, it isn't possible to execedd `u32::MAX` bindings.
         Self(index as u32)
     }
 
-    pub(crate) fn index(self) -> usize {
+    pub fn index(self) -> usize {
         self.0 as usize
     }
 }

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -37,6 +37,15 @@ impl SemanticModel {
     pub fn global_custom_variables(&self) -> &FxHashMap<String, CssGlobalCustomVariable> {
         &self.data.global_custom_variables
     }
+
+    pub fn find_rule_by_range(&self, target_range: TextRange) -> Option<&Rule> {
+        self.data
+            .range_to_rule
+            .iter()
+            .filter(|(rule_range, _)| rule_range.contains_range(target_range))
+            .min_by_key(|(rule_range, _)| rule_range.len())
+            .map(|(_, rule)| rule)
+    }
 }
 
 /// Contains the internal data of a `SemanticModel`.
@@ -52,6 +61,7 @@ pub(crate) struct SemanticModelData {
     pub(crate) rules: Vec<Rule>,
     /// Map of CSS variables declared in the `:root` selector or using the @property rule.
     pub(crate) global_custom_variables: FxHashMap<String, CssGlobalCustomVariable>,
+    pub(crate) range_to_rule: FxHashMap<TextRange, Rule>,
 }
 
 /// Represents a CSS rule set, including its selectors, declarations, and nested rules.

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -38,6 +38,11 @@ impl SemanticModel {
         &self.data.global_custom_variables
     }
 
+    pub fn get_rule_by_id(&self, id: RuleId) -> Option<&Rule> {
+        self.data.rules_by_id.get(&id)
+    }
+
+    /// Returns the rule that contains the given range.
     pub fn get_rule_by_range(&self, target_range: TextRange) -> Option<&Rule> {
         self.data
             .range_to_rule
@@ -57,10 +62,13 @@ pub(crate) struct SemanticModelData {
     pub(crate) root: CssRoot,
     /// Map to each by its range
     pub(crate) node_by_range: FxHashMap<TextRange, CssSyntaxNode>,
-    /// List of all the css rules
+    /// List of all top-level rules in the CSS document
     pub(crate) rules: Vec<Rule>,
     /// Map of CSS variables declared in the `:root` selector or using the @property rule.
     pub(crate) global_custom_variables: FxHashMap<String, CssGlobalCustomVariable>,
+    /// Map of all the rules by their id
+    pub(crate) rules_by_id: FxHashMap<RuleId, Rule>,
+    /// Map of the range of each rule to the rule itself
     pub(crate) range_to_rule: FxHashMap<TextRange, Rule>,
 }
 
@@ -82,12 +90,15 @@ pub(crate) struct SemanticModelData {
 ///
 #[derive(Debug, Clone)]
 pub struct Rule {
+    pub id: RuleId,
     /// The selectors associated with this rule.
     pub selectors: Vec<Selector>,
     /// The declarations within this rule.
     pub declarations: Vec<CssDeclaration>,
-    /// Any nested rules within this rule.
-    pub children: Vec<Rule>,
+    /// The id of the parent rule
+    pub parent_id: Option<RuleId>,
+    /// The ids of the child rules
+    pub child_ids: Vec<RuleId>,
     /// The text range of this rule in the source document.
     pub range: TextRange,
 }
@@ -166,4 +177,19 @@ pub enum CssGlobalCustomVariable {
         initial_value: Option<CssValue>,
         range: TextRange,
     },
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct RuleId(u32);
+
+impl RuleId {
+    pub(crate) fn new(index: usize) -> Self {
+        // SAFETY: We didn't handle files execedding `u32::MAX` bytes.
+        // Thus, it isn't possible to execedd `u32::MAX` bindings.
+        Self(index as u32)
+    }
+
+    pub(crate) fn index(self) -> usize {
+        self.0 as usize
+    }
 }

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -38,7 +38,7 @@ impl SemanticModel {
         &self.data.global_custom_variables
     }
 
-    pub fn find_rule_by_range(&self, target_range: TextRange) -> Option<&Rule> {
+    pub fn get_rule_by_range(&self, target_range: TextRange) -> Option<&Rule> {
         self.data
             .range_to_rule
             .iter()
@@ -80,7 +80,7 @@ pub(crate) struct SemanticModelData {
 /// │  }                                  │
 /// └─────────────────────────────────────┘
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Rule {
     /// The selectors associated with this rule.
     pub selectors: Vec<Selector>,


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
This PR improves the CSS semantic model by implementing a more efficient rule hierarchy tracking system and improving rule lookup.

### get_rule_by_range
I added a new public API, `get_rule_by_range` to the model that can be used in lint rules.

```css
.foo{
  color: red;
  .bar {
    color: blue;
    font-size: 20px;
    .baz {
      color: pink
    }
  }
}
```

```rust
let model = ctx.model();

let range = node.range(); // Consider node as `color: blue` in `.bar`

// Get the rule containing the given range
let rule = model.get_rule_by_range(range);

// See Selectors 
for selector in &rule.selectors {
    // Work with selectors
}

// See other declarations in the same scope
for declaration in &rule.declarations {
    // Work with declarations
}

// Access parent and child rules
if let Some(parent_id) = rule.parent_id {
    let parent_rule = model.get_rule_by_id(parent_id);
    // Work with parent rule
}

for child_id in &rule.child_ids {
    let child_rule = model.get_rule_by_id(*child_id);
    // Work with child rules
}
```

## Test Plan
CI should pass
<!-- What demonstrates that your implementation is correct? -->
