### PR TITLE
refactor(json): allow comments in jest.config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -541,6 +541,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- The JSON parser now allows comments in `jest.config.json`. Contributed by @Conaclos
+
 #### Bug fixes
 
 - Fix [#3287](https://github.com/biomejs/biome/issues/3287) nested selectors with pseudo-classes. Contributed by @denbezrukov

--- a/crates/biome_json_syntax/src/file_source.rs
+++ b/crates/biome_json_syntax/src/file_source.rs
@@ -66,6 +66,9 @@ impl JsonFileSource {
         // Uses `strip-json-comments`, which doesn't allow trailing commas by default
         // https://github.com/jshint/jshint/blob/0a5644f8f529e252e7dd0c0d54334ae435b13de0/src/cli.js#L538
         b".jshintrc",
+        // Uses `strip-json-comments`, which doesn't allow trailing commas by default
+        // https://github.com/jestjs/jest/blob/bd1c6db7c15c23788ca3e09c919138e48dd3b28a/packages/jest-config/src/readConfigFileAndSetRootDir.ts#L46
+        b"jest.config.json",
         // Just strip comments
         // https://github.com/palantir/tslint/blob/285fc1db18d1fd24680d6a2282c6445abf1566ee/src/configuration.ts#L268
         b"tslint.json",


### PR DESCRIPTION
## Summary

Recognize `jest.config.json` files as JSON files allowing comments.

## Test Plan

CI must pass.
