### PR TITLE
fix(useStrictMode): check actual directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
+- [useStrictMode](https://biomejs.dev/linter/rules/use-strict-mode/) now reports Script files with dome diretcives, but without the `use strict` directive. Contributed by @Conaclos
+
 - The CSS parser now accepts the characters U+FFDCF and U+FFFD in identifiers. Contributed by @Conaclos
 
 ## v1.9.1 (2024-09-15)

--- a/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/invalid-with-directive.cjs
+++ b/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/invalid-with-directive.cjs
@@ -1,0 +1,1 @@
+"use server";

--- a/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/invalid-with-directive.cjs.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/invalid-with-directive.cjs.snap
@@ -1,0 +1,30 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid-with-directive.cjs
+---
+# Input
+```cjs
+"use server";
+
+```
+
+# Diagnostics
+```
+invalid-with-directive.cjs:1:1 lint/nursery/useStrictMode  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Unexpected absence of the directive "use strict".
+  
+  > 1 │ "use server";
+      │ ^^^^^^^^^^^^^
+    2 │ 
+  
+  i Strict mode allows to opt-in some optimisations of the runtime engines, and it eliminates some JavaScript silent errors by changing them to throw errors.
+  
+  i Check the for more information regarding strict mode.
+  
+  i Safe fix: Insert a top level"use strict" .
+  
+    1 │ "use·server";"use·strict";
+      │              +++++++++++++
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/invalid.js.snap
@@ -33,7 +33,7 @@ invalid.js:3:1 lint/nursery/useStrictMode  FIXABLE  ━━━━━━━━━�
   
     1 1 │   
     2 2 │   
-      3 │ + "use·strict"
+      3 │ + "use·strict";
       4 │ + 
     3 5 │   function f() {
     4 6 │   	return "lorem ipsum"

--- a/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/valid-with-directive.cjs
+++ b/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/valid-with-directive.cjs
@@ -1,0 +1,2 @@
+"use server";
+"use strict";

--- a/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/valid-with-directive.cjs.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useStrictMode/valid-with-directive.cjs.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-with-directive.cjs
+---
+# Input
+```cjs
+"use server";
+"use strict";
+```


### PR DESCRIPTION
## Summary

`noStrictMode` didn't report files with some directives that are not `use strict`.
I am unsure if it was intended.

I also improved the code fix that now add a semicolon and keep previous directives.

Also, I removed the file module kind check because we only query `JsScript` nodes that imply Script module kind.

## Test Plan

I added some tests.
