### PR TITLE
fix(parser/html): correctly lex tag names and attribute names

### DIFF
--- a/crates/biome_html_parser/src/lexer/tests.rs
+++ b/crates/biome_html_parser/src/lexer/tests.rs
@@ -150,6 +150,21 @@ fn element() {
 }
 
 #[test]
+fn element_with_text() {
+    assert_lex! {
+        "<div>abcdefghijklmnopqrstuvwxyz!@_-:;</div>",
+        L_ANGLE: 1,
+        HTML_LITERAL: 3,
+        R_ANGLE: 1,
+        HTML_LITERAL: 32,
+        L_ANGLE: 1,
+        SLASH: 1,
+        HTML_LITERAL: 3,
+        R_ANGLE: 1,
+    }
+}
+
+#[test]
 fn doctype_with_quirk() {
     assert_lex! {
         "<!DOCTYPE HTML>",
@@ -187,6 +202,18 @@ fn element_with_attributes() {
         HTML_LITERAL: 5,
         EQ:1,
         HTML_STRING_LITERAL: 19,
+        R_ANGLE: 1,
+    }
+}
+
+#[test]
+fn element_with_dashed_attributes() {
+    assert_lex! {
+        "<div aria-hidden>",
+        L_ANGLE: 1,
+        HTML_LITERAL: 3,
+        WHITESPACE: 1,
+        HTML_LITERAL: 11,
         R_ANGLE: 1,
     }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR fixes the lexing of html tag names and attribute names to allow all the characters defined in the HTML spec.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
See: https://html.spec.whatwg.org/#elements-2

Also added some unit tests.
