### PR TITLE
fix(parser/html): fix parsing `html` keyword in doctype

### DIFF
--- a/crates/biome_html_parser/src/lexer/mod.rs
+++ b/crates/biome_html_parser/src/lexer/mod.rs
@@ -2,8 +2,8 @@ mod tests;
 
 use crate::token_source::HtmlLexContext;
 use biome_html_syntax::HtmlSyntaxKind::{
-    COMMENT, DOCTYPE_KW, EOF, ERROR_TOKEN, HTML_LITERAL, HTML_STRING_LITERAL, NEWLINE, TOMBSTONE,
-    UNICODE_BOM, WHITESPACE,
+    COMMENT, DOCTYPE_KW, EOF, ERROR_TOKEN, HTML_KW, HTML_LITERAL, HTML_STRING_LITERAL, NEWLINE,
+    TOMBSTONE, UNICODE_BOM, WHITESPACE,
 };
 use biome_html_syntax::{HtmlSyntaxKind, TextLen, TextSize, T};
 use biome_parser::diagnostic::ParseDiagnostic;
@@ -149,6 +149,7 @@ impl<'src> HtmlLexer<'src> {
 
         match &buffer[..len] {
             b"doctype" | b"DOCTYPE" => DOCTYPE_KW,
+            b"html" | b"HTML" => HTML_KW,
             _ => HTML_LITERAL,
         }
     }

--- a/crates/biome_html_parser/src/lexer/tests.rs
+++ b/crates/biome_html_parser/src/lexer/tests.rs
@@ -157,7 +157,7 @@ fn doctype_with_quirk() {
         BANG: 1,
         DOCTYPE_KW: 7,
         WHITESPACE: 1,
-        HTML_LITERAL: 4,
+        HTML_KW: 4,
         R_ANGLE: 1,
     }
 }
@@ -170,7 +170,7 @@ fn doctype_with_quirk_and_system() {
         BANG: 1,
         DOCTYPE_KW: 7,
         WHITESPACE: 1,
-        HTML_LITERAL: 4,
+        HTML_KW: 4,
         WHITESPACE: 1,
         HTML_STRING_LITERAL: 44,
         R_ANGLE: 1,

--- a/crates/biome_html_parser/src/syntax/mod.rs
+++ b/crates/biome_html_parser/src/syntax/mod.rs
@@ -43,6 +43,10 @@ fn parse_doc_type(p: &mut HtmlParser) -> ParsedSyntax {
         p.eat(T![doctype]);
     }
 
+    if p.at(T![html]) {
+        p.eat(T![html]);
+    }
+
     p.eat(T![>]);
 
     Present(m.complete(p, HTML_DIRECTIVE))

--- a/crates/biome_html_parser/tests/html_specs/ok/ok2.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/ok2.html
@@ -1,0 +1,1 @@
+<!doctype html>

--- a/crates/biome_html_parser/tests/html_specs/ok/ok2.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/ok2.html.snap
@@ -1,0 +1,50 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```css
+<!doctype html>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    directive: HtmlDirective {
+        l_angle_token: L_ANGLE@0..1 "<" [] [],
+        excl_token: BANG@1..2 "!" [] [],
+        doctype_token: DOCTYPE_KW@2..10 "doctype" [] [Whitespace(" ")],
+        html_token: HTML_KW@10..14 "html" [] [],
+        quirk_token: missing (optional),
+        public_id_token: missing (optional),
+        system_id_token: missing (optional),
+        r_angle_token: R_ANGLE@14..15 ">" [] [],
+    },
+    html: missing (optional),
+    eof_token: EOF@15..16 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..16
+  0: (empty)
+  1: HTML_DIRECTIVE@0..15
+    0: L_ANGLE@0..1 "<" [] []
+    1: BANG@1..2 "!" [] []
+    2: DOCTYPE_KW@2..10 "doctype" [] [Whitespace(" ")]
+    3: HTML_KW@10..14 "html" [] []
+    4: (empty)
+    5: (empty)
+    6: (empty)
+    7: R_ANGLE@14..15 ">" [] []
+  2: (empty)
+  3: EOF@15..16 "" [Newline("\n")] []
+
+```

--- a/xtask/codegen/html.ungram
+++ b/xtask/codegen/html.ungram
@@ -116,7 +116,7 @@ HtmlAttribute =
 
 
 // <a href="">
-//       ^^^^
+//        ^^^
 HtmlAttributeInitializerClause =
 	'='
 	value: HtmlString


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

This fixes incorrect lexing and parsing for HTML in the `doctype` directive node. It doesn't completely resolve everything parsing related to `doctype` -- I've left that to a future PR because the context for `quirk`, `public_id` and `system_id` is not really clear, even from looking at the HTML spec. But this _should_ reasonably cover modern html documents.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Updated the unit tests
