### PR TITLE
fix(useValidAriaValues): correctly check property types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -467,7 +467,15 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - [noRedeclare](https://biomejs.dev/linter/rules/no-redeclare/) no longer report a variable named as the function expression where it is declared. Contributed by @Conaclos
 
-- [noMultipleSpacesInRegularExpressionLiterals](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals/) now correctly provides a code fix when unicode characters are used.
+- [noMultipleSpacesInRegularExpressionLiterals](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals/) now correctly provides a code fix when Unicode characters are used. Contributed by @Conaclos
+
+- [useValidAriaValues](https://biomejs.dev/linter/rules/use-valid-aria-values/) now correctly check property types ([3748](https://github.com/biomejs/biome/issues/3748)).
+
+  Properties that expect a string now accept arbitrary text.
+  An identifiers can now be made up of any characters except ASCII whitespace.
+  An identifier list can now be separated by any ASCII whitespace.
+
+  Contributed by @Conaclos
 
 - `useAdjacentOverloadSignatures` no longer reports a `#private` class member and a public class member that share the same name ([#3309](https://github.com/biomejs/biome/issues/3309)).
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_values.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_values.rs
@@ -118,8 +118,20 @@ impl Rule for UseValidAriaValues {
                     }
                 )
             }
-            AriaPropertyTypeEnum::Id |
-            AriaPropertyTypeEnum::Idlist |
+            AriaPropertyTypeEnum::Id => {
+                diagnostic.note(
+                    markup!{
+                        "The only supported value is an HTML identifier."
+                    }
+                )
+            }
+            AriaPropertyTypeEnum::Idlist => {
+                diagnostic.note(
+                    markup!{
+                        "The only supported value is a space-separated list of HTML identifiers."
+                    }
+                )
+            }
             AriaPropertyTypeEnum::String => {
                 diagnostic.note(
                     markup!{

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAriaValues/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAriaValues/invalid.jsx.snap
@@ -119,7 +119,7 @@ invalid.jsx:6:15 lint/a11y/useValidAriaValues ━━━━━━━━━━━�
     7 │ var a = <span aria-relevant="fancy"></span>;
     8 │ var a = <span aria-labelledby=""></span>;
   
-  i The only supported value is text.
+  i The only supported value is an HTML identifier.
   
 
 ```
@@ -158,7 +158,7 @@ invalid.jsx:8:15 lint/a11y/useValidAriaValues ━━━━━━━━━━━�
      9 │ var a = <span aria-labelledby={``}></span>;
     10 │ var a = <span aria-labelledby={""}></span>;
   
-  i The only supported value is text.
+  i The only supported value is a space-separated list of HTML identifiers.
   
 
 ```
@@ -175,7 +175,7 @@ invalid.jsx:9:15 lint/a11y/useValidAriaValues ━━━━━━━━━━━�
     10 │ var a = <span aria-labelledby={""}></span>;
     11 │ var a = <span aria-details=""></span>;
   
-  i The only supported value is text.
+  i The only supported value is a space-separated list of HTML identifiers.
   
 
 ```
@@ -192,7 +192,7 @@ invalid.jsx:10:15 lint/a11y/useValidAriaValues ━━━━━━━━━━━
     11 │ var a = <span aria-details=""></span>;
     12 │ var a = <span aria-setsize="hey"></span>;
   
-  i The only supported value is text.
+  i The only supported value is a space-separated list of HTML identifiers.
   
 
 ```
@@ -209,7 +209,7 @@ invalid.jsx:11:15 lint/a11y/useValidAriaValues ━━━━━━━━━━━
     12 │ var a = <span aria-setsize="hey"></span>;
     13 │ var a = <span aria-valuemax="hey"></span>;
   
-  i The only supported value is text.
+  i The only supported value is an HTML identifier.
   
 
 ```
@@ -291,5 +291,3 @@ invalid.jsx:15:15 lint/a11y/useValidAriaValues ━━━━━━━━━━━
   
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAriaValues/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAriaValues/valid.jsx
@@ -14,6 +14,8 @@ var a = <span aria-invalid={false}></span>;
 var a = <span role="checkbox" aria-errormessage="someid" ></span>;
 var a = <span role="checkbox" aria-relevant="additions" ></span>;
 var a = <span role="checkbox" aria-relevant="additions all" ></span>;
+var a = <span role="checkbox" aria-relevant=" additions   all " ></span>;
 var a = <span aria-labelledby="id" ></span>;
 var a = <span aria-labelledby="fooId barId" ></span>;
 var a = <span aria-details="someid" ></span>;
+var a = <button type="button" aria-keyshortcuts="1">Click Me</button>;

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAriaValues/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAriaValues/valid.jsx.snap
@@ -20,10 +20,10 @@ var a = <span aria-invalid={false}></span>;
 var a = <span role="checkbox" aria-errormessage="someid" ></span>;
 var a = <span role="checkbox" aria-relevant="additions" ></span>;
 var a = <span role="checkbox" aria-relevant="additions all" ></span>;
+var a = <span role="checkbox" aria-relevant=" additions   all " ></span>;
 var a = <span aria-labelledby="id" ></span>;
 var a = <span aria-labelledby="fooId barId" ></span>;
 var a = <span aria-details="someid" ></span>;
+var a = <button type="button" aria-keyshortcuts="1">Click Me</button>;
 
 ```
-
-


### PR DESCRIPTION
## Summary

Fix #3748

This PR fixes several bugs and improves the diagnostics of `useValidAriaValues`.

- Properties that expect a string now accept arbitrary text.
- An identifiers can now be made up of any characters except ASCII whitespace.
- An identifier list can now be separated by any ASCII whitespace.

## Test Plan

I added some tests.