### PR TITLE
fix(editorconfig): fix editorconfig not being loaded when running `biome ci`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### CLI
 
+#### Bug fixes
+
+- `useEditorConfig` now loads the editorconfig when running `biome ci` [#3864](https://github.com/biomejs/biome/issues/3864). Contributed by @dyc3
+
 ### Configuration
 
 ### Editors

--- a/crates/biome_cli/tests/cases/editorconfig.rs
+++ b/crates/biome_cli/tests/cases/editorconfig.rs
@@ -360,3 +360,95 @@ indent_style = space
         result,
     ));
 }
+
+#[test]
+fn should_use_editorconfig_ci() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let editorconfig = Path::new(".editorconfig");
+    fs.insert(
+        editorconfig.into(),
+        r#"
+[*]
+max_line_length = 300
+"#,
+    );
+
+    let test_file = Path::new("test.js");
+    let contents = r#"console.log("really long string that should cause a break if the line width remains at the default 80 characters");
+"#;
+    fs.insert(test_file.into(), contents);
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("ci"),
+                ("--use-editorconfig=true"),
+                test_file.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, test_file, contents);
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_use_editorconfig_ci",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_use_editorconfig_ci_enabled_from_biome_conf() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let editorconfig = Path::new(".editorconfig");
+    fs.insert(
+        editorconfig.into(),
+        r#"
+[*]
+max_line_length = 300
+"#,
+    );
+
+    let biomeconfig = Path::new("biome.json");
+    fs.insert(
+        biomeconfig.into(),
+        r#"{
+    "formatter": {
+        "useEditorconfig": true
+    }
+}
+"#,
+    );
+
+    let test_file = Path::new("test.js");
+    let contents = r#"console.log("really long string that should cause a break if the line width remains at the default 80 characters");
+"#;
+    fs.insert(test_file.into(), contents);
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("ci"), test_file.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, test_file, contents);
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_use_editorconfig_ci_enabled_from_biome_conf",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_use_editorconfig_ci.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_use_editorconfig_ci.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `.editorconfig`
+
+```editorconfig
+
+[*]
+max_line_length = 300
+
+```
+
+## `test.js`
+
+```js
+console.log("really long string that should cause a break if the line width remains at the default 80 characters");
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_use_editorconfig_ci_enabled_from_biome_conf.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_use_editorconfig_ci_enabled_from_biome_conf.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "useEditorconfig": true
+  }
+}
+```
+
+## `.editorconfig`
+
+```editorconfig
+
+[*]
+max_line_length = 300
+
+```
+
+## `test.js`
+
+```js
+console.log("really long string that should cause a break if the line width remains at the default 80 characters");
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This makes biome load `.editorconfig` files when running `biome ci`.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

fixes #3864

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added unit tests
