### PR TITLE
chore: add `noConsole` options documentation

### DIFF
--- a/crates/biome_js_analyze/src/lint/suspicious/no_console.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_console.rs
@@ -25,6 +25,19 @@ declare_lint_rule! {
     /// console.error('hello world')
     /// ```
     ///
+    /// ## Options
+    ///
+    /// Use the options to specify the allowed `console` methods.
+    ///
+    /// ```json
+    /// {
+    ///   "//": "...",
+    ///   "options": {
+    ///     "allow": ["assert", "error", "info", "warn"]
+    ///   }
+    /// }
+    /// ```
+    ///
     pub NoConsole {
         version: "1.6.0",
         name: "noConsole",


### PR DESCRIPTION
## Summary

This PR adds `noConsole` options documentation. (The `allow` option was added in #3786.)

## Test Plan

N/A