### PR TITLE
feat(grit): add regex support in Grit queries

### DIFF
--- a/crates/biome_grit_patterns/src/errors.rs
+++ b/crates/biome_grit_patterns/src/errors.rs
@@ -24,6 +24,9 @@ pub enum CompileError {
     /// A metavariable was expected at the given range.
     InvalidMetavariableRange(ByteRange),
 
+    /// Regular expressions are not allowed on the right-hand side of a rule.
+    InvalidRegexPosition,
+
     /// Incorrect reference to a metavariable.
     MetavariableNotFound(String),
 
@@ -89,6 +92,9 @@ impl Diagnostic for CompileError {
             CompileError::InvalidMetavariableRange(_) => {
                 fmt.write_markup(markup! { "Invalid range for metavariable" })
             }
+            CompileError::InvalidRegexPosition => fmt.write_markup(
+                markup! { "Regular expressions are not allowed on the right-hand side of a rule" },
+            ),
             CompileError::MetavariableNotFound(var) => {
                 fmt.write_markup(markup! { "Metavariable not found: "{{var}} })
             }

--- a/crates/biome_grit_patterns/src/pattern_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler.rs
@@ -56,6 +56,7 @@ mod or_compiler;
 mod predicate_call_compiler;
 mod predicate_compiler;
 mod predicate_return_compiler;
+mod regex_compiler;
 mod rewrite_compiler;
 mod sequential_compiler;
 mod snippet_compiler;
@@ -88,6 +89,7 @@ use biome_grit_syntax::{AnyGritMaybeCurlyPattern, AnyGritPattern, GritSyntaxKind
 use biome_rowan::AstNode as _;
 use grit_pattern_matcher::pattern::{DynamicPattern, DynamicSnippet, DynamicSnippetPart, Pattern};
 use node_like_compiler::NodeLikeCompiler;
+use regex_compiler::RegexCompiler;
 
 pub(crate) use self::auto_wrap::auto_wrap_pattern;
 
@@ -211,7 +213,9 @@ impl PatternCompiler {
             AnyGritPattern::GritPatternWhere(node) => Ok(Pattern::Where(Box::new(
                 WhereCompiler::from_node(node, context)?,
             ))),
-            AnyGritPattern::GritRegexPattern(_) => todo!(),
+            AnyGritPattern::GritRegexPattern(node) => Ok(Pattern::Regex(Box::new(
+                RegexCompiler::from_node(node, context, is_rhs)?,
+            ))),
             AnyGritPattern::GritRewrite(node) => Ok(Pattern::Rewrite(Box::new(
                 RewriteCompiler::from_node(node, context)?,
             ))),

--- a/crates/biome_grit_patterns/src/pattern_compiler/regex_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/regex_compiler.rs
@@ -1,0 +1,69 @@
+use super::{compilation_context::NodeCompilationContext, variable_compiler::VariableCompiler};
+use crate::{
+    diagnostics::CompilerDiagnostic, grit_context::GritQueryContext,
+    pattern_compiler::snippet_compiler::parse_snippet_content, util::TextRangeGritExt,
+    CompileError,
+};
+use biome_grit_syntax::{AnyGritRegex, GritRegexPattern};
+use grit_pattern_matcher::pattern::{RegexLike, RegexPattern};
+use grit_util::Language;
+
+pub(crate) struct RegexCompiler;
+
+impl RegexCompiler {
+    pub(crate) fn from_node(
+        node: &GritRegexPattern,
+        context: &mut NodeCompilationContext,
+        is_rhs: bool,
+    ) -> Result<RegexPattern<GritQueryContext>, CompileError> {
+        if is_rhs {
+            return Err(CompileError::InvalidRegexPosition);
+        }
+
+        let regex = match node.regex()? {
+            AnyGritRegex::GritRegexLiteral(regex_node) => {
+                let token = regex_node.value_token()?;
+                let regex = token.text_trimmed();
+                debug_assert!(regex.starts_with("r\"") && regex.ends_with('"'));
+                RegexLike::Regex(regex[2..regex.len() - 1].to_string())
+            }
+            AnyGritRegex::GritSnippetRegexLiteral(regex_node) => {
+                let token = regex_node.value_token()?;
+                let regex = token.text_trimmed();
+                let range = token.text_trimmed_range().to_byte_range();
+                debug_assert!(regex.starts_with("r`") && regex.ends_with('`'));
+
+                if !context
+                    .compilation
+                    .lang
+                    .metavariable_regex()
+                    .is_match(regex)
+                {
+                    let alternative = format!("r\"{}\"", &regex[2..regex.len() - 1]);
+                    context.log(CompilerDiagnostic::new_warning(
+                        format!("Unnecessary use of metavariable snippet syntax without metavariables. Replace {regex} with {alternative}"),
+                        token.text_trimmed_range(),
+                    ));
+                }
+
+                let pattern =
+                    parse_snippet_content(&regex[2..regex.len() - 1], range, context, is_rhs)?;
+                RegexLike::Pattern(Box::new(pattern))
+            }
+        };
+
+        let variables: Vec<_> = node
+            .variables()
+            .and_then(|variables| variables.args().ok())
+            .map(|args| {
+                args.grit_variable_list()
+                    .into_iter()
+                    .filter_map(Result::ok)
+                    .map(|variable| VariableCompiler::from_node(&variable, context))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(RegexPattern::new(regex, variables))
+    }
+}

--- a/crates/biome_grit_patterns/tests/specs/ts/regex.grit
+++ b/crates/biome_grit_patterns/tests/specs/ts/regex.grit
@@ -1,0 +1,4 @@
+`console.log($message)` where {
+    $name = "Lucy",
+    $message <: r`"([a-zA-Z]*), Lucy"`($greeting) => `$name, $greeting`
+}

--- a/crates/biome_grit_patterns/tests/specs/ts/regex.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/regex.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_grit_patterns/tests/spec_tests.rs
-assertion_line: 81
 expression: regex
 ---
 SnapshotResult {

--- a/crates/biome_grit_patterns/tests/specs/ts/regex.snap.new
+++ b/crates/biome_grit_patterns/tests/specs/ts/regex.snap.new
@@ -1,0 +1,13 @@
+---
+source: crates/biome_grit_patterns/tests/spec_tests.rs
+assertion_line: 81
+expression: regex
+---
+SnapshotResult {
+    messages: [],
+    matched_ranges: [
+        "2:1-2:27",
+    ],
+    rewritten_files: [],
+    created_files: [],
+}

--- a/crates/biome_grit_patterns/tests/specs/ts/regex.ts
+++ b/crates/biome_grit_patterns/tests/specs/ts/regex.ts
@@ -1,0 +1,2 @@
+console.log("Hello, Bert");
+console.log("Hello, Lucy");


### PR DESCRIPTION
## Summary

Another missing feature implemented in Grit queries: regex support.

## Test Plan

Test case added.
