### PR TITLE
refactor(biome_parser): use enumflags2 for `TokenFlag ` and remove `bitflags`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,6 @@ dependencies = [
  "biome_suppression",
  "biome_test_utils",
  "biome_unicode_table",
- "bitflags 2.6.0",
  "bitvec",
  "enumflags2",
  "insta",
@@ -776,7 +775,6 @@ dependencies = [
  "biome_parser",
  "biome_rowan",
  "biome_unicode_table",
- "bitflags 2.6.0",
  "drop_bomb",
  "enumflags2",
  "expect-test",
@@ -968,8 +966,8 @@ dependencies = [
  "biome_diagnostics",
  "biome_rowan",
  "biome_unicode_table",
- "bitflags 2.6.0",
  "drop_bomb",
+ "enumflags2",
  "unicode-bom",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,6 @@ tests_macros         = { path = "./crates/tests_macros" }
 
 # Crates needed in the workspace
 anyhow             = "1.0.86"
-bitflags           = "2.6.0"
 bpaf               = { version = "0.9.12", features = ["derive"] }
 countme            = "3.0.1"
 crossbeam          = "0.8.4"

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -26,7 +26,6 @@ biome_rowan              = { workspace = true }
 biome_string_case        = { workspace = true }
 biome_suppression        = { workspace = true }
 biome_unicode_table      = { workspace = true }
-bitflags                 = { workspace = true }
 bitvec                   = "1.0.1"
 enumflags2               = { workspace = true }
 natord                   = { workspace = true }

--- a/crates/biome_js_parser/Cargo.toml
+++ b/crates/biome_js_parser/Cargo.toml
@@ -18,7 +18,6 @@ biome_js_syntax     = { workspace = true }
 biome_parser        = { workspace = true }
 biome_rowan         = { workspace = true }
 biome_unicode_table = { workspace = true }
-bitflags            = { workspace = true }
 drop_bomb           = "0.1.5"
 enumflags2          = { workspace = true }
 indexmap            = { workspace = true }

--- a/crates/biome_parser/Cargo.toml
+++ b/crates/biome_parser/Cargo.toml
@@ -15,8 +15,8 @@ biome_console       = { workspace = true }
 biome_diagnostics   = { workspace = true }
 biome_rowan         = { workspace = true }
 biome_unicode_table = { workspace = true }
-bitflags            = { workspace = true }
 drop_bomb           = "0.1.5"
+enumflags2          = { workspace = true }
 unicode-bom         = { workspace = true }
 
 [lints]


### PR DESCRIPTION
## Summary

Closes #3157

Adds `enumflags2` to `biome_parser` `TokenFlag ` and removes `bitflags` dependency from all `Cargo.toml` files where it is referenced.

## Test Plan

I ran `cargo t` on the root and all tests passed. Current CI should pass