### PR TITLE
chore: tweak `useConsistentArrayType` rule documentation

### DIFF
--- a/crates/biome_js_analyze/src/lint/style/use_consistent_array_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_consistent_array_type.rs
@@ -64,8 +64,8 @@ declare_lint_rule! {
     /// ### syntax
     ///
     /// The syntax to use:
-    /// - `generic`, array declarations will be converted to `Array<T>` or `ReadonlyArray<T>`
-    /// - `shorthand`, array declarations will be converted to `T[]` or `readonly T[]`
+    /// - `generic`: array declarations will be converted to `Array<T>` or `ReadonlyArray<T>`
+    /// - `shorthand`: array declarations will be converted to `T[]` or `readonly T[]`
     ///
     /// Default: `shorthand`
     ///

--- a/crates/biome_js_analyze/src/lint/style/use_consistent_array_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_consistent_array_type.rs
@@ -49,9 +49,8 @@ declare_lint_rule! {
     /// ```
     ///
     /// ## Options
-    /// The rule provides two options that help to specify what type of array declarations to use.
     ///
-    /// Default: "shorthand"
+    /// Use the options to specify the syntax of array declarations to use.
     ///
     /// ```json
     /// {
@@ -61,10 +60,14 @@ declare_lint_rule! {
     ///     }
     /// }
     /// ```
-    /// ### Syntax
     ///
-    /// By default, all array declarations will be converted to `T[]` or `readonly T[]`, which it means `shorthand`,
-    /// or if the options is set to the "generic", that all will converted to `Array<T>` or `ReadonlyArray<T>`.
+    /// ### syntax
+    ///
+    /// The syntax to use:
+    /// - `generic`, array declarations will be converted to `Array<T>` or `ReadonlyArray<T>`
+    /// - `shorthand`, array declarations will be converted to `T[]` or `readonly T[]`
+    ///
+    /// Default: `shorthand`
     ///
     pub UseConsistentArrayType {
         version: "1.5.0",


### PR DESCRIPTION
## Summary

These are few minor changes in `useConsistentArrayType` rule documentation:

- "Default" was is move into the description of the option
- the heading is now set in lower case (`syntax`) to match the option name
- and I used bullet points (similar to [`useNamingConvention`](https://biomejs.dev/linter/rules/use-naming-convention/) documentation)

## Test Plan

N/A