### PR TITLE
fix(grit): fix matching multiple args

### DIFF
--- a/crates/biome_grit_patterns/src/grit_node_patterns.rs
+++ b/crates/biome_grit_patterns/src/grit_node_patterns.rs
@@ -47,6 +47,14 @@ impl Matcher<GritQueryContext> for GritNodePattern {
         let Some(node) = binding.singleton() else {
             return Ok(false);
         };
+        if binding.is_list() {
+            return self.execute(
+                &ResolvedPattern::from_node_binding(node),
+                init_state,
+                context,
+                logs,
+            );
+        }
 
         if node.kind() != self.kind {
             return Ok(false);
@@ -158,13 +166,11 @@ impl Matcher<GritQueryContext> for GritLeafNodePattern {
         let Some(node) = binding.get_last_binding().and_then(Binding::singleton) else {
             return Ok(false);
         };
-        if let Some(class) = &self.equivalence_class {
-            Ok(class.are_equivalent(node.kind(), node.text()))
-        } else if self.kind != node.kind() {
-            Ok(false)
-        } else {
-            Ok(node.text() == self.text)
-        }
+
+        Ok(match &self.equivalence_class {
+            Some(class) => class.are_equivalent(node.kind(), node.text()),
+            None => node.kind() == self.kind && node.text() == self.text,
+        })
     }
 }
 

--- a/crates/biome_grit_patterns/tests/specs/ts/functionToArrow.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/functionToArrow.snap
@@ -6,6 +6,7 @@ SnapshotResult {
     messages: [],
     matched_ranges: [
         "1:1-2:2",
+        "4:1-5:2",
     ],
     rewritten_files: [],
     created_files: [],

--- a/crates/biome_grit_patterns/tests/specs/ts/functionToArrow.ts
+++ b/crates/biome_grit_patterns/tests/specs/ts/functionToArrow.ts
@@ -1,2 +1,8 @@
 function foo(apple) {
 }
+
+function bar(apple, pear) {
+}
+
+function baz() {
+}

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
@@ -145,7 +145,8 @@ impl Rule for NoUselessConstructor {
         for parameter in constructor.parameters().ok()?.parameters() {
             let decorators = match parameter.ok()? {
                 AnyJsConstructorParameter::AnyJsFormalParameter(
-                    AnyJsFormalParameter::JsBogusParameter(_),
+                    AnyJsFormalParameter::JsBogusParameter(_)
+                    | AnyJsFormalParameter::JsMetavariable(_),
                 )
                 | AnyJsConstructorParameter::TsPropertyParameter(_) => {
                     // Ignore constructors with Bogus parameters or parameter properties

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
@@ -310,7 +310,8 @@ impl AnyMember {
             },
             AnyMember::TsPropertyParameter(ts_property) => {
                 match ts_property.formal_parameter().ok()? {
-                    AnyJsFormalParameter::JsBogusParameter(_) => None,
+                    AnyJsFormalParameter::JsBogusParameter(_)
+                    | AnyJsFormalParameter::JsMetavariable(_) => None,
                     AnyJsFormalParameter::JsFormalParameter(param) => Some(
                         param
                             .binding()
@@ -348,7 +349,8 @@ impl AnyMember {
             },
             AnyMember::TsPropertyParameter(ts_property) => {
                 match ts_property.formal_parameter().ok()? {
-                    AnyJsFormalParameter::JsBogusParameter(_) => None,
+                    AnyJsFormalParameter::JsBogusParameter(_)
+                    | AnyJsFormalParameter::JsMetavariable(_) => None,
                     AnyJsFormalParameter::JsFormalParameter(param) => Some(
                         param
                             .binding()

--- a/crates/biome_js_analyze/src/lint/style/no_parameter_assign.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_parameter_assign.rs
@@ -106,7 +106,9 @@ impl Rule for NoParameterAssign {
 fn binding_of(param: &AnyJsParameter) -> Option<AnyJsBindingPattern> {
     match param {
         AnyJsParameter::AnyJsFormalParameter(formal_param) => match &formal_param {
-            AnyJsFormalParameter::JsBogusParameter(_) => None,
+            AnyJsFormalParameter::JsBogusParameter(_) | AnyJsFormalParameter::JsMetavariable(_) => {
+                None
+            }
             AnyJsFormalParameter::JsFormalParameter(param) => param.binding().ok(),
         },
         AnyJsParameter::JsRestParameter(param) => param.binding().ok(),

--- a/crates/biome_js_formatter/src/js/any/formal_parameter.rs
+++ b/crates/biome_js_formatter/src/js/any/formal_parameter.rs
@@ -10,6 +10,7 @@ impl FormatRule<AnyJsFormalParameter> for FormatAnyJsFormalParameter {
         match node {
             AnyJsFormalParameter::JsBogusParameter(node) => node.format().fmt(f),
             AnyJsFormalParameter::JsFormalParameter(node) => node.format().fmt(f),
+            AnyJsFormalParameter::JsMetavariable(node) => node.format().fmt(f),
         }
     }
 }

--- a/crates/biome_js_formatter/src/js/bindings/parameters.rs
+++ b/crates/biome_js_formatter/src/js/bindings/parameters.rs
@@ -281,7 +281,9 @@ pub(crate) fn should_hug_function_parameters(
                     }
                 }
             }
-            AnyJsFormalParameter::JsBogusParameter(_) => return Err(FormatError::SyntaxError),
+            AnyJsFormalParameter::JsBogusParameter(_) | AnyJsFormalParameter::JsMetavariable(_) => {
+                return Err(FormatError::SyntaxError)
+            }
         };
 
         Ok(result)

--- a/crates/biome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -399,9 +399,10 @@ fn has_rest_object_or_array_parameter(parameters: &AnyJsArrowFunctionParameters)
                             | AnyJsBindingPattern::JsObjectBindingPattern(_))
                     )
                 }
-                AnyJsParameter::AnyJsFormalParameter(AnyJsFormalParameter::JsBogusParameter(_)) => {
-                    false
-                }
+                AnyJsParameter::AnyJsFormalParameter(
+                    AnyJsFormalParameter::JsBogusParameter(_)
+                    | AnyJsFormalParameter::JsMetavariable(_),
+                ) => false,
                 AnyJsParameter::TsThisParameter(_) => false,
                 AnyJsParameter::JsRestParameter(_) => true,
             }),

--- a/crates/biome_js_parser/src/syntax/function.rs
+++ b/crates/biome_js_parser/src/syntax/function.rs
@@ -29,6 +29,8 @@ use biome_js_syntax::{JsSyntaxKind, TextRange, T};
 use biome_parser::ParserProgress;
 use biome_rowan::SyntaxKind;
 
+use super::metavariable::parse_metavariable;
+
 /// A function declaration, this could be async and or a generator. This takes a marker
 /// because you need to first advance over async or start a marker and feed it in.
 // test js function_decl
@@ -1367,6 +1369,10 @@ pub(super) fn parse_parameters_list(
             }
 
             progress.assert_progressing(p);
+
+            if parse_metavariable(p).is_present() {
+                break;
+            }
 
             let parameter = parse_parameter(
                 p,

--- a/crates/biome_js_syntax/src/generated/nodes.rs
+++ b/crates/biome_js_syntax/src/generated/nodes.rs
@@ -14334,6 +14334,7 @@ impl AnyJsForInitializer {
 pub enum AnyJsFormalParameter {
     JsBogusParameter(JsBogusParameter),
     JsFormalParameter(JsFormalParameter),
+    JsMetavariable(JsMetavariable),
 }
 impl AnyJsFormalParameter {
     pub fn as_js_bogus_parameter(&self) -> Option<&JsBogusParameter> {
@@ -14345,6 +14346,12 @@ impl AnyJsFormalParameter {
     pub fn as_js_formal_parameter(&self) -> Option<&JsFormalParameter> {
         match &self {
             AnyJsFormalParameter::JsFormalParameter(item) => Some(item),
+            _ => None,
+        }
+    }
+    pub fn as_js_metavariable(&self) -> Option<&JsMetavariable> {
+        match &self {
+            AnyJsFormalParameter::JsMetavariable(item) => Some(item),
             _ => None,
         }
     }
@@ -32197,12 +32204,21 @@ impl From<JsFormalParameter> for AnyJsFormalParameter {
         AnyJsFormalParameter::JsFormalParameter(node)
     }
 }
+impl From<JsMetavariable> for AnyJsFormalParameter {
+    fn from(node: JsMetavariable) -> AnyJsFormalParameter {
+        AnyJsFormalParameter::JsMetavariable(node)
+    }
+}
 impl AstNode for AnyJsFormalParameter {
     type Language = Language;
-    const KIND_SET: SyntaxKindSet<Language> =
-        JsBogusParameter::KIND_SET.union(JsFormalParameter::KIND_SET);
+    const KIND_SET: SyntaxKindSet<Language> = JsBogusParameter::KIND_SET
+        .union(JsFormalParameter::KIND_SET)
+        .union(JsMetavariable::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
-        matches!(kind, JS_BOGUS_PARAMETER | JS_FORMAL_PARAMETER)
+        matches!(
+            kind,
+            JS_BOGUS_PARAMETER | JS_FORMAL_PARAMETER | JS_METAVARIABLE
+        )
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -32212,6 +32228,7 @@ impl AstNode for AnyJsFormalParameter {
             JS_FORMAL_PARAMETER => {
                 AnyJsFormalParameter::JsFormalParameter(JsFormalParameter { syntax })
             }
+            JS_METAVARIABLE => AnyJsFormalParameter::JsMetavariable(JsMetavariable { syntax }),
             _ => return None,
         };
         Some(res)
@@ -32220,12 +32237,14 @@ impl AstNode for AnyJsFormalParameter {
         match self {
             AnyJsFormalParameter::JsBogusParameter(it) => &it.syntax,
             AnyJsFormalParameter::JsFormalParameter(it) => &it.syntax,
+            AnyJsFormalParameter::JsMetavariable(it) => &it.syntax,
         }
     }
     fn into_syntax(self) -> SyntaxNode {
         match self {
             AnyJsFormalParameter::JsBogusParameter(it) => it.syntax,
             AnyJsFormalParameter::JsFormalParameter(it) => it.syntax,
+            AnyJsFormalParameter::JsMetavariable(it) => it.syntax,
         }
     }
 }
@@ -32234,6 +32253,7 @@ impl std::fmt::Debug for AnyJsFormalParameter {
         match self {
             AnyJsFormalParameter::JsBogusParameter(it) => std::fmt::Debug::fmt(it, f),
             AnyJsFormalParameter::JsFormalParameter(it) => std::fmt::Debug::fmt(it, f),
+            AnyJsFormalParameter::JsMetavariable(it) => std::fmt::Debug::fmt(it, f),
         }
     }
 }
@@ -32242,6 +32262,7 @@ impl From<AnyJsFormalParameter> for SyntaxNode {
         match n {
             AnyJsFormalParameter::JsBogusParameter(it) => it.into(),
             AnyJsFormalParameter::JsFormalParameter(it) => it.into(),
+            AnyJsFormalParameter::JsMetavariable(it) => it.into(),
         }
     }
 }

--- a/crates/biome_js_syntax/src/parameter_ext.rs
+++ b/crates/biome_js_syntax/src/parameter_ext.rs
@@ -537,7 +537,9 @@ impl AnyJsFormalParameter {
     /// Returns the list of decorators of the parameter if the parameter is decorated.
     pub fn decorators(&self) -> Option<JsDecoratorList> {
         match self {
-            AnyJsFormalParameter::JsBogusParameter(_) => None,
+            AnyJsFormalParameter::JsBogusParameter(_) | AnyJsFormalParameter::JsMetavariable(_) => {
+                None
+            }
             AnyJsFormalParameter::JsFormalParameter(parameter) => Some(parameter.decorators()),
         }
     }
@@ -545,7 +547,9 @@ impl AnyJsFormalParameter {
     /// Returns the type annotation of the parameter if any.
     pub fn type_annotation(&self) -> Option<TsTypeAnnotation> {
         match self {
-            AnyJsFormalParameter::JsBogusParameter(_) => None,
+            AnyJsFormalParameter::JsBogusParameter(_) | AnyJsFormalParameter::JsMetavariable(_) => {
+                None
+            }
             AnyJsFormalParameter::JsFormalParameter(parameter) => parameter.type_annotation(),
         }
     }

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -1602,6 +1602,7 @@ JsParameterList = (AnyJsParameter (',' AnyJsParameter)* ','?)
 AnyJsFormalParameter =
 	JsFormalParameter
 	| JsBogusParameter
+	| JsMetavariable
 
 AnyJsParameter =
 	AnyJsFormalParameter


### PR DESCRIPTION
## Summary

We had an issue with matching function arguments in Grit queries, that prevented metavariables from matching multiple arguments. In short, the metavariable was consumed by the `JsFormalParameter` and stored inside one of its slots. This wasn't a problem if you only tried to match a single argument with no other syntax, but if you wanted the metavariable to match anything more, it wouldn't work.

To fix it, I made sure `JsMetavariable` can be accepted in our grammar _next to_ `JsFormalParameter` and updated the JS parser so it's accepted there.

I also extended our list handling in the bindings a bit to be more in line with how Grit's reference implementation does it. The change in `GritBinding::singleton()` seems it's actually necessary, but some of the others may not be. It's probably better this way, but we don't have the test coverage yet to say for sure :sweat_smile: 

## Test Plan

Added a test case.
