### PR TITLE
fix(js_analyzer): don't flag duplicate hooks in describe.each for lint/suspicious/noDuplicateTestHooks

### DIFF
--- a/crates/biome_js_analyze/tests/specs/suspicious/noDuplicateTestHooks/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDuplicateTestHooks/invalid.js.snap
@@ -308,15 +308,16 @@ invalid.js:69:3 lint/suspicious/noDuplicateTestHooks ━━━━━━━━━
 ```
 
 ```
-invalid.js:91:3 lint/suspicious/noDuplicateTestHooks ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:78:2 lint/suspicious/noDuplicateTestHooks ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Disallow duplicate setup and teardown hooks.
   
-    90 │ 	describe.each(["world"])("%s", () => {
-  > 91 │ 		beforeEach(() => {});
-       │ 		^^^^^^^^^^^^^^^^^^^^
-    92 │ 		beforeEach(() => {});
-    93 │ 
+    76 │ describe.each(["hello"])("%s", () => {
+    77 │ 	beforeEach(() => {});
+  > 78 │ 	beforeEach(() => {});
+       │ 	^^^^^^^^^^^^^^^^^^^^
+    79 │ 
+    80 │ 	it("is not fine", () => {});
   
   i Disallow beforeEach duplicacy inside the describe function.
   

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDuplicateTestHooks/valid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDuplicateTestHooks/valid.js
@@ -67,3 +67,17 @@ describe("something", () => {
 		it("is fine", () => {});
 	});
 });
+
+describe("hello", () => {
+	beforeEach(() => {});
+
+	describe.each(['hello'])(
+		"given an input %p",
+		() => {
+			beforeEach(() => {});
+
+			it("should be fine", () => {});
+		},
+	);
+});
+

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDuplicateTestHooks/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDuplicateTestHooks/valid.js.snap
@@ -74,6 +74,18 @@ describe("something", () => {
 	});
 });
 
+describe("hello", () => {
+	beforeEach(() => {});
+
+	describe.each(['hello'])(
+		"given an input %p",
+		() => {
+			beforeEach(() => {});
+
+			it("should be fine", () => {});
+		},
+	);
+});
+
+
 ```
-
-


### PR DESCRIPTION

## Summary

Fixes https://github.com/biomejs/biome/issues/3291

Since noDuplicateTestHooks didn't know that `describe.each` has a different syntax from `describe`

## Test Plan

Added a new test for `describe.each` hook
