### PR TITLE
fix(linter): fix rule `noFocusedTests` checking test call expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Allow `aria-label` on heading to prevent `useHeadingContent` diagnostic ([#3767](https://github.com/biomejs/biome/pull/3767)). Contributed by @anthonyshew
 
+- Fix edge case [#3791](https://github.com/biomejs/biome/issues/3791) for rule `noFocusedTests` being used with non-string-like expressions ([#3793](https://github.com/biomejs/biome/pull/3793)). Contributed by @h-a-n-a
+
 ### Configuration
 
 - Add support for loading configuration from `.editorconfig` files ([#1724](https://github.com/biomejs/biome/issues/1724)).

--- a/crates/biome_js_analyze/tests/specs/suspicious/noFocusedTests/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noFocusedTests/invalid.js
@@ -12,3 +12,15 @@ test["only"]("bar", function () {});
 
 fdescribe("foo", () => {});
 fit("foo", () => {});
+
+describe.only(bar, () => {});
+it.only(bar, () => {});
+test.only(bar, () => {});
+
+describe.only(foo.bar, () => {});
+it.only(foo.bar, () => {});
+test.only(foo.bar, () => {});
+
+describe.only(name = name || "bar", () => {});
+it.only(name = name || "bar", () => {});
+test.only(name = name || "bar", () => {});

--- a/crates/biome_js_analyze/tests/specs/suspicious/noFocusedTests/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noFocusedTests/invalid.js.snap
@@ -19,6 +19,18 @@ test["only"]("bar", function () {});
 fdescribe("foo", () => {});
 fit("foo", () => {});
 
+describe.only(bar, () => {});
+it.only(bar, () => {});
+test.only(bar, () => {});
+
+describe.only(foo.bar, () => {});
+it.only(foo.bar, () => {});
+test.only(foo.bar, () => {});
+
+describe.only(name = name || "bar", () => {});
+it.only(name = name || "bar", () => {});
+test.only(name = name || "bar", () => {});
+
 ```
 
 # Diagnostics
@@ -261,6 +273,7 @@ invalid.js:14:1 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━�
   > 14 │ fit("foo", () => {});
        │ ^^^
     15 │ 
+    16 │ describe.only(bar, () => {});
   
   i The 'only' method is often used for debugging or during implementation. It should be removed before deploying to production.
   
@@ -273,6 +286,210 @@ invalid.js:14:1 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━�
     14    │ - fit("foo",·()·=>·{});
        14 │ + it("foo",·()·=>·{});
     15 15 │   
+    16 16 │   describe.only(bar, () => {});
   
+
+```
+
+```
+invalid.js:16:10 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    14 │ fit("foo", () => {});
+    15 │ 
+  > 16 │ describe.only(bar, () => {});
+       │          ^^^^
+    17 │ it.only(bar, () => {});
+    18 │ test.only(bar, () => {});
+  
+  i The 'only' method is often used for debugging or during implementation. It should be removed before deploying to production.
+  
+  i Consider removing 'only' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    16 │ describe.only(bar,·()·=>·{});
+       │         -----                
+
+```
+
+```
+invalid.js:17:4 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    16 │ describe.only(bar, () => {});
+  > 17 │ it.only(bar, () => {});
+       │    ^^^^
+    18 │ test.only(bar, () => {});
+    19 │ 
+  
+  i The 'only' method is often used for debugging or during implementation. It should be removed before deploying to production.
+  
+  i Consider removing 'only' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    17 │ it.only(bar,·()·=>·{});
+       │   -----                
+
+```
+
+```
+invalid.js:18:6 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    16 │ describe.only(bar, () => {});
+    17 │ it.only(bar, () => {});
+  > 18 │ test.only(bar, () => {});
+       │      ^^^^
+    19 │ 
+    20 │ describe.only(foo.bar, () => {});
+  
+  i The 'only' method is often used for debugging or during implementation. It should be removed before deploying to production.
+  
+  i Consider removing 'only' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    18 │ test.only(bar,·()·=>·{});
+       │     -----                
+
+```
+
+```
+invalid.js:20:10 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    18 │ test.only(bar, () => {});
+    19 │ 
+  > 20 │ describe.only(foo.bar, () => {});
+       │          ^^^^
+    21 │ it.only(foo.bar, () => {});
+    22 │ test.only(foo.bar, () => {});
+  
+  i The 'only' method is often used for debugging or during implementation. It should be removed before deploying to production.
+  
+  i Consider removing 'only' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    20 │ describe.only(foo.bar,·()·=>·{});
+       │         -----                    
+
+```
+
+```
+invalid.js:21:4 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    20 │ describe.only(foo.bar, () => {});
+  > 21 │ it.only(foo.bar, () => {});
+       │    ^^^^
+    22 │ test.only(foo.bar, () => {});
+    23 │ 
+  
+  i The 'only' method is often used for debugging or during implementation. It should be removed before deploying to production.
+  
+  i Consider removing 'only' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    21 │ it.only(foo.bar,·()·=>·{});
+       │   -----                    
+
+```
+
+```
+invalid.js:22:6 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    20 │ describe.only(foo.bar, () => {});
+    21 │ it.only(foo.bar, () => {});
+  > 22 │ test.only(foo.bar, () => {});
+       │      ^^^^
+    23 │ 
+    24 │ describe.only(name = name || "bar", () => {});
+  
+  i The 'only' method is often used for debugging or during implementation. It should be removed before deploying to production.
+  
+  i Consider removing 'only' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    22 │ test.only(foo.bar,·()·=>·{});
+       │     -----                    
+
+```
+
+```
+invalid.js:24:10 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    22 │ test.only(foo.bar, () => {});
+    23 │ 
+  > 24 │ describe.only(name = name || "bar", () => {});
+       │          ^^^^
+    25 │ it.only(name = name || "bar", () => {});
+    26 │ test.only(name = name || "bar", () => {});
+  
+  i The 'only' method is often used for debugging or during implementation. It should be removed before deploying to production.
+  
+  i Consider removing 'only' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    24 │ describe.only(name·=·name·||·"bar",·()·=>·{});
+       │         -----                                 
+
+```
+
+```
+invalid.js:25:4 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    24 │ describe.only(name = name || "bar", () => {});
+  > 25 │ it.only(name = name || "bar", () => {});
+       │    ^^^^
+    26 │ test.only(name = name || "bar", () => {});
+    27 │ 
+  
+  i The 'only' method is often used for debugging or during implementation. It should be removed before deploying to production.
+  
+  i Consider removing 'only' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    25 │ it.only(name·=·name·||·"bar",·()·=>·{});
+       │   -----                                 
+
+```
+
+```
+invalid.js:26:6 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    24 │ describe.only(name = name || "bar", () => {});
+    25 │ it.only(name = name || "bar", () => {});
+  > 26 │ test.only(name = name || "bar", () => {});
+       │      ^^^^
+    27 │ 
+  
+  i The 'only' method is often used for debugging or during implementation. It should be removed before deploying to production.
+  
+  i Consider removing 'only' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    26 │ test.only(name·=·name·||·"bar",·()·=>·{});
+       │     -----                                 
 
 ```

--- a/crates/biome_js_syntax/src/expr_ext.rs
+++ b/crates/biome_js_syntax/src/expr_ext.rs
@@ -1814,16 +1814,10 @@ impl JsCallExpression {
             }
 
             // it("description", ..)
-            (
-                Some(Ok(AnyJsCallArgument::AnyJsExpression(
-                    JsTemplateExpression(_)
-                    | AnyJsLiteralExpression(
-                        self::AnyJsLiteralExpression::JsStringLiteralExpression(_),
-                    ),
-                ))),
-                Some(Ok(second)),
-                third,
-            ) if arguments.args().len() <= 3 && callee.contains_a_test_pattern()? => {
+            // it(Test.name, ..)
+            (Some(Ok(AnyJsCallArgument::AnyJsExpression(_))), Some(Ok(second)), third)
+                if arguments.args().len() <= 3 && callee.contains_a_test_pattern()? =>
+            {
                 // it('name', callback, duration)
                 if !matches!(
                     third,
@@ -2065,6 +2059,29 @@ mod test {
             call_expression.callee().unwrap().contains_a_test_pattern(),
             Ok(false)
         );
+    }
+
+    #[test]
+    fn matches_test_call_expression() {
+        let call_expression = extract_call_expression("test.only(name, () => {});");
+        assert_eq!(call_expression.is_test_call_expression(), Ok(true));
+
+        let call_expression = extract_call_expression("test.only(Test.name, () => {});");
+        assert_eq!(call_expression.is_test_call_expression(), Ok(true));
+
+        let call_expression =
+            extract_call_expression("test.only(name = name || 'test', () => {});");
+        assert_eq!(call_expression.is_test_call_expression(), Ok(true));
+
+        let call_expression = extract_call_expression("describe.only(name, () => {});");
+        assert_eq!(call_expression.is_test_call_expression(), Ok(true));
+
+        let call_expression = extract_call_expression("describe.only(Test.name, () => {});");
+        assert_eq!(call_expression.is_test_call_expression(), Ok(true));
+
+        let call_expression =
+            extract_call_expression("describe.only(name = name || 'test', () => {});");
+        assert_eq!(call_expression.is_test_call_expression(), Ok(true));
     }
 
     #[test]


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

closes #3791

Fixed a case where test call expressions are failed to be treated as one of them.

**Previously:**

```js
describe.only("foo", () => {});
describe.only(foo, () => {}); // ❌ failed to report as linter error
```

Only supports test call expressions with string-like expressions.

**Currently:**

```js
describe.only("foo", () => {});

// works with any JavaScript expression
describe.only(foo, () => {});
describe.only(foo.bar, () => {});
```

Every JavaScript expression is supported.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Tests are added.

<!-- What demonstrates that your implementation is correct? -->
