### PR TITLE
fix(grit): fix matching names in Grit queries

### DIFF
--- a/crates/biome_grit_patterns/src/grit_target_language/js_target_language.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language/js_target_language.rs
@@ -99,6 +99,7 @@ impl GritTargetLanguageImpl for JsTargetLanguage {
         &[
             ("", ""),
             ("import ", " from 'GRIT_PACKAGE';"),
+            ("GRIT_OBJECT.", ""),
             ("GRIT_VALUE ", " GRIT_VALUE"),
             ("class GRIT_CLASS ", " {}"),
             ("class GRIT_CLASS { ", " GRIT_PROP = 'GRIT_VALUE'; }"),

--- a/crates/biome_grit_patterns/tests/specs/ts/match.grit
+++ b/crates/biome_grit_patterns/tests/specs/ts/match.grit
@@ -1,0 +1,3 @@
+`console.$method($message)` where {
+    $method <: or { `log`, `info`, `warn`, `error` }
+}

--- a/crates/biome_grit_patterns/tests/specs/ts/match.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/match.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_grit_patterns/tests/spec_tests.rs
+expression: match
+---
+SnapshotResult {
+    messages: [],
+    matched_ranges: [
+        "1:1-1:23",
+        "2:1-2:29",
+    ],
+    rewritten_files: [],
+    created_files: [],
+}

--- a/crates/biome_grit_patterns/tests/specs/ts/match.ts
+++ b/crates/biome_grit_patterns/tests/specs/ts/match.ts
@@ -1,0 +1,3 @@
+console.log("matches");
+console.error("matches too");
+console.other("won't match");


### PR DESCRIPTION
## Summary

Grit code snippets were not yet able to match `JsName` nodes due to a difference in our JS grammar and the TreeSitter grammer we ported from. This was resolved by adding a new context string that allows parsing snippets that match the `JsName` position.

## Test Plan

Test case added.
