### PR TITLE
fix: preserve other children in `useConsistentCurlyBraces`

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_consistent_curly_braces.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_consistent_curly_braces.rs
@@ -270,6 +270,8 @@ impl Rule for UseConsistentCurlyBraces {
 
                     let child_list = node.parent::<JsxChildList>()?;
                     let mut children = vec![];
+                    let mut iter = (&child_list).into_iter();
+                    children.extend(iter.by_ref().take_while(|c| c != node));
                     if let Some(leading_comments_expr) = leading_comments_expr {
                         children.push(leading_comments_expr);
                     }
@@ -277,6 +279,7 @@ impl Rule for UseConsistentCurlyBraces {
                     if let Some(trailing_comments_expr) = trailing_comments_expr {
                         children.push(trailing_comments_expr);
                     }
+                    children.extend(iter);
                     let new_child_list = make::jsx_child_list(children);
 
                     mutation.replace_element_discard_trivia(

--- a/crates/biome_js_analyze/tests/specs/nursery/useConsistentCurlyBraces/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useConsistentCurlyBraces/invalid.jsx
@@ -10,4 +10,6 @@
 }</Foo>
 
 <Foo>{/*comment*/'Hello world'/*comment*/}</Foo>
+
+<Foo>{x}{'y'}{z}</Foo>
 </>

--- a/crates/biome_js_analyze/tests/specs/nursery/useConsistentCurlyBraces/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useConsistentCurlyBraces/invalid.jsx.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 86
 expression: invalid.jsx
 ---
 # Input
@@ -16,6 +17,8 @@ expression: invalid.jsx
 }</Foo>
 
 <Foo>{/*comment*/'Hello world'/*comment*/}</Foo>
+
+<Foo>{x}{'y'}{z}</Foo>
 </>
 
 ```
@@ -123,8 +126,8 @@ invalid.jsx:12:6 lint/nursery/useConsistentCurlyBraces  FIXABLE  ━━━━━
     11 │ 
   > 12 │ <Foo>{/*comment*/'Hello world'/*comment*/}</Foo>
        │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    13 │ </>
-    14 │ 
+    13 │ 
+    14 │ <Foo>{x}{'y'}{z}</Foo>
   
   i JSX child does not need to be wrapped in curly braces.
   
@@ -134,8 +137,29 @@ invalid.jsx:12:6 lint/nursery/useConsistentCurlyBraces  FIXABLE  ━━━━━
     11 11 │   
     12    │ - <Foo>{/*comment*/'Hello·world'/*comment*/}</Foo>
        12 │ + <Foo>{/*comment*/}Hello·world{/*comment*/}</Foo>
-    13 13 │   </>
-    14 14 │   
+    13 13 │   
+    14 14 │   <Foo>{x}{'y'}{z}</Foo>
   
+
+```
+
+```
+invalid.jsx:14:9 lint/nursery/useConsistentCurlyBraces  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Should not have curly braces around expression.
+  
+    12 │ <Foo>{/*comment*/'Hello world'/*comment*/}</Foo>
+    13 │ 
+  > 14 │ <Foo>{x}{'y'}{z}</Foo>
+       │         ^^^^^
+    15 │ </>
+    16 │ 
+  
+  i JSX child does not need to be wrapped in curly braces.
+  
+  i Unsafe fix: Remove curly braces around the expression.
+  
+    14 │ <Foo>{x}{'y'}{z}</Foo>
+       │         -- --         
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

PR https://github.com/biomejs/biome/pull/3182 added the `useConsistentCurlyBraces` rule. However, the automatic fix provided by the rule inadvertently removes other child nodes under the parent node. This behavior should be corrected to preserve these nodes.

```
invalid.jsx:14:9 lint/nursery/useConsistentCurlyBraces  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ! Should not have curly braces around expression.
  
    12 │ <Foo>{/*comment*/'Hello world'/*comment*/}</Foo>
    13 │ 
  > 14 │ <Foo>{x}{'y'}{z}</Foo>
       │         ^^^^^
    15 │ </>
    16 │ 
  
  i JSX child does not need to be wrapped in curly braces.
  
  i Unsafe fix: Remove curly braces around the expression.
  
    14 │ <Foo>{x}{'y'}{z}</Foo>
       │      ----- -----      

```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

See test spec.

```
cargo test -p biome_js_analyze use_consistent_curly_braces
```