### PR TITLE
refactor(noRedeclare): ignore var named as function expression name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -465,6 +465,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare/) no longer report a variable named as the function expression where it is declared. Contributed by @Conaclos
+
 - [noMultipleSpacesInRegularExpressionLiterals](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals/) now correctly provides a code fix when unicode characters are used.
 
 - `useAdjacentOverloadSignatures` no longer reports a `#private` class member and a public class member that share the same name ([#3309](https://github.com/biomejs/biome/issues/3309)).

--- a/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
@@ -141,8 +141,11 @@ fn check_redeclarations_in_single_scope(scope: &Scope, redeclarations: &mut Vec<
             for binding in function_scope.bindings() {
                 let id_binding = binding.tree();
                 if let Some(decl) = id_binding.declaration() {
-                    let name = id_binding.text();
-                    declarations.insert(name, (id_binding.syntax().text_trimmed_range(), decl));
+                    // Ignore the function itself.
+                    if !matches!(decl, AnyJsBindingDeclaration::JsFunctionExpression(_)) {
+                        let name = id_binding.text();
+                        declarations.insert(name, (id_binding.syntax().text_trimmed_range(), decl));
+                    }
                 }
             }
         }

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid.jsonc
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid.jsonc
@@ -11,5 +11,6 @@
 	"class C { static { var a; { let a; } } }",
 	"class C { static { let a; { let a; } } }",
 	"class C { static { { let a; } { let a; } } }",
-  "interface A { [index: string]: string; [index: number]: string; }"
+    "interface A { [index: string]: string; [index: number]: string; }",
+	"const foo = function foo() { const foo = 0; }"
 ]

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid.jsonc.snap
@@ -71,4 +71,7 @@ class C { static { { let a; } { let a; } } }
 interface A { [index: string]: string; [index: number]: string; }
 ```
 
-
+# Input
+```cjs
+const foo = function foo() { const foo = 0; }
+```


### PR DESCRIPTION
## Summary

Previously, Biome reported `foof` as redeclared.

```js
const f = function foo() { const foo = 0; }
```

## Test Plan

I added a test