### PR TITLE
fix(css_parser): accept U+FDCF and U+FFFD in identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Parser
 
+#### Bug fixes
+
+- The CSS parser now accepts the characters U+FFDCF and U+FFFD in identifiers. Contributed by @Conaclos
+
 ## v1.9.1 (2024-09-15)
 
 ### CLI

--- a/crates/biome_unicode_table/src/lib.rs
+++ b/crates/biome_unicode_table/src/lib.rs
@@ -13,6 +13,7 @@ pub fn is_html_id_start(c: char) -> bool {
 }
 
 /// Is `c` a CSS non-ascii character.
+/// See https://drafts.csswg.org/css-syntax-3/#ident-token-diagram
 #[inline]
 pub fn is_css_non_ascii(c: char) -> bool {
     matches!(
@@ -29,8 +30,8 @@ pub fn is_css_non_ascii(c: char) -> bool {
         | 0x2070..=0x218F
         | 0x2C00..=0x2FEF
         | 0x3001..=0xD7FF
-        | 0xF900..0xFDCF
-        | 0xFDF0..0xFFFD
+        | 0xF900..=0xFDCF
+        | 0xFDF0..=0xFFFD
         | 0x10000..
     )
 }


### PR DESCRIPTION
## Summary

The ranges should be inclusive.

## Test Plan

CI must pass.
