### PR TITLE
fix(config): handle `unset` and `off` values in editorconfig files

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_emit_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_emit_diagnostics.snap
@@ -1,0 +1,33 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `.editorconfig`
+
+```editorconfig
+
+[*]
+insert_final_newline = false
+
+```
+
+## `test.js`
+
+```js
+console.log("foo");
+
+```
+
+# Emitted Messages
+
+```block
+configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Key 'insert_final_newline' is incompatible with biome: Biome always inserts a final newline. Set this option to true.
+  
+
+```
+
+```block
+Formatted 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_configuration/src/diagnostics.rs
+++ b/crates/biome_configuration/src/diagnostics.rs
@@ -246,7 +246,7 @@ pub enum EditorConfigDiagnostic {
     /// Failed to parse the .editorconfig file.
     ParseFailed(ParseFailedDiagnostic),
     /// An option is completely incompatible with biome.
-    Incompatible(InconpatibleDiagnostic),
+    Incompatible(IncompatibleDiagnostic),
     /// A glob pattern that biome doesn't support.
     UnknownGlobPattern(UnknownGlobPatternDiagnostic),
     /// A glob pattern that contains invalid syntax.
@@ -255,7 +255,7 @@ pub enum EditorConfigDiagnostic {
 
 impl EditorConfigDiagnostic {
     pub fn incompatible(key: impl Into<String>, message: impl Into<String>) -> Self {
-        Self::Incompatible(InconpatibleDiagnostic {
+        Self::Incompatible(IncompatibleDiagnostic {
             message: MessageAndDescription::from(
                 markup! { "Key '"{key.into()}"' is incompatible with biome: "{message.into()}}
                     .to_owned(),
@@ -299,7 +299,7 @@ pub struct ParseFailedDiagnostic {
     category = "configuration",
     severity = Error,
 )]
-pub struct InconpatibleDiagnostic {
+pub struct IncompatibleDiagnostic {
     #[message]
     #[description]
     pub message: MessageAndDescription,

--- a/crates/biome_configuration/src/editorconfig.rs
+++ b/crates/biome_configuration/src/editorconfig.rs
@@ -83,12 +83,14 @@ impl EditorConfig {
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(default)]
 pub struct EditorConfigOptions {
-    indent_style: Option<IndentStyle>,
-    #[serde(deserialize_with = "deserialize_optional_indent_width_from_string")]
-    indent_size: Option<IndentWidth>,
-    end_of_line: Option<LineEnding>,
-    #[serde(deserialize_with = "deserialize_optional_line_width_from_string")]
-    max_line_length: Option<LineWidth>,
+    #[serde(deserialize_with = "deserialize_optional_value_from_string")]
+    indent_style: EditorconfigValue<IndentStyle>,
+    #[serde(deserialize_with = "deserialize_optional_value_from_string")]
+    indent_size: EditorconfigValue<IndentWidth>,
+    #[serde(deserialize_with = "deserialize_optional_value_from_string")]
+    end_of_line: EditorconfigValue<LineEnding>,
+    #[serde(deserialize_with = "deserialize_optional_value_from_string")]
+    max_line_length: EditorconfigValue<LineWidth>,
     // Not a biome option, but we need it to emit a diagnostic when this is set to false.
     #[serde(deserialize_with = "deserialize_optional_bool_from_string")]
     insert_final_newline: Option<bool>,
@@ -97,20 +99,20 @@ pub struct EditorConfigOptions {
 impl EditorConfigOptions {
     pub fn to_biome(self) -> PartialFormatterConfiguration {
         PartialFormatterConfiguration {
-            indent_style: self.indent_style,
-            indent_width: self.indent_size,
-            line_ending: self.end_of_line,
-            line_width: self.max_line_length,
+            indent_style: self.indent_style.into(),
+            indent_width: self.indent_size.into(),
+            line_ending: self.end_of_line.into(),
+            line_width: self.max_line_length.into(),
             ..Default::default()
         }
     }
 
     pub fn to_biome_override(self) -> OverrideFormatterConfiguration {
         OverrideFormatterConfiguration {
-            indent_style: self.indent_style,
-            indent_width: self.indent_size,
-            line_ending: self.end_of_line,
-            line_width: self.max_line_length,
+            indent_style: self.indent_style.into(),
+            indent_width: self.indent_size.into(),
+            line_ending: self.end_of_line.into(),
+            line_width: self.max_line_length.into(),
             ..Default::default()
         }
     }
@@ -121,10 +123,35 @@ impl EditorConfigOptions {
         if let Some(false) = self.insert_final_newline {
             errors.push(EditorConfigDiagnostic::incompatible(
                 "insert_final_newline",
-                "Biome always inserts a final newline.",
+                "Biome always inserts a final newline. Set this option to true.",
             ));
         }
         errors
+    }
+}
+
+/// Represents a value in an .editorconfig file.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(untagged)]
+pub enum EditorconfigValue<T> {
+    /// The value was explicitly specified.
+    Explicit(T),
+    /// Use the default value for this option. This occurs when the value is `unset`.
+    Default,
+    /// The value was not specified.
+    #[default]
+    None,
+}
+
+// This is an `Into` because implementing `From` is not possible because you can't implement traits for a type you don't own.
+#[allow(clippy::from_over_into)]
+impl<T: Default> Into<Option<T>> for EditorconfigValue<T> {
+    fn into(self) -> Option<T> {
+        match self {
+            EditorconfigValue::Explicit(v) => Some(v),
+            EditorconfigValue::Default => Some(T::default()),
+            EditorconfigValue::None => None,
+        }
     }
 }
 
@@ -147,28 +174,21 @@ where
     deserialize_bool_from_string(deserializer).map(Some)
 }
 
-fn deserialize_optional_indent_width_from_string<'de, D>(
+fn deserialize_optional_value_from_string<'de, D, T>(
     deserializer: D,
-) -> Result<Option<IndentWidth>, D::Error>
+) -> Result<EditorconfigValue<T>, D::Error>
 where
     D: Deserializer<'de>,
+    T: FromStr,
+    T::Err: std::fmt::Display,
 {
     let s = String::deserialize(deserializer)?;
-    IndentWidth::from_str(s.as_str())
-        .map_err(serde::de::Error::custom)
-        .map(Some)
-}
-
-fn deserialize_optional_line_width_from_string<'de, D>(
-    deserializer: D,
-) -> Result<Option<LineWidth>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    LineWidth::from_str(s.as_str())
-        .map_err(serde::de::Error::custom)
-        .map(Some)
+    match s.as_str() {
+        "unset" | "off" => Ok(EditorconfigValue::Default),
+        _ => T::from_str(s.as_str())
+            .map_err(serde::de::Error::custom)
+            .map(EditorconfigValue::Explicit),
+    }
 }
 
 /// Turn an unknown glob pattern into a list of known glob patterns. This is part of a hack to support all editorconfig patterns.
@@ -408,6 +428,53 @@ insert_final_newline = false
         let (_, errors) = conf.to_biome();
         assert_eq!(errors.len(), 1);
         assert!(matches!(errors[0], EditorConfigDiagnostic::Incompatible(_)));
+    }
+
+    #[test]
+    fn should_parse_editorconfig_with_unset_values() {
+        let input = r#"
+root = true
+
+[*]
+indent_style = unset
+indent_size = unset
+end_of_line = unset
+max_line_length = unset
+"#;
+
+        let conf = parse_str(input).expect("Failed to parse editorconfig");
+        assert!(matches!(
+            conf.options["*"].indent_style,
+            EditorconfigValue::Default
+        ));
+        assert!(matches!(
+            conf.options["*"].indent_size,
+            EditorconfigValue::Default
+        ));
+        assert!(matches!(
+            conf.options["*"].end_of_line,
+            EditorconfigValue::Default
+        ));
+        assert!(matches!(
+            conf.options["*"].max_line_length,
+            EditorconfigValue::Default
+        ));
+    }
+
+    #[test]
+    fn should_parse_editorconfig_with_max_line_length_off() {
+        let input = r#"
+root = true
+
+[*]
+max_line_length = off
+"#;
+
+        let conf = parse_str(input).expect("Failed to parse editorconfig");
+        assert!(matches!(
+            conf.options["*"].max_line_length,
+            EditorconfigValue::Default,
+        ));
     }
 
     #[test]


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
In the editorconfig spec, `unset` means "use the default value" and `off` (in the context of `max_line_length`) means "completely turn off the line limit".

This PR aims to implement the behavior for `unset`, and `off`. ~provide a better diagnostic when encountering `off`. We technically can't really handle `off` because biome doesn't have a mechanism to turn off the max line length enforcement.~

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #3886
closes #3904

## Test Plan
Added some unit tests and a cli snapshot test
<!-- What demonstrates that your implementation is correct? -->
