### PR TITLE
feat(grit): support language-specific snippets in Grit queries

### DIFF
--- a/crates/biome_grit_patterns/src/errors.rs
+++ b/crates/biome_grit_patterns/src/errors.rs
@@ -59,6 +59,9 @@ pub enum CompileError {
     /// Unknown function or predicate.
     UnknownFunctionOrPredicate(String),
 
+    /// Unknown target language.
+    UnknownTargetLanguage(String),
+
     /// Unknown variable.
     UnknownVariable(String),
 }
@@ -116,6 +119,9 @@ impl Diagnostic for CompileError {
             }
             CompileError::UnknownFunctionOrPredicate(name) => {
                 fmt.write_markup(markup! { "Unknown function or predicate: "{{name}} })
+            }
+            CompileError::UnknownTargetLanguage(lang) => {
+                fmt.write_markup(markup! { "Unknown target language: "{{lang}} })
             }
             CompileError::UnknownVariable(var) => {
                 fmt.write_markup(markup! { "Unknown variable: "{{var}} })

--- a/crates/biome_grit_patterns/src/pattern_compiler/literal_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/literal_compiler.rs
@@ -2,7 +2,9 @@ use super::{
     compilation_context::NodeCompilationContext, list_compiler::ListCompiler,
     map_compiler::MapCompiler, snippet_compiler::parse_snippet_content,
 };
-use crate::{grit_context::GritQueryContext, util::TextRangeGritExt, CompileError};
+use crate::{
+    grit_context::GritQueryContext, util::TextRangeGritExt, CompileError, GritTargetLanguage,
+};
 use biome_grit_syntax::{AnyGritCodeSnippetSource, AnyGritLiteral, GritSyntaxKind};
 use biome_rowan::AstNode;
 use grit_pattern_matcher::pattern::{
@@ -29,7 +31,19 @@ impl LiteralCompiler {
                     debug_assert!(text.len() >= 2, "Literals must have quotes");
                     parse_snippet_content(&text[1..text.len() - 1], range, context, is_rhs)
                 }
-                AnyGritCodeSnippetSource::GritLanguageSpecificSnippet(_) => todo!(),
+                AnyGritCodeSnippetSource::GritLanguageSpecificSnippet(node) => {
+                    let lang_node = node.language()?;
+                    let lang_name = lang_node.text();
+                    if GritTargetLanguage::from_extension(&lang_name).is_none() {
+                        return Err(CompileError::UnknownTargetLanguage(lang_name));
+                    }
+
+                    let snippet_token = node.snippet_token()?;
+                    let source = snippet_token.text_trimmed();
+                    let range = node.syntax().text_trimmed_range().to_byte_range();
+                    debug_assert!(source.len() >= 2, "Literals must have quotes");
+                    parse_snippet_content(&source[1..source.len() - 1], range, context, is_rhs)
+                }
                 AnyGritCodeSnippetSource::GritRawBacktickSnippetLiteral(_) => todo!(),
             },
             AnyGritLiteral::GritDoubleLiteral(node) => Ok(Pattern::FloatConstant(

--- a/crates/biome_grit_patterns/tests/specs/ts/whereClause.grit
+++ b/crates/biome_grit_patterns/tests/specs/ts/whereClause.grit
@@ -1,0 +1,1 @@
+`console.log($message)` => . where $message <: js"'Hello, world!'"

--- a/crates/biome_grit_patterns/tests/specs/ts/whereClause.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/whereClause.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_grit_patterns/tests/spec_tests.rs
+expression: whereClause
+---
+SnapshotResult {
+    messages: [],
+    matched_ranges: [
+        "2:1-2:29",
+    ],
+    rewritten_files: [],
+    created_files: [],
+}

--- a/crates/biome_grit_patterns/tests/specs/ts/whereClause.ts
+++ b/crates/biome_grit_patterns/tests/specs/ts/whereClause.ts
@@ -1,0 +1,2 @@
+console.log('Hi');
+console.log('Hello, world!');


### PR DESCRIPTION
## Summary

Adds support for language-specific snippets in Grit queries. We only support one target language thus far, so it's purely a syntax thing for now.

## Test Plan

Added test case.