### PR TITLE
feat(grit): syntax support for raw snippets in Grit queries

### DIFF
--- a/crates/biome_grit_patterns/src/errors.rs
+++ b/crates/biome_grit_patterns/src/errors.rs
@@ -24,6 +24,9 @@ pub enum CompileError {
     /// A metavariable was expected at the given range.
     InvalidMetavariableRange(ByteRange),
 
+    /// Raw snippets are only allowed on the right-hand side of a rule.
+    InvalidRawSnippetPosition,
+
     /// Regular expressions are not allowed on the right-hand side of a rule.
     InvalidRegexPosition,
 
@@ -90,6 +93,9 @@ impl Diagnostic for CompileError {
                 fmt.write_markup(markup! { "Duplicate parameters" })
             }
             CompileError::InvalidMetavariableRange(_) => {
+                fmt.write_markup(markup! { "Invalid range for metavariable" })
+            }
+            CompileError::InvalidRawSnippetPosition => {
                 fmt.write_markup(markup! { "Invalid range for metavariable" })
             }
             CompileError::InvalidRegexPosition => fmt.write_markup(

--- a/crates/biome_grit_patterns/src/pattern_compiler/literal_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/literal_compiler.rs
@@ -44,7 +44,17 @@ impl LiteralCompiler {
                     debug_assert!(source.len() >= 2, "Literals must have quotes");
                     parse_snippet_content(&source[1..source.len() - 1], range, context, is_rhs)
                 }
-                AnyGritCodeSnippetSource::GritRawBacktickSnippetLiteral(_) => todo!(),
+                AnyGritCodeSnippetSource::GritRawBacktickSnippetLiteral(node) => {
+                    if !is_rhs {
+                        return Err(CompileError::InvalidRawSnippetPosition);
+                    }
+
+                    let token = node.value_token()?;
+                    let source = token.text_trimmed();
+                    let range = token.text_trimmed_range().to_byte_range();
+                    debug_assert!(source.starts_with("raw`") && source.ends_with('`'));
+                    parse_snippet_content(&source[4..source.len() - 1], range, context, is_rhs)
+                }
             },
             AnyGritLiteral::GritDoubleLiteral(node) => Ok(Pattern::FloatConstant(
                 FloatConstant::new(node.value_token()?.text_trimmed().parse().map_err(|err| {

--- a/crates/biome_grit_patterns/tests/specs/ts/rawSnippet.grit
+++ b/crates/biome_grit_patterns/tests/specs/ts/rawSnippet.grit
@@ -1,0 +1,1 @@
+`console.log($message)` => raw`if(' // I like broken code"`

--- a/crates/biome_grit_patterns/tests/specs/ts/rawSnippet.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/rawSnippet.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_grit_patterns/tests/spec_tests.rs
+expression: rawSnippet
+---
+SnapshotResult {
+    messages: [],
+    matched_ranges: [
+        "1:1-1:29",
+    ],
+    rewritten_files: [],
+    created_files: [],
+}

--- a/crates/biome_grit_patterns/tests/specs/ts/rawSnippet.ts
+++ b/crates/biome_grit_patterns/tests/specs/ts/rawSnippet.ts
@@ -1,0 +1,1 @@
+console.log('Hello, world!');


### PR DESCRIPTION
## Summary

Adds syntax support for raw snippets. It doesn't do much since we don't support rewrites yet anyway, but it was the last item missing in our syntax support, so might as well support it :)

## Test Plan

Test case added.
