### PR TITLE
fix(aria): remove concept for alert like roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ New entries must be placed in a section entitled `Unreleased`.
 Read
 our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
+## Unreleased
+
+### Analyzer
+
+### CLI
+
+### Configuration
+
+### Editors
+
+### Formatter
+
+### JavaScript APIs
+
+### Linter
+
+#### Bug fixes
+
+- [useSemanticElements](https://biomejs.dev/linter/rules/use-semantic-elements/): ignore `alert` and `alertdialog` roles ([3858](https://github.com/biomejs/biome/issues/3858)). Controbuted by @Conaclos
+
+### Parser
+
 ## v1.9.0 (2024-09-12)
 
 ### Analyzer

--- a/crates/biome_aria/src/roles.rs
+++ b/crates/biome_aria/src/roles.rs
@@ -195,7 +195,6 @@ define_role! {
     AlertRole {
         PROPS: [],
         ROLES: ["section"],
-        CONCEPTS: &[("alert", &[])],
     }
 }
 define_role! {
@@ -203,7 +202,6 @@ define_role! {
     AlertDialogRole {
         PROPS: [],
         ROLES: ["structure"],
-        CONCEPTS: &[("alert", &[])],
     }
 }
 define_role! {
@@ -849,8 +847,6 @@ impl<'a> AriaRoles {
         "button",
         "article",
         "dialog",
-        "alert",
-        "alertdialog",
         "cell",
         "columnheader",
         "definition",
@@ -1228,8 +1224,6 @@ impl<'a> AriaRoles {
                 "button" => &ButtonRole as &dyn AriaRoleDefinitionWithConcepts,
                 "article" => &ArticleRole as &dyn AriaRoleDefinitionWithConcepts,
                 "dialog" => &DialogRole as &dyn AriaRoleDefinitionWithConcepts,
-                "alert" => &AlertRole as &dyn AriaRoleDefinitionWithConcepts,
-                "alertdialog" => &AlertDialogRole as &dyn AriaRoleDefinitionWithConcepts,
                 "cell" => &CellRole as &dyn AriaRoleDefinitionWithConcepts,
                 "columnheader" => &ColumnHeaderRole as &dyn AriaRoleDefinitionWithConcepts,
                 "definition" => &DefinitionRole as &dyn AriaRoleDefinitionWithConcepts,
@@ -1289,8 +1283,6 @@ impl<'a> AriaRoles {
             "button" => &ButtonRole as &dyn AriaRoleDefinitionWithConcepts,
             "article" => &ArticleRole as &dyn AriaRoleDefinitionWithConcepts,
             "dialog" => &DialogRole as &dyn AriaRoleDefinitionWithConcepts,
-            "alert" => &AlertRole as &dyn AriaRoleDefinitionWithConcepts,
-            "alertdialog" => &AlertDialogRole as &dyn AriaRoleDefinitionWithConcepts,
             "cell" => &CellRole as &dyn AriaRoleDefinitionWithConcepts,
             "columnheader" => &ColumnHeaderRole as &dyn AriaRoleDefinitionWithConcepts,
             "definition" => &DefinitionRole as &dyn AriaRoleDefinitionWithConcepts,

--- a/crates/biome_js_analyze/tests/specs/a11y/useSemanticElements/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useSemanticElements/invalid.jsx
@@ -8,8 +8,6 @@
     <div role="button" ></div>
     <div role="article" ></div>
     <div role="dialog" ></div>
-    <div role="alert" ></div>
-    <div role="alertdialog" ></div>
     <div role="cell" ></div>
     <div role="columnheader" ></div>
     <div role="definition" ></div>

--- a/crates/biome_js_analyze/tests/specs/a11y/useSemanticElements/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useSemanticElements/invalid.jsx.snap
@@ -14,8 +14,6 @@ expression: invalid.jsx
     <div role="button" ></div>
     <div role="article" ></div>
     <div role="dialog" ></div>
-    <div role="alert" ></div>
-    <div role="alertdialog" ></div>
     <div role="cell" ></div>
     <div role="columnheader" ></div>
     <div role="definition" ></div>
@@ -206,7 +204,7 @@ invalid.jsx:9:10 lint/a11y/useSemanticElements ━━━━━━━━━━━
    > 9 │     <div role="article" ></div>
        │          ^^^^^^^^^^^^^^
     10 │     <div role="dialog" ></div>
-    11 │     <div role="alert" ></div>
+    11 │     <div role="cell" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -224,8 +222,8 @@ invalid.jsx:10:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
      9 │     <div role="article" ></div>
   > 10 │     <div role="dialog" ></div>
        │          ^^^^^^^^^^^^^
-    11 │     <div role="alert" ></div>
-    12 │     <div role="alertdialog" ></div>
+    11 │     <div role="cell" ></div>
+    12 │     <div role="columnheader" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -236,15 +234,15 @@ invalid.jsx:10:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:11:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <alert>
+    <td>
   
   
      9 │     <div role="article" ></div>
     10 │     <div role="dialog" ></div>
-  > 11 │     <div role="alert" ></div>
-       │          ^^^^^^^^^^^^
-    12 │     <div role="alertdialog" ></div>
-    13 │     <div role="cell" ></div>
+  > 11 │     <div role="cell" ></div>
+       │          ^^^^^^^^^^^
+    12 │     <div role="columnheader" ></div>
+    13 │     <div role="definition" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -255,15 +253,15 @@ invalid.jsx:11:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:12:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <alert>
+    <th scope="col">
   
   
     10 │     <div role="dialog" ></div>
-    11 │     <div role="alert" ></div>
-  > 12 │     <div role="alertdialog" ></div>
-       │          ^^^^^^^^^^^^^^^^^^
-    13 │     <div role="cell" ></div>
-    14 │     <div role="columnheader" ></div>
+    11 │     <div role="cell" ></div>
+  > 12 │     <div role="columnheader" ></div>
+       │          ^^^^^^^^^^^^^^^^^^^
+    13 │     <div role="definition" ></div>
+    14 │     <div role="figure" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -274,15 +272,16 @@ invalid.jsx:12:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:13:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <td>
+    <dd>
+    <dfn>
   
   
-    11 │     <div role="alert" ></div>
-    12 │     <div role="alertdialog" ></div>
-  > 13 │     <div role="cell" ></div>
-       │          ^^^^^^^^^^^
-    14 │     <div role="columnheader" ></div>
-    15 │     <div role="definition" ></div>
+    11 │     <div role="cell" ></div>
+    12 │     <div role="columnheader" ></div>
+  > 13 │     <div role="definition" ></div>
+       │          ^^^^^^^^^^^^^^^^^
+    14 │     <div role="figure" ></div>
+    15 │     <div role="form" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -293,15 +292,15 @@ invalid.jsx:13:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:14:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <th scope="col">
+    <figure>
   
   
-    12 │     <div role="alertdialog" ></div>
-    13 │     <div role="cell" ></div>
-  > 14 │     <div role="columnheader" ></div>
-       │          ^^^^^^^^^^^^^^^^^^^
-    15 │     <div role="definition" ></div>
-    16 │     <div role="figure" ></div>
+    12 │     <div role="columnheader" ></div>
+    13 │     <div role="definition" ></div>
+  > 14 │     <div role="figure" ></div>
+       │          ^^^^^^^^^^^^^
+    15 │     <div role="form" ></div>
+    16 │     <div role="graphics-document" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -312,16 +311,15 @@ invalid.jsx:14:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:15:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <dd>
-    <dfn>
+    <form>
   
   
-    13 │     <div role="cell" ></div>
-    14 │     <div role="columnheader" ></div>
-  > 15 │     <div role="definition" ></div>
-       │          ^^^^^^^^^^^^^^^^^
-    16 │     <div role="figure" ></div>
-    17 │     <div role="form" ></div>
+    13 │     <div role="definition" ></div>
+    14 │     <div role="figure" ></div>
+  > 15 │     <div role="form" ></div>
+       │          ^^^^^^^^^^^
+    16 │     <div role="graphics-document" ></div>
+    17 │     <div role="graphics-object" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -332,15 +330,17 @@ invalid.jsx:15:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:16:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <figure>
+    <graphics-object>
+    <img>
+    <article>
   
   
-    14 │     <div role="columnheader" ></div>
-    15 │     <div role="definition" ></div>
-  > 16 │     <div role="figure" ></div>
-       │          ^^^^^^^^^^^^^
-    17 │     <div role="form" ></div>
-    18 │     <div role="graphics-document" ></div>
+    14 │     <div role="figure" ></div>
+    15 │     <div role="form" ></div>
+  > 16 │     <div role="graphics-document" ></div>
+       │          ^^^^^^^^^^^^^^^^^^^^^^^^
+    17 │     <div role="graphics-object" ></div>
+    18 │     <div role="grid" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -351,15 +351,18 @@ invalid.jsx:16:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:17:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <form>
+    <graphics-document>
+    <group>
+    <img>
+    <graphics-symbol>
   
   
-    15 │     <div role="definition" ></div>
-    16 │     <div role="figure" ></div>
-  > 17 │     <div role="form" ></div>
-       │          ^^^^^^^^^^^
-    18 │     <div role="graphics-document" ></div>
-    19 │     <div role="graphics-object" ></div>
+    15 │     <div role="form" ></div>
+    16 │     <div role="graphics-document" ></div>
+  > 17 │     <div role="graphics-object" ></div>
+       │          ^^^^^^^^^^^^^^^^^^^^^^
+    18 │     <div role="grid" ></div>
+    19 │     <div role="gridcell" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -370,17 +373,15 @@ invalid.jsx:17:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:18:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <graphics-object>
-    <img>
-    <article>
+    <table>
   
   
-    16 │     <div role="figure" ></div>
-    17 │     <div role="form" ></div>
-  > 18 │     <div role="graphics-document" ></div>
-       │          ^^^^^^^^^^^^^^^^^^^^^^^^
-    19 │     <div role="graphics-object" ></div>
-    20 │     <div role="grid" ></div>
+    16 │     <div role="graphics-document" ></div>
+    17 │     <div role="graphics-object" ></div>
+  > 18 │     <div role="grid" ></div>
+       │          ^^^^^^^^^^^
+    19 │     <div role="gridcell" ></div>
+    20 │     <div role="group" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -391,18 +392,15 @@ invalid.jsx:18:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:19:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <graphics-document>
-    <group>
-    <img>
-    <graphics-symbol>
+    <td>
   
   
-    17 │     <div role="form" ></div>
-    18 │     <div role="graphics-document" ></div>
-  > 19 │     <div role="graphics-object" ></div>
-       │          ^^^^^^^^^^^^^^^^^^^^^^
-    20 │     <div role="grid" ></div>
-    21 │     <div role="gridcell" ></div>
+    17 │     <div role="graphics-object" ></div>
+    18 │     <div role="grid" ></div>
+  > 19 │     <div role="gridcell" ></div>
+       │          ^^^^^^^^^^^^^^^
+    20 │     <div role="group" ></div>
+    21 │     <div role="img" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -413,15 +411,15 @@ invalid.jsx:19:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:20:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <table>
+    <fieldset>
   
   
-    18 │     <div role="graphics-document" ></div>
-    19 │     <div role="graphics-object" ></div>
-  > 20 │     <div role="grid" ></div>
-       │          ^^^^^^^^^^^
-    21 │     <div role="gridcell" ></div>
-    22 │     <div role="group" ></div>
+    18 │     <div role="grid" ></div>
+    19 │     <div role="gridcell" ></div>
+  > 20 │     <div role="group" ></div>
+       │          ^^^^^^^^^^^^
+    21 │     <div role="img" ></div>
+    22 │     <div role="link" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -432,15 +430,15 @@ invalid.jsx:20:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:21:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <td>
+    <img>
   
   
-    19 │     <div role="graphics-object" ></div>
-    20 │     <div role="grid" ></div>
-  > 21 │     <div role="gridcell" ></div>
-       │          ^^^^^^^^^^^^^^^
-    22 │     <div role="group" ></div>
-    23 │     <div role="img" ></div>
+    19 │     <div role="gridcell" ></div>
+    20 │     <div role="group" ></div>
+  > 21 │     <div role="img" ></div>
+       │          ^^^^^^^^^^
+    22 │     <div role="link" ></div>
+    23 │     <div role="list" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -451,15 +449,16 @@ invalid.jsx:21:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:22:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <fieldset>
+    <a>
+    <link>
   
   
-    20 │     <div role="grid" ></div>
-    21 │     <div role="gridcell" ></div>
-  > 22 │     <div role="group" ></div>
-       │          ^^^^^^^^^^^^
-    23 │     <div role="img" ></div>
-    24 │     <div role="link" ></div>
+    20 │     <div role="group" ></div>
+    21 │     <div role="img" ></div>
+  > 22 │     <div role="link" ></div>
+       │          ^^^^^^^^^^^
+    23 │     <div role="list" ></div>
+    24 │     <div role="listbox" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -470,15 +469,16 @@ invalid.jsx:22:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:23:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <img>
+    <ol>
+    <ul>
   
   
-    21 │     <div role="gridcell" ></div>
-    22 │     <div role="group" ></div>
-  > 23 │     <div role="img" ></div>
-       │          ^^^^^^^^^^
-    24 │     <div role="link" ></div>
-    25 │     <div role="list" ></div>
+    21 │     <div role="img" ></div>
+    22 │     <div role="link" ></div>
+  > 23 │     <div role="list" ></div>
+       │          ^^^^^^^^^^^
+    24 │     <div role="listbox" ></div>
+    25 │     <div role="listitem" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -489,16 +489,15 @@ invalid.jsx:23:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:24:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <a>
-    <link>
+    <select>
   
   
-    22 │     <div role="group" ></div>
-    23 │     <div role="img" ></div>
-  > 24 │     <div role="link" ></div>
-       │          ^^^^^^^^^^^
-    25 │     <div role="list" ></div>
-    26 │     <div role="listbox" ></div>
+    22 │     <div role="link" ></div>
+    23 │     <div role="list" ></div>
+  > 24 │     <div role="listbox" ></div>
+       │          ^^^^^^^^^^^^^^
+    25 │     <div role="listitem" ></div>
+    26 │     <div role="navigation" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -509,16 +508,15 @@ invalid.jsx:24:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:25:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <ol>
-    <ul>
+    <li>
   
   
-    23 │     <div role="img" ></div>
-    24 │     <div role="link" ></div>
-  > 25 │     <div role="list" ></div>
-       │          ^^^^^^^^^^^
-    26 │     <div role="listbox" ></div>
-    27 │     <div role="listitem" ></div>
+    23 │     <div role="list" ></div>
+    24 │     <div role="listbox" ></div>
+  > 25 │     <div role="listitem" ></div>
+       │          ^^^^^^^^^^^^^^^
+    26 │     <div role="navigation" ></div>
+    27 │     <div role="row" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -529,15 +527,15 @@ invalid.jsx:25:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:26:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <select>
+    <nav>
   
   
-    24 │     <div role="link" ></div>
-    25 │     <div role="list" ></div>
-  > 26 │     <div role="listbox" ></div>
-       │          ^^^^^^^^^^^^^^
-    27 │     <div role="listitem" ></div>
-    28 │     <div role="navigation" ></div>
+    24 │     <div role="listbox" ></div>
+    25 │     <div role="listitem" ></div>
+  > 26 │     <div role="navigation" ></div>
+       │          ^^^^^^^^^^^^^^^^^
+    27 │     <div role="row" ></div>
+    28 │     <div role="rowgroup" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -548,15 +546,15 @@ invalid.jsx:26:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:27:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <li>
+    <tr>
   
   
-    25 │     <div role="list" ></div>
-    26 │     <div role="listbox" ></div>
-  > 27 │     <div role="listitem" ></div>
-       │          ^^^^^^^^^^^^^^^
-    28 │     <div role="navigation" ></div>
-    29 │     <div role="row" ></div>
+    25 │     <div role="listitem" ></div>
+    26 │     <div role="navigation" ></div>
+  > 27 │     <div role="row" ></div>
+       │          ^^^^^^^^^^
+    28 │     <div role="rowgroup" ></div>
+    29 │     <div role="rowheader" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -567,15 +565,17 @@ invalid.jsx:27:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:28:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <nav>
+    <tbody>
+    <tfoot>
+    <thead>
   
   
-    26 │     <div role="listbox" ></div>
-    27 │     <div role="listitem" ></div>
-  > 28 │     <div role="navigation" ></div>
-       │          ^^^^^^^^^^^^^^^^^
-    29 │     <div role="row" ></div>
-    30 │     <div role="rowgroup" ></div>
+    26 │     <div role="navigation" ></div>
+    27 │     <div role="row" ></div>
+  > 28 │     <div role="rowgroup" ></div>
+       │          ^^^^^^^^^^^^^^^
+    29 │     <div role="rowheader" ></div>
+    30 │     <div role="search" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -586,15 +586,15 @@ invalid.jsx:28:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:29:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <tr>
+    <th scope="row">
   
   
-    27 │     <div role="listitem" ></div>
-    28 │     <div role="navigation" ></div>
-  > 29 │     <div role="row" ></div>
-       │          ^^^^^^^^^^
-    30 │     <div role="rowgroup" ></div>
-    31 │     <div role="rowheader" ></div>
+    27 │     <div role="row" ></div>
+    28 │     <div role="rowgroup" ></div>
+  > 29 │     <div role="rowheader" ></div>
+       │          ^^^^^^^^^^^^^^^^
+    30 │     <div role="search" ></div>
+    31 │     <div role="searchbox" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -605,17 +605,15 @@ invalid.jsx:29:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:30:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <tbody>
-    <tfoot>
-    <thead>
+    <input type="search">
   
   
-    28 │     <div role="navigation" ></div>
-    29 │     <div role="row" ></div>
-  > 30 │     <div role="rowgroup" ></div>
-       │          ^^^^^^^^^^^^^^^
-    31 │     <div role="rowheader" ></div>
-    32 │     <div role="search" ></div>
+    28 │     <div role="rowgroup" ></div>
+    29 │     <div role="rowheader" ></div>
+  > 30 │     <div role="search" ></div>
+       │          ^^^^^^^^^^^^^
+    31 │     <div role="searchbox" ></div>
+    32 │     <div role="table" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -626,15 +624,15 @@ invalid.jsx:30:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:31:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <th scope="row">
+    <input type="search">
   
   
-    29 │     <div role="row" ></div>
-    30 │     <div role="rowgroup" ></div>
-  > 31 │     <div role="rowheader" ></div>
+    29 │     <div role="rowheader" ></div>
+    30 │     <div role="search" ></div>
+  > 31 │     <div role="searchbox" ></div>
        │          ^^^^^^^^^^^^^^^^
-    32 │     <div role="search" ></div>
-    33 │     <div role="searchbox" ></div>
+    32 │     <div role="table" ></div>
+    33 │     <div role="term" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -645,15 +643,15 @@ invalid.jsx:31:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:32:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <input type="search">
+    <table>
   
   
-    30 │     <div role="rowgroup" ></div>
-    31 │     <div role="rowheader" ></div>
-  > 32 │     <div role="search" ></div>
-       │          ^^^^^^^^^^^^^
-    33 │     <div role="searchbox" ></div>
-    34 │     <div role="table" ></div>
+    30 │     <div role="search" ></div>
+    31 │     <div role="searchbox" ></div>
+  > 32 │     <div role="table" ></div>
+       │          ^^^^^^^^^^^^
+    33 │     <div role="term" ></div>
+    34 │     <div role="textbox" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -664,15 +662,15 @@ invalid.jsx:32:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:33:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <input type="search">
+    <dt>
   
   
-    31 │     <div role="rowheader" ></div>
-    32 │     <div role="search" ></div>
-  > 33 │     <div role="searchbox" ></div>
-       │          ^^^^^^^^^^^^^^^^
-    34 │     <div role="table" ></div>
-    35 │     <div role="term" ></div>
+    31 │     <div role="searchbox" ></div>
+    32 │     <div role="table" ></div>
+  > 33 │     <div role="term" ></div>
+       │          ^^^^^^^^^^^
+    34 │     <div role="textbox" ></div>
+    35 │     <div role="generic" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -683,15 +681,16 @@ invalid.jsx:33:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:34:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <table>
+    <textarea>
+    <input type="search">
   
   
-    32 │     <div role="search" ></div>
-    33 │     <div role="searchbox" ></div>
-  > 34 │     <div role="table" ></div>
-       │          ^^^^^^^^^^^^
-    35 │     <div role="term" ></div>
-    36 │     <div role="textbox" ></div>
+    32 │     <div role="table" ></div>
+    33 │     <div role="term" ></div>
+  > 34 │     <div role="textbox" ></div>
+       │          ^^^^^^^^^^^^^^
+    35 │     <div role="generic" ></div>
+    36 │     <div role="caption" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -702,15 +701,16 @@ invalid.jsx:34:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:35:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <dt>
+    <div>
+    <span>
   
   
-    33 │     <div role="searchbox" ></div>
-    34 │     <div role="table" ></div>
-  > 35 │     <div role="term" ></div>
-       │          ^^^^^^^^^^^
-    36 │     <div role="textbox" ></div>
-    37 │     <div role="generic" ></div>
+    33 │     <div role="term" ></div>
+    34 │     <div role="textbox" ></div>
+  > 35 │     <div role="generic" ></div>
+       │          ^^^^^^^^^^^^^^
+    36 │     <div role="caption" ></div>
+    37 │     <div role="main" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -721,16 +721,17 @@ invalid.jsx:35:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:36:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <textarea>
-    <input type="search">
+    <caption>
+    <figcaption>
+    <legend>
   
   
-    34 │     <div role="table" ></div>
-    35 │     <div role="term" ></div>
-  > 36 │     <div role="textbox" ></div>
+    34 │     <div role="textbox" ></div>
+    35 │     <div role="generic" ></div>
+  > 36 │     <div role="caption" ></div>
        │          ^^^^^^^^^^^^^^
-    37 │     <div role="generic" ></div>
-    38 │     <div role="caption" ></div>
+    37 │     <div role="main" ></div>
+    38 │     <div role="time" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -741,16 +742,15 @@ invalid.jsx:36:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:37:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <div>
-    <span>
+    <main>
   
   
-    35 │     <div role="term" ></div>
-    36 │     <div role="textbox" ></div>
-  > 37 │     <div role="generic" ></div>
-       │          ^^^^^^^^^^^^^^
-    38 │     <div role="caption" ></div>
-    39 │     <div role="main" ></div>
+    35 │     <div role="generic" ></div>
+    36 │     <div role="caption" ></div>
+  > 37 │     <div role="main" ></div>
+       │          ^^^^^^^^^^^
+    38 │     <div role="time" ></div>
+    39 │     <div role="p" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -761,17 +761,15 @@ invalid.jsx:37:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:38:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <caption>
-    <figcaption>
-    <legend>
+    <time>
   
   
-    36 │     <div role="textbox" ></div>
-    37 │     <div role="generic" ></div>
-  > 38 │     <div role="caption" ></div>
-       │          ^^^^^^^^^^^^^^
-    39 │     <div role="main" ></div>
-    40 │     <div role="time" ></div>
+    36 │     <div role="caption" ></div>
+    37 │     <div role="main" ></div>
+  > 38 │     <div role="time" ></div>
+       │          ^^^^^^^^^^^
+    39 │     <div role="p" ></div>
+    40 │     <div role="aside" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -782,15 +780,15 @@ invalid.jsx:38:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:39:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <main>
+    <p>
   
   
-    37 │     <div role="generic" ></div>
-    38 │     <div role="caption" ></div>
-  > 39 │     <div role="main" ></div>
-       │          ^^^^^^^^^^^
-    40 │     <div role="time" ></div>
-    41 │     <div role="p" ></div>
+    37 │     <div role="main" ></div>
+    38 │     <div role="time" ></div>
+  > 39 │     <div role="p" ></div>
+       │          ^^^^^^^^
+    40 │     <div role="aside" ></div>
+    41 │     <div role="blockquote" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -801,15 +799,15 @@ invalid.jsx:39:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:40:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <time>
+    <aside>
   
   
-    38 │     <div role="caption" ></div>
-    39 │     <div role="main" ></div>
-  > 40 │     <div role="time" ></div>
-       │          ^^^^^^^^^^^
-    41 │     <div role="p" ></div>
-    42 │     <div role="aside" ></div>
+    38 │     <div role="time" ></div>
+    39 │     <div role="p" ></div>
+  > 40 │     <div role="aside" ></div>
+       │          ^^^^^^^^^^^^
+    41 │     <div role="blockquote" ></div>
+    42 │     <div role="associationlist" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -820,15 +818,15 @@ invalid.jsx:40:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:41:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <p>
+    <blockquote>
   
   
-    39 │     <div role="main" ></div>
-    40 │     <div role="time" ></div>
-  > 41 │     <div role="p" ></div>
-       │          ^^^^^^^^
-    42 │     <div role="aside" ></div>
-    43 │     <div role="blockquote" ></div>
+    39 │     <div role="p" ></div>
+    40 │     <div role="aside" ></div>
+  > 41 │     <div role="blockquote" ></div>
+       │          ^^^^^^^^^^^^^^^^^
+    42 │     <div role="associationlist" ></div>
+    43 │     <div role="status" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -839,15 +837,15 @@ invalid.jsx:41:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:42:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <aside>
+    <dl>
   
   
-    40 │     <div role="time" ></div>
-    41 │     <div role="p" ></div>
-  > 42 │     <div role="aside" ></div>
-       │          ^^^^^^^^^^^^
-    43 │     <div role="blockquote" ></div>
-    44 │     <div role="associationlist" ></div>
+    40 │     <div role="aside" ></div>
+    41 │     <div role="blockquote" ></div>
+  > 42 │     <div role="associationlist" ></div>
+       │          ^^^^^^^^^^^^^^^^^^^^^^
+    43 │     <div role="status" ></div>
+    44 │     <div role="contentinfo" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -858,15 +856,15 @@ invalid.jsx:42:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:43:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <blockquote>
+    <output>
   
   
-    41 │     <div role="p" ></div>
-    42 │     <div role="aside" ></div>
-  > 43 │     <div role="blockquote" ></div>
-       │          ^^^^^^^^^^^^^^^^^
-    44 │     <div role="associationlist" ></div>
-    45 │     <div role="status" ></div>
+    41 │     <div role="blockquote" ></div>
+    42 │     <div role="associationlist" ></div>
+  > 43 │     <div role="status" ></div>
+       │          ^^^^^^^^^^^^^
+    44 │     <div role="contentinfo" ></div>
+    45 │     <div role="region" ></div>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -877,15 +875,15 @@ invalid.jsx:43:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:44:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <dl>
+    <footer>
   
   
-    42 │     <div role="aside" ></div>
-    43 │     <div role="blockquote" ></div>
-  > 44 │     <div role="associationlist" ></div>
-       │          ^^^^^^^^^^^^^^^^^^^^^^
-    45 │     <div role="status" ></div>
-    46 │     <div role="contentinfo" ></div>
+    42 │     <div role="associationlist" ></div>
+    43 │     <div role="status" ></div>
+  > 44 │     <div role="contentinfo" ></div>
+       │          ^^^^^^^^^^^^^^^^^^
+    45 │     <div role="region" ></div>
+    46 │ </>
   
   i For examples and more information, see WAI-ARIA Roles
   
@@ -896,53 +894,15 @@ invalid.jsx:44:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:45:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <output>
-  
-  
-    43 │     <div role="blockquote" ></div>
-    44 │     <div role="associationlist" ></div>
-  > 45 │     <div role="status" ></div>
-       │          ^^^^^^^^^^^^^
-    46 │     <div role="contentinfo" ></div>
-    47 │     <div role="region" ></div>
-  
-  i For examples and more information, see WAI-ARIA Roles
-  
-
-```
-
-```
-invalid.jsx:46:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The elements with the following roles can be changed to the following elements:
-    <footer>
-  
-  
-    44 │     <div role="associationlist" ></div>
-    45 │     <div role="status" ></div>
-  > 46 │     <div role="contentinfo" ></div>
-       │          ^^^^^^^^^^^^^^^^^^
-    47 │     <div role="region" ></div>
-    48 │ </>
-  
-  i For examples and more information, see WAI-ARIA Roles
-  
-
-```
-
-```
-invalid.jsx:47:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The elements with the following roles can be changed to the following elements:
     <section>
   
   
-    45 │     <div role="status" ></div>
-    46 │     <div role="contentinfo" ></div>
-  > 47 │     <div role="region" ></div>
+    43 │     <div role="status" ></div>
+    44 │     <div role="contentinfo" ></div>
+  > 45 │     <div role="region" ></div>
        │          ^^^^^^^^^^^^^
-    48 │ </>
-    49 │ 
+    46 │ </>
+    47 │ 
   
   i For examples and more information, see WAI-ARIA Roles
   

--- a/crates/biome_js_analyze/tests/specs/a11y/useSemanticElements/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useSemanticElements/valid.jsx
@@ -15,3 +15,8 @@ export const Component2 = () => (
 
 export const C = <svg role="img" aria-label="Description of your SVG image">
 </svg>;
+
+<>
+    <div role="alert"></div>
+    <div role="alertdialog"></div>
+</>

--- a/crates/biome_js_analyze/tests/specs/a11y/useSemanticElements/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useSemanticElements/valid.jsx.snap
@@ -22,4 +22,41 @@ export const Component2 = () => (
 export const C = <svg role="img" aria-label="Description of your SVG image">
 </svg>;
 
+<>
+    <div role="alert"></div>
+    <div role="alertdialog"></div>
+</>
+```
+
+# Diagnostics
+```
+valid.jsx:20:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The element with this role can be changed to a DOM element that already this role.
+  
+    19 │ <>
+  > 20 │     <div role="alert"></div>
+       │          ^^^^^^^^^^^^
+    21 │     <div role="alertdialog"></div>
+    22 │ </>
+  
+  i For examples and more information, see WAI-ARIA Roles
+  
+
+```
+
+```
+valid.jsx:21:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The element with this role can be changed to a DOM element that already this role.
+  
+    19 │ <>
+    20 │     <div role="alert"></div>
+  > 21 │     <div role="alertdialog"></div>
+       │          ^^^^^^^^^^^^^^^^^^
+    22 │ </>
+  
+  i For examples and more information, see WAI-ARIA Roles
+  
+
 ```


### PR DESCRIPTION
## Summary

Fix #3858

The [alert role](https://www.w3.org/TR/wai-aria-1.2/#alert) and [alertdialog role](https://www.w3.org/TR/wai-aria-1.2/#alert) have no associated concepts according to the spec.

I noticed several errors in the provided metadata (divergence from the spec). Also, this is modeled on the 1.1 spec. We should update it to 1.2.
All these fixes are out of scope for this PR.

## Test Plan

I updated the tests.