### PR TITLE
refactor(biome_js_parser/lexer): use enumflags2 for `RegexFlag`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,6 +778,7 @@ dependencies = [
  "biome_unicode_table",
  "bitflags 2.6.0",
  "drop_bomb",
+ "enumflags2",
  "expect-test",
  "indexmap 2.5.0",
  "quickcheck",

--- a/crates/biome_js_parser/Cargo.toml
+++ b/crates/biome_js_parser/Cargo.toml
@@ -20,6 +20,7 @@ biome_rowan         = { workspace = true }
 biome_unicode_table = { workspace = true }
 bitflags            = { workspace = true }
 drop_bomb           = "0.1.5"
+enumflags2          = { workspace = true }
 indexmap            = { workspace = true }
 rustc-hash          = { workspace = true }
 schemars            = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

Part of https://github.com/biomejs/biome/issues/3157

Adds `enumflags2` to `biome_js_parser/lexer`.

## Test Plan

I ran `cargo t` on the root and all tests passed. Current CI should pass