### PR TITLE
feat(format/html): impl non-verbatim formatting for directive and element tags

### DIFF
--- a/crates/biome_html_formatter/src/html/auxiliary/closing_element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/closing_element.rs
@@ -1,10 +1,27 @@
 use crate::prelude::*;
-use biome_html_syntax::HtmlClosingElement;
-use biome_rowan::AstNode;
+use biome_formatter::write;
+use biome_html_syntax::{HtmlClosingElement, HtmlClosingElementFields};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatHtmlClosingElement;
 impl FormatNodeRule<HtmlClosingElement> for FormatHtmlClosingElement {
     fn fmt_fields(&self, node: &HtmlClosingElement, f: &mut HtmlFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let HtmlClosingElementFields {
+            l_angle_token,
+            name,
+            slash_token,
+            r_angle_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                l_angle_token.format(),
+                slash_token.format(),
+                name.format(),
+                r_angle_token.format(),
+            ]
+        )?;
+
+        Ok(())
     }
 }

--- a/crates/biome_html_formatter/src/html/auxiliary/directive.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/directive.rs
@@ -1,10 +1,43 @@
 use crate::prelude::*;
-use biome_html_syntax::HtmlDirective;
-use biome_rowan::AstNode;
+use biome_formatter::write;
+use biome_html_syntax::{HtmlDirective, HtmlDirectiveFields};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatHtmlDirective;
 impl FormatNodeRule<HtmlDirective> for FormatHtmlDirective {
     fn fmt_fields(&self, node: &HtmlDirective, f: &mut HtmlFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let HtmlDirectiveFields {
+            l_angle_token,
+            excl_token,
+            doctype_token,
+            html_token,
+            quirk_token,
+            public_id_token,
+            system_id_token,
+            r_angle_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                l_angle_token.format(),
+                excl_token.format(),
+                doctype_token.format(),
+            ]
+        )?;
+        if let Some(html) = html_token {
+            write!(f, [space()])?;
+            html.format().fmt(f)?;
+        }
+        if let Some(quirk) = quirk_token {
+            quirk.format().fmt(f)?;
+        }
+        if let Some(public_id) = public_id_token {
+            public_id.format().fmt(f)?;
+        }
+        if let Some(system_id) = system_id_token {
+            system_id.format().fmt(f)?;
+        }
+        write!(f, [r_angle_token.format(), hard_line_break()])?;
+        Ok(())
     }
 }

--- a/crates/biome_html_formatter/src/html/auxiliary/element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/element.rs
@@ -1,10 +1,25 @@
 use crate::prelude::*;
-use biome_html_syntax::HtmlElement;
-use biome_rowan::AstNode;
+use biome_formatter::write;
+use biome_html_syntax::{HtmlElement, HtmlElementFields};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatHtmlElement;
 impl FormatNodeRule<HtmlElement> for FormatHtmlElement {
     fn fmt_fields(&self, node: &HtmlElement, f: &mut HtmlFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let HtmlElementFields {
+            opening_element,
+            children,
+            closing_element,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                opening_element.format(),
+                children.format(),
+                closing_element.format(),
+            ]
+        )?;
+
+        Ok(())
     }
 }

--- a/crates/biome_html_formatter/src/html/auxiliary/name.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/name.rs
@@ -1,10 +1,12 @@
 use crate::prelude::*;
-use biome_html_syntax::HtmlName;
-use biome_rowan::AstNode;
+use biome_formatter::write;
+use biome_html_syntax::{HtmlName, HtmlNameFields};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatHtmlName;
 impl FormatNodeRule<HtmlName> for FormatHtmlName {
     fn fmt_fields(&self, node: &HtmlName, f: &mut HtmlFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let HtmlNameFields { value_token } = node.as_fields();
+
+        write![f, [value_token.format()]]
     }
 }

--- a/crates/biome_html_formatter/src/html/auxiliary/opening_element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/opening_element.rs
@@ -1,10 +1,27 @@
 use crate::prelude::*;
-use biome_html_syntax::HtmlOpeningElement;
-use biome_rowan::AstNode;
+use biome_formatter::write;
+use biome_html_syntax::{HtmlOpeningElement, HtmlOpeningElementFields};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatHtmlOpeningElement;
 impl FormatNodeRule<HtmlOpeningElement> for FormatHtmlOpeningElement {
     fn fmt_fields(&self, node: &HtmlOpeningElement, f: &mut HtmlFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let HtmlOpeningElementFields {
+            l_angle_token,
+            name,
+            attributes,
+            r_angle_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                l_angle_token.format(),
+                name.format(),
+                attributes.format(),
+                r_angle_token.format(),
+            ]
+        )?;
+
+        Ok(())
     }
 }

--- a/crates/biome_html_formatter/src/html/auxiliary/root.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/root.rs
@@ -1,10 +1,22 @@
 use crate::prelude::*;
 use biome_html_syntax::HtmlRoot;
-use biome_rowan::AstNode;
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatHtmlRoot;
 impl FormatNodeRule<HtmlRoot> for FormatHtmlRoot {
     fn fmt_fields(&self, node: &HtmlRoot, f: &mut HtmlFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        if let Some(bom) = node.bom_token() {
+            bom.format().fmt(f)?;
+        }
+        if let Some(directive) = node.directive() {
+            directive.format().fmt(f)?;
+        }
+        if let Some(html) = node.html() {
+            html.format().fmt(f)?;
+        }
+        if let Ok(eof) = node.eof_token() {
+            eof.format().fmt(f)?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/biome_html_formatter/src/html/auxiliary/self_closing_element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/self_closing_element.rs
@@ -1,10 +1,28 @@
 use crate::prelude::*;
-use biome_html_syntax::HtmlSelfClosingElement;
-use biome_rowan::AstNode;
+use biome_formatter::write;
+use biome_html_syntax::{HtmlSelfClosingElement, HtmlSelfClosingElementFields};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatHtmlSelfClosingElement;
 impl FormatNodeRule<HtmlSelfClosingElement> for FormatHtmlSelfClosingElement {
     fn fmt_fields(&self, node: &HtmlSelfClosingElement, f: &mut HtmlFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let HtmlSelfClosingElementFields {
+            l_angle_token,
+            name,
+            attributes,
+            slash_token,
+            r_angle_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                l_angle_token.format(),
+                name.format(),
+                attributes.format(),
+                soft_line_break_or_space(),
+                slash_token.format(),
+                r_angle_token.format()
+            ]
+        )
     }
 }

--- a/crates/biome_html_formatter/src/prelude.rs
+++ b/crates/biome_html_formatter/src/prelude.rs
@@ -3,6 +3,6 @@ pub(crate) use crate::{
     format_verbatim_node, AsFormat, FormatNodeRule, FormatResult, FormatRule, FormattedIterExt,
     HtmlFormatContext, HtmlFormatter,
 };
-pub(crate) use biome_formatter::Format;
+pub(crate) use biome_formatter::prelude::*;
 #[allow(unused_imports)]
 pub(crate) use biome_rowan::{AstNode, AstNodeList};


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR refactors the directive and element tag formatters to not use the verbatim formatter. This allows testing and experimentation with formatters for child tokens. Without this, it's not possible to test formatters for attribute and element lists.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
It builds.
