### PR TITLE
refactor(noConsole): add `allow` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -446,6 +446,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - The rule `noRedundantUseStrict` no longer reports `use strict` when the `package.json` marks the file as a script using the field `"type": "commonjs"`. Contributed by @ematipico
 
+- [noConsole](https://biomejs.dev/linter/rules/no-console/) now accepts an option that specifies some allowed calls on `console`. Contributed by @Conaclos
+
 #### Bug fixes
 
 - Don't request alt text for elements hidden from assistive technologies ([#3316](https://github.com/biomejs/biome/issues/3316)). Contributed by @robintown

--- a/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
@@ -207,6 +207,20 @@ fn migrate_eslint_rule(
         eslint_eslint::Rule::Any(name, severity) => {
             let _ = migrate_eslint_any_rule(rules, &name, severity, opts, results);
         }
+        eslint_eslint::Rule::NoConsole(conf) => {
+            if migrate_eslint_any_rule(rules, &name, conf.severity(), opts, results) {
+                if let eslint_eslint::RuleConf::Option(severity, rule_options) = conf {
+                    let group = rules.nursery.get_or_insert_with(Default::default);
+                    group.no_console = Some(biome_config::RuleFixConfiguration::WithOptions(
+                        biome_config::RuleWithFixOptions {
+                            level: severity.into(),
+                            fix: None,
+                            options: Box::new((*rule_options).into()),
+                        },
+                    ));
+                }
+            }
+        }
         eslint_eslint::Rule::NoRestrictedGlobals(conf) => {
             if migrate_eslint_any_rule(rules, &name, conf.severity(), opts, results) {
                 let severity = conf.severity();

--- a/crates/biome_js_analyze/src/lint/nursery/no_console.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_console.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
     RuleSource,
 };
 use biome_console::markup;
+use biome_deserialize_macros::Deserializable;
 use biome_js_syntax::{
     global_identifier, AnyJsMemberExpression, JsCallExpression, JsExpressionStatement,
 };
@@ -11,6 +12,10 @@ use biome_rowan::{AstNode, BatchMutationExt};
 
 declare_lint_rule! {
     /// Disallow the use of `console`.
+    ///
+    /// In a browser environment, it’s considered a best practice to log messages using `console`.
+    /// Such messages are considered to be for debugging purposes and therefore not suitable to ship to the client.
+    /// In general, calls using `console` should be stripped before being pushed to production.
     ///
     /// ## Examples
     ///
@@ -34,7 +39,7 @@ impl Rule for NoConsole {
     type Query = Semantic<JsCallExpression>;
     type State = ();
     type Signals = Option<Self::State>;
-    type Options = ();
+    type Options = Box<NoConsoleOptions>;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let call_expression = ctx.query();
@@ -45,6 +50,17 @@ impl Rule for NoConsole {
         let (reference, name) = global_identifier(&object)?;
         if name.text() != "console" {
             return None;
+        }
+        if let Some(member_name) = member_expression.member_name() {
+            let member_name = member_name.text();
+            if ctx
+                .options()
+                .allow
+                .iter()
+                .any(|allowed| allowed == member_name)
+            {
+                return None;
+            }
         }
         model.binding(&reference).is_none().then_some(())
     }
@@ -57,11 +73,11 @@ impl Rule for NoConsole {
                 rule_category!(),
                 node.syntax().text_trimmed_range(),
                 markup! {
-                    "Don't use "<Emphasis>"console"</Emphasis>
+                    "Don't use "<Emphasis>"console"</Emphasis>"."
                 },
             )
             .note(markup! {
-                "Usage of "<Emphasis>"console"</Emphasis>" is disallowed."
+                "The use of "<Emphasis>"console"</Emphasis>" is often reserved for debugging."
             }),
         )
     }
@@ -69,7 +85,6 @@ impl Rule for NoConsole {
     fn action(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {
         let call_expression = ctx.query();
         let mut mutation = ctx.root().begin();
-
         match JsExpressionStatement::cast(call_expression.syntax().parent()?) {
             Some(stmt) if stmt.semicolon_token().is_some() => {
                 mutation.remove_node(stmt);
@@ -78,12 +93,21 @@ impl Rule for NoConsole {
                 mutation.remove_node(call_expression.clone());
             }
         }
-
         Some(JsRuleAction::new(
             ActionCategory::QuickFix,
             ctx.metadata().applicability(),
-            markup! { "Remove console" }.to_owned(),
+            markup! { "Remove "<Emphasis>"console"</Emphasis>"." }.to_owned(),
             mutation,
         ))
     }
+}
+
+#[derive(
+    Clone, Debug, Default, Deserializable, Eq, PartialEq, serde::Deserialize, serde::Serialize,
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct NoConsoleOptions {
+    /// Allowed calls on the console object.
+    pub allow: Vec<String>,
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/noConsole/allowlist.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noConsole/allowlist.js
@@ -1,0 +1,7 @@
+console.log("invalid");
+console.debug("invalid");
+
+console.info("ok");
+console.warn("ok");
+console.error("ok");
+console.assert(true, "ok");

--- a/crates/biome_js_analyze/tests/specs/nursery/noConsole/allowlist.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noConsole/allowlist.js.snap
@@ -1,0 +1,58 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: allowlist.js
+---
+# Input
+```jsx
+console.log("invalid");
+console.debug("invalid");
+
+console.info("ok");
+console.warn("ok");
+console.error("ok");
+console.assert(true, "ok");
+
+```
+
+# Diagnostics
+```
+allowlist.js:1:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't use console.
+  
+  > 1 │ console.log("invalid");
+      │ ^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ console.debug("invalid");
+    3 │ 
+  
+  i The use of console is often reserved for debugging.
+  
+  i Unsafe fix: Remove console.
+  
+    1 │ console.log("invalid");
+      │ -----------------------
+
+```
+
+```
+allowlist.js:2:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't use console.
+  
+    1 │ console.log("invalid");
+  > 2 │ console.debug("invalid");
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+    4 │ console.info("ok");
+  
+  i The use of console is often reserved for debugging.
+  
+  i Unsafe fix: Remove console.
+  
+    1 1 │   console.log("invalid");
+    2   │ - console.debug("invalid");
+    3 2 │   
+    4 3 │   console.info("ok");
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noConsole/allowlist.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noConsole/allowlist.options.json
@@ -1,0 +1,14 @@
+{
+    "linter": {
+        "rules": {
+            "nursery": {
+                "noConsole": {
+                    "level": "warn",
+                    "options": {
+                        "allow": ["assert", "error", "info", "warn"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noConsole/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noConsole/invalid.js.snap
@@ -20,16 +20,16 @@ globalThis.console.warn();
 ```
 invalid.js:1:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Don't use console
+  ! Don't use console.
   
   > 1 │ console.log('hello world')
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
     2 │ console.info('hello world')
     3 │ console.warn('hello world')
   
-  i Usage of console is disallowed.
+  i The use of console is often reserved for debugging.
   
-  i Unsafe fix: Remove console
+  i Unsafe fix: Remove console.
   
     1 │ console.log('hello·world')
       │ --------------------------
@@ -39,7 +39,7 @@ invalid.js:1:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.js:2:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Don't use console
+  ! Don't use console.
   
     1 │ console.log('hello world')
   > 2 │ console.info('hello world')
@@ -47,9 +47,9 @@ invalid.js:2:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
     3 │ console.warn('hello world')
     4 │ console.table('hello world')
   
-  i Usage of console is disallowed.
+  i The use of console is often reserved for debugging.
   
-  i Unsafe fix: Remove console
+  i Unsafe fix: Remove console.
   
      1 1 │   console.log('hello world')
      2   │ - console.info('hello·world')
@@ -62,7 +62,7 @@ invalid.js:2:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.js:3:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Don't use console
+  ! Don't use console.
   
     1 │ console.log('hello world')
     2 │ console.info('hello world')
@@ -71,9 +71,9 @@ invalid.js:3:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
     4 │ console.table('hello world')
     5 │ console.error('hello world')
   
-  i Usage of console is disallowed.
+  i The use of console is often reserved for debugging.
   
-  i Unsafe fix: Remove console
+  i Unsafe fix: Remove console.
   
      1 1 │   console.log('hello world')
      2 2 │   console.info('hello world')
@@ -87,7 +87,7 @@ invalid.js:3:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.js:4:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Don't use console
+  ! Don't use console.
   
     2 │ console.info('hello world')
     3 │ console.warn('hello world')
@@ -96,9 +96,9 @@ invalid.js:4:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
     5 │ console.error('hello world')
     6 │ console.nonExistent('hello world')
   
-  i Usage of console is disallowed.
+  i The use of console is often reserved for debugging.
   
-  i Unsafe fix: Remove console
+  i Unsafe fix: Remove console.
   
      2 2 │   console.info('hello world')
      3 3 │   console.warn('hello world')
@@ -112,7 +112,7 @@ invalid.js:4:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.js:5:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Don't use console
+  ! Don't use console.
   
     3 │ console.warn('hello world')
     4 │ console.table('hello world')
@@ -121,9 +121,9 @@ invalid.js:5:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
     6 │ console.nonExistent('hello world')
     7 │ console.log('with semicolon');
   
-  i Usage of console is disallowed.
+  i The use of console is often reserved for debugging.
   
-  i Unsafe fix: Remove console
+  i Unsafe fix: Remove console.
   
      3 3 │   console.warn('hello world')
      4 4 │   console.table('hello world')
@@ -137,7 +137,7 @@ invalid.js:5:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.js:6:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Don't use console
+  ! Don't use console.
   
     4 │ console.table('hello world')
     5 │ console.error('hello world')
@@ -146,9 +146,9 @@ invalid.js:6:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
     7 │ console.log('with semicolon');
     8 │ 
   
-  i Usage of console is disallowed.
+  i The use of console is often reserved for debugging.
   
-  i Unsafe fix: Remove console
+  i Unsafe fix: Remove console.
   
      4 4 │   console.table('hello world')
      5 5 │   console.error('hello world')
@@ -162,7 +162,7 @@ invalid.js:6:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.js:7:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Don't use console
+  ! Don't use console.
   
     5 │ console.error('hello world')
     6 │ console.nonExistent('hello world')
@@ -171,9 +171,9 @@ invalid.js:7:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
     8 │ 
     9 │ globalThis.console.warn();
   
-  i Usage of console is disallowed.
+  i The use of console is often reserved for debugging.
   
-  i Unsafe fix: Remove console
+  i Unsafe fix: Remove console.
   
      5 5 │   console.error('hello world')
      6 6 │   console.nonExistent('hello world')
@@ -187,7 +187,7 @@ invalid.js:7:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
 ```
 invalid.js:9:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Don't use console
+  ! Don't use console.
   
      7 │ console.log('with semicolon');
      8 │ 
@@ -195,9 +195,9 @@ invalid.js:9:1 lint/nursery/noConsole  FIXABLE  ━━━━━━━━━━�
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
     10 │ 
   
-  i Usage of console is disallowed.
+  i The use of console is often reserved for debugging.
   
-  i Unsafe fix: Remove console
+  i Unsafe fix: Remove console.
   
      6 6 │   console.nonExistent('hello world')
      7 7 │   console.log('with semicolon');

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1150,7 +1150,7 @@ export interface Nursery {
 	/**
 	 * Disallow the use of console.
 	 */
-	noConsole?: RuleFixConfiguration_for_Null;
+	noConsole?: RuleFixConfiguration_for_NoConsoleOptions;
 	/**
 	 * Disallow using a callback in asynchronous tests and hooks.
 	 */
@@ -1945,6 +1945,9 @@ export type RuleConfiguration_for_HooksOptions =
 export type RuleConfiguration_for_DeprecatedHooksOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_DeprecatedHooksOptions;
+export type RuleFixConfiguration_for_NoConsoleOptions =
+	| RulePlainConfiguration
+	| RuleWithFixOptions_for_NoConsoleOptions;
 export type RuleConfiguration_for_NoLabelWithoutControlOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_NoLabelWithoutControlOptions;
@@ -2063,6 +2066,20 @@ export interface RuleWithOptions_for_DeprecatedHooksOptions {
 	 * Rule's options
 	 */
 	options: DeprecatedHooksOptions;
+}
+export interface RuleWithFixOptions_for_NoConsoleOptions {
+	/**
+	 * The kind of the code actions emitted by the rule
+	 */
+	fix?: FixKind;
+	/**
+	 * The severity of the emitted diagnostics by the rule
+	 */
+	level: RulePlainConfiguration;
+	/**
+	 * Rule's options
+	 */
+	options: NoConsoleOptions;
 }
 export interface RuleWithOptions_for_NoLabelWithoutControlOptions {
 	/**
@@ -2244,6 +2261,12 @@ export interface HooksOptions {
  * Options for the `useHookAtTopLevel` rule have been deprecated, since we now use the React hook naming convention to determine whether a function is a hook.
  */
 export interface DeprecatedHooksOptions {}
+export interface NoConsoleOptions {
+	/**
+	 * Allowed calls on the console object.
+	 */
+	allow: string[];
+}
 export interface NoLabelWithoutControlOptions {
 	/**
 	 * Array of component names that should be considered the same as an `input` element.

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1847,6 +1847,24 @@
 			},
 			"additionalProperties": false
 		},
+		"NoConsoleConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithNoConsoleOptions" }
+			]
+		},
+		"NoConsoleOptions": {
+			"type": "object",
+			"required": ["allow"],
+			"properties": {
+				"allow": {
+					"description": "Allowed calls on the console object.",
+					"type": "array",
+					"items": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
 		"NoDoubleEqualsConfiguration": {
 			"anyOf": [
 				{ "$ref": "#/definitions/RulePlainConfiguration" },
@@ -1922,7 +1940,7 @@
 				"noConsole": {
 					"description": "Disallow the use of console.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "$ref": "#/definitions/NoConsoleConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -2766,6 +2784,25 @@
 				"options": {
 					"description": "Rule's options",
 					"allOf": [{ "$ref": "#/definitions/NamingConventionOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNoConsoleOptions": {
+			"type": "object",
+			"required": ["level", "options"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/NoConsoleOptions" }]
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## Summary

Add an option to `noConsole` that allows to specify an allowlist of methods.
This is the same option that provided by ESLint.

I also implemented the code for `migrate eslint`.
I improved the diagnostics and the rule description.

## Test Plan

I added some tests.
