### PR TITLE
feat(parser/html): correctly parse void elements

### DIFF
--- a/crates/biome_html_factory/src/generated/node_factory.rs
+++ b/crates/biome_html_factory/src/generated/node_factory.rs
@@ -210,19 +210,40 @@ pub fn html_self_closing_element(
     l_angle_token: SyntaxToken,
     name: HtmlName,
     attributes: HtmlAttributeList,
-    slash_token: SyntaxToken,
     r_angle_token: SyntaxToken,
-) -> HtmlSelfClosingElement {
-    HtmlSelfClosingElement::unwrap_cast(SyntaxNode::new_detached(
-        HtmlSyntaxKind::HTML_SELF_CLOSING_ELEMENT,
-        [
-            Some(SyntaxElement::Token(l_angle_token)),
-            Some(SyntaxElement::Node(name.into_syntax())),
-            Some(SyntaxElement::Node(attributes.into_syntax())),
-            Some(SyntaxElement::Token(slash_token)),
-            Some(SyntaxElement::Token(r_angle_token)),
-        ],
-    ))
+) -> HtmlSelfClosingElementBuilder {
+    HtmlSelfClosingElementBuilder {
+        l_angle_token,
+        name,
+        attributes,
+        r_angle_token,
+        slash_token: None,
+    }
+}
+pub struct HtmlSelfClosingElementBuilder {
+    l_angle_token: SyntaxToken,
+    name: HtmlName,
+    attributes: HtmlAttributeList,
+    r_angle_token: SyntaxToken,
+    slash_token: Option<SyntaxToken>,
+}
+impl HtmlSelfClosingElementBuilder {
+    pub fn with_slash_token(mut self, slash_token: SyntaxToken) -> Self {
+        self.slash_token = Some(slash_token);
+        self
+    }
+    pub fn build(self) -> HtmlSelfClosingElement {
+        HtmlSelfClosingElement::unwrap_cast(SyntaxNode::new_detached(
+            HtmlSyntaxKind::HTML_SELF_CLOSING_ELEMENT,
+            [
+                Some(SyntaxElement::Token(self.l_angle_token)),
+                Some(SyntaxElement::Node(self.name.into_syntax())),
+                Some(SyntaxElement::Node(self.attributes.into_syntax())),
+                self.slash_token.map(|token| SyntaxElement::Token(token)),
+                Some(SyntaxElement::Token(self.r_angle_token)),
+            ],
+        ))
+    }
 }
 pub fn html_string(value_token: SyntaxToken) -> HtmlString {
     HtmlString::unwrap_cast(SyntaxNode::new_detached(

--- a/crates/biome_html_parser/src/syntax/parse_error.rs
+++ b/crates/biome_html_parser/src/syntax/parse_error.rs
@@ -30,6 +30,10 @@ pub(crate) fn expected_closing_tag(p: &HtmlParser, range: TextRange) -> ParseDia
     expected_node("closing tag", range, p).into_diagnostic(p)
 }
 
+pub(crate) fn expected_matching_closing_tag(p: &HtmlParser, range: TextRange) -> ParseDiagnostic {
+    expected_node("matching closing tag", range, p).into_diagnostic(p)
+}
+
 /// The parser was encountered a tag that does not have a name.
 ///
 /// ```html
@@ -38,4 +42,17 @@ pub(crate) fn expected_closing_tag(p: &HtmlParser, range: TextRange) -> ParseDia
 /// ```
 pub(crate) fn expected_element_name(p: &HtmlParser, range: TextRange) -> ParseDiagnostic {
     expected_node("element name", range, p).into_diagnostic(p)
+}
+
+/// Void elements should not have a closing tag.
+///
+/// ```html
+/// <img></img>
+///      ^^^^^^ should not have a closing tag
+/// ```
+pub(crate) fn void_element_should_not_have_closing_tag(
+    _p: &HtmlParser,
+    range: TextRange,
+) -> ParseDiagnostic {
+    ParseDiagnostic::new("Void elements should not have a closing tag.", range)
 }

--- a/crates/biome_html_parser/tests/html_specs/error/element/br-with-end.html
+++ b/crates/biome_html_parser/tests/html_specs/error/element/br-with-end.html
@@ -1,0 +1,1 @@
+<span>foo<br>This text is inside br.</br>bar</span>

--- a/crates/biome_html_parser/tests/html_specs/error/element/br-with-end.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/element/br-with-end.html.snap
@@ -1,0 +1,164 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```html
+<span>foo<br>This text is inside br.</br>bar</span>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    directive: missing (optional),
+    html: HtmlBogusElement {
+        items: [
+            HtmlOpeningElement {
+                l_angle_token: L_ANGLE@0..1 "<" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@1..5 "span" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@5..6 ">" [] [],
+            },
+            HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@6..9 "foo" [] [],
+                },
+                HtmlSelfClosingElement {
+                    l_angle_token: L_ANGLE@9..10 "<" [] [],
+                    name: HtmlName {
+                        value_token: HTML_LITERAL@10..12 "br" [] [],
+                    },
+                    attributes: HtmlAttributeList [],
+                    slash_token: missing (optional),
+                    r_angle_token: R_ANGLE@12..13 ">" [] [],
+                },
+                HtmlContent {
+                    value_token: HTML_LITERAL@13..18 "This" [] [Whitespace(" ")],
+                },
+                HtmlContent {
+                    value_token: HTML_LITERAL@18..23 "text" [] [Whitespace(" ")],
+                },
+                HtmlContent {
+                    value_token: HTML_LITERAL@23..26 "is" [] [Whitespace(" ")],
+                },
+                HtmlContent {
+                    value_token: HTML_LITERAL@26..33 "inside" [] [Whitespace(" ")],
+                },
+                HtmlContent {
+                    value_token: HTML_LITERAL@33..36 "br." [] [],
+                },
+            ],
+            HtmlBogusElement {
+                items: [
+                    L_ANGLE@36..37 "<" [] [],
+                    SLASH@37..38 "/" [] [],
+                    HtmlName {
+                        value_token: HTML_LITERAL@38..40 "br" [] [],
+                    },
+                    R_ANGLE@40..41 ">" [] [],
+                ],
+            },
+            HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@41..44 "bar" [] [],
+                },
+            ],
+            HtmlClosingElement {
+                l_angle_token: L_ANGLE@44..45 "<" [] [],
+                slash_token: SLASH@45..46 "/" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@46..50 "span" [] [],
+                },
+                r_angle_token: R_ANGLE@50..51 ">" [] [],
+            },
+        ],
+    },
+    eof_token: EOF@51..52 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..52
+  0: (empty)
+  1: (empty)
+  2: HTML_BOGUS_ELEMENT@0..51
+    0: HTML_OPENING_ELEMENT@0..6
+      0: L_ANGLE@0..1 "<" [] []
+      1: HTML_NAME@1..5
+        0: HTML_LITERAL@1..5 "span" [] []
+      2: HTML_ATTRIBUTE_LIST@5..5
+      3: R_ANGLE@5..6 ">" [] []
+    1: HTML_ELEMENT_LIST@6..36
+      0: HTML_CONTENT@6..9
+        0: HTML_LITERAL@6..9 "foo" [] []
+      1: HTML_SELF_CLOSING_ELEMENT@9..13
+        0: L_ANGLE@9..10 "<" [] []
+        1: HTML_NAME@10..12
+          0: HTML_LITERAL@10..12 "br" [] []
+        2: HTML_ATTRIBUTE_LIST@12..12
+        3: (empty)
+        4: R_ANGLE@12..13 ">" [] []
+      2: HTML_CONTENT@13..18
+        0: HTML_LITERAL@13..18 "This" [] [Whitespace(" ")]
+      3: HTML_CONTENT@18..23
+        0: HTML_LITERAL@18..23 "text" [] [Whitespace(" ")]
+      4: HTML_CONTENT@23..26
+        0: HTML_LITERAL@23..26 "is" [] [Whitespace(" ")]
+      5: HTML_CONTENT@26..33
+        0: HTML_LITERAL@26..33 "inside" [] [Whitespace(" ")]
+      6: HTML_CONTENT@33..36
+        0: HTML_LITERAL@33..36 "br." [] []
+    2: HTML_BOGUS_ELEMENT@36..41
+      0: L_ANGLE@36..37 "<" [] []
+      1: SLASH@37..38 "/" [] []
+      2: HTML_NAME@38..40
+        0: HTML_LITERAL@38..40 "br" [] []
+      3: R_ANGLE@40..41 ">" [] []
+    3: HTML_ELEMENT_LIST@41..44
+      0: HTML_CONTENT@41..44
+        0: HTML_LITERAL@41..44 "bar" [] []
+    4: HTML_CLOSING_ELEMENT@44..51
+      0: L_ANGLE@44..45 "<" [] []
+      1: SLASH@45..46 "/" [] []
+      2: HTML_NAME@46..50
+        0: HTML_LITERAL@46..50 "span" [] []
+      3: R_ANGLE@50..51 ">" [] []
+  3: EOF@51..52 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+br-with-end.html:1:39 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Void elements should not have a closing tag.
+  
+  > 1 │ <span>foo<br>This text is inside br.</br>bar</span>
+      │                                       ^^
+    2 │ 
+  
+br-with-end.html:1:37 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a matching closing tag but instead found '</br>'.
+  
+  > 1 │ <span>foo<br>This text is inside br.</br>bar</span>
+      │                                     ^^^^^
+    2 │ 
+  
+  i Expected a matching closing tag here.
+  
+  > 1 │ <span>foo<br>This text is inside br.</br>bar</span>
+      │                                     ^^^^^
+    2 │ 
+  
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br-in-span.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br-in-span.html
@@ -1,0 +1,1 @@
+<span>foo<br>bar</span>

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br-in-span.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br-in-span.html.snap
@@ -1,0 +1,91 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```html
+<span>foo<br>bar</span>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    directive: missing (optional),
+    html: HtmlElement {
+        opening_element: HtmlOpeningElement {
+            l_angle_token: L_ANGLE@0..1 "<" [] [],
+            name: HtmlName {
+                value_token: HTML_LITERAL@1..5 "span" [] [],
+            },
+            attributes: HtmlAttributeList [],
+            r_angle_token: R_ANGLE@5..6 ">" [] [],
+        },
+        children: HtmlElementList [
+            HtmlContent {
+                value_token: HTML_LITERAL@6..9 "foo" [] [],
+            },
+            HtmlSelfClosingElement {
+                l_angle_token: L_ANGLE@9..10 "<" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@10..12 "br" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                slash_token: missing (optional),
+                r_angle_token: R_ANGLE@12..13 ">" [] [],
+            },
+            HtmlContent {
+                value_token: HTML_LITERAL@13..16 "bar" [] [],
+            },
+        ],
+        closing_element: HtmlClosingElement {
+            l_angle_token: L_ANGLE@16..17 "<" [] [],
+            slash_token: SLASH@17..18 "/" [] [],
+            name: HtmlName {
+                value_token: HTML_LITERAL@18..22 "span" [] [],
+            },
+            r_angle_token: R_ANGLE@22..23 ">" [] [],
+        },
+    },
+    eof_token: EOF@23..24 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..24
+  0: (empty)
+  1: (empty)
+  2: HTML_ELEMENT@0..23
+    0: HTML_OPENING_ELEMENT@0..6
+      0: L_ANGLE@0..1 "<" [] []
+      1: HTML_NAME@1..5
+        0: HTML_LITERAL@1..5 "span" [] []
+      2: HTML_ATTRIBUTE_LIST@5..5
+      3: R_ANGLE@5..6 ">" [] []
+    1: HTML_ELEMENT_LIST@6..16
+      0: HTML_CONTENT@6..9
+        0: HTML_LITERAL@6..9 "foo" [] []
+      1: HTML_SELF_CLOSING_ELEMENT@9..13
+        0: L_ANGLE@9..10 "<" [] []
+        1: HTML_NAME@10..12
+          0: HTML_LITERAL@10..12 "br" [] []
+        2: HTML_ATTRIBUTE_LIST@12..12
+        3: (empty)
+        4: R_ANGLE@12..13 ">" [] []
+      2: HTML_CONTENT@13..16
+        0: HTML_LITERAL@13..16 "bar" [] []
+    2: HTML_CLOSING_ELEMENT@16..23
+      0: L_ANGLE@16..17 "<" [] []
+      1: SLASH@17..18 "/" [] []
+      2: HTML_NAME@18..22
+        0: HTML_LITERAL@18..22 "span" [] []
+      3: R_ANGLE@22..23 ">" [] []
+  3: EOF@23..24 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br.html
@@ -1,0 +1,1 @@
+foo<br>bar

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br.html.snap
@@ -1,0 +1,33 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```html
+foo<br>bar
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    directive: missing (optional),
+    html: missing (optional),
+    eof_token: EOF@0..11 "foo<br>bar\n" [] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..11
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: EOF@0..11 "foo<br>bar\n" [] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/meta.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/meta.html
@@ -1,0 +1,3 @@
+<head>
+	<meta charset="utf-8">
+</head>

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/meta.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/meta.html.snap
@@ -1,0 +1,107 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```html
+<head>
+	<meta charset="utf-8">
+</head>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    directive: missing (optional),
+    html: HtmlElement {
+        opening_element: HtmlOpeningElement {
+            l_angle_token: L_ANGLE@0..1 "<" [] [],
+            name: HtmlName {
+                value_token: HTML_LITERAL@1..5 "head" [] [],
+            },
+            attributes: HtmlAttributeList [],
+            r_angle_token: R_ANGLE@5..6 ">" [] [],
+        },
+        children: HtmlElementList [
+            HtmlContent {
+                value_token: HTML_LITERAL@6..8 "\n\t" [] [],
+            },
+            HtmlSelfClosingElement {
+                l_angle_token: L_ANGLE@8..9 "<" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@9..14 "meta" [] [Whitespace(" ")],
+                },
+                attributes: HtmlAttributeList [
+                    HtmlAttribute {
+                        name: HtmlName {
+                            value_token: HTML_LITERAL@14..21 "charset" [] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@21..22 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@22..29 "\"utf-8\"" [] [],
+                            },
+                        },
+                    },
+                ],
+                slash_token: missing (optional),
+                r_angle_token: R_ANGLE@29..30 ">" [] [],
+            },
+        ],
+        closing_element: HtmlClosingElement {
+            l_angle_token: L_ANGLE@30..32 "<" [Newline("\n")] [],
+            slash_token: SLASH@32..33 "/" [] [],
+            name: HtmlName {
+                value_token: HTML_LITERAL@33..37 "head" [] [],
+            },
+            r_angle_token: R_ANGLE@37..38 ">" [] [],
+        },
+    },
+    eof_token: EOF@38..39 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..39
+  0: (empty)
+  1: (empty)
+  2: HTML_ELEMENT@0..38
+    0: HTML_OPENING_ELEMENT@0..6
+      0: L_ANGLE@0..1 "<" [] []
+      1: HTML_NAME@1..5
+        0: HTML_LITERAL@1..5 "head" [] []
+      2: HTML_ATTRIBUTE_LIST@5..5
+      3: R_ANGLE@5..6 ">" [] []
+    1: HTML_ELEMENT_LIST@6..30
+      0: HTML_CONTENT@6..8
+        0: HTML_LITERAL@6..8 "\n\t" [] []
+      1: HTML_SELF_CLOSING_ELEMENT@8..30
+        0: L_ANGLE@8..9 "<" [] []
+        1: HTML_NAME@9..14
+          0: HTML_LITERAL@9..14 "meta" [] [Whitespace(" ")]
+        2: HTML_ATTRIBUTE_LIST@14..29
+          0: HTML_ATTRIBUTE@14..29
+            0: HTML_NAME@14..21
+              0: HTML_LITERAL@14..21 "charset" [] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@21..29
+              0: EQ@21..22 "=" [] []
+              1: HTML_STRING@22..29
+                0: HTML_STRING_LITERAL@22..29 "\"utf-8\"" [] []
+        3: (empty)
+        4: R_ANGLE@29..30 ">" [] []
+    2: HTML_CLOSING_ELEMENT@30..38
+      0: L_ANGLE@30..32 "<" [Newline("\n")] []
+      1: SLASH@32..33 "/" [] []
+      2: HTML_NAME@33..37
+        0: HTML_LITERAL@33..37 "head" [] []
+      3: R_ANGLE@37..38 ">" [] []
+  3: EOF@38..39 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/wbr.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/wbr.html
@@ -1,0 +1,2 @@
+<p>So then she pointed at the tiger and screamed
+	there<wbr>is<wbr>no<wbr>way<wbr>you<wbr>are<wbr>ever<wbr>going<wbr>to<wbr>catch<wbr>me!</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/wbr.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/wbr.html.snap
@@ -1,0 +1,281 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```html
+<p>So then she pointed at the tiger and screamed
+	there<wbr>is<wbr>no<wbr>way<wbr>you<wbr>are<wbr>ever<wbr>going<wbr>to<wbr>catch<wbr>me!</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    directive: missing (optional),
+    html: HtmlElement {
+        opening_element: HtmlOpeningElement {
+            l_angle_token: L_ANGLE@0..1 "<" [] [],
+            name: HtmlName {
+                value_token: HTML_LITERAL@1..2 "p" [] [],
+            },
+            attributes: HtmlAttributeList [],
+            r_angle_token: R_ANGLE@2..3 ">" [] [],
+        },
+        children: HtmlElementList [
+            HtmlContent {
+                value_token: HTML_LITERAL@3..55 "So then she pointed at the tiger and screamed\n\tthere" [] [],
+            },
+            HtmlSelfClosingElement {
+                l_angle_token: L_ANGLE@55..56 "<" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@56..59 "wbr" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                slash_token: missing (optional),
+                r_angle_token: R_ANGLE@59..60 ">" [] [],
+            },
+            HtmlContent {
+                value_token: HTML_LITERAL@60..62 "is" [] [],
+            },
+            HtmlSelfClosingElement {
+                l_angle_token: L_ANGLE@62..63 "<" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@63..66 "wbr" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                slash_token: missing (optional),
+                r_angle_token: R_ANGLE@66..67 ">" [] [],
+            },
+            HtmlContent {
+                value_token: HTML_LITERAL@67..69 "no" [] [],
+            },
+            HtmlSelfClosingElement {
+                l_angle_token: L_ANGLE@69..70 "<" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@70..73 "wbr" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                slash_token: missing (optional),
+                r_angle_token: R_ANGLE@73..74 ">" [] [],
+            },
+            HtmlContent {
+                value_token: HTML_LITERAL@74..77 "way" [] [],
+            },
+            HtmlSelfClosingElement {
+                l_angle_token: L_ANGLE@77..78 "<" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@78..81 "wbr" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                slash_token: missing (optional),
+                r_angle_token: R_ANGLE@81..82 ">" [] [],
+            },
+            HtmlContent {
+                value_token: HTML_LITERAL@82..85 "you" [] [],
+            },
+            HtmlSelfClosingElement {
+                l_angle_token: L_ANGLE@85..86 "<" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@86..89 "wbr" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                slash_token: missing (optional),
+                r_angle_token: R_ANGLE@89..90 ">" [] [],
+            },
+            HtmlContent {
+                value_token: HTML_LITERAL@90..93 "are" [] [],
+            },
+            HtmlSelfClosingElement {
+                l_angle_token: L_ANGLE@93..94 "<" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@94..97 "wbr" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                slash_token: missing (optional),
+                r_angle_token: R_ANGLE@97..98 ">" [] [],
+            },
+            HtmlContent {
+                value_token: HTML_LITERAL@98..102 "ever" [] [],
+            },
+            HtmlSelfClosingElement {
+                l_angle_token: L_ANGLE@102..103 "<" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@103..106 "wbr" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                slash_token: missing (optional),
+                r_angle_token: R_ANGLE@106..107 ">" [] [],
+            },
+            HtmlContent {
+                value_token: HTML_LITERAL@107..112 "going" [] [],
+            },
+            HtmlSelfClosingElement {
+                l_angle_token: L_ANGLE@112..113 "<" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@113..116 "wbr" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                slash_token: missing (optional),
+                r_angle_token: R_ANGLE@116..117 ">" [] [],
+            },
+            HtmlContent {
+                value_token: HTML_LITERAL@117..119 "to" [] [],
+            },
+            HtmlSelfClosingElement {
+                l_angle_token: L_ANGLE@119..120 "<" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@120..123 "wbr" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                slash_token: missing (optional),
+                r_angle_token: R_ANGLE@123..124 ">" [] [],
+            },
+            HtmlContent {
+                value_token: HTML_LITERAL@124..129 "catch" [] [],
+            },
+            HtmlSelfClosingElement {
+                l_angle_token: L_ANGLE@129..130 "<" [] [],
+                name: HtmlName {
+                    value_token: HTML_LITERAL@130..133 "wbr" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                slash_token: missing (optional),
+                r_angle_token: R_ANGLE@133..134 ">" [] [],
+            },
+            HtmlContent {
+                value_token: HTML_LITERAL@134..137 "me!" [] [],
+            },
+        ],
+        closing_element: HtmlClosingElement {
+            l_angle_token: L_ANGLE@137..138 "<" [] [],
+            slash_token: SLASH@138..139 "/" [] [],
+            name: HtmlName {
+                value_token: HTML_LITERAL@139..140 "p" [] [],
+            },
+            r_angle_token: R_ANGLE@140..141 ">" [] [],
+        },
+    },
+    eof_token: EOF@141..142 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..142
+  0: (empty)
+  1: (empty)
+  2: HTML_ELEMENT@0..141
+    0: HTML_OPENING_ELEMENT@0..3
+      0: L_ANGLE@0..1 "<" [] []
+      1: HTML_NAME@1..2
+        0: HTML_LITERAL@1..2 "p" [] []
+      2: HTML_ATTRIBUTE_LIST@2..2
+      3: R_ANGLE@2..3 ">" [] []
+    1: HTML_ELEMENT_LIST@3..137
+      0: HTML_CONTENT@3..55
+        0: HTML_LITERAL@3..55 "So then she pointed at the tiger and screamed\n\tthere" [] []
+      1: HTML_SELF_CLOSING_ELEMENT@55..60
+        0: L_ANGLE@55..56 "<" [] []
+        1: HTML_NAME@56..59
+          0: HTML_LITERAL@56..59 "wbr" [] []
+        2: HTML_ATTRIBUTE_LIST@59..59
+        3: (empty)
+        4: R_ANGLE@59..60 ">" [] []
+      2: HTML_CONTENT@60..62
+        0: HTML_LITERAL@60..62 "is" [] []
+      3: HTML_SELF_CLOSING_ELEMENT@62..67
+        0: L_ANGLE@62..63 "<" [] []
+        1: HTML_NAME@63..66
+          0: HTML_LITERAL@63..66 "wbr" [] []
+        2: HTML_ATTRIBUTE_LIST@66..66
+        3: (empty)
+        4: R_ANGLE@66..67 ">" [] []
+      4: HTML_CONTENT@67..69
+        0: HTML_LITERAL@67..69 "no" [] []
+      5: HTML_SELF_CLOSING_ELEMENT@69..74
+        0: L_ANGLE@69..70 "<" [] []
+        1: HTML_NAME@70..73
+          0: HTML_LITERAL@70..73 "wbr" [] []
+        2: HTML_ATTRIBUTE_LIST@73..73
+        3: (empty)
+        4: R_ANGLE@73..74 ">" [] []
+      6: HTML_CONTENT@74..77
+        0: HTML_LITERAL@74..77 "way" [] []
+      7: HTML_SELF_CLOSING_ELEMENT@77..82
+        0: L_ANGLE@77..78 "<" [] []
+        1: HTML_NAME@78..81
+          0: HTML_LITERAL@78..81 "wbr" [] []
+        2: HTML_ATTRIBUTE_LIST@81..81
+        3: (empty)
+        4: R_ANGLE@81..82 ">" [] []
+      8: HTML_CONTENT@82..85
+        0: HTML_LITERAL@82..85 "you" [] []
+      9: HTML_SELF_CLOSING_ELEMENT@85..90
+        0: L_ANGLE@85..86 "<" [] []
+        1: HTML_NAME@86..89
+          0: HTML_LITERAL@86..89 "wbr" [] []
+        2: HTML_ATTRIBUTE_LIST@89..89
+        3: (empty)
+        4: R_ANGLE@89..90 ">" [] []
+      10: HTML_CONTENT@90..93
+        0: HTML_LITERAL@90..93 "are" [] []
+      11: HTML_SELF_CLOSING_ELEMENT@93..98
+        0: L_ANGLE@93..94 "<" [] []
+        1: HTML_NAME@94..97
+          0: HTML_LITERAL@94..97 "wbr" [] []
+        2: HTML_ATTRIBUTE_LIST@97..97
+        3: (empty)
+        4: R_ANGLE@97..98 ">" [] []
+      12: HTML_CONTENT@98..102
+        0: HTML_LITERAL@98..102 "ever" [] []
+      13: HTML_SELF_CLOSING_ELEMENT@102..107
+        0: L_ANGLE@102..103 "<" [] []
+        1: HTML_NAME@103..106
+          0: HTML_LITERAL@103..106 "wbr" [] []
+        2: HTML_ATTRIBUTE_LIST@106..106
+        3: (empty)
+        4: R_ANGLE@106..107 ">" [] []
+      14: HTML_CONTENT@107..112
+        0: HTML_LITERAL@107..112 "going" [] []
+      15: HTML_SELF_CLOSING_ELEMENT@112..117
+        0: L_ANGLE@112..113 "<" [] []
+        1: HTML_NAME@113..116
+          0: HTML_LITERAL@113..116 "wbr" [] []
+        2: HTML_ATTRIBUTE_LIST@116..116
+        3: (empty)
+        4: R_ANGLE@116..117 ">" [] []
+      16: HTML_CONTENT@117..119
+        0: HTML_LITERAL@117..119 "to" [] []
+      17: HTML_SELF_CLOSING_ELEMENT@119..124
+        0: L_ANGLE@119..120 "<" [] []
+        1: HTML_NAME@120..123
+          0: HTML_LITERAL@120..123 "wbr" [] []
+        2: HTML_ATTRIBUTE_LIST@123..123
+        3: (empty)
+        4: R_ANGLE@123..124 ">" [] []
+      18: HTML_CONTENT@124..129
+        0: HTML_LITERAL@124..129 "catch" [] []
+      19: HTML_SELF_CLOSING_ELEMENT@129..134
+        0: L_ANGLE@129..130 "<" [] []
+        1: HTML_NAME@130..133
+          0: HTML_LITERAL@130..133 "wbr" [] []
+        2: HTML_ATTRIBUTE_LIST@133..133
+        3: (empty)
+        4: R_ANGLE@133..134 ">" [] []
+      20: HTML_CONTENT@134..137
+        0: HTML_LITERAL@134..137 "me!" [] []
+    2: HTML_CLOSING_ELEMENT@137..141
+      0: L_ANGLE@137..138 "<" [] []
+      1: SLASH@138..139 "/" [] []
+      2: HTML_NAME@139..140
+        0: HTML_LITERAL@139..140 "p" [] []
+      3: R_ANGLE@140..141 ">" [] []
+  3: EOF@141..142 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_syntax/src/generated/nodes.rs
+++ b/crates/biome_html_syntax/src/generated/nodes.rs
@@ -469,8 +469,8 @@ impl HtmlSelfClosingElement {
     pub fn attributes(&self) -> HtmlAttributeList {
         support::list(&self.syntax, 2usize)
     }
-    pub fn slash_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 3usize)
+    pub fn slash_token(&self) -> Option<SyntaxToken> {
+        support::token(&self.syntax, 3usize)
     }
     pub fn r_angle_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 4usize)
@@ -489,7 +489,7 @@ pub struct HtmlSelfClosingElementFields {
     pub l_angle_token: SyntaxResult<SyntaxToken>,
     pub name: SyntaxResult<HtmlName>,
     pub attributes: HtmlAttributeList,
-    pub slash_token: SyntaxResult<SyntaxToken>,
+    pub slash_token: Option<SyntaxToken>,
     pub r_angle_token: SyntaxResult<SyntaxToken>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -1030,7 +1030,7 @@ impl std::fmt::Debug for HtmlSelfClosingElement {
             .field("attributes", &self.attributes())
             .field(
                 "slash_token",
-                &support::DebugSyntaxResult(self.slash_token()),
+                &support::DebugOptionalElement(self.slash_token()),
             )
             .field(
                 "r_angle_token",

--- a/crates/biome_html_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_html_syntax/src/generated/nodes_mut.rs
@@ -214,10 +214,10 @@ impl HtmlSelfClosingElement {
                 .splice_slots(2usize..=2usize, once(Some(element.into_syntax().into()))),
         )
     }
-    pub fn with_slash_token(self, element: SyntaxToken) -> Self {
+    pub fn with_slash_token(self, element: Option<SyntaxToken>) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(3usize..=3usize, once(Some(element.into()))),
+                .splice_slots(3usize..=3usize, once(element.map(|element| element.into()))),
         )
     }
     pub fn with_r_angle_token(self, element: SyntaxToken) -> Self {

--- a/crates/biome_html_syntax/src/lib.rs
+++ b/crates/biome_html_syntax/src/lib.rs
@@ -8,7 +8,9 @@ pub use biome_rowan::{TextLen, TextRange, TextSize, TokenAtOffset, TriviaPieceKi
 pub use file_source::HtmlFileSource;
 pub use syntax_node::*;
 
-use crate::HtmlSyntaxKind::{HTML_BOGUS, HTML_BOGUS_ATTRIBUTE};
+use crate::HtmlSyntaxKind::{
+    HTML_BOGUS, HTML_BOGUS_ATTRIBUTE, HTML_BOGUS_ELEMENT, HTML_CLOSING_ELEMENT,
+};
 use biome_rowan::{AstNode, RawSyntaxKind, SyntaxKind, TokenText};
 
 impl From<u16> for HtmlSyntaxKind {
@@ -51,7 +53,8 @@ impl biome_rowan::SyntaxKind for HtmlSyntaxKind {
     fn to_bogus(&self) -> Self {
         match self {
             kind if AnyHtmlAttribute::can_cast(*kind) => HTML_BOGUS_ATTRIBUTE,
-            kind if AnyHtmlElement::can_cast(*kind) => HTML_BOGUS_ATTRIBUTE,
+            kind if AnyHtmlElement::can_cast(*kind) => HTML_BOGUS_ELEMENT,
+            HTML_CLOSING_ELEMENT => HTML_BOGUS_ELEMENT,
 
             _ => HTML_BOGUS,
         }

--- a/xtask/codegen/html.ungram
+++ b/xtask/codegen/html.ungram
@@ -76,7 +76,7 @@ HtmlSelfClosingElement =
 	'<'
 	name: HtmlName
 	attributes: HtmlAttributeList
-	'/'
+	'/'?
 	'>'
 
 HtmlElement =


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Void elements are elements whose content model is "nothing", meaning that they should not have an end tag, and therefore, have no children.
In browsers, this requirement is imposed very forgivingly. Given that Biome doesn't aim to write browser-grade parsers, we can afford to be a little more strict.

The parser now checks the tag name to know if it should be self closing. If it encounters a closing tag for a void element, it will emit a diagnostic.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added snapshot tests.

See the HTML spec: https://html.spec.whatwg.org/#void-elements
