### PR TITLE
ci: fix broken CLI binary copy step for NPM publish

### DIFF
--- a/packages/@biomejs/biome/scripts/generate-packages.mjs
+++ b/packages/@biomejs/biome/scripts/generate-packages.mjs
@@ -58,11 +58,14 @@ function copyBinaryToNativePackage(platform, arch) {
 	);
 	const binaryTarget = resolve(packageRoot, `biome${ext}`);
 
-	if (fs.existsSync(binaryTarget)) {
-		console.log(`Copy binary ${binaryTarget}`);
-		fs.copyFileSync(binarySource, binaryTarget);
-		fs.chmodSync(binaryTarget, 0o755);
+	if (!fs.existsSync(binarySource)) {
+		console.error(`Source for binary for ${buildName} not found at: ${binarySource}`);
+		process.exit(1);
 	}
+
+	console.log(`Copy binary ${binaryTarget}`);
+	fs.copyFileSync(binarySource, binaryTarget);
+	fs.chmodSync(binaryTarget, 0o755);
 }
 
 function updateWasmPackage(target) {


### PR DESCRIPTION
## Summary

Fixes #3804 - see that issue for discussion.

## Test Plan

I'm not sure that it's possible to validate conclusively that this fixes #3804 without privileged access to the repository, as it's part of the NPM publish workflow.
