### PR TITLE
fix(noUndeclaredDependencies): ignore invalid package names, bun import, and recognize Definitely Typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
-- [useSemanticElements](https://biomejs.dev/linter/rules/use-semantic-elements/): ignore `alert` and `alertdialog` roles ([3858](https://github.com/biomejs/biome/issues/3858)). Controbuted by @Conaclos
+- [useSemanticElements](https://biomejs.dev/linter/rules/use-semantic-elements/) now ignores `alert` and `alertdialog` roles ([3858](https://github.com/biomejs/biome/issues/3858)). Contributed by @Conaclos
+
+- [noUndeclaredDependencies](https://biomejs.dev/linter/rules/no-undeclared-dependencies/) now ignores `@/` imports and recognizes type imports from Definitely Typed and `bun` imports. Contributed by @Conaclos
 
 ### Parser
 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.package.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.package.json
@@ -9,7 +9,8 @@
 		"tailwindcss": "3.4.1"
 	},
 	"devDependencies": {
-		"@testing-library/react": "1.0.0"
+		"@testing-library/react": "1.0.0",
+		"@types/lodash": "1.0.0"
 	},
 	"peerDependencies": {
 		"peer-dep": "1.0.0"

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts
@@ -1,9 +1,3 @@
----
-source: crates/biome_js_analyze/tests/spec_tests.rs
-expression: valid.js
----
-# Input
-```jsx
 import "./valid";
 import "react";
 import "@testing-library/react";
@@ -26,4 +20,11 @@ import "peer-dep";
 import "optional-dep";
 
 import "my-package"
-```
+
+import "@/internal";
+import "#internal";
+
+// import from `@types/jest`
+import type * as jest from "lodash";
+
+import "bun";

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts.snap
@@ -1,3 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```ts
 import "./valid";
 import "react";
 import "@testing-library/react";
@@ -20,3 +26,12 @@ import "peer-dep";
 import "optional-dep";
 
 import "my-package"
+
+import "@/internal";
+import "#internal";
+
+// import from `@types/jest`
+import type * as jest from "lodash";
+
+import "bun";
+```


### PR DESCRIPTION
## Summary

Fix #3874
Fix #3872

We now ensure that the package name is valid before checking if it is a dependency.
Note that I deliberately accepted some invalid package names (package names starting with an underscore and package name with uppercase character) in order to catch users' typo errors.

We also ignore `bun` imports.
This looks fair because the NPM module named `bun` is from the `bun` runtime.

## Test Plan

I added some tests.
